### PR TITLE
feat: Span visualization command

### DIFF
--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -77,7 +77,7 @@ fn main() -> anyhow::Result<()> {
             let report = report_builder.finish();
             report.print((&filename, Source::from(source)))?;
 
-            std::process::exit(1);
+            Ok(())
         }
         Args::Parse { file } => {
             let (doc, _) = load_file(&file)?;
@@ -120,7 +120,7 @@ fn main() -> anyhow::Result<()> {
             let report = report_builder.finish();
             report.print((&filename, Source::from(source)))?;
 
-            std::process::exit(1);
+            Ok(())
         }
         Args::Words => {
             let dict = FstDictionary::curated();

--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -99,7 +99,8 @@ fn main() -> anyhow::Result<()> {
                 .map(|s| s.to_string_lossy().into())
                 .unwrap_or("<file>".to_string());
 
-            let mut report_builder = Report::build(ReportKind::Advice, &filename, 0);
+            let mut report_builder =
+                Report::build(ReportKind::Custom("Spans", primary_color), &filename, 0);
             let mut color = primary_color;
             for token in doc.tokens() {
                 report_builder = report_builder.with_label(

--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -93,18 +93,27 @@ fn main() -> anyhow::Result<()> {
             let (doc, source) = load_file(&file)?;
 
             let primary_color = Color::Blue;
+            let secondary_color = Color::Magenta;
             let filename = file
                 .file_name()
                 .map(|s| s.to_string_lossy().into())
                 .unwrap_or("<file>".to_string());
 
             let mut report_builder = Report::build(ReportKind::Advice, &filename, 0);
+            let mut color = primary_color;
             for token in doc.tokens() {
                 report_builder = report_builder.with_label(
                     Label::new((&filename, token.span.into()))
                         .with_message(format!("[{}, {})", token.span.start, token.span.end))
-                        .with_color(primary_color),
+                        .with_color(color),
                 );
+
+                // Alternate colors so spans are clear
+                color = if color == primary_color {
+                    secondary_color
+                } else {
+                    primary_color
+                };
             }
 
             let report = report_builder.finish();

--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -26,6 +26,11 @@ enum Args {
         /// The file you wish to parse.
         file: PathBuf,
     },
+    /// Parse a provided document and show the spans of the detected tokens.
+    Spans {
+        /// The file you wish to display the spans.
+        file: PathBuf,
+    },
     /// Emit decompressed, line-separated list of words in Harper's dictionary.
     Words,
 }
@@ -83,6 +88,29 @@ fn main() -> anyhow::Result<()> {
             }
 
             Ok(())
+        }
+        Args::Spans { file } => {
+            let (doc, source) = load_file(&file)?;
+
+            let primary_color = Color::Blue;
+            let filename = file
+                .file_name()
+                .map(|s| s.to_string_lossy().into())
+                .unwrap_or("<file>".to_string());
+
+            let mut report_builder = Report::build(ReportKind::Advice, &filename, 0);
+            for token in doc.tokens() {
+                report_builder = report_builder.with_label(
+                    Label::new((&filename, token.span.into()))
+                        .with_message(format!("[{}, {})", token.span.start, token.span.end))
+                        .with_color(primary_color),
+                );
+            }
+
+            let report = report_builder.finish();
+            report.print((&filename, Source::from(source)))?;
+
+            std::process::exit(1);
         }
         Args::Words => {
             let dict = FstDictionary::curated();

--- a/justfile
+++ b/justfile
@@ -173,6 +173,10 @@ parse file:
 lint file:
   cargo run --bin harper-cli -- lint {{file}}
 
+# Show the spans of the parsed tokens overlapped on the file.
+spans file:
+  cargo run --bin harper-cli -- spans {{file}}
+
 # Add a noun to Harper's curated dictionary.
 addnoun noun:
   #! /bin/bash


### PR DESCRIPTION
Added a command to harper-cli and the justfile that visually displays spans on a parsed file.

It can be painstaking to verify that a parser is working correctly when writing one, but this command makes it easier to verify that the correct spans are being chosen.

I created this to assist me in implementing the typst parser (#302), but am spinning it off into it's own PR since it is pretty distinct.

The output is rather cluttered because it prints the span numbers as well. I'm split on this one, it can be helpful because you can cross-reference with the output of `just parse` to check what each span corresponds to, but it also makes the output less readable (or at least a lot longer vertically).

Example usage:
![image](https://github.com/user-attachments/assets/e10fcd46-282c-4575-b529-379cffe08008)

Note: it alternates colors to make adjacent spans stand out.