### PR TITLE
fix(core): updates to SpelledNumbers

### DIFF
--- a/harper-core/src/linting/spelled_numbers.rs
+++ b/harper-core/src/linting/spelled_numbers.rs
@@ -121,4 +121,12 @@ mod tests {
     fn does_not_correct_ten() {
         assert_suggestion_result("There are 10 pigs.", SpelledNumbers, "There are 10 pigs.");
     }
+
+    /// Check that the algorithm won't stack overflow or return `None` for any numbers within the specified range.
+    #[test]
+    fn services_range() {
+        for i in 0..1000 {
+            spell_out_number(i).unwrap();
+        }
+    }
 }


### PR DESCRIPTION
- Fix comments
- Change from suggesting if <= 10 to < 10
- Expand spelling function (110 would give stack overflow before)
- Update tests accordingly

I wasn't able to find an "Automattic style guide" as referenced in recent
commits on this, but it is rather standard to spell out numbers under but not
including 10. This is what APA does, and I believe MLA as well.

Recent commits also didn't update doc comments to reflect new behavior, so I
fixed that.

One thing to keep in mind, but I don't think is implemented yet, is that
numbers beginning sentences should always be spelled out, so it would be best
to expand behavior to include this in further enhancements.
