### PR TITLE
Support using a different `harper-ls` executable than the one bundled in the VSCode extension

### DIFF
--- a/packages/vscode-plugin/CHANGELOG.md
+++ b/packages/vscode-plugin/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Linting Python, Shellscript/Bash, and Git Commit files now work properly.
 - Add support for Nix and Plaintext files.
+- Add the `harper-ls.path` setting to optionally use a different `harper-ls` executable.
 
 ## 0.12.0
 

--- a/packages/vscode-plugin/README.md
+++ b/packages/vscode-plugin/README.md
@@ -20,10 +20,11 @@ If you use OpenVSX, for instance if you use VSCodium, you'll want to install fro
 
 ### Settings
 
-| Setting                        | Possible Values                                   | Default Value   | Description                                                       |
-| ------------------------------ | ------------------------------------------------- | --------------- | ----------------------------------------------------------------- |
-| `harper-ls.linters.*`          | `true`, `false`                                   | Varies          | Detect and provide suggestions in a variety of common situations. |
-| `harper-ls.diagnosticSeverity` | `"error"`, `"hint"`, `"information"`, `"warning"` | `"information"` | How severe do you want diagnostics to appear in the editor?       |
+| Setting                        | Type                                              | Default Value   | Description                                                                                                                                                 |
+| ------------------------------ | ------------------------------------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `harper-ls.path`               | `string`                                          | `""`            | Optional path to a `harper-ls` executable to use. Primarily useful if the bundled binary doesn't work in your system like in immutable Linux distributions. |
+| `harper-ls.linters.*`          | `boolean`                                         | Varies          | Detect and provide suggestions in a variety of common situations.                                                                                           |
+| `harper-ls.diagnosticSeverity` | `"error"`, `"hint"`, `"information"`, `"warning"` | `"information"` | How severe do you want diagnostics to appear in the editor?                                                                                                 |
 
 ## Developing and Contributing
 

--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -66,6 +66,11 @@
 			"type": "object",
 			"title": "Harper",
 			"properties": {
+				"harper-ls.path": {
+					"scope": "resource",
+					"type": "string",
+					"description": "Optional path to a harper-ls executable to use."
+				},
 				"harper-ls.linters.spell_check": {
 					"scope": "resource",
 					"type": "boolean",


### PR DESCRIPTION
Closes #321

I didn't add a test for the new setting since it'd be hard to distinguish if the extension is actually using a different binary or if it's just ignoring the setting and is using what's bundled because output wise, changing to a different executable should yield the same diagnostics in the editor.