### PR TITLE
docs: Fixup README links for language server integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you want to use Harper on your machine, you have three choices.
 
 `harper-ls` provides an integration that works for most code editors.
 
-[Read more here.](./harper-ls/README.md)
+[Read more here.](https://writewithharper.com/docs/integrations/language-server)
 
 ### Harper Obsidian Integration
 

--- a/harper-ls/README.md
+++ b/harper-ls/README.md
@@ -1,3 +1,3 @@
 # `harper-ls`
 
-Documentation for `harper-ls` has moved to the main [website](https://writewithharper.com/integrations/language-server).
+Documentation for `harper-ls` has moved to the main [website](https://writewithharper.com/docs/integrations/language-server).


### PR DESCRIPTION
Can revert first commit if you want to point to the `harper-ls` subdirectory initially. I was just looking for the website.