### PR TITLE
feat(vscode-plugin): Add CMake Support

### DIFF
--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -32,6 +32,7 @@
 	],
 	"activationEvents": [
 		"onLanguage:c",
+		"onLanguage:cmake",
 		"onLanguage:cpp",
 		"onLanguage:csharp",
 		"onLanguage:git-commit",

--- a/packages/vscode-plugin/src/tests/fixtures/languages/CMakeLists.txt
+++ b/packages/vscode-plugin/src/tests/fixtures/languages/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.10)
+project(HelloWorld)
+add_executable(HelloWorld #[[ Errorz ]] cpp.cpp)

--- a/packages/vscode-plugin/src/tests/suite/languages.test.ts
+++ b/packages/vscode-plugin/src/tests/suite/languages.test.ts
@@ -21,8 +21,9 @@ describe('Languages >', () => {
 		// Uncomment when #65 is fixed.
 		// { type: 'Shellscript without extension', file: 'shellscript', row: 2, column: 2 },
 
-		// VSCode doesn't support Haskell, Nix, and TOML files out of the box. Uncomment when you figure
-		// out how to support them during testing.
+		// VSCode doesn't support CMake, Haskell, Nix, and TOML files out of the box. Uncomment when you
+		// figure out how to support them during testing.
+		// { type: 'CMake', file: 'CMakeLists.txt', row: 2, column: 30 },
 		// { type: 'Haskell', file: 'haskell.hs', row: 1, column: 3 },
 		// { type: 'Nix', file: 'nix.nix', row: 1, column: 2 },
 		// { type: 'TOML', file: 'toml.toml', row: 1, column: 2 },


### PR DESCRIPTION
Add CMake support to the VSCode extension as per #353.

As an aside, I was about to update the changelog but I noticed that it was removed in ace693c00fe7128919c545ffbd22ec0b176b2fcc with the reasoning that it doesn't get updated. I just wanted to ask, what exactly wasn't being updated? Since, as far as I can recall, it was updated every time the extension was. Did it mean that the `## Unreleased` section wasn't being updated to the correct version every release? If so, that can be remedied by adding a command to also bump it in the `justfile` `bump-versions` recipe. I can add that to this PR, if you think it's a good idea.