### PR TITLE
feat(vscode-plugin): Add Literate Haskell and Typst Support + some doc updates

### DIFF
--- a/harper-ls/src/backend.rs
+++ b/harper-ls/src/backend.rs
@@ -227,7 +227,7 @@ impl Backend {
                     Some(Box::new(ts_parser))
                 }
             }
-            "lhaskell" => {
+            "literate haskell" | "lhaskell" => {
                 let parser = LiterateHaskellParser;
 
                 if let Some(new_dict) = parser.create_ident_dict(&Arc::new(source)) {

--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -42,6 +42,7 @@
 		"onLanguage:java",
 		"onLanguage:javascript",
 		"onLanguage:javascriptreact",
+		"onLanguage:literate haskell",
 		"onLanguage:lua",
 		"onLanguage:markdown",
 		"onLanguage:nix",

--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -54,7 +54,8 @@
 		"onLanguage:swift",
 		"onLanguage:toml",
 		"onLanguage:typescript",
-		"onLanguage:typescriptreact"
+		"onLanguage:typescriptreact",
+		"onLanguage:typst"
 	],
 	"main": "./build/extension.js",
 	"contributes": {

--- a/packages/vscode-plugin/src/tests/fixtures/languages/literate-haskell.lhs
+++ b/packages/vscode-plugin/src/tests/fixtures/languages/literate-haskell.lhs
@@ -4,3 +4,4 @@ main = putStrLn "Hello World!"
 \end{code}
 
 Errorz
+

--- a/packages/vscode-plugin/src/tests/fixtures/languages/literate-haskell.lhs
+++ b/packages/vscode-plugin/src/tests/fixtures/languages/literate-haskell.lhs
@@ -1,0 +1,6 @@
+\begin{code}
+main :: IO ()
+main = putStrLn "Hello World!"
+\end{code}
+
+Errorz

--- a/packages/vscode-plugin/src/tests/fixtures/languages/typst.typ
+++ b/packages/vscode-plugin/src/tests/fixtures/languages/typst.typ
@@ -1,3 +1,4 @@
 = Title
 
 *Errorz*
+

--- a/packages/vscode-plugin/src/tests/fixtures/languages/typst.typ
+++ b/packages/vscode-plugin/src/tests/fixtures/languages/typst.typ
@@ -1,0 +1,3 @@
+= Title
+
+*Errorz*

--- a/packages/vscode-plugin/src/tests/suite/languages.test.ts
+++ b/packages/vscode-plugin/src/tests/suite/languages.test.ts
@@ -21,13 +21,14 @@ describe('Languages >', () => {
 		// Uncomment when #65 is fixed.
 		// { type: 'Shellscript without extension', file: 'shellscript', row: 2, column: 2 },
 
-		// VSCode doesn't support CMake, Haskell, Literate Haskell, Nix, and TOML files out of the box.
-		// Uncomment when you figure out how to support them during testing.
+		// VSCode doesn't support CMake, Haskell, Literate Haskell, Nix, TOML, and Typst files out of
+		// the box. Uncomment when you figure out how to support them during testing.
 		// { type: 'CMake', file: 'CMakeLists.txt', row: 2, column: 30 },
 		// { type: 'Haskell', file: 'haskell.hs', row: 1, column: 3 },
 		// { type: 'Literate Haskell', file: 'literate-haskell.lhs', row: 5, column: 0 },
 		// { type: 'Nix', file: 'nix.nix', row: 1, column: 2 },
 		// { type: 'TOML', file: 'toml.toml', row: 1, column: 2 },
+		// { type: 'Typst', file: 'typst.typ', row: 2, column: 1 },
 
 		{ type: 'C', file: 'c.c', row: 2, column: 3 },
 		{ type: 'C++', file: 'cpp.cpp', row: 3, column: 5 },

--- a/packages/vscode-plugin/src/tests/suite/languages.test.ts
+++ b/packages/vscode-plugin/src/tests/suite/languages.test.ts
@@ -21,10 +21,11 @@ describe('Languages >', () => {
 		// Uncomment when #65 is fixed.
 		// { type: 'Shellscript without extension', file: 'shellscript', row: 2, column: 2 },
 
-		// VSCode doesn't support CMake, Haskell, Nix, and TOML files out of the box. Uncomment when you
-		// figure out how to support them during testing.
+		// VSCode doesn't support CMake, Haskell, Literate Haskell, Nix, and TOML files out of the box.
+		// Uncomment when you figure out how to support them during testing.
 		// { type: 'CMake', file: 'CMakeLists.txt', row: 2, column: 30 },
 		// { type: 'Haskell', file: 'haskell.hs', row: 1, column: 3 },
+		// { type: 'Literate Haskell', file: 'literate-haskell.lhs', row: 5, column: 0 },
 		// { type: 'Nix', file: 'nix.nix', row: 1, column: 2 },
 		// { type: 'TOML', file: 'toml.toml', row: 1, column: 2 },
 

--- a/packages/web/src/app.css
+++ b/packages/web/src/app.css
@@ -96,3 +96,11 @@ textarea {
 .header {
 	top: 6px !important;
 }
+
+th[align='center'] {
+	text-align: center;
+}
+
+th[align='right'] {
+	text-align: right;
+}

--- a/packages/web/src/routes/docs/integrations/language-server/+page.md
+++ b/packages/web/src/routes/docs/integrations/language-server/+page.md
@@ -75,30 +75,34 @@ If you use Neovim, [read this documentation](./neovim#Configuration).
 
 `harper-ls` supports a wide variety of programming and markup languages.
 
-| Language   |    Language ID    | Just Comments |
-| :--------- | :---------------: | ------------: |
-| Markdown   |    `markdown`     |            ✅ |
-| HTML       |      `html`       |            ❎ |
-| Email      |      `mail`       |            ❎ |
-| Rust       |      `rust`       |            ✅ |
-| Python     |     `python`      |            ✅ |
-| Nix        |       `nix`       |            ✅ |
-| JavaScript |   `javascript`    |            ✅ |
-| TypeScript |   `typescript`    |            ✅ |
-| React JSX  | `javascriptreact` |            ✅ |
-| React TSX  | `typescriptreact` |            ✅ |
-| Go         |       `go`        |            ✅ |
-| C          |        `c`        |            ✅ |
-| C++        |       `cpp`       |            ✅ |
-| CMake      |      `cmake`      |            ✅ |
-| Ruby       |      `ruby`       |            ✅ |
-| Swift      |      `swift`      |            ✅ |
-| C#         |     `csharp`      |            ✅ |
-| TOML       |      `toml`       |            ✅ |
-| Lua        |       `lua`       |            ✅ |
-| Shell      |   `shellscript`   |            ✅ |
-| Java       |      `java`       |            ✅ |
-| Haskell    |     `haskell`     |            ✅ |
+| Language          |          Language ID          | Comments Only |
+| :---------------- | :---------------------------: | ------------: |
+| C                 |              `c`              |            ✅ |
+| CMake             |            `cmake`            |            ✅ |
+| C++               |             `cpp`             |            ✅ |
+| C#                |           `csharp`            |            ✅ |
+| Email             |            `mail`             |               |
+| Git Commit        |   `git-commit`/`gitcommit`    |               |
+| Go                |             `go`              |            ✅ |
+| Haskell           |           `haskell`           |            ✅ |
+| HTML              |            `html`             |               |
+| Java              |            `java`             |            ✅ |
+| JavaScript        |         `javascript`          |            ✅ |
+| JavaScript React  |       `javascriptreact`       |            ✅ |
+| Literate Haskell  | `literate haskell`/`lhaskell` |               |
+| Lua               |             `lua`             |            ✅ |
+| Markdown          |          `markdown`           |               |
+| Nix               |             `nix`             |            ✅ |
+| Plain Text        |          `plaintext`          |               |
+| Python            |           `python`            |            ✅ |
+| Ruby              |            `ruby`             |            ✅ |
+| Rust              |            `rust`             |            ✅ |
+| Shell/Bash Script |         `shellscript`         |            ✅ |
+| Swift             |            `swift`            |            ✅ |
+| TOML              |            `toml`             |            ✅ |
+| TypeScript        |         `typescript`          |            ✅ |
+| TypeScript React  |       `typescriptreact`       |            ✅ |
+| Typst             |            `typst`            |               |
 
 Want your language added?
 Let us know by [commenting on this issue](https://github.com/Automattic/harper/issues/79).


### PR DESCRIPTION
- Support Literate Haskell. I used `literate haskell` as the language ID instead of `lhaskell` since [that's what's used by the official VSCode Haskell extension](https://github.com/haskell/vscode-haskell/blob/cf7df9a68f8d2c4d42a4b061531652b644cc5b36/package.json#L63).
- Support Typst.
- Update the supported languages section of the docs.
  - Alphabetize the languages.
  - Add missing languages.
  - Update language names based on [the spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem).
  - Update the language IDs to reflect what's currently in the codebase.
  - Remove the ❎s since they were hard to spot. I didn't even notice that there were ❎s and thought all of them were ✅s until I looked at the table closely. I don't think removing them impacts the clarity of what's being presented by the table.
  - Add some table styles so the headers actually align with the rest of the table.