### PR TITLE
fix(core): infinite lint loops

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -45440,7 +45440,8 @@ thatch/14MDRSZG
 thatcher/1M
 thatching/14M
 thaw/41MDGS
-the/-+81JG~
+the/-+J~
+thing/SM
 theater/1SM
 theatergoer/1SM
 theatrical/51YS

--- a/harper-core/src/linting/currency_placement.rs
+++ b/harper-core/src/linting/currency_placement.rs
@@ -16,8 +16,8 @@ impl Linter for CurrencyPlacement {
                 lints.extend(generate_lint_for_tokens(*a, *b, document));
             }
 
-            for (a, b, c) in chunk.iter().tuple_windows() {
-                if !b.kind.is_whitespace() {
+            for (p, a, b, c) in chunk.iter().tuple_windows() {
+                if !b.kind.is_whitespace() || p.kind.is_currency() {
                     continue;
                 }
 

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -122,5 +122,8 @@ mod tests {
         let transformed_str: String = text.iter().collect();
 
         assert_eq!(transformed_str.as_str(), expected_result);
+
+        // Applying the suggestions should fix all the lints.
+        assert_lint_count(&transformed_str, linter, 0);
     }
 }

--- a/harper-core/src/linting/pronoun_contraction/avoid_contraction.rs
+++ b/harper-core/src/linting/pronoun_contraction/avoid_contraction.rs
@@ -43,28 +43,3 @@ impl PatternLinter for AvoidContraction {
         "This rule looks for situations where a contraction was used where it shouldn't."
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use crate::linting::tests::assert_suggestion_result;
-
-    use super::AvoidContraction;
-
-    #[test]
-    fn issue_139() {
-        assert_suggestion_result(
-            "it would be great if you're PR was merged into tower-lsp",
-            AvoidContraction::default(),
-            "it would be great if your PR was merged into tower-lsp",
-        );
-    }
-
-    #[test]
-    fn car() {
-        assert_suggestion_result(
-            "You're car is black.",
-            AvoidContraction::default(),
-            "Your car is black.",
-        );
-    }
-}

--- a/harper-core/src/linting/pronoun_contraction/mod.rs
+++ b/harper-core/src/linting/pronoun_contraction/mod.rs
@@ -7,3 +7,45 @@ use avoid_contraction::AvoidContraction;
 use should_contract::ShouldContract;
 
 merge_linters! {PronounContraction => ShouldContract, AvoidContraction => "Choosing when to contract pronouns is a challenging art. This rule looks for faults." }
+
+#[cfg(test)]
+mod tests {
+    use super::PronounContraction;
+    use crate::linting::tests::assert_suggestion_result;
+
+    #[test]
+    fn issue_225() {
+        assert_suggestion_result(
+            "Your the man",
+            PronounContraction::default(),
+            "You're the man",
+        );
+    }
+
+    #[test]
+    fn were_team() {
+        assert_suggestion_result(
+            "Were the best team.",
+            PronounContraction::default(),
+            "We're the best team.",
+        );
+    }
+
+    #[test]
+    fn issue_139() {
+        assert_suggestion_result(
+            "it would be great if you're PR was merged into tower-lsp",
+            PronounContraction::default(),
+            "it would be great if your PR was merged into tower-lsp",
+        );
+    }
+
+    #[test]
+    fn car() {
+        assert_suggestion_result(
+            "You're car is black.",
+            PronounContraction::default(),
+            "Your car is black.",
+        );
+    }
+}

--- a/harper-core/src/linting/pronoun_contraction/should_contract.rs
+++ b/harper-core/src/linting/pronoun_contraction/should_contract.rs
@@ -60,23 +60,3 @@ impl PatternLinter for ShouldContract {
         "Neglecting the apostrophe when contracting pronouns with \"are\" (like \"your\" and \"you are\") is a fatal, but extremely common mistake to make."
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::ShouldContract;
-    use crate::linting::tests::assert_suggestion_result;
-
-    #[test]
-    fn issue_225() {
-        assert_suggestion_result("Your the man", ShouldContract::default(), "You're the man");
-    }
-
-    #[test]
-    fn were_team() {
-        assert_suggestion_result(
-            "Were the best team.",
-            ShouldContract::default(),
-            "We're the best team.",
-        );
-    }
-}


### PR DESCRIPTION
In we solved #225, but the rule we created had an issue that resulted in an infinite loop. One would "fix" a problem, but the fix would create another problem that the same rule would pick up.

This demonstrated a hole in our testing tools, which this PR aims to fill. By checking to make sure all invocations of `assert_suggestion` result create no new lints, we can cut down on this kind of error significantly. 

By doing this in fact, we also found a bug in #376.