### PR TITLE
feat(#393): add clap version & about attributes

### DIFF
--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -11,7 +11,9 @@ use harper_core::parsers::{Markdown, MarkdownOptions};
 use harper_core::{remove_overlaps, Dictionary, Document, FstDictionary, TokenKind};
 use harper_literate_haskell::LiterateHaskellParser;
 
+/// A debugging tool for the Harper grammar checker.
 #[derive(Debug, Parser)]
+#[command(version, about)]
 enum Args {
     /// Lint a provided document.
     Lint {

--- a/harper-ls/src/main.rs
+++ b/harper-ls/src/main.rs
@@ -25,6 +25,7 @@ static DEFAULT_ADDRESS: &str = "127.0.0.1:4000";
 ///
 /// Will listen on 127.0.0.1:4000 by default.
 #[derive(Debug, Parser)]
+#[command(version, about)]
 struct Args {
     /// Set to listen on standard input / output rather than TCP.
     #[arg(short, long, default_value_t = false)]


### PR DESCRIPTION
Clap has `about` and `version` attributes that can be added to provide users with a bit more info.

- Added `#[command(about, version)]` to harper-ls
- Added `#[command(about, version)]` to harper-cli
- Added short doc comment about harper-cli being a debugging tool
  - Doc comment will be used for about and will appear in the help menu of harper-cli

Closes #393