### PR TITLE
typos/spelling/grammar fixes in comments, docs, and strings

### DIFF
--- a/harper-comments/src/comment_parsers/jsdoc.rs
+++ b/harper-comments/src/comment_parsers/jsdoc.rs
@@ -121,7 +121,7 @@ pub(super) fn mark_inline_tags(tokens: &mut [Token]) {
     }
 }
 
-/// Checks if the provided token slice begins with an inline tag, returning it's
+/// Checks if the provided token slice begins with an inline tag, returning its
 /// end if so.
 fn parse_inline_tag(tokens: &[Token]) -> Option<usize> {
     if !matches!(

--- a/harper-core/src/linting/pronoun_contraction/avoid_contraction.rs
+++ b/harper-core/src/linting/pronoun_contraction/avoid_contraction.rs
@@ -34,7 +34,8 @@ impl PatternLinter for AvoidContraction {
                 vec!['y', 'o', 'u', 'r'],
                 word,
             )],
-            message: "It appears you intended to use the possessive version of this word".to_owned(),
+            message: "It appears you intended to use the possessive version of this word"
+                .to_owned(),
             priority: 63,
         }
     }

--- a/harper-core/src/linting/pronoun_contraction/avoid_contraction.rs
+++ b/harper-core/src/linting/pronoun_contraction/avoid_contraction.rs
@@ -34,13 +34,13 @@ impl PatternLinter for AvoidContraction {
                 vec!['y', 'o', 'u', 'r'],
                 word,
             )],
-            message: "I appears you intended to use the possessive version of this word".to_owned(),
+            message: "It appears you intended to use the possessive version of this word".to_owned(),
             priority: 63,
         }
     }
 
     fn description(&self) -> &'static str {
-        "This rule looks for situations where a contraction was used where it shouldn't."
+        "This rule looks for situations where a contraction was used where it shouldn't have been."
     }
 }
 

--- a/harper-core/src/linting/spelled_numbers.rs
+++ b/harper-core/src/linting/spelled_numbers.rs
@@ -35,7 +35,7 @@ impl Linter for SpelledNumbers {
     }
 }
 
-/// Converts a number to it's spelled-out variant.
+/// Converts a number to its spelled-out variant.
 ///
 /// For example: 100 -> one hundred.
 ///

--- a/harper-core/src/parsers/mask.rs
+++ b/harper-core/src/parsers/mask.rs
@@ -35,7 +35,7 @@ where
         let mut last_allowed: Option<Span> = None;
 
         for (span, content) in mask.iter_allowed(source) {
-            // Check if there was a line break between the last chunk.
+            // Check for a line break separating the current chunk from the preceding one.
             if let Some(last_allowed) = last_allowed {
                 let intervening = Span::new(last_allowed.end, span.start);
 

--- a/harper-core/src/token_kind.rs
+++ b/harper-core/src/token_kind.rs
@@ -155,7 +155,7 @@ impl TokenKind {
         self.with_default_data() == other.with_default_data()
     }
 
-    /// Produces a copy of `self` with any inner data replaced with it's default
+    /// Produces a copy of `self` with any inner data replaced with its default
     /// value. Useful for making comparisons on just the variant of the
     /// enum.
     pub fn with_default_data(&self) -> Self {

--- a/harper-ls/src/config.rs
+++ b/harper-ls/src/config.rs
@@ -35,7 +35,7 @@ impl DiagnosticSeverity {
 #[derive(Debug, Clone, Default)]
 pub struct CodeActionConfig {
     /// Instructs `harper-ls` to place unstable code actions last.
-    /// In this case, "unstable" refers their existence and action.
+    /// In this case, "unstable" refers to their existence and action.
     ///
     /// For example, we always want to allow users to add "misspelled" elements
     /// to dictionary, regardless of the spelling suggestions.

--- a/packages/harper.js/src/loadWasm.ts
+++ b/packages/harper.js/src/loadWasm.ts
@@ -14,7 +14,7 @@ export function setWasmUri(uri: string) {
 	curWasmUri = uri;
 }
 
-/** Load the WebAssembly manually and dynamically, making sure to setup infrastructure.
+/** Load the WebAssembly manually and dynamically, making sure to set up infrastructure.
  * You can use an optional data URL for the WebAssembly file if the module is being loaded from a Web Worker.
  * */
 export default async function loadWasm() {

--- a/packages/web/src/routes/+page.svelte
+++ b/packages/web/src/routes/+page.svelte
@@ -103,7 +103,7 @@
 <Section>
 	<span slot="title">Wicked Fast</span>
 	<span slot="subtitle"
-		>Since Harper runs on <strong>your</strong> devices, its able to serve up suggestions in under
+		>Since Harper runs on <strong>your</strong> devices, it's able to serve up suggestions in under
 		10 milliseconds.
 		<br />
 		<br />

--- a/packages/web/src/routes/docs/contributors/architecture/+page.md
+++ b/packages/web/src/routes/docs/contributors/architecture/+page.md
@@ -13,7 +13,7 @@ Hopefully, we can reduce that 10x down to something a little more reasonable.
 
 Harper tries to do one thing well: find grammatical and spelling errors in English text.
 If possible, provide suggestions to correct those errors.
-An error and it's possible corrections together form what we call a lint.
+An error and its possible corrections together form what we call a lint.
 
 In this vein, Harper serves the role of a [Linter](<https://en.wikipedia.org/wiki/Lint_(software)>) for English.
 

--- a/packages/web/src/routes/docs/contributors/committing/+page.md
+++ b/packages/web/src/routes/docs/contributors/committing/+page.md
@@ -7,7 +7,7 @@ Before creating a pull request, please make sure all your commits follow the lin
 
 Additionally, to minimize the labor required to review your commit, we run a relatively strict suite of formatting and linting programs.
 We highly recommend that you run both `just format` and `just precommit` before submitting a pull request.
-If those scripts don't work in your environment, we run `just precommit` through GitHub actions inside of pull requests, so you may make modifications and push until the checks pass.
+If those scripts don't work in your environment, we run `just precommit` through GitHub Actions inside of pull requests, so you may make modifications and push until the checks pass.
 
 If this sounds intimidating, don't worry.
 We are entirely willing to work with you to make sure your code can make it into Harper, just know it might take a little longer.

--- a/packages/web/src/routes/docs/contributors/environment/+page.md
+++ b/packages/web/src/routes/docs/contributors/environment/+page.md
@@ -15,10 +15,11 @@ To use the tooling required to build and debug Harper, you'll need to the follow
 - `pandoc`
 
 We develop a set of tools, accessible via `just`, to build and debug Harper's algorithm (otherwise known as `harper-core`) and its various integrations.
-To get see all the tools in your toolbox run:
+The source code is in the `justfile` [at the root of the repository](https://github.com/Automattic/harper/blob/master/justfile).
+To see all the tools in the toolbox, run:
 
 ```bash
 just --list
 ```
 
-Before getting started, we highly recommend that you run `just setup` to populate your build caches and download all dependencies.
+Before making any modifications, we highly recommend that you run `just setup` to populate your build caches and download all dependencies.

--- a/packages/web/src/routes/docs/integrations/neovim/+page.md
+++ b/packages/web/src/routes/docs/integrations/neovim/+page.md
@@ -49,7 +49,7 @@ As such, you can view this page as canonical documentation for the available con
 
 ### Markdown-Specific Config
 
-The Markdown parser has it's own configuration option, used to modify its behavior in specific ways.
+The Markdown parser has its own configuration option, used to modify its behavior in specific ways.
 For example, the title of a link is linted by default, but this behavior can be changed through the `ignore_link_title` key:
 
 ```lua


### PR DESCRIPTION
In `mask.rs` I was confused by 'between the last chunk".
Normally 'between' means between two things.
I wasn't sure if this should mean 'within the last chunk' or 'between the last two chunks' or 'between the last chunk and this chunk' etc, so I went with what I thought was the most likely. You better check.

Sorry I didn't run `just format` and `just precommit` because I don't know what those are and a quick Google didn't help. Git, GitHub, and build systems are still weak points.