### PR TITLE
fix(core): indexing problems

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -49771,3 +49771,4 @@ Harper/SM
 a8c/SM
 a11n/1
 a12s/9
+intergenerational

--- a/harper-core/src/patterns/is_not_title_case.rs
+++ b/harper-core/src/patterns/is_not_title_case.rs
@@ -24,8 +24,7 @@ impl<D: Dictionary> Pattern for IsNotTitleCase<D> {
         }
 
         let matched_chars = tokens[0..inner_match].span().unwrap().get_content(source);
-
-        if make_title_case(tokens, source, &self.dict) != matched_chars {
+        if make_title_case(&tokens[0..inner_match], source, &self.dict) != matched_chars {
             inner_match
         } else {
             0

--- a/harper-core/src/title_case.rs
+++ b/harper-core/src/title_case.rs
@@ -50,7 +50,7 @@ pub fn make_title_case(toks: &[Token], source: &[char], dict: &impl Dictionary) 
         } else {
             // The whole word should be lowercase.
             for i in word.span {
-                output[i - start_index] = output[i].to_ascii_lowercase();
+                output[i - start_index] = output[i - start_index].to_ascii_lowercase();
             }
         }
     }

--- a/harper-core/tests/run_tests.rs
+++ b/harper-core/tests/run_tests.rs
@@ -48,3 +48,6 @@ create_test!(amazon_hostname.md, 0);
 create_test!(issue_159.md, 1);
 create_test!(issue_358.md, 0);
 create_test!(issue_195.md, 0);
+
+// Make sure it doesn't panic
+create_test!(lukas_homework.md, 3);

--- a/harper-core/tests/test_sources/lukas_homework.md
+++ b/harper-core/tests/test_sources/lukas_homework.md
@@ -1,0 +1,23 @@
+# Native American Assimilation and Activism Week Two Reflection
+
+> This is the first in a bi-weekly series that I will be publishing for my Native
+American Assimilation and Activism class. Every two weeks we make posts
+sharing what we learned in the class. Unfortunately, due to weather in England I
+was unable to make it back to the United States in time for the first lecture.
+
+One of the key discussions in Monday's lecture/discussion was since time
+immemorial and teaching around that. Time Immemorium is a period before
+human memory, and involved other human species, travel stories, and creation
+stories. Some of the key lessons I learned from that class were:
+
+* Humans branched from some common ancestor that had multiple other human species branch off
+    * We are not evolved from chimps but also have a shared ancestor
+* Many genetic evolutional specializations have to do with environmental adaptation
+    * Some of these adaptations were shared when isolated groups had visitors (Weaving rivers theory)
+    * Also related: Intergenerational Trauma
+
+Oregon and Washington have been leading the country when it comes to
+integrating Native Americans into their school curriculum. This includes
+adding Since Time Immemorium curriculum. These advances have the
+possibility to significantly improve the awareness and appreciation of Native
+American Peoples who have and still live in these lands.


### PR DESCRIPTION
@lukasmwerner sent me a file that revealed two problems:

- If Harper attempted to make a chunk of text title case (that had a previously lower-case word at the end of input) it would try to access memory out of bounds.
- If the 'UnitedOrganization` rule encountered a correct capitalization of `United States`, it would create a false positive.

This PR solves both problems.

@lukasmwerner, would you mind compiling this branch and confirming that it solves those issues?