### PR TITLE
fix typo: remove extraneous 'to'

### DIFF
--- a/packages/web/src/routes/docs/contributors/environment/+page.md
+++ b/packages/web/src/routes/docs/contributors/environment/+page.md
@@ -2,7 +2,7 @@
 title: Set Up Your Environment
 ---
 
-To use the tooling required to build and debug Harper, you'll need to the following programs available in your `$PATH`.
+To use the tooling required to build and debug Harper, you'll need the following programs available in your `$PATH`.
 
 - [`just`](https://github.com/casey/just)
 - `bash`


### PR DESCRIPTION
I changed

you'll need to the following programs available in your `$PATH`

to

you'll need the following programs available in your `$PATH`

But perhaps another fix is preferred, such as:

you'll need to have the following programs available in your `$PATH`