### PR TITLE
feat(harper-core): Mark shebangs as unlintable

### DIFF
--- a/harper-comments/src/comment_parser.rs
+++ b/harper-comments/src/comment_parser.rs
@@ -108,3 +108,23 @@ impl Parser for CommentParser {
         self.inner.parse(source)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{CommentParser, MarkdownOptions, Parser};
+    use harper_core::TokenKind;
+
+    #[test]
+    fn shebang_unlintable() {
+        let source = String::from("#!/usr/bin/env python3")
+            .chars()
+            .collect::<Vec<char>>();
+        let markdown_options = MarkdownOptions::default();
+
+        let parser = CommentParser::new_from_language_id("python", markdown_options).unwrap();
+        let tokens = parser.parse(&source);
+        let kinds: Vec<_> = tokens.into_iter().map(|v| v.kind).collect();
+
+        assert!(kinds == &[TokenKind::Unlintable]);
+    }
+}

--- a/harper-core/src/parsers/mask.rs
+++ b/harper-core/src/parsers/mask.rs
@@ -35,6 +35,12 @@ where
         let mut last_allowed: Option<Span> = None;
 
         for (span, content) in mask.iter_allowed(source) {
+            // Check if the span is a shebang
+            if content.len() >= 2 && content[0..2] == ['#', '!'] {
+                tokens.push(Token::new(span, TokenKind::Unlintable));
+                continue;
+            }
+
             // Check for a line break separating the current chunk from the preceding one.
             if let Some(last_allowed) = last_allowed {
                 let intervening = Span::new(last_allowed.end, span.start);


### PR DESCRIPTION
Closes #65.

## Changes

- Adds check to see if the content is a shebang, in the parse function.
- Add test to comment parser to make sure that comments with shebang are ignored

I am not sure if this is a great solution since this should only apply to comment parsers, but I could not find an elegant solution for that.