### PR TITLE
Clean Up `harper-ls` logs

### DIFF
--- a/harper-ls/src/backend.rs
+++ b/harper-ls/src/backend.rs
@@ -87,7 +87,10 @@ impl Backend {
             .await
             .context("Unable to get the file path.")?;
 
-        load_dict(path).await.or(Ok(FullDictionary::new()))
+        load_dict(path)
+            .await
+            .map_err(|err| info!("{err}"))
+            .or(Ok(FullDictionary::new()))
     }
 
     async fn save_file_dictionary(&self, url: &Url, dict: impl Dictionary) -> Result<()> {

--- a/harper-ls/src/backend.rs
+++ b/harper-ls/src/backend.rs
@@ -87,10 +87,7 @@ impl Backend {
             .await
             .context("Unable to get the file path.")?;
 
-        load_dict(path)
-            .await
-            .map_err(|err| info!("{err}"))
-            .or(Ok(FullDictionary::new()))
+        load_dict(path).await.or(Ok(FullDictionary::new()))
     }
 
     async fn save_file_dictionary(&self, url: &Url, dict: impl Dictionary) -> Result<()> {

--- a/harper-ls/src/main.rs
+++ b/harper-ls/src/main.rs
@@ -38,6 +38,7 @@ struct Args {
 async fn main() -> anyhow::Result<()> {
     let subscriber = FmtSubscriber::builder()
         .map_writer(move |_| stderr)
+        .with_ansi(false)
         .with_max_level(Level::WARN)
         .finish();
 

--- a/harper-ls/src/main.rs
+++ b/harper-ls/src/main.rs
@@ -38,7 +38,7 @@ struct Args {
 async fn main() -> anyhow::Result<()> {
     let subscriber = FmtSubscriber::builder()
         .map_writer(move |_| stderr)
-        .with_max_level(Level::INFO)
+        .with_max_level(Level::WARN)
         .finish();
 
     tracing::subscriber::set_global_default(subscriber)?;


### PR DESCRIPTION
We've been seeing a lot of erroneous logs being made (see #443), cluttering buffers and making debugging more challenging. This PR aims to reduce this clutter by:

1. Reducing the number of logs `harper-ls` produces.
2. Reducing the noise within each log.