### PR TITLE
 feat(harper.js): added ability to explicitly set config to the default

### DIFF
--- a/harper-wasm/src/lib.rs
+++ b/harper-wasm/src/lib.rs
@@ -105,6 +105,10 @@ impl Linter {
         self.lint_group.config.serialize(&serializer).unwrap()
     }
 
+    pub fn fill_lint_config_with_default(&mut self) {
+        self.lint_group.config.fill_default_values();
+    }
+
     pub fn set_lint_config_from_object(&mut self, object: JsValue) -> Result<(), String> {
         self.lint_group.config =
             serde_wasm_bindgen::from_value(object).map_err(|v| v.to_string())?;

--- a/harper-wasm/src/lib.rs
+++ b/harper-wasm/src/lib.rs
@@ -111,10 +111,6 @@ impl Linter {
         self.lint_group.config.serialize(&serializer).unwrap()
     }
 
-    pub fn fill_lint_config_with_default(&mut self) {
-        self.lint_group.config.fill_default_values();
-    }
-
     pub fn set_lint_config_from_object(&mut self, object: JsValue) -> Result<(), String> {
         self.lint_group.config =
             serde_wasm_bindgen::from_value(object).map_err(|v| v.to_string())?;
@@ -264,6 +260,25 @@ impl Lint {
     pub fn message(&self) -> String {
         self.inner.message.clone()
     }
+}
+
+#[wasm_bindgen]
+pub fn get_default_lint_config_as_json() -> String {
+    let mut config = LintGroupConfig::default();
+    config.fill_default_values();
+
+    serde_json::to_string(&config).unwrap()
+}
+
+#[wasm_bindgen]
+pub fn get_default_lint_config() -> JsValue {
+    let mut config = LintGroupConfig::default();
+    config.fill_default_values();
+
+    // Important for downstream JSON serialization
+    let serializer = serde_wasm_bindgen::Serializer::json_compatible();
+
+    config.serialize(&serializer).unwrap()
 }
 
 /// A struct that represents two character indices in a string: a start and an end.

--- a/packages/harper.js/src/Linter.test.ts
+++ b/packages/harper.js/src/Linter.test.ts
@@ -125,9 +125,7 @@ for (const [linterName, Linter] of Object.entries(linters)) {
 	test(`${linterName} default lint config has no null values`, async () => {
 		const linter = new Linter();
 
-		await linter.setLintConfigToDefault();
-
-		const lintConfig = await linter.getLintConfig();
+		const lintConfig = await linter.getDefaultLintConfig();
 
 		for (const value of Object.values(lintConfig)) {
 			expect(value).not.toBeNull();

--- a/packages/harper.js/src/Linter.test.ts
+++ b/packages/harper.js/src/Linter.test.ts
@@ -121,6 +121,18 @@ for (const [linterName, Linter] of Object.entries(linters)) {
 			expect(value).not.toHaveLength(0);
 		}
 	});
+
+	test(`${linterName} default lint config has no null values`, async () => {
+		const linter = new Linter();
+
+		await linter.setLintConfigToDefault();
+
+		const lintConfig = await linter.getLintConfig();
+
+		for (const value of Object.values(lintConfig)) {
+			expect(value).not.toBeNull();
+		}
+	});
 }
 
 test('Linters have the same config format', async () => {

--- a/packages/harper.js/src/Linter.ts
+++ b/packages/harper.js/src/Linter.ts
@@ -25,8 +25,13 @@ export default interface Linter {
 	/** Get the linter's current configuration. */
 	getLintConfig(): Promise<LintConfig>;
 
-	/** Set the linter's current configuration to the official Harper default. */
-	setLintConfigToDefault(): Promise<void>;
+	/** Get the default (unset) linter configuration as JSON.
+	 * This method does not effect the caller's lint configuration, nor does it return the current one. */
+	getDefaultLintConfigAsJSON(): Promise<string>;
+
+	/** Get the default (unset) linter configuration.
+	 * This method does not effect the caller's lint configuration, nor does it return the current one. */
+	getDefaultLintConfig(): Promise<LintConfig>;
 
 	/** Set the linter's current configuration. */
 	setLintConfig(config: LintConfig): Promise<void>;

--- a/packages/harper.js/src/Linter.ts
+++ b/packages/harper.js/src/Linter.ts
@@ -25,6 +25,9 @@ export default interface Linter {
 	/** Get the linter's current configuration. */
 	getLintConfig(): Promise<LintConfig>;
 
+	/** Set the linter's current configuration to the official Harper default. */
+	setLintConfigToDefault(): Promise<void>;
+
 	/** Set the linter's current configuration. */
 	setLintConfig(config: LintConfig): Promise<void>;
 

--- a/packages/harper.js/src/LocalLinter.ts
+++ b/packages/harper.js/src/LocalLinter.ts
@@ -53,6 +53,18 @@ export default class LocalLinter implements Linter {
 		return this.inner!.get_lint_config_as_object();
 	}
 
+	async getDefaultLintConfigAsJSON(): Promise<string> {
+		const wasm = await loadWasm();
+
+		return wasm.get_default_lint_config_as_json();
+	}
+
+	async getDefaultLintConfig(): Promise<LintConfig> {
+		const wasm = await loadWasm();
+
+		return wasm.get_default_lint_config();
+	}
+
 	async setLintConfig(config: LintConfig): Promise<void> {
 		await this.initialize();
 
@@ -84,11 +96,5 @@ export default class LocalLinter implements Linter {
 	async getLintDescriptionsAsJSON(): Promise<string> {
 		await this.initialize();
 		return this.inner!.get_lint_descriptions_as_json();
-	}
-
-	async setLintConfigToDefault(): Promise<void> {
-		await this.initialize();
-
-		this.inner?.fill_lint_config_with_default();
 	}
 }

--- a/packages/harper.js/src/LocalLinter.ts
+++ b/packages/harper.js/src/LocalLinter.ts
@@ -84,4 +84,10 @@ export default class LocalLinter implements Linter {
 		await this.initialize();
 		return this.inner!.get_lint_descriptions_as_json();
 	}
+
+	async setLintConfigToDefault(): Promise<void> {
+		await this.initialize();
+
+		this.inner?.fill_lint_config_with_default();
+	}
 }

--- a/packages/harper.js/src/WorkerLinter/index.ts
+++ b/packages/harper.js/src/WorkerLinter/index.ts
@@ -105,8 +105,12 @@ export default class WorkerLinter implements Linter {
 		return JSON.parse(await this.getLintDescriptionsAsJSON()) as Record<string, string>;
 	}
 
-	setLintConfigToDefault(): Promise<void> {
-		return this.rpc('setLintConfigToDefault', []);
+	getDefaultLintConfigAsJSON(): Promise<string> {
+		return this.rpc('getDefaultLintConfigAsJSON', []);
+	}
+
+	async getDefaultLintConfig(): Promise<LintConfig> {
+		return JSON.parse(await this.getDefaultLintConfigAsJSON()) as LintConfig;
 	}
 
 	/** Run a procedure on the remote worker. */

--- a/packages/harper.js/src/WorkerLinter/index.ts
+++ b/packages/harper.js/src/WorkerLinter/index.ts
@@ -106,6 +106,10 @@ export default class WorkerLinter implements Linter {
 		return JSON.parse(await this.getLintDescriptionsAsJSON()) as Record<string, string>;
 	}
 
+	setLintConfigToDefault(): Promise<void> {
+		return this.rpc('setLintConfigToDefault', []);
+	}
+
 	/** Run a procedure on the remote worker. */
 	private async rpc(procName: string, args: any[]): Promise<any> {
 		const promise = new Promise((resolve, reject) => {

--- a/packages/web/src/lib/DefaultNeovimConfig.svelte
+++ b/packages/web/src/lib/DefaultNeovimConfig.svelte
@@ -1,0 +1,36 @@
+<script>
+	import { LocalLinter } from 'harper.js';
+	import { CopyCode } from '@sveltepress/theme-default/components';
+	import { Button } from 'flowbite-svelte';
+
+	let linter = new LocalLinter();
+
+	let head = `lspconfig.harper_ls.setup {
+  settings = {
+    ["harper-ls"] = {
+      linters = {
+`;
+
+	let tail = `      }
+    }
+  },
+}`;
+
+	async function generateConfig() {
+		await linter.setLintConfigToDefault();
+		let config = await linter.getLintConfig();
+
+		let rows = Object.entries(config)
+			.map(([key, value]) => `\t${key} = ${value},`)
+			.reduce((prev, cur) => prev + '\n' + cur);
+
+		return head + rows + tail;
+	}
+
+	async function copyConfig() {
+		let defaultConfig = await generateConfig();
+		navigator.clipboard.writeText(defaultConfig);
+	}
+</script>
+
+<Button onclick={copyConfig}>Copy Default Config</Button>

--- a/packages/web/src/lib/DefaultNeovimConfig.svelte
+++ b/packages/web/src/lib/DefaultNeovimConfig.svelte
@@ -1,6 +1,5 @@
 <script>
 	import { LocalLinter } from 'harper.js';
-	import { CopyCode } from '@sveltepress/theme-default/components';
 	import { Button } from 'flowbite-svelte';
 
 	let linter = new LocalLinter();

--- a/packages/web/src/lib/DefaultNeovimConfig.svelte
+++ b/packages/web/src/lib/DefaultNeovimConfig.svelte
@@ -16,11 +16,10 @@
 }`;
 
 	async function generateConfig() {
-		await linter.setLintConfigToDefault();
-		let config = await linter.getLintConfig();
+		let default_config = await linter.getDefaultLintConfig();
 
-		let rows = Object.entries(config)
-			.map(([key, value]) => `\t${key} = ${value},`)
+		let rows = Object.entries(default_config)
+			.map(([key, value]) => `\t\t\t${key} = ${value},`)
 			.reduce((prev, cur) => prev + '\n' + cur);
 
 		return head + rows + tail;
@@ -32,4 +31,4 @@
 	}
 </script>
 
-<Button onclick={copyConfig}>Copy Default Config</Button>
+<Button onclick={copyConfig}>Copy Default Config to Clipboard</Button>

--- a/packages/web/src/routes/docs/integrations/neovim/+page.md
+++ b/packages/web/src/routes/docs/integrations/neovim/+page.md
@@ -109,6 +109,12 @@ lspconfig.harper_ls.setup {
 }
 ```
 
+<script>
+import DefaultNeovimConfig from "$lib/DefaultNeovimConfig.svelte"
+</script>
+
+<DefaultNeovimConfig/>
+
 By default, `harper-ls` will mark all diagnostics with HINT.
 If you want to configure this, refer below:
 


### PR DESCRIPTION
In editors like Obsidian, we need to know what actual values the default config holds. This PR takes a stateful approach to the matter, allowing you to call a method on a `Linter` to set its configuration to the global default.

This PR also adds a button that will copy a Neovim-specific version of this default configuration to the clipboard for use in Lua configuration of `harper-ls`.

If SveltePress/sveltepress#310 is implemented, we will replace the button with the more reader-friendly alternative. 