### PR TITLE
Improvements to `PluralConjugate`

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -49457,7 +49457,7 @@ you'd/
 you'll/
 you're/
 you've/
-you/841SMH~
+you/84SMH~
 young/514TMR
 youngish/5
 youngster/1MS

--- a/harper-core/src/linting/plural_conjugate.rs
+++ b/harper-core/src/linting/plural_conjugate.rs
@@ -18,7 +18,7 @@ impl Default for PluralConjugate {
 
         let non_plural_case = SequencePattern::default()
             .then(Box::new(|tok: &Token, _source: &[char]| {
-                tok.kind.is_not_plural_noun() && tok.kind.is_noun() && !tok.kind.is_pronoun()
+                tok.kind.is_not_plural_noun() && tok.kind.is_noun()
             }))
             .then_whitespace()
             .then_exact_word("are");
@@ -98,6 +98,15 @@ mod tests {
             "If you are testing it, try harder.",
             PluralConjugate::default(),
             0,
+        );
+    }
+
+    #[test]
+    fn pronoun_singular() {
+        assert_suggestion_result(
+            "If he are testing it.",
+            PluralConjugate::default(),
+            "If he is testing it.",
         );
     }
 }

--- a/harper-core/src/linting/plural_conjugate.rs
+++ b/harper-core/src/linting/plural_conjugate.rs
@@ -18,7 +18,7 @@ impl Default for PluralConjugate {
 
         let non_plural_case = SequencePattern::default()
             .then(Box::new(|tok: &Token, _source: &[char]| {
-                tok.kind.is_not_plural_noun() && tok.kind.is_noun()
+                tok.kind.is_not_plural_noun() && tok.kind.is_noun() && !tok.kind.is_pronoun()
             }))
             .then_whitespace()
             .then_exact_word("are");
@@ -61,7 +61,7 @@ impl PatternLinter for PluralConjugate {
 
 #[cfg(test)]
 mod tests {
-    use crate::linting::tests::assert_suggestion_result;
+    use crate::linting::tests::{assert_lint_count, assert_suggestion_result};
 
     use super::PluralConjugate;
 
@@ -89,6 +89,15 @@ mod tests {
             "The house are just sitting there.",
             PluralConjugate::default(),
             "The house is just sitting there.",
+        );
+    }
+
+    #[test]
+    fn review_doc_page() {
+        assert_lint_count(
+            "If you are testing it, try harder.",
+            PluralConjugate::default(),
+            0,
         );
     }
 }

--- a/harper-core/src/token_kind.rs
+++ b/harper-core/src/token_kind.rs
@@ -304,6 +304,14 @@ impl TokenKind {
         metadata.is_linking_verb()
     }
 
+    pub fn is_not_pronoun_noun(&self) -> bool {
+        let TokenKind::Word(metadata) = self else {
+            return true;
+        };
+
+        metadata.is_not_pronoun_noun()
+    }
+
     pub fn is_not_plural_noun(&self) -> bool {
         let TokenKind::Word(metadata) = self else {
             return true;


### PR DESCRIPTION
I saw some issues with this rule while working on some documentation. This PR sets "you" to be potentially plural and adds some test cases.