### PR TITLE
Reword description of "that which" to avoid ironic redundancy

### DIFF
--- a/harper-core/src/linting/that_which.rs
+++ b/harper-core/src/linting/that_which.rs
@@ -58,7 +58,7 @@ impl PatternLinter for ThatWhich {
     }
 
     fn description(&self) -> &'static str {
-        "Repeating the word \"that\" twice is often redundant. `That which` is easier to read."
+        "Repeating the word \"that\" is often redundant. The phrase `that which` is easier to read."
     }
 }
 


### PR DESCRIPTION
"Repeat twice" is redundant and perhaps ambiguous. If you repeat a thing, you've already done it twice. If you repeat it twice have you now done it three times?

I asked an LLM to copyedit this, confirm whether it's a real redundancy, and ask it for a rewording. I think it did a better job than I could've done on my own:

- **Removed "twice"**: The phrase "Repeating the word 'that' twice" was changed to "Repeating the word 'that'" to eliminate redundancy. The concept of repetition inherently implies that it can occur multiple times, so specifying "twice" is unnecessary.
- **Clarified the second sentence**: The phrase "That which" was kept, but the context was made clearer by stating it as "The phrase that which is easier to read."