### PR TITLE
fix two grammatical errors

### DIFF
--- a/harper-core/src/linting/use_genitive.rs
+++ b/harper-core/src/linting/use_genitive.rs
@@ -9,7 +9,7 @@ pub struct UseGenitive {
 
 impl UseGenitive {
     fn new() -> Self {
-        // Define the environment in the genitive case __should__ be used in.
+        // Define the environment in which the genitive case __should__ be used.
         let environment = Lrc::new(SequencePattern::default().then_whitespace().then(Box::new(
             EitherPattern::new(vec![
                     Box::new(
@@ -69,7 +69,7 @@ impl PatternLinter for UseGenitive {
     }
 
     fn description(&self) -> &'static str {
-        "Looks situations where the genitive case of \"there\" should be used."
+        "Looks for situations where the genitive case of \"there\" should be used."
     }
 }
 


### PR DESCRIPTION
1. awkward "preposition bracketing"
2. missing "for" in "looks for"

Other valid fixes for 1. would be
- Define the environment where the genitive case __should__ be used.
- Define the environment the genitive case __should__ be used in.