### PR TITLE
work-in-progress lint for "despite of" to accompany issue #501

### DIFF
--- a/harper-core/src/linting/despite_of.rs
+++ b/harper-core/src/linting/despite_of.rs
@@ -1,0 +1,95 @@
+use itertools::Itertools;
+
+use crate::{
+    patterns::{Pattern, SequencePattern, WordPatternGroup},
+    Lrc, Token, TokenStringExt,
+};
+
+use super::{Lint, LintKind, PatternLinter, Suggestion};
+
+pub struct DespiteOf {
+    pattern: Box<dyn Pattern>,
+}
+
+impl Default for DespiteOf {
+    fn default() -> Self {
+        let mut pattern = WordPatternGroup::default();
+
+        let matching_pattern = Lrc::new(
+            SequencePattern::default()
+                .then_exact_word_or_lowercase("Despite")
+                .then_whitespace()
+                .then_exact_word("of"),
+        );
+
+        // TODO I don't actually know what these seemingly redundant lines are for
+        // TODO should it be the words I'm replacing, the substitutions, one uppercase and one lowercase?
+        pattern.add("of", Box::new(matching_pattern.clone()));
+        pattern.add("Despite", Box::new(matching_pattern));
+
+        Self {
+            pattern: Box::new(pattern),
+        }
+    }
+}
+
+impl PatternLinter for DespiteOf {
+    fn pattern(&self) -> &dyn Pattern {
+        self.pattern.as_ref()
+    }
+
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
+        let suggestion = format!(
+            // TODO I think the {} don't belong here. Also how to handle upper vs lower case?
+            "in spite of {}", // "despite {}", // TODO how to make multiple suggestions?
+            matched_tokens[0]
+                .span
+                .get_content(source)
+                .iter()
+                .collect::<String>()
+        )
+        .chars()
+        .collect_vec();
+
+        Lint {
+            span: matched_tokens.span().unwrap(),
+            lint_kind: LintKind::Repetition,
+            suggestions: vec![Suggestion::ReplaceWith(suggestion)],
+            message: "The phrase “despite of” is incorrect in English. Use either “despite” or “in spite of”.".to_string(),
+            priority: 126,
+        }
+    }
+
+    fn description(&self) -> &'static str {
+        "Flag “despite of”."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::assert_lint_count;
+    use super::DespiteOf;
+
+    #[test]
+    fn catches_lowercase() {
+        assert_lint_count(
+            "The team performed well, despite of the difficulties they faced.",
+            DespiteOf::default(),
+            1,
+        );
+    }
+
+    #[test]
+    fn catches_different_cases() {
+        assert_lint_count("Despite the rain, we went for a walk.", DespiteOf::default(), 1);
+    }
+
+    #[test]
+    fn likes_correction() {
+        assert_lint_count(
+            "The team performed well, despite the difficulties they faced. In spite of the rain, we went for a walk.",
+            DespiteOf::default(),
+            0,
+        );
+    }
+}

--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -31,6 +31,7 @@ use super::that_which::ThatWhich;
 use super::unclosed_quotes::UnclosedQuotes;
 use super::use_genitive::UseGenitive;
 use super::wrong_quotes::WrongQuotes;
+use super::despite_of::DespiteOf;
 use super::{CurrencyPlacement, Lint, Linter, OxfordComma};
 use crate::{Dictionary, Document};
 
@@ -189,7 +190,8 @@ create_lint_group_config!(
     OxfordComma => true,
     PronounContraction => true,
     CurrencyPlacement => true,
-    SomewhatSomething => true
+    SomewhatSomething => true,
+    DespiteOf => true
 );
 
 impl<T: Dictionary + Default> Default for LintGroup<T> {

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -32,6 +32,7 @@ mod that_which;
 mod unclosed_quotes;
 mod use_genitive;
 mod wrong_quotes;
+mod despite_of;
 
 pub use an_a::AnA;
 pub use avoid_curses::AvoidCurses;
@@ -68,6 +69,7 @@ pub use that_which::ThatWhich;
 pub use unclosed_quotes::UnclosedQuotes;
 pub use use_genitive::UseGenitive;
 pub use wrong_quotes::WrongQuotes;
+pub use despite_of::DespiteOf;
 
 use crate::Document;
 

--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -342,6 +342,12 @@
 					"type": "boolean",
 					"default": false,
 					"description": "The key on the keyboard often used as a quotation mark is actually a double-apostrophe. Use the correct character."
+				},
+				"harper-ls.linters.despite_of": {
+					"scope": "resource",
+					"type": "boolean",
+					"default": false,
+					"description": "Flag “despite of”."
 				}
 			}
 		}


### PR DESCRIPTION
Here's my first naïve attempt to make a real linter rule

This goes with issue #501 

Look at the TODOs and other comments to see where I am confused about what to do or if something is supported.

Should produce:
```
% just lint ~/harper-test/harper-test.md
cargo run --bin harper-cli -- lint /Users/hippietrail/harper-test/harper-test.md
warning: /Users/hippietrail/harper/harper-wasm/Cargo.toml: unused manifest key: package.private
warning: /Users/hippietrail/harper/harper-cli/Cargo.toml: unused manifest key: package.private
    Blocking waiting for file lock on build directory
   Compiling harper-core v0.17.0 (/Users/hippietrail/harper/harper-core)
   Compiling harper-tree-sitter v0.17.0 (/Users/hippietrail/harper/harper-tree-sitter)
   Compiling harper-typst v0.17.0 (/Users/hippietrail/harper/harper-typst)
   Compiling harper-html v0.17.0 (/Users/hippietrail/harper/harper-html)
   Compiling harper-comments v0.17.0 (/Users/hippietrail/harper/harper-comments)
   Compiling harper-literate-haskell v0.17.0 (/Users/hippietrail/harper/harper-literate-haskell)
   Compiling harper-cli v0.1.0 (/Users/hippietrail/harper/harper-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.39s
     Running `target/debug/harper-cli lint /Users/hippietrail/harper-test/harper-test.md`
Advice: 
   ╭─[harper-test.md:1:1]
   │
 5 │ Despite of everything, I have to do this.
   │ ─────┬────  
   │      ╰────── The phrase “despite of” is incorrect in English. Use either “despite” or “in spite of”.
───╯
```