### PR TITLE
Apply rule from issue #465 to core document.rs

### DIFF
--- a/harper-core/src/document.rs
+++ b/harper-core/src/document.rs
@@ -233,7 +233,7 @@ impl Document {
     }
 
     /// Searches for quotation marks and fills the
-    /// [`Punctuation::Quote::twin_loc`] field. This is on a best effort
+    /// [`Punctuation::Quote::twin_loc`] field. This is on a best-effort
     /// basis.
     ///
     /// Current algorithm is basic and could use some work.


### PR DESCRIPTION
when best-effort is an adjective it should by connected using a hyphen