### PR TITLE
feat(html): condense spaces like most HTML parsers

### DIFF
--- a/harper-html/src/lib.rs
+++ b/harper-html/src/lib.rs
@@ -1,9 +1,10 @@
 use harper_core::parsers::{self, Parser, PlainEnglish};
-use harper_core::Token;
+use harper_core::{Token, TokenKind};
 use harper_tree_sitter::TreeSitterMasker;
 use tree_sitter::Node;
 
 pub struct HtmlParser {
+    /// Used to grab the text nodes.
     inner: parsers::Mask<TreeSitterMasker, PlainEnglish>,
 }
 
@@ -26,6 +27,14 @@ impl Default for HtmlParser {
 
 impl Parser for HtmlParser {
     fn parse(&self, source: &[char]) -> Vec<Token> {
-        self.inner.parse(source)
+        let mut tokens = self.inner.parse(source);
+
+        for token in &mut tokens {
+            if let TokenKind::Space(v) = &mut token.kind {
+                *v = (*v).clamp(0, 1);
+            }
+        }
+
+        tokens
     }
 }

--- a/harper-html/tests/run_tests.rs
+++ b/harper-html/tests/run_tests.rs
@@ -38,3 +38,4 @@ macro_rules! create_test {
 
 create_test!(run_on.html, 0);
 create_test!(issue_156.html, 0);
+create_test!(issue_541.html, 0);

--- a/harper-html/tests/test_sources/issue_541.html
+++ b/harper-html/tests/test_sources/issue_541.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+</head>
+
+<body>
+  <p>
+    This block contains multiple lines of HTML. If Harper is throwing a "too many spaces" lint, it's
+    because <code>harper-html</code> isn't properly parsing the indent.
+  </p>
+</body>
+
+</html>


### PR DESCRIPTION
Fixes #541 by condensing spaces to achieve similar behavior to proper HTML parsers. 