### PR TITLE
fix(core): #548 `you` is not a verb

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -49459,7 +49459,7 @@ you'd/
 you'll/
 you're/
 you've/
-you/84SMH~
+you/8SMH~
 young/514TMR
 youngish/5
 youngster/1MS

--- a/harper-core/src/linting/lets_confusion/mod.rs
+++ b/harper-core/src/linting/lets_confusion/mod.rs
@@ -9,7 +9,7 @@ merge_linters!(LetsConfusion => LetUsRedundancy, NoContractionWithVerb => "It's 
 
 #[cfg(test)]
 mod tests {
-    use crate::linting::tests::assert_suggestion_result;
+    use crate::linting::tests::{assert_lint_count, assert_suggestion_result};
 
     use super::LetsConfusion;
 
@@ -45,5 +45,14 @@ mod tests {
     #[test]
     fn issue_470_missing_subject() {
         assert_suggestion_result("let play", LetsConfusion::default(), "let's play");
+    }
+
+    #[test]
+    fn issue_548() {
+        assert_lint_count(
+            "A simple web app that lets you fetch random issues.",
+            LetsConfusion::default(),
+            0,
+        );
     }
 }


### PR DESCRIPTION
For some reason, "you" was marked as a verb, which caused #548.