### PR TITLE
clean up strange character at end-of-line

### DIFF
--- a/harper-core/src/linting/matcher.rs
+++ b/harper-core/src/linting/matcher.rs
@@ -125,7 +125,7 @@ impl Matcher {
             "hr" => "hour",
             "w/o" => "without",
             "w/" => "with",
-            "wordlist" => "word list" ,
+            "wordlist" => "word list",
             "the","challenged" => "that challenged",
             "stdin" => "standard input",
             "stdout" => "standard output",


### PR DESCRIPTION
Somehow this character got into this file: [`U+2028` Line Separator Unicode Character](https://www.compart.com/en/unicode/U+2028)

<img width="525" alt="image" src="https://github.com/user-attachments/assets/3bf4295f-37c0-4fa8-909e-c4bf7a8c0441" />
