### PR TITLE
feat(web): add link to the Discord server

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Just make sure to read [our contribution guidelines first.](https://github.com/a
 - [`harper-ls` Documentation](https://writewithharper.com/docs/integrations/language-server)
 - [Neovim Support](https://writewithharper.com/docs/integrations/neovim)
 - [`harper.js` Documentation](https://writewithharper.com/docs/harperjs/introduction)
+- [Official Discord Server](https://discord.com/invite/JBqcAaKrzQ)
 
 ## Huge Thanks
 

--- a/packages/web/src/routes/docs/contributors/introduction/+page.md
+++ b/packages/web/src/routes/docs/contributors/introduction/+page.md
@@ -4,6 +4,6 @@ title: Introduction to Contributing
 
 Harper is completely open to outside contributions of any kind.
 
-If you have a feature request or bug to report, please [create an issue](https://github.com/automattic/harper/issues) and we'll get back to you as soon as we can.
+If you have a feature request or bug to report, please [create an issue](https://github.com/automattic/harper/issues) or ask us [a question on Discord](https://discord.gg/JBqcAaKrzQ) and we'll get back to you as soon as we can.
 
 If you're interested in making a change to the code, we have documentation on [setting up your environment](./environment) and [getting your changes merged in](./committing).

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
 				editLink: `https://github.com/automattic/harper/edit/master/packages/web/src/routes/:route`,
 				logo: '/circle-logo.png',
 				github: 'https://github.com/automattic/harper',
+				discord: 'https://discord.gg/JBqcAaKrzQ',
 				themeColor: {
 					primary: '#818eae',
 					dark: '#355280',


### PR DESCRIPTION
The Harper project has grown to a size where synchronous communication methods are now necessary. After careful deliberation, I've decided that a Discord server is an appropriate place for that. 

I've created the server. This PR just adds the link to the necessary spots on the website and README.