### PR TITLE
docs(obsidian): notify people they should use up-to-date Electron

### DIFF
--- a/packages/web/src/routes/docs/integrations/obsidian/+page.md
+++ b/packages/web/src/routes/docs/integrations/obsidian/+page.md
@@ -41,10 +41,16 @@ The Harper plugin is a powerful, privacy-first grammar and spell-checking tool d
 
 ## Installation Guide
 
-1. Open Obsidian and navigate to **Settings → Community Plugins → Browse**.
-2. Search for "Harper" in the plugin library.
-3. Click "Install" and then "Enable."
-4. Start typing in your notes—Harper will automatically highlight errors as you go!
+- Open Obsidian and navigate to **Settings → Community Plugins → Browse**.
+- Search for "Harper" in the plugin library.
+- Click "Install" and then "Enable."
+- Start typing in your notes—Harper will automatically highlight errors as you go!
+
+---
+
+:::warning[Notice]
+Harper expects an up-to-date version of Electron. If you have issues, [reinstall Obsidian](https://obsidian.md/download) or otherwise update your Electron version.
+:::
 
 ## Future Development
 


### PR DESCRIPTION
In older versions of Electron, there's [a bug that removes the Request object from the global context](https://github.com/electron/electron/pull/42419). Since Harper uses this object, it will not work on that version of Electron. This is the fundamental cause of #338. 

Beyond instructing users to update their Electron version (which this PR does), there doesn't seem to be a fix for this.