### PR TITLE
feat: change `just addnoun` to have different affixes as per #595

### DIFF
--- a/justfile
+++ b/justfile
@@ -234,7 +234,11 @@ addnoun noun:
     exit 0
   fi
 
-  echo "{{noun}}/SM" >> $DICT_FILE
+  if [[ "{{noun}}" =~ ^[A-Z] ]]; then
+    echo "{{noun}}/M" >> $DICT_FILE
+  else
+    echo "{{noun}}/SM" >> $DICT_FILE
+  fi
 
 # Search Harper's curated dictionary for a specific word
 searchdictfor word:


### PR DESCRIPTION
Addresses #595 to add only `/M` for capitalized words = proper nouns but continue adding `/SM` for lowercase words = common nouns.

This means all nouns will be eligible for possessive but only common nouns will be eligible for plural.

For proper nouns that do have plurals, edit the curated dictionary manually.