### PR TITLE
feat: add `harper-cli forms` and `just getforms`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,6 +607,7 @@ dependencies = [
  "harper-core",
  "harper-literate-haskell",
  "harper-typst",
+ "hashbrown 0.15.2",
  "serde",
  "serde_json",
 ]

--- a/harper-cli/Cargo.toml
+++ b/harper-cli/Cargo.toml
@@ -14,6 +14,7 @@ harper-literate-haskell = { path = "../harper-literate-haskell", version = "0.19
 harper-core = { path = "../harper-core", version = "0.19.0" }
 harper-comments = { path = "../harper-comments", version = "0.19.0" }
 harper-typst = { path = "../harper-typst", version = "0.19.0" }
+hashbrown = "0.15.2"
 serde = { version = "1.0.214", features = ["derive"] }
 serde_json = "1.0.138"
 

--- a/harper-core/src/lib.rs
+++ b/harper-core/src/lib.rs
@@ -16,7 +16,7 @@ pub mod parsers;
 pub mod patterns;
 mod punctuation;
 mod span;
-mod spell;
+pub mod spell;
 mod sync;
 mod title_case;
 mod token;

--- a/harper-core/src/spell/hunspell/mod.rs
+++ b/harper-core/src/spell/hunspell/mod.rs
@@ -3,7 +3,7 @@ mod attribute_list;
 mod error;
 mod expansion;
 mod matcher;
-mod word_list;
+pub mod word_list;
 
 pub use attribute_list::AttributeList;
 use attribute_list::HumanReadableAttributeList;

--- a/harper-core/src/spell/mod.rs
+++ b/harper-core/src/spell/mod.rs
@@ -12,7 +12,7 @@ pub use self::merged_dictionary::MergedDictionary;
 mod dictionary;
 mod fst_dictionary;
 mod full_dictionary;
-mod hunspell;
+pub mod hunspell;
 mod merged_dictionary;
 
 #[derive(PartialEq, Debug)]

--- a/justfile
+++ b/justfile
@@ -256,6 +256,9 @@ userdictoverlap:
 # Get the metadata associated with a particular word in Harper's dictionary as JSON.
 getmetadata word:
   cargo run --bin harper-cli -- metadata {{word}}
+# Get all the forms of a word using the affixes.
+getforms word:
+  cargo run --bin harper-cli -- forms {{word}}
 
 bump-versions: update-vscode-linters
   #! /bin/bash


### PR DESCRIPTION
These take an annotated word in the form of a hunspell entry, apply all the affix rules for the annotations, and output all the resulting word forms:

```
% just getforms workspace/1MS

workspace
workspace's
workspaces

% target/debug/harper-cli forms absorber/1MS
absorbers
absorber
absorber's
```

This implements my feature request in #606 
A version of this can be added to an expanded `just addnoun` so the user can confirm that no unexpected forms will be allowed and no legitimate forms will be flagged, before they add the word.