### PR TITLE
bench(harper.js): add benchmarks for configuration methods

### DIFF
--- a/packages/harper.js/src/Linter.bench.ts
+++ b/packages/harper.js/src/Linter.bench.ts
@@ -1,0 +1,31 @@
+import { bench } from 'vitest';
+import LocalLinter from './LocalLinter';
+import WorkerLinter from './WorkerLinter';
+
+const linters = {
+	WorkerLinter: WorkerLinter,
+	LocalLinter: LocalLinter
+};
+
+for (const [linterName, Linter] of Object.entries(linters)) {
+	const linter = new Linter();
+
+	// Prime caches
+	linter.setup();
+
+	const defaultConfig = await linter.getDefaultLintConfig();
+	const emptyIgnoreState = await linter.exportIgnoredLints();
+
+	bench(`${linterName} set lint configuration`, async () => {
+		await linter.setLintConfig(defaultConfig);
+	});
+
+	bench(`${linterName} get lint configuration`, async () => {
+		await linter.getLintConfig();
+	});
+
+	bench(`${linterName} reset ignore state`, async () => {
+		await linter.clearIgnoredLints();
+		await linter.importIgnoredLints(emptyIgnoreState);
+	});
+}

--- a/packages/harper.js/src/LocalLinter.ts
+++ b/packages/harper.js/src/LocalLinter.ts
@@ -20,6 +20,9 @@ export default class LocalLinter implements Linter {
 	async setup(): Promise<void> {
 		await this.initialize();
 		this.inner!.lint('', Language.Plain);
+
+		const exported = await this.exportIgnoredLints();
+		await this.importIgnoredLints(exported);
 	}
 
 	async lint(text: string, options?: LintOptions): Promise<Lint[]> {


### PR DESCRIPTION
I had some issues while working on an integration. These configuration methods sometimes would take quite a while, which would block a queue. This PR increases visibility into these methods.
