### PR TITLE
feat(core): create rule for the possessive version of "you"

### DIFF
--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -22,6 +22,7 @@ use super::phrase_corrections::{
     ThatChallenged, TurnItOff,
 };
 use super::plural_conjugate::PluralConjugate;
+use super::possessive_your::PossessiveYour;
 use super::pronoun_contraction::PronounContraction;
 use super::proper_noun_capitalization_linters::{
     AmazonNames, Americas, AppleNames, AzureNames, ChineseCommunistParty, GoogleNames, Holidays,
@@ -160,6 +161,7 @@ macro_rules! create_lint_group_config {
 }
 
 create_lint_group_config!(
+    PossessiveYour => true,
     SpelledNumbers => false,
     AnA => true,
     SentenceCapitalization => true,
@@ -195,7 +197,7 @@ create_lint_group_config!(
     MergeWords => true,
     PluralConjugate => false,
     OxfordComma => true,
-    NoOxfordComma => true,
+    NoOxfordComma => false,
     PronounContraction => true,
     CurrencyPlacement => true,
     SomewhatSomething => true,

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -28,6 +28,7 @@ mod oxford_comma;
 mod pattern_linter;
 mod phrase_corrections;
 mod plural_conjugate;
+mod possessive_your;
 mod pronoun_contraction;
 mod proper_noun_capitalization_linters;
 mod repeated_words;
@@ -71,6 +72,7 @@ pub use phrase_corrections::{
     ThatChallenged, TurnItOff,
 };
 pub use plural_conjugate::PluralConjugate;
+pub use possessive_your::PossessiveYour;
 pub use pronoun_contraction::PronounContraction;
 pub use proper_noun_capitalization_linters::{
     AmazonNames, Americas, AppleNames, AzureNames, ChineseCommunistParty, GoogleNames, Holidays,

--- a/harper-core/src/linting/possessive_your.rs
+++ b/harper-core/src/linting/possessive_your.rs
@@ -1,0 +1,65 @@
+use crate::{
+    patterns::{Pattern, SequencePattern},
+    Token,
+};
+
+use super::{Lint, LintKind, PatternLinter, Suggestion};
+
+pub struct PossessiveYour {
+    pattern: Box<dyn Pattern>,
+}
+
+impl Default for PossessiveYour {
+    fn default() -> Self {
+        let pattern = SequencePattern::aco("you").then_whitespace().then(Box::new(
+            |tok: &Token, _source: &[char]| tok.kind.is_noun() && !tok.kind.is_verb(),
+        ));
+
+        Self {
+            pattern: Box::new(pattern),
+        }
+    }
+}
+
+impl PatternLinter for PossessiveYour {
+    fn pattern(&self) -> &dyn Pattern {
+        self.pattern.as_ref()
+    }
+
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
+        let span = matched_tokens.first().unwrap().span;
+        let orig_chars = span.get_content(source);
+
+        Lint {
+            span,
+            lint_kind: LintKind::WordChoice,
+            suggestions: vec![
+                Suggestion::replace_with_match_case("your".chars().collect(), orig_chars),
+                Suggestion::replace_with_match_case("you're an".chars().collect(), orig_chars),
+            ],
+            message: "The possesive version of this word is more common in this context."
+                .to_owned(),
+            ..Default::default()
+        }
+    }
+
+    fn description(&self) -> &'static str {
+        "The possessive version of `you` is more common before nouns."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::assert_suggestion_result;
+
+    use super::PossessiveYour;
+
+    #[test]
+    fn your_comments() {
+        assert_suggestion_result(
+            "You comments may end up in the documentation.",
+            PossessiveYour::default(),
+            "Your comments may end up in the documentation.",
+        );
+    }
+}

--- a/packages/vscode-plugin/README.md
+++ b/packages/vscode-plugin/README.md
@@ -2,7 +2,7 @@
 
 Harper is the next-generation grammar checker for your code. It catches common stylistic errors, as well as complex grammatical or layout-related problems. It works for almost [all common programming languages](./language-server#Supported-Languages) and a number of markup formats.
 
-If you use Rust, Java, JavaScript, or any number of other programming languages, you comments may be ending up as part of your API's documentation. If that's the case, grammatical mistakes in your code could be down-ranking your site on search results and tarnishing your reputation for quality.
+If you use Rust, Java, JavaScript, or any number of other programming languages, your comments may end up as part of your API's documentation. If that's the case, grammatical mistakes in your code could be down-ranking your site on search results and tarnishing your reputation for quality.
 
 Most importantly, Harper runs on-device and uses barely any memory at all. That means you can get feedback on your work in milliseconds, dramatically increasing your iteration speed.
 

--- a/packages/web/src/routes/docs/integrations/visual-studio-code/+page.md
+++ b/packages/web/src/routes/docs/integrations/visual-studio-code/+page.md
@@ -4,7 +4,7 @@ title: Visual Studio Code
 
 Harper is the next-generation grammar checker for your code. It catches common stylistic errors, as well as complex grammatical or layout-related problems. It works for almost [all common programming languages](./language-server#Supported-Languages) and a number of markup formats.
 
-If you use Rust, Java, JavaScript, or any number of other programming languages, you comments may be ending up as part of your API's documentation. If that's the case, grammatical mistakes in your code could be down-ranking your site on search results and tarnishing your reputation for quality.
+If you use Rust, Java, JavaScript, or any number of other programming languages, your comments may be ending up as part of your API's documentation. If that's the case, grammatical mistakes in your code could be down-ranking your site on search results and tarnishing your reputation for quality.
 
 Most importantly, Harper runs on-device and uses barely any memory at all. That means you can get feedback on your work in milliseconds, dramatically increasing your iteration speed.
 


### PR DESCRIPTION
The feedback in #602 made me aware we weren't covering this.

I've also included some small fixes (like making sure both `OxfordCommas` and `NoOxfordCommas` aren't both enabled by default).