### PR TITLE
bug: reverse correcting "supposed to" to "suppose to"

### DIFF
--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -18,7 +18,7 @@ use super::multiple_sequential_pronouns::MultipleSequentialPronouns;
 use super::number_suffix_capitalization::NumberSuffixCapitalization;
 use super::phrase_corrections::{
     AndAlike, BadRap, BatedBreath, BeckAndCall, ChangeTack, EnMasse, HumanLife, HungerPang,
-    LetAlone, LoAndBehold, NeedHelp, NoLonger, OfCourse, SneakingSuspicion, SupposeTo,
+    LetAlone, LoAndBehold, NeedHelp, NoLonger, OfCourse, SneakingSuspicion, SupposedTo,
     ThatChallenged, TurnItOff,
 };
 use super::plural_conjugate::PluralConjugate;
@@ -217,7 +217,7 @@ create_lint_group_config!(
     LetAlone => true,
     LoAndBehold => true,
     SneakingSuspicion => true,
-    SupposeTo => true
+    SupposedTo => true
 );
 
 impl<T: Dictionary + Default> Default for LintGroup<T> {

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -67,7 +67,7 @@ pub use oxford_comma::OxfordComma;
 pub use pattern_linter::PatternLinter;
 pub use phrase_corrections::{
     AndAlike, BadRap, BatedBreath, BeckAndCall, ChangeTack, EnMasse, HumanLife, HungerPang,
-    LetAlone, LoAndBehold, NeedHelp, NoLonger, OfCourse, SneakingSuspicion, SupposeTo,
+    LetAlone, LoAndBehold, NeedHelp, NoLonger, OfCourse, SneakingSuspicion, SupposedTo,
     ThatChallenged, TurnItOff,
 };
 pub use plural_conjugate::PluralConjugate;

--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -83,7 +83,7 @@ create_linter_for_phrase!(EnMasse, "en masse", 1);
 create_linter_for_phrase!(LetAlone, "let alone", 1);
 create_linter_for_phrase!(LoAndBehold, "lo and behold", 2);
 create_linter_for_phrase!(SneakingSuspicion, "sneaking suspicion", 3);
-create_linter_for_phrase!(SupposeTo, "suppose to", 1);
+create_linter_for_phrase!(SupposeTo, "supposed to", 1);
 
 #[cfg(test)]
 mod tests {
@@ -183,6 +183,6 @@ mod tests {
 
     #[test]
     fn supposed_to() {
-        assert_suggestion_result("supposed to", SupposeTo::default(), "suppose to");
+        assert_suggestion_result("suppose to", SupposeTo::default(), "supposed to");
     }
 }

--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -83,7 +83,7 @@ create_linter_for_phrase!(EnMasse, "en masse", 1);
 create_linter_for_phrase!(LetAlone, "let alone", 1);
 create_linter_for_phrase!(LoAndBehold, "lo and behold", 2);
 create_linter_for_phrase!(SneakingSuspicion, "sneaking suspicion", 3);
-create_linter_for_phrase!(SupposeTo, "supposed to", 1);
+create_linter_for_phrase!(SupposedTo, "supposed to", 1);
 
 #[cfg(test)]
 mod tests {
@@ -91,7 +91,7 @@ mod tests {
 
     use super::{
         BadRap, BatedBreath, ChangeTack, EnMasse, HungerPang, LetAlone, LoAndBehold, OfCourse,
-        SneakingSuspicion, SupposeTo, TurnItOff,
+        SneakingSuspicion, SupposedTo, TurnItOff,
     };
 
     #[test]
@@ -183,6 +183,6 @@ mod tests {
 
     #[test]
     fn supposed_to() {
-        assert_suggestion_result("suppose to", SupposeTo::default(), "supposed to");
+        assert_suggestion_result("suppose to", SupposedTo::default(), "supposed to");
     }
 }


### PR DESCRIPTION
I'm assuming this was a typo or thinko.

"Supposed to" is the correct phrase. "Suppose to" is the error.

References:
- https://grammarist.com/spelling/supposed-to/
- https://english.stackexchange.com/questions/8129/supposed-to-or-suppose-to
- https://quillbot.com/blog/definitions/supposed-to/
- https://www.reddit.com/r/grammar/comments/n171gz/suppose_to_or_supposed_to/
- https://langeek.co/en/grammar/course/1613/suppose-vs-supposed