### PR TITLE
grammar agreement in obsidion plugin comment

### DIFF
--- a/packages/obsidian-plugin/src/lint.ts
+++ b/packages/obsidian-plugin/src/lint.ts
@@ -82,7 +82,7 @@ interface LintConfig {
 	tooltipFilter?: null | DiagnosticFilter;
 	/// Can be used to control what kind of transactions cause lint
 	/// hover tooltips associated with the given document range to be
-	/// hidden. By default any transactions that changes the line
+	/// hidden. By default any transaction that changes the line
 	/// around the range will hide it. Returning null falls back to this
 	/// behavior.
 	hideOn?: (tr: Transaction, from: number, to: number) => boolean | null;


### PR DESCRIPTION
By default any **transactions** that **changes** the line → By default any **transaction** that **changes** the line

(Alternatively, "By default any **transactions** that **change** the line" would also be correct.)