### PR TITLE
Cut-and-paste error in "report error" template

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-grammatical-error.md
+++ b/.github/ISSUE_TEMPLATE/report-grammatical-error.md
@@ -1,6 +1,6 @@
 ---
 name: Report Grammatical Error
-about: If a grammatical error is not found by Harper, let us tus now
+about: If a grammatical error is not found by Harper, let us know
 title: ''
 labels: enhancement, harper-core, linting
 assignees: ''


### PR DESCRIPTION
Apologies if this was intentional but it looks like cut-and-paste gone wrong:

let us **tus now** → let us **know**