### PR TITLE
feat: if spellcheck only has one suggestion mention it directly

### DIFF
--- a/harper-core/src/linting/spell_check.rs
+++ b/harper-core/src/linting/spell_check.rs
@@ -76,17 +76,27 @@ impl<T: Dictionary> Linter for SpellCheck<T> {
             }
 
             let suggestions = possibilities
-                .into_iter()
+                .iter()
                 .map(|word| Suggestion::ReplaceWith(word.to_vec()));
+
+            // If there's only one suggestion, save the user a step in the GUI
+            let message = if suggestions.len() == 1 {
+                format!(
+                    "Did you mean “{}”?",
+                    possibilities.last().unwrap().iter().collect::<String>()
+                )
+            } else {
+                format!(
+                    "Did you mean to spell “{}” this way?",
+                    document.get_span_content_str(word.span)
+                )
+            };
 
             lints.push(Lint {
                 span: word.span,
                 lint_kind: LintKind::Spelling,
                 suggestions: suggestions.collect(),
-                message: format!(
-                    "Did you mean to spell “{}” this way?",
-                    document.get_span_content_str(word.span)
-                ),
+                message,
                 priority: 63,
             })
         }


### PR DESCRIPTION
When the spellchecker has suggestions you have to click on Quick Fix to see them.
First:  
<img width="558" alt="Screenshot 2025-02-10 at 1 55 52 am" src="https://github.com/user-attachments/assets/de569137-4b54-4d2a-b492-01fd903ad7eb" />
Second:  
<img width="555" alt="Screenshot 2025-02-10 at 1 56 06 am" src="https://github.com/user-attachments/assets/f21674f3-264d-4296-bb56-44e077db8014" />

But when `matcher.rs` suggests a fix it tells you directly, without having to click on Quick Fix
<img width="541" alt="image" src="https://github.com/user-attachments/assets/66e5697c-d4df-4c63-a06a-2912c106fbd8" />

So use the same text in spell_check as in matcher when there's only one suggestion.
<img width="555" alt="Screenshot 2025-02-10 at 1 55 29 am" src="https://github.com/user-attachments/assets/21ab82cf-c8ec-4fa4-a33f-a28f864d1e52" />
