### PR TITLE
fix(obsidian): correctly handle Unicode conversions

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -20082,10 +20082,9 @@ diaereses/1
 diaeresis/1M
 diagnose/4DSG
 diagnosis/14M
-diagnostic/51S
+diagnostic/51MS
 diagnostically/
 diagnostician/1SM
-diagnostics/1M
 diagonal/51SMY
 diagram/14SM
 diagrammatic/5


### PR DESCRIPTION
Fixes #609 by correctly converting between character indexes (used by Harper) and Unicode code point indexes (used by Obsidian).

I may decide to move this logic into `harper.js` later.