### PR TITLE
feat: Flag "discuss about" instead of "discuss"

### DIFF
--- a/harper-core/src/linting/matcher.rs
+++ b/harper-core/src/linting/matcher.rs
@@ -200,6 +200,10 @@ impl Matcher {
 
         // wrong set phrases and collocations
         triggers.extend(pt! {
+            "discuss", "about" => "discuss",
+            "discussed", "about" => "discussed",
+            "discusses", "about" => "discusses",
+            "discussing", "about" => "discussing",
             "same", "than" => "same as",
             "Same", "than" => "same as"
         });


### PR DESCRIPTION
This is very common in Indian English but I've heard it in Euroenglish as well.

Examples from GitHub:
- Hi, Today after 3 hours, I'm at live YouTube Podcast, **discussing about** Meteor 3 at small devices like Raspberry Pi.
- this repository **discusses about** core concepts in react

Unfortunately there seem to be rare false positives:
- However, I think that raises some similar challenges to what I **discussed about** option 1 above: it creates a pressure to organize the configuration in a way ...

But this sounds wrong in other ways anyway. Better would be "discussed in", "mentioned in", "covered in"...