### PR TITLE
Implements #505 could of, should of, would of -> ... have

### DIFF
--- a/harper-core/src/linting/matcher.rs
+++ b/harper-core/src/linting/matcher.rs
@@ -200,6 +200,18 @@ impl Matcher {
 
         // wrong set phrases and collocations
         triggers.extend(pt! {
+            "could", "of" => "could have",
+            "could", "of" => "could've",
+            "couldn't", "of" => "couldn't have",
+            "had", "of" => "had have",
+            "had", "of" => "had've",
+            "hadn't", "of" => "hadn't have",
+            "should", "of" => "should have",
+            "should", "of" => "should've",
+            "shouldn't", "of" => "shouldn't have",
+            "would", "of" => "would have",
+            "would", "of" => "would've",
+            "wouldn't", "of" => "wouldn't have",
             "same", "than" => "same as",
             "Same", "than" => "same as"
         });


### PR DESCRIPTION
[#505 feat: Flag "would of", "could of", and "should of", etc](https://github.com/Automattic/harper/issues/505)

Supports negative and contracted versions.
<img width="376" alt="image" src="https://github.com/user-attachments/assets/b8064504-63ae-4bf5-9909-53f37d583ada" />
