### PR TITLE
feat: Sample forms `jot` and `shuf`

### DIFF
--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -47,7 +47,7 @@ enum Args {
     /// Get the metadata associated with a particular word.
     Metadata { word: String },
     /// Get all the forms of a word using the affixes.
-    Forms { word: String },
+    Forms { words: Vec<String> },
     /// Emit a decompressed, line-separated list of the words in Harper's dictionary.
     Words,
     /// Print the default config with descriptions.
@@ -176,20 +176,34 @@ fn main() -> anyhow::Result<()> {
 
             Ok(())
         }
-        Args::Forms { word } => {
-            let hunspell_word_list = format!("1\n{word}");
-            let words = parse_word_list(&hunspell_word_list.to_string()).unwrap();
-
-            let attributes = parse_default_attribute_list();
-
+        Args::Forms { words } => {
             let mut expanded: HashMap<CharString, WordMetadata> = HashMap::new();
+            let attributes = parse_default_attribute_list();
+            let total = words.len();
 
-            attributes.expand_marked_words(words, &mut expanded);
+            for (index, word) in words.iter().enumerate() {
+                expanded.clear();
 
-            expanded.keys().for_each(|form| {
-                let string_form: String = form.iter().collect();
-                println!("{}", string_form);
-            });
+                let hunspell_word_list = format!("1\n{word}");
+                let words = parse_word_list(&hunspell_word_list.to_string()).unwrap();
+                attributes.expand_marked_words(words, &mut expanded);
+
+                println!(
+                    "{}{}{}",
+                    if index > 0 { "\n" } else { "" },
+                    if total != 1 {
+                        format!("{}/{}: ", index + 1, total)
+                    } else {
+                        "".to_string()
+                    },
+                    word
+                );
+                expanded.keys().for_each(|form| {
+                    let string_form: String = form.iter().collect();
+                    println!("  - {}", string_form);
+                });
+            }
+
             Ok(())
         }
         Args::Config => {

--- a/justfile
+++ b/justfile
@@ -271,9 +271,19 @@ sampleforms count:
   fi
 
   total_lines=$(wc -l < $DICT_FILE)
-  words=$(jot -r {{count}} 1 "$total_lines" | while read -r line_num; do \
-    sed -n "$line_num"p $DICT_FILE; \
-  done)
+  
+  # Cross-platform random line selection
+  if command -v shuf >/dev/null 2>&1; then
+    words=$(shuf -n "{{count}}" "$DICT_FILE")
+  elif command -v jot >/dev/null 2>&1; then
+    words=$(jot -r "{{count}}" 1 "$total_lines" | while read -r line_num; do \
+      sed -n "$line_num"p "$DICT_FILE"; \
+    done)
+  else
+    echo "Error: Neither 'shuf' nor 'jot' found. Cannot generate random words." >&2
+    exit 1
+  fi
+  
   cargo run --bin harper-cli -- forms $words
 
 bump-versions: update-vscode-linters

--- a/justfile
+++ b/justfile
@@ -262,6 +262,7 @@ getforms word:
 # Get a random sample of words from Harper's dictionary and list all forms of each.
 sampleforms count:
   #!/bin/bash
+  set -eo pipefail
   DICT_FILE=./harper-core/dictionary.dict 
   # USER_DICT_FILE="$HOME/.config/harper-ls/dictionary.txt"
 

--- a/justfile
+++ b/justfile
@@ -259,6 +259,21 @@ getmetadata word:
 # Get all the forms of a word using the affixes.
 getforms word:
   cargo run --bin harper-cli -- forms {{word}}
+# Get a random sample of words from Harper's dictionary and list all forms of each.
+sampleforms count:
+  #!/bin/bash
+  DICT_FILE=./harper-core/dictionary.dict 
+  # USER_DICT_FILE="$HOME/.config/harper-ls/dictionary.txt"
+
+  if [ "{{count}}" -eq 0 ]; then
+    exit 0
+  fi
+
+  total_lines=$(wc -l < $DICT_FILE)
+  words=$(jot -r {{count}} 1 "$total_lines" | while read -r line_num; do \
+    sed -n "$line_num"p $DICT_FILE; \
+  done)
+  cargo run --bin harper-cli -- forms $words
 
 bump-versions: update-vscode-linters
   #! /bin/bash


### PR DESCRIPTION
New version of `just sampleforms` that should work on systems with either `shuf` or `jot`. macOS only has the latter.

Please test.