### PR TITLE
Remove Duplicate Spelling Suggestions

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -685,7 +685,6 @@ AstroTurf/1M
 Asturias/2M
 Asuncion/M
 Aswan/2M
-At/SM
 Atacama/2M
 Atahualpa/M
 Atalanta/2M
@@ -1908,7 +1907,6 @@ Ceylonese/51
 Cezanne/M
 Cf/M
 Ch'in/2M
-Ch/N
 Chablis/21M
 Chad/21M
 Chadian/51MS
@@ -4065,7 +4063,6 @@ Gwendoline/2M
 Gwendolyn/2M
 Gwyn/2M
 Gypsy/125SM
-H/152M
 HBO/2M
 HBase/M
 HDD/1
@@ -8307,7 +8304,6 @@ Reyna/M
 Reynaldo/M
 Reynolds/2M
 Rf/M
-Rh/1M
 Rhea/2M
 Rhee/2M
 Rheingau/M

--- a/harper-core/src/spell/fst_dictionary.rs
+++ b/harper-core/src/spell/fst_dictionary.rs
@@ -94,7 +94,7 @@ impl FstDictionary {
 }
 
 fn build_dfa(max_distance: u8, query: &str) -> DFA {
-    // Insert if does not exist
+    // Insert if it does not exist
     AUTOMATON_BUILDERS.with_borrow_mut(|v| {
         if !v.iter().any(|t| t.0 == max_distance) {
             v.push((
@@ -181,6 +181,7 @@ impl Dictionary for FstDictionary {
         }
 
         merged.sort_unstable_by_key(|v| v.word);
+        merged.dedup_by_key(|v| v.word);
         merged.sort_unstable_by_key(|v| v.edit_distance);
         merged.truncate(max_results);
 
@@ -265,5 +266,12 @@ mod tests {
             .all(|(a, b)| a <= b);
 
         assert!(is_sorted_by_dist)
+    }
+
+    #[test]
+    fn curated_contains_no_duplicates() {
+        let dict = FstDictionary::curated();
+
+        assert!(dict.words.iter().map(|(word, _)| word).all_unique());
     }
 }

--- a/harper-core/src/spell/mod.rs
+++ b/harper-core/src/spell/mod.rs
@@ -15,7 +15,7 @@ mod full_dictionary;
 pub mod hunspell;
 mod merged_dictionary;
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Hash, Eq)]
 pub struct FuzzyMatchResult<'a> {
     word: &'a [char],
     edit_distance: u8,
@@ -85,6 +85,7 @@ pub fn suggest_correct_spelling<'a>(
         .fuzzy_match(misspelled_word, max_edit_dist, result_limit)
         .into_iter()
         .collect();
+
     order_suggestions(matches)
 }
 
@@ -145,7 +146,7 @@ mod tests {
     }
 
     #[test]
-    fn produces_no_duplicates() {
+    fn punctation_no_duplicates() {
         let results = suggest_correct_spelling_str(
             "punctation",
             RESULT_LIMIT,
@@ -153,9 +154,7 @@ mod tests {
             &FstDictionary::curated(),
         );
 
-        dbg!(&results, results.iter().unique().collect_vec());
-
-        assert_eq!(results.iter().unique().count(), results.len())
+        assert!(results.iter().all_unique())
     }
 
     /// Ensures that the suggestions are ordered taking into account commonality
@@ -248,6 +247,20 @@ mod tests {
         dbg!(&results);
 
         assert!(results.iter().take(3).contains(&"need".to_string()));
+    }
+
+    #[test]
+    fn issue_624_no_duplicates() {
+        let results = suggest_correct_spelling_str(
+            "Semantical",
+            RESULT_LIMIT,
+            MAX_EDIT_DIST,
+            &FstDictionary::curated(),
+        );
+
+        dbg!(&results);
+
+        assert!(results.iter().all_unique())
     }
 
     #[test]

--- a/harper-core/src/spell/mod.rs
+++ b/harper-core/src/spell/mod.rs
@@ -134,8 +134,8 @@ mod tests {
         FstDictionary, FullDictionary,
     };
 
-    const RESULT_LIMIT: usize = 60;
-    const MAX_EDIT_DIST: u8 = 3;
+    const RESULT_LIMIT: usize = 100;
+    const MAX_EDIT_DIST: u8 = 2;
 
     #[test]
     fn normalizes_weve() {


### PR DESCRIPTION
Fixes #624.

The `FstDictionary` searches for both the given capitalization ("Hwllo") and the lowercase form ("hwllo"). We were getting duplicate suggestions when those two searches were merged together and had overlaps.