### PR TITLE
feat(web): make underlines animate into existence on page load

### DIFF
--- a/packages/.eslintrc.cjs
+++ b/packages/.eslintrc.cjs
@@ -10,6 +10,7 @@ module.exports = {
 		'prettier/prettier': 'error',
 		// Just annoying
 		'@typescript-eslint/no-explicit-any': ['off'],
+		'@typescript-eslint/no-unused-vars': ['off'],
 		'@typescript-eslint/ban-ts-comment': ['off']
 	},
 	parser: '@typescript-eslint/parser',

--- a/packages/web/src/lib/Editor.svelte
+++ b/packages/web/src/lib/Editor.svelte
@@ -3,7 +3,7 @@
 	import demo from '../../../../demo.md?raw';
 	import Underlines from '$lib/Underlines.svelte';
 	import { Button } from 'flowbite-svelte';
-	import type { Lint, WorkerLinter } from 'harper.js';
+	import { type Lint, type WorkerLinter, SuggestionKind } from 'harper.js';
 	import CheckMark from '$lib/CheckMark.svelte';
 	import { fly } from 'svelte/transition';
 	import lintKindColor from './lintKindColor';
@@ -16,14 +16,8 @@
 	let editor: HTMLTextAreaElement | null;
 	let linter: WorkerLinter;
 
-	let remove;
-	let replace;
-
 	(async () => {
-		let { WorkerLinter, SuggestionKind } = await import('harper.js');
-		remove = SuggestionKind.Remove;
-		replace = SuggestionKind.Replace;
-
+		let { WorkerLinter } = await import('harper.js');
 		linter = new WorkerLinter();
 
 		await linter.setup();
@@ -113,9 +107,9 @@
 												.applySuggestion(content, suggestion, lint.span())
 												.then((edited) => (content = edited))}
 									>
-										{#if suggestion.kind() == remove}
+										{#if suggestion.kind() == SuggestionKind.Remove}
 											Remove "{lint.get_problem_text()}"
-										{:else if suggestion.kind() == replace}
+										{:else if suggestion.kind() == SuggestionKind.Replace}
 											Replace "{lint.get_problem_text()}" with "{suggestion.get_replacement_text()}"
 										{:else}
 											Insert "{suggestion.get_replacement_text()}" after "{lint.get_problem_text()}"

--- a/packages/web/src/lib/Underlines.svelte
+++ b/packages/web/src/lib/Underlines.svelte
@@ -5,7 +5,6 @@
 	// For now, it works.
 
 	import type { Lint } from 'harper.js';
-	import { WorkerLinter } from 'harper.js';
 	import lintKindColor from '$lib/lintKindColor';
 
 	export let content: string;
@@ -34,11 +33,18 @@
 
 	let lints: [Lint, number][] = [];
 	let lintHighlights: HTMLSpanElement[] = [];
-	let linter = new WorkerLinter();
-	linter.setup();
+	let linter: WorkerLinter;
+
+	(async () => {
+		let { WorkerLinter, SuggestionKind } = await import('harper.js');
+
+		linter = new WorkerLinter();
+
+		await linter.setup();
+	})();
 
 	$: linter
-		.lint(content)
+		?.lint(content)
 		.then(
 			(newLints) =>
 				(lints = newLints

--- a/packages/web/src/lib/Underlines.svelte
+++ b/packages/web/src/lib/Underlines.svelte
@@ -4,7 +4,7 @@
 	// Someday, I'll return to it and spruce it up.
 	// For now, it works.
 
-	import type { Lint } from 'harper.js';
+	import type { Lint, WorkerLinter } from 'harper.js';
 	import lintKindColor from '$lib/lintKindColor';
 
 	export let content: string;
@@ -14,10 +14,10 @@
 
 	let loadTime = Date.now();
 
-	function slideUnderline(node, { duration = 300 }) {
+	function slideUnderline(node: any) {
 		return {
-			duration,
-			css: (t) => {
+			duration: 300,
+			css: (t: number) => {
 				if (Date.now() - loadTime > 2000) {
 					t = 1;
 				}
@@ -36,7 +36,7 @@
 	let linter: WorkerLinter;
 
 	(async () => {
-		let { WorkerLinter, SuggestionKind } = await import('harper.js');
+		let { WorkerLinter } = await import('harper.js');
 
 		linter = new WorkerLinter();
 

--- a/packages/web/src/lib/Underlines.svelte
+++ b/packages/web/src/lib/Underlines.svelte
@@ -11,6 +11,27 @@
 	export let content: string;
 	export let focusLintIndex: number | undefined;
 
+	import { quintOut } from 'svelte/easing';
+
+	let loadTime = Date.now();
+
+	function slideUnderline(node, { duration = 300 }) {
+		return {
+			duration,
+			css: (t) => {
+				if (Date.now() - loadTime > 2000) {
+					t = 1;
+				}
+
+				return `
+        transform: scaleX(${t});
+        transform-origin: left;
+      `;
+			},
+			easing: quintOut
+		};
+	}
+
 	let lints: [Lint, number][] = [];
 	let lintHighlights: HTMLSpanElement[] = [];
 	let linter = new WorkerLinter();
@@ -49,6 +70,7 @@
 		content: string;
 		index: number;
 		color: string;
+		context: string;
 	};
 
 	type UnderlineToken = string | null | undefined | UnderlineDetails;
@@ -75,7 +97,8 @@
 					focused: lintIndex === focusLintIndex,
 					index: lintIndex,
 					content: lint.get_problem_text().replaceAll(' ', '\u00A0'),
-					color: lintKindColor(lint.lint_kind())
+					color: lintKindColor(lint.lint_kind()),
+					context: prevContent[prevContent.length - 1] ?? ''
 				};
 
 				return [...prevContent, lintContent];
@@ -113,6 +136,7 @@
 					<button
 						class={`underlinespecial transition-all rounded-sm ${chunk.focused ? 'animate-after-bigbounce text-white' : 'text-transparent'}`}
 						bind:this={lintHighlights[chunk.index]}
+						in:slideUnderline
 						on:click={() =>
 							chunk != null && typeof chunk == 'object' && (focusLintIndex = chunk.index)}
 						style={`--line-color: ${chunk.color}; --line-width: ${chunk.focused ? '4px' : '2px'}; --bg-color: ${chunk.focused ? '#dbafb3' : 'transparent'};`}


### PR DESCRIPTION
Shown in the attached GIF. Note that there are intentionally no animations _after_ the page load is loaded.


https://github.com/user-attachments/assets/75cdd692-540e-4191-81f3-d29005a3f62f


