### PR TITLE
fix: change "and alike" phrase correction to "and the like"

### DIFF
--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -30,7 +30,7 @@ use super::multiple_sequential_pronouns::MultipleSequentialPronouns;
 use super::nobody::Nobody;
 use super::number_suffix_capitalization::NumberSuffixCapitalization;
 use super::phrase_corrections::{
-    AndAlike, BadRap, BatedBreath, BeckAndCall, ChangeTack, EnMasse, HumanLife, HungerPang,
+    AndTheLike, BadRap, BatedBreath, BeckAndCall, ChangeTack, EnMasse, HumanLife, HungerPang,
     LetAlone, LoAndBehold, NeedHelp, NoLonger, OfCourse, SneakingSuspicion, SpecialAttention,
     SupposedTo, ThanOthers, ThatChallenged, TurnItOff,
 };
@@ -273,7 +273,7 @@ create_lint_group_config!(
     ThatChallenged => true,
     TurnItOff => true,
     OfCourse => true,
-    AndAlike => true,
+    AndTheLike => true,
     BadRap => true,
     BatedBreath => true,
     BeckAndCall => true,

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -86,7 +86,7 @@ pub use number_suffix_capitalization::NumberSuffixCapitalization;
 pub use oxford_comma::OxfordComma;
 pub use pattern_linter::PatternLinter;
 pub use phrase_corrections::{
-    AndAlike, BadRap, BatedBreath, BeckAndCall, ChangeTack, EnMasse, HumanLife, HungerPang,
+    AndTheLike, BadRap, BatedBreath, BeckAndCall, ChangeTack, EnMasse, HumanLife, HungerPang,
     LetAlone, LoAndBehold, NeedHelp, NoLonger, OfCourse, SneakingSuspicion, SpecialAttention,
     SupposedTo, ThanOthers, ThatChallenged, TurnItOff,
 };

--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -76,7 +76,7 @@ create_linter_for_phrase!(ThatChallenged, "that challenged", 2);
 create_linter_for_phrase!(NoLonger, "no longer", 1);
 create_linter_for_phrase!(NeedHelp, "need help", 1);
 create_linter_for_phrase!(OfCourse, "of course", 1);
-create_linter_for_phrase!(AndAlike, "and alike", 1);
+create_linter_for_phrase!(AndTheLike, "and the like", 1);
 create_linter_for_phrase!(BadRap, "bad rap", 1);
 create_linter_for_phrase!(BatedBreath, "bated breath", 1);
 create_linter_for_phrase!(BeckAndCall, "beck and call", 1);


### PR DESCRIPTION
I thought "and alike" was only used by non-native English speakers. Not sure whether it was included here as a correct phrase on purpose or by accident.