### PR TITLE
Create linter for non-idiomatic "back in the days"

### DIFF
--- a/harper-core/src/linting/back_in_the_day.rs
+++ b/harper-core/src/linting/back_in_the_day.rs
@@ -1,0 +1,139 @@
+use itertools::Itertools;
+
+use crate::{
+    patterns::{ExactPhrase, OwnedPatternExt, Pattern, SequencePattern, WordSet},
+    Lrc, Token, TokenStringExt,
+};
+
+use super::{Lint, LintKind, PatternLinter, Suggestion};
+
+pub struct BackInTheDay {
+    pattern: Box<dyn Pattern>,
+    // The trailing words that should tell us to ignore the rule.
+    exceptions: Lrc<WordSet>,
+}
+
+impl Default for BackInTheDay {
+    fn default() -> Self {
+        let exceptions = Lrc::new(WordSet::all(&["of", "when"]));
+        let phrase = Lrc::new(ExactPhrase::from_phrase("back in the days"));
+
+        let pattern = SequencePattern::default()
+            .then(Box::new(phrase.clone()))
+            .then_whitespace()
+            .then(Box::new(exceptions.clone()))
+            .or(Box::new(phrase));
+
+        Self {
+            pattern: Box::new(pattern),
+            exceptions,
+        }
+    }
+}
+
+impl PatternLinter for BackInTheDay {
+    fn pattern(&self) -> &dyn Pattern {
+        self.pattern.as_ref()
+    }
+
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        dbg!(matched_tokens
+            .iter()
+            .map(|t| t.to_fat(source))
+            .enumerate()
+            .collect_vec());
+        if let Some(tail) = matched_tokens.get(8..) {
+            dbg!(tail.iter().map(|t| t.to_fat(source)).collect_vec());
+            if self.exceptions.matches(tail, source) != 0 {
+                return None;
+            }
+        }
+
+        let span = matched_tokens.span()?;
+        let chars = span.get_content(source);
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::WordChoice,
+            suggestions: vec![Suggestion::replace_with_match_case(
+                "back in the day".chars().collect(),
+                chars,
+            )],
+            message: "Use the more idiomatic version of this phrase.".to_owned(),
+            priority: 127,
+        })
+    }
+
+    fn description(&self) -> &'static str {
+        "This linter flags instances of the nonstandard phrase `back in the days`. The correct, more accepted form is `back in the day`"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BackInTheDay;
+    use crate::linting::tests::{assert_lint_count, assert_suggestion_result};
+
+    #[test]
+    fn detects_gem_update_case() {
+        assert_suggestion_result(
+            "... has been resolved through a gem update back in the days",
+            BackInTheDay::default(),
+            "... has been resolved through a gem update back in the day",
+        );
+    }
+
+    #[test]
+    fn detects_install_case() {
+        assert_suggestion_result(
+            "Back in the days we're used to install it directly from ...",
+            BackInTheDay::default(),
+            "Back in the day we're used to install it directly from ...",
+        );
+    }
+
+    #[test]
+    fn detects_composer_json_case() {
+        assert_suggestion_result(
+            "Back in the days there was only composer.json and ...",
+            BackInTheDay::default(),
+            "Back in the day there was only composer.json and ...",
+        );
+    }
+
+    #[test]
+    fn detects_version_release_case() {
+        assert_suggestion_result(
+            "... should have been released back in the days in a version 11",
+            BackInTheDay::default(),
+            "... should have been released back in the day in a version 11",
+        );
+    }
+
+    #[test]
+    fn avoids_false_positive_springfox() {
+        assert_lint_count(
+            "Back in the days of SpringFox, there were several requests to ...",
+            BackInTheDay::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn avoids_false_positive_ie() {
+        assert_lint_count(
+            "Back in the days of IE, Powershell used to ...",
+            BackInTheDay::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn avoids_false_positive_code_usage() {
+        assert_lint_count(
+            "Back in the days when I had 100% of my code in ...",
+            BackInTheDay::default(),
+            0,
+        );
+    }
+}

--- a/harper-core/src/linting/back_in_the_day.rs
+++ b/harper-core/src/linting/back_in_the_day.rs
@@ -1,5 +1,3 @@
-use itertools::Itertools;
-
 use crate::{
     patterns::{ExactPhrase, OwnedPatternExt, Pattern, SequencePattern, WordSet},
     Lrc, Token, TokenStringExt,
@@ -37,13 +35,7 @@ impl PatternLinter for BackInTheDay {
     }
 
     fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
-        dbg!(matched_tokens
-            .iter()
-            .map(|t| t.to_fat(source))
-            .enumerate()
-            .collect_vec());
         if let Some(tail) = matched_tokens.get(8..) {
-            dbg!(tail.iter().map(|t| t.to_fat(source)).collect_vec());
             if self.exceptions.matches(tail, source) != 0 {
                 return None;
             }

--- a/harper-core/src/linting/boring_words.rs
+++ b/harper-core/src/linting/boring_words.rs
@@ -30,11 +30,11 @@ impl PatternLinter for BoringWords {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
-        let matched_word = matched_tokens.span().unwrap().get_content_string(source);
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let matched_word = matched_tokens.span()?.get_content_string(source);
 
-        Lint {
-            span: matched_tokens.span().unwrap(),
+        Some(Lint {
+            span: matched_tokens.span()?,
             lint_kind: LintKind::Enhancement,
             suggestions: vec![],
             message: format!(
@@ -42,7 +42,7 @@ impl PatternLinter for BoringWords {
                 matched_word
             ),
             priority: 127,
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/chock_full.rs
+++ b/harper-core/src/linting/chock_full.rs
@@ -30,10 +30,10 @@ impl PatternLinter for ChockFull {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_toks: &[Token], source: &[char]) -> Lint {
-        let span = matched_toks.span().unwrap();
+    fn match_to_lint(&self, matched_toks: &[Token], source: &[char]) -> Option<Lint> {
+        let span = matched_toks.span()?;
 
-        Lint {
+        Some(Lint {
             span,
             lint_kind: LintKind::WordChoice,
             suggestions: vec![Suggestion::replace_with_match_case_str(
@@ -49,7 +49,7 @@ impl PatternLinter for ChockFull {
                 }
             ),
             priority: 126,
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/closed_compounds.rs
+++ b/harper-core/src/linting/closed_compounds.rs
@@ -26,11 +26,11 @@ macro_rules! create_closed_compound_linter {
                 self.pattern.as_ref()
             }
 
-            fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
-                let span = matched_tokens.span().unwrap();
+            fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+                let span = matched_tokens.span()?;
                 let orig_chars = span.get_content(source);
 
-                Lint {
+                Some(Lint {
                     span,
                     lint_kind: LintKind::WordChoice,
                     suggestions: vec![Suggestion::replace_with_match_case(
@@ -39,7 +39,7 @@ macro_rules! create_closed_compound_linter {
                     )],
                     message: format!("Did you mean the closed compound `{}`?", $correct),
                     ..Default::default()
-                }
+                })
             }
 
             fn description(&self) -> &'static str {

--- a/harper-core/src/linting/compound_nouns/general_compound_nouns.rs
+++ b/harper-core/src/linting/compound_nouns/general_compound_nouns.rs
@@ -56,16 +56,15 @@ impl PatternLinter for GeneralCompoundNouns {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
-        let span = matched_tokens.span().unwrap();
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let span = matched_tokens.span()?;
         let orig = span.get_content(source);
         // If the pattern matched, this will not return `None`.
-        let word = self
-            .split_pattern
-            .get_merged_word(matched_tokens[0], matched_tokens[2], source)
-            .unwrap();
+        let word =
+            self.split_pattern
+                .get_merged_word(matched_tokens[0], matched_tokens[2], source)?;
 
-        Lint {
+        Some(Lint {
             span,
             lint_kind: LintKind::Spelling,
             suggestions: vec![Suggestion::replace_with_match_case(word.to_vec(), orig)],
@@ -74,7 +73,7 @@ impl PatternLinter for GeneralCompoundNouns {
                 word.to_string()
             ),
             priority: 63,
-        }
+        })
     }
 
     fn description(&self) -> &str {

--- a/harper-core/src/linting/compound_nouns/implied_ownership_compound_nouns.rs
+++ b/harper-core/src/linting/compound_nouns/implied_ownership_compound_nouns.rs
@@ -36,15 +36,14 @@ impl PatternLinter for ImpliedOwnershipCompoundNouns {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
-        let span = matched_tokens[2..].span().unwrap();
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let span = matched_tokens[2..].span()?;
         // If the pattern matched, this will not return `None`.
-        let word = self
-            .split_pattern
-            .get_merged_word(matched_tokens[2], matched_tokens[4], source)
-            .unwrap();
+        let word =
+            self.split_pattern
+                .get_merged_word(matched_tokens[2], matched_tokens[4], source)?;
 
-        Lint {
+        Some(Lint {
             span,
             lint_kind: LintKind::Spelling,
             suggestions: vec![Suggestion::ReplaceWith(word.to_vec())],
@@ -53,7 +52,7 @@ impl PatternLinter for ImpliedOwnershipCompoundNouns {
                 word.to_string()
             ),
             priority: 63,
-        }
+        })
     }
 
     fn description(&self) -> &str {

--- a/harper-core/src/linting/dashes.rs
+++ b/harper-core/src/linting/dashes.rs
@@ -30,26 +30,26 @@ impl PatternLinter for Dashes {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], _source: &[char]) -> Lint {
-        let span = matched_tokens.span().unwrap();
+    fn match_to_lint(&self, matched_tokens: &[Token], _source: &[char]) -> Option<Lint> {
+        let span = matched_tokens.span()?;
         let lint_kind = LintKind::Formatting;
 
         match matched_tokens.len() {
-            2 => Lint {
+            2 => Some(Lint {
                 span,
                 lint_kind,
                 suggestions: vec![Suggestion::ReplaceWith(vec!['–'])],
                 message: "A sequence of hyphens is not an en dash.".to_owned(),
                 priority: 63,
-            },
-            3 => Lint {
+            }),
+            3 => Some(Lint {
                 span,
                 lint_kind,
                 suggestions: vec![Suggestion::ReplaceWith(vec!['—'])],
                 message: "A sequence of hyphens is not an em dash.".to_owned(),
                 priority: 63,
-            },
-            _ => panic!("Received unexpected number of tokens."),
+            }),
+            _ => Some(panic!("Received unexpected number of tokens.")),
         }
     }
 

--- a/harper-core/src/linting/dashes.rs
+++ b/harper-core/src/linting/dashes.rs
@@ -49,7 +49,7 @@ impl PatternLinter for Dashes {
                 message: "A sequence of hyphens is not an em dash.".to_owned(),
                 priority: 63,
             }),
-            _ => Some(panic!("Received unexpected number of tokens.")),
+            _ => panic!("Received unexpected number of tokens."),
         }
     }
 

--- a/harper-core/src/linting/despite_of.rs
+++ b/harper-core/src/linting/despite_of.rs
@@ -26,11 +26,11 @@ impl PatternLinter for DespiteOf {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched: &[Token], source: &[char]) -> Lint {
-        let span = matched.span().unwrap();
+    fn match_to_lint(&self, matched: &[Token], source: &[char]) -> Option<Lint> {
+        let span = matched.span()?;
         let matched = span.get_content(source);
 
-        Lint {
+        Some(Lint {
             span,
             lint_kind: LintKind::WordChoice,
             suggestions: vec![
@@ -39,7 +39,7 @@ impl PatternLinter for DespiteOf {
             ],
             message: "The phrase “despite of” is incorrect. Please use either “despite” or “in spite of” instead.".to_string(),
             priority: 126,
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/dot_initialisms.rs
+++ b/harper-core/src/linting/dot_initialisms.rs
@@ -37,19 +37,19 @@ impl PatternLinter for DotInitialisms {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
-        let found_word_tok = matched_tokens.first().unwrap();
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let found_word_tok = matched_tokens.first()?;
         let found_word = found_word_tok.span.get_content_string(source);
 
-        let correction = self.corrections.get(found_word.as_str()).unwrap();
+        let correction = self.corrections.get(found_word.as_str())?;
 
-        Lint {
-            span: matched_tokens.span().unwrap(),
+        Some(Lint {
+            span: matched_tokens.span()?,
             lint_kind: LintKind::Formatting,
             suggestions: vec![Suggestion::ReplaceWith(correction.chars().collect())],
             message: "Initialisms should have dot-separated letters.".to_owned(),
             priority: 63,
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/ellipsis_length.rs
+++ b/harper-core/src/linting/ellipsis_length.rs
@@ -9,7 +9,7 @@ use crate::TokenStringExt;
 pub struct EllipsisLength;
 
 impl Linter for EllipsisLength {
-    fn lint(&mut self, document: &crate::Document) -> Vec<super::Lint> {
+    fn lint(&mut self, document: &crate::Document) -> Vec<Lint> {
         let mut lints = Vec::new();
 
         for tok in document.iter_ellipsiss() {

--- a/harper-core/src/linting/hereby.rs
+++ b/harper-core/src/linting/hereby.rs
@@ -28,10 +28,10 @@ impl PatternLinter for Hereby {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
-        let span = matched_tokens[0..3].span().unwrap();
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let span = matched_tokens[0..3].span()?;
         let orig_chars = span.get_content(source);
-        Lint {
+        Some(Lint {
             span,
             lint_kind: LintKind::WordChoice,
             suggestions: vec![Suggestion::replace_with_match_case(
@@ -40,7 +40,7 @@ impl PatternLinter for Hereby {
             )],
             message: "Did you mean the closed compound `hereby`?".to_owned(),
             ..Default::default()
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/hop_hope/to_hop.rs
+++ b/harper-core/src/linting/hop_hope/to_hop.rs
@@ -41,13 +41,13 @@ impl PatternLinter for ToHop {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
         let offending_word = matched_tokens[0];
         let word_chars = offending_word.span.get_content(source);
         let word = word_chars.to_string();
-        let correct = Self::to_correct(&word).unwrap();
+        let correct = Self::to_correct(&word)?;
 
-        Lint {
+        Some(Lint {
             span: offending_word.span,
             lint_kind: LintKind::WordChoice,
             suggestions: vec![Suggestion::replace_with_match_case(
@@ -59,7 +59,7 @@ impl PatternLinter for ToHop {
                 correct.to_string()
             ),
             ..Default::default()
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/hop_hope/to_hope.rs
+++ b/harper-core/src/linting/hop_hope/to_hope.rs
@@ -27,11 +27,11 @@ impl PatternLinter for ToHope {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
         let offending_word = matched_tokens[2];
         let word_chars = offending_word.span.get_content(source);
 
-        Lint {
+        Some(Lint {
             span: offending_word.span,
             lint_kind: LintKind::WordChoice,
             suggestions: vec![Suggestion::replace_with_match_case(
@@ -40,7 +40,7 @@ impl PatternLinter for ToHope {
             )],
             message: "Did you mean to use 'hope' instead of 'hop' in this context?".to_string(),
             ..Default::default()
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/hyphenate_number_day.rs
+++ b/harper-core/src/linting/hyphenate_number_day.rs
@@ -41,11 +41,11 @@ impl PatternLinter for HyphenateNumberDay {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], _source: &[char]) -> Lint {
+    fn match_to_lint(&self, matched_tokens: &[Token], _source: &[char]) -> Option<Lint> {
         let number = matched_tokens[0].kind.expect_number();
         let space = matched_tokens[1];
 
-        Lint {
+        Some(Lint {
             span: space.span,
             lint_kind: LintKind::Miscellaneous,
             suggestions: vec![Suggestion::ReplaceWith(vec!['-'])],
@@ -54,7 +54,7 @@ impl PatternLinter for HyphenateNumberDay {
                 number
             ),
             priority: 31,
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/left_right_hand.rs
+++ b/harper-core/src/linting/left_right_hand.rs
@@ -29,17 +29,17 @@ impl PatternLinter for LeftRightHand {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], _source: &[char]) -> Lint {
+    fn match_to_lint(&self, matched_tokens: &[Token], _source: &[char]) -> Option<Lint> {
         let space = matched_tokens[1];
 
-        Lint {
+        Some(Lint {
             span: space.span,
             lint_kind: LintKind::Miscellaneous,
             suggestions: vec![Suggestion::ReplaceWith(vec!['-'])],
             message: "Use a hyphen in `left-hand` or `right-hand` when modifying a noun."
                 .to_owned(),
             priority: 31,
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/lets_confusion/let_us_redundancy.rs
+++ b/harper-core/src/linting/lets_confusion/let_us_redundancy.rs
@@ -26,16 +26,12 @@ impl PatternLinter for LetUsRedundancy {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
-        let template = matched_tokens.span().unwrap().get_content(source);
-        let pronoun = matched_tokens
-            .last()
-            .unwrap()
-            .span
-            .get_content_string(source);
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let template = matched_tokens.span()?.get_content(source);
+        let pronoun = matched_tokens.last()?.span.get_content_string(source);
 
-        Lint {
-            span: matched_tokens.span().unwrap(),
+        Some(Lint {
+            span: matched_tokens.span()?,
             lint_kind: LintKind::Repetition,
             suggestions: vec![
                 Suggestion::replace_with_match_case(
@@ -50,7 +46,7 @@ impl PatternLinter for LetUsRedundancy {
             message: "`let's` stands for `let us`, so including another pronoun is redundant."
                 .to_owned(),
             priority: 31,
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
+++ b/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
@@ -28,11 +28,11 @@ impl PatternLinter for NoContractionWithVerb {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
-        let problem_span = matched_tokens.first().unwrap().span;
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let problem_span = matched_tokens.first()?.span;
         let template = problem_span.get_content(source);
 
-        Lint {
+        Some(Lint {
             span: problem_span,
             lint_kind: LintKind::WordChoice,
             suggestions: vec![
@@ -41,7 +41,7 @@ impl PatternLinter for NoContractionWithVerb {
             ],
             message: "It seems you forgot to include a subject here.".to_owned(),
             priority: 31,
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/likewise.rs
+++ b/harper-core/src/linting/likewise.rs
@@ -34,10 +34,10 @@ impl PatternLinter for Likewise {
     fn pattern(&self) -> &dyn Pattern {
         self.pattern.as_ref()
     }
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
-        let span = matched_tokens.span().unwrap();
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let span = matched_tokens.span()?;
         let orig_chars = span.get_content(source);
-        Lint {
+        Some(Lint {
             span,
             lint_kind: LintKind::WordChoice,
             suggestions: vec![Suggestion::replace_with_match_case(
@@ -46,7 +46,7 @@ impl PatternLinter for Likewise {
             )],
             message: format!("Did you mean the closed compound `{}`?", "likewise"),
             ..Default::default()
-        }
+        })
     }
     fn description(&self) -> &'static str {
         "Looks for incorrect spacing inside the closed compound `likewise`."

--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use super::an_a::AnA;
 use super::avoid_curses::AvoidCurses;
+use super::back_in_the_day::BackInTheDay;
 use super::boring_words::BoringWords;
 use super::capitalize_personal_pronouns::CapitalizePersonalPronouns;
 use super::chock_full::ChockFull;
@@ -200,6 +201,7 @@ macro_rules! create_lint_group_config {
 }
 
 create_lint_group_config!(
+    BackInTheDay => true,
     WordPressDotcom => true,
     DayOneNames => true,
     PocketCastsNames => true,

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -4,6 +4,7 @@
 
 mod an_a;
 mod avoid_curses;
+mod back_in_the_day;
 mod boring_words;
 mod capitalize_personal_pronouns;
 mod chock_full;
@@ -61,6 +62,7 @@ mod wrong_quotes;
 
 pub use an_a::AnA;
 pub use avoid_curses::AvoidCurses;
+pub use back_in_the_day::BackInTheDay;
 pub use boring_words::BoringWords;
 pub use capitalize_personal_pronouns::CapitalizePersonalPronouns;
 pub use chock_full::ChockFull;

--- a/harper-core/src/linting/multiple_sequential_pronouns.rs
+++ b/harper-core/src/linting/multiple_sequential_pronouns.rs
@@ -41,7 +41,7 @@ impl PatternLinter for MultipleSequentialPronouns {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
         let mut suggestions = Vec::new();
 
         if matched_tokens.len() == 3 {
@@ -53,13 +53,13 @@ impl PatternLinter for MultipleSequentialPronouns {
             ));
         }
 
-        Lint {
-            span: matched_tokens.span().unwrap(),
+        Some(Lint {
+            span: matched_tokens.span()?,
             lint_kind: LintKind::Repetition,
             message: "There are too many personal pronouns in sequence here.".to_owned(),
             priority: 63,
             suggestions,
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/no_oxford_comma.rs
+++ b/harper-core/src/linting/no_oxford_comma.rs
@@ -23,17 +23,17 @@ impl NoOxfordComma {
         }
     }
 
-    fn match_to_lint(&self, matched_toks: &[Token], _source: &[char]) -> Lint {
-        let last_comma_index = matched_toks.last_comma_index().unwrap();
+    fn match_to_lint(&self, matched_toks: &[Token], _source: &[char]) -> Option<Lint> {
+        let last_comma_index = matched_toks.last_comma_index()?;
         let offender = matched_toks[last_comma_index];
 
-        Lint {
+        Some(Lint {
             span: offender.span,
             lint_kind: LintKind::Style,
             suggestions: vec![Suggestion::Remove],
             message: "Remove the Oxford comma here.".to_owned(),
             priority: 31,
-        }
+        })
     }
 }
 
@@ -65,7 +65,7 @@ impl Linter for NoOxfordComma {
                         document.get_source(),
                     );
 
-                    lints.push(lint);
+                    lints.extend(lint);
                     tok_cursor += match_len;
                 } else {
                     tok_cursor += 1;

--- a/harper-core/src/linting/nobody.rs
+++ b/harper-core/src/linting/nobody.rs
@@ -27,10 +27,10 @@ impl PatternLinter for Nobody {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
-        let span = matched_tokens[0..3].span().unwrap();
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let span = matched_tokens[0..3].span()?;
         let orig_chars = span.get_content(source);
-        Lint {
+        Some(Lint {
             span,
             lint_kind: LintKind::WordChoice,
             suggestions: vec![Suggestion::replace_with_match_case(
@@ -39,7 +39,7 @@ impl PatternLinter for Nobody {
             )],
             message: format!("Did you mean the closed compound `{}`?", "nobody"),
             ..Default::default()
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/out_of_date.rs
+++ b/harper-core/src/linting/out_of_date.rs
@@ -28,11 +28,11 @@ impl PatternLinter for OutOfDate {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
-        let span = matched_tokens.span().unwrap();
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let span = matched_tokens.span()?;
         let problem_text = span.get_content(source);
 
-        Lint {
+        Some(Lint {
             span,
             lint_kind: LintKind::Miscellaneous,
             suggestions: vec![Suggestion::replace_with_match_case(
@@ -41,7 +41,7 @@ impl PatternLinter for OutOfDate {
             )],
             message: "Did you mean the compound adjective?".to_owned(),
             priority: 31,
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/oxford_comma.rs
+++ b/harper-core/src/linting/oxford_comma.rs
@@ -27,17 +27,17 @@ impl OxfordComma {
         }
     }
 
-    fn match_to_lint(&self, matched_toks: &[Token], _source: &[char]) -> Lint {
-        let conj_index = matched_toks.last_conjunction_index().unwrap();
+    fn match_to_lint(&self, matched_toks: &[Token], _source: &[char]) -> Option<Lint> {
+        let conj_index = matched_toks.last_conjunction_index()?;
         let offender = matched_toks[conj_index - 2];
 
-        Lint {
+        Some(Lint {
             span: offender.span,
             lint_kind: LintKind::Style,
             suggestions: vec![Suggestion::InsertAfter(vec![','])],
             message: "An Oxford comma is necessary here.".to_owned(),
             priority: 31,
-        }
+        })
     }
 }
 
@@ -69,7 +69,7 @@ impl Linter for OxfordComma {
                         document.get_source(),
                     );
 
-                    lints.push(lint);
+                    lints.extend(lint);
                     tok_cursor += match_len;
                 } else {
                     tok_cursor += 1;

--- a/harper-core/src/linting/pattern_linter.rs
+++ b/harper-core/src/linting/pattern_linter.rs
@@ -12,7 +12,9 @@ pub trait PatternLinter {
     fn pattern(&self) -> &dyn Pattern;
     /// If any portions of a [`Document`](crate::Document) match [`Self::pattern`], they are passed through [`PatternLinter::match_to_lint`] to be
     /// transformed into a [`Lint`] for editor consumption.
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint;
+    ///
+    /// This function may return `None` to elect _not_ to produce a lint.
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint>;
     /// A user-facing description of what kinds of grammatical errors this rule looks for.
     /// It is usually shown in settings menus.
     fn description(&self) -> &str;

--- a/harper-core/src/linting/pattern_linter.rs
+++ b/harper-core/src/linting/pattern_linter.rs
@@ -28,7 +28,9 @@ pub trait PatternLinter: Send + Sync {
     fn pattern(&self) -> &dyn Pattern;
     /// If any portions of a [`Document`](crate::Document) match [`Self::pattern`], they are passed through [`PatternLinter::match_to_lint`] to be
     /// transformed into a [`Lint`] for editor consumption.
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint;
+    ///
+    /// This function may return `None` to elect _not_ to produce a lint.
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint>;
     /// A user-facing description of what kinds of grammatical errors this rule looks for.
     /// It is usually shown in settings menus.
     fn description(&self) -> &str;
@@ -56,7 +58,7 @@ where
                     let lint =
                         self.match_to_lint(&chunk[tok_cursor..tok_cursor + match_len], source);
 
-                    lints.push(lint);
+                    lints.extend(lint);
                     tok_cursor += match_len;
                 } else {
                     tok_cursor += 1;

--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -29,11 +29,11 @@ macro_rules! create_linter_map_phrase {
                 self.pattern.as_ref()
             }
 
-            fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
-                let span = matched_tokens.span().unwrap();
+            fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+                let span = matched_tokens.span()?;
                 let matched_text = span.get_content(source);
 
-                Lint {
+                Some(Lint {
                     span,
                     lint_kind: LintKind::Miscellaneous,
                     suggestions: vec![$(
@@ -44,7 +44,7 @@ macro_rules! create_linter_map_phrase {
                     )*],
                     message: $message.to_string(),
                     priority: 31,
-                }
+                })
             }
 
             fn description(&self) -> &'static str {

--- a/harper-core/src/linting/pique_interest.rs
+++ b/harper-core/src/linting/pique_interest.rs
@@ -46,12 +46,12 @@ impl PatternLinter for PiqueInterest {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
         let span = matched_tokens[0].span;
         let word = span.get_content_string(source).to_lowercase();
-        let correct = Self::to_correct(&word).unwrap();
+        let correct = Self::to_correct(&word)?;
 
-        Lint {
+        Some(Lint {
             span,
             lint_kind: LintKind::WordChoice,
             suggestions: vec![Suggestion::replace_with_match_case(
@@ -64,7 +64,7 @@ impl PatternLinter for PiqueInterest {
                 word,
             ),
             priority: 31,
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/plural_conjugate.rs
+++ b/harper-core/src/linting/plural_conjugate.rs
@@ -36,8 +36,8 @@ impl PatternLinter for PluralConjugate {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], _source: &[char]) -> Lint {
-        let should_be_plural = matched_tokens.first().unwrap().kind.is_plural_noun();
+    fn match_to_lint(&self, matched_tokens: &[Token], _source: &[char]) -> Option<Lint> {
+        let should_be_plural = matched_tokens.first()?.kind.is_plural_noun();
 
         let sug = if should_be_plural {
             vec!['a', 'r', 'e']
@@ -45,13 +45,13 @@ impl PatternLinter for PluralConjugate {
             vec!['i', 's']
         };
 
-        Lint {
-            span: matched_tokens.last().unwrap().span,
+        Some(Lint {
+            span: matched_tokens.last()?.span,
             lint_kind: LintKind::WordChoice,
             suggestions: vec![Suggestion::ReplaceWith(sug)],
             message: "Use the alternative conjugation of this verb to be consistent with the noun's plural nature.".to_owned(),
             priority: 63,
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/possessive_your.rs
+++ b/harper-core/src/linting/possessive_your.rs
@@ -28,11 +28,11 @@ impl PatternLinter for PossessiveYour {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
-        let span = matched_tokens.first().unwrap().span;
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let span = matched_tokens.first()?.span;
         let orig_chars = span.get_content(source);
 
-        Lint {
+        Some(Lint {
             span,
             lint_kind: LintKind::WordChoice,
             suggestions: vec![
@@ -42,7 +42,7 @@ impl PatternLinter for PossessiveYour {
             message: "The possesive version of this word is more common in this context."
                 .to_owned(),
             ..Default::default()
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/pronoun_contraction/avoid_contraction.rs
+++ b/harper-core/src/linting/pronoun_contraction/avoid_contraction.rs
@@ -28,10 +28,10 @@ impl PatternLinter for AvoidContraction {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
         let word = matched_tokens[0].span.get_content(source);
 
-        Lint {
+        Some(Lint {
             span: matched_tokens[0].span,
             lint_kind: LintKind::WordChoice,
             suggestions: vec![Suggestion::replace_with_match_case(
@@ -41,7 +41,7 @@ impl PatternLinter for AvoidContraction {
             message: "It appears you intended to use the possessive version of this word"
                 .to_owned(),
             priority: 63,
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/pronoun_contraction/should_contract.rs
+++ b/harper-core/src/linting/pronoun_contraction/should_contract.rs
@@ -42,10 +42,10 @@ impl PatternLinter for ShouldContract {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
         let mistake = matched_tokens[0].span.get_content(source);
 
-        Lint {
+        Some(Lint {
             span: matched_tokens[0].span,
             lint_kind: LintKind::WordChoice,
             suggestions: Self::mistake_to_correct(&mistake.to_lower().to_string())
@@ -53,7 +53,7 @@ impl PatternLinter for ShouldContract {
                 .collect(),
             message: "Use the contraction or separate the words instead.".to_string(),
             priority: 31,
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/proper_noun_capitalization_linters.rs
+++ b/harper-core/src/linting/proper_noun_capitalization_linters.rs
@@ -40,16 +40,16 @@ macro_rules! create_linter_for {
                 self.pattern.as_ref()
             }
 
-            fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
+            fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
                 let proper = make_title_case(matched_tokens, source, &self.dict);
 
-                Lint {
-                    span: matched_tokens.span().unwrap(),
+                Some(Lint {
+                    span: matched_tokens.span()?,
                     lint_kind: LintKind::Capitalization,
                     suggestions: vec![Suggestion::ReplaceWith(proper)],
                     message: $message.to_string(),
                     priority: 31,
-                }
+                })
             }
 
             fn description(&self) -> &'static str {

--- a/harper-core/src/linting/somewhat_something.rs
+++ b/harper-core/src/linting/somewhat_something.rs
@@ -28,17 +28,17 @@ impl PatternLinter for SomewhatSomething {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
-        let span = matched_tokens.first().unwrap().span;
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let span = matched_tokens.first()?.span;
         let og = span.get_content(source);
 
-        Lint {
+        Some(Lint {
             span,
             lint_kind: LintKind::Style,
             suggestions: vec![Suggestion::replace_with_match_case_str("something", og)],
             message: "Use the traditional form.".to_owned(),
             priority: 63,
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/terminating_conjunctions.rs
+++ b/harper-core/src/linting/terminating_conjunctions.rs
@@ -49,11 +49,11 @@ impl PatternLinter for TerminatingConjunctions {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[crate::Token], source: &[char]) -> Lint {
+    fn match_to_lint(&self, matched_tokens: &[crate::Token], source: &[char]) -> Option<Lint> {
         let word_span = matched_tokens[1].span;
         let word = word_span.get_content_string(source);
 
-        Lint {
+        Some(Lint {
             span: word_span,
             lint_kind: LintKind::Miscellaneous,
             suggestions: vec![],
@@ -62,7 +62,7 @@ impl PatternLinter for TerminatingConjunctions {
                  clause."
             ),
             priority: 63,
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/that_which.rs
+++ b/harper-core/src/linting/that_which.rs
@@ -36,7 +36,7 @@ impl PatternLinter for ThatWhich {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
         let suggestion = format!(
             "{} which",
             matched_tokens[0]
@@ -48,13 +48,13 @@ impl PatternLinter for ThatWhich {
         .chars()
         .collect_vec();
 
-        Lint {
-            span: matched_tokens.span().unwrap(),
+        Some(Lint {
+            span: matched_tokens.span()?,
             lint_kind: LintKind::Repetition,
             suggestions: vec![Suggestion::ReplaceWith(suggestion)],
             message: "“that that” sometimes means “that which”, which is clearer.".to_string(),
             priority: 126,
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/then_than.rs
+++ b/harper-core/src/linting/then_than.rs
@@ -34,11 +34,11 @@ impl PatternLinter for ThenThan {
     fn pattern(&self) -> &dyn Pattern {
         self.pattern.as_ref()
     }
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
-        let span = matched_tokens.last().unwrap().span;
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let span = matched_tokens.last()?.span;
         let offending_text = span.get_content(source);
 
-        Lint {
+        Some(Lint {
             span,
             lint_kind: LintKind::Miscellaneous,
             suggestions: vec![Suggestion::replace_with_match_case(
@@ -47,7 +47,7 @@ impl PatternLinter for ThenThan {
             )],
             message: "Did you mean `than`?".to_string(),
             priority: 31,
-        }
+        })
     }
     fn description(&self) -> &'static str {
         "Corrects the misuse of `then` to `than`."

--- a/harper-core/src/linting/use_genitive.rs
+++ b/harper-core/src/linting/use_genitive.rs
@@ -58,14 +58,14 @@ impl PatternLinter for UseGenitive {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], _source: &[char]) -> Lint {
-        Lint {
+    fn match_to_lint(&self, matched_tokens: &[Token], _source: &[char]) -> Option<Lint> {
+        Some(Lint {
             span: matched_tokens[2].span,
             lint_kind: LintKind::Miscellaneous,
             suggestions: vec![Suggestion::ReplaceWith(vec!['t', 'h', 'e', 'i', 'r'])],
             message: "Use the genitive case.".to_string(),
             priority: 31,
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/was_aloud.rs
+++ b/harper-core/src/linting/was_aloud.rs
@@ -26,11 +26,11 @@ impl PatternLinter for WasAloud {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
         let verb = matched_tokens[0].span.get_content_string(source);
 
-        Lint {
-            span: matched_tokens.span().unwrap(),
+        Some(Lint {
+            span: matched_tokens.span()?,
             lint_kind: LintKind::WordChoice,
             suggestions: vec![Suggestion::replace_with_match_case(
                 format!("{} allowed", verb).chars().collect(),
@@ -38,7 +38,7 @@ impl PatternLinter for WasAloud {
             )],
             message: format!("Did you mean `{verb} allowed`?"),
             priority: 31,
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/whereas.rs
+++ b/harper-core/src/linting/whereas.rs
@@ -27,11 +27,11 @@ impl PatternLinter for Whereas {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Lint {
-        let span = matched_tokens.span().unwrap();
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let span = matched_tokens.span()?;
         let orig_chars = span.get_content(source);
 
-        Lint {
+        Some(Lint {
             span,
             lint_kind: LintKind::WordChoice,
             suggestions: vec![Suggestion::replace_with_match_case(
@@ -40,7 +40,7 @@ impl PatternLinter for Whereas {
             )],
             message: "`Whereas` is commonly mistaken for `where as`.".to_owned(),
             ..Default::default()
-        }
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/patterns/either_pattern.rs
+++ b/harper-core/src/patterns/either_pattern.rs
@@ -2,7 +2,7 @@ use crate::Token;
 
 use super::Pattern;
 
-/// A pattern that returns the value of the first non-zero match in a list.
+/// A pattern that returns the value of the longest match in a list.
 #[derive(Default)]
 pub struct EitherPattern {
     patterns: Vec<Box<dyn Pattern>>,
@@ -20,14 +20,16 @@ impl EitherPattern {
 
 impl Pattern for EitherPattern {
     fn matches(&self, tokens: &[Token], source: &[char]) -> usize {
+        let mut longest = 0;
+
         for pattern in self.patterns.iter() {
             let match_len = pattern.matches(tokens, source);
 
-            if match_len > 0 {
-                return match_len;
+            if match_len > longest {
+                longest = match_len
             }
         }
 
-        0
+        longest
     }
 }


### PR DESCRIPTION
Should resolve #702. 

Two things happened here. 

1. I modified the `PatternLinter` trait to allow cancelling a lint in the `match_lint` phase by returning `Option::None`.
2. I wrote a linter to implement #702.