### PR TITLE
fix(core): `someways` is not a noun

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -42777,7 +42777,7 @@ somatosensory/5
 somber/54PY
 somberness/1M
 sombrero/1MS
-some/8~
+some/8~j5
 somebody/81SM
 someday/
 somehow/
@@ -42789,7 +42789,8 @@ somersetted/4
 somersetting/4
 something/8541SM
 sometime/5S
-someway/S
+someway/
+someways/j
 somewhat/81S
 somewhere/1
 somnambulism/1M

--- a/harper-core/src/linting/compound_nouns/mod.rs
+++ b/harper-core/src/linting/compound_nouns/mod.rs
@@ -255,4 +255,13 @@ mod tests {
     fn allow_issue_661() {
         assert_lint_count("I may be wrong.", CompoundNouns::default(), 0);
     }
+
+    #[test]
+    fn allow_issue_704() {
+        assert_lint_count(
+            "Here are some ways to do that:",
+            CompoundNouns::default(),
+            0,
+        );
+    }
 }


### PR DESCRIPTION
Fixes #704 by fixing the `someways` dictionary entry that previously declared it a noun.