### PR TITLE
Make `Lintkind::Spelling` exclusive to one rule.

### DIFF
--- a/harper-core/src/linting/compound_nouns/general_compound_nouns.rs
+++ b/harper-core/src/linting/compound_nouns/general_compound_nouns.rs
@@ -67,7 +67,7 @@ impl PatternLinter for GeneralCompoundNouns {
 
         Lint {
             span,
-            lint_kind: LintKind::Spelling,
+            lint_kind: LintKind::WordChoice,
             suggestions: vec![Suggestion::replace_with_match_case(word.to_vec(), orig)],
             message: format!(
                 "Did you mean the closed compound noun “{}”?",

--- a/harper-core/src/linting/compound_nouns/implied_ownership_compound_nouns.rs
+++ b/harper-core/src/linting/compound_nouns/implied_ownership_compound_nouns.rs
@@ -46,7 +46,7 @@ impl PatternLinter for ImpliedOwnershipCompoundNouns {
 
         Lint {
             span,
-            lint_kind: LintKind::Spelling,
+            lint_kind: LintKind::WordChoice,
             suggestions: vec![Suggestion::ReplaceWith(word.to_vec())],
             message: format!(
                 "The possessive noun implies ownership of the closed compound noun “{}”.",

--- a/harper-core/src/linting/lint_kind.rs
+++ b/harper-core/src/linting/lint_kind.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 /// the existing categories.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Is, Default, Hash, PartialEq)]
 pub enum LintKind {
+    /// This should only be used by linters doing spellcheck on individual words.
     Spelling,
     Capitalization,
     Style,


### PR DESCRIPTION
`LintKind::Spelling` should only be used by the spellcheck rule