### PR TITLE
feat(core): allow the `ThenThan` linter to cover more cases

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -30189,7 +30189,7 @@ lepton/1MS
 lesbian/514SM
 lesbianism/1M
 lesion/14MS
-less/+4517MNRX
+less/+457NRX
 lessee/14MS
 lessen/47GD
 lesson/41MS
@@ -32690,7 +32690,7 @@ morbidity/1M
 morbidness/1M
 mordancy/1M
 mordant/514SMY
-more/8514MS
+more/8514S
 moreish/5
 morel/1SM
 moreover/

--- a/harper-core/src/linting/then_than.rs
+++ b/harper-core/src/linting/then_than.rs
@@ -1,25 +1,28 @@
 use super::{Lint, LintKind, PatternLinter};
 use crate::linting::Suggestion;
-use crate::patterns::{OwnedPatternExt, Pattern, SequencePattern, WordSet};
+use crate::patterns::{All, Invert, OwnedPatternExt, Pattern, SequencePattern, WordSet};
 use crate::Token;
 
 #[doc = "Corrects the misuse of `then` to `than`."]
 pub struct ThenThan {
     pattern: Box<dyn Pattern>,
 }
+
 impl ThenThan {
     pub fn new() -> Self {
         Self {
-            pattern: Box::new(
-                SequencePattern::default()
-                    .then(Box::new(WordSet::all(&["better", "other"]).or(Box::new(
-                        |tok: &Token, _source: &[char]| {
-                            tok.kind.is_adjective() && !tok.kind.is_noun()
-                        },
-                    ))))
-                    .then_whitespace()
-                    .then_any_capitalization_of("then"),
-            ),
+            pattern: Box::new(All::new(vec![
+                Box::new(
+                    SequencePattern::default()
+                        .then(Box::new(WordSet::all(&["better", "other"]).or(Box::new(
+                            |tok: &Token, _source: &[char]| tok.kind.is_adjective(),
+                        ))))
+                        .then_whitespace()
+                        .then_any_capitalization_of("then"),
+                ),
+                // Denotes exceptions to the rule.
+                Box::new(Invert::new(Box::new(WordSet::all(&["back"])))),
+            ])),
         }
     }
 }
@@ -58,6 +61,56 @@ impl PatternLinter for ThenThan {
 mod tests {
     use super::ThenThan;
     use crate::linting::tests::{assert_lint_count, assert_suggestion_result};
+
+    #[test]
+    fn allows_back_then() {
+        assert_lint_count("I was a gross kid back then.", ThenThan::default(), 0);
+    }
+
+    #[test]
+    fn catches_shorter_then() {
+        assert_suggestion_result(
+            "One was shorter then the other.",
+            ThenThan::default(),
+            "One was shorter than the other.",
+        );
+    }
+
+    #[test]
+    fn catches_better_then() {
+        assert_suggestion_result(
+            "One was better then the other.",
+            ThenThan::default(),
+            "One was better than the other.",
+        );
+    }
+
+    #[test]
+    fn catches_longer_then() {
+        assert_suggestion_result(
+            "One was longer then the other.",
+            ThenThan::default(),
+            "One was longer than the other.",
+        );
+    }
+
+    #[test]
+    fn catches_less_then() {
+        assert_suggestion_result(
+            "I eat less then you.",
+            ThenThan::default(),
+            "I eat less than you.",
+        );
+    }
+
+    #[test]
+    fn catches_more_then() {
+        assert_suggestion_result(
+            "I eat more then you.",
+            ThenThan::default(),
+            "I eat more than you.",
+        );
+    }
 
     #[test]
     fn stronger_should_change() {
@@ -107,5 +160,15 @@ mod tests {
             ThenThan::default(),
             "There was no one other than us at the campsite.",
         );
+    }
+
+    #[test]
+    fn allows_and_then() {
+        assert_lint_count("And then we left.", ThenThan::default(), 0);
+    }
+
+    #[test]
+    fn allows_this_then() {
+        assert_lint_count("Do this then that.", ThenThan::default(), 0);
     }
 }

--- a/harper-core/src/patterns/all.rs
+++ b/harper-core/src/patterns/all.rs
@@ -12,6 +12,10 @@ pub struct All {
 }
 
 impl All {
+    pub fn new(children: Vec<Box<dyn Pattern>>) -> Self {
+        Self { children }
+    }
+
     pub fn add(&mut self, p: Box<dyn Pattern>) {
         self.children.push(p);
     }


### PR DESCRIPTION
I was writing some documentation and made the mistake of using `then` when I meant `than`, but Harper didn't catch it. I've added some more test cases and allowed the rule to be more general, as well as adding space to define exceptions to the rule.