### PR TITLE
feat: github template for reporting false positives

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-false-positive.md
+++ b/.github/ISSUE_TEMPLATE/report-false-positive.md
@@ -1,0 +1,22 @@
+---
+name: Report False Positive
+about: If Harper flags an error that is not actually wrong, let us know
+title: ''
+labels: bug, harper-core, linting, false-positive
+assignees: ''
+
+---
+
+## Description
+
+Provide a detailed description of the false positive flagged by Harper.
+
+Is it only flagging a non-error or is a spurious fix also suggested?
+
+## Resources
+
+If the problem is not obvious, some online resources clarifying the relevant grammar point can be useful.
+
+## Screenshots
+
+If applicable, add screenshots to help explain the false positive.

--- a/.github/ISSUE_TEMPLATE/report-grammatical-error.md
+++ b/.github/ISSUE_TEMPLATE/report-grammatical-error.md
@@ -19,6 +19,6 @@ If there are any resources online we can reference that described grammatical ru
 
 Please provide at least three examples of the grammatical error in real text.
 
-## Potential false positives
+## Potential False Positives
 
-If a combination of words is wrong on its own but not when before or after certain words, let us know.
+If there is any grammatical context in which the error may lie (for example, a word may always be invalid if preceded by a preposition), let us know. Provide a few examples, if possible.

--- a/.github/ISSUE_TEMPLATE/report-grammatical-error.md
+++ b/.github/ISSUE_TEMPLATE/report-grammatical-error.md
@@ -18,3 +18,7 @@ If there are any resources online we can reference that described grammatical ru
 ## Examples
 
 Please provide at least three examples of the grammatical error in real text.
+
+## Potential false positives
+
+If a combination of words is wrong on its own but not when before or after certain words, let us know.


### PR DESCRIPTION
- Also adds a `false-positive` github issue label
- And adds a 'Potential false positives' section to the template for reporting grammatical errors