### PR TITLE
fix(vscode-plugin): update config keys to new standard

### DIFF
--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -77,7 +77,7 @@
 					"type": "string",
 					"description": "Optional path to a harper-ls executable to use."
 				},
-				"harper-ls.codeActions.forceStable": {
+				"harper-ls.codeActions.ForceStable": {
 					"scope": "resource",
 					"type": "boolean",
 					"default": false,
@@ -106,7 +106,7 @@
 					"default": false,
 					"description": "Only lint English text in documents that are a mixture of English and another language."
 				},
-				"harper-ls.markdown.ignore_link_title": {
+				"harper-ls.markdown.IgnoreLinkTitle": {
 					"scope": "resource",
 					"type": "boolean",
 					"default": false,


### PR DESCRIPTION
Was left out from the overhaul. Together with #726, should close #667.