### PR TITLE
fix(core): restrict `GeneralCompoundNouns` to ignore adverb prefixes

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -12252,7 +12252,7 @@ anvil/14MS
 anxiety/1SM
 anxious/5YP
 anxiousness/1M
-any/8~
+any/8~j5
 anybody/8SM
 anyhow/5
 anymore/

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -10772,7 +10772,7 @@ Zworykin/M
 Zyrtec/M
 Zyuganov/M
 Zzz
-a/-+457~
+a/-+57~
 as/j
 aah/14
 aardvark/1SM
@@ -33088,7 +33088,7 @@ muzak/14
 muzzily/
 muzzle/14DSMG
 muzzy/51P
-my/~
+my/~5
 mycologist/1SM
 mycology/1M
 myelitis/1M
@@ -41772,8 +41772,8 @@ shot/514MS
 shotgun/14SM
 shotgunned/4
 shotgunning/4
-should/41
-should've/
+should/4
+should've/4
 shoulder/14MDGS
 shouldn't/41
 shout/14ZGMDRS
@@ -45631,7 +45631,7 @@ thirteenths/1
 thirtieth/51M
 thirtieths/1
 thirty/1HSM
-this/81~
+this/81~5
 thistle/1MS
 thistledown/1M
 thither/5

--- a/harper-core/src/linting/compound_nouns/general_compound_nouns.rs
+++ b/harper-core/src/linting/compound_nouns/general_compound_nouns.rs
@@ -25,6 +25,14 @@ impl Default for GeneralCompoundNouns {
                     return false;
                 };
 
+                meta.article || meta.is_adjective()
+            })
+            .then_whitespace()
+            .then(|tok: &Token, _: &[char]| {
+                let Some(Some(meta)) = tok.kind.as_word() else {
+                    return false;
+                };
+
                 tok.span.len() > 1 && !meta.article && !meta.preposition && !meta.is_adverb()
             })
             .then_whitespace()
@@ -41,8 +49,13 @@ impl Default for GeneralCompoundNouns {
         }));
 
         let mut pattern = All::default();
-        pattern.add(Box::new(split_pattern.clone()));
         pattern.add(Box::new(exceptions_pattern));
+        pattern.add(Box::new(
+            SequencePattern::default()
+                .then_anything()
+                .then_anything()
+                .then(split_pattern.clone()),
+        ));
 
         Self {
             pattern: Box::new(pattern),
@@ -57,12 +70,12 @@ impl PatternLinter for GeneralCompoundNouns {
     }
 
     fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
-        let span = matched_tokens.span()?;
+        let span = matched_tokens[2..].span()?;
         let orig = span.get_content(source);
         // If the pattern matched, this will not return `None`.
         let word =
             self.split_pattern
-                .get_merged_word(matched_tokens[0], matched_tokens[2], source)?;
+                .get_merged_word(matched_tokens[2], matched_tokens[4], source)?;
 
         Some(Lint {
             span,

--- a/harper-core/src/linting/compound_nouns/general_compound_nouns.rs
+++ b/harper-core/src/linting/compound_nouns/general_compound_nouns.rs
@@ -25,7 +25,7 @@ impl Default for GeneralCompoundNouns {
                     return false;
                 };
 
-                tok.span.len() > 1 && !meta.article && !meta.preposition
+                tok.span.len() > 1 && !meta.article && !meta.preposition && !meta.is_adverb()
             })
             .then_whitespace()
             .then(|tok: &Token, _: &[char]| {

--- a/harper-core/src/linting/compound_nouns/implied_action_compound_nouns.rs
+++ b/harper-core/src/linting/compound_nouns/implied_action_compound_nouns.rs
@@ -1,0 +1,64 @@
+use crate::{
+    CharStringExt, Lrc, TokenStringExt, linting::PatternLinter, patterns::SplitCompoundWord,
+};
+
+use super::{Lint, LintKind, Suggestion};
+
+use crate::{
+    Token,
+    patterns::{Pattern, SequencePattern},
+};
+
+/// Looks for closed compound nouns which can be condensed due to their position after a
+/// possessive noun (which implies ownership).
+pub struct ImpliedActionCompoundNouns {
+    pattern: Box<dyn Pattern>,
+    split_pattern: Lrc<SplitCompoundWord>,
+}
+
+impl Default for ImpliedActionCompoundNouns {
+    fn default() -> Self {
+        let split_pattern = Lrc::new(SplitCompoundWord::new(|meta| meta.is_noun()));
+        let pattern = SequencePattern::default()
+            .then(split_pattern.clone())
+            .then_whitespace()
+            .then(|tok: &Token, _source: &[char]| {
+                tok.kind.is_verb() && !tok.kind.is_likely_homograph()
+            });
+
+        Self {
+            pattern: Box::new(pattern),
+            split_pattern,
+        }
+    }
+}
+
+impl PatternLinter for ImpliedActionCompoundNouns {
+    fn pattern(&self) -> &dyn Pattern {
+        self.pattern.as_ref()
+    }
+
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let span = matched_tokens[0..3].span()?;
+        let orig = span.get_content(source);
+        // If the pattern matched, this will not return `None`.
+        let word =
+            self.split_pattern
+                .get_merged_word(matched_tokens[0], matched_tokens[2], source)?;
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::WordChoice,
+            suggestions: vec![Suggestion::replace_with_match_case(word.to_vec(), orig)],
+            message: format!(
+                "The verb here implies the existence of the closed compound noun “{}”.",
+                word.to_string()
+            ),
+            priority: 63,
+        })
+    }
+
+    fn description(&self) -> &str {
+        "Detects split compound nouns preceding an action and suggests merging them."
+    }
+}

--- a/harper-core/src/linting/compound_nouns/mod.rs
+++ b/harper-core/src/linting/compound_nouns/mod.rs
@@ -1,12 +1,14 @@
 mod general_compound_nouns;
+mod implied_action_compound_nouns;
 mod implied_ownership_compound_nouns;
 
 use super::{Lint, LintKind, Suggestion, merge_linters::merge_linters};
 
 use general_compound_nouns::GeneralCompoundNouns;
+use implied_action_compound_nouns::ImpliedActionCompoundNouns;
 use implied_ownership_compound_nouns::ImpliedOwnershipCompoundNouns;
 
-merge_linters!(CompoundNouns => GeneralCompoundNouns, ImpliedOwnershipCompoundNouns => "Detects compound nouns split by a space and suggests merging them when both parts form a valid noun." );
+merge_linters!(CompoundNouns => GeneralCompoundNouns, ImpliedOwnershipCompoundNouns, ImpliedActionCompoundNouns => "Detects compound nouns split by a space and suggests merging them when both parts form a valid noun." );
 
 #[cfg(test)]
 mod tests {
@@ -269,6 +271,15 @@ mod tests {
     fn allows_issue_721() {
         assert_lint_count(
             "So if you adjust any one of these adjusters that can have a negative or a positive effect.",
+            CompoundNouns::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn allows_678() {
+        assert_lint_count(
+            "they can't catch all the bugs.",
             CompoundNouns::default(),
             0,
         );

--- a/harper-core/src/linting/compound_nouns/mod.rs
+++ b/harper-core/src/linting/compound_nouns/mod.rs
@@ -264,4 +264,13 @@ mod tests {
             0,
         );
     }
+
+    #[test]
+    fn allows_issue_721() {
+        assert_lint_count(
+            "So if you adjust any one of these adjusters that can have a negative or a positive effect.",
+            CompoundNouns::default(),
+            0,
+        );
+    }
 }

--- a/harper-core/src/linting/repeated_words.rs
+++ b/harper-core/src/linting/repeated_words.rs
@@ -12,7 +12,7 @@ pub struct RepeatedWords {
 impl RepeatedWords {
     pub fn new() -> Self {
         Self {
-            special_cases: vec![char_string!("is")],
+            special_cases: vec![char_string!("is"), char_string!("this")],
         }
     }
 

--- a/harper-core/src/linting/repeated_words.rs
+++ b/harper-core/src/linting/repeated_words.rs
@@ -1,7 +1,6 @@
-use smallvec::smallvec;
-
 use super::{Lint, LintKind, Linter, Suggestion};
 use crate::TokenStringExt;
+use crate::char_string::char_string;
 use crate::{CharString, CharStringExt, Document, Span};
 
 #[derive(Debug, Clone)]
@@ -13,12 +12,7 @@ pub struct RepeatedWords {
 impl RepeatedWords {
     pub fn new() -> Self {
         Self {
-            special_cases: vec![
-                smallvec!['i', 's'],
-                smallvec!['a'],
-                smallvec!['o', 'n'],
-                smallvec!['a', 'n', 'd'],
-            ],
+            special_cases: vec![char_string!("is")],
         }
     }
 
@@ -48,7 +42,10 @@ impl Linter for RepeatedWords {
                 let word_a = document.get_span_content(tok_a.span);
                 let word_b = document.get_span_content(tok_b.span);
 
-                if (!tok_a.kind.is_likely_homograph() || self.is_special_case(word_a))
+                if (tok_a.kind.is_preposition()
+                    || tok_a.kind.is_conjunction()
+                    || !tok_a.kind.is_likely_homograph()
+                    || self.is_special_case(word_a))
                     && word_a.to_lower() == word_b.to_lower()
                 {
                     let intervening_tokens = &chunk[idx_a + 1..*idx_b];

--- a/harper-core/src/linting/then_than.rs
+++ b/harper-core/src/linting/then_than.rs
@@ -21,7 +21,7 @@ impl ThenThan {
                         .then_any_capitalization_of("then"),
                 ),
                 // Denotes exceptions to the rule.
-                Box::new(Invert::new(WordSet::new(&["back"]))),
+                Box::new(Invert::new(WordSet::new(&["back", "this"]))),
             ])),
         }
     }

--- a/harper-core/src/patterns/noun_phrase.rs
+++ b/harper-core/src/patterns/noun_phrase.rs
@@ -87,7 +87,7 @@ mod tests {
         assert_eq!(
             matches,
             vec![
-                Span::new(2, 5),
+                Span::new(0, 5),
                 Span::new(8, 9),
                 Span::new(11, 12),
                 Span::new(14, 15),

--- a/harper-core/src/patterns/sequence_pattern.rs
+++ b/harper-core/src/patterns/sequence_pattern.rs
@@ -166,7 +166,7 @@ impl SequencePattern {
     }
 
     /// Match against any single token.
-    /// More of a filler then anything else.
+    /// More of a filler than anything else.
     pub fn then_anything(mut self) -> Self {
         self.token_patterns.push(Box::new(AnyPattern));
         self

--- a/harper-core/src/token_kind.rs
+++ b/harper-core/src/token_kind.rs
@@ -133,6 +133,16 @@ impl TokenKind {
         matches!(self, TokenKind::Punctuation(Punctuation::Currency(..)))
     }
 
+    pub fn is_preposition(&self) -> bool {
+        matches!(
+            self,
+            TokenKind::Word(Some(WordMetadata {
+                preposition: true,
+                ..
+            }))
+        )
+    }
+
     pub fn is_article(&self) -> bool {
         matches!(
             self,

--- a/harper-core/src/word_metadata.rs
+++ b/harper-core/src/word_metadata.rs
@@ -34,7 +34,7 @@ macro_rules! generate_metadata_queries {
                     return true;
                 }
 
-                [$(
+                [self.article, self.preposition, $(
                     self.[< is_ $category >](),
                 )*].iter().map(|b| *b as u8).sum::<u8>() > 1
             }


### PR DESCRIPTION
Resolves #721.