### PR TITLE
fix(core): edge case found in Harper's documentation

### DIFF
--- a/harper-core/src/linting/possessive_your.rs
+++ b/harper-core/src/linting/possessive_your.rs
@@ -15,7 +15,7 @@ impl Default for PossessiveYour {
             SequencePattern::aco("you")
                 .then_whitespace()
                 .then(|tok: &Token, _source: &[char]| {
-                    tok.kind.is_noun() && !tok.kind.is_verb() && !tok.kind.is_adverb()
+                    tok.kind.is_noun() && !tok.kind.is_likely_homograph()
                 });
 
         Self {
@@ -53,7 +53,7 @@ impl PatternLinter for PossessiveYour {
 
 #[cfg(test)]
 mod tests {
-    use crate::linting::tests::assert_suggestion_result;
+    use crate::linting::tests::{assert_lint_count, assert_suggestion_result};
 
     use super::PossessiveYour;
 
@@ -63,6 +63,15 @@ mod tests {
             "You comments may end up in the documentation.",
             PossessiveYour::default(),
             "Your comments may end up in the documentation.",
+        );
+    }
+
+    #[test]
+    fn allow_intro_page() {
+        assert_lint_count(
+            "You can try out an editor that uses Harper under-the-hood here.",
+            PossessiveYour::default(),
+            0,
         );
     }
 }

--- a/packages/web/src/routes/docs/about/+page.md
+++ b/packages/web/src/routes/docs/about/+page.md
@@ -10,7 +10,7 @@ Most Harper users are catching their mistakes in Neovim, [Obsidian](./integratio
 </script>
 
 <div class="h-96">
-    <Editor content={`You can try out a editor that uses\nHarper under-the-hood here.\n\nIt is rnning in your browser right now. \n\nNo server required!`}/>
+    <Editor content={`You can try out a editor that uses\nHarper under the hood here.\n\nIt is rnning in your browser right now. \n\nNo server required!`}/>
 </div>
 
 ## How Does It Work?


### PR DESCRIPTION
While working on documentation, I found a bug in the `PossessiveYour` rule. I've added a test case for it and modified the rule to work properly.

![image](https://github.com/user-attachments/assets/6c423b59-7e51-45b4-81bc-673c956f9d45)