### PR TITLE
feat(core): added plural form of integration

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -28586,7 +28586,7 @@ intaglio/14MS
 integer/1MS
 integral/51SMY
 integrate/4AEVNGSD
-integration/1EAM
+integration/1EAMS
 integrator/1SM
 integrity/1M
 integument/1SM


### PR DESCRIPTION
This pr adds the plural of `integration` -> `integrations` to the dictionary. Here are the new expansions of the word:

![image](https://github.com/user-attachments/assets/c9cb0da3-387f-45e5-b7df-4ec0166d0f5e)

I thought `reintegrations` and `disintegrations` seem a little weird. `disintegrations` is listed as a plural of `disintegration` on merriam-webster so I think that's fine, but `reintegrations` is not listed as a word. Chat-GPT says it's correct and refers to "multiple instances of something being restored or brought back together", but I'm not sure how reliable that is haha. Opening this as a draft until we can decide. 