### PR TITLE
doc(web): updated environment and language-server documentation on the website

### DIFF
--- a/packages/web/src/routes/docs/contributors/environment/+page.md
+++ b/packages/web/src/routes/docs/contributors/environment/+page.md
@@ -22,4 +22,6 @@ To see all the tools in the toolbox, run:
 just --list
 ```
 
+> Please note that `just build-web` _only_ builds the website for production, while `just dev-web` also spins up a development server.
+
 Before making any modifications, we highly recommend that you run `just setup` to populate your build caches and download all dependencies.

--- a/packages/web/src/routes/docs/integrations/language-server/+page.md
+++ b/packages/web/src/routes/docs/integrations/language-server/+page.md
@@ -14,14 +14,25 @@ To install `harper-ls`, simply run:
 cargo install harper-ls --locked
 ```
 
-If you are on a Debian-based Linux distribution, you may need to install `build-essential`.
+For this to work, make sure that `~/.cargo/bin` is in your system `$PATH`. If you are on a Debian-based Linux distribution, you may need to install `build-essential`.
 
 ### Arch Linux
 
-Harper is available through the `extra` repo:
+**Stable Release**
+
+The latest stable release is available through the `extra` repo:
 
 ```bash
 sudo pacman -S harper
+```
+
+**Bleeding-Edge**
+
+If you want the latest bleeding-edge, you can install `harper-git` from the [Arch User Repository](https://aur.archlinux.org/packages/harper-git) with your favorite AUR helper:
+
+```bash
+paru -S harper-git
+# or yay -S harper-git, etc.
 ```
 
 ### Scoop


### PR DESCRIPTION
# Issues 
N/A

# Description
This PR updates the documentation website to include instructions for the new `harper-git` AUR package. It also clarifies the difference between `just dev-web` and `just build-web`.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
I used `just dev-web` to preview my changes on the development server.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
