### PR TITLE
feat: tests for sentences containing a decade

### DIFF
--- a/harper-core/src/lexing/mod.rs
+++ b/harper-core/src/lexing/mod.rs
@@ -470,4 +470,62 @@ mod tests {
         let source: Vec<_> = "'90s".chars().collect();
         assert!(lex_long_decade(&source).is_none());
     }
+
+    #[test]
+    fn accepts_sentence_with_decade() {
+        let sentence: Vec<_> = "To the early 1990s there were a lot of Movies where the bad guys were former Russian intelligence agents.".chars().collect();
+        let expected_tokens = [
+            TokenKind::Word(None),
+            TokenKind::Space(1),
+            TokenKind::Word(None),
+            TokenKind::Space(1),
+            TokenKind::Word(None),
+            TokenKind::Space(1),
+            TokenKind::Decade,
+        ];
+
+        let mut next_index = 0;
+
+        for expected_token in expected_tokens.iter() {
+            if next_index >= sentence.len() {
+                break; // Exit if we've processed the entire source
+            }
+
+            let token = lex_token(&sentence[next_index..]).expect("Failed to lex token");
+            assert_eq!(token.token, *expected_token);
+            next_index += token.next_index;
+        }
+    }
+
+    #[test]
+    fn rejects_sentence_with_number() {
+        let sentence: Vec<_> = "To the early 1990s there were a lot of Movies where the bad guys were former Russian intelligence agents.".chars().collect();
+        let expected_tokens = [
+            TokenKind::Word(None),
+            TokenKind::Space(1),
+            TokenKind::Word(None),
+            TokenKind::Space(1),
+            TokenKind::Word(None),
+            TokenKind::Space(1),
+            TokenKind::Number(Default::default()),
+        ];
+
+        let mut next_index = 0;
+
+        for (i, expected_token) in expected_tokens.iter().enumerate() {
+            if next_index >= sentence.len() {
+                break; // Exit if we've processed the entire source
+            }
+
+            let token = lex_token(&sentence[next_index..]).expect("Failed to lex token");
+
+            if i < 6 {
+                assert_eq!(token.token, *expected_token);
+            } else {
+                assert_ne!(token.token, *expected_token);
+            }
+
+            next_index += token.next_index;
+        }
+    }
 }


### PR DESCRIPTION
# Issues 
I only [mentioned it in Discord](https://discord.com/channels/1335035237213671495/1335035237213671498/1342765690813157388) when nobody else was active.

On builds straight from master I was seeing the 's' after decades like '1990s' flagged, even though my decade lexer has been merged.

# Description
I checked the tests and we only had unit tests looking for edge cases. This adds a positive and a negative test against the sentence mentioned. Let me know if there's a better way to code them or if they belong in some other file. The other lexers in `harper-core/src/lexing/mod.rs` also didn't have any in-context tests.

# How Has This Been Tested?
`cargo test` passes all tests but `just test` gives strange new errors I've never seen before, including creating supposed screenshot png's but those are all blank. I think this is something unrelated that's been pushed to master in the same timeframe my decade lexer was pushed??

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
