### PR TITLE
fix: better ascii and hex digit checks

### DIFF
--- a/harper-core/src/lexing/url.rs
+++ b/harper-core/src/lexing/url.rs
@@ -120,7 +120,7 @@ fn is_unreserved(c: char) -> bool {
 }
 
 fn is_hex(c: char) -> bool {
-    c.is_ascii_digit() || matches!(c, 'A'..='F' | 'a'..='f')
+    c.is_ascii_hexdigit()
 }
 
 /// Lex an escaped hex code, returning the subsequent index


### PR DESCRIPTION
# Issues 
No issues. Spotted these things while fixing another issue in the same source file.

# Description
Fixed character APIs that checked being numeral instead of checking English (ASCII) digits only:

- `.is_alphanumeric` → `.is_ascii_alphanumeric`
- `.is_numeric` → `.is_ascii_digit`

Use `.is_ascii_hexdigit` instead of manually checking `a-f` etc

# How Has This Been Tested?
I made sure all the existing tests still passed plus I added checks for number parsing, which we didn't yet have.

I expected digits from other alphabets to pass but although they passed the character detection they didn't pass being parsed into floats. Now they are rejected earlier when checking the characters.

For English numbers, I tested integers, decimals, and scientific notation. I included tests for explicitly negative and positive numbers but those tests failed. This may or may not be a problem at some stage so I left those two tests there but commented out.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
