### PR TITLE
fix(core): remove bad `Forthwith` rule

### DIFF
--- a/harper-core/src/linting/closed_compounds.rs
+++ b/harper-core/src/linting/closed_compounds.rs
@@ -58,7 +58,6 @@ pub fn lint_group() -> LintGroup {
         "Anyhow"          => ("any how", "anyhow"),
         "Nonetheless"     => ("none the less", "nonetheless"),
         "Thereupon"       => ("there upon", "thereupon"),
-        "Forthwith"       => ("forth with", "forthwith"),
         "Insofar"         => ("in so far", "insofar"),
         "Whereupon"       => ("where upon", "whereupon"),
         "Upward"          => ("up ward", "upward"),

--- a/harper-core/src/linting/closed_compounds.rs
+++ b/harper-core/src/linting/closed_compounds.rs
@@ -179,13 +179,6 @@ mod tests {
     }
 
     #[test]
-    fn forth_with() {
-        let test_sentence = "Please reply forth with to our previous inquiry.";
-        let expected = "Please reply forthwith to our previous inquiry.";
-        assert_suggestion_result(test_sentence, lint_group(), expected);
-    }
-
-    #[test]
     fn in_so_far() {
         let test_sentence = "This rule applies in so far as it covers all cases.";
         let expected = "This rule applies insofar as it covers all cases.";


### PR DESCRIPTION
# Issues 

Resolves #771

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

I don't believe the `forthwith` rule as actually constructive. For reference, I don't believe LanguageTool covers it. It's not a very common word and there doesn't seem to be a heuristic for it. It's best to just remove it.
