### PR TITLE
fix(core): don't ignore blocking word-likes

### DIFF
--- a/harper-core/src/linting/an_a.rs
+++ b/harper-core/src/linting/an_a.rs
@@ -14,8 +14,13 @@ impl Linter for AnA {
 
         for chunk in document.iter_chunks() {
             for (first_idx, second_idx) in chunk.iter_word_indices().tuple_windows() {
-                // [`TokenKind::Unlintable`] might be semantic words.
-                if chunk[first_idx..second_idx].iter_unlintables().count() > 0 {
+                // [`TokenKind::Unlintable`] might have semantic meaning.
+                if chunk[first_idx..second_idx].iter_unlintables().count() > 0
+                    || chunk[first_idx + 1..second_idx]
+                        .iter_word_like_indices()
+                        .count()
+                        > 0
+                {
                     continue;
                 }
 
@@ -264,5 +269,10 @@ mod tests {
             AnA,
             1,
         );
+    }
+
+    #[test]
+    fn allow_issue_751() {
+        assert_lint_count("He got a 52% approval rating.", AnA, 0);
     }
 }


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->

Fixes #751

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

The `AnA` linter would ignore situations where a word-like would stand between the article and the subject. This PR ignores those situations.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I've added a unit test from the issue.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
