### PR TITLE
feat: implement false positive "the great might of"

### DIFF
--- a/harper-core/src/linting/modal_of.rs
+++ b/harper-core/src/linting/modal_of.rs
@@ -1,6 +1,6 @@
 use crate::{
     Lrc, Token, TokenStringExt,
-    patterns::{OwnedPatternExt, Pattern, SequencePattern, WordSet},
+    patterns::{EitherPattern, Pattern, SequencePattern, WordSet},
 };
 
 use super::{Lint, LintKind, PatternLinter, Suggestion};
@@ -34,12 +34,35 @@ impl Default for ModalOf {
                 .then_exact_word("course"),
         );
 
+        let modal_of_course = Lrc::new(
+            SequencePattern::default()
+                .then(modal_of.clone())
+                .then(ws_course.clone()),
+        );
+
+        let anyword_might_of = Lrc::new(
+            SequencePattern::default()
+                .then_any_word()
+                .then_whitespace()
+                .then_exact_word("might")
+                .then_whitespace()
+                .then_exact_word("of"),
+        );
+
+        let anyword_might_of_course = Lrc::new(
+            SequencePattern::default()
+                .then(anyword_might_of.clone())
+                .then(ws_course.clone()),
+        );
+
         Self {
             pattern: Box::new(
-                SequencePattern::default()
-                    .then(modal_of.clone())
-                    .then(ws_course.clone())
-                    .or(Box::new(modal_of.clone())),
+                EitherPattern::new(vec![
+                    Box::new(anyword_might_of_course),
+                    Box::new(modal_of_course),
+                    Box::new(anyword_might_of),
+                    Box::new(modal_of),
+                ])
             ),
         }
     }
@@ -51,25 +74,45 @@ impl PatternLinter for ModalOf {
     }
 
     fn match_to_lint(&self, matched_toks: &[Token], source_chars: &[char]) -> Option<Lint> {
-        if matched_toks.len() != 3 {
-            return None;
-        }
+        let modal_index = match matched_toks.len() {
+            // Without context, always an error from the start
+            3 => 0,
+            5 => {
+                // False positives: modal _ of _ course / adj. _ might _ of / art. _ might _ of
+                let w3_text = matched_toks.last().unwrap().span.get_content(source_chars).iter().collect::<String>();
+                if w3_text.as_str() != "of" {
+                    return None;
+                }
+                let w1_kind = matched_toks.first().unwrap().kind;
+                // the might of something, great might of something
+                if w1_kind.is_adjective() || w1_kind.is_article() {
+                    return None;
+                }
+                // not a false positive, skip context before
+                2
+            }
+            // False positive: <word> _ might _ of _ course
+            7 => return None,
+            _ => unreachable!(),
+        };
 
-        let span_modal_of = matched_toks[0..3].span().unwrap();
-        let span_modal = matched_toks[0].span;
+        let span_modal_of = matched_toks[modal_index..modal_index + 3].span().unwrap();
 
-        let modal_have = format!("{} have", span_modal.get_content_string(source_chars))
+        let modal_have = format!("{} have", matched_toks[modal_index].span.get_content_string(source_chars))
             .chars()
             .collect();
-        let modal_ws_of = span_modal_of.get_content(source_chars);
 
-        Some(Lint {
+        return Some(Lint {
             span: span_modal_of,
             lint_kind: LintKind::WordChoice,
-            suggestions: vec![Suggestion::replace_with_match_case(modal_have, modal_ws_of)],
+            suggestions: vec![Suggestion::replace_with_match_case(
+                modal_have,
+                span_modal_of.get_content(source_chars),
+            )],
             message: "Use `have` rather than `of` here.".to_string(),
             priority: 126,
-        })
+        });
+
     }
 
     fn description(&self) -> &'static str {
@@ -100,8 +143,18 @@ mod tests {
     }
 
     #[test]
-    fn test_false_positive() {
+    fn test_false_positive_of_course() {
         assert_lint_count("should of course", ModalOf::default(), 0);
+    }
+
+    #[test]
+    fn test_false_positive_the_might_of() {
+        assert_lint_count("the might of", ModalOf::default(), 0);
+    }
+
+    #[test]
+    fn test_false_positive_great_might_of() {
+        assert_lint_count("great might of", ModalOf::default(), 0);
     }
 
     #[test]
@@ -223,6 +276,15 @@ mod tests {
     fn doesnt_catch_would_of_course_just() {
         assert_lint_count(
             "I would of course just test this by compiling with MATX_MULTI_GPU=ON",
+            ModalOf::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn doesnt_catch_to_take_on_the_full_might_of_nato() {
+        assert_lint_count(
+            "To take on the full might of NATO.",
             ModalOf::default(),
             0,
         );

--- a/harper-core/src/linting/modal_of.rs
+++ b/harper-core/src/linting/modal_of.rs
@@ -111,7 +111,7 @@ impl PatternLinter for ModalOf {
         .chars()
         .collect();
 
-        return Some(Lint {
+        Some(Lint {
             span: span_modal_of,
             lint_kind: LintKind::WordChoice,
             suggestions: vec![Suggestion::replace_with_match_case(
@@ -120,7 +120,7 @@ impl PatternLinter for ModalOf {
             )],
             message: "Use `have` rather than `of` here.".to_string(),
             priority: 126,
-        });
+        })
     }
 
     fn description(&self) -> &'static str {

--- a/harper-core/src/linting/modal_of.rs
+++ b/harper-core/src/linting/modal_of.rs
@@ -56,14 +56,12 @@ impl Default for ModalOf {
         );
 
         Self {
-            pattern: Box::new(
-                EitherPattern::new(vec![
-                    Box::new(anyword_might_of_course),
-                    Box::new(modal_of_course),
-                    Box::new(anyword_might_of),
-                    Box::new(modal_of),
-                ])
-            ),
+            pattern: Box::new(EitherPattern::new(vec![
+                Box::new(anyword_might_of_course),
+                Box::new(modal_of_course),
+                Box::new(anyword_might_of),
+                Box::new(modal_of),
+            ])),
         }
     }
 }
@@ -79,7 +77,13 @@ impl PatternLinter for ModalOf {
             3 => 0,
             5 => {
                 // False positives: modal _ of _ course / adj. _ might _ of / art. _ might _ of
-                let w3_text = matched_toks.last().unwrap().span.get_content(source_chars).iter().collect::<String>();
+                let w3_text = matched_toks
+                    .last()
+                    .unwrap()
+                    .span
+                    .get_content(source_chars)
+                    .iter()
+                    .collect::<String>();
                 if w3_text.as_str() != "of" {
                     return None;
                 }
@@ -98,9 +102,14 @@ impl PatternLinter for ModalOf {
 
         let span_modal_of = matched_toks[modal_index..modal_index + 3].span().unwrap();
 
-        let modal_have = format!("{} have", matched_toks[modal_index].span.get_content_string(source_chars))
-            .chars()
-            .collect();
+        let modal_have = format!(
+            "{} have",
+            matched_toks[modal_index]
+                .span
+                .get_content_string(source_chars)
+        )
+        .chars()
+        .collect();
 
         return Some(Lint {
             span: span_modal_of,
@@ -112,7 +121,6 @@ impl PatternLinter for ModalOf {
             message: "Use `have` rather than `of` here.".to_string(),
             priority: 126,
         });
-
     }
 
     fn description(&self) -> &'static str {
@@ -283,10 +291,6 @@ mod tests {
 
     #[test]
     fn doesnt_catch_to_take_on_the_full_might_of_nato() {
-        assert_lint_count(
-            "To take on the full might of NATO.",
-            ModalOf::default(),
-            0,
-        );
+        assert_lint_count("To take on the full might of NATO.", ModalOf::default(), 0);
     }
 }


### PR DESCRIPTION
# Issues 
#792

# Description
Fixes the false positive bug where "might of" should not be corrected to "might have" when "might" is a noun as in "the might of the army" or "the great might of the military"

# How Has This Been Tested?
I added new unit tests for the "the might" and "adj. might" cases.
I added a new unit test with the real-world sentence that led to me to this false positive.

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
