### PR TITLE
feat(web): create page for debugging the title-case algo

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -36,6 +36,7 @@
 		"harper.js": "link:../harper.js",
 		"lodash-es": "^4.17.21",
 		"reveal.js": "^5.1.0",
-		"svelte-intersection-observer": "^1.0.0"
+		"svelte-intersection-observer": "^1.0.0",
+		"typed.js": "^2.1.0"
 	}
 }

--- a/packages/web/src/routes/titlecase/+page.svelte
+++ b/packages/web/src/routes/titlecase/+page.svelte
@@ -1,0 +1,76 @@
+<script>
+	import { onMount } from 'svelte';
+	import { Textarea } from 'flowbite-svelte';
+	import Typed from 'typed.js';
+	import { WorkerLinter } from 'harper.js';
+
+	let textareaRef;
+	let linter = new WorkerLinter();
+
+	let text = $state('');
+
+	$effect(() => {
+		linter.toTitleCase(text).then((t) => (text = t));
+	});
+
+	onMount(() => {
+		const typed = new Typed('#titleCaseInputField', {
+			strings: [
+				'Click Here to Write an Article Title',
+				'Click Here to Write a Blog Title',
+				'Click Here to Write a Social Media Post Title',
+				'Click Here to Write a Newsletter Title',
+				'Click Here to Write a Video Script Title',
+				'Click Here to Write a Press Release Title',
+				'Click Here to Brainstorm a New Ebook Title'
+			],
+			typeSpeed: 50,
+			showCursor: false,
+			attr: 'placeholder'
+		});
+
+		return () => typed.destroy();
+	});
+</script>
+
+<h1>Title Case Converter</h1>
+
+<div class="fixed left-0 top-0 w-screen h-screen bg-white dark:bg-black z-1000">
+	<div class="max-w-4xl mx-auto shadow-md border-gray-300 dark:border-x h-full">
+		<!-- Header -->
+		<header class="border-b border-gray-300 p-4">
+			<div class="flex justify-between items-center">
+				<h1 class="text-3xl font-serif font-bold">The News, Written by You</h1>
+				<span class="text-sm">July 4th 1776</span>
+			</div>
+			<div class="flex justify-between mt-2">
+				<div class="text-xs">Vol. 123, No. 45</div>
+				<div class="text-xs">Your trusted news source</div>
+			</div>
+		</header>
+
+		<main class="p-4 md:p-6">
+			<article class="mb-8">
+				<Textarea
+					bind:value={text}
+					rows="1"
+					class="heading-textarea font-serif text-2xl md:text-3xl font-bold border-none focus:ring-2 focus:ring-blue-200 bg-transparent p-0 resize-none overflow-hidden"
+					id="titleCaseInputField"
+				/>
+				<div class="text-sm mb-3">By John Doe, Staff Writer</div>
+
+				<p class="leading-relaxed">
+					<a href="/">Harper</a> ships out-of-the box with everything you need to perform complex operations
+					on English text at the edge. That includes converting text to title-case.
+				</p>
+
+				<p class="leading-relaxed">
+					Just enter your text in the heading above and it'll be converted to title case following
+					the <a href="https://www.chicagomanualofstyle.org/home.html">Chicago Style</a>. Your
+					privacy means something. Keep your data where you want it: in your hands and on your
+					device.
+				</p>
+			</article>
+		</main>
+	</div>
+</div>

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -5069,7 +5069,7 @@ gzip-size@^6.0.0:
     duplexer "^0.1.2"
 
 "harper.js@link:harper.js":
-  version "0.22.0"
+  version "0.23.0"
 
 has-bigints@^1.0.2:
   version "1.1.0"
@@ -8616,6 +8616,11 @@ typed-rest-client@^1.8.4:
     tunnel "0.0.6"
     underscore "^1.12.1"
 
+typed.js@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/typed.js/-/typed.js-2.1.0.tgz#b97a06111a5f57d6a59acfdd36d4f9b891ee13b4"
+  integrity sha512-bDuXEf7YcaKN4g08NMTUM6G90XU25CK3bh6U0THC/Mod/QPKlEt9g/EjvbYB8x2Qwr2p6J6I3NrsoYaVnY6wsQ==
+
 typescript@5.7.3, typescript@^5.7.3, typescript@~5.7.3:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
@@ -9016,6 +9021,7 @@ vscode-uri@^3.0.8:
 
 "wasm@link:../harper-wasm/pkg":
   version "0.0.0"
+  uid ""
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

In order to test Harper's title case algorithm, I've created a public page to convert any case text to title case, similar to [titlecaseconverter.com](https://titlecaseconverter.com/).

I've also spent some time making it pretty.

# Demo

https://github.com/user-attachments/assets/2f633a28-c0ee-4984-87d9-6c56bd1edd97



# How Has This Been Tested?
I've opened and edited the heading on both Firefox and Chrome manually.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
