### PR TITLE
fix: add missing "gotten rid off" to other "rid off"

### DIFF
--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -363,6 +363,12 @@ pub fn lint_group() -> LintGroup {
             "Did you mean `got rid of`?",
             "Ensures `got rid of` is used instead of `got rid off`."
         ),
+        "GottenRidOff" => (
+            ["gotten rid off"],
+            ["gotten rid of"],
+            "Did you mean `gotten rid of`?",
+            "Ensures `gotten rid of` is used instead of `gotten rid off`."
+        ),
         "LastButNotLeast" => (
             ["last but not the least", "last, but not the least", "last but, not least"],
             ["last but not least"],
@@ -616,7 +622,6 @@ mod tests {
 
     use super::lint_group;
 
-    // todo: 4 tests: get/gets/getting rid off
     #[test]
     fn get_rid_off() {
         assert_suggestion_result(
@@ -625,6 +630,8 @@ mod tests {
             "Please bump axios version to get rid of npm warning #624",
         );
     }
+
+    #[test]
     fn gets_rid_off() {
         assert_suggestion_result(
             "Adding at as a runtime dependency gets rid off that error",
@@ -632,6 +639,8 @@ mod tests {
             "Adding at as a runtime dependency gets rid of that error",
         );
     }
+
+    #[test]
     fn getting_rid_off() {
         assert_suggestion_result(
             "getting rid off of all the complexity of the different accesses method of API service providers",
@@ -639,11 +648,22 @@ mod tests {
             "getting rid of of all the complexity of the different accesses method of API service providers",
         );
     }
+
+    #[test]
     fn got_rid_off() {
         assert_suggestion_result(
             "For now we got rid off circular deps in model tree structure and it's API.",
             lint_group(),
             "For now we got rid of circular deps in model tree structure and it's API.",
+        );
+    }
+
+    #[test]
+    fn gotten_rid_off() {
+        assert_suggestion_result(
+            "The baX variable thingy I have gotten rid off, that was due to a bad character in the encryption key.",
+            lint_group(),
+            "The baX variable thingy I have gotten rid of, that was due to a bad character in the encryption key.",
         );
     }
 


### PR DESCRIPTION
# Issues 
No issue was filed. It went straight to PR.

# Description
<!-- Please include a summary of the change. -->
When I converted all of the inflections of "to get rid off" to use `phrase_corrections.rs` I neglected to convert the past participle `gotten rid off`.

When I added a test I noticed the other tests were missing their `#[test]` so I added those too.

Other PRs related to this one: #685 and #717 

# Demo
N/A

# How Has This Been Tested?
Added a new test for the past participle form using a sentence from GitHub.
Did `cargo test` and `just test` and everything passed.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
