### PR TITLE
fix: fall back to `grep` when `rg` is not available

### DIFF
--- a/justfile
+++ b/justfile
@@ -260,7 +260,12 @@ addnoun noun:
 
 # Search Harper's curated dictionary for a specific word
 searchdictfor word:
-  cargo run --bin harper-cli -- words | rg {{word}}
+  #! /bin/bash
+  if command -v rg > /dev/null; then
+    cargo run --bin harper-cli -- words | rg {{word}}
+  else
+    cargo run --bin harper-cli -- words | grep {{word}}
+  fi
 
 # Find words in the user's `harper-ls/dictionary.txt` for words already in the curated dictionary.
 userdictoverlap:


### PR DESCRIPTION
# Issues 
N/A 

# Description
<!-- Please include a summary of the change. -->
I noticed that `just searchfor` crashed on my machine.
It turned out to be because [ripgrep](https://github.com/BurntSushi/ripgrep) isn't installed in macOS.
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->
I ran into this problem while reading #847 

# Demo
N/A

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
Ran it some random words. I don't think there are tests applicable to `just`?

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
