### PR TITLE
feat: mask out comments beginning with spellchecker:ignore

### DIFF
--- a/harper-comments/src/comment_parser.rs
+++ b/harper-comments/src/comment_parser.rs
@@ -3,13 +3,13 @@ use std::path::Path;
 use comment_parsers::{Go, JavaDoc, JsDoc, Unit};
 use harper_core::parsers::{self, MarkdownOptions, Parser};
 use harper_core::{MutableDictionary, Token};
-use harper_tree_sitter::TreeSitterMasker;
 use tree_sitter::Node;
 
 use crate::comment_parsers;
+use crate::masker::CommentMasker;
 
 pub struct CommentParser {
-    inner: parsers::Mask<TreeSitterMasker, Box<dyn Parser>>,
+    inner: parsers::Mask<CommentMasker, Box<dyn Parser>>,
 }
 
 impl CommentParser {
@@ -57,7 +57,7 @@ impl CommentParser {
 
         Some(Self {
             inner: parsers::Mask::new(
-                TreeSitterMasker::new(language, Self::node_condition),
+                CommentMasker::new(language, Self::node_condition),
                 comment_parser,
             ),
         })

--- a/harper-comments/src/lib.rs
+++ b/harper-comments/src/lib.rs
@@ -2,4 +2,5 @@
 
 mod comment_parser;
 mod comment_parsers;
+mod masker;
 pub use comment_parser::CommentParser;

--- a/harper-comments/src/masker.rs
+++ b/harper-comments/src/masker.rs
@@ -1,0 +1,56 @@
+use harper_core::{Masker, MutableDictionary};
+use harper_tree_sitter::TreeSitterMasker;
+
+pub struct CommentMasker {
+    inner: TreeSitterMasker,
+    ignore_condition: Box<dyn Fn(&String) -> bool + Send + Sync>,
+}
+
+impl CommentMasker {
+    pub fn create_ident_dict(&self, source: &[char]) -> Option<MutableDictionary> {
+        self.inner.create_ident_dict(source)
+    }
+
+    pub fn new(
+        language: tree_sitter::Language,
+        ts_node_condition: fn(&tree_sitter::Node) -> bool,
+    ) -> Self {
+        Self::new_with_ignore_condition(
+            language,
+            ts_node_condition,
+            Box::new(|text| {
+                text.contains("spellchecker:ignore")
+                    || text.contains("spellchecker: ignore")
+                    || text.contains("spellcheck:ignore")
+                    || text.contains("spellcheck: ignore")
+                    || text.contains("cspell:ignore")
+                    || text.contains("cspell: ignore")
+                    || text.contains("harper:ignore")
+                    || text.contains("harper: ignore")
+            }),
+        )
+    }
+
+    pub fn new_with_ignore_condition(
+        language: tree_sitter::Language,
+        ts_node_condition: fn(&tree_sitter::Node) -> bool,
+        ignore_condition: Box<dyn Fn(&String) -> bool + Send + Sync>,
+    ) -> Self {
+        Self {
+            inner: TreeSitterMasker::new(language, ts_node_condition),
+            ignore_condition,
+        }
+    }
+}
+
+impl Masker for CommentMasker {
+    fn create_mask(&self, source: &[char]) -> harper_core::Mask {
+        self.inner
+            .create_mask(source)
+            .iter_allowed(source)
+            .map(|(span, chars)| (span, chars.iter().collect::<String>()))
+            .filter(|(_, text)| !(self.ignore_condition)(text))
+            .map(|(span, _)| span)
+            .collect()
+    }
+}

--- a/harper-comments/tests/language_support.rs
+++ b/harper-comments/tests/language_support.rs
@@ -51,6 +51,10 @@ create_test!(javadoc_complex.java, 4);
 create_test!(issue_132.rs, 1);
 create_test!(laravel_app.php, 2);
 
+// Checks that some comments are masked out
+create_test!(ignore_comments.rs, 1);
+create_test!(ignore_comments.c, 1);
+
 // These are to make sure nothing crashes.
 create_test!(empty.js, 0);
 create_test!(issue_229.js, 0);

--- a/harper-comments/tests/language_support_sources/ignore_comments.c
+++ b/harper-comments/tests/language_support_sources/ignore_comments.c
@@ -1,0 +1,4 @@
+// This comment is spellcheckd
+int main() {
+  // spellchecker:ignore Thear be code in here
+}

--- a/harper-comments/tests/language_support_sources/ignore_comments.rs
+++ b/harper-comments/tests/language_support_sources/ignore_comments.rs
@@ -1,0 +1,7 @@
+/// spellcheck:ignore splling error
+/// This applies to the entire comment block
+#[derive(Debug)]
+/// Ths comment block is checked
+pub struct Testing {
+    // spellchecker: ignore ths struct isnt done yt
+}

--- a/harper-core/src/mask/mod.rs
+++ b/harper-core/src/mask/mod.rs
@@ -24,15 +24,16 @@ pub struct Mask {
 
 impl FromIterator<Span> for Mask {
     fn from_iter<T: IntoIterator<Item = Span>>(iter: T) -> Self {
-        let spans = iter.into_iter().sorted_by_key(|span| span.start);
+        let allowed = iter
+            .into_iter()
+            .sorted_by_key(|span| span.start)
+            .collect_vec();
         assert!(
-            spans.clone().tuple_windows().all(|(a, b)| b.start >= a.end),
+            allowed.is_sorted_by(|a, b| a.end <= b.start),
             "Masker elements cannot overlap and must be sorted!"
         );
 
-        Self {
-            allowed: spans.collect(),
-        }
+        Self { allowed }
     }
 }
 

--- a/harper-tree-sitter/src/lib.rs
+++ b/harper-tree-sitter/src/lib.rs
@@ -106,7 +106,10 @@ impl Masker for TreeSitterMasker {
         let mut mask = Mask::new_blank();
 
         for span in comments_spans {
-            mask.push_allowed(span);
+            let text = span.get_content_string(source);
+            if !(text.contains("spellchecker:ignore") || text.contains("spellchecker: ignore")) {
+                mask.push_allowed(span);
+            }
         }
 
         mask.merge_whitespace_sep(source);

--- a/harper-tree-sitter/src/lib.rs
+++ b/harper-tree-sitter/src/lib.rs
@@ -106,10 +106,7 @@ impl Masker for TreeSitterMasker {
         let mut mask = Mask::new_blank();
 
         for span in comments_spans {
-            let text = span.get_content_string(source);
-            if !(text.contains("spellchecker:ignore") || text.contains("spellchecker: ignore")) {
-                mask.push_allowed(span);
-            }
+            mask.push_allowed(span);
         }
 
         mask.merge_whitespace_sep(source);


### PR DESCRIPTION
Still needs some tests. I'm not sure this is the cleanest way to accomplish this, but I based it on a comment @elijah-potter once made about something similar (I think shebangs).