### PR TITLE
Just getforms improvements

### DIFF
--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -235,10 +235,7 @@ fn main() -> anyhow::Result<()> {
                         "'{}' is already in the dictionary but not annotated.",
                         arg_bare_word
                     ),
-                    _ => format!(
-                        "'{}' is not in the dictionary yet.",
-                        arg_bare_word
-                    ),
+                    _ => format!("'{}' is not in the dictionary yet.", arg_bare_word),
                 };
 
                 let mut different_annot = false;
@@ -257,7 +254,8 @@ fn main() -> anyhow::Result<()> {
                         );
                     } else {
                         status_summary.push_str(
-                            format!("\n  Your annotations are the same as the dictionary.\n").as_str(),
+                            format!("\n  Your annotations are the same as the dictionary.\n")
+                                .as_str(),
                         );
                     }
                 }
@@ -287,7 +285,8 @@ fn main() -> anyhow::Result<()> {
                 };
 
                 let should_print_old_info = already_annotated;
-                let should_print_new_info = arg_annot.is_some() && (!already_annotated || different_annot);
+                let should_print_new_info =
+                    arg_annot.is_some() && (!already_annotated || different_annot);
 
                 if should_print_old_info {
                     println!("Old, from the dictionary:");

--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -249,14 +249,11 @@ fn main() -> anyhow::Result<()> {
                         != arg_annot.unwrap().chars().collect()
                     {
                         different_annot = true;
-                        status_summary.push_str(
-                            format!("\n  Your annotations differ from the dictionary.\n").as_str(),
-                        );
+                        status_summary
+                            .push_str("\n  Your annotations differ from the dictionary.\n");
                     } else {
-                        status_summary.push_str(
-                            format!("\n  Your annotations are the same as the dictionary.\n")
-                                .as_str(),
-                        );
+                        status_summary
+                            .push_str("\n  Your annotations are the same as the dictionary.\n");
                     }
                 }
 

--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 use std::collections::BTreeMap;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process;
 
@@ -11,7 +12,9 @@ use harper_comments::CommentParser;
 use harper_core::linting::{LintGroup, Linter};
 use harper_core::parsers::{Markdown, MarkdownOptions};
 use harper_core::spell::hunspell::parse_default_attribute_list;
+use harper_core::spell::hunspell::parse_default_word_list;
 use harper_core::spell::hunspell::word_list::parse_word_list;
+use harper_core::spell::hunspell::word_list::MarkedWord;
 use harper_core::{
     remove_overlaps, CharString, CharStringExt, Dictionary, Document, FstDictionary, TokenKind,
     TokenStringExt, WordMetadata,
@@ -199,32 +202,104 @@ fn main() -> anyhow::Result<()> {
 
             Ok(())
         }
-        Args::Forms { words } => {
-            let mut expanded: HashMap<CharString, WordMetadata> = HashMap::new();
-            let attributes = parse_default_attribute_list();
-            let total = words.len();
+        Args::Forms { words: args_words } => {
+            let default_attrs = parse_default_attribute_list();
+            let args_total = args_words.len();
 
-            for (index, word) in words.iter().enumerate() {
-                expanded.clear();
+            let default_marked_words = parse_default_word_list().unwrap();
 
-                let hunspell_word_list = format!("1\n{word}");
-                let words = parse_word_list(&hunspell_word_list.to_string()).unwrap();
-                attributes.expand_marked_words(words, &mut expanded);
+            for (arg_index, arg_word) in args_words.iter().enumerate() {
+                let mut arg_bare_word = arg_word.to_string();
+                let mut arg_annot = None;
+                if let Some((word_part, annot_part)) = arg_word.split_once('/') {
+                    arg_bare_word = word_part.to_string();
+                    arg_annot = Some(annot_part);
+                }
 
-                println!(
-                    "{}{}{}",
-                    if index > 0 { "\n" } else { "" },
-                    if total != 1 {
-                        format!("{}/{}: ", index + 1, total)
+                let mut already_in_dict = false;
+                let mut already_annotated = false;
+                let old_annot = get_annotations(&default_marked_words, &arg_bare_word);
+
+                if let Some(ref annot) = old_annot {
+                    already_in_dict = true;
+                    already_annotated = !annot.is_empty();
+                }
+
+                let mut status_summary = match (already_in_dict, already_annotated) {
+                    (true, true) => format!(
+                        "'{}' is already in the dictionary with annotation `{}`.",
+                        arg_bare_word,
+                        old_annot.clone().unwrap()
+                    ),
+                    (true, false) => format!(
+                        "'{}' is already in the dictionary but not annotated.",
+                        arg_bare_word
+                    ),
+                    _ => format!(
+                        "'{}' is not in the dictionary yet.",
+                        arg_bare_word
+                    ),
+                };
+
+                let mut different_annot = false;
+
+                if already_annotated && arg_annot.is_some() {
+                    if old_annot
+                        .clone()
+                        .unwrap()
+                        .chars()
+                        .collect::<HashSet<char>>()
+                        != arg_annot.unwrap().chars().collect()
+                    {
+                        different_annot = true;
+                        status_summary.push_str(
+                            format!("\n  Your annotations differ from the dictionary.\n").as_str(),
+                        );
                     } else {
-                        "".to_string()
-                    },
-                    word
-                );
-                expanded.keys().for_each(|form| {
-                    let string_form: String = form.iter().collect();
-                    println!("  - {}", string_form);
-                });
+                        status_summary.push_str(
+                            format!("\n  Your annotations are the same as the dictionary.\n").as_str(),
+                        );
+                    }
+                }
+
+                println!("{}", status_summary);
+
+                let print_word_info = |arg_index: usize, arg_word: &str| {
+                    let mut our_expanded_word: HashMap<CharString, WordMetadata> = HashMap::new();
+                    let our_marked_word = parse_word_list(&format!("1\n{arg_word}")).unwrap();
+                    default_attrs.expand_marked_words(our_marked_word, &mut our_expanded_word);
+
+                    println!(
+                        "{}{}{}",
+                        if arg_index > 0 { "\n" } else { "" },
+                        if args_total != 1 {
+                            format!("{}/{}: ", arg_index + 1, args_total)
+                        } else {
+                            "".to_string()
+                        },
+                        arg_word
+                    );
+
+                    our_expanded_word.keys().for_each(|form| {
+                        let string_form: String = form.iter().collect();
+                        println!("  - {}", string_form);
+                    });
+                };
+
+                let should_print_old_info = already_annotated;
+                let should_print_new_info = arg_annot.is_some() && (!already_annotated || different_annot);
+
+                if should_print_old_info {
+                    println!("Old, from the dictionary:");
+                    print_word_info(
+                        arg_index,
+                        &format!("{}/{}", arg_bare_word, old_annot.unwrap()),
+                    );
+                }
+                if should_print_new_info {
+                    println!("New, from you:");
+                    print_word_info(arg_index, arg_word);
+                }
             }
 
             Ok(())
@@ -305,4 +380,15 @@ fn load_file(file: &Path, markdown_options: MarkdownOptions) -> anyhow::Result<(
         };
 
     Ok((Document::new_curated(&source, &parser), source))
+}
+
+fn get_annotations(marked_words: &[MarkedWord], word: &str) -> Option<String> {
+    for marked_word in marked_words.iter() {
+        let mw = &marked_word.letters;
+        let mw = mw.iter().collect::<String>();
+        if mw == word {
+            return Some(marked_word.attributes.iter().collect::<String>());
+        }
+    }
+    None
 }


### PR DESCRIPTION
# Issues 
N/A

# Description
<!-- Please include a summary of the change. -->
Previously `just getforms` (and `harper-cli forms`) would only expand the affix annotations provided on the commandline. Now it will first check if the word on the commandline is already in the dictionary, if it is annotated there, and if those annotations differ from those provided on the commandline. It will then print the old expansions, new expansions, or both.
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->
See [ficcdaf's comments](https://github.com/Automattic/harper/pull/847#issuecomment-2708414662) in #847 

# Demo
<img width="573" alt="Screenshot 2025-03-09 at 4 28 45 pm" src="https://github.com/user-attachments/assets/806417c6-9a80-4323-b1f7-0406d8d50d6f" />
<img width="380" alt="Screenshot 2025-03-09 at 4 29 08 pm" src="https://github.com/user-attachments/assets/86d638c2-73ec-453e-8409-cc363638bbc1" />

# How Has This Been Tested?
I manually tried to test every combination of words and annotations already in the dictionary and not, etc.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes

I'm open to suggestions on adding unit tests.