### PR TITLE
Cache busting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,7 +739,6 @@ dependencies = [
  "foldhash",
  "fst",
  "hashbrown 0.15.2",
- "indexmap",
  "is-macro",
  "itertools 0.14.0",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,6 +795,7 @@ dependencies = [
  "harper-html",
  "harper-literate-haskell",
  "harper-typst",
+ "indexmap",
  "itertools 0.14.0",
  "once_cell",
  "open",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,8 +736,10 @@ dependencies = [
  "blanket",
  "cached",
  "criterion",
+ "foldhash",
  "fst",
  "hashbrown 0.15.2",
+ "indexmap",
  "is-macro",
  "itertools 0.14.0",
  "lazy_static",
@@ -1032,6 +1034,7 @@ checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+ "serde",
 ]
 
 [[package]]

--- a/harper-core/Cargo.toml
+++ b/harper-core/Cargo.toml
@@ -28,7 +28,6 @@ levenshtein_automata = { version = "0.2.1", features = ["fst_automaton"] }
 cached = "0.54.0"
 lru = "0.13.0"
 foldhash = "0.1.4"
-indexmap = { version = "2.7.1", features = ["serde"] }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", default-features = false }

--- a/harper-core/Cargo.toml
+++ b/harper-core/Cargo.toml
@@ -27,6 +27,8 @@ unicode-width = "0.2.0"
 levenshtein_automata = { version = "0.2.1", features = ["fst_automaton"] }
 cached = "0.54.0"
 lru = "0.13.0"
+foldhash = "0.1.4"
+indexmap = { version = "2.7.1", features = ["serde"] }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", default-features = false }

--- a/harper-core/src/ignored_lints/mod.rs
+++ b/harper-core/src/ignored_lints/mod.rs
@@ -48,6 +48,10 @@ impl IgnoredLints {
 
     /// Remove ignored Lints from a [`Vec`].
     pub fn remove_ignored(&self, lints: &mut Vec<Lint>, document: &Document) {
+        if self.context_hashes.is_empty() {
+            return;
+        }
+
         lints.retain(|lint| !self.is_ignored(lint, document));
     }
 }

--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use cached::proc_macro::cached;
 use hashbrown::HashMap;
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 use super::Lint;
@@ -67,7 +68,7 @@ use std::num::NonZero;
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 #[serde(transparent)]
 pub struct LintGroupConfig {
-    inner: HashMap<String, Option<bool>>,
+    inner: IndexMap<String, Option<bool>>,
 }
 
 #[cached]
@@ -85,7 +86,7 @@ impl LintGroupConfig {
     /// Remove any configuration attached to a rule.
     /// This allows it to assume its default (curated) state.
     pub fn unset_rule_enabled(&mut self, key: impl AsRef<str>) {
-        self.inner.remove_entry(key.as_ref());
+        self.inner.swap_remove_entry(key.as_ref());
     }
 
     pub fn set_rule_enabled_if_unset(&mut self, key: impl AsRef<str>, val: bool) {
@@ -111,7 +112,7 @@ impl LintGroupConfig {
     ///
     /// Conflicting keys will be overridden by the value in the other group.
     pub fn merge_from(&mut self, other: &mut LintGroupConfig) {
-        for (key, val) in other.inner.drain() {
+        for (key, val) in other.inner.drain(..) {
             if val.is_none() {
                 continue;
             }

--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -1,14 +1,17 @@
 use std::collections::BTreeMap;
+use std::hash::Hash;
+use std::hash::{BuildHasher, Hasher};
 use std::mem;
+use std::num::NonZero;
 use std::sync::Arc;
 
 use cached::proc_macro::cached;
+use foldhash::quality::RandomState;
 use hashbrown::HashMap;
 use indexmap::IndexMap;
+use lru::LruCache;
 use serde::{Deserialize, Serialize};
 
-use super::Lint;
-use super::PatternLinterCache;
 use super::an_a::AnA;
 use super::avoid_curses::AvoidCurses;
 use super::back_in_the_day::BackInTheDay;
@@ -39,6 +42,7 @@ use super::nobody::Nobody;
 use super::number_suffix_capitalization::NumberSuffixCapitalization;
 use super::out_of_date::OutOfDate;
 use super::oxymorons::Oxymorons;
+use super::pattern_linter::run_on_chunk;
 use super::pique_interest::PiqueInterest;
 use super::plural_conjugate::PluralConjugate;
 use super::possessive_your::PossessiveYour;
@@ -60,8 +64,9 @@ use super::whereas::Whereas;
 use super::wordpress_dotcom::WordPressDotcom;
 use super::wrong_quotes::WrongQuotes;
 use super::{CurrencyPlacement, Linter, NoOxfordComma, OxfordComma};
-use crate::Document;
+use super::{Lint, PatternLinter};
 use crate::linting::{closed_compounds, phrase_corrections};
+use crate::{CharString, Document, TokenStringExt};
 use crate::{Dictionary, MutableDictionary};
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
@@ -132,28 +137,79 @@ impl LintGroupConfig {
     }
 }
 
-#[derive(Default)]
+impl Hash for LintGroupConfig {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        for (key, value) in &self.inner {
+            hasher.write(key.as_bytes());
+            if let Some(value) = value {
+                hasher.write_u8(1);
+                hasher.write_u8(*value as u8);
+            } else {
+                hasher.write_u8(0);
+                hasher.write_u8(0);
+            }
+        }
+    }
+}
+
 pub struct LintGroup {
     pub config: LintGroupConfig,
     /// We use a binary map here so the ordering is stable.
-    inner: BTreeMap<String, Box<dyn Linter>>,
+    linters: BTreeMap<String, Box<dyn Linter>>,
+    /// We use a binary map here so the ordering is stable.
+    pattern_linters: BTreeMap<String, Box<dyn PatternLinter>>,
+    /// Since [`PatternLinter`]s operate on a chunk-basis, we can store a
+    /// mapping of `Chunk -> Lint` and only re-run the pattern linters
+    /// when a chunk changes.
+    ///
+    /// Since the pattern linter results also depend on the config, we hash it and pass it as part
+    /// of the key.
+    chunk_pattern_cache: LruCache<(CharString, u64), Vec<Lint>>,
+    hasher_builder: RandomState,
 }
 
 impl LintGroup {
     pub fn empty() -> Self {
         Self {
             config: LintGroupConfig::default(),
-            inner: BTreeMap::new(),
+            linters: BTreeMap::new(),
+            pattern_linters: BTreeMap::new(),
+            chunk_pattern_cache: LruCache::new(NonZero::new(10000).unwrap()),
+            hasher_builder: RandomState::default(),
         }
+    }
+
+    /// Check if the group already contains a linter with a given name.
+    pub fn contains_key(&self, name: impl AsRef<str>) -> bool {
+        self.linters.contains_key(name.as_ref()) || self.pattern_linters.contains_key(name.as_ref())
     }
 
     /// Add a [`Linter`] to the group, returning whether the operation was successful.
     /// If it returns `false`, it is because a linter with that key already existed in the group.
     pub fn add(&mut self, name: impl AsRef<str>, linter: Box<dyn Linter>) -> bool {
-        if self.inner.contains_key(name.as_ref()) {
+        if self.contains_key(&name) {
             false
         } else {
-            self.inner.insert(name.as_ref().to_string(), linter);
+            self.linters.insert(name.as_ref().to_string(), linter);
+            true
+        }
+    }
+
+    /// Add a [`PatternLinter`] to the group, returning whether the operation was successful.
+    /// If it returns `false`, it is because a linter with that key already existed in the group.
+    ///
+    /// This function is not significantly different from [`Self::add`], but allows us to take
+    /// advantage of some properties of [`PatterLinter`]s for cache optimization.
+    pub fn add_pattern_linter(
+        &mut self,
+        name: impl AsRef<str>,
+        linter: Box<dyn PatternLinter>,
+    ) -> bool {
+        if self.contains_key(&name) {
+            false
+        } else {
+            self.pattern_linters
+                .insert(name.as_ref().to_string(), linter);
             true
         }
     }
@@ -163,15 +219,26 @@ impl LintGroup {
     pub fn merge_from(&mut self, other: &mut LintGroup) {
         self.config.merge_from(&mut other.config);
 
-        let other_map = std::mem::take(&mut other.inner);
+        let other_linters = std::mem::take(&mut other.linters);
+        self.linters.extend(other_linters);
 
-        self.inner.extend(other_map);
+        let other_pattern_linters = std::mem::take(&mut other.pattern_linters);
+        self.pattern_linters.extend(other_pattern_linters);
+    }
+
+    pub fn iter_keys(&self) -> impl Iterator<Item = &str> {
+        self.linters
+            .keys()
+            .chain(self.pattern_linters.keys())
+            .map(|v| v.as_str())
     }
 
     /// Set all contained rules to a specific value.
     /// Passing `None` will unset that rule, allowing it to assume its default state.
     pub fn set_all_rules_to(&mut self, enabled: Option<bool>) {
-        for key in self.inner.keys() {
+        let keys = self.iter_keys().map(|v| v.to_string()).collect::<Vec<_>>();
+
+        for key in keys {
             match enabled {
                 Some(v) => self.config.set_rule_enabled(key, v),
                 None => self.config.unset_rule_enabled(key),
@@ -180,9 +247,14 @@ impl LintGroup {
     }
 
     pub fn all_descriptions(&self) -> HashMap<&str, &str> {
-        self.inner
+        self.linters
             .iter()
             .map(|(key, value)| (key.as_str(), value.description()))
+            .chain(
+                self.pattern_linters
+                    .iter()
+                    .map(|(key, value)| (key.as_str(), PatternLinter::description(value))),
+            )
             .collect()
     }
 
@@ -205,10 +277,7 @@ impl LintGroup {
 
         macro_rules! insert_pattern_rule {
             ($rule:ident, $default_config:expr) => {
-                out.add(
-                    stringify!($rule),
-                    Box::new(PatternLinterCache::new_default_size($rule::default())),
-                );
+                out.add_pattern_linter(stringify!($rule), Box::new($rule::default()));
                 out.config
                     .set_rule_enabled(stringify!($rule), $default_config);
             };
@@ -223,9 +292,9 @@ impl LintGroup {
         // Add all the more complex rules to the group.
         insert_pattern_rule!(BackInTheDay, true);
         insert_struct_rule!(WordPressDotcom, true);
-        insert_struct_rule!(OutOfDate, true);
-        insert_struct_rule!(ThenThan, true);
-        insert_struct_rule!(PiqueInterest, true);
+        insert_pattern_rule!(OutOfDate, true);
+        insert_pattern_rule!(ThenThan, true);
+        insert_pattern_rule!(PiqueInterest, true);
         insert_pattern_rule!(WasAloud, true);
         insert_pattern_rule!(HyphenateNumberDay, true);
         insert_pattern_rule!(LeftRightHand, true);
@@ -247,12 +316,12 @@ impl LintGroup {
         insert_struct_rule!(Matcher, true);
         insert_struct_rule!(CorrectNumberSuffix, true);
         insert_struct_rule!(NumberSuffixCapitalization, true);
-        insert_struct_rule!(MultipleSequentialPronouns, true);
+        insert_pattern_rule!(MultipleSequentialPronouns, true);
         insert_struct_rule!(LinkingVerbs, false);
         insert_struct_rule!(AvoidCurses, true);
-        insert_struct_rule!(TerminatingConjunctions, true);
+        insert_pattern_rule!(TerminatingConjunctions, true);
         insert_struct_rule!(EllipsisLength, true);
-        insert_struct_rule!(DotInitialisms, true);
+        insert_pattern_rule!(DotInitialisms, true);
         insert_pattern_rule!(BoringWords, false);
         insert_pattern_rule!(UseGenitive, false);
         insert_pattern_rule!(ThatWhich, true);
@@ -287,13 +356,47 @@ impl LintGroup {
     }
 }
 
+impl Default for LintGroup {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
 impl Linter for LintGroup {
     fn lint(&mut self, document: &Document) -> Vec<Lint> {
         let mut results = Vec::new();
 
-        for (key, linter) in &mut self.inner {
+        // Normal linters
+        for (key, linter) in &mut self.linters {
             if self.config.is_rule_enabled(key) {
                 results.extend(linter.lint(document));
+            }
+        }
+
+        // Pattern linters
+        for chunk in document.iter_chunks() {
+            let Some(chunk_span) = chunk.span() else {
+                continue;
+            };
+
+            let chunk_chars = document.get_span_content(chunk_span);
+            let config_hash = self.hasher_builder.hash_one(&self.config);
+            let key = (chunk_chars.into(), config_hash);
+
+            if let Some(hit) = self.chunk_pattern_cache.get(&key) {
+                results.extend(hit.iter().cloned());
+            } else {
+                let mut pattern_lints = Vec::new();
+
+                for (key, linter) in &mut self.pattern_linters {
+                    if self.config.is_rule_enabled(key) {
+                        pattern_lints.extend(run_on_chunk(linter, chunk, document.get_source()));
+                    }
+                }
+
+                self.chunk_pattern_cache.put(key, pattern_lints.clone());
+
+                results.append(&mut pattern_lints);
             }
         }
 

--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -63,7 +63,6 @@ use super::{CurrencyPlacement, Linter, NoOxfordComma, OxfordComma};
 use crate::Document;
 use crate::linting::{closed_compounds, phrase_corrections};
 use crate::{Dictionary, MutableDictionary};
-use std::num::NonZero;
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 #[serde(transparent)]
@@ -208,10 +207,7 @@ impl LintGroup {
             ($rule:ident, $default_config:expr) => {
                 out.add(
                     stringify!($rule),
-                    Box::new(PatternLinterCache::new(
-                        $rule::default(),
-                        NonZero::new(1000).unwrap(),
-                    )),
+                    Box::new(PatternLinterCache::new_default_size($rule::default())),
                 );
                 out.config
                     .set_rule_enabled(stringify!($rule), $default_config);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -103,7 +103,7 @@ pub use number_suffix_capitalization::NumberSuffixCapitalization;
 pub use out_of_date::OutOfDate;
 pub use oxford_comma::OxfordComma;
 pub use oxymorons::Oxymorons;
-pub use pattern_linter::{PatternLinter, PatternLinterCache};
+pub use pattern_linter::PatternLinter;
 pub use pique_interest::PiqueInterest;
 pub use plural_conjugate::PluralConjugate;
 pub use possessive_your::PossessiveYour;

--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -1,5 +1,4 @@
 use super::{LintGroup, MapPhraseLinter, PatternLinterCache};
-use std::num::NonZero;
 
 /// Produce a [`LintGroup`] that looks for errors in common phrases.
 /// Comes pre-configured with the recommended default settings.
@@ -13,14 +12,13 @@ pub fn lint_group() -> LintGroup {
             $(
                 $group.add(
                     $name,
-                    Box::new(PatternLinterCache::new(
+                    Box::new(PatternLinterCache::new_default_size(
                         MapPhraseLinter::new_exact_phrases(
                             $input,
                             $corrections,
                             $hint,
                             $description
                         ),
-                        NonZero::new(1000).unwrap()
                     )),
                 );
             )+

--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -1,4 +1,4 @@
-use super::{LintGroup, MapPhraseLinter, PatternLinterCache};
+use super::{LintGroup, MapPhraseLinter};
 
 /// Produce a [`LintGroup`] that looks for errors in common phrases.
 /// Comes pre-configured with the recommended default settings.
@@ -10,16 +10,16 @@ pub fn lint_group() -> LintGroup {
             $($name:expr => ($input:expr, $corrections:expr, $hint:expr, $description:expr)),+ $(,)?
         }) => {
             $(
-                $group.add(
+                $group.add_pattern_linter(
                     $name,
-                    Box::new(PatternLinterCache::new_default_size(
+                    Box::new(
                         MapPhraseLinter::new_exact_phrases(
                             $input,
                             $corrections,
                             $hint,
                             $description
                         ),
-                    )),
+                    ),
                 );
             )+
         };

--- a/harper-core/src/linting/proper_noun_capitalization_linters.rs
+++ b/harper-core/src/linting/proper_noun_capitalization_linters.rs
@@ -8,7 +8,6 @@ use crate::parsers::PlainEnglish;
 use crate::patterns::{ExactPhrase, Pattern, PatternMap};
 use crate::{Dictionary, Document};
 use crate::{Token, TokenStringExt};
-use std::num::NonZero;
 use std::sync::Arc;
 
 /// A linter that corrects the capitalization of multi-word proper nouns.
@@ -120,13 +119,12 @@ fn lint_group_from_json(json: &str, dictionary: Arc<impl Dictionary + 'static>) 
     for (key, rule) in rules.into_iter() {
         group.add(
             key,
-            Box::new(PatternLinterCache::new(
+            Box::new(PatternLinterCache::new_default_size(
                 ProperNounCapitalizationLinter::new_strs(
                     rule.canonical,
                     rule.description,
                     dictionary.clone(),
                 ),
-                NonZero::new(1000).unwrap(),
             )),
         );
     }

--- a/harper-core/src/linting/proper_noun_capitalization_linters.rs
+++ b/harper-core/src/linting/proper_noun_capitalization_linters.rs
@@ -1,7 +1,6 @@
 use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
 
-use super::pattern_linter::PatternLinterCache;
 use super::{Lint, LintKind, Suggestion};
 use super::{LintGroup, PatternLinter};
 use crate::parsers::PlainEnglish;
@@ -117,14 +116,12 @@ fn lint_group_from_json(json: &str, dictionary: Arc<impl Dictionary + 'static>) 
     let rules: HashMap<String, RuleEntry> = serde_json::from_str(json).unwrap();
 
     for (key, rule) in rules.into_iter() {
-        group.add(
+        group.add_pattern_linter(
             key,
-            Box::new(PatternLinterCache::new_default_size(
-                ProperNounCapitalizationLinter::new_strs(
-                    rule.canonical,
-                    rule.description,
-                    dictionary.clone(),
-                ),
+            Box::new(ProperNounCapitalizationLinter::new_strs(
+                rule.canonical,
+                rule.description,
+                dictionary.clone(),
             )),
         );
     }

--- a/harper-ls/Cargo.toml
+++ b/harper-ls/Cargo.toml
@@ -27,6 +27,7 @@ resolve-path = "0.1.0"
 open = "5.3.0"
 futures = "0.3.31"
 serde = { version = "1.0.218", features = ["derive"] }
+indexmap = { version = "2.7.1", features = ["serde"] }
 
 [features]
 default = []

--- a/harper-ls/src/main.rs
+++ b/harper-ls/src/main.rs
@@ -39,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
     let subscriber = FmtSubscriber::builder()
         .map_writer(move |_| stderr)
         .with_ansi(false)
-        .with_max_level(Level::WARN)
+        .with_max_level(Level::INFO)
         .finish();
 
     tracing::subscriber::set_global_default(subscriber)?;

--- a/harper-ls/src/main.rs
+++ b/harper-ls/src/main.rs
@@ -39,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
     let subscriber = FmtSubscriber::builder()
         .map_writer(move |_| stderr)
         .with_ansi(false)
-        .with_max_level(Level::INFO)
+        .with_max_level(Level::WARN)
         .finish();
 
     tracing::subscriber::set_global_default(subscriber)?;

--- a/packages/harper.js/src/Linter.test.ts
+++ b/packages/harper.js/src/Linter.test.ts
@@ -206,18 +206,3 @@ test('Linters have the same config format', async () => {
 		expect(config).toBeTypeOf('object');
 	}
 });
-
-test('Linters have the same JSON config format', async () => {
-	const configs = [];
-
-	for (const Linter of Object.values(linters)) {
-		const linter = new Linter();
-
-		configs.push(await linter.getLintConfigAsJSON());
-	}
-
-	for (const config of configs) {
-		expect(config).toEqual(configs[0]);
-		expect(config).toBeTypeOf('string');
-	}
-});


### PR DESCRIPTION
# Issues 

#472 is now the largest performance problem to address. After the work in this PR, running the Matcher now accounts for 50% of total incremental lint time.

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

In a private discussion with @nyonson, I was informed that Harper was starting to slow down on one of his larger documents. This was a result of large cache misses (and expensive cache lookups). 

This weekend, I sat down for a few hours to iron them out. As a result, we saw a further 50% improvement on incremental lint times, as well as an improvement to initial lint times (thanks to less expensive cache misses).

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually on my machine. I'll be adding some more integration tests. In the meantime, @lukasmwerner, would you mind running this branch for your notes? I want to identify any possible configuration problems.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
