### PR TITLE
Build against an older GLIBC version

### DIFF
--- a/.github/workflows/build_harper_binaries.yml
+++ b/.github/workflows/build_harper_binaries.yml
@@ -95,7 +95,7 @@ jobs:
           command: ${{ matrix.platform.command }}
           target: ${{ matrix.platform.target }}
           args: "--locked --release --bin ${{ matrix.platform.project }}"
-          force-use-cross: true
+          force-use-cross: ${{ matrix.platform.os == 'ubuntu-latest' }}
           strip: true
       - name: Package as archive
         shell: bash

--- a/.github/workflows/build_harper_binaries.yml
+++ b/.github/workflows/build_harper_binaries.yml
@@ -90,12 +90,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Build binary
-        uses: houseabsolute/actions-rust-cross@v0
+        uses: houseabsolute/actions-rust-cross@v1
         with:
           command: ${{ matrix.platform.command }}
           target: ${{ matrix.platform.target }}
           args: "--locked --release --bin ${{ matrix.platform.project }}"
           force-use-cross: true
+          strip: true
       - name: Package as archive
         shell: bash
         run: |

--- a/.github/workflows/build_harper_binaries.yml
+++ b/.github/workflows/build_harper_binaries.yml
@@ -95,7 +95,7 @@ jobs:
           command: ${{ matrix.platform.command }}
           target: ${{ matrix.platform.target }}
           args: "--locked --release --bin ${{ matrix.platform.project }}"
-          strip: true
+          force-use-cross: true
       - name: Package as archive
         shell: bash
         run: |

--- a/.github/workflows/package_vscode_plugin.yml
+++ b/.github/workflows/package_vscode_plugin.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           target: ${{ matrix.platform.rust_target }}
           args: "--locked --release --bin harper-ls"
-          force-use-cross: true
+          force-use-cross: ${{ matrix.platform.os == 'ubuntu-latest' }}
           strip: true
       - name: Package extension
         shell: bash

--- a/.github/workflows/package_vscode_plugin.yml
+++ b/.github/workflows/package_vscode_plugin.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           target: ${{ matrix.platform.rust_target }}
           args: "--locked --release --bin harper-ls"
-          strip: true
+          force-use-cross: true
       - name: Package extension
         shell: bash
         run: |

--- a/.github/workflows/package_vscode_plugin.yml
+++ b/.github/workflows/package_vscode_plugin.yml
@@ -36,11 +36,12 @@ jobs:
         with:
           node-version-file: ".node-version"
       - name: Build harper-ls
-        uses: houseabsolute/actions-rust-cross@v0
+        uses: houseabsolute/actions-rust-cross@v1
         with:
           target: ${{ matrix.platform.rust_target }}
           args: "--locked --release --bin harper-ls"
           force-use-cross: true
+          strip: true
       - name: Package extension
         shell: bash
         run: |

--- a/.github/workflows/release_harper_binaries.yml
+++ b/.github/workflows/release_harper_binaries.yml
@@ -89,12 +89,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Build binary
-        uses: houseabsolute/actions-rust-cross@v0
+        uses: houseabsolute/actions-rust-cross@v1
         with:
           command: ${{ matrix.platform.command }}
           target: ${{ matrix.platform.target }}
           args: "--locked --release --bin ${{ matrix.platform.project }}"
           force-use-cross: true
+          strip: true
       - name: Package as archive
         shell: bash
         run: |

--- a/.github/workflows/release_harper_binaries.yml
+++ b/.github/workflows/release_harper_binaries.yml
@@ -94,7 +94,7 @@ jobs:
           command: ${{ matrix.platform.command }}
           target: ${{ matrix.platform.target }}
           args: "--locked --release --bin ${{ matrix.platform.project }}"
-          force-use-cross: true
+          force-use-cross: ${{ matrix.platform.os == 'ubuntu-latest' }}
           strip: true
       - name: Package as archive
         shell: bash

--- a/.github/workflows/release_harper_binaries.yml
+++ b/.github/workflows/release_harper_binaries.yml
@@ -94,7 +94,7 @@ jobs:
           command: ${{ matrix.platform.command }}
           target: ${{ matrix.platform.target }}
           args: "--locked --release --bin ${{ matrix.platform.project }}"
-          strip: true
+          force-use-cross: true
       - name: Package as archive
         shell: bash
         run: |

--- a/.github/workflows/release_vscode_plugin.yml
+++ b/.github/workflows/release_vscode_plugin.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           target: ${{ matrix.platform.rust_target }}
           args: "--locked --release --bin harper-ls"
-          force-use-cross: true
+          force-use-cross: ${{ matrix.platform.os == 'ubuntu-latest' }}
           strip: true
       - name: Package extension
         id: package_extension

--- a/.github/workflows/release_vscode_plugin.yml
+++ b/.github/workflows/release_vscode_plugin.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           target: ${{ matrix.platform.rust_target }}
           args: "--locked --release --bin harper-ls"
-          strip: true
+          force-use-cross: true
       - name: Package extension
         id: package_extension
         shell: bash

--- a/.github/workflows/release_vscode_plugin.yml
+++ b/.github/workflows/release_vscode_plugin.yml
@@ -35,11 +35,12 @@ jobs:
         with:
           node-version-file: ".node-version"
       - name: Build harper-ls
-        uses: houseabsolute/actions-rust-cross@v0
+        uses: houseabsolute/actions-rust-cross@v1
         with:
           target: ${{ matrix.platform.rust_target }}
           args: "--locked --release --bin harper-ls"
           force-use-cross: true
+          strip: true
       - name: Package extension
         id: package_extension
         shell: bash


### PR DESCRIPTION
# Issues 
#850 
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

Up until recently, we've been building the Linux binaries on Ubuntu 20.04 (which means they get built with the right GLIBC version). Recently, GitHub has https://github.com/actions/runner-images/issues/11101. I updated the image but neglected to consider this as a side effect. 

Since we're already using `cross` to build our binaries, it should be pretty easy to use it to build against an older GLIBC version (while still using `ubuntu-latest`).

## Relevant Links

- [Cross' Supported Targets Table](https://github.com/cross-rs/cross#supported-targets)

# How Has This Been Tested?

Since the problem is in our CI, the only way to test is to run the builds here, in GitHub Actions. 

I'll then try running the built binaries inside a local `ubuntu:20.04` Docker container.

# Checklist

- [x] I have performed a self-review of my own code