### PR TITLE
feat: Added Linux musl compilations

### DIFF
--- a/.github/workflows/build_harper_binaries.yml
+++ b/.github/workflows/build_harper_binaries.yml
@@ -48,6 +48,20 @@ jobs:
             bin: harper-ls
             name: harper-ls-aarch64-unknown-linux-gnu.tar.gz
             command: build
+          - release_for: Linux-x86_64-musl
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            project: harper-ls
+            bin: harper-ls
+            name: harper-ls-x86_64-unknown-linux-musl.tar.gz
+            command: build
+          - release_for: Linux-aarch64-musl
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            project: harper-ls
+            bin: harper-ls
+            name: harper-ls-aarch64-unknown-linux-musl.tar.gz
+            command: build
 
           - release_for: Windows-x86_64
             os: windows-latest
@@ -83,6 +97,20 @@ jobs:
             project: harper-cli
             bin: harper-cli
             name: harper-cli-aarch64-unknown-linux-gnu.tar.gz
+            command: build
+          - release_for: Linux-x86_64-musl
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            project: harper-cli
+            bin: harper-cli
+            name: harper-cli-x86_64-unknown-linux-musl.tar.gz
+            command: build
+          - release_for: Linux-aarch64-musl
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            project: harper-cli
+            bin: harper-cli
+            name: harper-cli-aarch64-unknown-linux-musl.tar.gz
             command: build
 
     runs-on: ${{ matrix.platform.os }}

--- a/.github/workflows/release_harper_binaries.yml
+++ b/.github/workflows/release_harper_binaries.yml
@@ -47,6 +47,20 @@ jobs:
             bin: harper-ls
             name: harper-ls-aarch64-unknown-linux-gnu.tar.gz
             command: build
+          - release_for: Linux-x86_64-musl
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            project: harper-ls
+            bin: harper-ls
+            name: harper-ls-x86_64-unknown-linux-musl.tar.gz
+            command: build
+          - release_for: Linux-aarch64-musl
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            project: harper-ls
+            bin: harper-ls
+            name: harper-ls-aarch64-unknown-linux-musl.tar.gz
+            command: build
 
           - release_for: Windows-x86_64
             os: windows-latest
@@ -82,6 +96,20 @@ jobs:
             project: harper-cli
             bin: harper-cli
             name: harper-cli-aarch64-unknown-linux-gnu.tar.gz
+            command: build
+          - release_for: Linux-x86_64-musl
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            project: harper-cli
+            bin: harper-cli
+            name: harper-cli-x86_64-unknown-linux-musl.tar.gz
+            command: build
+          - release_for: Linux-aarch64-musl
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            project: harper-cli
+            bin: harper-cli
+            name: harper-cli-aarch64-unknown-linux-musl.tar.gz
             command: build
 
     runs-on: ${{ matrix.platform.os }}


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
**Branch created out of #877.**

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->
This PR adds compilation support for Linux musl. **Depends on #877.**

`cross` supports g++ for musl targets, but the only way to make `actions-rust-cross` successfully compile Harper is to enable `force-use-cross` introduced with v1. After a few hours of headache, I spotted #877 by @elijah-potter which simplified my commit quite well.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->
N/A

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
See https://github.com/kiding/harper/actions.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
