### PR TITLE
docs(ls): give example config that disables `sentence_capitalization`

### DIFF
--- a/packages/web/src/routes/docs/integrations/neovim/+page.md
+++ b/packages/web/src/routes/docs/integrations/neovim/+page.md
@@ -20,7 +20,7 @@ require('lspconfig').harper_ls.setup {}
 
 Additionally, you can also configure things like which linters to use or how you want code actions to appear. Below is an example config where everything is set to their default values:
 
-```lua title=inti.lua
+```lua title=init.lua
 require('lspconfig').harper_ls.setup {
   settings = {
     ["harper-ls"] = {
@@ -57,6 +57,24 @@ This example only contains some of the available linters, check out our [rules p
 :::
 
 For more information on what each of these configs do, you can head over to the [configuration section](./language-server#Configuration) of our `harper-ls` documentation.
+
+## Common Config Changes
+
+Programmers often find certain rules have too much of a hair-trigger.
+The below config is a simple cut-and-paste that gives you much fewer false-positives.
+
+```lua title=init.lua
+require('lspconfig').harper_ls.setup {
+  settings = {
+    ["harper-ls"] = {
+      linters = {
+        SentenceCapitalization = false,
+        SpellCheck = false
+      }
+    }
+  }
+}
+```
 
 ## Additional Links
 


### PR DESCRIPTION
# Issues 

I saw this [comment on Reddit](https://www.reddit.com/r/neovim/comments/1j7ookn/comment/mgz1tb2/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button), which makes me believe this isn't as well documented as it could be.

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

Added a little example section for Neovim users who want to disable `sentence_capitalization`.

# Demo
![image](https://github.com/user-attachments/assets/4a36d746-e603-4dff-a1e4-b4c61de0792e)
<!-- Please describe how you tested your changes. -->