### PR TITLE
fix(core): insert paragraph breaks after code blocks

### DIFF
--- a/harper-core/src/parsers/mod.rs
+++ b/harper-core/src/parsers/mod.rs
@@ -109,7 +109,7 @@ mod tests {
                 Space(1),
                 TokenKind::blank_word(),
                 Punctuation(Punctuation::Comma),
-                Newline(2),
+                ParagraphBreak,
                 TokenKind::blank_word(),
                 Space(1),
                 TokenKind::blank_word(),


### PR DESCRIPTION
# Issues 

#880

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

It looks like Harper was omitting the paragraph break after the code block, which meant that it inferred the code block's `Unlintable` token to part of the sentence. This PR make a few tweaks to fix that behavior and adds a test for it.

# How Has This Been Tested?

An additional unit test, as well as manual test shots.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
