### PR TITLE
fix: two spelling mistakes based on homophones

### DIFF
--- a/harper-core/src/linting/sentence_capitalization.rs
+++ b/harper-core/src/linting/sentence_capitalization.rs
@@ -136,7 +136,7 @@ mod tests {
     }
 
     #[test]
-    fn unphased_unlintable() {
+    fn unfazed_unlintable() {
         assert_lint_count(
             "the linter should not be affected by `this` unlintable.",
             SentenceCapitalization,
@@ -145,7 +145,7 @@ mod tests {
     }
 
     #[test]
-    fn unphased_ellipsis() {
+    fn unfazed_ellipsis() {
         assert_lint_count(
             "the linter should not be affected by... that ellipsis.",
             SentenceCapitalization,
@@ -154,7 +154,7 @@ mod tests {
     }
 
     #[test]
-    fn unphased_comma() {
+    fn unfazed_comma() {
         assert_lint_count(
             "the linter should not be affected by, that comma.",
             SentenceCapitalization,

--- a/harper-core/src/punctuation.rs
+++ b/harper-core/src/punctuation.rs
@@ -68,7 +68,7 @@ pub enum Punctuation {
     /// `@`
     At,
     /// `^`
-    Carrot,
+    Caret,
     /// `+`
     Plus,
     Currency(Currency),
@@ -110,7 +110,7 @@ impl Punctuation {
             '–' => Punctuation::EnDash,
             '—' => Punctuation::EmDash,
             '…' => Punctuation::Ellipsis,
-            '^' => Punctuation::Carrot,
+            '^' => Punctuation::Caret,
             '+' => Punctuation::Plus,
             '|' => Punctuation::Pipe,
             '_' => Punctuation::Underscore,


### PR DESCRIPTION
# Issues 
N/A

# Description
I spotted two homophone-spellos in the source:
- carrots are root vegetables
- carets are `^`
- unphased means not in phases
- unfazed means remaining calm in the face of adversity

# How Has This Been Tested?
`cargo test` runs with no failures.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
