### PR TITLE
feat: linter for "as far back as" to replace "as early back as"

### DIFF
--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -1205,11 +1205,7 @@ mod tests {
 
     #[test]
     fn detect_as_early_back_as() {
-        assert_suggestion_result(
-            "as early back as",
-            lint_group(),
-            "as far back as",
-        );
+        assert_suggestion_result("as early back as", lint_group(), "as far back as");
     }
 
     #[test]

--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -721,6 +721,12 @@ pub fn lint_group() -> LintGroup {
             "Retain `monumentous` for jocular effect. Otherwise `momentous` indicates great signifcance while `monumental` indicates imposing size.",
             "Advises using `momentous` or `monumental` instead of `monumentous` for serious usage."
         ),
+        "AsFarBackAs" => (
+            ["as early back as"],
+            ["as far back as"],
+            "Use `as far back as` for referring to a time in the past.",
+            "Corrects nonstandard `as early back as` to `as far back as`."
+        ),
     });
 
     group.set_all_rules_to(Some(true));
@@ -1194,6 +1200,24 @@ mod tests {
             "I think that would be a monumentous step in the right direction, and would DEFINATLY turn heads in not just the music industry, but every ...",
             lint_group(),
             "I think that would be a momentous step in the right direction, and would DEFINATLY turn heads in not just the music industry, but every ...",
+        );
+    }
+
+    #[test]
+    fn detect_as_early_back_as() {
+        assert_suggestion_result(
+            "as early back as",
+            lint_group(),
+            "as far back as",
+        );
+    }
+
+    #[test]
+    fn detect_as_early_back_as_real_world() {
+        assert_suggestion_result(
+            "skin overrides also supports a wide variety of minecraft versions - as early back as 1.14.4.",
+            lint_group(),
+            "skin overrides also supports a wide variety of minecraft versions - as far back as 1.14.4.",
         );
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description
I just heard "as early back as" for the first time in a YouTube video. It sounded strange to me but I found a few instances on GitHub and many on the rest of the Internet. But it's several orders of magnitude rarer than "as far back as".

# How Has This Been Tested?
- I added an atomic unit test with just this phrase.
- I added a real world unit test with an actual sentence I found on GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes

# Other examples
- 28 Sept 2019 — Issue Details. Electron Version: 6.0.10 (but happening **as early back as** 1.x.x and 2.x.x for us).
- skin overrides also supports a wide variety of minecraft versions - **as early back as** 1.14.4. note that only versions since 1.19.4 have the ui, and only ...
- ... **as early back as** the 1930s with The Man Who Awoke. However, the technology has been too expensive for it to really become commonplace. Today we live in a ...
