### PR TITLE
feat: expand the "get rid off" lint to cover "get ride of"

### DIFF
--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -374,31 +374,31 @@ pub fn lint_group() -> LintGroup {
             "Corrects `hunger pain` to `hunger pang`."
         ),
         "GetRidOff" => (
-            ["get rid off"],
+            ["get rid off", "get ride of", "get ride off"],
             ["get rid of"],
             "Did you mean `get rid of`?",
             "Ensures `get rid of` is used instead of `get rid off`."
         ),
         "GetsRidOff" => (
-            ["gets rid off"],
+            ["gets rid off", "gets ride of", "gets ride off"],
             ["gets rid of"],
             "Did you mean `gets rid of`?",
             "Ensures `gets rid of` is used instead of `gets rid off`."
             ),
         "GettingRidOff" => (
-            ["getting rid off"],
+            ["getting rid off", "getting ride of", "getting ride off"],
             ["getting rid of"],
             "Did you mean `getting rid of`?",
             "Ensures `getting rid of` is used instead of `getting rid off`."
         ),
         "GotRidOff" => (
-            ["got rid off"],
+            ["got rid off", "got ride of", "got ride off"],
             ["got rid of"],
             "Did you mean `got rid of`?",
             "Ensures `got rid of` is used instead of `got rid off`."
         ),
         "GottenRidOff" => (
-            ["gotten rid off"],
+            ["gotten rid off", "gotten ride of", "gotten ride off"],
             ["gotten rid of"],
             "Did you mean `gotten rid of`?",
             "Ensures `gotten rid of` is used instead of `gotten rid off`."
@@ -778,6 +778,60 @@ mod tests {
             "The baX variable thingy I have gotten rid off, that was due to a bad character in the encryption key.",
             lint_group(),
             "The baX variable thingy I have gotten rid of, that was due to a bad character in the encryption key.",
+        );
+    }
+
+    #[test]
+    fn get_ride_of() {
+        assert_suggestion_result(
+            "Get ride of \"WARNING Deprecated: markdown_github. Use gfm\"",
+            lint_group(),
+            "Get rid of \"WARNING Deprecated: markdown_github. Use gfm\"",
+        );
+    }
+
+    #[test]
+    fn get_ride_off() {
+        assert_suggestion_result(
+            "This exact hack was what I trying to get ride off. ",
+            lint_group(),
+            "This exact hack was what I trying to get rid of. ",
+        );
+    }
+
+    #[test]
+    fn getting_ride_of() {
+        assert_suggestion_result(
+            "If you have any idea how to fix this without getting ride of bootstrap I would be thankfull.",
+            lint_group(),
+            "If you have any idea how to fix this without getting rid of bootstrap I would be thankfull.",
+        );
+    }
+
+    #[test]
+    fn gets_ride_of() {
+        assert_suggestion_result(
+            ".. gets ride of a central back-end/server and eliminates all the risks associated to it.",
+            lint_group(),
+            ".. gets rid of a central back-end/server and eliminates all the risks associated to it.",
+        );
+    }
+
+    #[test]
+    fn gotten_ride_of() {
+        assert_suggestion_result(
+            "I have gotten ride of the react-table and everything works just fine.",
+            lint_group(),
+            "I have gotten rid of the react-table and everything works just fine.",
+        );
+    }
+
+    #[test]
+    fn got_ride_of() {
+        assert_suggestion_result(
+            "I had to adjust the labels on the free version because you guys got ride of ...",
+            lint_group(),
+            "I had to adjust the labels on the free version because you guys got rid of ...",
         );
     }
 


### PR DESCRIPTION
# Issues 
N/A

# Description
I noticed my fingers typing "get ride of" when I wanted to write "get rid of" so I checked GitHub and it's very common, so I'm adding it to the "get rid off" lint.

# How Has This Been Tested?
I added unit tests based on all the variants of "get ride of" or "get ride off" that I could find examples of on GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
