### PR TITLE
feat: linter for "each and everyone"

### DIFF
--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -751,6 +751,12 @@ pub fn lint_group() -> LintGroup {
             "Use `as far back as` for referring to a time in the past.",
             "Corrects nonstandard `as early back as` to `as far back as`."
         ),
+        "EachAndEveryOne" => (
+            ["each and everyone"],
+            ["each and every one"],
+            "Use `each and every one` for referring to a group of people or things.",
+            "Corrects `each and everyone` to `each and every one`."
+        ),
     });
 
     group.set_all_rules_to(Some(true));
@@ -1294,6 +1300,20 @@ mod tests {
             "skin overrides also supports a wide variety of minecraft versions - as early back as 1.14.4.",
             lint_group(),
             "skin overrides also supports a wide variety of minecraft versions - as far back as 1.14.4.",
+        );
+    }
+
+    #[test]
+    fn detect_each_and_everyone() {
+        assert_suggestion_result("each and everyone", lint_group(), "each and every one");
+    }
+
+    #[test]
+    fn detect_each_and_everyone_real_world() {
+        assert_suggestion_result(
+            "I have modified each and everyone of them to keep only the best of the best!",
+            lint_group(),
+            "I have modified each and every one of them to keep only the best of the best!",
         );
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description
Just the kind of thing phrase_corrections was intended for. Very common on GitHub:
- This community will help **each and everyone** who is facing issue in opensource and share job opportunities, resources, etc. 
- ... **each and everyone** of them is not a good idea and also just not feasible.
- ... for them to ship it same as they already do for vscode (so that not **each and everyone** has to ...
- Composing a state which can be scoped/pulledback to allow **each and everyone** of them to work off of the same piece of state can prove to be challenging.

# References
- [Is it each and every one or everyone?](https://quillbot.com/blog/frequently-asked-questions/is-it-each-and-every-one-or-everyone/)
- [Is "each and everyone" redundant? - English ...](https://english.stackexchange.com/questions/309813/is-each-and-everyone-redundant)
- [Everyone vs Every One | Difference & Examples - QuillBot](https://quillbot.com/blog/commonly-confused-words/everyone-vs-every-one/)
- [Everyone vs. Every One–What's the Difference](https://www.grammarly.com/blog/commonly-confused-words/everyone-vs-every-one/)
- [EACH AND EVERY ONE | English meaning](https://dictionary.cambridge.org/dictionary/english/each-and-every-one)

# How Has This Been Tested?
- I added an atomic unit test for just this phrase on its own.
- I added a real-world unit test for the phrase in context as found on GitHub.
- I ran `cargo test` which resulted in no fails

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
