### PR TITLE
hotfix(core): properly store spans in `PatternLinter` cache

### DIFF
--- a/harper-core/src/span.rs
+++ b/harper-core/src/span.rs
@@ -2,6 +2,8 @@ use std::ops::Range;
 
 use serde::{Deserialize, Serialize};
 
+use crate::CharStringExt;
+
 /// A window in a [`char`] sequence.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct Span {
@@ -57,7 +59,14 @@ impl Span {
 
     /// Get the associated content. Will panic if any aspect is invalid.
     pub fn get_content<'a>(&self, source: &'a [char]) -> &'a [char] {
-        self.try_get_content(source).unwrap()
+        match self.try_get_content(source) {
+            Some(v) => v,
+            None => panic!(
+                "Could not get position {:?} within \"{}\"",
+                self,
+                source.to_string()
+            ),
+        }
     }
 
     pub fn get_content_string(&self, source: &[char]) -> String {


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

The `PatternLinter` cache previously assumed that document chunks would never move. This was incorrect and has been rectified.

# Demo

Before this PR, lint results would slide around as the document would be modified.

![image](https://github.com/user-attachments/assets/6c8722e7-ed06-432e-9635-0714728ba120)

Now they're rock-solid.

![image](https://github.com/user-attachments/assets/d39c0560-ddba-4e21-b019-ee11eae6b8da)


# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
