### PR TITLE
fix(vscode-plugin): ignore non-existent ".git" files, support untitled/unsaved files on VS Code

### DIFF
--- a/harper-ls/src/backend.rs
+++ b/harper-ls/src/backend.rs
@@ -51,6 +51,11 @@ impl Backend {
 
     /// Load a specific file's dictionary
     async fn load_file_dictionary(&self, url: &Url) -> anyhow::Result<MutableDictionary> {
+        // VS Code's unsaved documents have "untitled" scheme
+        if url.scheme() == "untitled" {
+            return Ok(MutableDictionary::new());
+        }
+
         let path = self
             .get_file_dict_path(url)
             .await

--- a/packages/vscode-plugin/src/extension.ts
+++ b/packages/vscode-plugin/src/extension.ts
@@ -31,7 +31,13 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
 	clientOptions.documentSelector = manifest.activationEvents
 		.filter((e) => e.startsWith('onLanguage:'))
-		.map((e) => ({ language: e.split(':')[1], scheme: 'file' }));
+		.flatMap((e) => {
+			const language = e.split(':')[1];
+			return [
+				{ language, scheme: 'file' },
+				{ language, scheme: 'untitled' }
+			];
+		});
 
 	clientOptions.outputChannel = window.createOutputChannel('Harper');
 	context.subscriptions.push(clientOptions.outputChannel);

--- a/packages/vscode-plugin/src/extension.ts
+++ b/packages/vscode-plugin/src/extension.ts
@@ -31,7 +31,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
 	clientOptions.documentSelector = manifest.activationEvents
 		.filter((e) => e.startsWith('onLanguage:'))
-		.map((e) => ({ language: e.split(':')[1] }));
+		.map((e) => ({ language: e.split(':')[1], scheme: 'file' }));
 
 	clientOptions.outputChannel = window.createOutputChannel('Harper');
 	context.subscriptions.push(clientOptions.outputChannel);

--- a/packages/vscode-plugin/src/tests/suite/helper.ts
+++ b/packages/vscode-plugin/src/tests/suite/helper.ts
@@ -27,6 +27,13 @@ export async function openFile(...pathSegments: string[]): Promise<Uri> {
 	return uri;
 }
 
+export async function openUntitled(text: string): Promise<Uri> {
+	const document = await workspace.openTextDocument();
+	const editor = await window.showTextDocument(document);
+	await editor.edit((editBuilder) => editBuilder.insert(new Position(0, 0), text));
+	return document.uri;
+}
+
 export function getActualDiagnostics(resource: Uri): Diagnostic[] {
 	return languages.getDiagnostics(resource).filter((d) => d.source === 'Harper');
 }

--- a/packages/vscode-plugin/src/tests/suite/integration.test.ts
+++ b/packages/vscode-plugin/src/tests/suite/integration.test.ts
@@ -45,12 +45,18 @@ describe('Integration >', () => {
 		);
 	});
 
-	it('does nothing for untitled', async () => {
+	it('gives correct diagnostics for untitled', async () => {
 		const untitledUri = await openUntitled('Errorz');
+
+		// Wait for `harper-ls` to send diagnostics
+		await sleep(500);
 
 		compareActualVsExpectedDiagnostics(
 			getActualDiagnostics(untitledUri),
-			createExpectedDiagnostics()
+			createExpectedDiagnostics({
+				message: 'Did you mean to spell “Errorz” this way?',
+				range: createRange(0, 0, 0, 6)
+			})
 		);
 	});
 

--- a/packages/vscode-plugin/src/tests/suite/integration.test.ts
+++ b/packages/vscode-plugin/src/tests/suite/integration.test.ts
@@ -9,6 +9,7 @@ import {
 	createRange,
 	getActualDiagnostics,
 	openFile,
+	openUntitled,
 	sleep
 } from './helper';
 
@@ -95,5 +96,14 @@ describe('Integration >', () => {
 		// Restore and reopen deleted file
 		await workspace.fs.writeFile(markdownUri, markdownContent);
 		await openFile('integration.md');
+	});
+
+	it('does nothing for untitled', async () => {
+		const untitledUri = await openUntitled('Errorz');
+
+		compareActualVsExpectedDiagnostics(
+			getActualDiagnostics(untitledUri),
+			createExpectedDiagnostics()
+		);
 	});
 });

--- a/packages/vscode-plugin/src/tests/suite/integration.test.ts
+++ b/packages/vscode-plugin/src/tests/suite/integration.test.ts
@@ -29,7 +29,7 @@ describe('Integration >', () => {
 		expect(harper.isActive).toBe(true);
 	});
 
-	it('gives correct diagnostics', () => {
+	it('gives correct diagnostics for files', () => {
 		compareActualVsExpectedDiagnostics(
 			getActualDiagnostics(markdownUri),
 			createExpectedDiagnostics(
@@ -42,6 +42,15 @@ describe('Integration >', () => {
 					range: createRange(2, 26, 2, 32)
 				}
 			)
+		);
+	});
+
+	it('does nothing for untitled', async () => {
+		const untitledUri = await openUntitled('Errorz');
+
+		compareActualVsExpectedDiagnostics(
+			getActualDiagnostics(untitledUri),
+			createExpectedDiagnostics()
 		);
 	});
 
@@ -96,14 +105,5 @@ describe('Integration >', () => {
 		// Restore and reopen deleted file
 		await workspace.fs.writeFile(markdownUri, markdownContent);
 		await openFile('integration.md');
-	});
-
-	it('does nothing for untitled', async () => {
-		const untitledUri = await openUntitled('Errorz');
-
-		compareActualVsExpectedDiagnostics(
-			getActualDiagnostics(untitledUri),
-			createExpectedDiagnostics()
-		);
 	});
 });


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
Fixes #487. Fixes #382.

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

This PR restricts `clientOptions.documentSelector` to the `file` and **`untitled` scheme, and changes `load_file_dictionary` to always succeed on the `untitled` scheme.**  This will prevent the non-existent `.git` files from showing up in Problems since they use `gitfs` scheme[^1], **and make Harper work on untitled/unsaved files. `HarperAddToFileDict` should fail as expected.**

VS Code's documentation[^2] suggests there may be other schemes like ~~`untitled`,~~ `http`, `ftp`, etc. Harper never worked with `untitled` with an error saying `ERROR harper_ls::backend: Unable to generate the file dictionary.` Harper's `file_dict_name` assumes `url` is a file path, so this shouldn't break any preexisting feature.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->
N/A

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
To test for `untitled`: open a new document, type `Errorz`, check Output, see ~~no error.~~ **one error saying `Did you mean to spell “Errorz” this way?`.**
To test for `.git`: 
```bash
mkdir test && cd test
git init
echo 'Errorz' > test.txt
git add test.txt
code .
```
Check Problems, see no error for `test.txt.git`.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes

[^1]: https://github.com/microsoft/vscode/pull/86674
[^2]: https://code.visualstudio.com/api/references/document-selector