### PR TITLE
feat: insert newline automatically in `just addnoun`

### DIFF
--- a/justfile
+++ b/justfile
@@ -266,7 +266,8 @@ addnoun noun:
   fi
 
   # Echo the noun with its flags to the dictionary file
-  echo "{{noun}}/$flags" >> $DICT_FILE
+  [[ -s $DICT_FILE && -n $(tail -c1 "$DICT_FILE") ]] && echo >> "$DICT_FILE"
+  echo "{{noun}}/$flags" >> "$DICT_FILE"
 
 # Search Harper's curated dictionary for a specific word
 searchdictfor word:


### PR DESCRIPTION
# Issues 
#904
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

I've modified the `just addnoun` script to automatically insert a newline if one is not present at the end of the dictionary.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
