### PR TITLE
fix(core): reduce ambiguity for `AvoidContraction`

### DIFF
--- a/harper-core/src/linting/pronoun_contraction/avoid_contraction.rs
+++ b/harper-core/src/linting/pronoun_contraction/avoid_contraction.rs
@@ -11,9 +11,11 @@ pub struct AvoidContraction {
 
 impl Default for AvoidContraction {
     fn default() -> Self {
-        let pattern = SequencePattern::aco("you're")
-            .then_whitespace()
-            .then(|tok: &Token, _source: &[char]| tok.kind.is_noun() && !tok.kind.is_adjective());
+        let pattern = SequencePattern::aco("you're").then_whitespace().then(
+            |tok: &Token, _source: &[char]| {
+                tok.kind.is_nominal() && !tok.kind.is_likely_homograph()
+            },
+        );
 
         Self {
             pattern: Box::new(pattern),

--- a/harper-core/src/linting/pronoun_contraction/mod.rs
+++ b/harper-core/src/linting/pronoun_contraction/mod.rs
@@ -57,4 +57,19 @@ mod tests {
             0,
         );
     }
+
+    #[test]
+    fn issue_576() {
+        assert_lint_count(
+            "If you're not happy you try again.",
+            PronounContraction::default(),
+            0,
+        );
+        assert_lint_count("No you're not.", PronounContraction::default(), 0);
+        assert_lint_count(
+            "Even if you're not fluent in arm assembly, you surely noticed this.",
+            PronounContraction::default(),
+            0,
+        );
+    }
 }


### PR DESCRIPTION
# Issues 

I've added tests from #576 

# Description

I reduced the potential ambiguity of the `AvoidContraction` rule to require higher certainty.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
