### PR TITLE
feat(core): create new test assertion for `nth` suggestion results

### DIFF
--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -171,10 +171,17 @@ mod tests {
         );
     }
 
-    /// Runs a provided linter on text, applies the first suggestion from each lint
+    /// Runs a provided linter on text, applies the nth suggestion from each lint
     /// and asserts whether the result is equal to a given value.
+    ///
+    /// Note that `n` starts at zero.
     #[track_caller]
-    pub fn assert_suggestion_result(text: &str, mut linter: impl Linter, expected_result: &str) {
+    pub fn assert_nth_suggestion_result(
+        text: &str,
+        mut linter: impl Linter,
+        expected_result: &str,
+        n: usize,
+    ) {
         let mut text_chars: Vec<char> = text.chars().collect();
 
         let mut iter_count = 0;
@@ -190,7 +197,7 @@ mod tests {
             let lints = linter.lint(&test);
 
             if let Some(lint) = lints.first() {
-                if let Some(sug) = lint.suggestions.first() {
+                if let Some(sug) = lint.suggestions.get(n) {
                     sug.apply(lint.span, &mut text_chars);
 
                     let transformed_str: String = text_chars.iter().collect();
@@ -221,31 +228,10 @@ mod tests {
         assert_lint_count(&transformed_str, linter, 0);
     }
 
-    /// Runs a provided linter on text, applies the second suggestion from each
-    /// lint and asserts whether the result is equal to a given value.
+    /// Runs a provided linter on text, applies the first suggestion from each lint
+    /// and asserts whether the result is equal to a given value.
     #[track_caller]
-    pub fn assert_second_suggestion_result(
-        text: &str,
-        mut linter: impl Linter,
-        expected_result: &str,
-    ) {
-        let test = Document::new_markdown_default_curated(text);
-        let lints = linter.lint(&test);
-
-        let mut text: Vec<char> = text.chars().collect();
-
-        for lint in lints {
-            dbg!(&lint);
-            if let Some(sug) = lint.suggestions.get(1) {
-                sug.apply(lint.span, &mut text);
-            }
-        }
-
-        let transformed_str: String = text.iter().collect();
-
-        assert_eq!(transformed_str.as_str(), expected_result);
-
-        // Applying the suggestions should fix all the lints.
-        assert_lint_count(&transformed_str, linter, 0);
+    pub fn assert_suggestion_result(text: &str, linter: impl Linter, expected_result: &str) {
+        assert_nth_suggestion_result(text, linter, expected_result, 0);
     }
 }

--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -773,7 +773,7 @@ pub fn lint_group() -> LintGroup {
 #[cfg(test)]
 mod tests {
     use crate::linting::tests::{
-        assert_lint_count, assert_second_suggestion_result, assert_suggestion_result,
+        assert_lint_count, assert_nth_suggestion_result, assert_suggestion_result,
     };
 
     use super::lint_group;
@@ -1179,10 +1179,11 @@ mod tests {
 
     #[test]
     fn suggests_ticking_clock() {
-        assert_second_suggestion_result(
+        assert_nth_suggestion_result(
             "The opportunity itself has a ticking time clock as all great opportunities do.",
             lint_group(),
             "The opportunity itself has a ticking clock as all great opportunities do.",
+            1,
         );
     }
 


### PR DESCRIPTION
# Issues 

Issue: #929
Follows on from my previous PR: #935 

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

I've introduced a new assertion that improves upon `assert_suggestion_result` to allow for assertions on the `nth` suggestion in a lint.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Existing tests that use `assert_second_suggestion_result` to use it.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code