### PR TITLE
docs: mention hidden library dependencies

### DIFF
--- a/packages/web/src/routes/docs/contributors/environment/+page.md
+++ b/packages/web/src/routes/docs/contributors/environment/+page.md
@@ -14,6 +14,14 @@ To use the tooling required to build and debug Harper, you'll need the following
 - `zip`
 - `pandoc`
 
+To run integration tests, you may also need `libnss3` and/or `libasound3`.
+These are installable in Ubuntu using `apt-get`.
+
+```bash
+sudo apt-get install libnss3
+sudo apt-get install libasound2
+```
+
 We develop a set of tools, accessible via `just`, to build and debug Harper's algorithm (otherwise known as `harper-core`) and its various integrations.
 The source code is in the `justfile` [at the root of the repository](https://github.com/Automattic/harper/blob/master/justfile).
 To see all the tools in the toolbox, run:


### PR DESCRIPTION
# Issues 

Cherry-picked from #689

# Description

Some Linux users need some previously unmentioned dependencies to run the VS Code integration tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
