### PR TITLE
chore: add comments describing major sections

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -1,4 +1,9 @@
-50640
+52000
+
+# Start of original dictionary import
+# This section is sorted alphabetically
+# This section contains general-purpose English words
+
 AA/1254M
 AAA/12
 AB/215M
@@ -50163,6 +50168,12 @@ zydeco/1M
 zygote/1SM
 zygotic/~5
 zymurgy/1M
+
+# End of original dictionary import
+# Words below this point have not been sorted alphabetically
+# This section contains mostly programming and technical terms
+# Some words may be very domain-specific
+
 StackOverflow/M
 CommonMark/M
 lex/~41D
@@ -50586,43 +50597,6 @@ cryptographic/5Q
 BRICS/
 JNI/2M
 Minix/2M
-# Experimental multi-word entries
-bench-warmer/1MS
-built-in/1MS5
-cross section/1MS
-cross-threaded/5
-de facto/51M
-easy peasy/5
-energy-efficient/5
-front-line/5
-front man/1M
-Greco-Roman/5
-ground-based/5
-high-level/5
-high-speed/5
-hissy fit/1MS
-holy moley
-holy moly
-jaw-droppingly/5
-kick start/4SDG
-knock-on effect/1MS
-laid-back/5
-left-wing/5
-low-profile/5
-mind-blowing/5
-neo-Nazi/15SM
-okey-dokey/1MS
-one-handed/5
-one-man/5
-one-off/5
-right-wing/5
-run-up/1MS
-short-term/5j
-shout-out/1S
-single-handedly/j
-third-party/5
-uh-oh
-un-American/5
 BRICS/
 here's/
 Americanisation/1MS!
@@ -50635,6 +50609,11 @@ Koranic/5
 Manilas/1
 Manilla/2M
 Roumania/2M
+
+# Start of dialect spelling dictionary import
+# This section contains mostly words that are spelled differently
+# In US English vs UK, Canadian, and Australian English etc
+
 abetter/1SM!
 abridgement/1MS!@
 absinth/1M!@
@@ -51795,9 +51774,57 @@ wainscotting/14MS@
 yogourt/1MS@
 yoghurt/1MS!
 probiotic/15SM
+
+# Experimental multi-word entries
+# Harper may not recognize these as words in documents
+# But it will be able to include them in suggestions
+
+bench-warmer/1MS
+built-in/1MS5
+cross section/1MS
+cross-threaded/5
+de facto/51M
+double-decker/5
+easy peasy/5
+energy-efficient/5
+front-line/5
+front man/1M
+Greco-Roman/5
+ground-based/5
+heavy-handed/5
+high-level/5
+high-speed/5
+hissy fit/1MS
+holy moley
+holy moly
+jaw-droppingly/5
+kick start/4SDG
+knock-on effect/1MS
+laid-back/5
+left-wing/5
+low-profile/5
+mind-blowing/5
+neo-Nazi/15SM
+okey-dokey/1MS
+one-handed/5
+one-man/5
+one-off/5
+right-wing/5
+run-up/1MS
+short-term/5j
+shout-out/1S
+single-handedly/j
+third-party/5
+uh-oh
+un-American/5
 user-friendly/5
 UTF-8/1M
 walkie-talkie/1MS
 well-known/5
 working-class/15MS
+
 # New entries may be added below this line
+# If you're not confident in using the affix annotations, add missing words here
+# And they will be reviewed
+# Word added using the `just addnoun` command will be added here
+


### PR DESCRIPTION
# Issues 
N/A

# Description
Added multi-line comments at each already existing section of the curated dictionary.
Mainly, the original import, the unsorted stuff added by users which may contain very domain-specific terms, the recent import of terms which differ in spelling between US and other regions, my experimental section of multi-word entries that contain spaces or hyphens, and the section at the bottom where `just addnoun` will add new entries with some advice to add manual changes there for users who are a bit uncertain.

I also updated the count at the top of the file to be big enough to contain the current number of entries.

The experimental multi-word section had been separated into two pieces, probably during a merge.

I added two or three more hyphenated terms.

I want to do more cleanup and reorganization but not until my remaining outstanding curation is included since merging might be too complicated between the current layout and layout after reorganizing.

# How Has This Been Tested?
`cargo test` still passes with 0 problems.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
