### PR TITLE
fix: 2 words in curated dict lack / before annotations

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -17597,14 +17597,14 @@ coloration/~1EM<
 coloratura/15MS<
 colorblind/5P<
 colorblindness/1M<
-colored's<
+colored's/<
 colored/~514U<
 coloreds/1<
 colorfast/5P<
 colorfastness/1M<
 colorful/~5PY<
 colorfulness/1M<
-coloring's<
+coloring's/<
 colorist/1S<
 colorization/1M<
 colorize/4DSG<


### PR DESCRIPTION
# Issues 
N/A

# Description
While updating my [syntax highlighter VS Code extension for `dictionary.dict`](https://github.com/hippietrail/harper-dict-syntax) I noticed some lines in red, indicating a syntax error.
On closer inspection I found that had the new `<` annotation flag indicating "American dialect" but did not have a `/` separating the word from the annotations.

As far as I can tell only two entries were affected: `colored's` and `coloring's`

# Demo
Before:
<img width="351" alt="Screenshot 2025-03-23 at 12 20 44 am" src="https://github.com/user-attachments/assets/9885810f-7534-4e1a-9c77-d594c3ef19f2" />
After:
<img width="297" alt="Screenshot 2025-03-23 at 12 22 01 am" src="https://github.com/user-attachments/assets/3e309c2f-cc70-44ac-95dc-24a5dc4a8e39" />

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
