### PR TITLE
fix: include the full set of personal pronouns and possessives

### DIFF
--- a/harper-core/src/linting/multiple_sequential_pronouns.rs
+++ b/harper-core/src/linting/multiple_sequential_pronouns.rs
@@ -12,8 +12,17 @@ pub struct MultipleSequentialPronouns {
 
 impl MultipleSequentialPronouns {
     fn new() -> Self {
+        // Some words occur in multiple positions in the paradigm
+        // but this is a set, so it doesn't matter and is much clearer
         let pronouns = Lrc::new(WordSet::new(&[
-            "me", "my", "I", "we", "you", "he", "him", "her", "she", "it", "they",
+            "I", "you", "he", "she", "it", // subject case, singular
+            "me", "you", "him", "her", "it", // object case, singular
+            "we", "you", "they", // subject case, plural
+            "us", "you", "them", // object case, plural
+            "mine", "yours", "his", "hers", // possessive pronouns, singular
+            "ours", "yours", "theirs", // possessive pronouns, plural
+            "my", "your", "his", "her", // possessive adjectives, singular
+            "our", "your", "their", // possessive adjectives, plural
         ]));
 
         Self {

--- a/harper-core/src/linting/multiple_sequential_pronouns.rs
+++ b/harper-core/src/linting/multiple_sequential_pronouns.rs
@@ -21,7 +21,7 @@ impl MultipleSequentialPronouns {
             "us", "you", "them", // object case, plural
             "mine", "yours", "his", "hers", // possessive pronouns, singular
             "ours", "yours", "theirs", // possessive pronouns, plural
-            "my", "your", "his", "her", // possessive adjectives, singular
+            "my", "your", "his", "her", "its", // possessive adjectives, singular
             "our", "your", "their", // possessive adjectives, plural
         ]));
 

--- a/harper-core/src/linting/multiple_sequential_pronouns.rs
+++ b/harper-core/src/linting/multiple_sequential_pronouns.rs
@@ -2,12 +2,16 @@ use super::Suggestion;
 use super::pattern_linter::PatternLinter;
 use crate::linting::LintKind;
 use crate::patterns::{Pattern, SequencePattern, WordSet};
-use crate::{Lint, Lrc, Token, TokenStringExt};
+use crate::{CharStringExt, Lint, Lrc, Token, TokenStringExt};
+use std::collections::HashSet;
 
 /// Linter that checks if multiple pronouns are being used right after each
 /// other. This is a common mistake to make during the revision process.
 pub struct MultipleSequentialPronouns {
     pattern: Box<dyn Pattern>,
+    subject_pronouns: HashSet<&'static str>,
+    object_pronouns: HashSet<&'static str>,
+    possessive_adjectives: HashSet<&'static str>,
 }
 
 impl MultipleSequentialPronouns {
@@ -25,6 +29,22 @@ impl MultipleSequentialPronouns {
             "our", "your", "their", // possessive adjectives, plural
         ]));
 
+        // TODO: temporary sets of pronouns - remove when WordMetadata has this info
+        let subject_pronouns = HashSet::from([
+            "I", "you", "he", "she", "it", // subject case, singular
+            "we", "you", "they", // subject case, plural
+        ]);
+
+        let object_pronouns = HashSet::from([
+            "me", "you", "him", "her", "it", // object case, singular
+            "us", "you", "them", // object case, plural
+        ]);
+
+        let possessive_adjectives = HashSet::from([
+            "my", "your", "his", "her", "its", // possessive adjectives, singular
+            "our", "your", "their", // possessive adjectives, plural
+        ]);
+
         Self {
             pattern: Box::new(
                 SequencePattern::default()
@@ -35,7 +55,22 @@ impl MultipleSequentialPronouns {
                             .then(pronouns.clone()),
                     ),
             ),
+            subject_pronouns,
+            object_pronouns,
+            possessive_adjectives,
         }
+    }
+
+    fn is_subject_pronoun(&self, word: &str) -> bool {
+        self.subject_pronouns.contains(word)
+    }
+
+    fn is_object_pronoun(&self, word: &str) -> bool {
+        self.object_pronouns.contains(word)
+    }
+
+    fn is_possessive_adjective(&self, word: &str) -> bool {
+        self.possessive_adjectives.contains(word)
     }
 }
 
@@ -48,6 +83,17 @@ impl PatternLinter for MultipleSequentialPronouns {
         let mut suggestions = Vec::new();
 
         if matched_tokens.len() == 3 {
+            let first_word = matched_tokens[0].span.get_content(source).to_string();
+            let second_word = matched_tokens[2].span.get_content(source).to_string();
+            // Bug 578: "I can lend you my car" - if 1st is object and second is possessive adjective, don't lint
+            if self.is_object_pronoun(&first_word) && self.is_possessive_adjective(&second_word) {
+                return None;
+            }
+            // Bug 724: "One told me they were able to begin reading" - if 1st is object ans second is subject, don't lint
+            if self.is_object_pronoun(&first_word) && self.is_subject_pronoun(&second_word) {
+                return None;
+            }
+
             suggestions.push(Suggestion::ReplaceWith(
                 matched_tokens[0].span.get_content(source).to_vec(),
             ));
@@ -111,7 +157,7 @@ mod tests {
     #[test]
     fn detects_multiple_pronouns_at_end() {
         assert_lint_count(
-            "...little bit about I want to do to me you.",
+            "...I need to explain this to you them.",
             MultipleSequentialPronouns::new(),
             1,
         )
@@ -120,5 +166,23 @@ mod tests {
     #[test]
     fn comma_separated() {
         assert_lint_count("To prove it, we...", MultipleSequentialPronouns::new(), 0)
+    }
+
+    #[test]
+    fn dont_flag_578() {
+        assert_lint_count(
+            "I can lend you my car.",
+            MultipleSequentialPronouns::new(),
+            0,
+        )
+    }
+
+    #[test]
+    fn dont_flag_724() {
+        assert_lint_count(
+            "One told me they were able to begin reading.",
+            MultipleSequentialPronouns::new(),
+            0,
+        )
     }
 }

--- a/harper-core/src/linting/multiple_sequential_pronouns.rs
+++ b/harper-core/src/linting/multiple_sequential_pronouns.rs
@@ -3,7 +3,7 @@ use super::pattern_linter::PatternLinter;
 use crate::linting::LintKind;
 use crate::patterns::{Pattern, SequencePattern, WordSet};
 use crate::{CharStringExt, Lint, Lrc, Token, TokenStringExt};
-use std::collections::HashSet;
+use hashbrown::HashSet;
 
 /// Linter that checks if multiple pronouns are being used right after each
 /// other. This is a common mistake to make during the revision process.


### PR DESCRIPTION
# Issues 
Also fixes #578 and #724.

# Description
The list of personal pronouns was not complete and only consisted of 11 words. They were in a haphazard order so hard to check at a glance.

I have now included all 22 personal pronouns and possessive adjectives (which are not pronouns but very commonly mislabeled as pronouns) in the form of a table-like paradigm to ensure it includes all combinations of subject case vs object case, singular vs plural, masculine vs feminine, vs neuter, possessive pronouns, and possessive adjectives.

Some words occur in multiple positions in the paradigm but this is fine since it's much easier to check at a glance to make sure no words are missing, and the result is a `WordSet` that can only contains one copy of each word.

Ideally newer features of `WordMetadata` should be used but they are only partially implemented so the types of the pronouns are hard-coded here temporarily.

# How Has This Been Tested?
I added unit tests using the sentences from the two bug reports.
It still passes all the tests in `cargo test`

* I did modify one of the existing tests to what I think is a more realistic ungrammatical sentence since the existing sentence.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
