### PR TITLE
fix(harper-ls): handle language mode change and VS Code auto detect

### DIFF
--- a/packages/vscode-plugin/src/tests/suite/helper.ts
+++ b/packages/vscode-plugin/src/tests/suite/helper.ts
@@ -11,6 +11,12 @@ import {
 	workspace,
 } from 'vscode';
 
+export async function closeAll(): Promise<void> {
+	for (const tabGroup of window.tabGroups.all) {
+		await window.tabGroups.close(tabGroup);
+	}
+}
+
 export async function activateHarper(): Promise<Extension<void>> {
 	const harper = extensions.getExtension('elijah-potter.harper')!;
 

--- a/packages/vscode-plugin/src/tests/suite/helper.ts
+++ b/packages/vscode-plugin/src/tests/suite/helper.ts
@@ -40,6 +40,11 @@ export async function openUntitled(text: string): Promise<Uri> {
 	return document.uri;
 }
 
+export async function setTextDocumentLanguage(uri: Uri, languageId: string): Promise<void> {
+	const document = await workspace.openTextDocument(uri);
+	languages.setTextDocumentLanguage(document, languageId);
+}
+
 export function getActualDiagnostics(resource: Uri): Diagnostic[] {
 	return languages.getDiagnostics(resource).filter((d) => d.source === 'Harper');
 }

--- a/packages/vscode-plugin/src/tests/suite/integration.test.ts
+++ b/packages/vscode-plugin/src/tests/suite/integration.test.ts
@@ -4,6 +4,7 @@ import { ConfigurationTarget, type Uri, commands, workspace } from 'vscode';
 
 import {
 	activateHarper,
+	closeAll,
 	compareActualVsExpectedDiagnostics,
 	createExpectedDiagnostics,
 	createRange,
@@ -18,6 +19,7 @@ describe('Integration >', () => {
 	let markdownUri: Uri;
 
 	beforeAll(async () => {
+		await closeAll();
 		harper = await activateHarper();
 		// Open test file so diagnostics can occur
 		markdownUri = await openFile('integration.md');

--- a/packages/vscode-plugin/src/tests/suite/integration.test.ts
+++ b/packages/vscode-plugin/src/tests/suite/integration.test.ts
@@ -11,6 +11,7 @@ import {
 	getActualDiagnostics,
 	openFile,
 	openUntitled,
+	setTextDocumentLanguage,
 	sleep,
 } from './helper';
 
@@ -58,6 +59,41 @@ describe('Integration >', () => {
 			createExpectedDiagnostics({
 				message: 'Did you mean to spell “Errorz” this way?',
 				range: createRange(0, 0, 0, 6),
+			}),
+		);
+	});
+
+	it('gives correct diagnostics when language is changed', async () => {
+		const untitledUri = await openUntitled('Errorz # Errorz');
+		await setTextDocumentLanguage(untitledUri, 'plaintext');
+
+		// Wait for `harper-ls` to send diagnostics
+		await sleep(500);
+
+		compareActualVsExpectedDiagnostics(
+			getActualDiagnostics(untitledUri),
+			createExpectedDiagnostics(
+				{
+					message: 'Did you mean to spell “Errorz” this way?',
+					range: createRange(0, 0, 0, 6),
+				},
+				{
+					message: 'Did you mean to spell “Errorz” this way?',
+					range: createRange(0, 9, 0, 15),
+				},
+			),
+		);
+
+		await setTextDocumentLanguage(untitledUri, 'shellscript');
+
+		// Wait for `harper-ls` to send diagnostics
+		await sleep(500);
+
+		compareActualVsExpectedDiagnostics(
+			getActualDiagnostics(untitledUri),
+			createExpectedDiagnostics({
+				message: 'Did you mean to spell “Errorz” this way?',
+				range: createRange(0, 9, 0, 15),
 			}),
 		);
 	});


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
N/A

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->
When someone changes the language mode of an opened document, Harper does not reflect the change, resulting in erroneous diagnostics. This has become apparent after #927 was introduced since `untitled`/unsaved documents default to auto detect or plain text, unless "Files: Default Language" (`files.defaultLanguage`) is configured.

The LSP specification states:[^1]
> If the language id of a document changes, the client needs to send a `textDocument/didClose` to the server followed by a `textDocument/didOpen` with the new language id if the server handles the new language id as well.

Harper so far has not implemented `did_close`. This PR implements `did_close` by removing the URL from `doc_state`. Sending an empty diagnostic is added since the `updates diagnostics when files are deleted` test would fail without it.

Might conflict with #960.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->
For a `file`:
<video src="https://github.com/user-attachments/assets/86fdb4d4-2b19-470b-9657-55d54d558591">

For an `untitled` and auto detect:
<video src="https://github.com/user-attachments/assets/5230e0cc-5617-4920-84b4-9362276726cc">

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
Tested with VS Code manually, and using the newly added test case.
Indirectly tested with Helix, Zed, Emacs, Neovim; they don't call an extra `did_open` when the view is split. 

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes

[^1]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didOpen