### PR TITLE
feat(core): flag "<adjective> of a"

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -43980,7 +43980,7 @@ starveling/15MS
 stash/14MDSG
 stasis/~1
 stat/~514MS
-state/~145DRSMYGNLX
+state/~14DRSMYGNLX
 statecraft/~1M
 stated/~45U
 stateful/5Y

--- a/harper-core/src/document.rs
+++ b/harper-core/src/document.rs
@@ -580,6 +580,7 @@ impl TokenStringExt for Document {
     create_fns_on_doc!(currency);
     create_fns_on_doc!(likely_homograph);
     create_fns_on_doc!(comma);
+    create_fns_on_doc!(adjective);
 
     fn first_sentence_word(&self) -> Option<&Token> {
         self.tokens.first_sentence_word()

--- a/harper-core/src/linting/adjective_of_a.rs
+++ b/harper-core/src/linting/adjective_of_a.rs
@@ -27,16 +27,16 @@ impl Linter for AdjectiveOfA {
             let word: &[char] = document.get_span_content(&adjective.span);
             // Avoid common false positives where the word is more common as a
             // noun than an adjective in this context.
-            if word == &['k', 'i', 'n', 'd']
-                || word == &['m', 'e', 'a', 'n', 'i', 'n', 'g']
-                || word == &['p', 'a', 'r', 't']
+            if word == ['k', 'i', 'n', 'd']
+                || word == ['m', 'e', 'a', 'n', 'i', 'n', 'g']
+                || word == ['p', 'a', 'r', 't']
             {
                 continue;
             }
             let len = word.len();
             if len > 2 {
                 let ending = &word[len - 2..len];
-                if ending == &['e', 'r'] || ending == &['s', 't'] {
+                if ending == ['e', 'r'] || ending == ['s', 't'] {
                     continue;
                 }
             }

--- a/harper-core/src/linting/adjective_of_a.rs
+++ b/harper-core/src/linting/adjective_of_a.rs
@@ -1,0 +1,168 @@
+use super::{Lint, LintKind, Linter, Suggestion};
+use crate::{Document, Span, TokenStringExt};
+
+/// Detect sequences of words of the form "adjective of a".
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AdjectiveOfA;
+
+impl Linter for AdjectiveOfA {
+    fn lint(&mut self, document: &Document) -> Vec<Lint> {
+        let mut lints = Vec::new();
+
+        for i in document.iter_adjective_indices() {
+            let adjective = document.get_token(i).unwrap();
+            let space_1 = document.get_token(i + 1);
+            let word_of = document.get_token(i + 2);
+            let space_2 = document.get_token(i + 3);
+            let a_or_an = document.get_token(i + 4);
+            // Ensure the adjective adjective is positive form, not comparative or superlative.
+            // Rightly prevents flagging: "for the better of a day"
+            // And "might not be the best of a given run"
+            // And "Which brings me to my best of a bad situation."
+            //
+            // But wrongly prevents flagging: "I don't think that's too much better of an idea."
+            // And: "see if you can give us a little better of an answer"
+            // And: "hopefully it won't be too much worse of a problem"
+            // And: "seems far worse of a result to me"
+            let word: &[char] = document.get_span_content(&adjective.span);
+            // Avoid common false positives where the word is more common as a
+            // noun than an adjective in this context.
+            if word == &['k', 'i', 'n', 'd']
+                || word == &['m', 'e', 'a', 'n', 'i', 'n', 'g']
+                || word == &['p', 'a', 'r', 't']
+            {
+                continue;
+            }
+            let len = word.len();
+            if len > 2 {
+                let ending = &word[len - 2..len];
+                if ending == &['e', 'r'] || ending == &['s', 't'] {
+                    continue;
+                }
+            }
+            // Check if it might also be valid as other parts of speech.
+            // This stops us flagging "meaning of a".
+            // But it also stops "good of a".
+            // if adjective.kind.is_likely_homograph() {
+            //     continue;
+            // }
+            if space_1.is_none() || word_of.is_none() || space_2.is_none() || a_or_an.is_none() {
+                continue;
+            }
+            let space_1 = space_1.unwrap();
+            if !space_1.kind.is_whitespace() {
+                continue;
+            }
+            let word_of = word_of.unwrap();
+            if !word_of.kind.is_word() {
+                continue;
+            }
+            let w2 = document.get_span_content(&word_of.span);
+            if w2 != ['o', 'f'] {
+                continue;
+            }
+            let space_2 = space_2.unwrap();
+            if !space_2.kind.is_whitespace() {
+                continue;
+            }
+            let a_or_an = a_or_an.unwrap();
+            if !a_or_an.kind.is_word() {
+                continue;
+            }
+            let w4 = document.get_span_content(&a_or_an.span);
+            if w4 != ['a'] && w4 != ['a', 'n'] {
+                continue;
+            }
+
+            // Whitespace may differ, add the other replacement if so
+            let mut sugg_1 = Vec::new();
+            sugg_1.extend_from_slice(document.get_span_content(&adjective.span));
+            sugg_1.extend_from_slice(document.get_span_content(&space_1.span));
+            sugg_1.extend_from_slice(document.get_span_content(&a_or_an.span));
+
+            let mut sugg_2 = Vec::new();
+            sugg_2.extend_from_slice(document.get_span_content(&adjective.span));
+            sugg_2.extend_from_slice(document.get_span_content(&space_2.span));
+            sugg_2.extend_from_slice(document.get_span_content(&a_or_an.span));
+
+            let mut suggestions = vec![Suggestion::ReplaceWith(sugg_1.clone())];
+            if sugg_1 != sugg_2 {
+                suggestions.push(Suggestion::ReplaceWith(sugg_2));
+            }
+
+            lints.push(Lint {
+                span: Span::new(adjective.span.start, a_or_an.span.end),
+                lint_kind: LintKind::Style,
+                suggestions,
+                message: "The word `of` is not needed here.".to_string(),
+                priority: 63,
+            });
+        }
+
+        lints
+    }
+
+    fn description(&self) -> &str {
+        "This rule looks for sequences of words of the form `adjective of a`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AdjectiveOfA;
+    use crate::linting::tests::{assert_lint_count, assert_suggestion_result};
+
+    #[test]
+    fn correct_large_of_a() {
+        assert_suggestion_result(
+            "Yeah I'm using as large of a batch size as I can on this machine",
+            AdjectiveOfA,
+            "Yeah I'm using as large a batch size as I can on this machine",
+        )
+    }
+
+    #[test]
+    fn correct_bad_of_an() {
+        assert_suggestion_result(
+            "- If forking is really that bad of an option, let's first decide where to put this.",
+            AdjectiveOfA,
+            "- If forking is really that bad an option, let's first decide where to put this.",
+        );
+    }
+
+    #[test]
+    fn dont_flag_comparative() {
+        assert_lint_count(
+            "I only worked with custom composer installers for the better of a day, so please excuse me if I missed a thing.",
+            AdjectiveOfA,
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_superlative() {
+        assert_lint_count(
+            "I am trying to use composites to visualize the worst of a set of metrics.",
+            AdjectiveOfA,
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_kind() {
+        assert_lint_count(
+            "Log.txt file automatic creation in PWD is kind of an anti-feature",
+            AdjectiveOfA,
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_part() {
+        assert_lint_count(
+            "cannot delete a food that is no longer part of a recipe",
+            AdjectiveOfA,
+            0,
+        );
+    }
+}

--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -11,6 +11,7 @@ use hashbrown::HashMap;
 use lru::LruCache;
 use serde::{Deserialize, Serialize};
 
+use super::adjective_of_a::AdjectiveOfA;
 use super::an_a::AnA;
 use super::avoid_curses::AvoidCurses;
 use super::back_in_the_day::BackInTheDay;
@@ -290,6 +291,7 @@ impl LintGroup {
         out.merge_from(&mut closed_compounds::lint_group());
 
         // Add all the more complex rules to the group.
+        insert_struct_rule!(AdjectiveOfA, true);
         insert_pattern_rule!(BackInTheDay, true);
         insert_struct_rule!(WordPressDotcom, true);
         insert_pattern_rule!(OutOfDate, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! See the [`Linter`] trait and the [documentation for authoring a rule](https://writewithharper.com/docs/contributors/author-a-rule) for more information.
 
+mod adjective_of_a;
 mod an_a;
 mod avoid_curses;
 mod back_in_the_day;
@@ -66,6 +67,7 @@ mod whereas;
 mod wordpress_dotcom;
 mod wrong_quotes;
 
+pub use adjective_of_a::AdjectiveOfA;
 pub use an_a::AnA;
 pub use avoid_curses::AvoidCurses;
 pub use back_in_the_day::BackInTheDay;

--- a/harper-core/src/token_string_ext.rs
+++ b/harper-core/src/token_string_ext.rs
@@ -74,6 +74,7 @@ pub trait TokenStringExt {
     create_decl_for!(currency);
     create_decl_for!(likely_homograph);
     create_decl_for!(comma);
+    create_decl_for!(adjective);
 
     fn iter_linking_verb_indices(&self) -> impl Iterator<Item = usize> + '_;
     fn iter_linking_verbs(&self) -> impl Iterator<Item = &Token> + '_;
@@ -117,6 +118,7 @@ impl TokenStringExt for [Token] {
     create_fns_for!(currency);
     create_fns_for!(likely_homograph);
     create_fns_for!(comma);
+    create_fns_for!(adjective);
 
     fn first_non_whitespace(&self) -> Option<&Token> {
         self.iter().find(|t| !t.kind.is_whitespace())


### PR DESCRIPTION
# Issues 
N/A

# Description
Flags phrases such as "How slow of a laptop are we talking here?" and suggests removing the "of".

It only flags adjectives in the positive degree (neither comparative or superlative).
It avoid a few hard-coded false positives where the adjective is much more common as a noun in this context.

This is so common, especially in American English, that many people might not know it's an error.
Some references:
- [WordReference](https://forum.wordreference.com/threads/not-that-adjective-of-a-noun.3260438/)
- [English StackExchange](https://english.stackexchange.com/questions/64605)
- [English StackExchange](https://english.stackexchange.com/questions/30011)
- [WordReference](https://forum.wordreference.com/threads/not-that-adjective-of-a-noun.2854358/)
- [r/grammar](https://www.reddit.com/r/grammar/comments/982svr/of_a/)
- [Language Log](http://itre.cis.upenn.edu/~myl/languagelog/archives/002283.html)
- [Language Log](https://languagelog.ldc.upenn.edu/nll/?p=25282)
- [Grammar Underground](https://www.grammarunderground.com/too-big-of-a-deal-or-too-big-a-deal.html)
- [Grammarphobia](https://www.grammarphobia.com/blog/2014/01/not-that-big-of-a-deal.html)
- [Pain in the English](https://painintheenglish.com/case/522)
- [Quora](https://www.quora.com/Which-of-the-following-is-correct-Its-too-big-a-problem-or-Its-too-big-of-a-problem)
- [Quora](https://www.quora.com/Are-both-of-these-phrases-grammatically-correct-it-s-not-that-big-of-a-deal-and-it-s-not-that-big-a-deal)
- [English StackExchange](https://english.stackexchange.com/questions/240248)
- [WordReference](https://forum.wordreference.com/threads/too-adjective-a-noun-too-expensive-a-desk.2634551/)

# Demo
<img width="899" alt="image" src="https://github.com/user-attachments/assets/f663c46a-1733-407c-8bed-1838925e9717" />

# How Has This Been Tested?
- I added tests based on sentences found on GitHub.
- I added tests that ensure the false positives are not triggered.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
