### PR TITLE
feat(comments): add `scala` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,6 +724,7 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-ruby",
  "tree-sitter-rust",
+ "tree-sitter-scala",
  "tree-sitter-swift",
  "tree-sitter-toml",
  "tree-sitter-typescript",
@@ -2221,6 +2222,16 @@ name = "tree-sitter-rust"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0832309b0b2b6d33760ce5c0e818cb47e1d72b468516bfe4134408926fa7594"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-scala"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fcf4628a88a3b5cbac3ff52658b924f3e545abddfa245ab9cf683c1adda350"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/harper-comments/Cargo.toml
+++ b/harper-comments/Cargo.toml
@@ -32,6 +32,7 @@ itertools = "0.14.0"
 tree-sitter-haskell = "0.15.0"
 tree-sitter-php = "=0.22.2"
 tree-sitter-dart = "0.0.4"
+tree-sitter-scala = "0.20.0"
 
 [dev-dependencies]
 paste = "1.0.15"

--- a/harper-comments/src/comment_parser.rs
+++ b/harper-comments/src/comment_parser.rs
@@ -43,6 +43,7 @@ impl CommentParser {
             "haskell" => tree_sitter_haskell::language(),
             "php" => tree_sitter_php::language_php(),
             "dart" => tree_sitter_dart::language(),
+            "scala" => tree_sitter_scala::language(),
             _ => return None,
         };
 
@@ -98,6 +99,7 @@ impl CommentParser {
             "hs" => "haskell",
             "php" => "php",
             "dart" => "dart",
+            "scala" | "sbt" | "mill" => "scala",
             _ => return None,
         })
     }

--- a/harper-comments/tests/language_support.rs
+++ b/harper-comments/tests/language_support.rs
@@ -54,6 +54,7 @@ create_test!(ignore_shebang_1.sh, 0);
 create_test!(ignore_shebang_2.sh, 0);
 create_test!(ignore_shebang_3.sh, 0);
 create_test!(ignore_shebang_4.sh, 1);
+create_test!(common.mill, 1);
 
 // Checks that some comments are masked out
 create_test!(ignore_comments.rs, 1);

--- a/harper-comments/tests/language_support_sources/common.mill
+++ b/harper-comments/tests/language_support_sources/common.mill
@@ -1,0 +1,19 @@
+import mill._, scalalib._
+
+object hello extends ScalaModule {
+  def scalaVersion = "2.13.8"
+
+  // Define third-party dependencies
+  def ivyDeps = Agg(
+    ivy"com.lihaoyi::scalatags:0.9.4",  // for HTML generation
+    ivy"com.lihaoyi::mainargs:0.6.2"     // for CLI argument parsing
+  )
+
+  // Define an test sub-module using a test framework.
+  object test extends ScalaTests {
+    def testFramework = "utest.runner.Framework"
+    def ivyDeps = Agg(
+      ivy"com.lihaoyi::utest:0.7.10"
+    )
+  }
+}

--- a/packages/web/src/routes/docs/integrations/language-server/+page.md
+++ b/packages/web/src/routes/docs/integrations/language-server/+page.md
@@ -248,6 +248,7 @@ These configs are under the `markdown` key:
 | Python            |           `python`            |            ✅ |
 | Ruby              |            `ruby`             |            ✅ |
 | Rust              |            `rust`             |            ✅ |
+| Scala             |           `scala`             |            ✅ |
 | Shell/Bash Script |         `shellscript`         |            ✅ |
 | Swift             |            `swift`            |            ✅ |
 | TOML              |            `toml`             |            ✅ |


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->

# Description

Add support for Scala comment parsing. The `.sbt` extension is for [Scala Build Tool](https://www.scala-sbt.org/), and the `.mill` extension is for [Mill](https://mill-build.org/mill/index.html).

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?

I ran `harper-cli` on a `.scala`, `.sbt`, and `.mill` file (with `./target/release/harper-cli lint -d American <path-to-file>`) and got lints on the comments. Doing the same with released `harper-cli` (installed from Homebrew) gives `Error: Could not detect language ID.`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
