### PR TITLE
Dialect indicator for VS Code extension

### DIFF
--- a/packages/vscode-plugin/src/extension.ts
+++ b/packages/vscode-plugin/src/extension.ts
@@ -2,6 +2,7 @@ import type { ExtensionContext } from 'vscode';
 import type { Executable, LanguageClientOptions } from 'vscode-languageclient/node';
 
 import { Uri, commands, window, workspace } from 'vscode';
+// import { StatusBarAlignment, type StatusBarItem } from 'vscode';
 import { LanguageClient, ResponseError, TransportKind } from 'vscode-languageclient/node';
 
 // There's no publicly available extension manifest type except for the internal one from VS Code's
@@ -51,6 +52,8 @@ const clientOptions: LanguageClientOptions = {
 	},
 };
 
+// let dialectStatusBarItem: StatusBarItem | undefined;
+
 export async function activate(context: ExtensionContext): Promise<void> {
 	serverOptions.command = getExecutablePath(context);
 
@@ -99,6 +102,37 @@ export async function activate(context: ExtensionContext): Promise<void> {
 	);
 
 	await startLanguageServer();
+
+	// Add status bar item for dialect
+	// dialectStatusBarItem = window.createStatusBarItem(StatusBarAlignment.Left, 1000);
+	// dialectStatusBarItem.command = 'harper.setDialect';
+	// context.subscriptions.push(dialectStatusBarItem);
+
+	// // Add command to change dialect
+	// context.subscriptions.push(
+	// 	commands.registerCommand('harper.setDialect', async () => {
+	// 		const selected = await window.showQuickPick(['American', 'British'], {
+	// 			placeHolder: 'Select dialect',
+	// 		});
+	// 		if (selected) {
+	// 			await workspace.getConfiguration('harper').update('dialect', selected, true);
+	// 			updateDialectStatusBar();
+	// 		}
+	// 	}),
+	// );
+
+	// // Update status bar when dialect changes
+	// context.subscriptions.push(
+	// 	workspace.onDidChangeConfiguration(async (event) => {
+	// 		if (event.affectsConfiguration('harper.dialect')) {
+	// 			updateDialectStatusBar();
+	// 		}
+	// 		// ... existing code ...
+	// 	}),
+	// );
+
+	// // Initialize status bar
+	// updateDialectStatusBar();
 }
 
 function getExecutablePath(context: ExtensionContext): string {
@@ -158,10 +192,24 @@ function showError(message: string, error: Error | unknown): void {
 	});
 }
 
+// function updateDialectStatusBar(): void {
+//     if (!dialectStatusBarItem) return;
+
+//     const dialect = workspace.getConfiguration('harper').get<string>('dialect', 'American');
+//     dialectStatusBarItem.text = `$(globe) ${dialect}`;
+//     dialectStatusBarItem.tooltip = `Click to change dialect (currently: ${dialect})`;
+//     dialectStatusBarItem.show();
+// 	console.log(`** Dialect set to ${dialect} **`, dialect);
+// }
+
 export function deactivate(): Thenable<void> | undefined {
 	if (!client) {
 		return undefined;
 	}
+
+	// if (dialectStatusBarItem) {
+	//     dialectStatusBarItem.dispose();
+	// }
 
 	return client.stop();
 }


### PR DESCRIPTION
# Issues 
#982 

# Description
Adds an indicator in the status bar for the English dialect set.

It reflects the **Workspace** setting, which seems to be the default. I don't know VS Code or its extension system deeply enough to know if this is the best solution.

On my setup I was able to confuse myself by changing the dialect in **User**.

Changing the Workspace setting instantly changes the flag, but does not reload the window. Some squiggles seem to be updated instantly, but not all of them.

It is possible to make the indicator clicking to change the setting but I haven't implemented this. It would be best to fully grok the Workspace vs User ramifications before attempting this.

It is possibly to add a Harper logo but not as a PNG or SVG. You need to do some font trickery: https://stackoverflow.com/a/76399730/527702

I tried to make the indicator appear as close to the document format indicator as possible. It doesn't seem to be possible to get them right next to each other.

# Demo
View from the settings:
<img width="622" alt="image" src="https://github.com/user-attachments/assets/81b1462d-698d-4c3d-ad0c-d93682414db2" />

View of position near file format indicator: 
<img width="543" alt="image" src="https://github.com/user-attachments/assets/12f6940a-2003-4134-903a-fd25574d9d96" />

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
Manually. I don't know if it would be possibly to add test code for this. Let me know.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
