### PR TITLE
fix(harper-cli): set American as the default dialect

### DIFF
--- a/harper-cli/Cargo.toml
+++ b/harper-cli/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/automattic/harper"
 [dependencies]
 anyhow = "1.0.97"
 ariadne = "0.4.1"
-clap = { version = "4.5.32", features = ["derive"] }
+clap = { version = "4.5.32", features = ["derive", "string"] }
 harper-literate-haskell = { path = "../harper-literate-haskell", version = "0.26.0" }
 harper-core = { path = "../harper-core", version = "0.26.0" }
 harper-comments = { path = "../harper-comments", version = "0.26.0" }

--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -34,7 +34,8 @@ enum Args {
         /// If omitted, `harper-cli` will run every rule.
         #[arg(short, long)]
         only_lint_with: Option<Vec<String>>,
-        #[arg(short, long)]
+        /// Specify the dialect.
+        #[arg(short, long, default_value = Dialect::American.to_string())]
         dialect: Dialect,
     },
     /// Parse a provided document and print the detected symbols.

--- a/harper-core/src/word_metadata.rs
+++ b/harper-core/src/word_metadata.rs
@@ -1,7 +1,7 @@
 use is_macro::Is;
 use paste::paste;
 use serde::{Deserialize, Serialize};
-use strum_macros::EnumString;
+use strum_macros::{Display, EnumString};
 
 use crate::WordId;
 
@@ -352,7 +352,7 @@ impl ConjunctionData {
 
 /// A regional dialect.
 #[derive(
-    Debug, Clone, Copy, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Hash, EnumString,
+    Debug, Clone, Copy, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Hash, EnumString, Display,
 )]
 pub enum Dialect {
     American,


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
N/A

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->
This PR sets American as the default dialect for harper-cli. [The document](https://writewithharper.com/docs/contributors/review#Testing-Using-Cargo-and-harper-cli) and `just dogfood` won't fail right away anymore.

And that's it!

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->
N/A

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
