### PR TITLE
feat: detect capitalized false positives

### DIFF
--- a/harper-core/src/linting/adjective_of_a.rs
+++ b/harper-core/src/linting/adjective_of_a.rs
@@ -19,17 +19,19 @@ impl Linter for AdjectiveOfA {
 
             // Rule out false positives
 
-            // "much of a" is a different and valid construction.
-            if adj_chars == ['m', 'u', 'c', 'h']
+            if match adj_chars {
+                // "much of a" is a different and valid construction.
+                ['m', 'u', 'c', 'h'] | ['M', 'u', 'c', 'h'] => true,
                 // The word is used more as a noun in this context.
                 // (using .kind.is_likely_homograph() here is too strict)
-                || adj_chars == ['k', 'i', 'n', 'd']
-                || adj_chars == ['m', 'e', 'a', 'n', 'i', 'n', 'g']
-                || adj_chars == ['p', 'a', 'r', 't']
-            {
+                ['k', 'i', 'n', 'd'] | ['K', 'i', 'n', 'd'] => true,
+                ['m', 'e', 'a', 'n', 'i', 'n', 'g'] | ['M', 'e', 'a', 'n', 'i', 'n', 'g'] => true,
+                ['p', 'a', 'r', 't'] | ['P', 'a', 'r', 't'] => true,
+                // TODO: consider "more of a" and "less of a"
+                _ => false,
+            } {
                 continue;
             }
-
             // Rule out comparatives and superlatives.
 
             // Pros:
@@ -172,6 +174,15 @@ mod tests {
     fn dont_flag_much() {
         assert_lint_count(
             "How much of a performance impact when switching from rails to rails-api ?",
+            AdjectiveOfA,
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_false_positive_upper() {
+        assert_lint_count(
+            "Quarkus Extension as Part of a Project inside a Monorepo?",
             AdjectiveOfA,
             0,
         );

--- a/harper-core/src/linting/adjective_of_a.rs
+++ b/harper-core/src/linting/adjective_of_a.rs
@@ -24,6 +24,7 @@ impl Linter for AdjectiveOfA {
                 ['m', 'u', 'c', 'h'] | ['M', 'u', 'c', 'h'] => true,
                 // The word is used more as a noun in this context.
                 // (using .kind.is_likely_homograph() here is too strict)
+                ['f', 'r', 'o', 'n', 't'] | ['F', 'r', 'o', 'n', 't'] => true,
                 ['k', 'i', 'n', 'd'] | ['K', 'i', 'n', 'd'] => true,
                 ['m', 'e', 'a', 'n', 'i', 'n', 'g'] | ['M', 'e', 'a', 'n', 'i', 'n', 'g'] => true,
                 ['p', 'a', 'r', 't'] | ['P', 'a', 'r', 't'] => true,


### PR DESCRIPTION
# Issues 
N/A

# Description
The false positives were not handled correctly when capitalized at the beginning of a sentence.

# How Has This Been Tested?
I added a new unit test with a capitalized word in the false-positive set.
`cargo test` has zero fails.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
