### PR TITLE
feat: more false positives: "inside of" & "out of"

### DIFF
--- a/harper-core/src/linting/adjective_of_a.rs
+++ b/harper-core/src/linting/adjective_of_a.rs
@@ -27,10 +27,13 @@ impl Linter for AdjectiveOfA {
                 ['o', 'u', 't'] | ['O', 'u', 't'] => true,
                 // The word is used more as a noun in this context.
                 // (using .kind.is_likely_homograph() here is too strict)
+                ['b', 'o', 't', 't', 'o', 'm'] | ['B', 'o', 't', 't', 'o', 'm'] => true,
                 ['f', 'r', 'o', 'n', 't'] | ['F', 'r', 'o', 'n', 't'] => true,
                 ['k', 'i', 'n', 'd'] | ['K', 'i', 'n', 'd'] => true,
                 ['m', 'e', 'a', 'n', 'i', 'n', 'g'] | ['M', 'e', 'a', 'n', 'i', 'n', 'g'] => true,
                 ['p', 'a', 'r', 't'] | ['P', 'a', 'r', 't'] => true,
+                ['s', 'h', 'a', 'd', 'o', 'w'] | ['S', 'h', 'a', 'd', 'o', 'w'] => true,
+                ['s', 'h', 'o', 'r', 't'] | ['S', 'h', 'o', 'r', 't'] => true,
                 ['s', 'o', 'm', 'e', 't', 'h', 'i', 'n', 'g']
                 | ['S', 'o', 'm', 'e', 't', 'h', 'i', 'n', 'g'] => true,
                 // TODO: consider "more of a" and "less of a" but they may have too many true positives
@@ -228,5 +231,23 @@ mod tests {
             AdjectiveOfA,
             0,
         );
+    }
+
+    #[test]
+    fn dont_flag_short() {
+        assert_lint_count(
+            "I found one Youtube short of an indonesian girl.",
+            AdjectiveOfA,
+            0,
+        )
+    }
+
+    #[test]
+    fn dont_flag_bottom() {
+        assert_lint_count(
+            "When leaves are just like coming out individually from the bottom of a fruit.",
+            AdjectiveOfA,
+            0,
+        )
     }
 }

--- a/harper-core/src/linting/adjective_of_a.rs
+++ b/harper-core/src/linting/adjective_of_a.rs
@@ -21,6 +21,7 @@ impl Linter for AdjectiveOfA {
 
             if match adj_chars {
                 // Different valid constructions.
+                ['f', 'u', 'l', 'l'] | ['F', 'u', 'l', 'l'] => true,
                 ['i', 'n', 's', 'i', 'd', 'e'] | ['I', 'n', 's', 'i', 'd', 'e'] => true,
                 ['m', 'u', 'c', 'h'] | ['M', 'u', 'c', 'h'] => true,
                 ['o', 'u', 't'] | ['O', 'u', 't'] => true,
@@ -204,6 +205,15 @@ mod tests {
     fn dont_flag_out() {
         assert_lint_count(
             "not only would he potentially be out of a job and back to sort of poverty",
+            AdjectiveOfA,
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_full() {
+        assert_lint_count(
+            "fortunately I happen to have this Tupperware full of an unceremoniously disassembled LED Mac Mini",
             AdjectiveOfA,
             0,
         );

--- a/harper-core/src/linting/adjective_of_a.rs
+++ b/harper-core/src/linting/adjective_of_a.rs
@@ -31,7 +31,9 @@ impl Linter for AdjectiveOfA {
                 ['k', 'i', 'n', 'd'] | ['K', 'i', 'n', 'd'] => true,
                 ['m', 'e', 'a', 'n', 'i', 'n', 'g'] | ['M', 'e', 'a', 'n', 'i', 'n', 'g'] => true,
                 ['p', 'a', 'r', 't'] | ['P', 'a', 'r', 't'] => true,
-                // TODO: consider "more of a" and "less of a"
+                ['s', 'o', 'm', 'e', 't', 'h', 'i', 'n', 'g']
+                | ['S', 'o', 'm', 'e', 't', 'h', 'i', 'n', 'g'] => true,
+                // TODO: consider "more of a" and "less of a" but they may have too many true positives
                 _ => false,
             } {
                 continue;
@@ -214,6 +216,15 @@ mod tests {
     fn dont_flag_full() {
         assert_lint_count(
             "fortunately I happen to have this Tupperware full of an unceremoniously disassembled LED Mac Mini",
+            AdjectiveOfA,
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_something() {
+        assert_lint_count(
+            "Well its popularity seems to be taking something of a dip right now.",
             AdjectiveOfA,
             0,
         );

--- a/harper-core/src/linting/adjective_of_a.rs
+++ b/harper-core/src/linting/adjective_of_a.rs
@@ -19,8 +19,10 @@ impl Linter for AdjectiveOfA {
 
             // Rule out false positives
 
-            // "much of a" is a different and valid construction.
-            if adj_chars == ['m', 'u', 'c', 'h']
+            // Different valid constructions.
+            if adj_chars == ['i', 'n', 's', 'i', 'd', 'e']
+                || adj_chars == ['m', 'u', 'c', 'h']
+                || adj_chars == ['o', 'u', 't']
                 // The word is used more as a noun in this context.
                 // (using .kind.is_likely_homograph() here is too strict)
                 || adj_chars == ['k', 'i', 'n', 'd']
@@ -172,6 +174,24 @@ mod tests {
     fn dont_flag_much() {
         assert_lint_count(
             "How much of a performance impact when switching from rails to rails-api ?",
+            AdjectiveOfA,
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_inside() {
+        assert_lint_count(
+            "Michael and Brock sat inside of a diner in Brandon",
+            AdjectiveOfA,
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_out() {
+        assert_lint_count(
+            "not only would he potentially be out of a job and back to sort of poverty",
             AdjectiveOfA,
             0,
         );

--- a/harper-core/src/linting/adjective_of_a.rs
+++ b/harper-core/src/linting/adjective_of_a.rs
@@ -31,6 +31,7 @@ impl Linter for AdjectiveOfA {
                 ['f', 'r', 'o', 'n', 't'] | ['F', 'r', 'o', 'n', 't'] => true,
                 ['k', 'i', 'n', 'd'] | ['K', 'i', 'n', 'd'] => true,
                 ['m', 'e', 'a', 'n', 'i', 'n', 'g'] | ['M', 'e', 'a', 'n', 'i', 'n', 'g'] => true,
+                ['o', 'n', 'e'] | ['O', 'n', 'e'] => true,
                 ['p', 'a', 'r', 't'] | ['P', 'a', 'r', 't'] => true,
                 ['s', 'h', 'a', 'd', 'o', 'w'] | ['S', 'h', 'a', 'd', 'o', 'w'] => true,
                 ['s', 'h', 'o', 'r', 't'] | ['S', 'h', 'o', 'r', 't'] => true,


### PR DESCRIPTION
# Issues 
N/A

# Description
Two more false positives found and handled: "inside of" and "out of".

# How Has This Been Tested?
- I added a unit test for each based on the sentences I found them in.
- `cargo test` succeeds 100%

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
