### PR TITLE
fix(wordpress): crashes when options menu is opened

### DIFF
--- a/packages/wordpress-plugin/src/harper/Logo.jsx
+++ b/packages/wordpress-plugin/src/harper/Logo.jsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 export default function Logo() {
 	return (
 		<svg

--- a/packages/wordpress-plugin/src/harper/index.tsx
+++ b/packages/wordpress-plugin/src/harper/index.tsx
@@ -9,9 +9,7 @@ import LinterProvider from './LinterProvider';
 function Sidebar() {
 	return (
 		<>
-			<PluginSidebarMoreMenuItem target="harper-sidebar" icon={Logo}>
-				Harper
-			</PluginSidebarMoreMenuItem>
+			<PluginSidebarMoreMenuItem target="harper-sidebar">Harper</PluginSidebarMoreMenuItem>
 			<PluginSidebar name="harper-sidebar" title="Harper" icon={Logo}>
 				<LinterProvider>
 					<SidebarControl />

--- a/packages/wordpress-plugin/src/harper/index.tsx
+++ b/packages/wordpress-plugin/src/harper/index.tsx
@@ -9,7 +9,9 @@ import LinterProvider from './LinterProvider';
 function Sidebar() {
 	return (
 		<>
-			<PluginSidebarMoreMenuItem target="harper-sidebar">Harper</PluginSidebarMoreMenuItem>
+			<PluginSidebarMoreMenuItem target="harper-sidebar" icon={Logo()}>
+				Harper
+			</PluginSidebarMoreMenuItem>
 			<PluginSidebar name="harper-sidebar" title="Harper" icon={Logo}>
 				<LinterProvider>
 					<SidebarControl />


### PR DESCRIPTION
# Issues 

# Description

This PR addresses a bug in the plugin that makes it impossible to open the 'more options' menu in the top-right of the Gutenberg editor.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
