### PR TITLE
docs: update link to website

### DIFF
--- a/packages/web/src/routes/+page.svelte
+++ b/packages/web/src/routes/+page.svelte
@@ -82,7 +82,7 @@ let mobile = $derived(width < 640);
 	<span slot="title">Native Everywhere</span>
 	<span slot="subtitle"
 		>Harper is both available as a <a
-			href="https://github.com/automattic/harper/tree/master/harper-ls">language server</a
+			href="https://writewithharper.com/docs/integrations/language-server">language server</a
 		>, and through WebAssembly, so you can get fantastic grammar checking anywhere you work.
 		<br /><br /> That said, we take extra care to make sure the
 		<a href="https://marketplace.visualstudio.com/items?itemName=elijah-potter.harper"


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
None

# Description
<!-- Please include a summary of the change. -->
Update link on main site to point to web documentation instead of old markdown doc.

Just discovered this tool, really neat stuff! I thought I'd open a quick pr when I noticed that the link on the main website was pointing to the wrong page.

Looking forward to keeping up with this project, nice work 👍🏻 
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->
none

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
I did not, just a link update so I hope everything is all good 👍🏻 

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
