### PR TITLE
feat(core): make `LintConfig` sorted by key

### DIFF
--- a/packages/harper.js/src/Linter.test.ts
+++ b/packages/harper.js/src/Linter.test.ts
@@ -210,12 +210,11 @@ test('Linters have the same JSON config format', async () => {
 	for (const Linter of Object.values(linters)) {
 		const linter = new Linter({ binary });
 
-		configs.push(await linter.getLintConfig());
+		configs.push(await linter.getLintConfigAsJSON());
 	}
 
 	for (const config of configs) {
-		// The keys of stringified configs would be unstable, so we'll just check the object.
 		expect(config).toEqual(configs[0]);
-		expect(config).toBeTypeOf('object');
+		expect(config).toBeTypeOf('string');
 	}
 });


### PR DESCRIPTION
# Issues 
#1011
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

The `LintConfig` type is now stored as a binary tree, ensuring that it will be always be serialized such that the keys are in sorted order.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I've added an additional unit test to `harper.js` to make sure it behaves as expected.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
