### PR TITLE
feat(obsidian): add debounce setting

### DIFF
--- a/packages/obsidian-plugin/src/HarperSettingTab.ts
+++ b/packages/obsidian-plugin/src/HarperSettingTab.ts
@@ -54,6 +54,22 @@ export class HarperSettingTab extends PluginSettingTab {
 				});
 		});
 
+		new Setting(containerEl)
+			.setName('Delay')
+			.setDesc(
+				'Set the delay (in milliseconds) before Harper checks your work after you make a change. Set to -1 for no delay.',
+			)
+			.addSlider((slider) => {
+				slider
+					.setDynamicTooltip()
+					.setLimits(-1, 10000, 50)
+					.setValue(this.settings.delay ?? -1)
+					.onChange(async (value) => {
+						this.settings.delay = value;
+						await this.plugin.initializeFromSettings(this.settings);
+					});
+			});
+
 		new Setting(containerEl).setName('The Danger Zone').addButton((button) => {
 			button
 				.setButtonText('Forget Ignored Suggestions')

--- a/packages/obsidian-plugin/src/index.ts
+++ b/packages/obsidian-plugin/src/index.ts
@@ -24,22 +24,27 @@ function suggestionToLabel(sug: Suggestion) {
 	}
 }
 
+const DEFAULT_DELAY = -1;
+
 export type Settings = {
 	ignoredLints?: string;
 	useWebWorker: boolean;
 	dialect?: Dialect;
 	lintSettings: LintConfig;
 	userDictionary?: string[];
+	delay?: number;
 };
 
 export default class HarperPlugin extends Plugin {
 	private harper: Linter;
 	private editorExtensions: Extension[];
+	private delay: number;
 
 	constructor(app: App, manifest: PluginManifest) {
 		super(app, manifest);
 		this.harper = new WorkerLinter({ binary: binaryInlined });
 		this.editorExtensions = [];
+		this.delay = DEFAULT_DELAY;
 	}
 
 	public async initializeFromSettings(settings: Settings | null) {
@@ -73,6 +78,8 @@ export default class HarperPlugin extends Plugin {
 		await this.harper.setLintConfig(settings.lintSettings);
 		this.harper.setup();
 
+		this.delay = settings.delay ?? DEFAULT_DELAY;
+
 		// Reinitialize it.
 		if (this.hasEditorLinter()) {
 			this.disableEditorLinter();
@@ -96,6 +103,7 @@ export default class HarperPlugin extends Plugin {
 			lintSettings: await this.harper.getLintConfig(),
 			userDictionary: await this.harper.exportWords(),
 			dialect: await this.harper.getDialect(),
+			delay: this.delay,
 		};
 	}
 
@@ -259,7 +267,7 @@ export default class HarperPlugin extends Plugin {
 				});
 			},
 			{
-				delay: -1,
+				delay: this.delay,
 			},
 		);
 	}


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

This PR adds a new setting to the Obsidian plugin called "delay" that delays linting until a certain amount of time after the user has finished typing. This is to avoid overwhelming the user with erroneous suggestions.

# Demo


https://github.com/user-attachments/assets/8eee5fc3-eb71-4451-83f9-7bf1e46fb738



# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manual testing.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
