### PR TITLE
refactor: remove unneeded logic for repeated words

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -26887,7 +26887,7 @@ gyroscopic/5
 gyve/14MGDS
 h/~145NRSXZGVJ
 h'm/
-ha/~4H
+ha/~
 haberdasher/1SM
 haberdashery/1SM
 habiliment/1SM
@@ -27241,6 +27241,7 @@ hateful/5PY
 hatefulness/1M
 hatemonger/1MS
 hater/1M
+hath/4
 hatpin/1S
 hatred/~1SM
 hatstand/15S

--- a/harper-core/src/linting/repeated_words.rs
+++ b/harper-core/src/linting/repeated_words.rs
@@ -12,7 +12,7 @@ pub struct RepeatedWords {
 impl RepeatedWords {
     pub fn new() -> Self {
         Self {
-            special_cases: vec![char_string!("is"), char_string!("this")],
+            special_cases: vec![char_string!("this")],
         }
     }
 

--- a/harper-core/src/word_metadata.rs
+++ b/harper-core/src/word_metadata.rs
@@ -45,10 +45,6 @@ macro_rules! generate_metadata_queries {
     ($($category:ident has $($sub:ident),*).*) => {
         paste! {
             pub fn is_likely_homograph(&self) -> bool {
-                if [$($(self.[< is_ $sub _ $category >](),)*)*].iter().map(|b| *b as u8).sum::<u8>() > 1 {
-                    return true;
-                }
-
                 [self.determiner, self.preposition, $(
                     self.[< is_ $category >](),
                 )*].iter().map(|b| *b as u8).sum::<u8>() > 1


### PR DESCRIPTION
# Issues 
N/A

# Description
I was considering making some special cases to the 'repeated words' lint for words which are repeated and not an error.
I decided that wasn't needed but while looking at the code I wondered about some of the logic.

There was a special case to ensure `is is` gets flagged.

This would've been due to logic testing words that can be repeated:
1. Homographs - words that are both noun and verb, or pronoun and adjective, etc.
2. Words that have multiple properties within one type of verb.

2 didn't seem right to me. There have been some changes to the affix code relating to parts-of-speech and properties etc. There have also been corrections to `dictionary.dict` with anomalous annotations.

I removed the test for homograph test #2 and the special case for "is" and with the current state of the affix system and the dictionary, all the tests pass with those removed.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
`cargo test` and `just test` pass all tests with no failures. I didn't add any new tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes