### PR TITLE
refactor: improve logic and robustness of then→than

### DIFF
--- a/harper-core/src/linting/then_than.rs
+++ b/harper-core/src/linting/then_than.rs
@@ -53,13 +53,13 @@ fn is_comparative_adjective(tok: &Token, source: &[char]) -> bool {
     tok.kind
         .is_adjective()
         .then(|| tok.span.get_content(source))
-        .map_or(false, |src| {
+        .is_some_and(|src| {
             // Regular comparative form?
             src.ends_with(&['e', 'r'])
                 // Irregular comparatives.
-                || src == &['l', 'e', 's', 's']
-                || src == &['m', 'o', 'r', 'e']
-                || src == &['w', 'o', 'r', 's', 'e']
+                || src == ['l', 'e', 's', 's']
+                || src == ['m', 'o', 'r', 'e']
+                || src == ['w', 'o', 'r', 's', 'e']
         })
 }
 

--- a/harper-core/src/linting/then_than.rs
+++ b/harper-core/src/linting/then_than.rs
@@ -2,7 +2,8 @@ use super::{Lint, LintKind, PatternLinter};
 use crate::Token;
 use crate::linting::Suggestion;
 use crate::patterns::{
-    All, AnyCapitalization, Invert, OwnedPatternExt, Pattern, SequencePattern, WordSet,
+    All, AnyCapitalization, EitherPattern, Invert, OwnedPatternExt, Pattern, SequencePattern,
+    WordSet,
 };
 
 #[doc = "Corrects the misuse of `then` to `than`."]
@@ -14,21 +15,52 @@ impl ThenThan {
     pub fn new() -> Self {
         Self {
             pattern: Box::new(All::new(vec![
-                Box::new(
-                    SequencePattern::default()
-                        .then(WordSet::new(&["better", "other"]).or(Box::new(
-                            |tok: &Token, _source: &[char]| tok.kind.is_adjective(),
-                        )))
-                        .then_whitespace()
-                        .then_any_capitalization_of("then")
-                        .then_whitespace()
-                        .then(Invert::new(AnyCapitalization::of("that"))),
-                ),
-                // Denotes exceptions to the rule.
+                Box::new(EitherPattern::new(vec![
+                    // Comparative form of adjective
+                    Box::new(
+                        SequencePattern::default()
+                            .then(WordSet::new(&["other"]).or(Box::new(
+                                |tok: &Token, source: &[char]| {
+                                    is_comparative_adjective(tok, source)
+                                },
+                            )))
+                            .then_whitespace()
+                            .then_any_capitalization_of("then")
+                            .then_whitespace()
+                            .then(Invert::new(AnyCapitalization::of("that"))),
+                    ),
+                    // Positive form of adjective following "more" or "less"
+                    Box::new(
+                        SequencePattern::default()
+                            .then(WordSet::new(&["more", "less"]))
+                            .then_whitespace()
+                            .then_adjective()
+                            .then_whitespace()
+                            .then_any_capitalization_of("then")
+                            .then_whitespace()
+                            .then(Invert::new(AnyCapitalization::of("that"))),
+                    ),
+                ])),
+                // Exceptions to the rule.
                 Box::new(Invert::new(WordSet::new(&["back", "this", "so", "but"]))),
             ])),
         }
     }
+}
+
+// TODO: This can be simplified or eliminated when the adjective improvements make it into the affix system.
+fn is_comparative_adjective(tok: &Token, source: &[char]) -> bool {
+    tok.kind
+        .is_adjective()
+        .then(|| tok.span.get_content(source))
+        .map_or(false, |src| {
+            // Regular comparative form?
+            src.ends_with(&['e', 'r'])
+                // Irregular comparatives.
+                || src == &['l', 'e', 's', 's']
+                || src == &['m', 'o', 'r', 'e']
+                || src == &['w', 'o', 'r', 's', 'e']
+        })
 }
 
 impl Default for ThenThan {
@@ -42,7 +74,8 @@ impl PatternLinter for ThenThan {
         self.pattern.as_ref()
     }
     fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
-        let span = matched_tokens[2].span;
+        // For both "stupider then X" and "more stupid then X", "then" is 3rd last token.
+        let span = matched_tokens[matched_tokens.len() - 3].span;
         let offending_text = span.get_content(source);
 
         Some(Lint {
@@ -330,6 +363,42 @@ mod tests {
             "We submitted the patch more recently then last week, so they should have it already.",
             ThenThan::default(),
             "We submitted the patch more recently than last week, so they should have it already.",
+        );
+    }
+
+    #[test]
+    fn allows_well_then() {
+        assert_lint_count(
+            "Well then we're just going to raise all of these taxes",
+            ThenThan::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn allows_nervous_then() {
+        assert_lint_count(
+            "I think both of us were getting nervous then because the system would have automatically aborted.",
+            ThenThan::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn flags_stupider_then_and_more_and_less_stupid_then() {
+        assert_lint_count(
+            "He was stupider then her but she was more stupid then some. Then again he was less stupid then some too.",
+            ThenThan::default(),
+            3,
+        );
+    }
+
+    #[test]
+    fn patch_worse_then() {
+        assert_suggestion_result(
+            "He was worse then her at writing code.",
+            ThenThan::default(),
+            "He was worse than her at writing code.",
         );
     }
 }

--- a/harper-core/src/linting/then_than.rs
+++ b/harper-core/src/linting/then_than.rs
@@ -19,7 +19,7 @@ impl ThenThan {
                     // Comparative form of adjective
                     Box::new(
                         SequencePattern::default()
-                            .then(WordSet::new(&["other"]).or(Box::new(
+                            .then(AnyCapitalization::of("other").or(Box::new(
                                 |tok: &Token, source: &[char]| {
                                     is_comparative_adjective(tok, source)
                                 },


### PR DESCRIPTION
# Issues 
N/A

# Description
Fixes one or two false positives I've spotted with "then" where "than" should be.

I made the logic more linguistically robust around how adjectives and comparison work in English.
In particular "than" can't be used after every adjective, only those inflected into the comparative form (faster), irregular comparatives (worse), and uninflected (positive) adjectives after the special words "more" or "less".

# How Has This Been Tested?

All existing tests pass and I added some I thought up to cover edge cases that either would've failed before, or might not be obvious even if they would've already passed, or for false positives I've spotted in the wild.

`cargo test` passes all tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
