### PR TITLE
feat: don't detect "my US" as sequential pronouns

### DIFF
--- a/harper-core/src/linting/multiple_sequential_pronouns.rs
+++ b/harper-core/src/linting/multiple_sequential_pronouns.rs
@@ -3,15 +3,14 @@ use super::pattern_linter::PatternLinter;
 use crate::linting::LintKind;
 use crate::patterns::{Pattern, SequencePattern, WordSet};
 use crate::{CharStringExt, Lint, Lrc, Token, TokenStringExt};
-use hashbrown::HashSet;
 
 /// Linter that checks if multiple pronouns are being used right after each
 /// other. This is a common mistake to make during the revision process.
 pub struct MultipleSequentialPronouns {
     pattern: Box<dyn Pattern>,
-    subject_pronouns: HashSet<&'static str>,
-    object_pronouns: HashSet<&'static str>,
-    possessive_adjectives: HashSet<&'static str>,
+    subject_pronouns: Lrc<WordSet>,
+    object_pronouns: Lrc<WordSet>,
+    possessive_adjectives: Lrc<WordSet>,
 }
 
 impl MultipleSequentialPronouns {
@@ -19,7 +18,7 @@ impl MultipleSequentialPronouns {
         // Some words occur in multiple positions in the paradigm
         // but this is a set, so it doesn't matter and is much clearer
         let pronouns = Lrc::new(WordSet::new(&[
-            "I", "you", "he", "she", "it", // subject case, singular
+            "i", "you", "he", "she", "it", // subject case, singular
             "me", "you", "him", "her", "it", // object case, singular
             "we", "you", "they", // subject case, plural
             "us", "you", "them", // object case, plural
@@ -30,20 +29,20 @@ impl MultipleSequentialPronouns {
         ]));
 
         // TODO: temporary sets of pronouns - remove when WordMetadata has this info
-        let subject_pronouns = HashSet::from([
-            "I", "you", "he", "she", "it", // subject case, singular
+        let subject_pronouns = Lrc::new(WordSet::new(&[
+            "i", "you", "he", "she", "it", // subject case, singular
             "we", "you", "they", // subject case, plural
-        ]);
+        ]));
 
-        let object_pronouns = HashSet::from([
+        let object_pronouns = Lrc::new(WordSet::new(&[
             "me", "you", "him", "her", "it", // object case, singular
             "us", "you", "them", // object case, plural
-        ]);
+        ]));
 
-        let possessive_adjectives = HashSet::from([
+        let possessive_adjectives = Lrc::new(WordSet::new(&[
             "my", "your", "his", "her", "its", // possessive adjectives, singular
             "our", "your", "their", // possessive adjectives, plural
-        ]);
+        ]));
 
         Self {
             pattern: Box::new(
@@ -62,15 +61,15 @@ impl MultipleSequentialPronouns {
     }
 
     fn is_subject_pronoun(&self, word: &str) -> bool {
-        self.subject_pronouns.contains(word)
+        self.subject_pronouns.contains(&word)
     }
 
     fn is_object_pronoun(&self, word: &str) -> bool {
-        self.object_pronouns.contains(word)
+        self.object_pronouns.contains(&word)
     }
 
     fn is_possessive_adjective(&self, word: &str) -> bool {
-        self.possessive_adjectives.contains(word)
+        self.possessive_adjectives.contains(&word)
     }
 }
 
@@ -83,7 +82,8 @@ impl PatternLinter for MultipleSequentialPronouns {
         let mut suggestions = Vec::new();
 
         if matched_tokens.len() == 3 {
-            let first_word = matched_tokens[0].span.get_content(source).to_string();
+            let first_word_raw = matched_tokens[0].span.get_content(source).to_string();
+            let first_word = first_word_raw.to_ascii_lowercase();
             let second_word = matched_tokens[2].span.get_content(source).to_string();
             // Bug 578: "I can lend you my car" - if 1st is object and second is possessive adjective, don't lint
             if self.is_object_pronoun(&first_word) && self.is_possessive_adjective(&second_word) {
@@ -91,6 +91,11 @@ impl PatternLinter for MultipleSequentialPronouns {
             }
             // Bug 724: "One told me they were able to begin reading" - if 1st is object ans second is subject, don't lint
             if self.is_object_pronoun(&first_word) && self.is_subject_pronoun(&second_word) {
+                return None;
+            }
+
+            // US is a qualifier meaning American, so uppercase after a possessive is OK.
+            if self.is_possessive_adjective(&first_word) && second_word == "US" {
                 return None;
             }
 
@@ -181,6 +186,24 @@ mod tests {
     fn dont_flag_724() {
         assert_lint_count(
             "One told me they were able to begin reading.",
+            MultipleSequentialPronouns::new(),
+            0,
+        )
+    }
+
+    #[test]
+    fn dont_flag_us() {
+        assert_lint_count(
+            "Take the plunge and pull plug from their US tech.",
+            MultipleSequentialPronouns::new(),
+            0,
+        )
+    }
+
+    #[test]
+    fn dont_flag_my_us_your_us() {
+        assert_lint_count(
+            "My US passport looks different from your US passport.",
             MultipleSequentialPronouns::new(),
             0,
         )

--- a/harper-core/src/patterns/word_set.rs
+++ b/harper-core/src/patterns/word_set.rs
@@ -21,6 +21,10 @@ impl WordSet {
         }
     }
 
+    pub fn contains(&self, word: &str) -> bool {
+        self.words.contains(&word.chars().collect())
+    }
+
     /// Create a new word set that matches against any word in the provided list.
     pub fn new(words: &[&'static str]) -> Self {
         let mut set = Self::default();


### PR DESCRIPTION
# Issues 
N/A

# Description

I noticed things like "Your US laws" get flagged as sequential pronouns.
Added exception for "US" after a possessive since it then functions as a noun.

I also refactored the logic to use `WordSet` rather than `HashSet` since the pattern already used it and comparisons wouldn't require conversion.

This required adding a `contains` method to `WordSet`.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I added a unit test based on the sentence that drew my attention to this false positive.
I added a unit test with a made-up sentence covering different pronouns in upper- and lowercase.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
