### PR TITLE
feat: Expand "cuz" to "because"

### DIFF
--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -923,6 +923,12 @@ pub fn lint_group() -> LintGroup {
             "Use `without` instead of `w/o`",
             "Expands the abbreviation `w/o` to the full word `without` for clarity."
         ),
+        "ExpandBecause" => (
+            ["cuz"],
+            ["because"],
+            "Use `because` instead of informal `cuz`",
+            "Expands the informal abbreviation `cuz` to the full word `because` for formailty."
+        )
     });
 
     group.set_all_rules_to(Some(true));

--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -927,7 +927,7 @@ pub fn lint_group() -> LintGroup {
             ["cuz"],
             ["because"],
             "Use `because` instead of informal `cuz`",
-            "Expands the informal abbreviation `cuz` to the full word `because` for formailty."
+            "Expands the informal abbreviation `cuz` to the full word `because` for formality."
         )
     });
 

--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -1761,4 +1761,13 @@ mod tests {
             "Another possible cause is simply that the application does not have file creation permissions on the other machine.",
         );
     }
+
+    #[test]
+    fn expand_cuz() {
+        assert_suggestion_result(
+            "Stick around cuz I got a surprise for you at the end.",
+            lint_group(),
+            "Stick around because I got a surprise for you at the end.",
+        );
+    }
 }


### PR DESCRIPTION
# Description

When dogfooding on YouTube transcripts they're always for of the word "cuz" for because. I know it's common not just on YouTube.

So I added an expansion to it similar to the ones for "stdout" and "w/o" but note that "cuz" is informal, which is a bit different from the others.

# How Has This Been Tested?

I added a unit test with a typical sentence from a YouTube transcript.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
