### PR TITLE
feat: Add special cases to sentence capitalization

### DIFF
--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -315,7 +315,6 @@ impl LintGroup {
         insert_pattern_rule!(PossessiveYour, true);
         insert_struct_rule!(SpelledNumbers, false);
         insert_struct_rule!(AnA, true);
-        insert_struct_rule!(SentenceCapitalization, true);
         insert_struct_rule!(UnclosedQuotes, true);
         insert_struct_rule!(LongSentences, true);
         insert_struct_rule!(RepeatedWords, true);
@@ -361,6 +360,12 @@ impl LintGroup {
             Box::new(InflectedVerbAfterTo::new(dictionary.clone(), dialect)),
         );
         out.config.set_rule_enabled("InflectedVerbAfterTo", true);
+
+        out.add(
+            "SentenceCapitalization",
+            Box::new(SentenceCapitalization::new(dictionary.clone(), dialect)),
+        );
+        out.config.set_rule_enabled("SentenceCapitalization", true);
 
         out
     }


### PR DESCRIPTION
# Issues 
#77 

# Description

Some "words" are not usually uppercased when they're first in a sentence. I introduce two heuristics to identify them:
1. Proper nouns which are usually trademarks
  iOS, macOS, iMac, npm, etc.
3. Any word that in its dictionary form starts with a lowercase letter and has at least one uppercase letter (before any apostrophe, hyphen, or space (though only the first is currently possible)
  mRNA, dB, eSIM, fMRI, kHz, kW, kWh

# How Has This Been Tested?

I added unit tests for each case using real-world sentences.
`cargo clippy` ` cargo test` `just test`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
