### PR TITLE
feat: implement `assert_any_suggestion_result` as in #950

### DIFF
--- a/harper-core/src/linting/possessive_your.rs
+++ b/harper-core/src/linting/possessive_your.rs
@@ -38,6 +38,7 @@ impl PatternLinter for PossessiveYour {
             lint_kind: LintKind::WordChoice,
             suggestions: vec![
                 Suggestion::replace_with_match_case("your".chars().collect(), orig_chars),
+                Suggestion::replace_with_match_case("you're a".chars().collect(), orig_chars),
                 Suggestion::replace_with_match_case("you're an".chars().collect(), orig_chars),
             ],
             message: "The possessive version of this word is more common in this context."


### PR DESCRIPTION
# Issues 
Closes #950 

# Description

Implements `assert_any_suggestion_result` so you don't have to include the exact suggestion number that you expect to match.

# How Has This Been Tested?

I added some unit tests using one of the linters that suggests more than one replacement, `possess_your`.
In doing so I noticed it returned one option with "an" but no matching one with "a", so I added that too.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
