### PR TITLE
feat: mention which verb triggered lint in msg

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -10192,7 +10192,7 @@ Tyree/2M
 Tyrolean/51
 Tyrone/21M
 Tyson/2M
-U/15+2M
+U/M                 # removed `1`noun `5`adj. `2`proper noun `+`prep., was interfering with linter heuristics. I only know this as an abbreviation for university
 UAE/2M              # United Arab Emirates
 UAR/2
 UAW/2
@@ -10212,7 +10212,7 @@ UPC/1
 UPI/21M
 UPS/142M
 URL/1S
-US/215M
+US/2M
 USA/21M
 USAF/2
 USAID/2M            # agency
@@ -35786,7 +35786,7 @@ omniscient/51
 omnivore/1MS
 omnivorous/~5PY
 omnivorousness/1M
-on/~5+4
+on/~5+              # verb sense is nonstandard dialectal and interferes with linter heuristics
 onboard/~5j4SDG
 once/~71M
 oncogene/1SM
@@ -48889,7 +48889,7 @@ tyrant/~154SM
 tyre/14MS!
 tyro/1MS
 tzatziki/1
-u/~185S
+# u/~185S           # probably left over from hunspell, causes havoc with linter heuristics
 ubiquitous/~5Y
 ubiquity/1M
 udder/1SM

--- a/harper-core/src/linting/compound_nouns/implied_instantiated_compound_nouns.rs
+++ b/harper-core/src/linting/compound_nouns/implied_instantiated_compound_nouns.rs
@@ -49,7 +49,8 @@ impl PatternLinter for ImpliedInstantiatedCompoundNouns {
             lint_kind: LintKind::WordChoice,
             suggestions: vec![Suggestion::replace_with_match_case(word.to_vec(), orig)],
             message: format!(
-                "The verb here implies the existence of the closed compound noun “{}”.",
+                "The auxiliary verb “{}” implies the existence of the closed compound noun “{}”.",
+                matched_tokens[4].span.get_content(source).to_string(),
                 word.to_string()
             ),
             priority: 63,


### PR DESCRIPTION
# Issues 
N/A

# Description

While hunting for why Harper wants to change "impact on US may be limited" to "onus" I first thought "on" being a rare verb was responsible.

I tweaked odditties in the the dictionary annotations that caused both "on" and "us" to be marked as verbs.

But it turned out the reason for that problem was not a verb to the left of the compound but to the right of the compound.

So I adjusted the linter message to include the verb responsible and thus clear for both users and developers.

(The surprising suggestion for "onus" still happens, that will be separate.)

# How Has This Been Tested?

`cargo test` and clippy are still happy.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
