### PR TITLE
feat: handle multiple derivations for words in the metadata

### DIFF
--- a/harper-core/src/fat_token.rs
+++ b/harper-core/src/fat_token.rs
@@ -4,7 +4,7 @@ use crate::{CharStringExt, TokenKind};
 
 /// A [`Token`](crate::Token) that holds its content as a fat [`Vec<char>`] rather than as a
 /// [`Span`](crate::Span).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, PartialOrd, Hash, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Hash, Eq)]
 pub struct FatToken {
     pub content: Vec<char>,
     pub kind: TokenKind,
@@ -20,7 +20,7 @@ impl From<FatStringToken> for FatToken {
 }
 
 /// Similar to a [`FatToken`], but uses a [`String`] as the underlying store.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, PartialOrd, Hash, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FatStringToken {
     pub content: String,
     pub kind: TokenKind,

--- a/harper-core/src/ignored_lints/lint_context.rs
+++ b/harper-core/src/ignored_lints/lint_context.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::hash::{Hash, Hasher};
 
 use crate::{
     Document, FatToken,
@@ -7,13 +8,23 @@ use crate::{
 
 /// A location-agnostic structure that attempts to captures the context and content that a [`Lint`]
 /// occurred.
-#[derive(Debug, Hash, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct LintContext {
     pub lint_kind: LintKind,
     pub suggestions: Vec<Suggestion>,
     pub message: String,
     pub priority: u8,
     pub tokens: Vec<FatToken>,
+}
+
+impl Hash for LintContext {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.lint_kind.hash(state);
+        self.suggestions.hash(state);
+        self.message.hash(state);
+        self.priority.hash(state);
+        self.tokens.hash(state);
+    }
 }
 
 impl LintContext {

--- a/harper-core/src/spell/fst_dictionary.rs
+++ b/harper-core/src/spell/fst_dictionary.rs
@@ -307,26 +307,27 @@ mod tests {
     #[test]
     fn plural_llamas_derived_from_llama() {
         let dict = FstDictionary::curated();
-
-        assert_eq!(
+        assert!(
             dict.get_word_metadata_str("llamas")
                 .unwrap()
                 .derived_from
-                .unwrap(),
-            WordId::from_word_str("llama")
-        )
+                .as_ref()
+                .unwrap()
+                .contains(&WordId::from_word_str("llama"))
+        );
     }
 
     #[test]
     fn plural_cats_derived_from_cat() {
         let dict = FstDictionary::curated();
 
-        assert_eq!(
+        assert!(
             dict.get_word_metadata_str("cats")
                 .unwrap()
                 .derived_from
-                .unwrap(),
-            WordId::from_word_str("cat")
+                .as_ref()
+                .unwrap()
+                .contains(&WordId::from_word_str("cat"))
         );
     }
 
@@ -334,12 +335,13 @@ mod tests {
     fn unhappy_derived_from_happy() {
         let dict = FstDictionary::curated();
 
-        assert_eq!(
+        assert!(
             dict.get_word_metadata_str("unhappy")
                 .unwrap()
                 .derived_from
-                .unwrap(),
-            WordId::from_word_str("happy")
+                .as_ref()
+                .unwrap()
+                .contains(&WordId::from_word_str("happy"))
         );
     }
 
@@ -347,12 +349,13 @@ mod tests {
     fn quickly_derived_from_quick() {
         let dict = FstDictionary::curated();
 
-        assert_eq!(
+        assert!(
             dict.get_word_metadata_str("quickly")
                 .unwrap()
                 .derived_from
-                .unwrap(),
-            WordId::from_word_str("quick")
+                .as_ref()
+                .unwrap()
+                .contains(&WordId::from_word_str("quick"))
         );
     }
 }

--- a/harper-core/src/spell/mod.rs
+++ b/harper-core/src/spell/mod.rs
@@ -14,7 +14,7 @@ mod rune;
 mod word_id;
 mod word_map;
 
-#[derive(PartialEq, Debug, Hash, Eq)]
+#[derive(PartialEq, Debug, Eq)]
 pub struct FuzzyMatchResult<'a> {
     pub word: &'a [char],
     pub edit_distance: u8,

--- a/harper-core/src/spell/rune/attribute_list.rs
+++ b/harper-core/src/spell/rune/attribute_list.rs
@@ -1,4 +1,4 @@
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
 use smallvec::ToSmallVec;
 
@@ -89,11 +89,17 @@ impl AttributeList {
                     );
                     let t_metadata = dest.get_metadata_mut_chars(&new_word).unwrap();
                     t_metadata.append(&metadata);
-                    t_metadata.derived_from = Some(WordId::from_word_chars(&word.letters))
+                    t_metadata
+                        .derived_from
+                        .get_or_insert_with(HashSet::new)
+                        .insert(WordId::from_word_chars(&word.letters));
                 }
             } else {
                 for (key, mut value) in new_words.into_iter() {
-                    value.derived_from = Some(WordId::from_word_chars(&word.letters));
+                    value
+                        .derived_from
+                        .get_or_insert_with(HashSet::new)
+                        .insert(WordId::from_word_chars(&word.letters));
 
                     if let Some(val) = dest.get_metadata_mut_chars(&key) {
                         val.append(&value);

--- a/harper-core/src/spell/word_id.rs
+++ b/harper-core/src/spell/word_id.rs
@@ -31,4 +31,8 @@ impl WordId {
         let chars: CharString = text.as_ref().chars().collect();
         Self::from_word_chars(chars)
     }
+
+    pub fn from_hash(hash: u64) -> Self {
+        Self { hash }
+    }
 }

--- a/harper-core/src/token_kind.rs
+++ b/harper-core/src/token_kind.rs
@@ -2,8 +2,9 @@ use is_macro::Is;
 use serde::{Deserialize, Serialize};
 
 use crate::{ConjunctionData, NounData, Number, PronounData, Punctuation, Quote, WordMetadata};
+use std::hash::{Hash, Hasher};
 
-#[derive(Debug, Is, Clone, Serialize, Deserialize, Default, PartialOrd, Hash, Eq, PartialEq)]
+#[derive(Debug, Is, Clone, Serialize, Deserialize, Default, Eq, PartialEq)]
 #[serde(tag = "kind", content = "value")]
 pub enum TokenKind {
     /// `None` if the word does not exist in the dictionary.
@@ -24,6 +25,49 @@ pub enum TokenKind {
     Unlintable,
     ParagraphBreak,
     Regexish,
+}
+
+impl Hash for TokenKind {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            TokenKind::Word(metadata) => {
+                metadata.hash(state);
+            }
+            TokenKind::Punctuation(punct) => {
+                punct.hash(state);
+            }
+            TokenKind::Decade => {
+                0.hash(state);
+            }
+            TokenKind::Number(number) => {
+                number.hash(state);
+            }
+            TokenKind::Space(space) => {
+                space.hash(state);
+            }
+            TokenKind::Newline(newline) => {
+                newline.hash(state);
+            }
+            TokenKind::EmailAddress => {
+                0.hash(state);
+            }
+            TokenKind::Url => {
+                0.hash(state);
+            }
+            TokenKind::Hostname => {
+                0.hash(state);
+            }
+            TokenKind::Unlintable => {
+                0.hash(state);
+            }
+            TokenKind::ParagraphBreak => {
+                0.hash(state);
+            }
+            TokenKind::Regexish => {
+                0.hash(state);
+            }
+        }
+    }
 }
 
 impl TokenKind {


### PR DESCRIPTION
# Issues 
N/A

# Description

The code currently assumes each word has either 0 or 1 derivations.
That is, either the word was directly included in the dictionary, or it was derived from one entry in the dictionary.

But in fact, words can be derived from multiple dictionary entries via different affix rules.

Some derivations are surprising since they're left over from the curated dictionary's origin as a pure spellchecker dictionary from Hunspell, where affixes were more about making the data structure compact than about storing grammatical information.

Most words with multiple derivations are due to one having a prefix in its dictionary entry and a suffix added via the affix attributes, and the other having a suffix in its entry and prefix added via the affix attributes.

There's probably another kind of conflict which this work doesn't uncover: A word having an entry directly in the dictionary, and another resulting from a different base word in the dictionary with a computed affix added.

# Demo

Running `target/debug/harper-cli metadata proactively`
```json
{
  "noun": null,
  "pronoun": null,
  "verb": null,
  "adjective": {
    "degree": null
  },
  "adverb": {},
  "conjunction": null,
  "swear": null,
  "dialect": null,
  "determiner": false,
  "preposition": false,
  "common": false,
  "derived_from": [
    {
      "hash": 9804073089439753757
    },
    {
      "hash": 16574093145829401086
    }
  ]
}
derived_from: ["proactive", "actively"]
```
Running `target/debug/harper-cli metadata bed`
```json
{
  "noun": {
    "is_proper": null,
    "is_plural": false,
    "is_possessive": null
  },
  "pronoun": null,
  "verb": {
    "is_linking": null,
    "is_auxiliary": null,
    "tense": null
  },
  "adjective": null,
  "adverb": null,
  "conjunction": null,
  "swear": null,
  "dialect": null,
  "determiner": false,
  "preposition": false,
  "common": true,
  "derived_from": [
    {
      "hash": 4768722997514414045
    }
  ]
}
derived_from: ["b"]
```

# How Has This Been Tested?

All tests still pass. Clippy is happy. No new tests were added yet.

Some other programmers' eyes should go over this since there are a few things I wasn't totally familiar with though everything ended up working.
Also, I'm not sure what consumes the output here. The way I'm outputting the array of `derived_from` is not JSON like the rest of the `just getmetadata` output. Maybe it would be better done another way.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
