### PR TITLE
feat: trail and error→trial and error

### DIFF
--- a/harper-core/src/linting/an_a.rs
+++ b/harper-core/src/linting/an_a.rs
@@ -92,7 +92,7 @@ fn to_lower_word(word: &[char]) -> Cow<'_, [char]> {
 
 /// Checks whether a provided word begins with a vowel _sound_.
 ///
-/// It was produced through trail and error.
+/// It was produced through trial and error.
 /// Matches with 99.71% and 99.77% of vowels and non-vowels in the
 /// Carnegie-Mellon University word -> pronunciation dataset.
 fn starts_with_vowel(word: &[char]) -> bool {

--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -923,6 +923,12 @@ pub fn lint_group() -> LintGroup {
             "Use `without` instead of `w/o`",
             "Expands the abbreviation `w/o` to the full word `without` for clarity."
         ),
+        "TrialAndError" => (
+            ["trail and error"],
+            ["trial and error"],
+            "You misspelled `trial`.",
+            "Corrects `trail` to `trial` in `trial and error`."
+        ),
     });
 
     group.set_all_rules_to(Some(true));
@@ -1753,6 +1759,15 @@ mod tests {
             "Another possible cause is simply that the application does not have file creation permissions on the another machine.",
             lint_group(),
             "Another possible cause is simply that the application does not have file creation permissions on the other machine.",
+        );
+    }
+
+    #[test]
+    fn correct_trail_and_error() {
+        assert_suggestion_result(
+            "It was produced through trail and error.",
+            lint_group(),
+            "It was produced through trial and error.",
         );
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

While looking into adding an "and" suggestion to the "a/an" linter I saw the typo "trail and error". This turns out to be common, so here's a lint.

# How Has This Been Tested?

Added the comment from the "a/an" linter as a unit test.
`cargo test`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
