### PR TITLE
fix: make modal-of linter case insensitive

### DIFF
--- a/harper-core/src/linting/modal_of.rs
+++ b/harper-core/src/linting/modal_of.rs
@@ -25,14 +25,10 @@ impl Default for ModalOf {
             SequencePattern::default()
                 .then(words)
                 .then_whitespace()
-                .then_exact_word("of"),
+                .t_aco("of"),
         );
 
-        let ws_course = Lrc::new(
-            SequencePattern::default()
-                .then_whitespace()
-                .then_exact_word("course"),
-        );
+        let ws_course = Lrc::new(SequencePattern::default().then_whitespace().t_aco("course"));
 
         let modal_of_course = Lrc::new(
             SequencePattern::default()
@@ -44,9 +40,9 @@ impl Default for ModalOf {
             SequencePattern::default()
                 .then_any_word()
                 .then_whitespace()
-                .then_exact_word("might")
+                .t_aco("might")
                 .then_whitespace()
-                .then_exact_word("of"),
+                .t_aco("of"),
         );
 
         let anyword_might_of_course = Lrc::new(

--- a/harper-core/src/linting/modal_of.rs
+++ b/harper-core/src/linting/modal_of.rs
@@ -289,4 +289,18 @@ mod tests {
     fn doesnt_catch_to_take_on_the_full_might_of_nato() {
         assert_lint_count("To take on the full might of NATO.", ModalOf::default(), 0);
     }
+
+    #[test]
+    fn doesnt_catch_mixed_case_of_course() {
+        assert_lint_count(
+            "... for now you could of Course put ...",
+            ModalOf::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn catches_mixed_case_could_of_put() {
+        assert_lint_count("... for now you could of Put ...", ModalOf::default(), 1);
+    }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

A YouTube transcript I was testing Harper on had the text 
> ... for now you could of
> Course put ...

It flagged "could of"
But then I noticed the "of" really was part of "of course" and there was no error.
This PR fixes that so that "of Course" will also be identified as a false positive.

# How Has This Been Tested?

I added two mixed-case tests. One to catch "could of" and one to make sure "could of course" is not caught.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
