### PR TITLE
`harper.js` API reference generation improvements

### DIFF
--- a/packages/harper.js/docs.sh
+++ b/packages/harper.js/docs.sh
@@ -1,34 +1,39 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 
-pnpm api-extractor run 
+pnpm api-extractor run
 pnpm api-documenter markdown -i temp
 
-rm -r html || true
-mkdir html || true
-
-echo Rendering HTML...
-# Check if parallel is available
-if ! command -v parallel &> /dev/null; then
-    echo "parallel not found, falling back to sequential processing"
-    for file in ./markdown/*.md
-    do 
-        BASE=$(basename $file .md)
-        pandoc $file -o html/$BASE.html
-        perl -pi -e 's/"\K([^"]+)\.md(?=")/\1.html/g' html/$BASE.html
-
-        echo '<link rel="stylesheet" href="https://unpkg.com/mvp.css">' >> html/$BASE.html
-    done
-else
-    parallel '
-        BASE=$(basename {} .md)
-        pandoc {} -o html/$BASE.html
-        perl -pi -e `s/\"\\K([^\\"]+)\\.md(?=\")/\\1.html/g` html/$BASE.html
-        echo "<link rel=\"stylesheet\" href=\"https://unpkg.com/mvp.css\">" >> "html/$BASE.html"
-    ' ::: ./markdown/*.md
+html_dir="./html"
+if [[ -d "$html_dir" ]]; then
+	echo "Deleting old output from ${html_dir}"
+	rm -r "$html_dir" || true
 fi
+mkdir "$html_dir" || true
 
-rm -r ../web/static/docs/harperjs || true
-mkdir -p ../web/static/docs/harperjs || true
-mv -f html ../web/static/docs/harperjs/ref 
+harperjs_docs_dir="../web/static/docs/harperjs"
+if [[ -d "$harperjs_docs_dir" ]]; then
+	echo "Deleting old output from ${harperjs_docs_dir}"
+	rm -r "$harperjs_docs_dir" || true
+fi
+mkdir -p "$harperjs_docs_dir" || true
+
+echo "Rendering HTML..."
+if command -v parallel &> /dev/null; then
+	parallel '
+        base=$(basename {} .md)
+        pandoc {} -o "html/${base}.html"
+        perl -pi -e '\''s/"\K([^"]+)\.md(?=")/\1.html/g'\'' "html/${base}.html"
+        echo '\''<link rel="stylesheet" href="https://unpkg.com/mvp.css">'\'' >> "html/${base}.html"
+    ' ::: ./markdown/*.md
+else
+	echo "parallel not found, falling back to sequential processing"
+	for file in ./markdown/*.md; do
+		base=$(basename "$file" .md)
+		pandoc "$file" -o "html/${base}.html"
+		perl -pi -e 's/"\K([^"]+)\.md(?=")/\1.html/g' "html/${base}.html"
+		echo '<link rel="stylesheet" href="https://unpkg.com/mvp.css">' >> "html/${base}.html"
+	done
+fi
+mv -f "$html_dir" "${harperjs_docs_dir}/ref"

--- a/packages/harper.js/docs.sh
+++ b/packages/harper.js/docs.sh
@@ -23,17 +23,25 @@ echo "Rendering HTML..."
 if command -v parallel &> /dev/null; then
 	parallel '
         base=$(basename {} .md)
-        pandoc {} -o "html/${base}.html"
+        title="${base#"harper.js."}"
+        pandoc -s \
+            -V pagetitle="${title} - Harper" \
+            -V description-meta="API reference documentation for harper.js" \
+            -V css="https://unpkg.com/mvp.css" \
+            -o "html/${base}.html" {}
         perl -pi -e '\''s/"\K([^"]+)\.md(?=")/\1.html/g'\'' "html/${base}.html"
-        echo '\''<link rel="stylesheet" href="https://unpkg.com/mvp.css">'\'' >> "html/${base}.html"
     ' ::: ./markdown/*.md
 else
 	echo "parallel not found, falling back to sequential processing"
 	for file in ./markdown/*.md; do
 		base=$(basename "$file" .md)
-		pandoc "$file" -o "html/${base}.html"
+		title="${base#"harper.js."}"
+		pandoc -s \
+			-V pagetitle="${title} - Harper" \
+			-V description-meta="API reference documentation for harper.js" \
+			-V css="https://unpkg.com/mvp.css" \
+			-o "html/${base}.html" "$file"
 		perl -pi -e 's/"\K([^"]+)\.md(?=")/\1.html/g' "html/${base}.html"
-		echo '<link rel="stylesheet" href="https://unpkg.com/mvp.css">' >> "html/${base}.html"
 	done
 fi
 mv -f "$html_dir" "${harperjs_docs_dir}/ref"

--- a/packages/harper.js/docs.sh
+++ b/packages/harper.js/docs.sh
@@ -33,7 +33,7 @@ if command -v parallel &> /dev/null; then
         pandoc -s \
             -V pagetitle="${base#"harper.js."} - Harper" \
             -V description-meta="API reference documentation for harper.js" \
-            -V css="https://unpkg.com/mvp.css" \
+            -V document-css="true" \
             -L "./temp/md_to_html.lua" \
             -o "html/${base}.html" {}
     ' ::: ./markdown/*.md
@@ -44,7 +44,7 @@ else
 		pandoc -s \
 			-V pagetitle="${base#"harper.js."} - Harper" \
 			-V description-meta="API reference documentation for harper.js" \
-			-V css="https://unpkg.com/mvp.css" \
+			-V document-css="true" \
 			-L "./temp/md_to_html.lua" \
 			-o "html/${base}.html" "$file"
 	done


### PR DESCRIPTION
# Issues 

None

# Description

I was going around the Harper website and noticed that the links to subpages in `/docs/harperjs/ref` were broken, so I fixed that here.

Along the way, I also improved the `docs.sh` script:

- Refactor a bit and prevent printing unnecessary errors. Mainly the "cannot remove `./html`" one.
- Generate standalone HTML pages with proper meta titles and descriptions instead of partials. A plus of this is we get some syntax highlighting for free.
- Use a Pandoc Lua filter when changing `.md`s to `.html`s in links instead of Perl. This is more robust as we're sure that it'll only specifically change link `href`s that end in `.md`.
- Use Pandoc's default document styling instead of MVP.css. This one is just personal preference and I'm open to revert it if you don't like it. I just find that the Pandoc styling has better spacing and the off-white is easier on the eyes instead of pure `#fff`. A plus of this is pages would load faster since they wouldn't need to connect to a third-party service anymore to get styling.

# Demo

Screenshot for the fourth bullet:

![pr-1](https://github.com/user-attachments/assets/bb260f48-535e-49c2-ba77-475079d785ca)

# How Has This Been Tested?

Manual testing locally

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
