### PR TITLE
Adj of a curation 2025 04 09

### DIFF
--- a/harper-core/src/linting/adjective_of_a.rs
+++ b/harper-core/src/linting/adjective_of_a.rs
@@ -12,6 +12,7 @@ const FALSE_POSITIVES: &[&str] = &[
     "equivalent",
     "full",
     "inside",
+    "up",
     // "more" is tricky but it often seems correct and idiomatic.
     "more",
     "much",
@@ -454,6 +455,15 @@ mod tests {
     fn dont_flag_clockwork() {
         assert_lint_count(
             "so something's wrong in this clockwork of a thing and I'm not going to bother taking this apart",
+            AdjectiveOfA,
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_up() {
+        assert_lint_count(
+            "Yeah gas is made up of a bunch of teenytiny particles all moving around.",
             AdjectiveOfA,
             0,
         );

--- a/harper-core/src/linting/adjective_of_a.rs
+++ b/harper-core/src/linting/adjective_of_a.rs
@@ -22,6 +22,7 @@ const FALSE_POSITIVES: &[&str] = &[
     "bit",
     "bottom",
     "chance",
+    "clockwork",
     "derivative",
     "dream",
     "front",
@@ -444,6 +445,15 @@ mod tests {
     fn dont_flag_equivalent() {
         assert_lint_count(
             "Rust's equivalent of a switch statement is a match expression",
+            AdjectiveOfA,
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_clockwork() {
+        assert_lint_count(
+            "so something's wrong in this clockwork of a thing and I'm not going to bother taking this apart",
             AdjectiveOfA,
             0,
         );


### PR DESCRIPTION
# Issues 
N/A

# Description

Identified two more false positives in the 'adjective of a' lint:
- clockwork of a
- up of a (as in made up)

# How Has This Been Tested?

One new test for each added based on the sentences I found them in.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
