### PR TITLE
feat: phrase corrections: like a plague, have went, case and point, aswell

### DIFF
--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -1032,6 +1032,12 @@ pub fn lint_group() -> LintGroup {
             "`Having gone` is the correct form.",
             "Corrects `having went` to `having gone`."
         ),
+        "HasGone" => (
+            ["has went"],
+            ["has gone"],
+            "`Has gone` is the correct form.",
+            "Corrects `has went` to `has gone`."
+        ),
     });
 
     group.set_all_rules_to(Some(true));
@@ -2087,6 +2093,15 @@ mod tests {
             "Having went through the setup guidelines and picking react starter, running npm run watch results in an error",
             lint_group(),
             "Having gone through the setup guidelines and picking react starter, running npm run watch results in an error",
+        );
+    }
+
+    #[test]
+    fn correct_has_went() {
+        assert_suggestion_result(
+            "I would like to report that the package request which you are loading has went into maintenance mode.",
+            lint_group(),
+            "I would like to report that the package request which you are loading has gone into maintenance mode.",
         );
     }
 }

--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -1014,6 +1014,24 @@ pub fn lint_group() -> LintGroup {
             "`Things are avoided `like the plague` not `like a plague`.",
             "Corrects `like a plague` to `like the plague`."
         ),
+        "HaveGone" => (
+            ["have went"],
+            ["have gone"],
+            "`Have gone` is the correct form.",
+            "Corrects `have went` to `have gone`."
+        ),
+        "HadGone" => (
+            ["had went"],
+            ["had gone"],
+            "`Had gone` is the correct form.",
+            "Corrects `had went` to `had gone`."
+        ),
+        "HavingGone" => (
+            ["having went"],
+            ["having gone"],
+            "`Having gone` is the correct form.",
+            "Corrects `having went` to `having gone`."
+        ),
     });
 
     group.set_all_rules_to(Some(true));
@@ -2042,6 +2060,33 @@ mod tests {
             "Below is the worst example of them all (avoid such coding like a plague):",
             lint_group(),
             "Below is the worst example of them all (avoid such coding like the plague):",
+        );
+    }
+
+    #[test]
+    fn correct_have_went() {
+        assert_suggestion_result(
+            "I have went into the btle.py file and added a print statement in _connect()",
+            lint_group(),
+            "I have gone into the btle.py file and added a print statement in _connect()",
+        );
+    }
+
+    #[test]
+    fn correct_had_went() {
+        assert_suggestion_result(
+            "Not sure if TroLoos had went from Tasmota->minimal->Tasmota, or directly Minimal->Tasmota, but going ESPHome->Minimal->Tasmota is not possible",
+            lint_group(),
+            "Not sure if TroLoos had gone from Tasmota->minimal->Tasmota, or directly Minimal->Tasmota, but going ESPHome->Minimal->Tasmota is not possible",
+        );
+    }
+
+    #[test]
+    fn correct_having_went() {
+        assert_suggestion_result(
+            "Having went through the setup guidelines and picking react starter, running npm run watch results in an error",
+            lint_group(),
+            "Having gone through the setup guidelines and picking react starter, running npm run watch results in an error",
         );
     }
 }

--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -1044,6 +1044,12 @@ pub fn lint_group() -> LintGroup {
             "`Case in point` is the correct form of the phrase.",
             "Corrects `case and point` to `case in point`."
         ),
+        "AsWell" => (
+            ["aswell"],
+            ["as well"],
+            "`as well` should be written as two words.",
+            "Corrects `aswell` to `as well`."
+        ),
     });
 
     group.set_all_rules_to(Some(true));
@@ -2117,6 +2123,15 @@ mod tests {
             "They are just not as high of a priority as other tasks that user's are requesting for, a case and point is I have never ran into this issue.",
             lint_group(),
             "They are just not as high of a priority as other tasks that user's are requesting for, a case in point is I have never ran into this issue.",
+        );
+    }
+
+    #[test]
+    fn correct_aswell() {
+        assert_suggestion_result(
+            "'wejoy' is a tool to read physical joystick devices, aswell as keyboards, create virtual joystick devices and output keyboard presses on a Linux system.",
+            lint_group(),
+            "'wejoy' is a tool to read physical joystick devices, as well as keyboards, create virtual joystick devices and output keyboard presses on a Linux system.",
         );
     }
 }

--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -1008,6 +1008,12 @@ pub fn lint_group() -> LintGroup {
             "`Suffice it to say` is more standard and more common variant.",
             "Corrects `suffice to say` to `suffice it to say`."
         ),
+        "LikeThePlague" => (
+            ["like a plague"],
+            ["like the plague"],
+            "`Things are avoided `like the plague` not `like a plague`.",
+            "Corrects `like a plague` to `like the plague`."
+        ),
     });
 
     group.set_all_rules_to(Some(true));
@@ -2027,6 +2033,15 @@ mod tests {
             "Build flutter releases in github actions for production only android for while.",
             lint_group(),
             "Build flutter releases in github actions for production only android for a while.",
+        );
+    }
+
+    #[test]
+    fn correct_like_a_plague() {
+        assert_suggestion_result(
+            "Below is the worst example of them all (avoid such coding like a plague):",
+            lint_group(),
+            "Below is the worst example of them all (avoid such coding like the plague):",
         );
     }
 }

--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -1038,6 +1038,12 @@ pub fn lint_group() -> LintGroup {
             "`Has gone` is the correct form.",
             "Corrects `has went` to `has gone`."
         ),
+        "CaseInPoint" => (
+            ["case and point"],
+            ["case in point"],
+            "`Case in point` is the correct form of the phrase.",
+            "Corrects `case and point` to `case in point`."
+        ),
     });
 
     group.set_all_rules_to(Some(true));
@@ -2102,6 +2108,15 @@ mod tests {
             "I would like to report that the package request which you are loading has went into maintenance mode.",
             lint_group(),
             "I would like to report that the package request which you are loading has gone into maintenance mode.",
+        );
+    }
+
+    #[test]
+    fn correct_case_and_point_spaced() {
+        assert_suggestion_result(
+            "They are just not as high of a priority as other tasks that user's are requesting for, a case and point is I have never ran into this issue.",
+            lint_group(),
+            "They are just not as high of a priority as other tasks that user's are requesting for, a case in point is I have never ran into this issue.",
         );
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

Another odd variant I heard for the first time today which is actually already pretty common.
Dictionaries say we avoid something "like the plague" but younger speakers have been avoiding things "like a plague".

- https://dictionary.cambridge.org/dictionary/english/avoid-like-the-plague
- https://www.collinsdictionary.com/dictionary/english/avoid-someone-or-something-like-the-plague
- https://www.oxfordlearnersdictionaries.com/definition/english/avoid#avoid_idmg_1
- https://www.merriam-webster.com/wordplay/avoid-like-the-plague-origin

I added another set of phrase corrections to this PR. Correcting the simple past tense form used to construct the perfect tenses of "to go"
- have went → have gone
- had went  → had gone
- having went → having gone

# How Has This Been Tested?

I added a unit test for each one based on an example sentence plucked from GitHub.

Note that there are false positives for "having went" but these have not been addressed.

Later I remembered an old one I noticed a few years ago:
- case and point → case in point

I added a unit test for it based on text found on GitHub too.

False positives may turn up for this one as well I think.

And once more:
- aswell → as well

Also with a GitHub-based unit test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
