### PR TITLE
chore: "off of a" false positive

### DIFF
--- a/harper-core/src/linting/adjective_of_a.rs
+++ b/harper-core/src/linting/adjective_of_a.rs
@@ -15,6 +15,7 @@ const FALSE_POSITIVES: &[&str] = &[
     "inside",
     "more",
     "much",
+    "off",
     "out",
     "shy",
     "up",
@@ -493,6 +494,17 @@ mod tests {
     fn dont_flag_fun() {
         assert_lint_count(
             "Remember that $4,000 Hermes horse bag I was making fun of a little while ago.",
+            AdjectiveOfA,
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_off() {
+        // Can be an adjective in e.g. "The TV is off".
+        // This should be in a different lint that handles based on/off/off of.
+        assert_lint_count(
+            "can't identify a person based off of an IP from 10 years ago",
             AdjectiveOfA,
             0,
         );


### PR DESCRIPTION
# Issues 
N/A

# Description

"off of a" should probably be subject to a linter dealing with "based on" / "based off" / "based off of" but it's not related to this linter. Nobody ever says "That's so very off of a switch."

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Added a unit test based on the context in which I found this false positive.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
