### PR TITLE
fix: reset vscode version to `1.96.2`

### DIFF
--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -20,7 +20,7 @@
 		"url": "https://github.com/automattic/harper/issues"
 	},
 	"engines": {
-		"vscode": "^1.99.0"
+		"vscode": "^1.96.2"
 	},
 	"categories": ["Other"],
 	"keywords": ["grammar", "spellcheck", "writing"],
@@ -1876,7 +1876,7 @@
 	"devDependencies": {
 		"@types/jasmine": "^5.1.7",
 		"@types/node": "catalog:",
-		"@types/vscode": "^1.99.0",
+		"@types/vscode": "^1.96.2",
 		"@vscode/test-electron": "^2.3.9",
 		"@vscode/vsce": "^3.3.0",
 		"esbuild": "^0.25.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,7 +169,7 @@ importers:
         specifier: 'catalog:'
         version: 22.13.10
       '@types/vscode':
-        specifier: ^1.99.0
+        specifier: ^1.96.2
         version: 1.99.0
       '@vscode/test-electron':
         specifier: ^2.3.9
@@ -9373,6 +9373,9 @@ packages:
   third-party-web@0.26.5:
     resolution: {integrity: sha512-tDuKQJUTfjvi9Fcrs1s6YAQAB9mzhTSbBZMfNgtWNmJlHuoFeXO6dzBFdGeCWRvYL50jQGK0jPsBZYxqZQJ2SA==}
 
+  third-party-web@0.26.6:
+    resolution: {integrity: sha512-GsjP92xycMK8qLTcQCacgzvffYzEqe29wyz3zdKVXlfRD5Kz1NatCTOZEeDaSd6uCZXvGd2CNVtQ89RNIhJWvA==}
+
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
@@ -12950,7 +12953,7 @@ snapshots:
 
   '@paulirish/trace_engine@0.0.44':
     dependencies:
-      third-party-web: 0.26.5
+      third-party-web: 0.26.6
 
   '@php-wasm/node-polyfills@0.6.16': {}
 
@@ -22498,6 +22501,8 @@ snapshots:
       any-promise: 1.3.0
 
   third-party-web@0.26.5: {}
+
+  third-party-web@0.26.6: {}
 
   through@2.3.8: {}
 


### PR DESCRIPTION
# Issues 
#1074 

# Description

This is the lowest-common-denominator to work with both VS Code forks, Cursor which is at 1.96.2 and Windsurf which is at 1.97.0

# Demo
<img width="223" alt="Screenshot 2025-04-18 at 5 19 52 pm" src="https://github.com/user-attachments/assets/9ae418ff-9027-4f0f-9299-5df1433a98d6" />
<img width="357" alt="Screenshot 2025-04-18 at 5 20 08 pm" src="https://github.com/user-attachments/assets/f60c50d1-0254-449b-b95f-4ba05e80ac09" />

# How Has This Been Tested?

I build (from Windsurf) using
`just setup` and `just package-vscode`

Then I installed the resulting VSIX manually from the command palette into both Windsurf and Cursor.

The status bar item with the dialect indicator and the new Harper logo showed up in both. Typing gibberish into the editor of both causes Harper to flag them as misspellings.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes