### PR TITLE
feat: handle some false positives in let/lets/let's/let us

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -30577,7 +30577,7 @@ juryman/1M
 jurymen/9
 jurywoman/1M
 jurywomen/9
-just/~514RYPT
+just/~54RYPT        # removed `1` noun. archaic and interferes with linter heuristics
 justice/~1IMS
 justifiable/~5U
 justifiably/Uj
@@ -42132,7 +42132,7 @@ rumourmonger/14SM!@
 rump/~14MYS
 rumple/41DSMG
 rumpus/1MS
-run/~415AM
+run/~41AMS          # removed `5` adj. a bit marginal and interferes with linter heuristics
 runabout/1MS
 runaround/1SM
 runaway/~15MS
@@ -42147,7 +42147,6 @@ runner/~1SM
 running/~451+M
 runny/5RT
 runoff/~1SM
-runs/~4
 runt/1MS
 runtime/~51
 runty/5RT

--- a/harper-core/src/linting/compound_nouns/implied_ownership_compound_nouns.rs
+++ b/harper-core/src/linting/compound_nouns/implied_ownership_compound_nouns.rs
@@ -11,6 +11,11 @@ use crate::{
 
 /// Looks for closed compound nouns which can be condensed due to their position after a
 /// possessive noun (which implies ownership).
+/// See also:
+/// harper-core/src/linting/lets_confusion/mod.rs
+/// harper-core/src/linting/lets_confusion/let_us_redundancy.rs
+/// harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
+/// harper-core/src/linting/pronoun_contraction/should_contract.rs
 pub struct ImpliedOwnershipCompoundNouns {
     pattern: Box<dyn Pattern>,
     split_pattern: Lrc<SplitCompoundWord>,
@@ -38,9 +43,14 @@ impl PatternLinter for ImpliedOwnershipCompoundNouns {
 
     fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
         // "Let's" can technically be a possessive noun (of a lease, or a let in tennis, etc.)
-        // but in practice it's almost always a contraction of "let us" before a verb.
-        let possessive = matched_tokens[0].span.get_content(source);
-        if possessive == ['l', 'e', 't', '\'', 's'] || possessive == ['L', 'e', 't', '\'', 's'] {
+        // but in practice it's almost always a contraction of "let us" before a verb
+        // or a mistake for "lets", the 3rd person singular present form of "to let".
+        let word_apostrophe_s = matched_tokens[0].span.get_content(source);
+        if word_apostrophe_s
+            .iter()
+            .map(|&c| c.to_ascii_lowercase())
+            .eq(['l', 'e', 't', '\'', 's'].iter().copied())
+        {
             return None;
         }
         let span = matched_tokens[2..].span()?;

--- a/harper-core/src/linting/lets_confusion/let_us_redundancy.rs
+++ b/harper-core/src/linting/lets_confusion/let_us_redundancy.rs
@@ -5,6 +5,11 @@ use crate::{
 
 use crate::linting::{Lint, LintKind, PatternLinter, Suggestion};
 
+/// See also:
+/// harper-core/src/linting/compound_nouns/implied_ownership_compound_nouns.rs
+/// harper-core/src/linting/lets_confusion/mod.rs
+/// harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
+/// harper-core/src/linting/pronoun_contraction/should_contract.rs
 pub struct LetUsRedundancy {
     pattern: Box<dyn Pattern>,
 }

--- a/harper-core/src/linting/lets_confusion/mod.rs
+++ b/harper-core/src/linting/lets_confusion/mod.rs
@@ -5,6 +5,11 @@ use super::merge_linters::merge_linters;
 use let_us_redundancy::LetUsRedundancy;
 use no_contraction_with_verb::NoContractionWithVerb;
 
+// See also:
+// harper-core/src/linting/compound_nouns/implied_ownership_compound_nouns.rs
+// harper-core/src/linting/lets_confusion/let_us_redundancy.rs
+// harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
+// harper-core/src/linting/pronoun_contraction/should_contract.rs
 merge_linters!(LetsConfusion => LetUsRedundancy, NoContractionWithVerb => "It's often hard to determine where the subject should go with the word `let`. This rule attempts to find common errors with redundancy and contractions that may lead to confusion for readers.");
 
 #[cfg(test)]
@@ -32,23 +37,44 @@ mod tests {
         assert_suggestion_result("let's me do", LetsConfusion::default(), "lets me do");
     }
 
+    // "push" is also a noun so in a context like "He always lets push come to shove".
+    // #[test]
+    // fn from_harper_docs() {
+    //     assert_suggestion_result(
+    //         "Often the longest and the shortest words are the most helpful, so lets push them first.",
+    //         LetsConfusion::default(),
+    //         "Often the longest and the shortest words are the most helpful, so let's push them first.",
+    //     );
+    // }
+
     #[test]
-    fn from_harper_docs() {
+    fn like_the_one_from_harper_docs() {
         assert_suggestion_result(
-            "Often the longest and the shortest words are the most helpful, so lets push them first.",
+            "Often the longest and the shortest words are the most helpful, so lets prioritize them.",
             LetsConfusion::default(),
-            "Often the longest and the shortest words are the most helpful, so let's push them first.",
+            "Often the longest and the shortest words are the most helpful, so let's prioritize them.",
         );
     }
 
+    // "play" is also a noun so in a context like "Sometimes the umpire lets play continue"
+    // #[test]
+    // fn issue_470_missing_apostrophe() {
+    //     assert_suggestion_result("lets play", LetsConfusion::default(), "let's play");
+    // }
+
+    // #[test]
+    // fn issue_470_missing_subject() {
+    //     assert_suggestion_result("let play", LetsConfusion::default(), "let's play");
+    // }
+
     #[test]
     fn issue_470_missing_apostrophe() {
-        assert_suggestion_result("lets play", LetsConfusion::default(), "let's play");
+        assert_suggestion_result("lets proceed", LetsConfusion::default(), "let's proceed");
     }
 
     #[test]
     fn issue_470_missing_subject() {
-        assert_suggestion_result("let play", LetsConfusion::default(), "let's play");
+        assert_suggestion_result("let proceed", LetsConfusion::default(), "let's proceed");
     }
 
     #[test]

--- a/harper-core/src/linting/lets_confusion/mod.rs
+++ b/harper-core/src/linting/lets_confusion/mod.rs
@@ -37,22 +37,12 @@ mod tests {
         assert_suggestion_result("let's me do", LetsConfusion::default(), "lets me do");
     }
 
-    // "push" is also a noun so in a context like "He always lets push come to shove".
-    // #[test]
-    // fn from_harper_docs() {
-    //     assert_suggestion_result(
-    //         "Often the longest and the shortest words are the most helpful, so lets push them first.",
-    //         LetsConfusion::default(),
-    //         "Often the longest and the shortest words are the most helpful, so let's push them first.",
-    //     );
-    // }
-
     #[test]
-    fn like_the_one_from_harper_docs() {
+    fn from_harper_docs() {
         assert_suggestion_result(
-            "Often the longest and the shortest words are the most helpful, so lets prioritize them.",
+            "Often the longest and the shortest words are the most helpful, so lets push them first.",
             LetsConfusion::default(),
-            "Often the longest and the shortest words are the most helpful, so let's prioritize them.",
+            "Often the longest and the shortest words are the most helpful, so let's push them first.",
         );
     }
 

--- a/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
+++ b/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
@@ -131,7 +131,11 @@ mod tests {
 
     #[test]
     fn dont_flag_lets_play() {
-        assert_lint_count("Sometimes the umpire lets play continue", NoContractionWithVerb::default(), 0);
+        assert_lint_count(
+            "Sometimes the umpire lets play continue",
+            NoContractionWithVerb::default(),
+            0,
+        );
     }
 
     // False positives where verb is a gerund/past participle

--- a/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
+++ b/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
@@ -21,7 +21,7 @@ impl Default for NoContractionWithVerb {
             .then(WordSet::new(&["lets", "let"]))
             .then_whitespace();
 
-        // Word is only a verb, and not the gerund/past participle form.
+        // Word is only a verb, and not the gerund/present participle form.
         let non_ing_verb = SequencePattern::default().then(|tok: &Token, source: &[char]| {
             let Some(Some(meta)) = tok.kind.as_word() else {
                 return false;

--- a/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
+++ b/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
@@ -86,14 +86,14 @@ mod tests {
 
     // Corrections
 
-    #[test]
-    fn fix_lets_runs() {
-        assert_suggestion_result(
-            "Now lets runs liminal",
-            NoContractionWithVerb::default(),
-            "Now let's runs liminal",
-        );
-    }
+    // #[test]
+    // fn fix_lets_runs() {
+    //     assert_suggestion_result(
+    //         "Now lets runs liminal",
+    //         NoContractionWithVerb::default(),
+    //         "Now let's runs liminal",
+    //     );
+    // }
 
     // False positives where verb is also a noun
 

--- a/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
+++ b/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
@@ -86,14 +86,14 @@ mod tests {
 
     // Corrections
 
-    // #[test]
-    // fn fix_lets_runs() {
-    //     assert_suggestion_result(
-    //         "Now lets runs liminal",
-    //         NoContractionWithVerb::default(),
-    //         "Now let's runs liminal",
-    //     );
-    // }
+    #[test]
+    fn fix_lets_inspect() {
+        assert_suggestion_result(
+            "In the end lets inspect with git-blame the results.",
+            NoContractionWithVerb::default(),
+            "In the end let's inspect with git-blame the results.",
+        );
+    }
 
     // False positives where verb is also a noun
 

--- a/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
+++ b/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
@@ -6,6 +6,11 @@ use crate::{
 
 use crate::linting::PatternLinter;
 
+/// See also:
+/// harper-core/src/linting/compound_nouns/implied_ownership_compound_nouns.rs
+/// harper-core/src/linting/lets_confusion/mod.rs
+/// harper-core/src/linting/lets_confusion/let_us_redundancy.rs
+/// harper-core/src/linting/pronoun_contraction/should_contract.rs
 pub struct NoContractionWithVerb {
     pattern: Box<dyn Pattern>,
 }
@@ -15,7 +20,32 @@ impl Default for NoContractionWithVerb {
         let pattern = SequencePattern::default()
             .then(WordSet::new(&["lets", "let"]))
             .then_whitespace()
-            .then_verb();
+            .then(|tok: &Token, source: &[char]| {
+                let Some(Some(meta)) = tok.kind.as_word() else {
+                    return false;
+                };
+
+                if !meta.is_verb() || meta.is_noun() || meta.is_adjective() {
+                    return false;
+                }
+
+                let tok_chars = tok.span.get_content(source);
+
+                // If it ends with 'ing' and is at least 5 chars long, it could be a gerund or past participle
+                // TODO: replace with metadata check when affix system supports verb forms
+                if tok_chars.len() < 5 {
+                    return true;
+                }
+
+                let is_ing_form = tok_chars
+                    .iter()
+                    .skip(tok_chars.len() - 3)
+                    .map(|&c| c.to_ascii_lowercase())
+                    .collect::<Vec<_>>()
+                    .ends_with(&['i', 'n', 'g']);
+
+                !is_ing_form
+            });
 
         Self {
             pattern: Box::new(pattern),
@@ -46,5 +76,83 @@ impl PatternLinter for NoContractionWithVerb {
 
     fn description(&self) -> &'static str {
         "Make sure you include a subject when giving permission to it."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NoContractionWithVerb;
+    use crate::linting::tests::{assert_lint_count, assert_suggestion_result};
+
+    // Corrections
+
+    #[test]
+    fn fix_lets_runs() {
+        assert_suggestion_result(
+            "Now lets runs liminal",
+            NoContractionWithVerb::default(),
+            "Now let's runs liminal",
+        );
+    }
+
+    // False positives where verb is also a noun
+
+    #[test]
+    fn dont_flag_let_chance() {
+        assert_lint_count("Let chance decide", NoContractionWithVerb::default(), 0);
+    }
+
+    #[test]
+    fn dont_flag_let_time() {
+        assert_lint_count(
+            "Let time granularity be parametrized",
+            NoContractionWithVerb::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_lets_staff() {
+        assert_lint_count(
+            "A plugin that backs up player's inventories and lets staff restore them or export it as a shulker.",
+            NoContractionWithVerb::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_lets_time() {
+        assert_lint_count(
+            "This is very different than demo recording, which just simulates a network level connection and lets time move at its own rate.",
+            NoContractionWithVerb::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_lets_play() {
+        assert_lint_count("Sometimes the umpire lets play continue", NoContractionWithVerb::default(), 0);
+    }
+
+    // False positives where verb is a gerund/past participle
+
+    #[test]
+    fn dont_flag_let_sleeping() {
+        assert_lint_count(
+            "Let sleeping logs lie.",
+            NoContractionWithVerb::default(),
+            0,
+        );
+    }
+
+    // False positives where verb is also an adjective
+
+    #[test]
+    fn dont_flag_let_processed() {
+        assert_lint_count(
+            "Let processed response be a new structure analogous to server auction response.",
+            NoContractionWithVerb::default(),
+            0,
+        );
     }
 }

--- a/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
+++ b/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
@@ -54,7 +54,7 @@ impl Default for NoContractionWithVerb {
             .then(|tok: &Token, _source: &[char]| tok.kind.is_verb() || tok.kind.is_noun())
             .then_whitespace()
             .then(|tok: &Token, _source: &[char]| {
-                tok.kind.is_determiner() || tok.kind.is_pronoun()
+                tok.kind.is_determiner() || tok.kind.is_pronoun() || tok.kind.is_conjunction()
             });
 
         let let_then_verb = let_ws.then(EitherPattern::new(vec![

--- a/harper-core/src/linting/pronoun_contraction/should_contract.rs
+++ b/harper-core/src/linting/pronoun_contraction/should_contract.rs
@@ -6,6 +6,11 @@ use crate::{
 use crate::Lint;
 use crate::linting::{LintKind, PatternLinter, Suggestion};
 
+/// See also:
+/// harper-core/src/linting/compound_nouns/implied_ownership_compound_nouns.rs
+/// harper-core/src/linting/lets_confusion/mod.rs
+/// harper-core/src/linting/lets_confusion/let_us_redundancy.rs
+/// harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
 pub struct ShouldContract {
     pattern: Box<dyn Pattern>,
 }

--- a/harper-core/tests/run_tests.rs
+++ b/harper-core/tests/run_tests.rs
@@ -48,8 +48,7 @@ create_test!(issue_195.md, 0, Dialect::American);
 create_test!(issue_118.md, 0, Dialect::American);
 create_test!(lots_of_latin.md, 0, Dialect::American);
 create_test!(pr_504.md, 1, Dialect::American);
-// 452.md is based on a verb which is also a noun, breaking a heuristic that detects false positives
-//create_test!(pr_452.md, 2, Dialect::American);
+create_test!(pr_452.md, 2, Dialect::American);
 create_test!(hex_basic_clean.md, 0, Dialect::American);
 create_test!(hex_basic_dirty.md, 1, Dialect::American);
 create_test!(misc_closed_compound_clean.md, 0, Dialect::American);

--- a/harper-core/tests/run_tests.rs
+++ b/harper-core/tests/run_tests.rs
@@ -48,7 +48,8 @@ create_test!(issue_195.md, 0, Dialect::American);
 create_test!(issue_118.md, 0, Dialect::American);
 create_test!(lots_of_latin.md, 0, Dialect::American);
 create_test!(pr_504.md, 1, Dialect::American);
-create_test!(pr_452.md, 2, Dialect::American);
+// 452.md is based on a verb which is also a noun, breaking a heuristic that detects false positives
+//create_test!(pr_452.md, 2, Dialect::American);
 create_test!(hex_basic_clean.md, 0, Dialect::American);
 create_test!(hex_basic_dirty.md, 1, Dialect::American);
 create_test!(misc_closed_compound_clean.md, 0, Dialect::American);


### PR DESCRIPTION
But doing so has a snowball effect on other tests!

# Issues 
May try to tackle: #470 #752 

# Description

Tackles false positives and other problems related to mixing up
let / lets / let's / let us

One problem was flagging `let`/`lets` to be replaced by `let's` if the next word is a verb, but there were many false positives caused by words which are both nouns and verbs.

Unfortunately simply ruling those out had flow-on effects in other lints or other tests.

I've commented out some of those tests and added comments about the problem.

Some may be able to be re-enabled if heuristics are devised to disambiguate whether such words are really verbs or nouns.

I've also added comments to explain how some of the existing logic works and renamed some identifiers I felt impeded clarity.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I've added a bunch of unit tests for various types of false positives.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
