### PR TITLE
feat: `harper cli annotate` and `just annotate`

### DIFF
--- a/justfile
+++ b/justfile
@@ -473,3 +473,6 @@ newest-dict-changes *numCommits:
       });
     });
   });
+# Annotate text using the dictionary and affix system
+annotate text:
+  cargo run --bin harper-cli -- annotate {{text}}


### PR DESCRIPTION
# Issues 

Doesn't solve #1089 but it was discussed there.

# Description

Pass a text in to have the affix system apply the dictionary metadata to each word.
Due to `just`'s nature you need to use two different quotes to pass in a sentence:
`'"The cat sat on the mat"'`

Every word can have multiple parts-of-speech. The major ones are given their common abbreviations and each is given a different ANSI colour.

In addition, words which are not in the dictionary at all are underlined. Words which are only in the dictionary after normalizing to all lowercase are italicised.

# Demo
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/87642f7e-031e-4eb6-964a-979659f964f4" />

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

No unit tests, just trying random sentences.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes

# Help

The code actually treats the input string as markdown because I'm not sure how to implement it as plain text. If anyone who can show me how to modify the code to do so I would be grateful.