### PR TITLE
feat: examples for using `harper.js` from `justfile`

### DIFF
--- a/justfile
+++ b/justfile
@@ -474,7 +474,7 @@ newest-dict-changes *numCommits:
     });
   });
 
-# Test using harper.js from packages/harper.js in `justfile`
+# Example of using harper.js with Node.js in `justfile`
 harperjsnode test_string:
   #! /usr/bin/env node
   (async () => {
@@ -485,7 +485,7 @@ harperjsnode test_string:
     console.log(lints.map(lint => lint.message()));
   })();
 
-# Test using harper.js from packages/harper.js in `justfile`
+# Example of using harper.js with Bun in `justfile`
 harperjsbun test_string:
   #! /usr/bin/env bun
   const hjs = require('{{justfile_directory()}}/packages/harper.js/');

--- a/justfile
+++ b/justfile
@@ -473,3 +473,23 @@ newest-dict-changes *numCommits:
       });
     });
   });
+
+# Test using harper.js from packages/harper.js in `justfile`
+harperjsnode test_string:
+  #! /usr/bin/env node
+  (async () => {
+    const hjs = await import('{{justfile_directory()}}/packages/harper.js/dist/harper.js');
+
+    const linter = new hjs.LocalLinter({ binary: hjs.binary });
+    const lints = await linter.lint('{{test_string}}');
+    console.log(lints.map(lint => lint.message()));
+  })();
+
+# Test using harper.js from packages/harper.js in `justfile`
+harperjsbun test_string:
+  #! /usr/bin/env bun
+  const hjs = require('{{justfile_directory()}}/packages/harper.js/');
+
+  const linter: hjs.LocalLinter = new hjs.LocalLinter({ binary: hjs.binary });
+  const lints = await linter.lint('{{test_string}}');
+  console.log(lints.map(lint => lint.message()));


### PR DESCRIPTION
# Issues 

Fixes #1096

# Description

Inlcudes bun and node examples

Node seems to require an IIFE, but I may be missing a trick. Bun is cleaner and can use TypeScript directly in the `justfile`

All I needed to get it to work was the `just` special which I'd used before but forgotten:
```js
require('{{justfile_directory()}}/packages/harper.js/')
```

# Demo
<img width="834" alt="image" src="https://github.com/user-attachments/assets/222a3561-91e0-46b6-89a5-a57409d3a123" />

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
