### PR TITLE
feat: implement dialect indicator for Obsidian plugin

### DIFF
--- a/packages/obsidian-plugin/src/HarperSettingTab.ts
+++ b/packages/obsidian-plugin/src/HarperSettingTab.ts
@@ -51,6 +51,7 @@ export class HarperSettingTab extends PluginSettingTab {
 				.onChange(async (value) => {
 					this.settings.dialect = Number.parseInt(value);
 					await this.plugin.initializeFromSettings(this.settings);
+					this.plugin.updateStatusBar();
 				});
 		});
 

--- a/packages/obsidian-plugin/src/HarperSettingTab.ts
+++ b/packages/obsidian-plugin/src/HarperSettingTab.ts
@@ -49,9 +49,10 @@ export class HarperSettingTab extends PluginSettingTab {
 				.addOption(Dialect.Australian.toString(), 'Australian')
 				.setValue((this.settings.dialect ?? Dialect.American).toString())
 				.onChange(async (value) => {
-					this.settings.dialect = Number.parseInt(value);
+					const dialect = Number.parseInt(value);
+					this.settings.dialect = dialect;
 					await this.plugin.initializeFromSettings(this.settings);
-					this.plugin.updateStatusBar();
+					this.plugin.updateStatusBar(dialect);
 				});
 		});
 

--- a/packages/obsidian-plugin/src/index.ts
+++ b/packages/obsidian-plugin/src/index.ts
@@ -162,7 +162,7 @@ export default class HarperPlugin extends Plugin {
 		this.dialectSpan = dialect;
 
 		this.harper.getDialect().then((dialectNum) => {
-			dialect.innerHTML = this.getDialectStatus(dialectNum);
+			this.updateStatusBar(dialectNum);
 			button.appendChild(dialect);
 		});
 

--- a/packages/obsidian-plugin/src/index.ts
+++ b/packages/obsidian-plugin/src/index.ts
@@ -1,7 +1,7 @@
 import type { Extension } from '@codemirror/state';
 import type { LintConfig, Linter, Suggestion } from 'harper.js';
 import {
-	type Dialect,
+	Dialect,
 	LocalLinter,
 	SuggestionKind,
 	WorkerLinter,
@@ -39,6 +39,7 @@ export default class HarperPlugin extends Plugin {
 	private harper: Linter;
 	private editorExtensions: Extension[];
 	private delay: number;
+	private statusBarItem: HTMLElement | null = null;
 
 	constructor(app: App, manifest: PluginManifest) {
 		super(app, manifest);
@@ -128,13 +129,44 @@ export default class HarperPlugin extends Plugin {
 	}
 
 	private setupStatusBar() {
+		// Remove the old status bar item
+		if (this.statusBarItem) {
+			this.statusBarItem.remove();
+		}
+
 		/** @type HTMLElement */
 		const statusBarItem = this.addStatusBarItem();
 		statusBarItem.className += ' mod-clickable';
+		this.statusBarItem = statusBarItem;
 
 		const button = document.createElement('span');
-		button.style = 'width:24px';
-		button.innerHTML = logoSvg;
+		button.style.display = 'flex';
+		button.style.alignItems = 'center';
+
+		const logo = document.createElement('span');
+		logo.style.width = '24px';
+		logo.innerHTML = logoSvg;
+
+		button.appendChild(logo);
+
+		this.harper.getDialect().then((dialectNum) => {
+			if (dialectNum !== undefined) {
+				const code = {
+					American: 'US',
+					Australian: 'AU',
+					British: 'GB',
+					Canadian: 'CA',
+				}[Dialect[dialectNum]];
+				if (code !== undefined) {
+					const dialect = document.createElement('span');
+					dialect.innerHTML += `${code
+						.split('')
+						.map((c) => String.fromCodePoint(c.charCodeAt(0) + 127397))
+						.join('')}${code}`;
+					button.appendChild(dialect);
+				}
+			}
+		});
 
 		button.addEventListener('click', (event) => {
 			const menu = new Menu();
@@ -268,6 +300,11 @@ export default class HarperPlugin extends Plugin {
 				delay: this.delay,
 			},
 		);
+	}
+
+	updateStatusBar() {
+		console.log('Updating status bar');
+		this.setupStatusBar();
 	}
 }
 


### PR DESCRIPTION
# Issues 
Part 2 of fixing #982

# Description

Next to the Harper logo/button in the status bar the country code and flag for the selected dialect are now displayed.
These update when the dialect setting is changed.

# Demo
<img width="498" alt="image" src="https://github.com/user-attachments/assets/f79dc938-bc80-47a7-a25b-96b18cd2c0e7" />

# How Has This Been Tested?

Manual testing.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
