### PR TITLE
feat: incase→in case

### DIFF
--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -1074,6 +1074,12 @@ pub fn lint_group() -> LintGroup {
             "Did you mean the verb `passed`?",
             "Suggests `past` for `passed` in case a verb was intended."
         ),
+        "InCase" => (
+            ["incase"],
+            ["in case"],
+            "`In case` should be written as two words.",
+            "Corrects `incase` to `in case`."
+        ),
     });
 
     group.set_all_rules_to(Some(true));
@@ -2192,6 +2198,15 @@ mod tests {
             "Return to computer, with enough time having past for the computer to go to full sleep.",
             lint_group(),
             "Return to computer, with enough time having passed for the computer to go to full sleep.",
+        );
+    }
+
+    #[test]
+    fn correct_in_case() {
+        assert_suggestion_result(
+            "Support for enum variable incase of reusable enum class",
+            lint_group(),
+            "Support for enum variable in case of reusable enum class",
         );
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

Flags the now-common "incase" and suggests writing it as two words "in case".

# How Has This Been Tested?

I added a unit test based on an example fished out of GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
