### PR TITLE
feat: client's side→client-side, server's side→server side

### DIFF
--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -1081,6 +1081,18 @@ pub fn lint_group() -> LintGroup {
             "Did you mean the verb `passed`?",
             "Suggests `past` for `passed` in case a verb was intended."
         ),
+        "ClientSide" => (
+            ["client's side"],
+            ["client-side"],
+            "In client-server contexts, use `client-side` rather than `client's side`.",
+            "Corrects `client's side` to `client-side`, which is usual in `client-server contexts`."
+        ),
+        "ServerSide" => (
+            ["server's side"],
+            ["server-side"],
+            "In client-server contexts, use `server-side` rather than `server's side`.",
+            "Corrects `server's side` to `server-side`, which is usual in `client-server contexts`."
+        ),
     });
 
     group.set_all_rules_to(Some(true));
@@ -2244,6 +2256,24 @@ mod tests {
             "CAPD worst-case-scenario cloud simulator for naughty clouds.",
             lint_group(),
             "CAPD worst-case scenario cloud simulator for naughty clouds.",
+        );
+    }
+
+    #[test]
+    fn correct_clients_side() {
+        assert_suggestion_result(
+            "I want to debug this server-side as I cannot find out why the connection is being refused from the client's side.",
+            lint_group(),
+            "I want to debug this server-side as I cannot find out why the connection is being refused from the client-side.",
+        );
+    }
+
+    #[test]
+    fn correct_servers_side() {
+        assert_suggestion_result(
+            "A client-server model where the client can execute commands in a terminal on the server's side",
+            lint_group(),
+            "A client-server model where the client can execute commands in a terminal on the server-side",
         );
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

I noticed the phrasing "client's side" in something I was reading and it didn't sound right. It turned out using "client's side" is really common, probably because it makes sends and sounds almost exactly the same as "client-side". "Server's side" instead of "server-side" isn't quite as common but is also out there.

My browser also flags these: 
<img width="190" alt="image" src="https://github.com/user-attachments/assets/66517675-f29e-4298-933e-cfe592d98f43" />

There are likely false positives when the context is not client-server computing and sometimes even in this context.
Perhaps "client side" and "server side" should also be suggested but the only style opinion I could find preferred the hyphenated version no matter where in the sentence.

# How Has This Been Tested?

Added a unit test for each based on sentences mined from GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
