### PR TITLE
feat: adds a `t_ws()` shorthand for `then_whitespace()` in the spirit of `t_aco()`

### DIFF
--- a/harper-core/src/patterns/sequence_pattern.rs
+++ b/harper-core/src/patterns/sequence_pattern.rs
@@ -150,6 +150,11 @@ impl SequencePattern {
         self
     }
 
+    /// Shorthand for [`Self::then_whitespace`].
+    pub fn t_ws(self) -> Self {
+        self.then_whitespace()
+    }
+
     /// Match against one or more whitespace tokens.
     pub fn then_whitespace(mut self) -> Self {
         self.token_patterns.push(Box::new(WhitespacePattern));

--- a/harper-core/src/patterns/sequence_pattern.rs
+++ b/harper-core/src/patterns/sequence_pattern.rs
@@ -232,4 +232,15 @@ mod tests {
             doc.get_tokens().len()
         );
     }
+
+    #[test]
+    fn match_t_aco_and_t_ws() {
+        let pat = SequencePattern::aco("foo").t_ws().t_aco("bar");
+        let doc = Document::new_plain_english_curated("foo\nBAR");
+
+        assert_eq!(
+            pat.matches(doc.get_tokens(), doc.get_source()),
+            doc.get_tokens().len()
+        );
+    }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

Just a little quality-of-life addition for `PatternLinter` coders. Whitespace is very minor and often between all the words in a pattern.

So just as 'then any capitalization of' has the `t_aco()` shorthand this introduces a `t_ws()` shorthand to allow patterns to be more expressive in less space.

# How Has This Been Tested?

Added a unit test for all of `aco()`, `t_ws()`, and `t_aco()`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
