### PR TITLE
Removed the useless `SequencePattern` in `IndefiniteArticle`

### DIFF
--- a/harper-core/src/patterns/indefinite_article.rs
+++ b/harper-core/src/patterns/indefinite_article.rs
@@ -1,15 +1,15 @@
 use crate::Token;
 
-use super::{Pattern, SequencePattern, WordSet};
+use super::{Pattern, WordSet};
 
 pub struct IndefiniteArticle {
-    inner: SequencePattern,
+    inner: WordSet,
 }
 
 impl Default for IndefiniteArticle {
     fn default() -> Self {
         Self {
-            inner: SequencePattern::default().then(WordSet::new(&["a", "an"])),
+            inner: WordSet::new(&["a", "an"]),
         }
     }
 }


### PR DESCRIPTION
# Description
`IndefiniteArticle` wrapped its internal `WordSet` into a `SequencePattern` for some reason. This doesn't change its behavior and strictly adds overhead for no reason. This PR removes the superfluous `SequencePattern`.

# How Has This Been Tested?
No change in behavior. Existing tests suffice.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
