### PR TITLE
feat: invest into→invest in

### DIFF
--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -1129,6 +1129,30 @@ pub fn lint_group() -> LintGroup {
             "A more vivid adjective would better convey intense hunger.",
             "Encourages vivid writing by suggesting `starving` instead of weaker expressions like `very hungry.`"
         ),
+        "InvestIn" => (
+            ["invest into"],
+            ["invest in"],
+            "Traditionally `invest` uses the preposition `in`.",
+            "`Invest` is traditionally followed by 'in,' not `into.`"
+        ),
+        "InvestedIn" => (
+            ["invested into"],
+            ["invested in"],
+            "Traditionally `invest` uses the preposition `in`.",
+            "`Invest` is traditionally followed by 'in,' not `into.`"
+        ),
+        "InvestingIn" => (
+            ["investing into"],
+            ["investing in"],
+            "Traditionally `invest` uses the preposition `in`.",
+            "`Invest` is traditionally followed by 'in,' not `into.`"
+        ),
+        "InvestsIn" => (
+            ["invests into"],
+            ["invests in"],
+            "Traditionally `invest` uses the preposition `in`.",
+            "`Invest` is traditionally followed by 'in,' not `into.`"
+        ),
     });
 
     group.set_all_rules_to(Some(true));
@@ -2369,6 +2393,42 @@ mod tests {
             "A client-server model where the client can execute commands in a terminal on the server's side",
             lint_group(),
             "A client-server model where the client can execute commands in a terminal on the server-side",
+        );
+    }
+
+    #[test]
+    fn corrects_invested_into() {
+        assert_suggestion_result(
+            "it's all automatically invested into a collection of loans that match the criteria that ...",
+            lint_group(),
+            "it's all automatically invested in a collection of loans that match the criteria that ...",
+        );
+    }
+
+    #[test]
+    fn corrects_invest_into() {
+        assert_suggestion_result(
+            "which represents the amount of money they want to invest into a particular deal.",
+            lint_group(),
+            "which represents the amount of money they want to invest in a particular deal.",
+        );
+    }
+
+    #[test]
+    fn corrects_investing_into() {
+        assert_suggestion_result(
+            "Taking dividends in cash (rather than automatically re-investing into the originating fund) can help alleviate the need for rebalancing.",
+            lint_group(),
+            "Taking dividends in cash (rather than automatically re-investing in the originating fund) can help alleviate the need for rebalancing.",
+        );
+    }
+
+    #[test]
+    fn corrects_invests_into() {
+        assert_suggestion_result(
+            "If a user invests into the protocol first using USDC but afterward changing to DAI, ...",
+            lint_group(),
+            "If a user invests in the protocol first using USDC but afterward changing to DAI, ...",
         );
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

At least on YouTube everybody now says "invest into" but it's still very far behind the traditional "invest in".

<img width="503" alt="image" src="https://github.com/user-attachments/assets/eec14715-0108-4dd0-ae5a-38415a2142e0" />

"Invest in" is in some professional dictionaries: [cambridge](https://dictionary.cambridge.org/dictionary/english/invest-in), [merriam-webster](https://www.merriam-webster.com/dictionary/invest%20in); but "invest into" isn't yet.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I added a unit test for each inflection based on sentences found on GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
