### PR TITLE
docs: fix incorrect documentation for some linters

### DIFF
--- a/harper-core/src/linting/correct_number_suffix.rs
+++ b/harper-core/src/linting/correct_number_suffix.rs
@@ -2,7 +2,7 @@ use super::{Lint, LintKind, Linter, Suggestion};
 use crate::{Document, NumberSuffix, Span, TokenKind};
 use crate::{Number, TokenStringExt};
 
-/// Detect and warn that the sentence is too long.
+/// Detect incorrect number suffix (e.g. "2st").
 #[derive(Debug, Clone, Copy, Default)]
 pub struct CorrectNumberSuffix;
 

--- a/harper-core/src/linting/linking_verbs.rs
+++ b/harper-core/src/linting/linking_verbs.rs
@@ -3,7 +3,9 @@ use crate::CharStringExt;
 use crate::Document;
 use crate::TokenStringExt;
 
-/// Detect and warn that the sentence is too long.
+/// Detect incorrect usage of linking verbs.
+///
+/// This ensures that linking verbs are preceded by a noun or pronoun.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct LinkingVerbs;
 

--- a/harper-core/src/linting/number_suffix_capitalization.rs
+++ b/harper-core/src/linting/number_suffix_capitalization.rs
@@ -2,7 +2,7 @@ use super::{Lint, LintKind, Linter, Suggestion};
 use crate::{Document, Span, TokenKind};
 use crate::{Number, TokenStringExt};
 
-/// Detect and warn that the sentence is too long.
+/// Detect incorrect capitalization for number suffixes (e.g. "2ND").
 #[derive(Debug, Clone, Copy, Default)]
 pub struct NumberSuffixCapitalization;
 


### PR DESCRIPTION

# Description
This PR provides some brief documentation to linters that currently incorrectly reuse documentation from the `LongSentences`  linter.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
