### PR TITLE
fix(core): don't lex the last period as part of a number

### DIFF
--- a/harper-core/src/lexing/mod.rs
+++ b/harper-core/src/lexing/mod.rs
@@ -84,15 +84,17 @@ pub fn lex_number(source: &[char]) -> Option<FoundToken> {
         if let Ok(n) = s.parse::<f64>() {
             let precision = s.chars().rev().position(|c| c == '.').unwrap_or_default();
 
-            return Some(FoundToken {
-                token: TokenKind::Number(Number {
-                    value: n.into(),
-                    suffix: None,
-                    radix: 10,
-                    precision,
-                }),
-                next_index: s.len(),
-            });
+            if !s.ends_with('.') {
+                return Some(FoundToken {
+                    token: TokenKind::Number(Number {
+                        value: n.into(),
+                        suffix: None,
+                        radix: 10,
+                        precision,
+                    }),
+                    next_index: s.len(),
+                });
+            }
         }
 
         s.pop();
@@ -309,6 +311,7 @@ fn lex_catch(_source: &[char]) -> Option<FoundToken> {
 #[cfg(test)]
 mod tests {
     use crate::Punctuation;
+    use crate::char_string::char_string;
     use crate::lexing::lex_plural_digit;
 
     use super::lex_hex_number;
@@ -902,5 +905,21 @@ mod tests {
 
             next_index += token.next_index;
         }
+    }
+
+    #[test]
+    fn issue_1010() {
+        let source = char_string!("3.");
+
+        let tok = lex_number(&source).unwrap();
+        assert_eq!(tok.next_index, 1);
+    }
+
+    #[test]
+    fn lexes_full_number() {
+        let source = char_string!("3.0");
+
+        let tok = lex_number(&source).unwrap();
+        assert_eq!(tok.next_index, 3);
     }
 }


### PR DESCRIPTION
# Issues 

Fixes #1010

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

I don't think it makes sense in pretty much any context to parse a terminating dot as part of a number.

For example, the sentence: `The I like the Switch 3.` 


# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Additional unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
