### PR TITLE
fix(core): runaway `harper-ls` processes

### DIFF
--- a/harper-ls/src/backend.rs
+++ b/harper-ls/src/backend.rs
@@ -306,7 +306,11 @@ impl Backend {
                     parser = Box::new(IsolateEnglish::new(parser, doc_state.dict.clone()));
                 }
 
-                doc_state.document = Document::new(text, &parser, &doc_state.dict);
+                // Don't lint on large documents.
+                // This should eventually be configurable, but that isn't necessary yet.
+                if text.len() < 120_000 {
+                    doc_state.document = Document::new(text, &parser, &doc_state.dict);
+                }
             }
         }
 


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->

Fixes #466

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

This adds a hard-coded limit to the filesize accepted by `harper-ls`. We might want to add a config option for this. I don't know of anyone that would use it, though. Let me know if that would be useful to you.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
