### PR TITLE
docs(readme): fix grammar and minor rephrasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Harper currently only supports English, but the core is extensible to support ot
 We consider long lint times bugs.
 If you encounter any significant performance issues, please create an issue on the topic.
 
-If you find a fix to any performance issue, we are open to the contribution.
-Just make sure to read [our contribution guidelines first.](https://github.com/automattic/harper/blob/master/CONTRIBUTING.md)
+If you find a fix to any performance issue, we would appreciate the contribution.
+Just please make sure to read [our contribution guidelines first.](https://github.com/automattic/harper/blob/master/CONTRIBUTING.md)
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Harper currently only supports English, but the core is extensible to support ot
 We consider long lint times bugs.
 If you encounter any significant performance issues, please create an issue on the topic.
 
-If you find a fix to any performance issue, we are open the contribution.
+If you find a fix to any performance issue, we are open to the contribution.
 Just make sure to read [our contribution guidelines first.](https://github.com/automattic/harper/blob/master/CONTRIBUTING.md)
 
 ## Links


### PR DESCRIPTION
# Description

Fixes a grammar mistake and applies some minor rephrasing in the *Performance Issues* section of the README. I'm not 100% sure the rephrasing is beneficial, so I put it into its own commit (I'm stuck in analysis paralysis at this point 😅).

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
