### PR TITLE
feat(harper-core/linting): add expand pull request phrase correction

### DIFF
--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -1177,6 +1177,12 @@ pub fn lint_group() -> LintGroup {
             "The correct term is `as well` with a space.",
             "Corrects `aswell`, which should be written as two words."
         ),
+        "ExpandPullRequest" => (
+            ["pr"],
+            ["pull request"],
+            "Use `pull request` instead of `pr`",
+            "Expands the abbreviation `pr` to `pull request` for clarity."
+        ),
     });
 
     group.set_all_rules_to(Some(true));

--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -2506,4 +2506,13 @@ mod tests {
             "format Cargo.toml as well #5893 - rust-lang/rustfmt",
         );
     }
+
+    #[test]
+    fn expand_pull_request() {
+        assert_suggestion_result(
+            "I'm implementing the feature in a PR.",
+            lint_group(),
+            "I'm implementing the feature in a pull request.",
+        );
+    }
 }


### PR DESCRIPTION
# Issues 
n/a


# Description

Adds a phrase correction rule that is similar to the other "expand" rules present in the file (such as for expanding dep/deps) to correct "pr" or "PR" to "pull request" for clarity.

<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

# Demo
n/a
# How Has This Been Tested?

Unit test (currently failing). I'm not sure how I can, with the current setup, have the correction *not* preserve the casing of the original text. The test fails because "PR" becomes "PULL REQUEST" instead of "pull request". Would appreciate feedback/guidance on how to make that happen.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
