### PR TITLE
feat(core): avoid providing multiple lints for a single long hyphen sequence in `Dashes`

### DIFF
--- a/harper-core/src/linting/dashes.rs
+++ b/harper-core/src/linting/dashes.rs
@@ -5,6 +5,9 @@ use crate::{
 
 use super::{Lint, LintKind, PatternLinter, Suggestion};
 
+const EN_DASH: char = '–';
+const EM_DASH: char = '—';
+
 pub struct Dashes {
     pattern: Box<dyn Pattern>,
 }
@@ -38,14 +41,14 @@ impl PatternLinter for Dashes {
             2 => Some(Lint {
                 span,
                 lint_kind,
-                suggestions: vec![Suggestion::ReplaceWith(vec!['–'])],
+                suggestions: vec![Suggestion::ReplaceWith(vec![EN_DASH])],
                 message: "A sequence of hyphens is not an en dash.".to_owned(),
                 priority: 63,
             }),
             3.. => Some(Lint {
                 span,
                 lint_kind,
-                suggestions: vec![Suggestion::ReplaceWith(vec!['—'])],
+                suggestions: vec![Suggestion::ReplaceWith(vec![EM_DASH])],
                 message: "A sequence of hyphens is not an em dash.".to_owned(),
                 priority: 63,
             }),
@@ -63,13 +66,14 @@ mod tests {
     use crate::linting::tests::{assert_suggestion_count, assert_suggestion_result};
 
     use super::Dashes;
+    use super::{EM_DASH, EN_DASH};
 
     #[test]
     fn catches_en_dash() {
         assert_suggestion_result(
             "pre--Industrial Revolution",
             Dashes::default(),
-            "pre–Industrial Revolution",
+            &format!("pre{EN_DASH}Industrial Revolution"),
         );
     }
 
@@ -78,7 +82,7 @@ mod tests {
         assert_suggestion_result(
             "'There is no box' --- Scott",
             Dashes::default(),
-            "'There is no box' — Scott",
+            &format!("'There is no box' {EM_DASH} Scott"),
         );
     }
 

--- a/harper-core/src/linting/dashes.rs
+++ b/harper-core/src/linting/dashes.rs
@@ -87,6 +87,15 @@ mod tests {
     }
 
     #[test]
+    fn suggests_em_dash_for_long_hyphen_sequences() {
+        assert_suggestion_result(
+            "'There is no box' ------ Scott",
+            Dashes::default(),
+            &format!("'There is no box' {EM_DASH} Scott"),
+        );
+    }
+
+    #[test]
     fn no_overlaps() {
         assert_suggestion_count("'There is no box' --- Scott", Dashes::default(), 1);
     }

--- a/harper-core/src/linting/dashes.rs
+++ b/harper-core/src/linting/dashes.rs
@@ -15,7 +15,7 @@ impl Default for Dashes {
         let em_dash = SequencePattern::default()
             .then_hyphen()
             .then_hyphen()
-            .then_hyphen();
+            .then_one_or_more_hyphens();
 
         let pattern = EitherPattern::new(vec![Box::new(em_dash), Box::new(en_dash)]);
 
@@ -42,7 +42,7 @@ impl PatternLinter for Dashes {
                 message: "A sequence of hyphens is not an en dash.".to_owned(),
                 priority: 63,
             }),
-            3 => Some(Lint {
+            3.. => Some(Lint {
                 span,
                 lint_kind,
                 suggestions: vec![Suggestion::ReplaceWith(vec!['—'])],
@@ -85,5 +85,10 @@ mod tests {
     #[test]
     fn no_overlaps() {
         assert_suggestion_count("'There is no box' --- Scott", Dashes::default(), 1);
+    }
+
+    #[test]
+    fn single_lint_for_long_hyphen_sequences() {
+        assert_suggestion_count("'There is no box' ------ Scott", Dashes::default(), 1);
     }
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
This PR modifies the `Dashes` linter to prevent it from suggesting multiple lints for a single long sequence of hyphens. Previously, if you had a line of 60 hyphens, you would get 20 lints suggesting you replace each triple hyphen with an em dash. With these changes, only a single lint will be provided (encompassing the whole sequence).
<!-- Any details that you think are important to review this PR? -->
While working on these changes, I noticed it can be very difficult if not impossible to visually discern between en and em dashes in some contexts. To reduce the potential for confusion, I extracted the dash literals into module-level `const`s. This did require making some of the tests more verbose with `format!`s though, so there is a tradeoff. I'm certainly open to undoing or modifying this "const extraction" if it's deemed to be detrimental.

# How Has This Been Tested?
- `cargo test`
- Briefly testing the modified build of `harper-ls` in a code editor.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
