### PR TITLE
fix: running individual tests was broken

### DIFF
--- a/harper-core/src/patterns/mod.rs
+++ b/harper-core/src/patterns/mod.rs
@@ -163,7 +163,7 @@ impl<F> Pattern for F
 where
     F: Fn(&Token, &[char]) -> bool,
 {
-    fn matches(&self, tokens: &[Token], source: &[char]) -> Option<NonZeroUsize> {
+    fn matches(&self, tokens: &[Token], source: &[char]) -> Option<usize> {
         if self(tokens.first()?, source) {
             Some(1)
         } else {


### PR DESCRIPTION
# Issues 
Fixes #1183 

# Description

The non-concurrent settings were still using `Option<NonZeroUsize>` but elsewhere had been changed to `Option<usize>`. Easy Fix! 

# Demo

<img width="821" alt="image" src="https://github.com/user-attachments/assets/fabf81f0-e718-403b-9bf5-5bb04f597639" /> 🎉

# How Has This Been Tested?

Clicked on various `Run` buttons in various source files in Windsurf.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
