### PR TITLE
chore(harper-core/dictionary): add Tree-sitter

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -52933,3 +52933,4 @@ Vercel/M2
 Netlify/M2
 SolidJS/M2
 Vue/M2
+Tree-sitter/M2


### PR DESCRIPTION
Related to https://github.com/Automattic/harper/issues/243, regression to fix the former in https://github.com/Automattic/harper/commit/ec345e7591861c585ab37b34a6cdc34ccdaf2486.

# Demo

From the CLI lint.

**Before**:
```
Advice: 
   ╭─[foo.md:1:1]
   │
 2 │ Did you hear about Tree-sitter? It definitely isn't spelled Treesitter.
   │                                                             ─────┬────  
   │                                                                  ╰────── Did you mean to spell “Treesitter” this way?
```

**After**:

```
Advice: 
   ╭─[foo.md:1:1]
   │
 2 │ Did you hear about Tree-sitter? It definitely isn't spelled Treesitter.
   │                                                             ─────┬────  
   │                                                                  ╰────── Did you mean “Tree-sitter”?
```

# How Has This Been Tested?
n/a

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
