### PR TITLE
chore(harper-core/dictionary): add manufacturable and favicon

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -24127,6 +24127,7 @@ fauvism/1M
 fauvist/51SM
 faux/~5
 fave/514S
+favicon/~1SM
 favor/~14ESMDG
 favorability/1MU
 favorable/~5U
@@ -32641,7 +32642,7 @@ mantle's
 mantra/~1MS
 manual/~15MYS
 manufacturability/1M
-manufacture/~14DRSMZGA
+manufacture/~14DRSMZGAB
 manufacturer/~1M
 manufacturing/~154MA
 manumission/1SM


### PR DESCRIPTION

# Issues 
n/a

# Description

Adds the -able suffix form to allow "manufacturable", adds a new common noun "favicon" (https://developer.mozilla.org/en-US/docs/Glossary/Favicon, https://en.wikipedia.org/wiki/Favicon). Favicon isn't in the dictionary per-se but I think it common enough to warrant adding?

# Demo
Before:
```
Advice: 
   ╭─[foo.md:1:1]
   │
 1 │ That is manufacturable.
   │         ───────┬──────  
   │                ╰──────── Did you mean “manufacture”?
 2 │ Did you add that favicon to the website yet?
   │                  ───┬───  
   │                     ╰───── Did you mean “falcon”?
───╯
```

After: (nothing)

# How Has This Been Tested?
n/a

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
