### PR TITLE
feat(ls): write sorted dictionaries

### DIFF
--- a/harper-ls/src/dictionary_io.rs
+++ b/harper-ls/src/dictionary_io.rs
@@ -1,4 +1,5 @@
 use anyhow::anyhow;
+use itertools::Itertools;
 use std::path::{Component, Path, PathBuf};
 
 use harper_core::{Dictionary, MutableDictionary, WordMetadata};
@@ -26,7 +27,7 @@ pub async fn save_dict(path: impl AsRef<Path>, dict: impl Dictionary) -> Result<
 async fn write_word_list(dict: impl Dictionary, mut w: impl AsyncWrite + Unpin) -> Result<()> {
     let mut cur_str = String::new();
 
-    for word in dict.words_iter() {
+    for word in dict.words_iter().sorted() {
         cur_str.clear();
         cur_str.extend(word);
 


### PR DESCRIPTION
# Issues 
#1169 

# Description
<!-- Please include a summary of the change. -->
This PR makes it so we sort the words iterator when saving the dictionary to disk. Thereby writing a sorted dictionary.
<!-- Any details that you think are important to review this PR? -->
This uses the [default ordering for strings](https://doc.rust-lang.org/std/primitive.str.html#impl-Ord-for-str), which means the resulting sort won't necessarily be alphabetic.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
Tested by using the code action to add to the global dictionary from Neovim. Running `sort -c` showed the dictionary file was properly sorted after adding a word. After an initial sort, adding a word no longer produced unreasonably large diffs in the dictionary file.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
