### PR TITLE
feat: dictionary curation and dialect tests

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -11769,7 +11769,7 @@ aftershave/1SM
 aftershock/1SM
 aftertaste/1SM
 afterthought/14SM
-afterward/~S<
+afterward/j~<
 afterwards/j!@_
 afterword/1MS
 again/~+

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -32681,9 +32681,9 @@ marge/~1
 margin/~14MS
 marginal/~51YS
 marginalia/1M
-marginality/1M
 marginalisation/1!_
 marginalise/4GDS!_
+marginality/1M
 marginalization/1M
 marginalize/4GDS
 maria/~1M
@@ -36733,8 +36733,8 @@ overrange/41GDS
 overrate/41GDS
 overreach/41GDS
 overreact/4SDG
-overread/54SDG
 overreaction/1SM
+overread/54SDG
 overrefined/45
 overregulate/4DSGN
 overreliance/1M
@@ -41580,8 +41580,8 @@ restroom/1SM
 restructuring/~41SM
 result/~41GSMD
 resultant/~51SM
-résumé/1SM
 resumé/1SM
+résumé/1SM
 resume/~41DSMG
 resumption/~1MS
 resupply/~41DSG
@@ -52344,13 +52344,16 @@ NYTimes/SM
 NYU/2M
 Neo4J/21M
 Neovim/M            # code editor
+Netlify/M2          # cloud
 Nikolay/SM
+NixOS/M2
 NoSQL/1
 Node.js/2M          # official spelling has dot
 NumPy/21M
 Nvidia/2M           # FIXME! elsewhere we have NVIDIA
 O'Reilly/2SM
 OAuth/M             # open authentication
+OCaml/M2            # programming language
 OG/1MS
 ORM/12S             # object-relational mapping
 OpenGL/SM           # open graphics library
@@ -52407,6 +52410,7 @@ Simplenote/2M
 Sioyek/M1
 Siri/2M             # voice assistant
 Snapchat/SM
+SolidJS/M2          # ui lib
 Soros/2M            # financier George Soros
 Spotify/2M
 Stellantis/2M       # car company
@@ -52425,6 +52429,7 @@ ThinkPad/2SM        # pc brand
 TikTok/SM
 Todo                # FIXME! elsewhere in Harper we refer to TODO and to-do
 Toronado/2MS        # car brand
+Tree-sitter/M2      # parsing
 Trocla/SM
 TrueNAS/SM
 Tumblr/2M
@@ -52441,14 +52446,17 @@ VPN/1SM             # virtual private network
 VR/2M
 Vaadin/SM
 VaultPress/2M
+Vercel/M2           # cloud
 VideoPress/2M
 Viktor/SM
 VirtualBox/21MS
 Vite/SM
+Vue/M2              # framework
 WAL/21SM
 WASI/MS
 WASM/MS             # see WebAssembly
 WD40/1M
+WSL/M2              # windows subsystem for linux
 Waymo/2M
 WebAssembly/M       # see WASM
 WebGPU/SM
@@ -52465,6 +52473,7 @@ Xorg/21MS
 Y2K/M               # year 2000
 YAML/2SM            # markup language
 Yazi/21MS
+Yoast/M2            # seo
 YubiKey/SM
 Zettelkasten/1M
 Zig/2M              # programming language
@@ -52891,8 +52900,8 @@ hook up/4
 knock out/4
 lock down/4
 log in/4
-log on/4
 log off/4
+log on/4
 log out/4
 look up/4
 meet up/4
@@ -52925,12 +52934,3 @@ work out/4
 # And they will be reviewed
 # Word added using the `just addnoun` command will be added here
 
-Yoast/M2
-NixOS/M2
-WSL/M2
-OCaml/M2
-Vercel/M2
-Netlify/M2
-SolidJS/M2
-Vue/M2
-Tree-sitter/M2

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -7486,6 +7486,7 @@ Numbers/2M
 Nunavut/2M
 Nunez/2M
 Nunki/2M
+Nürburgring/2M
 Nuremberg/2M        # city
 Nureyev/2M          # rudolf -
 NutraSweet/M        # trademark
@@ -8072,6 +8073,7 @@ Pinyin/21           # romanization
 Pippin/2M
 Piraeus/2M
 Pirandello/M
+Pirelli/12MS        # surname, tyres
 Pisa/2M             # city
 Pisces/21M
 Pisistratus/2M
@@ -10569,7 +10571,7 @@ Volcker/M
 Voldemort/14M
 Volga/21M
 Volgograd/2M
-Volkswagen/21M
+Volkswagen/21MS
 Volodymyr/2M
 Volstead/2M
 Volta/2M
@@ -13978,6 +13980,7 @@ basket/~14SM
 basketball/~14MS
 basketry/1M
 basketwork/1M
+basmati/1M
 basque/~1S
 bass/~514MS
 basset/~14SM
@@ -26517,6 +26520,7 @@ gooseneck/1MS
 goosestep/4S
 goosestepped/4
 goosestepping/4
+goosy/51MS
 gopher/~1SM
 gore/~14MGDS
 gorge/~145EDSG
@@ -27994,7 +27998,7 @@ historical/~51Y
 historicity/~1M
 historiographer/1MS
 historiography/~1M
-history/~14SM
+history/~1SM        # removed `4` verb sense is obsolte and interferes with heuristics
 histrionic/5SQ
 histrionics/1M
 hit/~4158SM
@@ -29672,6 +29676,7 @@ insert's
 insertion/~1AM
 insertions/~1
 insetting/4
+inshallah
 inshore/~5
 inside/~15+RSMZ
 insider/~1M
@@ -29935,6 +29940,7 @@ interpretative/5
 interpreted/~45U
 interpreter/~1MS
 interprocess/5
+interprovincial/5
 interracial/~5
 interred/~54E
 interregnum/~1SM
@@ -30324,6 +30330,7 @@ jangle/41DRSMZG
 jangler/1M
 janitor/~1SM
 janitorial/5
+jank/1M
 janky/5TR
 japan/~14SM
 japanned/4
@@ -35610,6 +35617,7 @@ notorious/~5Y
 notwithstanding/~7+
 nougat/1MS
 nought/154j8MS!@_
+noughties/9!_
 noun/~14KMS
 nourish/14DSLG
 nourishment/~1M
@@ -36636,6 +36644,7 @@ overexcite/4DSG
 overexercise/41GDS
 overexert/4SDG
 overexertion/1M
+overexploit/4GDS
 overexpose/4GDS
 overexposure/1M
 overextend/4DGS
@@ -41648,6 +41657,7 @@ retrofitting/41
 retrograde/~514DSG
 retrogress/41GVDS
 retrogression/1M
+retronic/5
 retrorocket/1MS
 retrospect/~14MDSGV
 retrospection/1M
@@ -42229,6 +42239,7 @@ runner/~1SM
 running/~451+M
 runny/5RT
 runoff/~1SM
+runout/1MS
 runt/1MS
 runtime/~51
 runty/5RT
@@ -52255,6 +52266,7 @@ GPT/1SM             # generative pre-trained transformer
 GPU/1S              # graphics processing unit
 Ganeti/SM
 Gateron/SM
+Gerber/1M           # file format
 GitLab/SM           # GitHub alternative
 Gmail/214SM
 Golang/SM           # programming language
@@ -52527,6 +52539,7 @@ wikilink/~1SM       # !! please check and comment !! elsewhere we have Wikilink
 # Harper may not recognize these as words in documents
 # But it will be able to include them in suggestions
 
+a lot
 ad nauseam/j
 add-on/1MS
 air-cooled/5
@@ -52544,6 +52557,7 @@ anti-vaxxer/1MS
 avant-garde/1M5
 back to back/j
 back-to-back/5
+barn find/1MS
 beck and call/1
 bell-pull/1MS
 bench-warmer/1MS
@@ -52553,6 +52567,7 @@ bona fide/j5
 boot up/4
 break out/4
 breaks out/4
+Bretton Woods/2M
 built-in/1MS5
 built-up/5
 car bomb/1MS
@@ -52711,6 +52726,7 @@ mind-blowing/5
 mind game/1MS
 mock up/4
 mock-up/1MS
+moon landing/1MS
 multiple-choice/5
 nail biter/1MS
 nano-farad/1MS
@@ -52839,6 +52855,7 @@ tom yam/1M
 top-end/5
 trade in/4
 trade-in/1MS
+two-door/51MS
 two-thirds/1
 type-check/4SDG
 type checking/1M

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -164,16 +164,6 @@ mod tests {
     use crate::{Document, FstDictionary, parsers::PlainEnglish};
 
     #[track_caller]
-    pub fn assert_nonzero_lint_count(text: &str, mut linter: impl Linter) {
-        let test = Document::new_markdown_default_curated(text);
-        let lints = linter.lint(&test);
-        assert!(
-            !lints.is_empty(),
-            "Expected \"{text}\" to create at least one lint, but it created none."
-        );
-    }
-
-    #[track_caller]
     pub fn assert_lint_count(text: &str, mut linter: impl Linter, count: usize) {
         let test = Document::new_markdown_default_curated(text);
         let lints = linter.lint(&test);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -164,6 +164,16 @@ mod tests {
     use crate::{Document, FstDictionary, parsers::PlainEnglish};
 
     #[track_caller]
+    pub fn assert_nonzero_lint_count(text: &str, mut linter: impl Linter) {
+        let test = Document::new_markdown_default_curated(text);
+        let lints = linter.lint(&test);
+        assert!(
+            !lints.is_empty(),
+            "Expected \"{text}\" to create at least one lint, but it created none."
+        );
+    }
+
+    #[track_caller]
     pub fn assert_lint_count(text: &str, mut linter: impl Linter, count: usize) {
         let test = Document::new_markdown_default_curated(text);
         let lints = linter.lint(&test);

--- a/harper-core/src/linting/spell_check.rs
+++ b/harper-core/src/linting/spell_check.rs
@@ -132,7 +132,8 @@ mod tests {
     use crate::{
         Dialect, FstDictionary,
         linting::tests::{
-            assert_lint_count, assert_suggestion_result, assert_top3_suggestion_result,
+            assert_lint_count, assert_nonzero_lint_count, assert_suggestion_result,
+            assert_top3_suggestion_result,
         },
     };
 
@@ -313,6 +314,50 @@ mod tests {
             "Abandonedware is abandoned. Do not bother submitting issues about the empty page bug. Author moved to greener pastures",
             SpellCheck::new(FstDictionary::curated(), Dialect::American),
             "Abandonware is abandoned. Do not bother submitting issues about the empty page bug. Author moved to greener pastures",
+        );
+    }
+
+    #[test]
+    fn commonwealth_afterwards() {
+        assert_lint_count(
+            "In Australia, Canada, and the UK, we prefer the spelling `afterwards`.",
+            SpellCheck::new(FstDictionary::curated(), Dialect::Australian),
+            0,
+        );
+        assert_lint_count(
+            "In Australia, Canada, and the UK, we prefer the spelling `afterwards`.",
+            SpellCheck::new(FstDictionary::curated(), Dialect::Canadian),
+            0,
+        );
+        assert_lint_count(
+            "In Australia, Canada, and the UK, we prefer the spelling `afterwards`.",
+            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            0,
+        );
+        assert_lint_count(
+            "But in America, we prefer the spelling `afterward`.",
+            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            0,
+        );
+    }
+
+    #[test]
+    fn flag_mixing_afterward_and_afterwards() {
+        assert_nonzero_lint_count(
+            "Mixing the 'afterward' and 'afterwards' spellings is an error in any dialect.",
+            SpellCheck::new(FstDictionary::curated(), Dialect::Australian),
+        );
+        assert_nonzero_lint_count(
+            "Mixing the 'afterward' and 'afterwards' spellings is an error in any dialect.",
+            SpellCheck::new(FstDictionary::curated(), Dialect::Canadian),
+        );
+        assert_nonzero_lint_count(
+            "Mixing the 'afterward' and 'afterwards' spellings is an error in any dialect.",
+            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+        );
+        assert_nonzero_lint_count(
+            "Mixing the 'afterward' and 'afterwards' spellings is an error in any dialect.",
+            SpellCheck::new(FstDictionary::curated(), Dialect::American),
         );
     }
 }

--- a/harper-core/src/linting/spell_check.rs
+++ b/harper-core/src/linting/spell_check.rs
@@ -132,8 +132,7 @@ mod tests {
     use crate::{
         Dialect, FstDictionary,
         linting::tests::{
-            assert_lint_count, assert_nonzero_lint_count, assert_suggestion_result,
-            assert_top3_suggestion_result,
+            assert_lint_count, assert_suggestion_result, assert_top3_suggestion_result,
         },
     };
 
@@ -318,46 +317,76 @@ mod tests {
     }
 
     #[test]
-    fn commonwealth_afterwards() {
+    fn afterwards_not_us() {
         assert_lint_count(
-            "In Australia, Canada, and the UK, we prefer the spelling `afterwards`.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::Australian),
-            0,
+            "afterwards",
+            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            1,
         );
+    }
+
+    #[test]
+    fn afterward_is_us() {
         assert_lint_count(
-            "In Australia, Canada, and the UK, we prefer the spelling `afterwards`.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::Canadian),
-            0,
-        );
-        assert_lint_count(
-            "In Australia, Canada, and the UK, we prefer the spelling `afterwards`.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
-            0,
-        );
-        assert_lint_count(
-            "But in America, we prefer the spelling `afterward`.",
+            "afterward",
             SpellCheck::new(FstDictionary::curated(), Dialect::American),
             0,
         );
     }
 
     #[test]
-    fn flag_mixing_afterward_and_afterwards() {
-        assert_nonzero_lint_count(
-            "Mixing the 'afterward' and 'afterwards' spellings is an error in any dialect.",
+    fn afterward_not_au() {
+        assert_lint_count(
+            "afterward",
             SpellCheck::new(FstDictionary::curated(), Dialect::Australian),
+            1,
         );
-        assert_nonzero_lint_count(
-            "Mixing the 'afterward' and 'afterwards' spellings is an error in any dialect.",
+    }
+
+    #[ignore = "Dialect Metadata field currently only allows a single dialect"]
+    #[test]
+    fn afterwards_is_au() {
+        assert_lint_count(
+            "afterwards",
+            SpellCheck::new(FstDictionary::curated(), Dialect::Australian),
+            0,
+        );
+    }
+
+    #[test]
+    fn afterward_not_ca() {
+        assert_lint_count(
+            "afterward",
             SpellCheck::new(FstDictionary::curated(), Dialect::Canadian),
+            1,
         );
-        assert_nonzero_lint_count(
-            "Mixing the 'afterward' and 'afterwards' spellings is an error in any dialect.",
+    }
+
+    #[ignore = "Dialect Metadata field currently only allows a single dialect"]
+    #[test]
+    fn afterwards_is_ca() {
+        assert_lint_count(
+            "afterwards",
+            SpellCheck::new(FstDictionary::curated(), Dialect::Canadian),
+            0,
+        );
+    }
+
+    #[test]
+    fn afterward_not_uk() {
+        assert_lint_count(
+            "afterward",
             SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            1,
         );
-        assert_nonzero_lint_count(
-            "Mixing the 'afterward' and 'afterwards' spellings is an error in any dialect.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+    }
+
+    #[test]
+    fn afterwards_is_uk() {
+        assert_lint_count(
+            "afterwards",
+            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            0,
         );
     }
 }

--- a/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
+++ b/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
@@ -635,7 +635,7 @@
 > mouse , come    over      with William the Conqueror . ” ( For , with all       her   knowledge of
 # NSg/V . NSg/V/P NSg/V/J/P P    NPrSg   D   NSg       . . . C/P . P    NSg/I/J/C I/J/D NSg/V     V/P
 > history , Alice had no      very clear   notion how   long      ago anything had happened . ) So
-# NSg/V   . NPr   V   NPrSg/P J    NSg/V/J NSg    NSg/C NPrSg/V/J J/P NSg/I/V  V   W?       . . NSg/I/J/C
+# NSg     . NPr   V   NPrSg/P J    NSg/V/J NSg    NSg/C NPrSg/V/J J/P NSg/I/V  V   W?       . . NSg/I/J/C
 > she began again : “ Où est   ma      chatte ? ” which was the first   sentence in          her   French
 # ISg V     P     . . ?  NPrSg NPrSg/J ?      . . I/C   V   D   NSg/V/J NSg/V    NPrSg/V/J/P I/J/D NPrSg/V/J
 > lesson - book  . The Mouse gave a   sudden leap    out         of  the water , and seemed to quiver
@@ -713,7 +713,7 @@
 > passion , Alice thought ) , and it        said in          a   low     trembling voice , “ Let   us      get   to
 # NPrSg/V . NPr   NSg/V   . . V/C NPrSg/ISg V/J  NPrSg/V/J/P D/P NSg/V/J V         NSg/V . . NSg/V NPr/ISg NSg/V P
 > the shore , and then    I’ll tell    you my history , and you’ll understand why   it        is I
-# D   NSg/V . V/C NSg/J/C W?   NPrSg/V IPl D  NSg/V   . V/C W?     V          NSg/V NPrSg/ISg VL ISg
+# D   NSg/V . V/C NSg/J/C W?   NPrSg/V IPl D  NSg     . V/C W?     V          NSg/V NPrSg/ISg VL ISg
 > hate  cats and dogs . ”
 # NSg/V NPl  V/C NPl  . .
 >
@@ -963,7 +963,7 @@
 >
 #
 > “ You promised to tell    me        your history , you know  , ” said Alice , “ and why   it        is you
-# . IPl W?       P  NPrSg/V NPrSg/ISg D    NSg/V   . IPl NSg/V . . V/J  NPr   . . V/C NSg/V NPrSg/ISg VL IPl
+# . IPl W?       P  NPrSg/V NPrSg/ISg D    NSg     . IPl NSg/V . . V/J  NPr   . . V/C NSg/V NPrSg/ISg VL IPl
 > hate  — C         and D       , ” she added in          a   whisper , half      afraid that    it        would  be     offended
 # NSg/V . NPrSg/V/J V/C NPrSg/J . . ISg W?    NPrSg/V/J/P D/P NSg/V   . NSg/V/J/P J      N/I/C/D NPrSg/ISg NSg/VX NSg/VX W?
 > again .
@@ -4167,7 +4167,7 @@
 >
 #
 > “ Come    on  , then    , ” said the Queen   , “ and he      shall tell    you his   history . ”
-# . NSg/V/P J/P . NSg/J/C . . V/J  D   NPrSg/V . . V/C NPr/ISg VX    NPrSg/V IPl ISg/D NSg/V   . .
+# . NSg/V/P J/P . NSg/J/C . . V/J  D   NPrSg/V . . V/C NPr/ISg VX    NPrSg/V IPl ISg/D NSg     . .
 >
 #
 > As    they walked off       together , Alice heard the King    say   in          a   low     voice , to the
@@ -4185,7 +4185,7 @@
 > know  what  a   Gryphon is , look  at        the picture . ) “ Up        , lazy    thing ! ” said the Queen   ,
 # NSg/V NSg/I D/P ?       VL . NSg/V NSg/I/V/P D   NSg/V   . . . NSg/V/J/P . NSg/V/J NSg/V . . V/J  D   NPrSg/V .
 > “ and take  this young     lady    to see   the Mock    Turtle , and to hear his   history . I
-# . V/C NSg/V I/D  NPrSg/V/J NPrSg/V P  NSg/V D   NSg/V/J NSg/V  . V/C P  V    ISg/D NSg/V   . ISg
+# . V/C NSg/V I/D  NPrSg/V/J NPrSg/V P  NSg/V D   NSg/V/J NSg/V  . V/C P  V    ISg/D NSg     . ISg
 > must  go      back    and see   after some  executions I   have   ordered ; ” and she walked off       ,
 # NSg/V NSg/V/J NSg/V/J V/C NSg/V J/P   I/J/R W?         ISg NSg/VX V/J     . . V/C ISg W?     NSg/V/J/P .
 > leaving Alice alone with the Gryphon . Alice did not   quite like        the look  of  the
@@ -4241,7 +4241,7 @@
 >
 #
 > “ This here    young     lady    , ” said the Gryphon , “ she wants for to know  your history ,
-# . I/D  NSg/J/R NPrSg/V/J NPrSg/V . . V/J  D   ?       . . ISg NPl   C/P P  NSg/V D    NSg/V   .
+# . I/D  NSg/J/R NPrSg/V/J NPrSg/V . . V/J  D   ?       . . ISg NPl   C/P P  NSg/V D    NSg     .
 > she do     . ”
 # ISg NSg/VX . .
 >
@@ -5541,7 +5541,7 @@
 > their slates and pencils had been  found and handed back    to them , they set       to
 # D     NPl    V/C NPl     V   NSg/V NSg/V V/C V/J    NSg/V/J P  N/I  . IPl  NPrSg/V/J P
 > work  very diligently to write out         a   history of  the accident , all       except the
-# NSg/V J    J/R        P  NSg/V NSg/V/J/R/P D/P NSg/V   V/P D   NSg/J    . NSg/I/J/C V/C/P  D
+# NSg/V J    J/R        P  NSg/V NSg/V/J/R/P D/P NSg     V/P D   NSg/J    . NSg/I/J/C V/C/P  D
 > Lizard , who     seemed too much  overcome to do     anything but     sit   with its   mouth open    ,
 # NSg    . NPrSg/I W?     W?  N/I/J NSg/V    P  NSg/VX NSg/I/V  NSg/C/P NSg/V P    ISg/D NSg/V NSg/V/J .
 > gazing up        into the roof  of  the court .

--- a/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
+++ b/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
@@ -39,7 +39,7 @@
 > much  out         of  the way   to hear the Rabbit say   to itself , “ Oh      dear    ! Oh      dear    ! I   shall
 # N/I/J NSg/V/J/R/P V/P D   NSg/J P  V    D   NSg/V  NSg/V P  I      . . NPrSg/V NSg/V/J . NPrSg/V NSg/V/J . ISg VX
 > be     late  ! ” ( when    she thought it        over      afterwards , it        occurred to her   that    she
-# NSg/VX NSg/J . . . NSg/I/C ISg NSg/V   NPrSg/ISg NSg/V/J/P NPl/R/Br   . NPrSg/ISg V        P  I/J/D N/I/C/D ISg
+# NSg/VX NSg/J . . . NSg/I/C ISg NSg/V   NPrSg/ISg NSg/V/J/P R/Br       . NPrSg/ISg V        P  I/J/D N/I/C/D ISg
 > ought    to have   wondered at        this , but     at        the time  it        all       seemed quite natural ) ;
 # NSg/I/VX P  NSg/VX W?       NSg/I/V/P I/D  . NSg/C/P NSg/I/V/P D   NSg/V NPrSg/ISg NSg/I/J/C W?     NSg   NSg/J   . .
 > but     when    the Rabbit actually took a   watch out         of  its   waistcoat - pocket  , and
@@ -5857,7 +5857,7 @@
 >
 #
 > “ No      , no      ! ” said the Queen   . “ Sentence first   — verdict afterwards . ”
-# . NPrSg/P . NPrSg/P . . V/J  D   NPrSg/V . . NSg/V    NSg/V/J . NSg     NPl/R/Br   . .
+# . NPrSg/P . NPrSg/P . . V/J  D   NPrSg/V . . NSg/V    NSg/V/J . NSg     R/Br       . .
 >
 #
 > “ Stuff and nonsense ! ” said Alice loudly . “ The idea of  having the sentence

--- a/harper-core/tests/text/tagged/Computer science.md
+++ b/harper-core/tests/text/tagged/Computer science.md
@@ -67,7 +67,7 @@
 >
 #
 > History
-# NSg/V
+# NSg
 >
 #
 > The earliest foundations of  what  would  become computer science predate the
@@ -129,7 +129,7 @@
 > published the 2nd of  the only two designs for mechanical analytical engines in
 # V/J       D   #   V/P D   W?   NSg NPl     C/P NSg/J      J          NPl     NPrSg/V/J/P
 > history . In          1914 , the Spanish engineer Leonardo Torres Quevedo published his
-# NSg/V   . NPrSg/V/J/P #    . D   NPrSg/J NSg/V    NPrSg    NPr    ?       V/J       ISg/D
+# NSg     . NPrSg/V/J/P #    . D   NPrSg/J NSg/V    NPrSg    NPr    ?       V/J       ISg/D
 > Essays on  Automatics , and designed , inspired by      Babbage , a   theoretical
 # NPl    J/P NPl        . V/C W?       . V/J      NSg/J/P NPr     . D/P J
 > electromechanical calculating machine which was to be     controlled by      a   read  - only

--- a/harper-core/tests/text/tagged/Part-of-speech tagging.md
+++ b/harper-core/tests/text/tagged/Part-of-speech tagging.md
@@ -157,7 +157,7 @@
 >
 #
 > History
-# NSg/V
+# NSg
 >
 #
 > The Brown     Corpus

--- a/harper-core/tests/text/tagged/The Great Gatsby.md
+++ b/harper-core/tests/text/tagged/The Great Gatsby.md
@@ -257,7 +257,7 @@
 > Across the courtesy bay     the white     palaces of  fashionable East    Egg   glittered
 # NSg/P  D   NSg/V/J  NSg/V/J D   NPrSg/V/J NPl     V/P NSg/J       NPrSg/J NSg/V W?
 > along the water , and the history of  the summer  really begins on  the evening I
-# P     D   NSg/V . V/C D   NSg/V   V/P D   NPrSg/V J/R    NPl    J/P D   NSg/V   ISg
+# P     D   NSg/V . V/C D   NSg     V/P D   NPrSg/V J/R    NPl    J/P D   NSg/V   ISg
 > drove over      there to have   dinner with the Tom     Buchanans . Daisy was my second
 # NSg/V NSg/V/J/P W?    P  NSg/VX NSg/V  P    D   NPrSg/V ?         . NPrSg V   D  NSg/V/J
 > cousin once  removed , and I’d known   Tom     in          college . And just after the war   I
@@ -3037,7 +3037,7 @@
 >
 #
 > “ The piece is known   , ” he      concluded lustily , “ as    ‘          Vladmir Tostoff’s Jazz  History
-# . D   NSg/V VL NSg/V/J . . NPr/ISg W?        R       . . NSg/R Unlintable ?       ?         NSg/V NSg/V
+# . D   NSg/V VL NSg/V/J . . NPr/ISg W?        R       . . NSg/R Unlintable ?       ?         NSg/V NSg
 > of  the World . ’ ”
 # V/P D   NSg/V . . .
 >
@@ -3055,7 +3055,7 @@
 > drinking helped to set       him off       from his   guests , for it        seemed to me        that    he      grew
 # V        W?     P  NPrSg/V/J I   NSg/V/J/P P    ISg/D NPl    . C/P NPrSg/ISg W?     P  NPrSg/ISg N/I/C/D NPr/ISg V
 > more        correct as    the fraternal hilarity increased . When    the “ Jazz  History of  the
-# NPrSg/I/V/J NSg/V/J NSg/R D   NSg/J     NSg      W?        . NSg/I/C D   . NSg/V NSg/V   V/P D
+# NPrSg/I/V/J NSg/V/J NSg/R D   NSg/J     NSg      W?        . NSg/I/C D   . NSg/V NSg     V/P D
 > World ” was over      , girls were  putting their heads on  men’s shoulders in          a
 # NSg/V . V   NSg/V/J/P . NPl   NSg/V NSg/V   D     NPl   J/P N$    NPl       NPrSg/V/J/P D/P
 > puppyish , convivial way   , girls were  swooning backward playfully into men’s arms ,
@@ -3987,7 +3987,7 @@
 > Little    Montenegro ! He      lifted up        the words and nodded at        them — with his   smile . The
 # NPrSg/I/J NPr        . NPr/ISg W?     NSg/V/J/P D   NPl   V/C V      NSg/I/V/P N/I  . P    ISg/D NSg/V . D
 > smile comprehended Montenegro’s troubled history and sympathized with the brave
-# NSg/V W?           N$           V/J      NSg/V   V/C W?          P    D   NSg/V/J
+# NSg/V W?           N$           V/J      NSg     V/C W?          P    D   NSg/V/J
 > struggles of  the Montenegrin people . It        appreciated fully the chain of  national
 # NPl       V/P D   NSg/J       NSg/V  . NPrSg/ISg V/J         V     D   NSg/V V/P NSg/J
 > circumstances which had elicited this tribute from Montenegro’s warm    little
@@ -8129,7 +8129,7 @@
 >
 #
 > “ That    was his   cousin . I   knew his   whole family history before he      left      . He      gave me
-# . N/I/C/D V   ISg/D NSg/V  . ISg V    ISg/D NSg/J NSg/J  NSg/V   C/P    NPr/ISg NPrSg/V/J . NPr/ISg V    NPrSg/ISg
+# . N/I/C/D V   ISg/D NSg/V  . ISg V    ISg/D NSg/J NSg/J  NSg     C/P    NPr/ISg NPrSg/V/J . NPr/ISg V    NPrSg/ISg
 > an  aluminum putter  that    I   use   to - day   . ”
 # D/P NSg/Ca   NSg/V/J N/I/C/D ISg NSg/V P  . NPrSg . .
 >
@@ -11633,7 +11633,7 @@
 > contemplation he      neither understood nor   desired , face  to face  for the last    time
 # NSg           NPr/ISg I/C     V/J        NSg/C V/J     . NSg/V P  NSg/V C/P D   NSg/V/J NSg/V
 > in          history with something commensurate to his   capacity for wonder .
-# NPrSg/V/J/P NSg/V   P    NSg/I/V/J V/J          P  ISg/D NSg/J    C/P NSg/V  .
+# NPrSg/V/J/P NSg     P    NSg/I/V/J V/J          P  ISg/D NSg/J    C/P NSg/V  .
 >
 #
 > And as    I   sat     there brooding on  the old   , unknown world , I   thought of  Gatsby’s

--- a/harper-core/tests/text/tagged/The Great Gatsby.md
+++ b/harper-core/tests/text/tagged/The Great Gatsby.md
@@ -273,7 +273,7 @@
 > one       of  those men who     reach such  an  acute   limited excellence at        twenty - one       that
 # NSg/I/V/J V/P I/D   NSg NPrSg/I NSg/V NSg/I D/P NSg/V/J NSg/V/J NSg        NSg/I/V/P NSg    . NSg/I/V/J N/I/C/D
 > everything afterward savors of  anti    - climax . His   family were  enormously
-# N/I/V      Am        NPl    V/P NSg/J/P . NSg/V  . ISg/D NSg/J  NSg/V J/R
+# N/I/V      R/Am      NPl    V/P NSg/J/P . NSg/V  . ISg/D NSg/J  NSg/V J/R
 > wealthy — even    in          college his   freedom with money was a   matter  for reproach — but     now
 # NSg/J   . NSg/V/J NPrSg/V/J/P NSg     ISg/D NSg     P    NSg/J V   D/P NSg/V/J C/P NSg/V    . NSg/C/P NPrSg/V/J/C
 > he’d left      Chicago and come    East    in          a   fashion that    rather    took your breath  away :
@@ -2215,7 +2215,7 @@
 >
 #
 > It        was nine o’clock — almost immediately afterward I   looked at        my watch and found
-# NPrSg/ISg V   NSg  W?      . NSg    J/R         Am        ISg W?     NSg/I/V/P D  NSg/V V/C NSg/V
+# NPrSg/ISg V   NSg  W?      . NSg    J/R         R/Am      ISg W?     NSg/I/V/P D  NSg/V V/C NSg/V
 > it        was ten . Mr  . McKee was asleep on  a   chair with his   fists clenched in          his   lap     ,
 # NPrSg/ISg V   NSg . NSg . NPr   V   J      J/P D/P NSg/V P    ISg/D NPl   W?       NPrSg/V/J/P ISg/D NSg/V/J .
 > like        a   photograph of  a   man         of  action  . Taking  out         my handkerchief I   wiped from
@@ -3739,7 +3739,7 @@
 > Catlips and the Bembergs and G. Earl  Muldoon , brother to that    Muldoon who
 # ?       V/C D   ?        V/C ?  NPrSg ?       . NSg/V/J P  N/I/C/D ?       NPrSg/I
 > afterward strangled his   wife  . Da        Fontano the promoter came    there , and Ed    Legros
-# Am        W?        ISg/D NSg/V . NPrSg/V/J ?       D   NSg/J    NSg/V/P W?    . V/C NPrSg ?
+# R/Am      W?        ISg/D NSg/V . NPrSg/V/J ?       D   NSg/J    NSg/V/P W?    . V/C NPrSg ?
 > and James B. ( “ Rot   - Gut     ” ) Ferret and the De    Jongs and Ernest Lilly — they came    to
 # V/C NPrPl ?  . . NSg/V . NSg/V/J . . NSg/V  V/C D   NPrSg ?     V/C NPr    NPrSg . IPl  NSg/V/P P
 > gamble  , and when    Ferret wandered into the garden  it        meant he      was cleaned out         and
@@ -7295,7 +7295,7 @@
 >
 #
 > Gatsby and I   in          turn  leaned down      and took the small     reluctant hand  . Afterward he
-# NPr    V/C ISg NPrSg/V/J/P NSg/V W?     NSg/V/J/P V/C V    D   NPrSg/V/J J         NSg/V . Am        NPr/ISg
+# NPr    V/C ISg NPrSg/V/J/P NSg/V W?     NSg/V/J/P V/C V    D   NPrSg/V/J J         NSg/V . R/Am      NPr/ISg
 > kept looking at        the child with surprise . I   don’t think he      had ever really
 # V    V       NSg/I/V/P D   NSg/V P    NSg/V    . ISg NSg/V NSg/V NPr/ISg V   J    J/R
 > believed in          its   existence before .
@@ -10339,7 +10339,7 @@
 >
 #
 > His   movements — he      was on  foot  all       the time  — were  afterward traced to Port
-# ISg/D NPl       . NPr/ISg V   J/P NSg/V NSg/I/J/C D   NSg/V . NSg/V Am        W?     P  NPrSg/V/J
+# ISg/D NPl       . NPr/ISg V   J/P NSg/V NSg/I/J/C D   NSg/V . NSg/V R/Am      W?     P  NPrSg/V/J
 > Roosevelt and then    to Gad’s Hill    , where he      bought a   sandwich that    he      didn’t eat   ,
 # NPr       V/C NSg/J/C P  ?     NPrSg/V . NSg/C NPr/ISg NSg/V  D/P NSg/V/J  N/I/C/D NPr/ISg V      NSg/V .
 > and a   cup   of  coffee  . He      must  have   been  tired and walking slowly , for he      didn’t
@@ -10413,7 +10413,7 @@
 >
 #
 > The chauffeur — he      was one       of  Wolfshiem’s protégés — heard the shots — afterward he
-# D   NSg/V     . NPr/ISg V   NSg/I/V/J V/P ?           ?        . V/J   D   NPl   . Am        NPr/ISg
+# D   NSg/V     . NPr/ISg V   NSg/I/V/J V/P ?           ?        . V/J   D   NPl   . R/Am      NPr/ISg
 > could  only say   that    he      hadn’t thought anything much  about them . I   drove from the
 # NSg/VX W?   NSg/V N/I/C/D NPr/ISg V      NSg/V   NSg/I/V  N/I/J J/P   N/I  . ISg NSg/V P    D
 > station directly to Gatsby’s house   and my rushing anxiously up        the front   steps
@@ -11413,7 +11413,7 @@
 > saw   Jordan Baker   and talked over      and around what  had happened to us      together ,
 # NSg/V NPr    NPrSg/J V/C W?     NSg/V/J/P V/C J/P    NSg/I V   W?       P  NPr/ISg J        .
 > and what  had happened afterward to me        , and she lay     perfectly still   , listening ,
-# V/C NSg/I V   W?       Am        P  NPrSg/ISg . V/C ISg NSg/V/J J/R       NSg/V/J . V         .
+# V/C NSg/I V   W?       R/Am      P  NPrSg/ISg . V/C ISg NSg/V/J J/R       NSg/V/J . V         .
 > in          a   big     chair .
 # NPrSg/V/J/P D/P NSg/V/J NSg/V .
 >


### PR DESCRIPTION
# Issues 
N/A

# Description

I merged, sorted, and commented new dictionary contributions.

I noticed that `afterwards` was being flagged even for Australian English where it's the preferred spelling.

- Fixed annotations for both `afterward` and `afterwards`
- Added tests for American vs Commonwealth dialects

I had trouble getting some tests to work with Australian English despite this. It turns out that the `dialect` field of the metadata is a string and can only hold one dialect. Changed to simpler tests, some of which are set to ignore with notes.

# How Has This Been Tested?

Added +ive and -ive unit tests for `afterward` and `afterward` for each dialect. Two are disabled due to the above limitation.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
