### PR TITLE
chore: convert commented out tests to use `#[ignore]`

### DIFF
--- a/harper-core/src/lexing/mod.rs
+++ b/harper-core/src/lexing/mod.rs
@@ -358,29 +358,29 @@ mod tests {
         ));
     }
 
-    // #[test]
-    // fn lexes_negative_1() {
-    //     let source: Vec<_> = "-1".chars().collect();
-    //     assert!(matches!(
-    //         lex_number(&source),
-    //         Some(FoundToken {
-    //             token: TokenKind::Number(_),
-    //             ..
-    //         })
-    //     ));
-    // }
+    #[ignore = "Negative numbers are not yet supported"]
+    fn lexes_negative_1() {
+        let source: Vec<_> = "-1".chars().collect();
+        assert!(matches!(
+            lex_number(&source),
+            Some(FoundToken {
+                token: TokenKind::Number(_),
+                ..
+            })
+        ));
+    }
 
-    // #[test]
-    // fn lexes_positive_1() {
-    //     let source: Vec<_> = "+1".chars().collect();
-    //     assert!(matches!(
-    //         lex_number(&source),
-    //         Some(FoundToken {
-    //             token: TokenKind::Number(_),
-    //             ..
-    //         })
-    //     ));
-    // }
+    #[ignore = "Positive numbers with a leading + are not supported"]
+    fn lexes_positive_1() {
+        let source: Vec<_> = "+1".chars().collect();
+        assert!(matches!(
+            lex_number(&source),
+            Some(FoundToken {
+                token: TokenKind::Number(_),
+                ..
+            })
+        ));
+    }
 
     #[test]
     fn lexes_pi() {

--- a/harper-core/src/linting/inflected_verb_after_to.rs
+++ b/harper-core/src/linting/inflected_verb_after_to.rs
@@ -119,11 +119,15 @@ mod tests {
         );
     }
 
-    // -ing forms can act as nouns, current heuristics cannot distinguish
-    // #[test]
-    // fn flag_to_checking() {
-    //     assert_lint_count("to checking", InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American), 1);
-    // }
+    #[test]
+    #[ignore = "-ing forms can act as nouns, current heuristics cannot distinguish"]
+    fn flag_to_checking() {
+        assert_lint_count(
+            "to checking",
+            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            1,
+        );
+    }
 
     #[test]
     fn dont_flag_check_ed() {
@@ -152,15 +156,15 @@ mod tests {
         );
     }
 
-    // can't check yet. 'capture' is noun as well as verb. "to nouns" is good English. we can't disambiguate verbs from nouns.
-    // #[test]
-    // fn check_993_suggestions() {
-    //     assert_suggestion_result(
-    //         "A location-agnostic structure that attempts to captures the context and content that a Lint occurred.",
-    //         InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
-    //         "A location-agnostic structure that attempts to capture the context and content that a Lint occurred.",
-    //     );
-    // }
+    #[test]
+    #[ignore = "can't check yet. 'capture' is noun as well as verb. \"to nouns\" is good English. we can't disambiguate verbs from nouns."]
+    fn check_993_suggestions() {
+        assert_suggestion_result(
+            "A location-agnostic structure that attempts to captures the context and content that a Lint occurred.",
+            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            "A location-agnostic structure that attempts to capture the context and content that a Lint occurred.",
+        );
+    }
 
     #[test]
     fn dont_flag_embarrass_not_in_dictionary() {
@@ -180,15 +184,15 @@ mod tests {
         );
     }
 
-    // can't check yet. 'catch' is noun as well as verb. "to nouns" is good English. we can't disambiguate verbs from nouns.
-    // #[test]
-    // fn corrects_es_ending() {
-    //     assert_suggestion_result(
-    //         "I need it to catches every exception.",
-    //         InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
-    //         "I need it to catch every exception.",
-    //     );
-    // }
+    #[test]
+    #[ignore = "can't check yet. 'catch' is noun as well as verb. 'to nouns' is good English. we can't disambiguate verbs from nouns."]
+    fn corrects_es_ending() {
+        assert_suggestion_result(
+            "I need it to catches every exception.",
+            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            "I need it to catch every exception.",
+        );
+    }
 
     #[test]
     fn corrects_ed_ending() {
@@ -217,15 +221,15 @@ mod tests {
         );
     }
 
-    // can't check yet. surprisingly, 'explore' is noun as well as verb. "to nouns" is good English. we can't disambiguate verbs from nouns.
-    // #[test]
-    // fn corrects_explor_ed() {
-    //     assert_suggestion_result(
-    //         "I went to explored distant galaxies.",
-    //         InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
-    //         "I went to explore distant galaxies.",
-    //     );
-    // }
+    #[test]
+    #[ignore = "can't check yet. surprisingly, 'explore' is noun as well as verb. 'to nouns' is good English. we can't disambiguate verbs from nouns."]
+    fn corrects_explor_ed() {
+        assert_suggestion_result(
+            "I went to explored distant galaxies.",
+            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            "I went to explore distant galaxies.",
+        );
+    }
 
     #[test]
     fn cant_flag_express_ed_also_noun() {

--- a/harper-core/src/linting/it_is.rs
+++ b/harper-core/src/linting/it_is.rs
@@ -120,15 +120,15 @@ mod tests {
         assert_lint_count("Its team lead is excellent.", ItIs::default(), 0);
     }
 
-    // This case fails, but I think that's acceptable.
-    // #[test]
-    // fn does_not_flag_non_adjective() {
-    //     assert_lint_count(
-    //         "The cat chased its tail around the room.",
-    //         ItIs::default(),
-    //         0,
-    //     );
-    // }
+    #[test]
+    #[ignore = "This case fails, but I think that's acceptable"]
+    fn does_not_flag_non_adjective() {
+        assert_lint_count(
+            "The cat chased its tail around the room.",
+            ItIs::default(),
+            0,
+        );
+    }
 
     #[test]
     fn does_not_flag_already_correct() {

--- a/harper-core/src/linting/lets_confusion/mod.rs
+++ b/harper-core/src/linting/lets_confusion/mod.rs
@@ -46,24 +46,25 @@ mod tests {
         );
     }
 
-    // "play" is also a noun so in a context like "Sometimes the umpire lets play continue"
-    // #[test]
-    // fn issue_470_missing_apostrophe() {
-    //     assert_suggestion_result("lets play", LetsConfusion::default(), "let's play");
-    // }
-
-    // #[test]
-    // fn issue_470_missing_subject() {
-    //     assert_suggestion_result("let play", LetsConfusion::default(), "let's play");
-    // }
+    #[test]
+    #[ignore = "\"play\" is also a noun so in a context like \"Sometimes the umpire lets play continue\""]
+    fn issue_470_missing_apostrophe_play() {
+        assert_suggestion_result("lets play", LetsConfusion::default(), "let's play");
+    }
 
     #[test]
-    fn issue_470_missing_apostrophe() {
+    #[ignore]
+    fn issue_470_missing_subject_play() {
+        assert_suggestion_result("let play", LetsConfusion::default(), "let's play");
+    }
+
+    #[test]
+    fn issue_470_missing_apostrophe_proceed() {
         assert_suggestion_result("lets proceed", LetsConfusion::default(), "let's proceed");
     }
 
     #[test]
-    fn issue_470_missing_subject() {
+    fn issue_470_missing_subject_proceed() {
         assert_suggestion_result("let proceed", LetsConfusion::default(), "let's proceed");
     }
 

--- a/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
+++ b/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
@@ -335,16 +335,15 @@ mod tests {
         );
     }
 
-    // "Shakedown" is a compound noun -- it's part of a comma-separated list with another noun "threat"
-    // But this is not easy to check for so is not implemented yet.
-    // #[test]
-    // fn dont_flag_a_threat_or_shakedown() {
-    //     assert_lint_count(
-    //         "Just a threat or Shakedown.",
-    //         PhrasalVerbAsCompoundNoun::default(),
-    //         0,
-    //     );
-    // }
+    #[test]
+    #[ignore = "\"Shakedown\" is a compound noun -- it's part of a comma-separated list with another noun \"threat\"\nBut this is not easy to check for so is not implemented yet."]
+    fn dont_flag_a_threat_or_shakedown() {
+        assert_lint_count(
+            "Just a threat or Shakedown.",
+            PhrasalVerbAsCompoundNoun::default(),
+            0,
+        );
+    }
 
     #[test]
     fn dont_flag_a_flyover() {

--- a/harper-core/src/linting/possessive_your.rs
+++ b/harper-core/src/linting/possessive_your.rs
@@ -107,12 +107,13 @@ mod tests {
         );
     }
 
-    // #[test]
-    // fn test_top3_suggestion_multiple() {
-    //     assert_top3_suggestion_result(
-    //         "You knowledge. You imagination. You icosahedron",
-    //         PossessiveYour::default(),
-    //         "Your knowledge. Your imagination. You're an icosahedron",
-    //     );
-    // }
+    #[test]
+    #[ignore]
+    fn test_top3_suggestion_multiple() {
+        assert_top3_suggestion_result(
+            "You knowledge. You imagination. You icosahedron",
+            PossessiveYour::default(),
+            "Your knowledge. Your imagination. You're an icosahedron",
+        );
+    }
 }

--- a/harper-core/src/linting/sentence_capitalization.rs
+++ b/harper-core/src/linting/sentence_capitalization.rs
@@ -214,15 +214,15 @@ mod tests {
         )
     }
 
-    // TODO: This can't work because currently hyphens are not included in tokenized words
-    // TODO: although they are now permitted in `dictionary.dict`
-    // #[test]
-    // fn uppercase_unamerican_at_start() {
-    //     assert_lint_count("un-American starts with a lowercase letter and contains an uppercase letter, but is not a proper noun or trademark.",
-    //         SentenceCapitalization::new(FstDictionary::curated(), Dialect::American),
-    //         1,
-    //     )
-    // }
+    #[test]
+    #[ignore = "This can't work because currently hyphens are not included in tokenized words\nalthough they are now permitted in `dictionary.dict`"]
+    fn uppercase_unamerican_at_start() {
+        assert_lint_count(
+            "un-American starts with a lowercase letter and contains an uppercase letter, but is not a proper noun or trademark.",
+            SentenceCapitalization::new(FstDictionary::curated(), Dialect::American),
+            1,
+        )
+    }
 
     #[test]
     fn allow_lowercase_proper_nouns() {

--- a/harper-core/src/linting/spell_check.rs
+++ b/harper-core/src/linting/spell_check.rs
@@ -268,14 +268,15 @@ mod tests {
         );
     }
 
-    // #[test]
-    // fn australian_labour_vs_labor() {
-    //     assert_lint_count(
-    //         "In Australia we write 'labour' but the political party is the 'Labor Party'.",
-    //         SpellCheck::new(FstDictionary::curated(), Dialect::Australian),
-    //         0,
-    //     )
-    // }
+    #[test]
+    #[ignore = "This test is broken due to the metadata dialect field not being a collection"]
+    fn australian_labour_vs_labor() {
+        assert_lint_count(
+            "In Australia we write 'labour' but the political party is the 'Labor Party'.",
+            SpellCheck::new(FstDictionary::curated(), Dialect::Australian),
+            0,
+        )
+    }
 
     #[test]
     fn australian_words_flagged_for_american_english() {

--- a/harper-core/src/spell/mutable_dictionary.rs
+++ b/harper-core/src/spell/mutable_dictionary.rs
@@ -270,6 +270,7 @@ mod tests {
     // TODO "this" is a determiner when used similarly to "the"
     // TODO but when used alone it's a "demonstrative pronoun"
     // TODO Harper previously wrongly classified it as a noun
+    // TODO .is_determiner() is not yet implemented
     // #[test]
     // fn this_is_determiner() {
     //     let dict = MutableDictionary::curated();


### PR DESCRIPTION
# Issues 
N/A

# Description

I just discovered that Rust tests allow a `#[ignore]` attribute that has an optional 'reason' field. I wasn't aware of so this before so now I've gone ahead and converted all commented-out tests to use it.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test` is still happy.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
