### PR TITLE
fix: exception for "how did you" in how-to linter

### DIFF
--- a/harper-core/src/linting/how_to.rs
+++ b/harper-core/src/linting/how_to.rs
@@ -22,10 +22,12 @@ impl Default for HowTo {
             .then_anything()
             .then_anything()
             .then(
-                InflectionOfBe::new().or(Box::new(|tok: &Token, _: &[char]| {
+                InflectionOfBe::new().or(Box::new(|tok: &Token, src: &[char]| {
                     tok.kind.is_auxiliary_verb()
                         || tok.kind.is_adjective()
                         || tok.kind.is_present_tense_verb()
+                        // Special case for "did" as in "how did you do that?"
+                        || tok.span.get_content_string(src).eq_ignore_ascii_case("did")
                 })),
             );
 
@@ -231,5 +233,11 @@ mod tests {
             HowTo::default(),
             0,
         );
+    }
+
+    #[test]
+    #[ignore]
+    fn dont_flag_how_did_you() {
+        assert_lint_count("How did you get to school every day?", HowTo::default(), 0);
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

While dogfooding I noticed sentences like "How did you do that" were flagged by the `HowTo` linter so I added a special exception.

# How Has This Been Tested?

I added a unit test with the sentence that revealed the problem.
All tests pass.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
