### PR TITLE
fix: add exception to possessive_your linter

### DIFF
--- a/harper-core/src/linting/possessive_your.rs
+++ b/harper-core/src/linting/possessive_your.rs
@@ -15,9 +15,11 @@ impl Default for PossessiveYour {
             SequencePattern::aco("you")
                 .then_whitespace()
                 .then(|tok: &Token, source: &[char]| {
-                    tok.kind.is_nominal()
-                        && !tok.kind.is_likely_homograph()
-                        && tok.span.get_content(source) != ['g', 'u', 'y', 's']
+                    if tok.kind.is_nominal() && !tok.kind.is_likely_homograph() {
+                        let word = tok.span.get_content_string(source).to_lowercase();
+                        return !matches!(word.as_str(), "guys" | "what's");
+                    }
+                    false
                 });
 
         Self {
@@ -50,7 +52,7 @@ impl PatternLinter for PossessiveYour {
     }
 
     fn description(&self) -> &'static str {
-        "The possessive version of `you` is more common before nouns."
+        "The possessive form of `you` is more likely before nouns."
     }
 }
 
@@ -107,12 +109,22 @@ mod tests {
         );
     }
 
-    // #[test]
-    // fn test_top3_suggestion_multiple() {
-    //     assert_top3_suggestion_result(
-    //         "You knowledge. You imagination. You icosahedron",
-    //         PossessiveYour::default(),
-    //         "Your knowledge. Your imagination. You're an icosahedron",
-    //     );
-    // }
+    #[test]
+    #[ignore]
+    fn test_top3_suggestion_multiple() {
+        assert_top3_suggestion_result(
+            "You knowledge. You imagination. You icosahedron",
+            PossessiveYour::default(),
+            "Your knowledge. Your imagination. You're an icosahedron",
+        );
+    }
+
+    #[test]
+    fn dont_flag_just_showing_you() {
+        assert_lint_count(
+            "I'm just showing you what's available and how to use it.",
+            PossessiveYour::default(),
+            0,
+        );
+    }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

Prevent flagging "showing you what's available".
I'm not generalizing yet until we have more data, just treating "what's" as special for now.

I also tweaked the description wording a little.

While I was there I change another commented-out test to use `#[ignore]`

# How Has This Been Tested?

I added a unit test using the sentence that revealed the false positive.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
