### PR TITLE
fix: heuristic for no-contraction-with-verb for "let go"

### DIFF
--- a/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
+++ b/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
@@ -33,20 +33,15 @@ impl Default for NoContractionWithVerb {
                 return false;
             }
 
-            let tok_chars = tok.span.get_content(source);
+            let lowercase = tok.span.get_content_string(source).to_lowercase();
 
             // If it ends with 'ing' and is at least 5 chars long, it could be a gerund or past participle
             // TODO: replace with metadata check when affix system supports verb forms
-            if tok_chars.len() < 5 {
+            if lowercase.len() < 5 {
                 return true;
             }
 
-            let is_ing_form = tok_chars
-                .iter()
-                .skip(tok_chars.len() - 3)
-                .map(|&c| c.to_ascii_lowercase())
-                .collect::<Vec<_>>()
-                .ends_with(&['i', 'n', 'g']);
+            let is_ing_form = lowercase.ends_with("ing");
 
             !is_ing_form
         });
@@ -57,7 +52,7 @@ impl Default for NoContractionWithVerb {
             .then(|tok: &Token, source: &[char]| {
                 tok.kind.is_verb()
                 // TODO: because 'US' is a noun, 'us' also gets marked as a noun
-                || (tok.kind.is_noun() && tok.span.get_content(source) != ['u', 's'])
+                || tok.kind.is_noun() && tok.span.get_content_string(source) != "us"
             })
             .then_whitespace()
             .then(|tok: &Token, _source: &[char]| {
@@ -81,6 +76,16 @@ impl PatternLinter for NoContractionWithVerb {
     }
 
     fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let (let_string, verb_string) = (
+            matched_tokens[0].span.get_content_string(source),
+            matched_tokens[2].span.get_content_string(source),
+        );
+
+        // "to let go" is a phrasal verb but "lets go" is quite a common mistak for "let's go"
+        if let_string == "let" && verb_string == "go" {
+            return None;
+        }
+
         let problem_span = matched_tokens.first()?.span;
         let template = problem_span.get_content(source);
 
@@ -209,5 +214,14 @@ mod tests {
     #[test]
     fn dont_flag_let_us() {
         assert_lint_count("Let us do this.", NoContractionWithVerb::default(), 0);
+    }
+
+    #[test]
+    fn dont_flag_let_go_1202() {
+        assert_lint_count(
+            "... until you hit your opponent, then let go and quickly retap",
+            NoContractionWithVerb::default(),
+            0,
+        );
     }
 }


### PR DESCRIPTION
# Issues 

Solves issue #1202

# Description

The phrasing in the bug report is inherently ambiguous even looking forward more and more tokens.
However, `lets go` is a very common mistake for `let's go` so worth flagging even though in a context like `he lets go of the ball` would an error. On the other hand `let go` is more likely to be part of a context like `he let go of the ball` that a mistake for `let's go`.
So this boils down to a frequence heuristic.

Which means false positives and negatives are still possible but less likely now.

I've also applied some refactoring I've learned to clean up the other code a little.

# How Has This Been Tested?

I made a unit test from the sentence in the screenshot in the issue.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
