### PR TITLE
fix: Remove verb property from "of"

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -35967,7 +35967,7 @@ oestrogen/1MS!_
 oestrous/5!_
 oestrus/1MS!_
 oeuvre/~1MS
-of/~+4
+of/~+
 off/~5+41SZGDRJ
 offal/1M
 offbeat/~15MS

--- a/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
+++ b/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
@@ -14,42 +14,42 @@
 # NSg/V   ISg . NSg/V/J/P D   NSg/V  . NSg/V
 >
 #
-> Alice was beginning to get   very tired of  sitting by      her   sister on  the bank  , and
-# NPr   V   NSg/V/J   P  NSg/V J    V/J   V/P NSg/V/J NSg/J/P I/J/D NSg/V  J/P D   NSg/V . V/C
-> of  having nothing to do     : once  or      twice she had peeped into the book  her   sister
-# V/P V      NSg/I/J P  NSg/VX . NSg/C NPrSg/C W?    ISg V   W?     P    D   NSg/V I/J/D NSg/V
+> Alice was beginning to get   very tired of sitting by      her   sister on  the bank  , and
+# NPr   V   NSg/V/J   P  NSg/V J    V/J   P  NSg/V/J NSg/J/P I/J/D NSg/V  J/P D   NSg/V . V/C
+> of having nothing to do     : once  or      twice she had peeped into the book  her   sister
+# P  V      NSg/I/J P  NSg/VX . NSg/C NPrSg/C W?    ISg V   W?     P    D   NSg/V I/J/D NSg/V
 > was reading , but     it        had no      pictures or      conversations in          it        , “ and what  is the use
 # V   NPrSg/V . NSg/C/P NPrSg/ISg V   NPrSg/P NPl      NPrSg/C NPl           NPrSg/V/J/P NPrSg/ISg . . V/C NSg/I VL D   NSg/V
-> of  a   book  , ” thought Alice “ without pictures or      conversations ? ”
-# V/P D/P NSg/V . . NSg/V   NPr   . C/P     NPl      NPrSg/C NPl           . .
+> of a   book  , ” thought Alice “ without pictures or      conversations ? ”
+# P  D/P NSg/V . . NSg/V   NPr   . C/P     NPl      NPrSg/C NPl           . .
 >
 #
 > So        she was considering in          her   own     mind  ( as    well    as    she could  , for the hot     day
 # NSg/I/J/C ISg V   V           NPrSg/V/J/P I/J/D NSg/V/J NSg/V . NSg/R NSg/V/J NSg/R ISg NSg/VX . C/P D   NSg/V/J NPrSg
-> made  her   feel      very sleepy and stupid ) , whether the pleasure of  making a
-# NSg/V I/J/D NSg/I/V/J J    NSg/J  V/C NSg/J  . . I/C     D   NSg/V    V/P NSg/V  D/P
-> daisy - chain would  be     worth   the trouble of  getting up        and picking the daisies ,
-# NPrSg . NSg/V NSg/VX NSg/VX NSg/V/J D   NSg/V   V/P NSg/V   NSg/V/J/P V/C V       D   NPl     .
+> made  her   feel      very sleepy and stupid ) , whether the pleasure of making a
+# NSg/V I/J/D NSg/I/V/J J    NSg/J  V/C NSg/J  . . I/C     D   NSg/V    P  NSg/V  D/P
+> daisy - chain would  be     worth   the trouble of getting up        and picking the daisies ,
+# NPrSg . NSg/V NSg/VX NSg/VX NSg/V/J D   NSg/V   P  NSg/V   NSg/V/J/P V/C V       D   NPl     .
 > when    suddenly a   White     Rabbit with pink    eyes ran   close   by      her   .
 # NSg/I/C J/R      D/P NPrSg/V/J NSg/V  P    NSg/V/J NPl  NSg/V NSg/V/J NSg/J/P I/J/D .
 >
 #
 > There was nothing so        very remarkable in          that    ; nor   did Alice think it        so        very
 # W?    V   NSg/I/J NSg/I/J/C J    W?         NPrSg/V/J/P N/I/C/D . NSg/C V   NPr   NSg/V NPrSg/ISg NSg/I/J/C J
-> much  out         of  the way   to hear the Rabbit say   to itself , “ Oh      dear    ! Oh      dear    ! I   shall
-# N/I/J NSg/V/J/R/P V/P D   NSg/J P  V    D   NSg/V  NSg/V P  I      . . NPrSg/V NSg/V/J . NPrSg/V NSg/V/J . ISg VX
+> much  out         of the way   to hear the Rabbit say   to itself , “ Oh      dear    ! Oh      dear    ! I   shall
+# N/I/J NSg/V/J/R/P P  D   NSg/J P  V    D   NSg/V  NSg/V P  I      . . NPrSg/V NSg/V/J . NPrSg/V NSg/V/J . ISg VX
 > be     late  ! ” ( when    she thought it        over      afterwards , it        occurred to her   that    she
 # NSg/VX NSg/J . . . NSg/I/C ISg NSg/V   NPrSg/ISg NSg/V/J/P R/Br       . NPrSg/ISg V        P  I/J/D N/I/C/D ISg
 > ought    to have   wondered at        this , but     at        the time  it        all       seemed quite natural ) ;
 # NSg/I/VX P  NSg/VX W?       NSg/I/V/P I/D  . NSg/C/P NSg/I/V/P D   NSg/V NPrSg/ISg NSg/I/J/C W?     NSg   NSg/J   . .
-> but     when    the Rabbit actually took a   watch out         of  its   waistcoat - pocket  , and
-# NSg/C/P NSg/I/C D   NSg/V  J/R      V    D/P NSg/V NSg/V/J/R/P V/P ISg/D NSg       . NSg/V/J . V/C
+> but     when    the Rabbit actually took a   watch out         of its   waistcoat - pocket  , and
+# NSg/C/P NSg/I/C D   NSg/V  J/R      V    D/P NSg/V NSg/V/J/R/P P  ISg/D NSg       . NSg/V/J . V/C
 > looked at        it        , and then    hurried on  , Alice started to her   feet , for it        flashed
 # W?     NSg/I/V/P NPrSg/ISg . V/C NSg/J/C V/J     J/P . NPr   W?      P  I/J/D NSg  . C/P NPrSg/ISg W?
 > across her   mind  that    she had never before seen  a   rabbit with either a
 # NSg/P  I/J/D NSg/V N/I/C/D ISg V   V     C/P    NSg/V D/P NSg/V  P    I/C    D/P
-> waistcoat - pocket  , or      a   watch to take  out         of  it        , and burning with curiosity , she
-# NSg       . NSg/V/J . NPrSg/C D/P NSg/V P  NSg/V NSg/V/J/R/P V/P NPrSg/ISg . V/C V       P    NSg       . ISg
+> waistcoat - pocket  , or      a   watch to take  out         of it        , and burning with curiosity , she
+# NSg       . NSg/V/J . NPrSg/C D/P NSg/V P  NSg/V NSg/V/J/R/P P  NPrSg/ISg . V/C V       P    NSg       . ISg
 > ran   across the field after it        , and fortunately was just in          time  to see   it        pop
 # NSg/V NSg/P  D   NSg/V J/P   NPrSg/ISg . V/C J/R         V   V/J  NPrSg/V/J/P NSg/V P  NSg/V NPrSg/ISg NSg/V/J
 > down      a   large rabbit - hole  under   the hedge .
@@ -71,33 +71,33 @@
 >
 #
 > Either the well    was very deep  , or      she fell    very slowly , for she had plenty  of
-# I/C    D   NSg/V/J V   J    NSg/J . NPrSg/C ISg NSg/V/J J    J/R    . C/P ISg V   NSg/I/J V/P
+# I/C    D   NSg/V/J V   J    NSg/J . NPrSg/C ISg NSg/V/J J    J/R    . C/P ISg V   NSg/I/J P
 > time  as    she went  down      to look  about her   and to wonder what  was going   to happen
 # NSg/V NSg/R ISg NSg/V NSg/V/J/P P  NSg/V J/P   I/J/D V/C P  NSg/V  NSg/I V   NSg/V/J P  V
 > next    . First   , she tried to look  down      and make  out         what  she was coming  to , but     it
 # NSg/J/P . NSg/V/J . ISg V/J   P  NSg/V NSg/V/J/P V/C NSg/V NSg/V/J/R/P NSg/I ISg V   NSg/V/J P  . NSg/C/P NPrSg/ISg
-> was too dark    to see   anything ; then    she looked at        the sides of  the well    , and
-# V   W?  NSg/V/J P  NSg/V NSg/I/V  . NSg/J/C ISg W?     NSg/I/V/P D   NPl   V/P D   NSg/V/J . V/C
+> was too dark    to see   anything ; then    she looked at        the sides of the well    , and
+# V   W?  NSg/V/J P  NSg/V NSg/I/V  . NSg/J/C ISg W?     NSg/I/V/P D   NPl   P  D   NSg/V/J . V/C
 > noticed that    they were  filled with cupboards and book  - shelves ; here    and there
 # V       N/I/C/D IPl  NSg/V V/J    P    NPl       V/C NSg/V . NPl     . NSg/J/R V/C W?
-> she saw   maps and pictures hung    upon pegs . She took down      a   jar   from one       of  the
-# ISg NSg/V NPl  V/C NPl      NPr/V/J P    NPl  . ISg V    NSg/V/J/P D/P NSg/V P    NSg/I/V/J V/P D
+> she saw   maps and pictures hung    upon pegs . She took down      a   jar   from one       of the
+# ISg NSg/V NPl  V/C NPl      NPr/V/J P    NPl  . ISg V    NSg/V/J/P D/P NSg/V P    NSg/I/V/J P  D
 > shelves as    she passed ; it        was labelled “ ORANGE    MARMALADE ” , but     to her   great
 # NPl     NSg/R ISg W?     . NPrSg/ISg V   V/J/Br   . NPrSg/V/J NSg/V     . . NSg/C/P P  I/J/D NSg/J
 > disappointment it        was empty   : she did not   like        to drop  the jar   for fear  of
-# NSg            NPrSg/ISg V   NSg/V/J . ISg V   NSg/C NSg/V/J/C/P P  NSg/V D   NSg/V C/P NSg/V V/P
-> killing somebody underneath , so        managed to put   it        into one       of  the cupboards as
-# NSg/V/J NSg/I    NSg/J/P    . NSg/I/J/C W?      P  NSg/V NPrSg/ISg P    NSg/I/V/J V/P D   NPl       NSg/R
+# NSg            NPrSg/ISg V   NSg/V/J . ISg V   NSg/C NSg/V/J/C/P P  NSg/V D   NSg/V C/P NSg/V P
+> killing somebody underneath , so        managed to put   it        into one       of the cupboards as
+# NSg/V/J NSg/I    NSg/J/P    . NSg/I/J/C W?      P  NSg/V NPrSg/ISg P    NSg/I/V/J P  D   NPl       NSg/R
 > she fell    past      it        .
 # ISg NSg/V/J NSg/V/J/P NPrSg/ISg .
 >
 #
 > “ Well    ! ” thought Alice to herself , “ after such  a   fall  as    this , I   shall think
 # . NSg/V/J . . NSg/V   NPr   P  I       . . J/P   NSg/I D/P NSg/V NSg/R I/D  . ISg VX    NSg/V
-> nothing of  tumbling down      stairs ! How   brave   they’ll all       think me        at        home    ! Why   , I
-# NSg/I/J V/P NSg/V    NSg/V/J/P NPl    . NSg/C NSg/V/J W?      NSg/I/J/C NSg/V NPrSg/ISg NSg/I/V/P NSg/V/J . NSg/V . ISg
-> wouldn’t say   anything about it        , even    if    I   fell    off       the top     of  the house   ! ” ( Which
-# VX       NSg/V NSg/I/V  J/P   NPrSg/ISg . NSg/V/J NSg/C ISg NSg/V/J NSg/V/J/P D   NSg/V/J V/P D   NPrSg/V . . . I/C
+> nothing of tumbling down      stairs ! How   brave   they’ll all       think me        at        home    ! Why   , I
+# NSg/I/J P  NSg/V    NSg/V/J/P NPl    . NSg/C NSg/V/J W?      NSg/I/J/C NSg/V NPrSg/ISg NSg/I/V/P NSg/V/J . NSg/V . ISg
+> wouldn’t say   anything about it        , even    if    I   fell    off       the top     of the house   ! ” ( Which
+# VX       NSg/V NSg/I/V  J/P   NPrSg/ISg . NSg/V/J NSg/C ISg NSg/V/J NSg/V/J/P D   NSg/V/J P  D   NPrSg/V . . . I/C
 > was very likely true    . )
 # V   J    NSg/J  NSg/V/J . .
 >
@@ -106,10 +106,10 @@
 # NSg/V/J/P . NSg/V/J/P . NSg/V/J/P . NSg/VX D   NSg/V V     NSg/V/P P  D/P NSg/V . . ISg NSg/V  NSg/C N/I/J/D NPrPl
 > I’ve fallen by      this time  ? ” she said aloud . “ I   must  be     getting somewhere near      the
 # W?   W?     NSg/J/P I/D  NSg/V . . ISg V/J  J     . . ISg NSg/V NSg/VX NSg/V   NSg       NSg/V/J/P D
-> centre   of  the earth   . Let   me        see   : that    would  be     four thousand miles down      , I
-# NSg/V/Br V/P D   NPrSg/V . NSg/V NPrSg/ISg NSg/V . N/I/C/D NSg/VX NSg/VX NSg  NSg      NPrPl NSg/V/J/P . ISg
-> think — ” ( for , you see   , Alice had learnt several things of  this sort  in          her
-# NSg/V . . . C/P . IPl NSg/V . NPr   V   V      J/D     NPl    V/P I/D  NSg/V NPrSg/V/J/P I/J/D
+> centre   of the earth   . Let   me        see   : that    would  be     four thousand miles down      , I
+# NSg/V/Br P  D   NPrSg/V . NSg/V NPrSg/ISg NSg/V . N/I/C/D NSg/VX NSg/VX NSg  NSg      NPrPl NSg/V/J/P . ISg
+> think — ” ( for , you see   , Alice had learnt several things of this sort  in          her
+# NSg/V . . . C/P . IPl NSg/V . NPr   V   V      J/D     NPl    P  I/D  NSg/V NPrSg/V/J/P I/J/D
 > lessons in          the schoolroom , and though this was not   a   very good      opportunity for
 # NPl     NPrSg/V/J/P D   NSg        . V/C V/C    I/D  V   NSg/C D/P J    NPrSg/V/J NSg         C/P
 > showing off       her   knowledge , as    there was no      one       to listen to her   , still   it        was
@@ -130,8 +130,8 @@
 # J        . D   NPl         . ISg NSg/V . . . ISg V   NPrSg/V/J NSg/V/J W?    V   NPrSg/P NSg/I/V/J
 > listening , this time  , as    it        didn’t sound   at        all       the right     word  ) “ — but     I   shall
 # V         . I/D  NSg/V . NSg/R NPrSg/ISg V      NSg/V/J NSg/I/V/P NSg/I/J/C D   NPrSg/V/J NSg/V . . . NSg/C/P ISg VX
-> have   to ask   them what  the name  of  the country is , you know  . Please , Ma’am , is
-# NSg/VX P  NSg/V N/I  NSg/I D   NSg/V V/P D   NSg/J   VL . IPl NSg/V . V      . NSg/V . VL
+> have   to ask   them what  the name  of the country is , you know  . Please , Ma’am , is
+# NSg/VX P  NSg/V N/I  NSg/I D   NSg/V P  D   NSg/J   VL . IPl NSg/V . V      . NSg/V . VL
 > this New     Zealand or      Australia ? ” ( and she tried to curtsey as    she spoke — fancy
 # I/D  NSg/V/J NPr     NPrSg/C NPr       . . . V/C ISg V/J   P  ?       NSg/R ISg NSg/V . NSg/V/J
 > curtseying as    you’re falling through the air   ! Do     you think you could  manage it        ? )
@@ -146,16 +146,16 @@
 # NSg/V/J/P . NSg/V/J/P . NSg/V/J/P . W?    V   NSg/I/J N/J/C P  NSg/VX . NSg/I/J/C NPr   J/R  V     V
 > again . “ Dinah’ll miss  me        very much  to - night , I   should think ! ” ( Dinah was the
 # P     . . ?        NSg/V NPrSg/ISg J    N/I/J P  . NSg/V . ISg VX     NSg/V . . . NPr   V   D
-> cat     . ) “ I   hope    they’ll remember her   saucer  of  milk  at        tea   - time  . Dinah my dear    ! I
-# NSg/V/J . . . ISg NPrSg/V W?      NSg/V    I/J/D NSg/V/J V/P NSg/V NSg/I/V/P NSg/V . NSg/V . NPr   D  NSg/V/J . ISg
+> cat     . ) “ I   hope    they’ll remember her   saucer  of milk  at        tea   - time  . Dinah my dear    ! I
+# NSg/V/J . . . ISg NPrSg/V W?      NSg/V    I/J/D NSg/V/J P  NSg/V NSg/I/V/P NSg/V . NSg/V . NPr   D  NSg/V/J . ISg
 > wish  you were  down      here    with me        ! There are no      mice  in          the air   , I’m afraid , but
 # NSg/V IPl NSg/V NSg/V/J/P NSg/J/R P    NPrSg/ISg . W?    V   NPrSg/P NSg/V NPrSg/V/J/P D   NSg/V . W?  J      . NSg/C/P
 > you might    catch a   bat   , and that’s very like        a   mouse , you know  . But     do     cats eat
 # IPl NSg/VX/J NSg/V D/P NSg/V . V/C N$     J    NSg/V/J/C/P D/P NSg/V . IPl NSg/V . NSg/C/P NSg/VX NPl  NSg/V
 > bats , I   wonder ? ” And here    Alice began to get   rather    sleepy , and went  on  saying
 # NPl  . ISg NSg/V  . . V/C NSg/J/R NPr   V     P  NSg/V NPrSg/V/J NSg/J  . V/C NSg/V J/P NSg/V
-> to herself , in          a   dreamy sort  of  way   , “ Do     cats eat   bats ? Do     cats eat   bats ? ” and
-# P  I       . NPrSg/V/J/P D/P J      NSg/V V/P NSg/J . . NSg/VX NPl  NSg/V NPl  . NSg/VX NPl  NSg/V NPl  . . V/C
+> to herself , in          a   dreamy sort  of way   , “ Do     cats eat   bats ? Do     cats eat   bats ? ” and
+# P  I       . NPrSg/V/J/P D/P J      NSg/V P  NSg/J . . NSg/VX NPl  NSg/V NPl  . NSg/VX NPl  NSg/V NPl  . . V/C
 > sometimes , “ Do     bats eat   cats ? ” for , you see   , as    she couldn’t answer either
 # R         . . NSg/VX NPl  NSg/V NPl  . . C/P . IPl NSg/V . NSg/R ISg V        NSg/V  I/C
 > question , it        didn’t much  matter  which way   she put   it        . She felt    that    she was
@@ -165,7 +165,7 @@
 > Dinah , and saying to her   very earnestly , “ Now         , Dinah , tell    me        the truth : did you
 # NPr   . V/C NSg/V  P  I/J/D J    J/R       . . NPrSg/V/J/C . NPr   . NPrSg/V NPrSg/ISg D   NSg/V . V   IPl
 > ever eat   a   bat   ? ” when    suddenly , thump ! thump ! down      she came    upon a   heap  of
-# J    NSg/V D/P NSg/V . . NSg/I/C J/R      . NSg/V . NSg/V . NSg/V/J/P ISg NSg/V/P P    D/P NSg/V V/P
+# J    NSg/V D/P NSg/V . . NSg/I/C J/R      . NSg/V . NSg/V . NSg/V/J/P ISg NSg/V/P P    D/P NSg/V P
 > sticks and dry     leaves , and the fall  was over      .
 # NPl    V/C NSg/V/J NPl    . V/C D   NSg/V V   NSg/V/J/P .
 >
@@ -183,7 +183,7 @@
 > She was close   behind  it        when    she turned the corner  , but     the Rabbit was no      longer
 # ISg V   NSg/V/J NSg/J/P NPrSg/ISg NSg/I/C ISg W?     D   NSg/V/J . NSg/C/P D   NSg/V  V   NPrSg/P NSg/J
 > to be     seen  : she found herself in          a   long      , low     hall  , which was lit     up        by      a   row   of
-# P  NSg/VX NSg/V . ISg NSg/V I       NPrSg/V/J/P D/P NPrSg/V/J . NSg/V/J NPrSg . I/C   V   NSg/V/J NSg/V/J/P NSg/J/P D/P NSg/V V/P
+# P  NSg/VX NSg/V . ISg NSg/V I       NPrSg/V/J/P D/P NPrSg/V/J . NSg/V/J NPrSg . I/C   V   NSg/V/J NSg/V/J/P NSg/J/P D/P NSg/V P
 > lamps hanging from the roof  .
 # NPl   NSg/V/J P    D   NSg/V .
 >
@@ -196,16 +196,16 @@
 # W?     J/R   NSg/V/J/P D   NSg/V/J . NSg/V/J   NSg/C ISg V   J    P  NSg/V NSg/V/J/R/P P     .
 >
 #
-> Suddenly she came    upon a   little    three - legged  table , all       made  of  solid glass   ;
-# J/R      ISg NSg/V/P P    D/P NPrSg/I/J NSg   . NSg/V/J NSg/V . NSg/I/J/C NSg/V V/P NSg/J NPrSg/V .
+> Suddenly she came    upon a   little    three - legged  table , all       made  of solid glass   ;
+# J/R      ISg NSg/V/P P    D/P NPrSg/I/J NSg   . NSg/V/J NSg/V . NSg/I/J/C NSg/V P  NSg/J NPrSg/V .
 > there was nothing on  it        except a   tiny  golden    key       , and Alice’s first   thought was
 # W?    V   NSg/I/J J/P NPrSg/ISg V/C/P  D/P NSg/J NPrSg/V/J NPrSg/V/J . V/C N$      NSg/V/J NSg/V   V
-> that    it        might    belong to one       of  the doors of  the hall  ; but     , alas ! either the
-# N/I/C/D NPrSg/ISg NSg/VX/J V/P    P  NSg/I/V/J V/P D   NPl   V/P D   NPrSg . NSg/C/P . NSg  . I/C    D
+> that    it        might    belong to one       of the doors of the hall  ; but     , alas ! either the
+# N/I/C/D NPrSg/ISg NSg/VX/J V/P    P  NSg/I/V/J P  D   NPl   P  D   NPrSg . NSg/C/P . NSg  . I/C    D
 > locks were  too large , or      the key       was too small     , but     at        any   rate  it        would  not
 # NPl   NSg/V W?  NSg/J . NPrSg/C D   NPrSg/V/J V   W?  NPrSg/V/J . NSg/C/P NSg/I/V/P I/R/D NSg/V NPrSg/ISg NSg/VX NSg/C
-> open    any   of  them . However , on  the second  time  round     , she came    upon a   low     curtain
-# NSg/V/J I/R/D V/P N/I  . C       . J/P D   NSg/V/J NSg/V NSg/V/J/P . ISg NSg/V/P P    D/P NSg/V/J NSg/V
+> open    any   of them . However , on  the second  time  round     , she came    upon a   low     curtain
+# NSg/V/J I/R/D P  N/I  . C       . J/P D   NSg/V/J NSg/V NSg/V/J/P . ISg NSg/V/P P    D/P NSg/V/J NSg/V
 > she had not   noticed before , and behind  it        was a   little    door  about fifteen inches
 # ISg V   NSg/C V       C/P    . V/C NSg/J/P NPrSg/ISg V   D/P NPrSg/I/J NSg/V J/P   NSg     NPl
 > high    : she tried the little    golden    key       in          the lock  , and to her   great delight it
@@ -218,18 +218,18 @@
 # NPr   V/J    D   NSg/V V/C NSg/V N/I/C/D NPrSg/ISg NSg P    D/P NPrSg/V/J NSg/V/J . NSg/C N/I/J
 > larger than a   rat   - hole  : she knelt down      and looked along the passage into the
 # J      C/P  D/P NSg/V . NSg/V . ISg V     NSg/V/J/P V/C W?     P     D   NSg/V/J P    D
-> loveliest garden  you ever saw   . How   she longed to get   out         of  that    dark    hall  , and
-# W?        NSg/V/J IPl J    NSg/V . NSg/C ISg W?     P  NSg/V NSg/V/J/R/P V/P N/I/C/D NSg/V/J NPrSg . V/C
-> wander about among those beds of  bright    flowers and those cool    fountains , but
-# NSg/V  J/P   P     I/D   NPl  V/P NPrSg/V/J NPrPl   V/C I/D   NSg/V/J NPl       . NSg/C/P
+> loveliest garden  you ever saw   . How   she longed to get   out         of that    dark    hall  , and
+# W?        NSg/V/J IPl J    NSg/V . NSg/C ISg W?     P  NSg/V NSg/V/J/R/P P  N/I/C/D NSg/V/J NPrSg . V/C
+> wander about among those beds of bright    flowers and those cool    fountains , but
+# NSg/V  J/P   P     I/D   NPl  P  NPrSg/V/J NPrPl   V/C I/D   NSg/V/J NPl       . NSg/C/P
 > she could  not   even    get   her   head      through the doorway ; “ and even    if    my head      would
 # ISg NSg/VX NSg/C NSg/V/J NSg/V I/J/D NPrSg/V/J NSg/J/P D   NSg     . . V/C NSg/V/J NSg/C D  NPrSg/V/J NSg/VX
-> go      through , ” thought poor    Alice , “ it        would  be     of  very little    use   without my
-# NSg/V/J NSg/J/P . . NSg/V   NSg/V/J NPr   . . NPrSg/ISg NSg/VX NSg/VX V/P J    NPrSg/I/J NSg/V C/P     D
+> go      through , ” thought poor    Alice , “ it        would  be     of very little    use   without my
+# NSg/V/J NSg/J/P . . NSg/V   NSg/V/J NPr   . . NPrSg/ISg NSg/VX NSg/VX P  J    NPrSg/I/J NSg/V C/P     D
 > shoulders . Oh      , how   I   wish  I   could  shut    up        like        a   telescope ! I   think I   could  , if
 # NPl       . NPrSg/V . NSg/C ISg NSg/V ISg NSg/VX NSg/V/J NSg/V/J/P NSg/V/J/C/P D/P NSg/V     . ISg NSg/V ISg NSg/VX . NSg/C
-> I   only knew how   to begin . ” For , you see   , so        many    out         - of  - the - way   things had
-# ISg W?   V    NSg/C P  NSg/V . . C/P . IPl NSg/V . NSg/I/J/C N/I/J/D NSg/V/J/R/P . V/P . D   . NSg/J NPl    V
+> I   only knew how   to begin . ” For , you see   , so        many    out         - of - the - way   things had
+# ISg W?   V    NSg/C P  NSg/V . . C/P . IPl NSg/V . NSg/I/J/C N/I/J/D NSg/V/J/R/P . P  . D   . NSg/J NPl    V
 > happened lately , that    Alice had begun to think that    very few things indeed were
 # W?       J/R    . N/I/C/D NPr   V   V     P  NSg/V N/I/C/D J    N/I NPl    W?     NSg/V
 > really impossible .
@@ -239,13 +239,13 @@
 > There seemed to be     no      use   in          waiting by      the little    door  , so        she went  back    to the
 # W?    W?     P  NSg/VX NPrSg/P NSg/V NPrSg/V/J/P NSg/V   NSg/J/P D   NPrSg/I/J NSg/V . NSg/I/J/C ISg NSg/V NSg/V/J P  D
 > table , half      hoping she might    find  another key       on  it        , or      at        any   rate  a   book  of
-# NSg/V . NSg/V/J/P V      ISg NSg/VX/J NSg/V I/D     NPrSg/V/J J/P NPrSg/ISg . NPrSg/C NSg/I/V/P I/R/D NSg/V D/P NSg/V V/P
+# NSg/V . NSg/V/J/P V      ISg NSg/VX/J NSg/V I/D     NPrSg/V/J J/P NPrSg/ISg . NPrSg/C NSg/I/V/P I/R/D NSg/V D/P NSg/V P
 > rules for shutting people up        like        telescopes : this time  she found a   little
 # NPl   C/P NSg/V    NSg/V  NSg/V/J/P NSg/V/J/C/P NPl        . I/D  NSg/V ISg NSg/V D/P NPrSg/I/J
 > bottle on  it        , ( “ which certainly was not   here    before , ” said Alice , ) and round     the
 # NSg/V  J/P NPrSg/ISg . . . I/C   J/R       V   NSg/C NSg/J/R C/P    . . V/J  NPr   . . V/C NSg/V/J/P D
-> neck  of  the bottle was a   paper   label , with the words “ DRINK ME        , ” beautifully
-# NSg/V V/P D   NSg/V  V   D/P NSg/V/J NSg/V . P    D   NPl   . NSg/V NPrSg/ISg . . J/R
+> neck  of the bottle was a   paper   label , with the words “ DRINK ME        , ” beautifully
+# NSg/V P  D   NSg/V  V   D/P NSg/V/J NSg/V . P    D   NPl   . NSg/V NPrSg/ISg . . J/R
 > printed on  it        in          large letters .
 # W?      J/P NPrSg/ISg NPrSg/V/J/P NSg/J NPl     .
 >
@@ -272,8 +272,8 @@
 #
 > However , this bottle was not   marked “ poison , ” so        Alice ventured to taste   it        , and
 # C       . I/D  NSg/V  V   NSg/C V/J    . NSg/V  . . NSg/I/J/C NPr   W?       P  NSg/V/J NPrSg/ISg . V/C
-> finding it        very nice      , ( it        had , in          fact , a   sort  of  mixed flavour  of  cherry  - tart    ,
-# NSg/V   NPrSg/ISg J    NPrSg/V/J . . NPrSg/ISg V   . NPrSg/V/J/P NSg  . D/P NSg/V V/P V/J   NSg/V/Br V/P NPrSg/J . NSg/V/J .
+> finding it        very nice      , ( it        had , in          fact , a   sort  of mixed flavour  of cherry  - tart    ,
+# NSg/V   NPrSg/ISg J    NPrSg/V/J . . NPrSg/ISg V   . NPrSg/V/J/P NSg  . D/P NSg/V P  V/J   NSg/V/Br P  NPrSg/J . NSg/V/J .
 > custard , pine  - apple , roast   turkey  , toffee , and hot     buttered toast , ) she very
 # NSg     . NSg/V . NPrSg . NSg/V/J NPrSg/J . NSg/V  . V/C NSg/V/J W?       NSg/V . . ISg J
 > soon finished it        off       .
@@ -296,8 +296,8 @@
 # I/D  . . C/P NPrSg/ISg NSg/VX/J NSg/V . IPl NSg/V . . V/J  NPr   P  I       . . NPrSg/V/J/P D  NSg/V/J NSg/V/J/R/P
 > altogether , like        a   candle . I   wonder what  I   should be     like        then    ? ” And she tried
 # NSg        . NSg/V/J/C/P D/P NSg/V  . ISg NSg/V  NSg/I ISg VX     NSg/VX NSg/V/J/C/P NSg/J/C . . V/C ISg V/J
-> to fancy   what  the flame   of  a   candle is like        after the candle is blown out         , for
-# P  NSg/V/J NSg/I D   NSg/V/J V/P D/P NSg/V  VL NSg/V/J/C/P J/P   D   NSg/V  VL V/J   NSg/V/J/R/P . C/P
+> to fancy   what  the flame   of a   candle is like        after the candle is blown out         , for
+# P  NSg/V/J NSg/I D   NSg/V/J P  D/P NSg/V  VL NSg/V/J/C/P J/P   D   NSg/V  VL V/J   NSg/V/J/R/P . C/P
 > she could  not   remember ever having seen  such  a   thing .
 # ISg NSg/VX NSg/C NSg/V    J    V      NSg/V NSg/I D/P NSg/V .
 >
@@ -310,8 +310,8 @@
 # ISg V   NSg/V/J   D   NPrSg/I/J NPrSg/V/J NPrSg/V/J . V/C NSg/I/C ISg NSg/V NSg/V/J P  D   NSg/V C/P
 > it        , she found she could  not   possibly reach it        : she could  see   it        quite plainly
 # NPrSg/ISg . ISg NSg/V ISg NSg/VX NSg/C R        NSg/V NPrSg/ISg . ISg NSg/VX NSg/V NPrSg/ISg NSg   J/R
-> through the glass   , and she tried her   best       to climb up        one       of  the legs of  the
-# NSg/J/P D   NPrSg/V . V/C ISg V/J   I/J/D NPrSg/VX/J P  NSg/V NSg/V/J/P NSg/I/V/J V/P D   NPl  V/P D
+> through the glass   , and she tried her   best       to climb up        one       of the legs of the
+# NSg/J/P D   NPrSg/V . V/C ISg V/J   I/J/D NPrSg/VX/J P  NSg/V NSg/V/J/P NSg/I/V/J P  D   NPl  P  D
 > table , but     it        was too slippery ; and when    she had tired herself out         with trying  ,
 # NSg/V . NSg/C/P NPrSg/ISg V   W?  J        . V/C NSg/I/C ISg V   V/J   I       NSg/V/J/R/P P    NSg/V/J .
 > the poor    little    thing sat     down      and cried .
@@ -327,13 +327,13 @@
 > scolded herself so        severely as    to bring tears into her   eyes ; and once  she
 # W?      I       NSg/I/J/C J/R      NSg/R P  V     NPl   P    I/J/D NPl  . V/C NSg/C ISg
 > remembered trying  to box   her   own     ears for having cheated herself in          a   game    of
-# V          NSg/V/J P  NSg/V I/J/D NSg/V/J NPl  C/P V      W?      I       NPrSg/V/J/P D/P NSg/V/J V/P
+# V          NSg/V/J P  NSg/V I/J/D NSg/V/J NPl  C/P V      W?      I       NPrSg/V/J/P D/P NSg/V/J P
 > croquet she was playing against herself , for this curious child was very fond    of
-# NSg/V   ISg V   V       C/P     I       . C/P I/D  J       NSg/V V   J    NSg/V/J V/P
+# NSg/V   ISg V   V       C/P     I       . C/P I/D  J       NSg/V V   J    NSg/V/J P
 > pretending to be     two people . “ But     it’s no      use   now         , ” thought poor    Alice , “ to
 # V          P  NSg/VX NSg NSg/V  . . NSg/C/P W?   NPrSg/P NSg/V NPrSg/V/J/C . . NSg/V   NSg/V/J NPr   . . P
-> pretend to be     two people ! Why   , there’s hardly enough of  me        left      to make  one
-# NSg/V/J P  NSg/VX NSg NSg/V  . NSg/V . W?      J/R    NSg/I  V/P NPrSg/ISg NPrSg/V/J P  NSg/V NSg/I/V/J
+> pretend to be     two people ! Why   , there’s hardly enough of me        left      to make  one
+# NSg/V/J P  NSg/VX NSg NSg/V  . NSg/V . W?      J/R    NSg/I  P  NPrSg/ISg NPrSg/V/J P  NSg/V NSg/I/V/J
 > respectable person ! ”
 # NSg/J       NSg/V  . .
 >
@@ -354,14 +354,14 @@
 #
 > She ate   a   little    bit   , and said anxiously to herself , “ Which way   ? Which way   ? ” ,
 # ISg NSg/V D/P NPrSg/I/J NSg/V . V/C V/J  J/R       P  I       . . I/C   NSg/J . I/C   NSg/J . . .
-> holding her   hand  on  the top     of  her   head      to feel      which way   it        was growing , and
-# NSg/V   I/J/D NSg/V J/P D   NSg/V/J V/P I/J/D NPrSg/V/J P  NSg/I/V/J I/C   NSg/J NPrSg/ISg V   NSg/V   . V/C
+> holding her   hand  on  the top     of her   head      to feel      which way   it        was growing , and
+# NSg/V   I/J/D NSg/V J/P D   NSg/V/J P  I/J/D NPrSg/V/J P  NSg/I/V/J I/C   NSg/J NPrSg/ISg V   NSg/V   . V/C
 > she was quite surprised to find  that    she remained the same size  : to be     sure ,
 # ISg V   NSg   W?        P  NSg/V N/I/C/D ISg W?       D   I/J  NSg/V . P  NSg/VX J    .
 > this generally happens when    one       eats cake  , but     Alice had got so        much  into the
 # I/D  J/R       NPl     NSg/I/C NSg/I/V/J NPl  NSg/V . NSg/C/P NPr   V   V   NSg/I/J/C N/I/J P    D
-> way   of  expecting nothing but     out         - of  - the - way   things to happen , that    it        seemed
-# NSg/J V/P V         NSg/I/J NSg/C/P NSg/V/J/R/P . V/P . D   . NSg/J NPl    P  V      . N/I/C/D NPrSg/ISg W?
+> way   of expecting nothing but     out         - of - the - way   things to happen , that    it        seemed
+# NSg/J P  V         NSg/I/J NSg/C/P NSg/V/J/R/P . P  . D   . NSg/J NPl    P  V      . N/I/C/D NPrSg/ISg W?
 > quite dull and stupid for life  to go      on  in          the common  way   .
 # NSg   V/J  V/C NSg/J  C/P NSg/V P  NSg/V/J J/P NPrSg/V/J/P D   NSg/V/J NSg/J .
 >
@@ -370,8 +370,8 @@
 # NSg/I/J/C ISg NPrSg/V/J P  NSg/V . V/C J    J/R  V/J      NSg/V/J/P D   NSg/V .
 >
 #
-> CHAPTER II : The Pool  of  Tears
-# NSg/V   W? . D   NSg/V V/P NPl
+> CHAPTER II : The Pool  of Tears
+# NSg/V   W? . D   NSg/V P  NPl
 >
 #
 > “ Curiouser and curiouser ! ” cried Alice ( she was so        much  surprised , that    for the
@@ -380,8 +380,8 @@
 # NSg    ISg NSg   V      NSg/C P  NSg/V NPrSg/V/J NPrSg/V/J . . . NPrSg/V/J/C W?  NSg/V/J NSg/V/J/R/P NSg/V/J/C/P
 > the largest telescope that    ever was ! Good      - bye     , feet ! ” ( for when    she looked down
 # D   W?      NSg/V     N/I/C/D J    V   . NPrSg/V/J . NSg/J/P . NSg  . . . C/P NSg/I/C ISg W?     NSg/V/J/P
-> at        her   feet , they seemed to be     almost out         of  sight , they were  getting so        far
-# NSg/I/V/P I/J/D NSg  . IPl  W?     P  NSg/VX NSg    NSg/V/J/R/P V/P NSg/V . IPl  NSg/V NSg/V   NSg/I/J/C NSg/V/J
+> at        her   feet , they seemed to be     almost out         of sight , they were  getting so        far
+# NSg/I/V/P I/J/D NSg  . IPl  W?     P  NSg/VX NSg    NSg/V/J/R/P P  NSg/V . IPl  NSg/V NSg/V   NSg/I/J/C NSg/V/J
 > off       ) . “ Oh      , my poor    little    feet , I   wonder who     will     put   on  your shoes and
 # NSg/V/J/P . . . NPrSg/V . D  NSg/V/J NPrSg/I/J NSg  . ISg NSg/V  NPrSg/I NPrSg/VX NSg/V J/P D    NPl   V/C
 > stockings for you now         , dears ? I’m sure I   shan’t be     able    ! I   shall be     a   great deal
@@ -390,8 +390,8 @@
 # W?  NSg/V/J NSg/V/J/P P  NSg/V   I      J/P   IPl . IPl NSg/V NSg/V  D   NPrSg/VX/J NSg/J IPl
 > can      ; — but     I   must  be     kind  to them , ” thought Alice , “ or      perhaps they won’t walk  the
 # NPrSg/VX . . NSg/C/P ISg NSg/V NSg/VX NSg/J P  N/I  . . NSg/V   NPr   . . NPrSg/C NSg     IPl  V     NSg/V D
-> way   I   want  to go      ! Let   me        see   : I’ll give  them a   new     pair  of  boots every
-# NSg/J ISg NSg/V P  NSg/V/J . NSg/V NPrSg/ISg NSg/V . W?   NSg/V N/I  D/P NSg/V/J NSg/V V/P NPl   D
+> way   I   want  to go      ! Let   me        see   : I’ll give  them a   new     pair  of boots every
+# NSg/J ISg NSg/V P  NSg/V/J . NSg/V NPrSg/ISg NSg/V . W?   NSg/V N/I  D/P NSg/V/J NSg/V P  NPl   D
 > Christmas . ”
 # NPrSg/V/J . .
 >
@@ -412,8 +412,8 @@
 # NPrSg/V NSg/V/J . NSg/I NSg/V/J  W?  V       . .
 >
 #
-> Just then    her   head      struck against the roof  of  the hall  : in          fact she was now         more
-# V/J  NSg/J/C I/J/D NPrSg/V/J V      C/P     D   NSg/V V/P D   NPrSg . NPrSg/V/J/P NSg  ISg V   NPrSg/V/J/C NPrSg/I/V/J
+> Just then    her   head      struck against the roof  of the hall  : in          fact she was now         more
+# V/J  NSg/J/C I/J/D NPrSg/V/J V      C/P     D   NSg/V P  D   NPrSg . NPrSg/V/J/P NSg  ISg V   NPrSg/V/J/C NPrSg/I/V/J
 > than nine feet high    , and she at        once  took up        the little    golden    key       and hurried
 # C/P  NSg  NSg  NSg/V/J . V/C ISg NSg/I/V/P NSg/C V    NSg/V/J/P D   NPrSg/I/J NPrSg/V/J NPrSg/V/J V/C V/J
 > off       to the garden  door  .
@@ -428,32 +428,32 @@
 # J    . ISg NSg/V/J NSg/V/J/P V/C V     P  NSg/V P     .
 >
 #
-> “ You ought    to be     ashamed of  yourself , ” said Alice , “ a   great girl  like        you , ” ( she
-# . IPl NSg/I/VX P  NSg/VX V/J     V/P I        . . V/J  NPr   . . D/P NSg/J NSg/V NSg/V/J/C/P IPl . . . ISg
+> “ You ought    to be     ashamed of yourself , ” said Alice , “ a   great girl  like        you , ” ( she
+# . IPl NSg/I/VX P  NSg/VX V/J     P  I        . . V/J  NPr   . . D/P NSg/J NSg/V NSg/V/J/C/P IPl . . . ISg
 > might    well    say   this ) , “ to go      on  crying in          this way   ! Stop  this moment , I   tell
 # NSg/VX/J NSg/V/J NSg/V I/D  . . . P  NSg/V/J J/P V      NPrSg/V/J/P I/D  NSg/J . NSg/V I/D  NSg    . ISg NPrSg/V
-> you ! ” But     she went  on  all       the same , shedding gallons of  tears , until there was a
-# IPl . . NSg/C/P ISg NSg/V J/P NSg/I/J/C D   I/J  . NSg/V    NPl     V/P NPl   . C/P   W?    V   D/P
+> you ! ” But     she went  on  all       the same , shedding gallons of tears , until there was a
+# IPl . . NSg/C/P ISg NSg/V J/P NSg/I/J/C D   I/J  . NSg/V    NPl     P  NPl   . C/P   W?    V   D/P
 > large pool  all       round     her   , about four inches deep  and reaching half      down      the
 # NSg/J NSg/V NSg/I/J/C NSg/V/J/P I/J/D . J/P   NSg  NPl    NSg/J V/C V        NSg/V/J/P NSg/V/J/P D
 > hall  .
 # NPrSg .
 >
 #
-> After a   time  she heard a   little    pattering of  feet in          the distance , and she
-# J/P   D/P NSg/V ISg V/J   D/P NPrSg/I/J V         V/P NSg  NPrSg/V/J/P D   NSg/V    . V/C ISg
+> After a   time  she heard a   little    pattering of feet in          the distance , and she
+# J/P   D/P NSg/V ISg V/J   D/P NPrSg/I/J V         P  NSg  NPrSg/V/J/P D   NSg/V    . V/C ISg
 > hastily dried her   eyes to see   what  was coming  . It        was the White     Rabbit
 # R       W?    I/J/D NPl  P  NSg/V NSg/I V   NSg/V/J . NPrSg/ISg V   D   NPrSg/V/J NSg/V
-> returning , splendidly dressed , with a   pair  of  white     kid   gloves in          one       hand  and a
-# V         . J/R        W?      . P    D/P NSg/V V/P NPrSg/V/J NSg/V NPl    NPrSg/V/J/P NSg/I/V/J NSg/V V/C D/P
+> returning , splendidly dressed , with a   pair  of white     kid   gloves in          one       hand  and a
+# V         . J/R        W?      . P    D/P NSg/V P  NPrSg/V/J NSg/V NPl    NPrSg/V/J/P NSg/I/V/J NSg/V V/C D/P
 > large fan   in          the other   : he      came    trotting along in          a   great hurry , muttering to
 # NSg/J NSg/V NPrSg/V/J/P D   NSg/V/J . NPr/ISg NSg/V/P NSg/V/J  P     NPrSg/V/J/P D/P NSg/J NSg/V . NSg/V     P
 > himself as    he      came    , “ Oh      ! the Duchess , the Duchess ! Oh      ! won’t she be     savage    if
 # I       NSg/R NPr/ISg NSg/V/P . . NPrSg/V . D   NSg/V   . D   NSg/V   . NPrSg/V . V     ISg NSg/VX NPrSg/V/J NSg/C
 > I’ve kept her   waiting ! ” Alice felt    so        desperate that    she was ready   to ask   help
 # W?   V    I/J/D NSg/V   . . NPr   NSg/V/J NSg/I/J/C NSg/J     N/I/C/D ISg V   NSg/V/J P  NSg/V NSg/V
-> of  any   one       ; so        , when    the Rabbit came    near      her   , she began , in          a   low     , timid voice ,
-# V/P I/R/D NSg/I/V/J . NSg/I/J/C . NSg/I/C D   NSg/V  NSg/V/P NSg/V/J/P I/J/D . ISg V     . NPrSg/V/J/P D/P NSg/V/J . J     NSg/V .
+> of any   one       ; so        , when    the Rabbit came    near      her   , she began , in          a   low     , timid voice ,
+# P  I/R/D NSg/I/V/J . NSg/I/J/C . NSg/I/C D   NSg/V  NSg/V/P NSg/V/J/P I/J/D . ISg V     . NPrSg/V/J/P D/P NSg/V/J . J     NSg/V .
 > “ If    you please , sir     — ” The Rabbit started violently , dropped the white     kid   gloves
 # . NSg/C IPl V      . NPrSg/V . . D   NSg/V  W?      J/R       . V/J     D   NPrSg/V/J NSg/V NPl
 > and the fan   , and skurried away into the darkness as    hard    as    he      could  go      .
@@ -472,18 +472,18 @@
 # NSg/V   . ISg NSg    NSg/V ISg NPrSg/VX NSg/V    NSg/V/J D/P NPrSg/I/J NSg/J     . NSg/C/P NSg/C W?
 > not   the same , the next    question is , Who     in          the world am        I   ? Ah      , that’s the great
 # NSg/C D   I/J  . D   NSg/J/P NSg/V    VL . NPrSg/I NPrSg/V/J/P D   NSg/V NPrSg/V/J ISg . NSg/I/V . N$     D   NSg/J
-> puzzle ! ” And she began thinking over      all       the children she knew that    were  of  the
-# NSg/V  . . V/C ISg V     V        NSg/V/J/P NSg/I/J/C D   NPl      ISg V    N/I/C/D NSg/V V/P D
-> same age   as    herself , to see   if    she could  have   been  changed for any   of  them .
-# I/J  NSg/V NSg/R I       . P  NSg/V NSg/C ISg NSg/VX NSg/VX NSg/V V/J     C/P I/R/D V/P N/I  .
+> puzzle ! ” And she began thinking over      all       the children she knew that    were  of the
+# NSg/V  . . V/C ISg V     V        NSg/V/J/P NSg/I/J/C D   NPl      ISg V    N/I/C/D NSg/V P  D
+> same age   as    herself , to see   if    she could  have   been  changed for any   of them .
+# I/J  NSg/V NSg/R I       . P  NSg/V NSg/C ISg NSg/VX NSg/VX NSg/V V/J     C/P I/R/D P  N/I  .
 >
 #
 > “ I’m sure I’m not   Ada , ” she said , “ for her   hair  goes  in          such  long      ringlets , and
 # . W?  J    W?  NSg/C NPr . . ISg V/J  . . C/P I/J/D NSg/V NSg/V NPrSg/V/J/P NSg/I NPrSg/V/J NPl      . V/C
 > mine    doesn’t go      in          ringlets at        all       ; and I’m sure I   can’t be     Mabel , for I   know
 # NSg/I/V V       NSg/V/J NPrSg/V/J/P NPl      NSg/I/V/P NSg/I/J/C . V/C W?  J    ISg VX    NSg/VX NPr   . C/P ISg NSg/V
-> all       sorts of  things , and she , oh      ! she knows such  a   very little    ! Besides , she’s
-# NSg/I/J/C NPl   V/P NPl    . V/C ISg . NPrSg/V . ISg NPl   NSg/I D/P J    NPrSg/I/J . NPl     . W?
+> all       sorts of things , and she , oh      ! she knows such  a   very little    ! Besides , she’s
+# NSg/I/J/C NPl   P  NPl    . V/C ISg . NPrSg/V . ISg NPl   NSg/I D/P J    NPrSg/I/J . NPl     . W?
 > she , and I’m I   , and — oh      dear    , how   puzzling it        all       is ! I’ll try     if    I   know  all       the
 # ISg . V/C W?  ISg . V/C . NPrSg/V NSg/V/J . NSg/C V        NPrSg/ISg NSg/I/J/C VL . W?   NSg/V/J NSg/C ISg NSg/V NSg/I/J/C D
 > things I   used to know  . Let   me        see   : four times five is twelve , and four times six
@@ -492,8 +492,8 @@
 # VL N        . V/C NSg  NPl   NSg   VL . NPrSg/V NSg/V/J . ISg VX    V     NSg/V P  NSg    NSg/I/V/P
 > that    rate  ! However , the Multiplication Table doesn’t signify : let’s try
 # N/I/C/D NSg/V . C       . D   NSg            NSg/V V       V       . N$    NSg/V/J
-> Geography . London is the capital of  Paris , and Paris is the capital of  Rome , and
-# NSg       . NPr    VL D   NSg/J   V/P NPr   . V/C NPr   VL D   NSg/J   V/P NPr  . V/C
+> Geography . London is the capital of Paris , and Paris is the capital of Rome , and
+# NSg       . NPr    VL D   NSg/J   P  NPr   . V/C NPr   VL D   NSg/J   P  NPr  . V/C
 > Rome — no      , that’s all       wrong   , I’m certain ! I   must  have   been  changed for Mabel ! I’ll
 # NPr  . NPrSg/P . N$     NSg/I/J/C NSg/V/J . W?  I/J     . ISg NSg/V NSg/VX NSg/V V/J     C/P NPr   . W?
 > try     and say   ‘          How   doth the little    — ’ ” and she crossed her   hands on  her   lap     as    if
@@ -506,8 +506,8 @@
 #
 > “ How   doth the little    crocodile Improve his   shining tail    , And pour  the waters
 # . NSg/C W?   D   NPrSg/I/J NSg/V     V       ISg/D V       NSg/V/J . V/C NSg/V D   NPrSg/V
-> of  the Nile On  every golden    scale !
-# V/P D   NPr  J/P D     NPrSg/V/J NSg/V .
+> of the Nile On  every golden    scale !
+# P  D   NPr  J/P D     NPrSg/V/J NSg/V .
 >
 #
 > “ How   cheerfully he      seems to grin  , How   neatly spread his   claws , And welcome
@@ -532,24 +532,24 @@
 # NPrSg/ISg N/I/C/D NSg/V/J . V/C NSg/J/C . NSg/C ISg NSg/V/J/C/P NSg/V/C N/I/C/D NSg/V  . W?   NSg/V/P NSg/V/J/P . NSg/C NSg/C . W?
 > stay    down      here    till      I’m somebody else  ’ — but     , oh      dear    ! ” cried Alice , with a   sudden
 # NSg/V/J NSg/V/J/P NSg/J/R NSg/V/C/P W?  NSg/I    N/J/C . . NSg/C/P . NPrSg/V NSg/V/J . . W?    NPr   . P    D/P NSg/J
-> burst of  tears , “ I   do     wish  they would  put   their heads down      ! I   am        so        very tired
-# NSg/V V/P NPl   . . ISg NSg/VX NSg/V IPl  NSg/VX NSg/V D     NPl   NSg/V/J/P . ISg NPrSg/V/J NSg/I/J/C J    V/J
-> of  being   all       alone here    ! ”
-# V/P NSg/V/C NSg/I/J/C J     NSg/J/R . .
+> burst of tears , “ I   do     wish  they would  put   their heads down      ! I   am        so        very tired
+# NSg/V P  NPl   . . ISg NSg/VX NSg/V IPl  NSg/VX NSg/V D     NPl   NSg/V/J/P . ISg NPrSg/V/J NSg/I/J/C J    V/J
+> of being   all       alone here    ! ”
+# P  NSg/V/C NSg/I/J/C J     NSg/J/R . .
 >
 #
 > As    she said this she looked down      at        her   hands , and was surprised to see   that    she
 # NSg/R ISg V/J  I/D  ISg W?     NSg/V/J/P NSg/I/V/P I/J/D NPl   . V/C V   W?        P  NSg/V N/I/C/D ISg
-> had put   on  one       of  the Rabbit’s little    white     kid   gloves while     she was talking .
-# V   NSg/V J/P NSg/I/V/J V/P D   N$       NPrSg/I/J NPrSg/V/J NSg/V NPl    NSg/V/C/P ISg V   V       .
+> had put   on  one       of the Rabbit’s little    white     kid   gloves while     she was talking .
+# V   NSg/V J/P NSg/I/V/J P  D   N$       NPrSg/I/J NPrSg/V/J NSg/V NPl    NSg/V/C/P ISg V   V       .
 > “ How   can      I   have   done    that    ? ” she thought . “ I   must  be     growing small     again . ” She
 # . NSg/C NPrSg/VX ISg NSg/VX NSg/V/J N/I/C/D . . ISg NSg/V   . . ISg NSg/V NSg/VX NSg/V   NPrSg/V/J P     . . ISg
 > got up        and went  to the table to measure herself by      it        , and found that    , as    nearly
 # V   NSg/V/J/P V/C NSg/V P  D   NSg/V P  NSg/V   I       NSg/J/P NPrSg/ISg . V/C NSg/V N/I/C/D . NSg/R J/R
 > as    she could  guess , she was now         about two feet high    , and was going   on  shrinking
 # NSg/R ISg NSg/VX NSg/V . ISg V   NPrSg/V/J/C J/P   NSg NSg  NSg/V/J . V/C V   NSg/V/J J/P V
-> rapidly : she soon found out         that    the cause   of  this was the fan   she was holding ,
-# J/R     . ISg J/R  NSg/V NSg/V/J/R/P N/I/C/D D   NSg/V/C V/P I/D  V   D   NSg/V ISg V   NSg/V   .
+> rapidly : she soon found out         that    the cause   of this was the fan   she was holding ,
+# J/R     . ISg J/R  NSg/V NSg/V/J/R/P N/I/C/D D   NSg/V/C P  I/D  V   D   NSg/V ISg V   NSg/V   .
 > and she dropped it        hastily , just in          time  to avoid shrinking away altogether .
 # V/C ISg V/J     NPrSg/ISg R       . V/J  NPrSg/V/J/P NSg/V P  V     V         V/J  NSg        .
 >
@@ -579,13 +579,13 @@
 > ( Alice had been  to the seaside once  in          her   life  , and had come    to the general
 # . NPr   V   NSg/V P  D   NPrSg/J NSg/C NPrSg/V/J/P I/J/D NSg/V . V/C V   NSg/V/P P  D   NSg/V/J
 > conclusion , that    wherever you go      to on  the English   coast you find  a   number  of
-# NSg        . N/I/C/D C        IPl NSg/V/J P  J/P D   NPrSg/V/J NSg/V IPl NSg/V D/P NSg/V/J V/P
+# NSg        . N/I/C/D C        IPl NSg/V/J P  J/P D   NPrSg/V/J NSg/V IPl NSg/V D/P NSg/V/J P
 > bathing machines in          the sea , some  children digging in          the sand    with wooden
 # NSg/V   NPl      NPrSg/V/J/P D   NSg . I/J/R NPl      NSg/V   NPrSg/V/J/P D   NSg/V/J P    J
-> spades , then    a   row   of  lodging houses , and behind  them a   railway station . )
-# NPl    . NSg/J/C D/P NSg/V V/P NSg/V   NPl    . V/C NSg/J/P N/I  D/P NSg     NSg/V   . .
-> However , she soon made  out         that    she was in          the pool  of  tears which she had wept
-# C       . ISg J/R  NSg/V NSg/V/J/R/P N/I/C/D ISg V   NPrSg/V/J/P D   NSg/V V/P NPl   I/C   ISg V   V
+> spades , then    a   row   of lodging houses , and behind  them a   railway station . )
+# NPl    . NSg/J/C D/P NSg/V P  NSg/V   NPl    . V/C NSg/J/P N/I  D/P NSg     NSg/V   . .
+> However , she soon made  out         that    she was in          the pool  of tears which she had wept
+# C       . ISg J/R  NSg/V NSg/V/J/R/P N/I/C/D ISg V   NPrSg/V/J/P D   NSg/V P  NPl   I/C   ISg V   V
 > when    she was nine feet high    .
 # NSg/I/C ISg V   NSg  NSg  NSg/V/J .
 >
@@ -610,22 +610,22 @@
 # J/R  NSg/V NSg/V/J/R/P N/I/C/D NPrSg/ISg V   W?   D/P NSg/V N/I/C/D V   V/J     NPrSg/V/J/P NSg/V/J/C/P I       .
 >
 #
-> “ Would  it        be     of  any   use   , now         , ” thought Alice , “ to speak to this mouse ?
-# . NSg/VX NPrSg/ISg NSg/VX V/P I/R/D NSg/V . NPrSg/V/J/C . . NSg/V   NPr   . . P  NSg/V P  I/D  NSg/V .
-> Everything is so        out         - of  - the - way   down      here    , that    I   should think very likely it
-# N/I/V      VL NSg/I/J/C NSg/V/J/R/P . V/P . D   . NSg/J NSg/V/J/P NSg/J/R . N/I/C/D ISg VX     NSg/V J    NSg/J  NPrSg/ISg
+> “ Would  it        be     of any   use   , now         , ” thought Alice , “ to speak to this mouse ?
+# . NSg/VX NPrSg/ISg NSg/VX P  I/R/D NSg/V . NPrSg/V/J/C . . NSg/V   NPr   . . P  NSg/V P  I/D  NSg/V .
+> Everything is so        out         - of - the - way   down      here    , that    I   should think very likely it
+# N/I/V      VL NSg/I/J/C NSg/V/J/R/P . P  . D   . NSg/J NSg/V/J/P NSg/J/R . N/I/C/D ISg VX     NSg/V J    NSg/J  NPrSg/ISg
 > can      talk  : at        any   rate  , there’s no      harm  in          trying  . ” So        she began : “ O         Mouse , do
 # NPrSg/VX NSg/V . NSg/I/V/P I/R/D NSg/V . W?      NPrSg/P NSg/V NPrSg/V/J/P NSg/V/J . . NSg/I/J/C ISg V     . . NPrSg/J/P NSg/V . NSg/VX
-> you know  the way   out         of  this pool  ? I   am        very tired of  swimming about here    , O
-# IPl NSg/V D   NSg/J NSg/V/J/R/P V/P I/D  NSg/V . ISg NPrSg/V/J J    V/J   V/P NSg/V    J/P   NSg/J/R . NPrSg/J/P
-> Mouse ! ” ( Alice thought this must  be     the right     way   of  speaking to a   mouse : she
-# NSg/V . . . NPr   NSg/V   I/D  NSg/V NSg/VX D   NPrSg/V/J NSg/J V/P V        P  D/P NSg/V . ISg
+> you know  the way   out         of this pool  ? I   am        very tired of swimming about here    , O
+# IPl NSg/V D   NSg/J NSg/V/J/R/P P  I/D  NSg/V . ISg NPrSg/V/J J    V/J   P  NSg/V    J/P   NSg/J/R . NPrSg/J/P
+> Mouse ! ” ( Alice thought this must  be     the right     way   of speaking to a   mouse : she
+# NSg/V . . . NPr   NSg/V   I/D  NSg/V NSg/VX D   NPrSg/V/J NSg/J P  V        P  D/P NSg/V . ISg
 > had never done    such  a   thing before , but     she remembered having seen  in          her
 # V   V     NSg/V/J NSg/I D/P NSg/V C/P    . NSg/C/P ISg V          V      NSg/V NPrSg/V/J/P I/J/D
-> brother’s Latin   Grammar , “ A   mouse — of  a   mouse — to a   mouse — a   mouse — O         mouse ! ” ) The
-# N$        NPrSg/J NSg/V   . . D/P NSg/V . V/P D/P NSg/V . P  D/P NSg/V . D/P NSg/V . NPrSg/J/P NSg/V . . . D
+> brother’s Latin   Grammar , “ A   mouse — of a   mouse — to a   mouse — a   mouse — O         mouse ! ” ) The
+# N$        NPrSg/J NSg/V   . . D/P NSg/V . P  D/P NSg/V . P  D/P NSg/V . D/P NSg/V . NPrSg/J/P NSg/V . . . D
 > Mouse looked at        her   rather    inquisitively , and seemed to her   to wink  with one       of
-# NSg/V W?     NSg/I/V/P I/J/D NPrSg/V/J J/R           . V/C W?     P  I/J/D P  NSg/V P    NSg/I/V/J V/P
+# NSg/V W?     NSg/I/V/P I/J/D NPrSg/V/J J/R           . V/C W?     P  I/J/D P  NSg/V P    NSg/I/V/J P
 > its   little    eyes , but     it        said nothing .
 # ISg/D NPrSg/I/J NPl  . NSg/C/P NPrSg/ISg V/J  NSg/I/J .
 >
@@ -633,13 +633,13 @@
 > “ Perhaps it        doesn’t understand English   , ” thought Alice ; “ I   daresay it’s a   French
 # . NSg     NPrSg/ISg V       V          NPrSg/V/J . . NSg/V   NPr   . . ISg V       W?   D/P NPrSg/V/J
 > mouse , come    over      with William the Conqueror . ” ( For , with all       her   knowledge of
-# NSg/V . NSg/V/P NSg/V/J/P P    NPrSg   D   NSg       . . . C/P . P    NSg/I/J/C I/J/D NSg/V     V/P
+# NSg/V . NSg/V/P NSg/V/J/P P    NPrSg   D   NSg       . . . C/P . P    NSg/I/J/C I/J/D NSg/V     P
 > history , Alice had no      very clear   notion how   long      ago anything had happened . ) So
 # NSg     . NPr   V   NPrSg/P J    NSg/V/J NSg    NSg/C NPrSg/V/J J/P NSg/I/V  V   W?       . . NSg/I/J/C
 > she began again : “ Où est   ma      chatte ? ” which was the first   sentence in          her   French
 # ISg V     P     . . ?  NPrSg NPrSg/J ?      . . I/C   V   D   NSg/V/J NSg/V    NPrSg/V/J/P I/J/D NPrSg/V/J
-> lesson - book  . The Mouse gave a   sudden leap    out         of  the water , and seemed to quiver
-# NSg/V  . NSg/V . D   NSg/V V    D/P NSg/J  NSg/V/J NSg/V/J/R/P V/P D   NSg/V . V/C W?     P  NSg/V/J
+> lesson - book  . The Mouse gave a   sudden leap    out         of the water , and seemed to quiver
+# NSg/V  . NSg/V . D   NSg/V V    D/P NSg/J  NSg/V/J NSg/V/J/R/P P  D   NSg/V . V/C W?     P  NSg/V/J
 > all       over      with fright  . “ Oh      , I   beg   your pardon ! ” cried Alice hastily , afraid that
 # NSg/I/J/C NSg/V/J/P P    NSg/V/J . . NPrSg/V . ISg NSg/V D    NSg/V  . . W?    NPr   R       . J      N/I/C/D
 > she had hurt    the poor    animal’s feelings . “ I   quite forgot you didn’t like        cats . ”
@@ -672,8 +672,8 @@
 # NPrSg/I/V/J NSg/C W?    NPrSg/V/J NSg/C . .
 >
 #
-> “ We  indeed ! ” cried the Mouse , who     was trembling down      to the end   of  his   tail    . “ As
-# . IPl W?     . . W?    D   NSg/V . NPrSg/I V   V         NSg/V/J/P P  D   NSg/V V/P ISg/D NSg/V/J . . NSg/R
+> “ We  indeed ! ” cried the Mouse , who     was trembling down      to the end   of his   tail    . “ As
+# . IPl W?     . . W?    D   NSg/V . NPrSg/I V   V         NSg/V/J/P P  D   NSg/V P  ISg/D NSg/V/J . . NSg/R
 > if    I   would  talk  on  such  a   subject ! Our family always hated cats : nasty , low     ,
 # NSg/C ISg NSg/VX NSg/V J/P NSg/I D/P NSg/V/J . D   NSg/J  W?     W?    NPl  . NSg/J . NSg/V/J .
 > vulgar things ! Don’t let   me        hear the name  again ! ”
@@ -681,17 +681,17 @@
 >
 #
 > “ I   won’t indeed ! ” said Alice , in          a   great hurry to change the subject of
-# . ISg V     W?     . . V/J  NPr   . NPrSg/V/J/P D/P NSg/J NSg/V P  NSg/V  D   NSg/V/J V/P
-> conversation . “ Are you — are you fond    — of  — of  dogs ? ” The Mouse did not   answer , so
-# NSg/V        . . V   IPl . V   IPl NSg/V/J . V/P . V/P NPl  . . D   NSg/V V   NSg/C NSg/V  . NSg/I/J/C
+# . ISg V     W?     . . V/J  NPr   . NPrSg/V/J/P D/P NSg/J NSg/V P  NSg/V  D   NSg/V/J P
+> conversation . “ Are you — are you fond    — of — of dogs ? ” The Mouse did not   answer , so
+# NSg/V        . . V   IPl . V   IPl NSg/V/J . P  . P  NPl  . . D   NSg/V V   NSg/C NSg/V  . NSg/I/J/C
 > Alice went  on  eagerly : “ There is such  a   nice      little    dog     near      our house   I   should
 # NPr   NSg/V J/P J/R     . . W?    VL NSg/I D/P NPrSg/V/J NPrSg/I/J NSg/V/J NSg/V/J/P D   NPrSg/V ISg VX
 > like        to show  you ! A   little    bright    - eyed terrier , you know  , with oh      , such  long
 # NSg/V/J/C/P P  NSg/V IPl . D/P NPrSg/I/J NPrSg/V/J . W?   NSg/J   . IPl NSg/V . P    NPrSg/V . NSg/I NPrSg/V/J
 > curly   brown     hair  ! And it’ll fetch things when    you throw them , and it’ll sit   up
 # NSg/J/R NPrSg/V/J NSg/V . V/C W?    NSg/V NPl    NSg/I/C IPl NSg/V N/I  . V/C W?    NSg/V NSg/V/J/P
-> and beg   for its   dinner , and all       sorts of  things — I   can’t remember half      of
-# V/C NSg/V C/P ISg/D NSg/V  . V/C NSg/I/J/C NPl   V/P NPl    . ISg VX    NSg/V    NSg/V/J/P V/P
+> and beg   for its   dinner , and all       sorts of things — I   can’t remember half      of
+# V/C NSg/V C/P ISg/D NSg/V  . V/C NSg/I/J/C NPl   P  NPl    . ISg VX    NSg/V    NSg/V/J/P P
 > them — and it        belongs to a   farmer  , you know  , and he      says it’s so        useful , it’s
 # N/I  . V/C NPrSg/ISg NPl     P  D/P NPrSg/J . IPl NSg/V . V/C NPr/ISg NPl  W?   NSg/I/J/C J      . W?
 > worth   a   hundred pounds ! He      says it        kills all       the rats and — oh      dear    ! ” cried Alice
@@ -740,8 +740,8 @@
 # NSg/V    NSg/V/J . NPrSg/V/J/P . V/C J             .
 >
 #
-> The first   question of  course was , how   to get   dry     again : they had a   consultation
-# D   NSg/V/J NSg/V    V/P NSg/V  V   . NSg/C P  NSg/V NSg/V/J P     . IPl  V   D/P NSg
+> The first   question of course was , how   to get   dry     again : they had a   consultation
+# D   NSg/V/J NSg/V    P  NSg/V  V   . NSg/C P  NSg/V NSg/V/J P     . IPl  V   D/P NSg
 > about this , and after a   few minutes it        seemed quite natural to Alice to find
 # J/P   I/D  . V/C J/P   D/P N/I NPl     NPrSg/ISg W?     NSg   NSg/J   P  NPr   P  NSg/V
 > herself talking familiarly with them , as    if    she had known   them all       her   life  .
@@ -756,10 +756,10 @@
 # W?      P  NPrSg/V ISg/D NSg/V . W?    V   NPrSg/P NPrSg/I/V/J P  NSg/VX V/J  .
 >
 #
-> At        last    the Mouse , who     seemed to be     a   person of  authority among them , called
-# NSg/I/V/P NSg/V/J D   NSg/V . NPrSg/I W?     P  NSg/VX D/P NSg/V  V/P NSg       P     N/I  . V/J
-> out         , “ Sit   down      , all       of  you , and listen to me        ! I’ll soon make  you dry     enough ! ”
-# NSg/V/J/R/P . . NSg/V NSg/V/J/P . NSg/I/J/C V/P IPl . V/C NSg/V  P  NPrSg/ISg . W?   J/R  NSg/V IPl NSg/V/J NSg/I  . .
+> At        last    the Mouse , who     seemed to be     a   person of authority among them , called
+# NSg/I/V/P NSg/V/J D   NSg/V . NPrSg/I W?     P  NSg/VX D/P NSg/V  P  NSg       P     N/I  . V/J
+> out         , “ Sit   down      , all       of you , and listen to me        ! I’ll soon make  you dry     enough ! ”
+# NSg/V/J/R/P . . NSg/V NSg/V/J/P . NSg/I/J/C P  IPl . V/C NSg/V  P  NPrSg/ISg . W?   J/R  NSg/V IPl NSg/V/J NSg/I  . .
 > They all       sat     down      at        once  , in          a   large ring  , with the Mouse in          the middle  . Alice
 # IPl  NSg/I/J/C NSg/V/J NSg/V/J/P NSg/I/V/P NSg/C . NPrSg/V/J/P D/P NSg/J NSg/V . P    D   NSg/V NPrSg/V/J/P D   NSg/V/J . NPr
 > kept her   eyes anxiously fixed on  it        , for she felt    sure she would  catch a   bad
@@ -774,10 +774,10 @@
 # W?     NSg/V ISg NSg/V . NSg/V   NSg/I/J/C NSg/V/J/P . NSg/C IPl V      . Unlintable NPrSg   D   NSg       .
 > whose cause   was favoured by      the pope    , was soon submitted to by      the English   , who
 # I     NSg/V/C V   W?       NSg/J/P D   NPrSg/V . V   J/R  V         P  NSg/J/P D   NPrSg/V/J . NPrSg/I
-> wanted leaders , and had been  of  late  much  accustomed to usurpation and conquest .
-# V/J    W?      . V/C V   NSg/V V/P NSg/J N/I/J V/J        P  NSg        V/C NSg/V    .
-> Edwin and Morcar , the earls of  Mercia and Northumbria — ’ ”
-# NPr   V/C ?      . D   NPl   V/P NPr    V/C ?           . . .
+> wanted leaders , and had been  of late  much  accustomed to usurpation and conquest .
+# V/J    W?      . V/C V   NSg/V P  NSg/J N/I/J V/J        P  NSg        V/C NSg/V    .
+> Edwin and Morcar , the earls of Mercia and Northumbria — ’ ”
+# NPr   V/C ?      . D   NPl   P  NPr    V/C ?           . . .
 >
 #
 > “ Ugh ! ” said the Lory , with a   shiver  .
@@ -796,18 +796,18 @@
 #
 > “ I   thought you did , ” said the Mouse . “ — I   proceed . ‘          Edwin and Morcar , the earls
 # . ISg NSg/V   IPl V   . . V/J  D   NSg/V . . . ISg V       . Unlintable NPr   V/C ?      . D   NPl
-> of  Mercia and Northumbria , declared for him : and even    Stigand , the patriotic
-# V/P NPr    V/C ?           . V/J      C/P I   . V/C NSg/V/J ?       . D   NSg/J
-> archbishop of  Canterbury , found it        advisable — ’ ”
-# NSg        V/P NPr        . NSg/V NPrSg/ISg J         . . .
+> of Mercia and Northumbria , declared for him : and even    Stigand , the patriotic
+# P  NPr    V/C ?           . V/J      C/P I   . V/C NSg/V/J ?       . D   NSg/J
+> archbishop of Canterbury , found it        advisable — ’ ”
+# NSg        P  NPr        . NSg/V NPrSg/ISg J         . . .
 >
 #
 > “ Found what  ? ” said the Duck  .
 # . NSg/V NSg/I . . V/J  D   NSg/V .
 >
 #
-> “ Found it        , ” the Mouse replied rather    crossly : “ of  course you know  what  ‘          it        ’
-# . NSg/V NPrSg/ISg . . D   NSg/V W?      NPrSg/V/J R       . . V/P NSg/V  IPl NSg/V NSg/I Unlintable NPrSg/ISg .
+> “ Found it        , ” the Mouse replied rather    crossly : “ of course you know  what  ‘          it        ’
+# . NSg/V NPrSg/ISg . . D   NSg/V W?      NPrSg/V/J R       . . P  NSg/V  IPl NSg/V NSg/I Unlintable NPrSg/ISg .
 > means . ”
 # NPl   . .
 >
@@ -822,8 +822,8 @@
 # D   NSg/V V   NSg/C NSg/V  I/D  NSg/V    . NSg/C/P J/R       NSg/V J/P . . Unlintable . NSg/V NPrSg/ISg
 > advisable to go      with Edgar Atheling to meet    William and offer   him the crown   .
 # J         P  NSg/V/J P    NPrSg ?        P  NSg/V/J NPrSg   V/C NSg/V/J I   D   NSg/V/J .
-> William’s conduct at        first   was moderate . But     the insolence of  his   Normans — ’ How
-# N$        NSg/V   NSg/I/V/P NSg/V/J V   NSg/V/J  . NSg/C/P D   NSg/V     V/P ISg/D NPl     . . NSg/C
+> William’s conduct at        first   was moderate . But     the insolence of his   Normans — ’ How
+# N$        NSg/V   NSg/I/V/P NSg/V/J V   NSg/V/J  . NSg/C/P D   NSg/V     P  ISg/D NPl     . . NSg/C
 > are you getting on  now         , my dear    ? ” it        continued , turning to Alice as    it        spoke .
 # V   IPl NSg/V   J/P NPrSg/V/J/C . D  NSg/V/J . . NPrSg/ISg W?        . NSg/V   P  NPr   NSg/R NPrSg/ISg NSg/V .
 >
@@ -836,16 +836,16 @@
 #
 > “ In          that    case    , ” said the Dodo solemnly , rising    to its   feet , “ I   move  that    the
 # . NPrSg/V/J/P N/I/C/D NPrSg/V . . V/J  D   NSg  J/R      . NSg/V/J/P P  ISg/D NSg  . . ISg NSg/V N/I/C/D D
-> meeting adjourn , for the immediate adoption of  more        energetic remedies — ”
-# NSg/V   V       . C/P D   J         NSg      V/P NPrSg/I/V/J NSg/J     NPl      . .
+> meeting adjourn , for the immediate adoption of more        energetic remedies — ”
+# NSg/V   V       . C/P D   J         NSg      P  NPrSg/I/V/J NSg/J     NPl      . .
 >
 #
-> “ Speak English   ! ” said the Eaglet . “ I   don’t know  the meaning of  half      those long
-# . NSg/V NPrSg/V/J . . V/J  D   NSg    . . ISg NSg/V NSg/V D   NSg/V/J V/P NSg/V/J/P I/D   NPrSg/V/J
+> “ Speak English   ! ” said the Eaglet . “ I   don’t know  the meaning of half      those long
+# . NSg/V NPrSg/V/J . . V/J  D   NSg    . . ISg NSg/V NSg/V D   NSg/V/J P  NSg/V/J/P I/D   NPrSg/V/J
 > words , and , what’s more        , I   don’t believe you do     either ! ” And the Eaglet bent
 # NPl   . V/C . N$     NPrSg/I/V/J . ISg NSg/V V       IPl NSg/VX I/C    . . V/C D   NSg    NSg/V/J
-> down      its   head      to hide  a   smile : some  of  the other   birds tittered audibly .
-# NSg/V/J/P ISg/D NPrSg/V/J P  NSg/V D/P NSg/V . I/J/R V/P D   NSg/V/J NPl   W?       R       .
+> down      its   head      to hide  a   smile : some  of the other   birds tittered audibly .
+# NSg/V/J/P ISg/D NPrSg/V/J P  NSg/V D/P NSg/V . I/J/R P  D   NSg/V/J NPl   W?       R       .
 >
 #
 > “ What  I   was going   to say   , ” said the Dodo in          an  offended tone    , “ was , that    the
@@ -870,8 +870,8 @@
 # NSg  W?      NPrSg/ISg . .
 >
 #
-> First   it        marked out         a   race  - course , in          a   sort  of  circle , ( “ the exact shape
-# NSg/V/J NPrSg/ISg V/J    NSg/V/J/R/P D/P NSg/V . NSg/V  . NPrSg/V/J/P D/P NSg/V V/P NSg/V  . . . D   V/J   NSg/V
+> First   it        marked out         a   race  - course , in          a   sort  of circle , ( “ the exact shape
+# NSg/V/J NPrSg/ISg V/J    NSg/V/J/R/P D/P NSg/V . NSg/V  . NPrSg/V/J/P D/P NSg/V P  NSg/V  . . . D   V/J   NSg/V
 > doesn’t matter  , ” it        said , ) and then    all       the party   were  placed along the course ,
 # V       NSg/V/J . . NPrSg/ISg V/J  . . V/C NSg/J/C NSg/I/J/C D   NSg/V/J NSg/V V      P     D   NSg/V  .
 > here    and there . There was no      “ One       , two , three , and away , ” but     they began running
@@ -886,24 +886,24 @@
 # IPl  NSg/I/J/C V/J     NSg/V/J/P NPrSg/ISg . V       . V/C V      . . NSg/C/P NPrSg/I V   NSg/V . .
 >
 #
-> This question the Dodo could  not   answer without a   great deal    of  thought , and it
-# I/D  NSg/V    D   NSg  NSg/VX NSg/C NSg/V  C/P     D/P NSg/J NSg/V/J V/P NSg/V   . V/C NPrSg/ISg
+> This question the Dodo could  not   answer without a   great deal    of thought , and it
+# I/D  NSg/V    D   NSg  NSg/VX NSg/C NSg/V  C/P     D/P NSg/J NSg/V/J P  NSg/V   . V/C NPrSg/ISg
 > sat     for a   long      time  with one       finger pressed upon its   forehead ( the position in
 # NSg/V/J C/P D/P NPrSg/V/J NSg/V P    NSg/I/V/J NSg/V  V/J     P    ISg/D NSg      . D   NSg/V    NPrSg/V/J/P
-> which you usually see   Shakespeare , in          the pictures of  him ) , while     the rest
-# I/C   IPl J/R     NSg/V NPrSg/V     . NPrSg/V/J/P D   NPl      V/P I   . . NSg/V/C/P D   NSg/V
+> which you usually see   Shakespeare , in          the pictures of him ) , while     the rest
+# I/C   IPl J/R     NSg/V NPrSg/V     . NPrSg/V/J/P D   NPl      P  I   . . NSg/V/C/P D   NSg/V
 > waited in          silence . At        last    the Dodo said , “ Everybody has won   , and all       must  have
 # W?     NPrSg/V/J/P NSg/V   . NSg/I/V/P NSg/V/J D   NSg  V/J  . . N/I       V   NSg/V . V/C NSg/I/J/C NSg/V NSg/VX
 > prizes . ”
 # NPl    . .
 >
 #
-> “ But     who     is to give  the prizes ? ” quite a   chorus of  voices asked .
-# . NSg/C/P NPrSg/I VL P  NSg/V D   NPl    . . NSg   D/P NSg/V  V/P NPl    V/J   .
+> “ But     who     is to give  the prizes ? ” quite a   chorus of voices asked .
+# . NSg/C/P NPrSg/I VL P  NSg/V D   NPl    . . NSg   D/P NSg/V  P  NPl    V/J   .
 >
 #
-> “ Why   , she , of  course , ” said the Dodo , pointing to Alice with one       finger ; and the
-# . NSg/V . ISg . V/P NSg/V  . . V/J  D   NSg  . V        P  NPr   P    NSg/I/V/J NSg/V  . V/C D
+> “ Why   , she , of course , ” said the Dodo , pointing to Alice with one       finger ; and the
+# . NSg/V . ISg . P  NSg/V  . . V/J  D   NSg  . V        P  NPr   P    NSg/I/V/J NSg/V  . V/C D
 > whole party   at        once  crowded round     her   , calling out         in          a   confused way   , “ Prizes !
 # NSg/J NSg/V/J NSg/I/V/P NSg/C V/J     NSg/V/J/P I/J/D . NSg/V   NSg/V/J/R/P NPrSg/V/J/P D/P V/J      NSg/J . . NPl    .
 > Prizes ! ”
@@ -912,8 +912,8 @@
 #
 > Alice had no      idea what  to do     , and in          despair she put   her   hand  in          her   pocket  , and
 # NPr   V   NPrSg/P NSg  NSg/I P  NSg/VX . V/C NPrSg/V/J/P NSg/V   ISg NSg/V I/J/D NSg/V NPrSg/V/J/P I/J/D NSg/V/J . V/C
-> pulled out         a   box   of  comfits , ( luckily the salt      water had not   got into it        ) , and
-# W?     NSg/V/J/R/P D/P NSg/V V/P NPl     . . R       D   NPrSg/V/J NSg/V V   NSg/C V   P    NPrSg/ISg . . V/C
+> pulled out         a   box   of comfits , ( luckily the salt      water had not   got into it        ) , and
+# W?     NSg/V/J/R/P D/P NSg/V P  NPl     . . R       D   NPrSg/V/J NSg/V V   NSg/C V   P    NPrSg/ISg . . V/C
 > handed them round     as    prizes . There was exactly one       a   - piece , all       round     .
 # V/J    N/I  NSg/V/J/P NSg/R NPl    . W?    V   J/R     NSg/I/V/J D/P . NSg/V . NSg/I/J/C NSg/V/J/P .
 >
@@ -922,8 +922,8 @@
 # . NSg/C/P ISg NSg/V NSg/VX D/P NSg/V/J I       . IPl NSg/V . . V/J  D   NSg/V .
 >
 #
-> “ Of  course , ” the Dodo replied very gravely . “ What  else  have   you got in          your
-# . V/P NSg/V  . . D   NSg  W?      J    J/R     . . NSg/I N/J/C NSg/VX IPl V   NPrSg/V/J/P D
+> “ Of course , ” the Dodo replied very gravely . “ What  else  have   you got in          your
+# . P  NSg/V  . . D   NSg  W?      J    J/R     . . NSg/I N/J/C NSg/VX IPl V   NPrSg/V/J/P D
 > pocket  ? ” he      went  on  , turning to Alice .
 # NSg/V/J . . NPr/ISg NSg/V J/P . NSg/V   P  NPr   .
 >
@@ -938,16 +938,16 @@
 #
 > Then    they all       crowded round     her   once  more        , while     the Dodo solemnly presented the
 # NSg/J/C IPl  NSg/I/J/C V/J     NSg/V/J/P I/J/D NSg/C NPrSg/I/V/J . NSg/V/C/P D   NSg  J/R      W?        D
-> thimble , saying “ We  beg   your acceptance of  this elegant thimble ; ” and , when    it
-# NSg/V   . NSg/V  . IPl NSg/V D    NSg        V/P I/D  NSg/J   NSg/V   . . V/C . NSg/I/C NPrSg/ISg
+> thimble , saying “ We  beg   your acceptance of this elegant thimble ; ” and , when    it
+# NSg/V   . NSg/V  . IPl NSg/V D    NSg        P  I/D  NSg/J   NSg/V   . . V/C . NSg/I/C NPrSg/ISg
 > had finished this short       speech , they all       cheered .
 # V   V/J      I/D  NPrSg/V/J/P NSg/V  . IPl  NSg/I/J/C W?      .
 >
 #
 > Alice thought the whole thing very absurd , but     they all       looked so        grave   that    she
 # NPr   NSg/V   D   NSg/J NSg/V J    NSg/J  . NSg/C/P IPl  NSg/I/J/C W?     NSg/I/J/C NSg/V/J N/I/C/D ISg
-> did not   dare     to laugh ; and , as    she could  not   think of  anything to say   , she
-# V   NSg/C NPrSg/VX P  NSg/V . V/C . NSg/R ISg NSg/VX NSg/C NSg/V V/P NSg/I/V  P  NSg/V . ISg
+> did not   dare     to laugh ; and , as    she could  not   think of anything to say   , she
+# V   NSg/C NPrSg/VX P  NSg/V . V/C . NSg/R ISg NSg/VX NSg/C NSg/V P  NSg/I/V  P  NSg/V . ISg
 > simply bowed , and took the thimble , looking as    solemn as    she could  .
 # R      V/J   . V/C V    D   NSg/V   . V       NSg/R J      NSg/R ISg NSg/VX .
 >
@@ -978,8 +978,8 @@
 # . NPrSg/ISg VL D/P NPrSg/V/J NSg/V/J . J/R       . . V/J  NPr   . V       NSg/V/J/P P    NSg/V  NSg/I/V/P D
 > Mouse’s tail    ; “ but     why   do     you call  it        sad     ? ” And she kept on  puzzling about it
 # N$      NSg/V/J . . NSg/C/P NSg/V NSg/VX IPl NSg/V NPrSg/ISg NSg/V/J . . V/C ISg V    J/P V        J/P   NPrSg/ISg
-> while     the Mouse was speaking , so        that    her   idea of  the tale  was something like
-# NSg/V/C/P D   NSg/V V   V        . NSg/I/J/C N/I/C/D I/J/D NSg  V/P D   NSg/V V   NSg/I/V/J NSg/V/J/C/P
+> while     the Mouse was speaking , so        that    her   idea of the tale  was something like
+# NSg/V/C/P D   NSg/V V   V        . NSg/I/J/C N/I/C/D I/J/D NSg  P  D   NSg/V V   NSg/I/V/J NSg/V/J/C/P
 > this : —
 # I/D  . .
 >
@@ -1008,8 +1008,8 @@
 #
 > “ You are not   attending ! ” said the Mouse to Alice severely . “ What  are you
 # . IPl V   NSg/C V         . . V/J  D   NSg/V P  NPr   J/R      . . NSg/I V   IPl
-> thinking of  ? ”
-# V        V/P . .
+> thinking of ? ”
+# V        P  . .
 >
 #
 > “ I   beg   your pardon , ” said Alice very humbly : “ you had got to the fifth   bend    , I
@@ -1028,8 +1028,8 @@
 # J/P   I/J/D . . NPrSg/V . NSg/VX NSg/V NPrSg/ISg NSg/V P  NSg/V/J NPrSg/ISg . .
 >
 #
-> “ I   shall do     nothing of  the sort  , ” said the Mouse , getting up        and walking away .
-# . ISg VX    NSg/VX NSg/I/J V/P D   NSg/V . . V/J  D   NSg/V . NSg/V   NSg/V/J/P V/C NSg/V/J V/J  .
+> “ I   shall do     nothing of the sort  , ” said the Mouse , getting up        and walking away .
+# . ISg VX    NSg/VX NSg/I/J P  D   NSg/V . . V/J  D   NSg/V . NSg/V   NSg/V/J/P V/C NSg/V/J V/J  .
 > “ You insult me        by      talking such  nonsense ! ”
 # . IPl NSg/V  NPrSg/ISg NSg/J/P V       NSg/I NSg/V/J  . .
 >
@@ -1053,15 +1053,15 @@
 >
 #
 > “ What  a   pity  it        wouldn’t stay    ! ” sighed the Lory , as    soon as    it        was quite out         of
-# . NSg/I D/P NSg/V NPrSg/ISg VX       NSg/V/J . . W?     D   ?    . NSg/R J/R  NSg/R NPrSg/ISg V   NSg   NSg/V/J/R/P V/P
-> sight ; and an  old   Crab  took the opportunity of  saying to her   daughter “ Ah      , my
-# NSg/V . V/C D/P NSg/J NSg/V V    D   NSg         V/P NSg/V  P  I/J/D NSg      . NSg/I/V . D
+# . NSg/I D/P NSg/V NPrSg/ISg VX       NSg/V/J . . W?     D   ?    . NSg/R J/R  NSg/R NPrSg/ISg V   NSg   NSg/V/J/R/P P
+> sight ; and an  old   Crab  took the opportunity of saying to her   daughter “ Ah      , my
+# NSg/V . V/C D/P NSg/J NSg/V V    D   NSg         P  NSg/V  P  I/J/D NSg      . NSg/I/V . D
 > dear    ! Let   this be     a   lesson to you never to lose  your temper  ! ” “ Hold    your tongue ,
 # NSg/V/J . NSg/V I/D  NSg/VX D/P NSg/V  P  IPl V     P  NSg/V D    NSg/V/J . . . NSg/V/J D    NSg/V  .
 > Ma      ! ” said the young     Crab  , a   little    snappishly . “ You’re enough to try     the
 # NPrSg/J . . V/J  D   NPrSg/V/J NSg/V . D/P NPrSg/I/J J/R        . . W?     NSg/I  P  NSg/V/J D
-> patience of  an  oyster  ! ”
-# NSg      V/P D/P NSg/V/J . .
+> patience of an  oyster  ! ”
+# NSg      P  D/P NSg/V/J . .
 >
 #
 > “ I   wish  I   had our Dinah here    , I   know  I   do     ! ” said Alice aloud , addressing nobody
@@ -1084,8 +1084,8 @@
 # NSg/R NSg/V NSg/I/V/P NPrSg/ISg . .
 >
 #
-> This speech caused a   remarkable sensation among the party   . Some  of  the birds
-# I/D  NSg/V  W?     D/P W?         NSg       P     D   NSg/V/J . I/J/R V/P D   NPl
+> This speech caused a   remarkable sensation among the party   . Some  of the birds
+# I/D  NSg/V  W?     D/P W?         NSg       P     D   NSg/V/J . I/J/R P  D   NPl
 > hurried off       at        once  : one       old   Magpie began wrapping itself up        very carefully ,
 # V/J     NSg/V/J/P NSg/I/V/P NSg/C . NSg/I/V/J NSg/J NSg/V  V     NSg/V    I      NSg/V/J/P J    J/R       .
 > remarking , “ I   really must  be     getting home    ; the night - air   doesn’t suit  my
@@ -1106,8 +1106,8 @@
 # NSg/V . NPrSg/V . D  NSg/V/J NPr   . ISg NSg/V  NSg/C ISg VX    J    NSg/V IPl I/R/D NPrSg/I/V/J . . V/C NSg/J/R
 > poor    Alice began to cry   again , for she felt    very lonely and low     - spirited . In          a
 # NSg/V/J NPr   V     P  NSg/V P     . C/P ISg NSg/V/J J    J/R    V/C NSg/V/J . V/J      . NPrSg/V/J/P D/P
-> little    while     , however , she again heard a   little    pattering of  footsteps in          the
-# NPrSg/I/J NSg/V/C/P . C       . ISg P     V/J   D/P NPrSg/I/J V         V/P NPl       NPrSg/V/J/P D
+> little    while     , however , she again heard a   little    pattering of footsteps in          the
+# NPrSg/I/J NSg/V/C/P . C       . ISg P     V/J   D/P NPrSg/I/J V         P  NPl       NPrSg/V/J/P D
 > distance , and she looked up        eagerly , half      hoping that    the Mouse had changed his
 # NSg/V    . V/C ISg W?     NSg/V/J/P J/R     . NSg/V/J/P V      N/I/C/D D   NSg/V V   V/J     ISg/D
 > mind  , and was coming  back    to finish his   story .
@@ -1128,8 +1128,8 @@
 # NPrSg/ISg W?       . NSg/R J    NSg/R NPl     V   NPl     . NSg/C NPrSg/VX ISg NSg/VX V/J     N/I  . ISg
 > wonder ? ” Alice guessed in          a   moment that    it        was looking for the fan   and the pair
 # NSg/V  . . NPr   W?      NPrSg/V/J/P D/P NSg    N/I/C/D NPrSg/ISg V   V       C/P D   NSg/V V/C D   NSg/V
-> of  white     kid   gloves , and she very good      - naturedly began hunting about for them ,
-# V/P NPrSg/V/J NSg/V NPl    . V/C ISg J    NPrSg/V/J . ?         V     NSg/V   J/P   C/P N/I  .
+> of white     kid   gloves , and she very good      - naturedly began hunting about for them ,
+# P  NPrSg/V/J NSg/V NPl    . V/C ISg J    NPrSg/V/J . ?         V     NSg/V   J/P   C/P N/I  .
 > but     they were  nowhere to be     seen  — everything seemed to have   changed since her
 # NSg/C/P IPl  NSg/V NSg/J   P  NSg/VX NSg/V . N/I/V      W?     P  NSg/VX V/J     C/P   I/J/D
 > swim  in          the pool  , and the great hall  , with the glass   table and the little    door  ,
@@ -1142,8 +1142,8 @@
 # J    J/R  D   NSg/V  V       NPr   . NSg/R ISg NSg/V NSg/V   J/P   . V/C V/J    NSg/V/J/R/P P
 > her   in          an  angry tone    , “ Why   , Mary Ann     , what  are you doing out         here    ? Run   home    this
 # I/J/D NPrSg/V/J/P D/P V/J   NSg/I/V . . NSg/V . NPr  NPrSg/J . NSg/I V   IPl NSg/V NSg/V/J/R/P NSg/J/R . NSg/V NSg/V/J I/D
-> moment , and fetch me        a   pair  of  gloves and a   fan   ! Quick   , now         ! ” And Alice was so
-# NSg    . V/C NSg/V NPrSg/ISg D/P NSg/V V/P NPl    V/C D/P NSg/V . NSg/V/J . NPrSg/V/J/C . . V/C NPr   V   NSg/I/J/C
+> moment , and fetch me        a   pair  of gloves and a   fan   ! Quick   , now         ! ” And Alice was so
+# NSg    . V/C NSg/V NPrSg/ISg D/P NSg/V P  NPl    V/C D/P NSg/V . NSg/V/J . NPrSg/V/J/C . . V/C NPr   V   NSg/I/J/C
 > much  frightened that    she ran   off       at        once  in          the direction it        pointed to , without
 # N/I/J W?         N/I/C/D ISg NSg/V NSg/V/J/P NSg/I/V/P NSg/C NPrSg/V/J/P D   NSg       NPrSg/ISg V/J     P  . C/P
 > trying  to explain the mistake it        had made  .
@@ -1156,12 +1156,12 @@
 # W?    NSg/VX NSg/I/C NPr/ISg NPl   NSg/V/J/R/P NPrSg/I ISg NPrSg/V/J . NSg/C/P W?  NSg/VX/J NSg/V I   ISg/D NSg/V V/C
 > gloves — that    is , if    I   can      find  them . ” As    she said this , she came    upon a   neat
 # NPl    . N/I/C/D VL . NSg/C ISg NPrSg/VX NSg/V N/I  . . NSg/R ISg V/J  I/D  . ISg NSg/V/P P    D/P NSg/J
-> little    house   , on  the door  of  which was a   bright    brass   plate with the name  “ W.
-# NPrSg/I/J NPrSg/V . J/P D   NSg/V V/P I/C   V   D/P NPrSg/V/J NSg/V/J NSg/V P    D   NSg/V . ?
+> little    house   , on  the door  of which was a   bright    brass   plate with the name  “ W.
+# NPrSg/I/J NPrSg/V . J/P D   NSg/V P  I/C   V   D/P NPrSg/V/J NSg/V/J NSg/V P    D   NSg/V . ?
 > RABBIT , ” engraved upon it        . She went  in          without knocking , and hurried upstairs ,
 # NSg/V  . . W?       P    NPrSg/ISg . ISg NSg/V NPrSg/V/J/P C/P     V        . V/C V/J     NSg/J    .
-> in          great fear  lest she should meet    the real  Mary Ann     , and be     turned out         of  the
-# NPrSg/V/J/P NSg/J NSg/V W?   ISg VX     NSg/V/J D   NSg/J NPr  NPrSg/J . V/C NSg/VX W?     NSg/V/J/R/P V/P D
+> in          great fear  lest she should meet    the real  Mary Ann     , and be     turned out         of the
+# NPrSg/V/J/P NSg/J NSg/V W?   ISg VX     NSg/V/J D   NSg/J NPr  NPrSg/J . V/C NSg/VX W?     NSg/V/J/R/P P  D
 > house   before she had found the fan   and gloves .
 # NPrSg/V C/P    ISg V   NSg/V D   NSg/V V/C NPl    .
 >
@@ -1170,8 +1170,8 @@
 # . NSg/C NSg/V/J NPrSg/ISg NPl   . . NPr   V/J  P  I       . . P  NSg/VX NSg/V/J NPl      C/P D/P NSg/V  .
 > I   suppose Dinah’ll be     sending me        on  messages next    ! ” And she began fancying the
 # ISg V       ?        NSg/VX V       NPrSg/ISg J/P NPl      NSg/J/P . . V/C ISg V     V        D
-> sort  of  thing that    would  happen : “ ‘          Miss  Alice ! Come    here    directly , and get   ready
-# NSg/V V/P NSg/V N/I/C/D NSg/VX V      . . Unlintable NSg/V NPr   . NSg/V/P NSg/J/R R/C      . V/C NSg/V NSg/V/J
+> sort  of thing that    would  happen : “ ‘          Miss  Alice ! Come    here    directly , and get   ready
+# NSg/V P  NSg/V N/I/C/D NSg/VX V      . . Unlintable NSg/V NPr   . NSg/V/P NSg/J/R R/C      . V/C NSg/V NSg/V/J
 > for your walk  ! ’ ‘          Coming  in          a   minute  , nurse ! But     I’ve got to see   that    the mouse
 # C/P D    NSg/V . . Unlintable NSg/V/J NPrSg/V/J/P D/P NSg/V/J . NSg/V . NSg/C/P W?   V   P  NSg/V N/I/C/D D   NSg/V
 > doesn’t get   out         . ’ Only I   don’t think , ” Alice went  on  , “ that    they’d let   Dinah
@@ -1182,10 +1182,10 @@
 #
 > By      this time  she had found her   way   into a   tidy    little    room    with a   table in          the
 # NSg/J/P I/D  NSg/V ISg V   NSg/V I/J/D NSg/J P    D/P NSg/V/J NPrSg/I/J NSg/V/J P    D/P NSg/V NPrSg/V/J/P D
-> window , and on  it        ( as    she had hoped ) a   fan   and two or      three pairs of  tiny  white
-# NSg/V  . V/C J/P NPrSg/ISg . NSg/R ISg V   W?    . D/P NSg/V V/C NSg NPrSg/C NSg   NPl   V/P NSg/J NPrSg/V/J
-> kid   gloves : she took up        the fan   and a   pair  of  the gloves , and was just going   to
-# NSg/V NPl    . ISg V    NSg/V/J/P D   NSg/V V/C D/P NSg/V V/P D   NPl    . V/C V   V/J  NSg/V/J P
+> window , and on  it        ( as    she had hoped ) a   fan   and two or      three pairs of tiny  white
+# NSg/V  . V/C J/P NPrSg/ISg . NSg/R ISg V   W?    . D/P NSg/V V/C NSg NPrSg/C NSg   NPl   P  NSg/J NPrSg/V/J
+> kid   gloves : she took up        the fan   and a   pair  of the gloves , and was just going   to
+# NSg/V NPl    . ISg V    NSg/V/J/P D   NSg/V V/C D/P NSg/V P  D   NPl    . V/C V   V/J  NSg/V/J P
 > leave the room    , when    her   eye   fell    upon a   little    bottle that    stood near      the
 # NSg/V D   NSg/V/J . NSg/I/C I/J/D NSg/V NSg/V/J P    D/P NPrSg/I/J NSg/V  N/I/C/D V     NSg/V/J/P D
 > looking - glass   . There was no      label this time  with the words “ DRINK ME        , ” but
@@ -1196,8 +1196,8 @@
 # V/J         VL J    P  V      . . ISg V/J  P  I       . . C        ISg NSg/V NPrSg/C NSg/V
 > anything ; so        I’ll just see   what  this bottle does  . I   do     hope    it’ll make  me        grow
 # NSg/I/V  . NSg/I/J/C W?   V/J  NSg/V NSg/I I/D  NSg/V  NSg/V . ISg NSg/VX NPrSg/V W?    NSg/V NPrSg/ISg V
-> large again , for really I’m quite tired of  being   such  a   tiny  little    thing ! ”
-# NSg/J P     . C/P J/R    W?  NSg   V/J   V/P NSg/V/C NSg/I D/P NSg/J NPrSg/I/J NSg/V . .
+> large again , for really I’m quite tired of being   such  a   tiny  little    thing ! ”
+# NSg/J P     . C/P J/R    W?  NSg   V/J   P  NSg/V/C NSg/I D/P NSg/J NPrSg/I/J NSg/V . .
 >
 #
 > It        did so        indeed , and much  sooner than she had expected : before she had drunk
@@ -1216,24 +1216,24 @@
 # NSg  . NPrSg/ISg V   W?  NSg/J P  NSg/V N/I/C/D . ISg NSg/V J/P NSg/V   . V/C NSg/V   . V/C J
 > soon had to kneel down      on  the floor : in          another minute  there was not   even    room
 # J/R  V   P  V     NSg/V/J/P J/P D   NSg/V . NPrSg/V/J/P I/D     NSg/V/J W?    V   NSg/C NSg/V/J NSg/V/J
-> for this , and she tried the effect of  lying   down      with one       elbow against the
-# C/P I/D  . V/C ISg V/J   D   NSg/V  V/P NSg/V/J NSg/V/J/P P    NSg/I/V/J NSg/V C/P     D
+> for this , and she tried the effect of lying   down      with one       elbow against the
+# C/P I/D  . V/C ISg V/J   D   NSg/V  P  NSg/V/J NSg/V/J/P P    NSg/I/V/J NSg/V C/P     D
 > door  , and the other   arm     curled round     her   head      . Still   she went  on  growing , and ,
 # NSg/V . V/C D   NSg/V/J NSg/V/J W?     NSg/V/J/P I/J/D NPrSg/V/J . NSg/V/J ISg NSg/V J/P NSg/V   . V/C .
-> as    a   last    resource , she put   one       arm     out         of  the window , and one       foot  up        the
-# NSg/R D/P NSg/V/J NSg/V    . ISg NSg/V NSg/I/V/J NSg/V/J NSg/V/J/R/P V/P D   NSg/V  . V/C NSg/I/V/J NSg/V NSg/V/J/P D
+> as    a   last    resource , she put   one       arm     out         of the window , and one       foot  up        the
+# NSg/R D/P NSg/V/J NSg/V    . ISg NSg/V NSg/I/V/J NSg/V/J NSg/V/J/R/P P  D   NSg/V  . V/C NSg/I/V/J NSg/V NSg/V/J/P D
 > chimney , and said to herself “ Now         I   can      do     no      more        , whatever happens . What  will
 # NSg/V   . V/C V/J  P  I       . NPrSg/V/J/C ISg NPrSg/VX NSg/VX NPrSg/P NPrSg/I/V/J . NSg/I/J  NPl     . NSg/I NPrSg/VX
-> become of  me        ? ”
-# V      V/P NPrSg/ISg . .
+> become of me        ? ”
+# V      P  NPrSg/ISg . .
 >
 #
 > Luckily for Alice , the little    magic   bottle had now         had its   full    effect , and she
 # R       C/P NPr   . D   NPrSg/I/J NSg/V/J NSg/V  V   NPrSg/V/J/C V   ISg/D NSg/V/J NSg/V  . V/C ISg
 > grew no      larger : still   it        was very uncomfortable , and , as    there seemed to be     no
 # V    NPrSg/P J      . NSg/V/J NPrSg/ISg V   J    J             . V/C . NSg/R W?    W?     P  NSg/VX NPrSg/P
-> sort  of  chance    of  her   ever getting out         of  the room    again , no      wonder she felt
-# NSg/V V/P NPrSg/V/J V/P I/J/D J    NSg/V   NSg/V/J/R/P V/P D   NSg/V/J P     . NPrSg/P NSg/V  ISg NSg/V/J
+> sort  of chance    of her   ever getting out         of the room    again , no      wonder she felt
+# NSg/V P  NPrSg/V/J P  I/J/D J    NSg/V   NSg/V/J/R/P P  D   NSg/V/J P     . NPrSg/P NSg/V  ISg NSg/V/J
 > unhappy .
 # NSg/V/J .
 >
@@ -1244,12 +1244,12 @@
 # NSg/V   J      V/C J       . V/C NSg/V/C V/J     J/P   NSg/J/P NSg/V V/C NPl     . ISg
 > almost wish  I   hadn’t gone  down      that    rabbit - hole  — and yet     — and yet     — it’s rather
 # NSg    NSg/V ISg V      V/J/P NSg/V/J/P N/I/C/D NSg/V  . NSg/V . V/C NSg/V/C . V/C NSg/V/C . W?   NPrSg/V/J
-> curious , you know  , this sort  of  life  ! I   do     wonder what  can      have   happened to me        !
-# J       . IPl NSg/V . I/D  NSg/V V/P NSg/V . ISg NSg/VX NSg/V  NSg/I NPrSg/VX NSg/VX W?       P  NPrSg/ISg .
-> When    I   used to read  fairy - tales , I   fancied that    kind  of  thing never happened ,
-# NSg/I/C ISg V/J  P  NSg/V NSg/J . NPl   . ISg W?      N/I/C/D NSg/J V/P NSg/V V     W?       .
-> and now         here    I   am        in          the middle  of  one       ! There ought    to be     a   book  written about
-# V/C NPrSg/V/J/C NSg/J/R ISg NPrSg/V/J NPrSg/V/J/P D   NSg/V/J V/P NSg/I/V/J . W?    NSg/I/VX P  NSg/VX D/P NSg/V V/J     J/P
+> curious , you know  , this sort  of life  ! I   do     wonder what  can      have   happened to me        !
+# J       . IPl NSg/V . I/D  NSg/V P  NSg/V . ISg NSg/VX NSg/V  NSg/I NPrSg/VX NSg/VX W?       P  NPrSg/ISg .
+> When    I   used to read  fairy - tales , I   fancied that    kind  of thing never happened ,
+# NSg/I/C ISg V/J  P  NSg/V NSg/J . NPl   . ISg W?      N/I/C/D NSg/J P  NSg/V V     W?       .
+> and now         here    I   am        in          the middle  of one       ! There ought    to be     a   book  written about
+# V/C NPrSg/V/J/C NSg/J/R ISg NPrSg/V/J NPrSg/V/J/P D   NSg/V/J P  NSg/I/V/J . W?    NSg/I/VX P  NSg/VX D/P NSg/V V/J     J/P
 > me        , that    there ought    ! And when    I   grow up        , I’ll write one       — but     I’m grown up        now         , ”
 # NPrSg/ISg . N/I/C/D W?    NSg/I/VX . V/C NSg/I/C ISg V    NSg/V/J/P . W?   NSg/V NSg/I/V/J . NSg/C/P W?  V/J   NSg/V/J/P NPrSg/V/J/C . .
 > she added in          a   sorrowful tone    ; “ at        least there’s no      room    to grow up        any   more
@@ -1276,22 +1276,22 @@
 #
 > And so        she went  on  , taking  first   one       side    and then    the other   , and making quite a
 # V/C NSg/I/J/C ISg NSg/V J/P . NSg/V/J NSg/V/J NSg/I/V/J NSg/V/J V/C NSg/J/C D   NSg/V/J . V/C NSg/V  NSg   D/P
-> conversation of  it        altogether ; but     after a   few minutes she heard a   voice
-# NSg/V        V/P NPrSg/ISg NSg        . NSg/C/P J/P   D/P N/I NPl     ISg V/J   D/P NSg/V
+> conversation of it        altogether ; but     after a   few minutes she heard a   voice
+# NSg/V        P  NPrSg/ISg NSg        . NSg/C/P J/P   D/P N/I NPl     ISg V/J   D/P NSg/V
 > outside   , and stopped to listen .
 # NSg/V/J/P . V/C V/J     P  NSg/V  .
 >
 #
 > “ Mary Ann     ! Mary Ann     ! ” said the voice . “ Fetch me        my gloves this moment ! ” Then
 # . NPr  NPrSg/J . NPr  NPrSg/J . . V/J  D   NSg/V . . NSg/V NPrSg/ISg D  NPl    I/D  NSg    . . NSg/J/C
-> came    a   little    pattering of  feet on  the stairs . Alice knew it        was the Rabbit
-# NSg/V/P D/P NPrSg/I/J V         V/P NSg  J/P D   NPl    . NPr   V    NPrSg/ISg V   D   NSg/V
+> came    a   little    pattering of feet on  the stairs . Alice knew it        was the Rabbit
+# NSg/V/P D/P NPrSg/I/J V         P  NSg  J/P D   NPl    . NPr   V    NPrSg/ISg V   D   NSg/V
 > coming  to look  for her   , and she trembled till      she shook   the house   , quite
 # NSg/V/J P  NSg/V C/P I/J/D . V/C ISg W?       NSg/V/C/P ISg NSg/V/J D   NPrSg/V . NSg
 > forgetting that    she was now         about a   thousand times as    large as    the Rabbit , and
 # NSg/V      N/I/C/D ISg V   NPrSg/V/J/C J/P   D/P NSg      NPl   NSg/R NSg/J NSg/R D   NSg/V  . V/C
-> had no      reason to be     afraid of  it        .
-# V   NPrSg/P NSg/V  P  NSg/VX J      V/P NPrSg/ISg .
+> had no      reason to be     afraid of it        .
+# V   NPrSg/P NSg/V  P  NSg/VX J      P  NPrSg/ISg .
 >
 #
 > Presently the Rabbit came    up        to the door  , and tried to open    it        ; but     , as    the door
@@ -1308,12 +1308,12 @@
 # . N/I/C/D IPl V     . . NSg/V   NPr   . V/C . J/P   NSg/V   NSg/V/C/P ISg W?      ISg V/J
 > the Rabbit just under   the window , she suddenly spread out         her   hand  , and made  a
 # D   NSg/V  V/J  NSg/J/P D   NSg/V  . ISg J/R      NSg/V  NSg/V/J/R/P I/J/D NSg/V . V/C NSg/V D/P
-> snatch in          the air   . She did not   get   hold    of  anything , but     she heard a   little
-# NSg/V  NPrSg/V/J/P D   NSg/V . ISg V   NSg/C NSg/V NSg/V/J V/P NSg/I/V  . NSg/C/P ISg V/J   D/P NPrSg/I/J
-> shriek and a   fall  , and a   crash   of  broken glass   , from which she concluded that    it
-# NSg/V  V/C D/P NSg/V . V/C D/P NSg/V/J V/P V/J    NPrSg/V . P    I/C   ISg W?        N/I/C/D NPrSg/ISg
-> was just possible it        had fallen into a   cucumber - frame , or      something of  the sort  .
-# V   V/J  NSg/J    NPrSg/ISg V   W?     P    D/P NSg      . NSg/V . NPrSg/C NSg/I/V/J V/P D   NSg/V .
+> snatch in          the air   . She did not   get   hold    of anything , but     she heard a   little
+# NSg/V  NPrSg/V/J/P D   NSg/V . ISg V   NSg/C NSg/V NSg/V/J P  NSg/I/V  . NSg/C/P ISg V/J   D/P NPrSg/I/J
+> shriek and a   fall  , and a   crash   of broken glass   , from which she concluded that    it
+# NSg/V  V/C D/P NSg/V . V/C D/P NSg/V/J P  V/J    NPrSg/V . P    I/C   ISg W?        N/I/C/D NPrSg/ISg
+> was just possible it        had fallen into a   cucumber - frame , or      something of the sort  .
+# V   V/J  NSg/J    NPrSg/ISg V   W?     P    D/P NSg      . NSg/V . NPrSg/C NSg/I/V/J P  D   NSg/V .
 >
 #
 > Next    came    an  angry voice — the Rabbit’s — “ Pat       ! Pat       ! Where are you ? ” And then    a
@@ -1326,8 +1326,8 @@
 #
 > “ Digging for apples , indeed ! ” said the Rabbit angrily . “ Here    ! Come    and help  me
 # . NSg/V   C/P NPl    . W?     . . V/J  D   NSg/V  R       . . NSg/J/R . NSg/V/P V/C NSg/V NPrSg/ISg
-> out         of  this ! ” ( Sounds of  more        broken glass   . )
-# NSg/V/J/R/P V/P I/D  . . . NPl    V/P NPrSg/I/V/J V/J    NPrSg/V . .
+> out         of this ! ” ( Sounds of more        broken glass   . )
+# NSg/V/J/R/P P  I/D  . . . NPl    P  NPrSg/I/V/J V/J    NPrSg/V . .
 >
 #
 > “ Now         tell    me        , Pat       , what’s that    in          the window ? ”
@@ -1358,10 +1358,10 @@
 # NPrSg/V IPl . IPl NPrSg/V/J . . V/C NSg/I/V/P NSg/V/J ISg NSg/V  NSg/V/J/R/P I/J/D NSg/V P     . V/C NSg/V
 > another snatch in          the air   . This time  there were  two little    shrieks , and more
 # I/D     NSg/V  NPrSg/V/J/P D   NSg/V . I/D  NSg/V W?    NSg/V NSg NPrSg/I/J NPl     . V/C NPrSg/I/V/J
-> sounds of  broken glass   . “ What  a   number  of  cucumber - frames there must  be     ! ”
-# NPl    V/P V/J    NPrSg/V . . NSg/I D/P NSg/V/J V/P NSg      . NPl    W?    NSg/V NSg/VX . .
-> thought Alice . “ I   wonder what  they’ll do     next    ! As    for pulling me        out         of  the
-# NSg/V   NPr   . . ISg NSg/V  NSg/I W?      NSg/VX NSg/J/P . NSg/R C/P V       NPrSg/ISg NSg/V/J/R/P V/P D
+> sounds of broken glass   . “ What  a   number  of cucumber - frames there must  be     ! ”
+# NPl    P  V/J    NPrSg/V . . NSg/I D/P NSg/V/J P  NSg      . NPl    W?    NSg/V NSg/VX . .
+> thought Alice . “ I   wonder what  they’ll do     next    ! As    for pulling me        out         of the
+# NSg/V   NPr   . . ISg NSg/V  NSg/I W?      NSg/VX NSg/J/P . NSg/R C/P V       NPrSg/ISg NSg/V/J/R/P P  D
 > window , I   only wish  they could  ! I’m sure I   don’t want  to stay    in          here    any
 # NSg/V  . ISg W?   NSg/V IPl  NSg/VX . W?  J    ISg NSg/V NSg/V P  NSg/V/J NPrSg/V/J/P NSg/J/R I/R/D
 > longer ! ”
@@ -1370,16 +1370,16 @@
 #
 > She waited for some  time  without hearing anything more        : at        last    came    a   rumbling
 # ISg W?     C/P I/J/R NSg/V C/P     NSg/V/J NSg/I/V  NPrSg/I/V/J . NSg/I/V/P NSg/V/J NSg/V/P D/P NSg/V/J
-> of  little    cartwheels , and the sound   of  a   good      many    voices all       talking together :
-# V/P NPrSg/I/J NPl        . V/C D   NSg/V/J V/P D/P NPrSg/V/J N/I/J/D NPl    NSg/I/J/C V       J        .
+> of little    cartwheels , and the sound   of a   good      many    voices all       talking together :
+# P  NPrSg/I/J NPl        . V/C D   NSg/V/J P  D/P NPrSg/V/J N/I/J/D NPl    NSg/I/J/C V       J        .
 > she made  out         the words : “ Where’s the other   ladder ? — Why   , I   hadn’t to bring but
 # ISg NSg/V NSg/V/J/R/P D   NPl   . . N$      D   NSg/V/J NSg/V  . . NSg/V . ISg V      P  V     NSg/C/P
 > one       ; Bill’s got the other   — Bill    ! fetch it        here    , lad ! — Here    , put   ’ em      up        at        this
 # NSg/I/V/J . N$     V   D   NSg/V/J . NPrSg/V . NSg/V NPrSg/ISg NSg/J/R . NSg . . NSg/J/R . NSg/V . NSg/I/J NSg/V/J/P NSg/I/V/P I/D
 > corner  — No      , tie   ’ em      together first   — they don’t reach half      high    enough yet     — Oh      !
 # NSg/V/J . NPrSg/P . NSg/V . NSg/I/J J        NSg/V/J . IPl  NSg/V NSg/V NSg/V/J/P NSg/V/J NSg/I  NSg/V/C . NPrSg/V .
-> they’ll do     well    enough ; don’t be     particular — Here    , Bill    ! catch hold    of  this
-# W?      NSg/VX NSg/V/J NSg/I  . NSg/V NSg/VX NSg/J      . NSg/J/R . NPrSg/V . NSg/V NSg/V/J V/P I/D
+> they’ll do     well    enough ; don’t be     particular — Here    , Bill    ! catch hold    of this
+# W?      NSg/VX NSg/V/J NSg/I  . NSg/V NSg/VX NSg/J      . NSg/J/R . NPrSg/V . NSg/V NSg/V/J P  I/D
 > rope  — Will     the roof  bear    ? — Mind  that    loose   slate   — Oh      , it’s coming  down      ! Heads
 # NSg/V . NPrSg/VX D   NSg/V NSg/V/J . . NSg/V N/I/C/D NSg/V/J NSg/V/J . NPrSg/V . W?   NSg/V/J NSg/V/J/P . NPl
 > below ! ” ( a   loud  crash   ) — “ Now         , who     did that    ? — It        was Bill    , I   fancy   — Who’s to go      down
@@ -1402,20 +1402,20 @@
 #
 > She drew  her   foot  as    far     down      the chimney as    she could  , and waited till      she
 # ISg NPr/V I/J/D NSg/V NSg/R NSg/V/J NSg/V/J/P D   NSg/V   NSg/R ISg NSg/VX . V/C W?     NSg/V/C/P ISg
-> heard a   little    animal ( she couldn’t guess of  what  sort  it        was ) scratching and
-# V/J   D/P NPrSg/I/J NSg/J  . ISg V        NSg/V V/P NSg/I NSg/V NPrSg/ISg V   . V          V/C
+> heard a   little    animal ( she couldn’t guess of what  sort  it        was ) scratching and
+# V/J   D/P NPrSg/I/J NSg/J  . ISg V        NSg/V P  NSg/I NSg/V NPrSg/ISg V   . V          V/C
 > scrambling about in          the chimney close   above   her   : then    , saying to herself “ This
 # V          J/P   NPrSg/V/J/P D   NSg/V   NSg/V/J NSg/J/P I/J/D . NSg/J/C . NSg/V  P  I       . I/D
 > is Bill    , ” she gave one       sharp     kick  , and waited to see   what  would  happen next    .
 # VL NPrSg/V . . ISg V    NSg/I/V/J NPrSg/V/J NSg/V . V/C W?     P  NSg/V NSg/I NSg/VX V      NSg/J/P .
 >
 #
-> The first   thing she heard was a   general chorus of  “ There goes  Bill    ! ” then    the
-# D   NSg/V/J NSg/V ISg V/J   V   D/P NSg/V/J NSg/V  V/P . W?    NSg/V NPrSg/V . . NSg/J/C D
+> The first   thing she heard was a   general chorus of “ There goes  Bill    ! ” then    the
+# D   NSg/V/J NSg/V ISg V/J   V   D/P NSg/V/J NSg/V  P  . W?    NSg/V NPrSg/V . . NSg/J/C D
 > Rabbit’s voice along — “ Catch him , you by      the hedge ! ” then    silence , and then
 # N$       NSg/V P     . . NSg/V I   . IPl NSg/J/P D   NSg/V . . NSg/J/C NSg/V   . V/C NSg/J/C
-> another confusion of  voices — “ Hold    up        his   head      — Brandy  now         — Don’t choke him — How   was
-# I/D     NSg/V     V/P NPl    . . NSg/V/J NSg/V/J/P ISg/D NPrSg/V/J . NPrSg/V NPrSg/V/J/C . NSg/V NSg/V I   . NSg/C V
+> another confusion of voices — “ Hold    up        his   head      — Brandy  now         — Don’t choke him — How   was
+# I/D     NSg/V     P  NPl    . . NSg/V/J NSg/V/J/P ISg/D NPrSg/V/J . NPrSg/V NPrSg/V/J/C . NSg/V NSg/V I   . NSg/C V
 > it        , old   fellow ? What  happened to you ? Tell    us      all       about it        ! ”
 # NPrSg/ISg . NSg/J NSg/V  . NSg/I W?       P  IPl . NPrSg/V NPr/ISg NSg/I/J/C J/P   NPrSg/ISg . .
 >
@@ -1450,12 +1450,12 @@
 # ?         NPrSg/VX NSg/VX . P  NSg/V P    . .
 >
 #
-> “ A   barrowful of  what  ? ” thought Alice ; but     she had not   long      to doubt , for the
-# . D/P ?         V/P NSg/I . . NSg/V   NPr   . NSg/C/P ISg V   NSg/C NPrSg/V/J P  NSg/V . C/P D
-> next    moment a   shower  of  little    pebbles came    rattling in          at        the window , and some
-# NSg/J/P NSg    D/P NSg/V/J V/P NPrSg/I/J NPl     NSg/V/P V        NPrSg/V/J/P NSg/I/V/P D   NSg/V  . V/C I/J/R
-> of  them hit       her   in          the face  . “ I’ll put   a   stop  to this , ” she said to herself , and
-# V/P N/I  NSg/I/V/J I/J/D NPrSg/V/J/P D   NSg/V . . W?   NSg/V D/P NSg/V P  I/D  . . ISg V/J  P  I       . V/C
+> “ A   barrowful of what  ? ” thought Alice ; but     she had not   long      to doubt , for the
+# . D/P ?         P  NSg/I . . NSg/V   NPr   . NSg/C/P ISg V   NSg/C NPrSg/V/J P  NSg/V . C/P D
+> next    moment a   shower  of little    pebbles came    rattling in          at        the window , and some
+# NSg/J/P NSg    D/P NSg/V/J P  NPrSg/I/J NPl     NSg/V/P V        NPrSg/V/J/P NSg/I/V/P D   NSg/V  . V/C I/J/R
+> of them hit       her   in          the face  . “ I’ll put   a   stop  to this , ” she said to herself , and
+# P  N/I  NSg/I/V/J I/J/D NPrSg/V/J/P D   NSg/V . . W?   NSg/V D/P NSg/V P  I/D  . . ISg V/J  P  I       . V/C
 > shouted out         , “ You’d better   not   do     that    again ! ” which produced another dead
 # W?      NSg/V/J/R/P . . W?    NSg/VX/J NSg/C NSg/VX N/I/C/D P     . . I/C   W?       I/D     NSg/V/J
 > silence .
@@ -1466,22 +1466,22 @@
 # NPr   V       P    I/J/R NSg/V    N/I/C/D D   NPl     NSg/V NSg/I/J/C NSg/V   P    NPrSg/I/J
 > cakes as    they lay     on  the floor , and a   bright    idea came    into her   head      . “ If    I   eat
 # NPl   NSg/R IPl  NSg/V/J J/P D   NSg/V . V/C D/P NPrSg/V/J NSg  NSg/V/P P    I/J/D NPrSg/V/J . . NSg/C ISg NSg/V
-> one       of  these cakes , ” she thought , “ it’s sure to make  some  change in          my size  ; and
-# NSg/I/V/J V/P I/D   NPl   . . ISg NSg/V   . . W?   J    P  NSg/V I/J/R NSg/V  NPrSg/V/J/P D  NSg/V . V/C
+> one       of these cakes , ” she thought , “ it’s sure to make  some  change in          my size  ; and
+# NSg/I/V/J P  I/D   NPl   . . ISg NSg/V   . . W?   J    P  NSg/V I/J/R NSg/V  NPrSg/V/J/P D  NSg/V . V/C
 > as    it        can’t possibly make  me        larger , it        must  make  me        smaller , I   suppose . ”
 # NSg/R NPrSg/ISg VX    R        NSg/V NPrSg/ISg J      . NPrSg/ISg NSg/V NSg/V NPrSg/ISg J       . ISg V       . .
 >
 #
-> So        she swallowed one       of  the cakes , and was delighted to find  that    she began
-# NSg/I/J/C ISg W?        NSg/I/V/J V/P D   NPl   . V/C V   V/J       P  NSg/V N/I/C/D ISg V
+> So        she swallowed one       of the cakes , and was delighted to find  that    she began
+# NSg/I/J/C ISg W?        NSg/I/V/J P  D   NPl   . V/C V   V/J       P  NSg/V N/I/C/D ISg V
 > shrinking directly . As    soon as    she was small     enough to get   through the door  , she
 # V         R/C      . NSg/R J/R  NSg/R ISg V   NPrSg/V/J NSg/I  P  NSg/V NSg/J/P D   NSg/V . ISg
-> ran   out         of  the house   , and found quite a   crowd of  little    animals and birds
-# NSg/V NSg/V/J/R/P V/P D   NPrSg/V . V/C NSg/V NSg   D/P NSg/V V/P NPrSg/I/J NPl     V/C NPl
+> ran   out         of the house   , and found quite a   crowd of little    animals and birds
+# NSg/V NSg/V/J/R/P P  D   NPrSg/V . V/C NSg/V NSg   D/P NSg/V P  NPrSg/I/J NPl     V/C NPl
 > waiting outside   . The poor    little    Lizard , Bill    , was in          the middle  , being   held up
 # NSg/V   NSg/V/J/P . D   NSg/V/J NPrSg/I/J NSg    . NPrSg/V . V   NPrSg/V/J/P D   NSg/V/J . NSg/V/C V    NSg/V/J/P
-> by      two guinea - pigs , who     were  giving it        something out         of  a   bottle . They all       made
-# NSg/J/P NSg NPrSg  . NPl  . NPrSg/I NSg/V V      NPrSg/ISg NSg/I/V/J NSg/V/J/R/P V/P D/P NSg/V  . IPl  NSg/I/J/C NSg/V
+> by      two guinea - pigs , who     were  giving it        something out         of a   bottle . They all       made
+# NSg/J/P NSg NPrSg  . NPl  . NPrSg/I NSg/V V      NPrSg/ISg NSg/I/V/J NSg/V/J/R/P P  D/P NSg/V  . IPl  NSg/I/J/C NSg/V
 > a   rush      at        Alice the moment she appeared ; but     she ran   off       as    hard    as    she could  ,
 # D/P NPrSg/V/J NSg/I/V/P NPr   D   NSg    ISg W?       . NSg/C/P ISg NSg/V NSg/V/J/P NSg/R NSg/V/J NSg/R ISg NSg/VX .
 > and soon found herself safe    in          a   thick   wood      .
@@ -1514,48 +1514,48 @@
 # D/P NSg/V/J NSg/I/V . V/C ISg V/J   NSg/V/J P  NSg/V   P  NPrSg/ISg . NSg/C/P ISg V   R
 > frightened all       the time  at        the thought that    it        might    be     hungry , in          which case    it
 # W?         NSg/I/J/C D   NSg/V NSg/I/V/P D   NSg/V   N/I/C/D NPrSg/ISg NSg/VX/J NSg/VX J      . NPrSg/V/J/P I/C   NPrSg/V NPrSg/ISg
-> would  be     very likely to eat   her   up        in          spite   of  all       her   coaxing .
-# NSg/VX NSg/VX J    NSg/J  P  NSg/V I/J/D NSg/V/J/P NPrSg/V/J/P NSg/V/P V/P NSg/I/J/C I/J/D NSg/V/J .
+> would  be     very likely to eat   her   up        in          spite   of all       her   coaxing .
+# NSg/VX NSg/VX J    NSg/J  P  NSg/V I/J/D NSg/V/J/P NPrSg/V/J/P NSg/V/P P  NSg/I/J/C I/J/D NSg/V/J .
 >
 #
-> Hardly knowing   what  she did , she picked up        a   little    bit   of  stick   , and held it
-# J/R    NSg/V/J/P NSg/I ISg V   . ISg W?     NSg/V/J/P D/P NPrSg/I/J NSg/V V/P NSg/V/J . V/C V    NPrSg/ISg
+> Hardly knowing   what  she did , she picked up        a   little    bit   of stick   , and held it
+# J/R    NSg/V/J/P NSg/I ISg V   . ISg W?     NSg/V/J/P D/P NPrSg/I/J NSg/V P  NSg/V/J . V/C V    NPrSg/ISg
 > out         to the puppy ; whereupon the puppy jumped into the air   off       all       its   feet at
 # NSg/V/J/R/P P  D   NSg/V . C         D   NSg/V W?     P    D   NSg/V NSg/V/J/P NSg/I/J/C ISg/D NSg  NSg/I/V/P
-> once  , with a   yelp  of  delight , and rushed at        the stick   , and made  believe to worry
-# NSg/C . P    D/P NSg/V V/P NSg/V/J . V/C W?     NSg/I/V/P D   NSg/V/J . V/C NSg/V V       P  NSg/V
+> once  , with a   yelp  of delight , and rushed at        the stick   , and made  believe to worry
+# NSg/C . P    D/P NSg/V P  NSg/V/J . V/C W?     NSg/I/V/P D   NSg/V/J . V/C NSg/V V       P  NSg/V
 > it        ; then    Alice dodged behind  a   great thistle , to keep  herself from being   run
 # NPrSg/ISg . NSg/J/C NPr   W?     NSg/J/P D/P NSg/J NSg     . P  NSg/V I       P    NSg/V/C NSg/V
 > over      ; and the moment she appeared on  the other   side    , the puppy made  another rush
 # NSg/V/J/P . V/C D   NSg    ISg W?       J/P D   NSg/V/J NSg/V/J . D   NSg/V NSg/V I/D     NPrSg/V/J
-> at        the stick   , and tumbled head      over      heels in          its   hurry to get   hold    of  it        ; then
-# NSg/I/V/P D   NSg/V/J . V/C W?      NPrSg/V/J NSg/V/J/P NPl   NPrSg/V/J/P ISg/D NSg/V P  NSg/V NSg/V/J V/P NPrSg/ISg . NSg/J/C
-> Alice , thinking it        was very like        having a   game    of  play  with a   cart  - horse , and
-# NPr   . V        NPrSg/ISg V   J    NSg/V/J/C/P V      D/P NSg/V/J V/P NSg/V P    D/P NSg/V . NSg/V . V/C
+> at        the stick   , and tumbled head      over      heels in          its   hurry to get   hold    of it        ; then
+# NSg/I/V/P D   NSg/V/J . V/C W?      NPrSg/V/J NSg/V/J/P NPl   NPrSg/V/J/P ISg/D NSg/V P  NSg/V NSg/V/J P  NPrSg/ISg . NSg/J/C
+> Alice , thinking it        was very like        having a   game    of play  with a   cart  - horse , and
+# NPr   . V        NPrSg/ISg V   J    NSg/V/J/C/P V      D/P NSg/V/J P  NSg/V P    D/P NSg/V . NSg/V . V/C
 > expecting every moment to be     trampled under   its   feet , ran   round     the thistle
 # V         D     NSg    P  NSg/VX W?       NSg/J/P ISg/D NSg  . NSg/V NSg/V/J/P D   NSg
-> again ; then    the puppy began a   series of  short       charges at        the stick   , running   a
-# P     . NSg/J/C D   NSg/V V     D/P NSg    V/P NPrSg/V/J/P NPl     NSg/I/V/P D   NSg/V/J . NSg/V/J/P D/P
+> again ; then    the puppy began a   series of short       charges at        the stick   , running   a
+# P     . NSg/J/C D   NSg/V V     D/P NSg    P  NPrSg/V/J/P NPl     NSg/I/V/P D   NSg/V/J . NSg/V/J/P D/P
 > very little    way   forwards each time  and a   long      way   back    , and barking hoarsely all
 # J    NPrSg/I/J NSg/J NPl      D    NSg/V V/C D/P NPrSg/V/J NSg/J NSg/V/J . V/C V       J/R      NSg/I/J/C
 > the while     , till      at        last    it        sat     down      a   good      way   off       , panting , with its   tongue
 # D   NSg/V/C/P . NSg/V/C/P NSg/I/V/P NSg/V/J NPrSg/ISg NSg/V/J NSg/V/J/P D/P NPrSg/V/J NSg/J NSg/V/J/P . V       . P    ISg/D NSg/V
-> hanging out         of  its   mouth , and its   great eyes half      shut    .
-# NSg/V/J NSg/V/J/R/P V/P ISg/D NSg/V . V/C ISg/D NSg/J NPl  NSg/V/J/P NSg/V/J .
+> hanging out         of its   mouth , and its   great eyes half      shut    .
+# NSg/V/J NSg/V/J/R/P P  ISg/D NSg/V . V/C ISg/D NSg/J NPl  NSg/V/J/P NSg/V/J .
 >
 #
 > This seemed to Alice a   good      opportunity for making her   escape ; so        she set       off       at
 # I/D  W?     P  NPr   D/P NPrSg/V/J NSg         C/P NSg/V  I/J/D NSg/V  . NSg/I/J/C ISg NPrSg/V/J NSg/V/J/P NSg/I/V/P
-> once  , and ran   till      she was quite tired and out         of  breath  , and till      the puppy’s
-# NSg/C . V/C NSg/V NSg/V/C/P ISg V   NSg   V/J   V/C NSg/V/J/R/P V/P NSg/V/J . V/C NSg/V/C/P D   N$
+> once  , and ran   till      she was quite tired and out         of breath  , and till      the puppy’s
+# NSg/C . V/C NSg/V NSg/V/C/P ISg V   NSg   V/J   V/C NSg/V/J/R/P P  NSg/V/J . V/C NSg/V/C/P D   N$
 > bark  sounded quite faint   in          the distance .
 # NSg/V W?      NSg   NSg/V/J NPrSg/V/J/P D   NSg/V    .
 >
 #
 > “ And yet     what  a   dear    little    puppy it        was ! ” said Alice , as    she leant against a
 # . V/C NSg/V/C NSg/I D/P NSg/V/J NPrSg/I/J NSg/V NPrSg/ISg V   . . V/J  NPr   . NSg/R ISg ?     C/P     D/P
-> buttercup to rest  herself , and fanned herself with one       of  the leaves : “ I   should
-# NSg       P  NSg/V I       . V/C V      I       P    NSg/I/V/J V/P D   NPl    . . ISg VX
+> buttercup to rest  herself , and fanned herself with one       of the leaves : “ I   should
+# NSg       P  NSg/V I       . V/C V      I       P    NSg/I/V/J P  D   NPl    . . ISg VX
 > have   liked teaching it        tricks very much  , if    — if    I’d only been  the right     size  to
 # NSg/VX W?    NSg/V    NPrSg/ISg NPl    J    N/I/J . NSg/C . NSg/C W?  W?   NSg/V D   NPrSg/V/J NSg/V P
 > do     it        ! Oh      dear    ! I’d nearly forgotten that    I’ve got to grow up        again ! Let   me
@@ -1568,26 +1568,26 @@
 #
 > The great question certainly was , what  ? Alice looked all       round     her   at        the
 # D   NSg/J NSg/V    J/R       V   . NSg/I . NPr   W?     NSg/I/J/C NSg/V/J/P I/J/D NSg/I/V/P D
-> flowers and the blades of  grass   , but     she did not   see   anything that    looked like
-# NPrPl   V/C D   NPl    V/P NPrSg/V . NSg/C/P ISg V   NSg/C NSg/V NSg/I/V  N/I/C/D W?     NSg/V/J/C/P
+> flowers and the blades of grass   , but     she did not   see   anything that    looked like
+# NPrPl   V/C D   NPl    P  NPrSg/V . NSg/C/P ISg V   NSg/C NSg/V NSg/I/V  N/I/C/D W?     NSg/V/J/C/P
 > the right     thing to eat   or      drink under   the circumstances . There was a   large
 # D   NPrSg/V/J NSg/V P  NSg/V NPrSg/C NSg/V NSg/J/P D   NPl           . W?    V   D/P NSg/J
 > mushroom growing near      her   , about the same height as    herself ; and when    she had
 # NSg/V/J  NSg/V   NSg/V/J/P I/J/D . J/P   D   I/J  NSg    NSg/R I       . V/C NSg/I/C ISg V
-> looked under   it        , and on  both sides of  it        , and behind  it        , it        occurred to her   that
-# W?     NSg/J/P NPrSg/ISg . V/C J/P I/C  NPl   V/P NPrSg/ISg . V/C NSg/J/P NPrSg/ISg . NPrSg/ISg V        P  I/J/D N/I/C/D
-> she might    as    well    look  and see   what  was on  the top     of  it        .
-# ISg NSg/VX/J NSg/R NSg/V/J NSg/V V/C NSg/V NSg/I V   J/P D   NSg/V/J V/P NPrSg/ISg .
+> looked under   it        , and on  both sides of it        , and behind  it        , it        occurred to her   that
+# W?     NSg/J/P NPrSg/ISg . V/C J/P I/C  NPl   P  NPrSg/ISg . V/C NSg/J/P NPrSg/ISg . NPrSg/ISg V        P  I/J/D N/I/C/D
+> she might    as    well    look  and see   what  was on  the top     of it        .
+# ISg NSg/VX/J NSg/R NSg/V/J NSg/V V/C NSg/V NSg/I V   J/P D   NSg/V/J P  NPrSg/ISg .
 >
 #
-> She stretched herself up        on  tiptoe  , and peeped over      the edge  of  the mushroom ,
-# ISg W?        I       NSg/V/J/P J/P NSg/V/J . V/C W?     NSg/V/J/P D   NSg/V V/P D   NSg/V/J  .
-> and her   eyes immediately met those of  a   large blue    caterpillar , that    was sitting
-# V/C I/J/D NPl  J/R         V   I/D   V/P D/P NSg/J NSg/V/J NSg/V       . N/I/C/D V   NSg/V/J
+> She stretched herself up        on  tiptoe  , and peeped over      the edge  of the mushroom ,
+# ISg W?        I       NSg/V/J/P J/P NSg/V/J . V/C W?     NSg/V/J/P D   NSg/V P  D   NSg/V/J  .
+> and her   eyes immediately met those of a   large blue    caterpillar , that    was sitting
+# V/C I/J/D NPl  J/R         V   I/D   P  D/P NSg/J NSg/V/J NSg/V       . N/I/C/D V   NSg/V/J
 > on  the top     with its   arms folded , quietly smoking a   long      hookah , and taking  not
 # J/P D   NSg/V/J P    ISg/D NPl  W?     . J/R     NSg/V/J D/P NPrSg/V/J NSg    . V/C NSg/V/J NSg/C
-> the smallest notice of  her   or      of  anything else  .
-# D   W?       NSg/V  V/P I/J/D NPrSg/C V/P NSg/I/V  N/J/C .
+> the smallest notice of her   or      of anything else  .
+# D   W?       NSg/V  P  I/J/D NPrSg/C P  NSg/I/V  N/J/C .
 >
 #
 > CHAPTER V     : Advice from a   Caterpillar
@@ -1596,8 +1596,8 @@
 #
 > The Caterpillar and Alice looked at        each other   for some  time  in          silence : at        last
 # D   NSg/V       V/C NPr   W?     NSg/I/V/P D    NSg/V/J C/P I/J/R NSg/V NPrSg/V/J/P NSg/V   . NSg/I/V/P NSg/V/J
-> the Caterpillar took the hookah out         of  its   mouth , and addressed her   in          a
-# D   NSg/V       V    D   NSg    NSg/V/J/R/P V/P ISg/D NSg/V . V/C V/J       I/J/D NPrSg/V/J/P D/P
+> the Caterpillar took the hookah out         of its   mouth , and addressed her   in          a
+# D   NSg/V       V    D   NSg    NSg/V/J/R/P P  ISg/D NSg/V . V/C V/J       I/J/D NPrSg/V/J/P D/P
 > languid , sleepy voice .
 # NSg/J   . NSg/J  NSg/V .
 >
@@ -1664,8 +1664,8 @@
 # . IPl . . V/J  D   NSg/V       J/R            . . NPrSg/I V   IPl . .
 >
 #
-> Which brought them back    again to the beginning of  the conversation . Alice felt    a
-# I/C   V       N/I  NSg/V/J P     P  D   NSg/V/J   V/P D   NSg/V        . NPr   NSg/V/J D/P
+> Which brought them back    again to the beginning of the conversation . Alice felt    a
+# I/C   V       N/I  NSg/V/J P     P  D   NSg/V/J   P  D   NSg/V        . NPr   NSg/V/J D/P
 > little    irritated at        the Caterpillar’s making such  very short       remarks , and she
 # NPrSg/I/J W?        NSg/I/V/P D   N$            NSg/V  NSg/I J    NPrSg/V/J/P NPl     . V/C ISg
 > drew  herself up        and said , very gravely , “ I   think , you ought    to tell    me        who     you
@@ -1678,10 +1678,10 @@
 # . NSg/V . . V/J  D   NSg/V       .
 >
 #
-> Here    was another puzzling question ; and as    Alice could  not   think of  any   good
-# NSg/J/R V   I/D     V        NSg/V    . V/C NSg/R NPr   NSg/VX NSg/C NSg/V V/P I/R/D NPrSg/V/J
-> reason , and as    the Caterpillar seemed to be     in          a   very unpleasant state of  mind  ,
-# NSg/V  . V/C NSg/R D   NSg/V       W?     P  NSg/VX NPrSg/V/J/P D/P J    NSg/J      NSg/V V/P NSg/V .
+> Here    was another puzzling question ; and as    Alice could  not   think of any   good
+# NSg/J/R V   I/D     V        NSg/V    . V/C NSg/R NPr   NSg/VX NSg/C NSg/V P  I/R/D NPrSg/V/J
+> reason , and as    the Caterpillar seemed to be     in          a   very unpleasant state of mind  ,
+# NSg/V  . V/C NSg/R D   NSg/V       W?     P  NSg/VX NPrSg/V/J/P D/P J    NSg/J      NSg/V P  NSg/V .
 > she turned away .
 # ISg W?     V/J  .
 >
@@ -1713,7 +1713,7 @@
 > after all       it        might    tell    her   something worth   hearing . For some  minutes it        puffed
 # J/P   NSg/I/J/C NPrSg/ISg NSg/VX/J NPrSg/V I/J/D NSg/I/V/J NSg/V/J NSg/V/J . C/P I/J/R NPl     NPrSg/ISg W?
 > away without speaking , but     at        last    it        unfolded its   arms , took the hookah out         of
-# V/J  C/P     V        . NSg/C/P NSg/I/V/P NSg/V/J NPrSg/ISg W?       ISg/D NPl  . V    D   NSg    NSg/V/J/R/P V/P
+# V/J  C/P     V        . NSg/C/P NSg/I/V/P NSg/V/J NPrSg/ISg W?       ISg/D NPl  . V    D   NSg    NSg/V/J/R/P P
 > its   mouth again , and said , “ So        you think you’re changed , do     you ? ”
 # ISg/D NSg/V P     . V/C V/J  . . NSg/I/J/C IPl NSg/V W?     V/J     . NSg/VX IPl . .
 >
@@ -1762,14 +1762,14 @@
 # . IPl V   NSg/J . . V/J  D   NSg   . . NSg/R ISg V         C/P    . V/C NSg/VX V/J   NSg/I/J
 > uncommonly fat     ; Yet     you turned a   back    - somersault in          at        the door  — Pray , what  is
 # J/R        NSg/V/J . NSg/V/C IPl W?     D/P NSg/V/J . NSg/V      NPrSg/V/J/P NSg/I/V/P D   NSg/V . V    . NSg/I VL
-> the reason of  that    ? ”
-# D   NSg/V  V/P N/I/C/D . .
+> the reason of that    ? ”
+# D   NSg/V  P  N/I/C/D . .
 >
 #
 > “ In          my youth , ” said the sage    , as    he      shook   his   grey         locks , “ I   kept all       my limbs
 # . NPrSg/V/J/P D  NSg   . . V/J  D   NSg/V/J . NSg/R NPr/ISg NSg/V/J ISg/D NPrSg/V/J/Br NPl   . . ISg V    NSg/I/J/C D  NPl
-> very supple By      the use   of  this ointment — one       shilling the box   — Allow me        to sell
-# J    V/J    NSg/J/P D   NSg/V V/P I/D  NSg      . NSg/I/V/J NSg/V    D   NSg/V . V     NPrSg/ISg P  NSg/V
+> very supple By      the use   of this ointment — one       shilling the box   — Allow me        to sell
+# J    V/J    NSg/J/P D   NSg/V P  I/D  NSg      . NSg/I/V/J NSg/V    D   NSg/V . V     NPrSg/ISg P  NSg/V
 > you a   couple  ? ”
 # IPl D/P NSg/V/J . .
 >
@@ -1786,14 +1786,14 @@
 # . NPrSg/V/J/P D  NSg   . . V/J  ISg/D NPrSg/V . . ISg V    P  D   NSg/V . V/C W?     D    NPrSg/V P
 > my wife  ; And the muscular strength , which it        gave to my jaw     , Has lasted the
 # D  NSg/V . V/C D   J        NSg/V    . I/C   NPrSg/ISg V    P  D  NSg/V/J . V   W?     D
-> rest  of  my life  . ”
-# NSg/V V/P D  NSg/V . .
+> rest  of my life  . ”
+# NSg/V P  D  NSg/V . .
 >
 #
 > “ You are old   , ” said the youth , “ one       would  hardly suppose That    your eye   was as
 # . IPl V   NSg/J . . V/J  D   NSg   . . NSg/I/V/J NSg/VX J/R    V       N/I/C/D D    NSg/V V   NSg/R
-> steady  as    ever ; Yet     you balanced an  eel   on  the end   of  your nose  — What  made  you
-# NSg/V/J NSg/R J    . NSg/V/C IPl W?       D/P NSg/V J/P D   NSg/V V/P D    NSg/V . NSg/I NSg/V IPl
+> steady  as    ever ; Yet     you balanced an  eel   on  the end   of your nose  — What  made  you
+# NSg/V/J NSg/R J    . NSg/V/C IPl W?       D/P NSg/V J/P D   NSg/V P  D    NSg/V . NSg/I NSg/V IPl
 > so        awfully clever ? ”
 # NSg/I/J/C J/R     J      . .
 >
@@ -1810,8 +1810,8 @@
 # . N/I/C/D VL NSg/C V/J  NPrSg/V/J . . V/J  D   NSg/V       .
 >
 #
-> “ Not   quite right     , I’m afraid , ” said Alice , timidly ; “ some  of  the words have   got
-# . NSg/C NSg   NPrSg/V/J . W?  J      . . V/J  NPr   . J/R     . . I/J/R V/P D   NPl   NSg/VX V
+> “ Not   quite right     , I’m afraid , ” said Alice , timidly ; “ some  of the words have   got
+# . NSg/C NSg   NPrSg/V/J . W?  J      . . V/J  NPr   . J/R     . . I/J/R P  D   NPl   NSg/VX V
 > altered . ”
 # NSg/V/J . .
 >
@@ -1864,8 +1864,8 @@
 #
 > “ But     I’m not   used to it        ! ” pleaded poor    Alice in          a   piteous tone    . And she thought
 # . NSg/C/P W?  NSg/C V/J  P  NPrSg/ISg . . W?      NSg/V/J NPr   NPrSg/V/J/P D/P J       NSg/I/V . V/C ISg NSg/V
-> of  herself , “ I   wish  the creatures wouldn’t be     so        easily offended ! ”
-# V/P I       . . ISg NSg/V D   NPl       VX       NSg/VX NSg/I/J/C R      W?       . .
+> of herself , “ I   wish  the creatures wouldn’t be     so        easily offended ! ”
+# P  I       . . ISg NSg/V D   NPl       VX       NSg/VX NSg/I/J/C R      W?       . .
 >
 #
 > “ You’ll get   used to it        in          time  , ” said the Caterpillar ; and it        put   the hookah
@@ -1876,8 +1876,8 @@
 #
 > This time  Alice waited patiently until it        chose to speak again . In          a   minute  or
 # I/D  NSg/V NPr   W?     R         C/P   NPrSg/ISg NSg/V P  NSg/V P     . NPrSg/V/J/P D/P NSg/V/J NPrSg/C
-> two the Caterpillar took the hookah out         of  its   mouth and yawned once  or      twice ,
-# NSg D   NSg/V       V    D   NSg    NSg/V/J/R/P V/P ISg/D NSg/V V/C W?     NSg/C NPrSg/C W?    .
+> two the Caterpillar took the hookah out         of its   mouth and yawned once  or      twice ,
+# NSg D   NSg/V       V    D   NSg    NSg/V/J/R/P P  ISg/D NSg/V V/C W?     NSg/C NPrSg/C W?    .
 > and shook   itself . Then    it        got down      off       the mushroom , and crawled away in          the
 # V/C NSg/V/J I      . NSg/J/C NPrSg/ISg V   NSg/V/J/P NSg/V/J/P D   NSg/V/J  . V/C W?      V/J  NPrSg/V/J/P D
 > grass   , merely remarking as    it        went  , “ One       side    will     make  you grow taller , and the
@@ -1886,28 +1886,28 @@
 # NSg/V/J NSg/V/J NPrSg/VX NSg/V IPl V    J       . .
 >
 #
-> “ One       side    of  what  ? The other   side    of  what  ? ” thought Alice to herself .
-# . NSg/I/V/J NSg/V/J V/P NSg/I . D   NSg/V/J NSg/V/J V/P NSg/I . . NSg/V   NPr   P  I       .
+> “ One       side    of what  ? The other   side    of what  ? ” thought Alice to herself .
+# . NSg/I/V/J NSg/V/J P  NSg/I . D   NSg/V/J NSg/V/J P  NSg/I . . NSg/V   NPr   P  I       .
 >
 #
-> “ Of  the mushroom , ” said the Caterpillar , just as    if    she had asked it        aloud ; and
-# . V/P D   NSg/V/J  . . V/J  D   NSg/V       . V/J  NSg/R NSg/C ISg V   V/J   NPrSg/ISg J     . V/C
-> in          another moment it        was out         of  sight .
-# NPrSg/V/J/P I/D     NSg    NPrSg/ISg V   NSg/V/J/R/P V/P NSg/V .
+> “ Of the mushroom , ” said the Caterpillar , just as    if    she had asked it        aloud ; and
+# . P  D   NSg/V/J  . . V/J  D   NSg/V       . V/J  NSg/R NSg/C ISg V   V/J   NPrSg/ISg J     . V/C
+> in          another moment it        was out         of sight .
+# NPrSg/V/J/P I/D     NSg    NPrSg/ISg V   NSg/V/J/R/P P  NSg/V .
 >
 #
 > Alice remained looking thoughtfully at        the mushroom for a   minute  , trying  to make
 # NPr   W?       V       J/R          NSg/I/V/P D   NSg/V/J  C/P D/P NSg/V/J . NSg/V/J P  NSg/V
-> out         which were  the two sides of  it        ; and as    it        was perfectly round     , she found
-# NSg/V/J/R/P I/C   NSg/V D   NSg NPl   V/P NPrSg/ISg . V/C NSg/R NPrSg/ISg V   J/R       NSg/V/J/P . ISg NSg/V
+> out         which were  the two sides of it        ; and as    it        was perfectly round     , she found
+# NSg/V/J/R/P I/C   NSg/V D   NSg NPl   P  NPrSg/ISg . V/C NSg/R NPrSg/ISg V   J/R       NSg/V/J/P . ISg NSg/V
 > this a   very difficult question . However , at        last    she stretched her   arms round     it
 # I/D  D/P J    V/J       NSg/V    . C       . NSg/I/V/P NSg/V/J ISg W?        I/J/D NPl  NSg/V/J/P NPrSg/ISg
-> as    far     as    they would  go      , and broke   off       a   bit   of  the edge  with each hand  .
-# NSg/R NSg/V/J NSg/R IPl  NSg/VX NSg/V/J . V/C NSg/V/J NSg/V/J/P D/P NSg/V V/P D   NSg/V P    D    NSg/V .
+> as    far     as    they would  go      , and broke   off       a   bit   of the edge  with each hand  .
+# NSg/R NSg/V/J NSg/R IPl  NSg/VX NSg/V/J . V/C NSg/V/J NSg/V/J/P D/P NSg/V P  D   NSg/V P    D    NSg/V .
 >
 #
-> “ And now         which is which ? ” she said to herself , and nibbled a   little    of  the
-# . V/C NPrSg/V/J/C I/C   VL I/C   . . ISg V/J  P  I       . V/C W?      D/P NPrSg/I/J V/P D
+> “ And now         which is which ? ” she said to herself , and nibbled a   little    of the
+# . V/C NPrSg/V/J/C I/C   VL I/C   . . ISg V/J  P  I       . V/C W?      D/P NPrSg/I/J P  D
 > right     - hand  bit   to try     the effect : the next    moment she felt    a   violent blow
 # NPrSg/V/J . NSg/V NSg/V P  NSg/V/J D   NSg/V  . D   NSg/J/P NSg    ISg NSg/V/J D/P NSg/V/J NSg/V/J
 > underneath her   chin    : it        had struck her   foot  !
@@ -1918,22 +1918,22 @@
 # ISg V   D/P NPrSg/V/J NSg/V/J W?         NSg/J/P I/D  J    NSg/J  NSg/V  . NSg/C/P ISg NSg/V/J N/I/C/D
 > there was no      time  to be     lost , as    she was shrinking rapidly ; so        she set       to work
 # W?    V   NPrSg/P NSg/V P  NSg/VX V/J  . NSg/R ISg V   V         J/R     . NSg/I/J/C ISg NPrSg/V/J P  NSg/V
-> at        once  to eat   some  of  the other   bit   . Her   chin    was pressed so        closely against
-# NSg/I/V/P NSg/C P  NSg/V I/J/R V/P D   NSg/V/J NSg/V . I/J/D NPrSg/V V   V/J     NSg/I/J/C J/R     C/P
+> at        once  to eat   some  of the other   bit   . Her   chin    was pressed so        closely against
+# NSg/I/V/P NSg/C P  NSg/V I/J/R P  D   NSg/V/J NSg/V . I/J/D NPrSg/V V   V/J     NSg/I/J/C J/R     C/P
 > her   foot  , that    there was hardly room    to open    her   mouth ; but     she did it        at        last    ,
 # I/J/D NSg/V . N/I/C/D W?    V   J/R    NSg/V/J P  NSg/V/J I/J/D NSg/V . NSg/C/P ISg V   NPrSg/ISg NSg/I/V/P NSg/V/J .
-> and managed to swallow a   morsel of  the lefthand bit   .
-# V/C W?      P  NSg/V   D/P NSg/V  V/P D   ?        NSg/V .
+> and managed to swallow a   morsel of the lefthand bit   .
+# V/C W?      P  NSg/V   D/P NSg/V  P  D   ?        NSg/V .
 >
 #
-> “ Come    , my head’s free    at        last    ! ” said Alice in          a   tone    of  delight , which changed
-# . NSg/V/P . D  N$     NSg/V/J NSg/I/V/P NSg/V/J . . V/J  NPr   NPrSg/V/J/P D/P NSg/I/V V/P NSg/V/J . I/C   V/J
+> “ Come    , my head’s free    at        last    ! ” said Alice in          a   tone    of delight , which changed
+# . NSg/V/P . D  N$     NSg/V/J NSg/I/V/P NSg/V/J . . V/J  NPr   NPrSg/V/J/P D/P NSg/I/V P  NSg/V/J . I/C   V/J
 > into alarm in          another moment , when    she found that    her   shoulders were  nowhere to
 # P    NSg/V NPrSg/V/J/P I/D     NSg    . NSg/I/C ISg NSg/V N/I/C/D I/J/D NPl       NSg/V NSg/J   P
 > be     found : all       she could  see   , when    she looked down      , was an  immense length of
-# NSg/VX NSg/V . NSg/I/J/C ISg NSg/VX NSg/V . NSg/I/C ISg W?     NSg/V/J/P . V   D/P NSg/J   NSg/V  V/P
-> neck  , which seemed to rise  like        a   stalk out         of  a   sea of  green     leaves that    lay
-# NSg/V . I/C   W?     P  NSg/V NSg/V/J/C/P D/P NSg/V NSg/V/J/R/P V/P D/P NSg V/P NPrSg/V/J NPl    N/I/C/D NSg/V/J
+# NSg/VX NSg/V . NSg/I/J/C ISg NSg/VX NSg/V . NSg/I/C ISg W?     NSg/V/J/P . V   D/P NSg/J   NSg/V  P
+> neck  , which seemed to rise  like        a   stalk out         of a   sea of green     leaves that    lay
+# NSg/V . I/C   W?     P  NSg/V NSg/V/J/C/P D/P NSg/V NSg/V/J/R/P P  D/P NSg P  NPrSg/V/J NPl    N/I/C/D NSg/V/J
 > far     below her   .
 # NSg/V/J P     I/J/D .
 >
@@ -1948,16 +1948,16 @@
 # J       NPrSg/V/J NPl    .
 >
 #
-> As    there seemed to be     no      chance    of  getting her   hands up        to her   head      , she tried
-# NSg/R W?    W?     P  NSg/VX NPrSg/P NPrSg/V/J V/P NSg/V   I/J/D NPl   NSg/V/J/P P  I/J/D NPrSg/V/J . ISg V/J
+> As    there seemed to be     no      chance    of getting her   hands up        to her   head      , she tried
+# NSg/R W?    W?     P  NSg/VX NPrSg/P NPrSg/V/J P  NSg/V   I/J/D NPl   NSg/V/J/P P  I/J/D NPrSg/V/J . ISg V/J
 > to get   her   head      down      to them , and was delighted to find  that    her   neck  would  bend
 # P  NSg/V I/J/D NPrSg/V/J NSg/V/J/P P  N/I  . V/C V   V/J       P  NSg/V N/I/C/D I/J/D NSg/V NSg/VX NPrSg/V
 > about easily in          any   direction , like        a   serpent . She had just succeeded in          curving
 # J/P   R      NPrSg/V/J/P I/R/D NSg       . NSg/V/J/C/P D/P NSg/V   . ISg V   V/J  W?        NPrSg/V/J/P V
 > it        down      into a   graceful zigzag  , and was going   to dive  in          among the leaves , which
 # NPrSg/ISg NSg/V/J/P P    D/P J        NSg/V/J . V/C V   NSg/V/J P  NSg/V NPrSg/V/J/P P     D   NPl    . I/C
-> she found to be     nothing but     the tops of  the trees under   which she had been
-# ISg NSg/V P  NSg/VX NSg/I/J NSg/C/P D   NPl  V/P D   NPl   NSg/J/P I/C   ISg V   NSg/V
+> she found to be     nothing but     the tops of the trees under   which she had been
+# ISg NSg/V P  NSg/VX NSg/I/J NSg/C/P D   NPl  P  D   NPl   NSg/J/P I/C   ISg V   NSg/V
 > wandering , when    a   sharp     hiss  made  her   draw  back    in          a   hurry : a   large pigeon had
 # V         . NSg/I/C D/P NPrSg/V/J NSg/V NSg/V I/J/D NSg/V NSg/V/J NPrSg/V/J/P D/P NSg/V . D/P NSg/J NSg/V  V
 > flown into her   face  , and was beating her   violently with its   wings .
@@ -1974,8 +1974,8 @@
 #
 > “ Serpent , I   say   again ! ” repeated the Pigeon , but     in          a   more        subdued tone    , and
 # . NSg/V   . ISg NSg/V P     . . V/J      D   NSg/V  . NSg/C/P NPrSg/V/J/P D/P NPrSg/I/V/J W?      NSg/I/V . V/C
-> added with a   kind  of  sob   , “ I’ve tried every way   , and nothing seems to suit
-# W?    P    D/P NSg/J V/P NSg/V . . W?   V/J   D     NSg/J . V/C NSg/I/J NPl   P  NSg/V
+> added with a   kind  of sob   , “ I’ve tried every way   , and nothing seems to suit
+# W?    P    D/P NSg/J P  NSg/V . . W?   V/J   D     NSg/J . V/C NSg/I/J NPl   P  NSg/V
 > them ! ”
 # N/I  . .
 >
@@ -1984,8 +1984,8 @@
 # . ISg V       D   NSg/J NSg  NSg/I W?     V       J/P   . . V/J  NPr   .
 >
 #
-> “ I’ve tried the roots of  trees , and I’ve tried banks , and I’ve tried hedges , ”
-# . W?   V/J   D   NPl   V/P NPl   . V/C W?   V/J   NPrPl . V/C W?   V/J   NPl    . .
+> “ I’ve tried the roots of trees , and I’ve tried banks , and I’ve tried hedges , ”
+# . W?   V/J   D   NPl   P  NPl   . V/C W?   V/J   NPrPl . V/C W?   V/J   NPl    . .
 > the Pigeon went  on  , without attending to her   ; “ but     those serpents ! There’s no
 # D   NSg/V  NSg/V J/P . C/P     V         P  I/J/D . . NSg/C/P I/D   NPl      . W?      NPrSg/P
 > pleasing them ! ”
@@ -2001,7 +2001,7 @@
 > “ As    if    it        wasn’t trouble enough hatching the eggs , ” said the Pigeon ; “ but     I   must
 # . NSg/R NSg/C NPrSg/ISg V      NSg/V   NSg/I  NSg/V    D   NPl  . . V/J  D   NSg/V  . . NSg/C/P ISg NSg/V
 > be     on  the look  - out         for serpents night and day   ! Why   , I   haven’t had a   wink  of
-# NSg/VX J/P D   NSg/V . NSg/V/J/R/P C/P NPl      NSg/V V/C NPrSg . NSg/V . ISg V       V   D/P NSg/V V/P
+# NSg/VX J/P D   NSg/V . NSg/V/J/R/P C/P NPl      NSg/V V/C NPrSg . NSg/V . ISg V       V   D/P NSg/V P
 > sleep these three weeks ! ”
 # NSg/V I/D   NSg   NPrPl . .
 >
@@ -2015,7 +2015,7 @@
 > “ And just as    I’d taken the highest tree  in          the wood      , ” continued the Pigeon ,
 # . V/C V/J  NSg/R W?  V/J   D   W?      NSg/V NPrSg/V/J/P D   NPrSg/V/J . . W?        D   NSg/V  .
 > raising its   voice to a   shriek , “ and just as    I   was thinking I   should be     free    of
-# V       ISg/D NSg/V P  D/P NSg/V  . . V/C V/J  NSg/R ISg V   V        ISg VX     NSg/VX NSg/V/J V/P
+# V       ISg/D NSg/V P  D/P NSg/V  . . V/C V/J  NSg/R ISg V   V        ISg VX     NSg/VX NSg/V/J P
 > them at        last    , they must  needs come    wriggling down      from the sky   ! Ugh , Serpent ! ”
 # N/I  NSg/I/V/P NSg/V/J . IPl  NSg/V NPl   NSg/V/P V         NSg/V/J/P P    D   NSg/V . W?  . NSg/V   . .
 >
@@ -2032,12 +2032,12 @@
 #
 > “ I   — I’m a   little    girl  , ” said Alice , rather    doubtfully , as    she remembered the
 # . ISg . W?  D/P NPrSg/I/J NSg/V . . V/J  NPr   . NPrSg/V/J J/R        . NSg/R ISg V          D
-> number  of  changes she had gone  through that    day   .
-# NSg/V/J V/P NPl     ISg V   V/J/P NSg/J/P N/I/C/D NPrSg .
+> number  of changes she had gone  through that    day   .
+# NSg/V/J P  NPl     ISg V   V/J/P NSg/J/P N/I/C/D NPrSg .
 >
 #
-> “ A   likely story indeed ! ” said the Pigeon in          a   tone    of  the deepest contempt .
-# . D/P NSg/J  NSg/V W?     . . V/J  D   NSg/V  NPrSg/V/J/P D/P NSg/I/V V/P D   W?      NSg      .
+> “ A   likely story indeed ! ” said the Pigeon in          a   tone    of the deepest contempt .
+# . D/P NSg/J  NSg/V W?     . . V/J  D   NSg/V  NPrSg/V/J/P D/P NSg/I/V P  D   W?      NSg      .
 > “ I’ve seen  a   good      many    little    girls in          my time  , but     never one       with such  a   neck
 # . W?   NSg/V D/P NPrSg/V/J N/I/J/D NPrSg/I/J NPl   NPrSg/V/J/P D  NSg/V . NSg/C/P V     NSg/I/V/J P    NSg/I D/P NSg/V
 > as    that    ! No      , no      ! You’re a   serpent ; and there’s no      use   denying it        . I   suppose
@@ -2054,14 +2054,14 @@
 #
 > “ I   don’t believe it        , ” said the Pigeon ; “ but     if    they do     , why   then    they’re a   kind
 # . ISg NSg/V V       NPrSg/ISg . . V/J  D   NSg/V  . . NSg/C/P NSg/C IPl  NSg/VX . NSg/V NSg/J/C W?      D/P NSg/J
-> of  serpent , that’s all       I   can      say   . ”
-# V/P NSg/V   . N$     NSg/I/J/C ISg NPrSg/VX NSg/V . .
+> of serpent , that’s all       I   can      say   . ”
+# P  NSg/V   . N$     NSg/I/J/C ISg NPrSg/VX NSg/V . .
 >
 #
 > This was such  a   new     idea to Alice , that    she was quite silent for a   minute  or
 # I/D  V   NSg/I D/P NSg/V/J NSg  P  NPr   . N/I/C/D ISg V   NSg   NSg/J  C/P D/P NSg/V/J NPrSg/C
-> two , which gave the Pigeon the opportunity of  adding , “ You’re looking for eggs ,
-# NSg . I/C   V    D   NSg/V  D   NSg         V/P V      . . W?     V       C/P NPl  .
+> two , which gave the Pigeon the opportunity of adding , “ You’re looking for eggs ,
+# NSg . I/C   V    D   NSg/V  D   NSg         P  V      . . W?     V       C/P NPl  .
 > I   know  that    well    enough ; and what  does  it        matter  to me        whether you’re a   little
 # ISg NSg/V N/I/C/D NSg/V/J NSg/I  . V/C NSg/I NSg/V NPrSg/ISg NSg/V/J P  NPrSg/ISg I/C     W?     D/P NPrSg/I/J
 > girl  or      a   serpent ? ”
@@ -2084,8 +2084,8 @@
 # NSg/V V    NSg/V   W?        P     D   NPl      . V/C D     NPrSg/V/J/C V/C NSg/J/C ISg V
 > to stop  and untwist it        . After a   while     she remembered that    she still   held the
 # P  NSg/V V/C NSg/V   NPrSg/ISg . J/P   D/P NSg/V/C/P ISg V          N/I/C/D ISg NSg/V/J V    D
-> pieces of  mushroom in          her   hands , and she set       to work  very carefully , nibbling
-# NPl    V/P NSg/V/J  NPrSg/V/J/P I/J/D NPl   . V/C ISg NPrSg/V/J P  NSg/V J    J/R       . V
+> pieces of mushroom in          her   hands , and she set       to work  very carefully , nibbling
+# NPl    P  NSg/V/J  NPrSg/V/J/P I/J/D NPl   . V/C ISg NPrSg/V/J P  NSg/V J    J/R       . V
 > first   at        one       and then    at        the other   , and growing sometimes taller and sometimes
 # NSg/V/J NSg/I/V/P NSg/I/V/J V/C NSg/J/C NSg/I/V/P D   NSg/V/J . V/C NSg/V   R         J      V/C R
 > shorter , until she had succeeded in          bringing herself down      to her   usual height .
@@ -2108,8 +2108,8 @@
 # NSg/V/P J/R      P    D/P NSg/V/J NSg/V . P    D/P NPrSg/I/J NPrSg/V NPrSg/V/J/P NPrSg/ISg J/P   NSg  NSg
 > high    . “ Whoever lives there , ” thought Alice , “ it’ll never do     to come    upon them
 # NSg/V/J . . I       NPl   W?    . . NSg/V   NPr   . . W?    V     NSg/VX P  NSg/V/P P    N/I
-> this size  : why   , I   should frighten them out         of  their wits ! ” So        she began nibbling
-# I/D  NSg/V . NSg/V . ISg VX     V        N/I  NSg/V/J/R/P V/P D     NSg  . . NSg/I/J/C ISg V     V
+> this size  : why   , I   should frighten them out         of their wits ! ” So        she began nibbling
+# I/D  NSg/V . NSg/V . ISg VX     V        N/I  NSg/V/J/R/P P  D     NSg  . . NSg/I/J/C ISg V     V
 > at        the righthand bit   again , and did not   venture to go      near      the house   till      she
 # NSg/I/V/P D   ?         NSg/V P     . V/C V   NSg/C NSg/V   P  NSg/V/J NSg/V/J/P D   NPrSg/V NSg/V/C/P ISg
 > had brought herself down      to nine inches high    .
@@ -2122,8 +2122,8 @@
 #
 > For a   minute  or      two she stood looking at        the house   , and wondering what  to do
 # C/P D/P NSg/V/J NPrSg/C NSg ISg V     V       NSg/I/V/P D   NPrSg/V . V/C NSg/V/J   NSg/I P  NSg/VX
-> next    , when    suddenly a   footman in          livery  came    running   out         of  the wood      — ( she
-# NSg/J/P . NSg/I/C J/R      D/P NSg     NPrSg/V/J/P NSg/V/J NSg/V/P NSg/V/J/P NSg/V/J/R/P V/P D   NPrSg/V/J . . ISg
+> next    , when    suddenly a   footman in          livery  came    running   out         of the wood      — ( she
+# NSg/J/P . NSg/I/C J/R      D/P NSg     NPrSg/V/J/P NSg/V/J NSg/V/P NSg/V/J/P NSg/V/J/R/P P  D   NPrSg/V/J . . ISg
 > considered him to be     a   footman because he      was in          livery  : otherwise , judging by
 # V/J        I   P  NSg/VX D/P NSg     C/P     NPr/ISg V   NPrSg/V/J/P NSg/V/J . J         . V       NSg/J/P
 > his   face  only , she would  have   called him a   fish  ) — and rapped loudly at        the door
@@ -2134,8 +2134,8 @@
 # NSg/V . V/C NSg/J NPl  NSg/V/J/C/P D/P NSg/V . V/C I/C  NPl     . NPr   V       . V   W?
 > hair  that    curled all       over      their heads . She felt    very curious to know  what  it        was
 # NSg/V N/I/C/D W?     NSg/I/J/C NSg/V/J/P D     NPl   . ISg NSg/V/J J    J       P  NSg/V NSg/I NPrSg/ISg V
-> all       about , and crept a   little    way   out         of  the wood      to listen .
-# NSg/I/J/C J/P   . V/C V     D/P NPrSg/I/J NSg/J NSg/V/J/R/P V/P D   NPrSg/V/J P  NSg/V  .
+> all       about , and crept a   little    way   out         of the wood      to listen .
+# NSg/I/J/C J/P   . V/C V     D/P NPrSg/I/J NSg/J NSg/V/J/R/P P  D   NPrSg/V/J P  NSg/V  .
 >
 #
 > The Fish  - Footman began by      producing from under   his   arm     a   great letter , nearly as
@@ -2144,8 +2144,8 @@
 # NSg/J NSg/R I       . V/C I/D  NPr/ISg V/J    NSg/V/J/P P  D   NSg/V/J . NSg/V  . NPrSg/V/J/P D/P J
 > tone    , “ For the Duchess . An  invitation from the Queen   to play  croquet . ” The
 # NSg/I/V . . C/P D   NSg/V   . D/P NSg        P    D   NPrSg/V P  NSg/V NSg/V   . . D
-> Frog  - Footman repeated , in          the same solemn tone    , only changing the order of  the
-# NSg/V . NSg     V/J      . NPrSg/V/J/P D   I/J  J      NSg/I/V . W?   NSg/V    D   NSg/V V/P D
+> Frog  - Footman repeated , in          the same solemn tone    , only changing the order of the
+# NSg/V . NSg     V/J      . NPrSg/V/J/P D   I/J  J      NSg/I/V . W?   NSg/V    D   NSg/V P  D
 > words a   little    , “ From the Queen   . An  invitation for the Duchess to play  croquet . ”
 # NPl   D/P NPrSg/I/J . . P    D   NPrSg/V . D/P NSg        C/P D   NSg/V   P  NSg/V NSg/V   . .
 >
@@ -2156,8 +2156,8 @@
 #
 > Alice laughed so        much  at        this , that    she had to run   back    into the wood      for fear
 # NPr   W?      NSg/I/J/C N/I/J NSg/I/V/P I/D  . N/I/C/D ISg V   P  NSg/V NSg/V/J P    D   NPrSg/V/J C/P NSg/V
-> of  their hearing her   ; and when    she next    peeped out         the Fish  - Footman was gone  ,
-# V/P D     NSg/V/J I/J/D . V/C NSg/I/C ISg NSg/J/P W?     NSg/V/J/R/P D   NSg/V . NSg     V   V/J/P .
+> of their hearing her   ; and when    she next    peeped out         the Fish  - Footman was gone  ,
+# P  D     NSg/V/J I/J/D . V/C NSg/I/C ISg NSg/J/P W?     NSg/V/J/R/P D   NSg/V . NSg     V   V/J/P .
 > and the other   was sitting on  the ground  near      the door  , staring stupidly up        into
 # V/C D   NSg/V/J V   NSg/V/J J/P D   NSg/V/J NSg/V/J/P D   NSg/V . V       J/R      NSg/V/J/P P
 > the sky   .
@@ -2168,10 +2168,10 @@
 # NPr   NSg/V J/R     NSg/V/J/P P  D   NSg/V . V/C W?      .
 >
 #
-> “ There’s no      sort  of  use   in          knocking , ” said the Footman , “ and that    for two
-# . W?      NPrSg/P NSg/V V/P NSg/V NPrSg/V/J/P V        . . V/J  D   NSg     . . V/C N/I/C/D C/P NSg
-> reasons . First   , because I’m on  the same side    of  the door  as    you are ; secondly ,
-# NPl     . NSg/V/J . C/P     W?  J/P D   I/J  NSg/V/J V/P D   NSg/V NSg/R IPl V   . J/R      .
+> “ There’s no      sort  of use   in          knocking , ” said the Footman , “ and that    for two
+# . W?      NPrSg/P NSg/V P  NSg/V NPrSg/V/J/P V        . . V/J  D   NSg     . . V/C N/I/C/D C/P NSg
+> reasons . First   , because I’m on  the same side    of the door  as    you are ; secondly ,
+# NPl     . NSg/V/J . C/P     W?  J/P D   I/J  NSg/V/J P  D   NSg/V NSg/R IPl V   . J/R      .
 > because they’re making such  a   noise inside  , no      one       could  possibly hear you . ” And
 # C/P     W?      NSg/V  NSg/I D/P NSg/V NSg/J/P . NPrSg/P NSg/I/V/J NSg/VX R        V    IPl . . V/C
 > certainly there was a   most    extraordinary noise going   on  within — a   constant
@@ -2196,8 +2196,8 @@
 # P    D   NSg/V NSg/I/J/C D   NSg/V NPr/ISg V   V        . V/C I/D  NPr   NSg/V   J/R
 > uncivil . “ But     perhaps he      can’t help  it        , ” she said to herself ; “ his   eyes are so
 # J       . . NSg/C/P NSg     NPr/ISg VX    NSg/V NPrSg/ISg . . ISg V/J  P  I       . . ISg/D NPl  V   NSg/I/J/C
-> very nearly at        the top     of  his   head      . But     at        any   rate  he      might    answer
-# J    J/R    NSg/I/V/P D   NSg/V/J V/P ISg/D NPrSg/V/J . NSg/C/P NSg/I/V/P I/R/D NSg/V NPr/ISg NSg/VX/J NSg/V
+> very nearly at        the top     of his   head      . But     at        any   rate  he      might    answer
+# J    J/R    NSg/I/V/P D   NSg/V/J P  ISg/D NPrSg/V/J . NSg/C/P NSg/I/V/P I/R/D NSg/V NPr/ISg NSg/VX/J NSg/V
 > questions . — How   am        I   to get   in          ? ” she repeated , aloud .
 # NPl       . . NSg/C NPrSg/V/J ISg P  NSg/V NPrSg/V/J/P . . ISg V/J      . J     .
 >
@@ -2206,12 +2206,12 @@
 # . ISg VX    NSg/V NSg/J/R . . D   NSg     V/J      . . NSg/V/C/P NSg      . .
 >
 #
-> At        this moment the door  of  the house   opened , and a   large plate came    skimming
-# NSg/I/V/P I/D  NSg    D   NSg/V V/P D   NPrSg/V V/J    . V/C D/P NSg/J NSg/V NSg/V/P NSg/V
+> At        this moment the door  of the house   opened , and a   large plate came    skimming
+# NSg/I/V/P I/D  NSg    D   NSg/V P  D   NPrSg/V V/J    . V/C D/P NSg/J NSg/V NSg/V/P NSg/V
 > out         , straight at        the Footman’s head      : it        just grazed his   nose  , and broke   to
 # NSg/V/J/R/P . NSg/V/J  NSg/I/V/P D   N$        NPrSg/V/J . NPrSg/ISg V/J  W?     ISg/D NSg/V . V/C NSg/V/J P
-> pieces against one       of  the trees behind  him .
-# NPl    C/P     NSg/I/V/J V/P D   NPl   NSg/J/P I   .
+> pieces against one       of the trees behind  him .
+# NPl    C/P     NSg/I/V/J P  D   NPl   NSg/J/P I   .
 >
 #
 > “ — or      next    day   , maybe   , ” the Footman continued in          the same tone    , exactly as    if
@@ -2258,14 +2258,14 @@
 # J       . . V/C ISg V/J    D   NSg/V V/C NSg/V NPrSg/V/J/P .
 >
 #
-> The door  led right     into a   large kitchen , which was full    of  smoke from one       end   to
-# D   NSg/V NSg NPrSg/V/J P    D/P NSg/J NSg/V   . I/C   V   NSg/V/J V/P NSg/V P    NSg/I/V/J NSg/V P
+> The door  led right     into a   large kitchen , which was full    of smoke from one       end   to
+# D   NSg/V NSg NPrSg/V/J P    D/P NSg/J NSg/V   . I/C   V   NSg/V/J P  NSg/V P    NSg/I/V/J NSg/V P
 > the other   : the Duchess was sitting on  a   three - legged  stool in          the middle  ,
 # D   NSg/V/J . D   NSg/V   V   NSg/V/J J/P D/P NSg   . NSg/V/J NSg/V NPrSg/V/J/P D   NSg/V/J .
 > nursing a   baby    ; the cook    was leaning over      the fire    , stirring a   large cauldron
 # NSg/V/J D/P NSg/V/J . D   NPrSg/V V   NSg/V   NSg/V/J/P D   NSg/V/J . NSg/V/J  D/P NSg/J NSg
-> which seemed to be     full    of  soup  .
-# I/C   W?     P  NSg/VX NSg/V/J V/P NSg/V .
+> which seemed to be     full    of soup  .
+# I/C   W?     P  NSg/VX NSg/V/J P  NSg/V .
 >
 #
 > “ There’s certainly too much  pepper in          that    soup  ! ” Alice said to herself , as    well
@@ -2274,8 +2274,8 @@
 # NSg/R ISg NSg/VX C/P V        .
 >
 #
-> There was certainly too much  of  it        in          the air   . Even    the Duchess sneezed
-# W?    V   J/R       W?  N/I/J V/P NPrSg/ISg NPrSg/V/J/P D   NSg/V . NSg/V/J D   NSg/V   W?
+> There was certainly too much  of it        in          the air   . Even    the Duchess sneezed
+# W?    V   J/R       W?  N/I/J P  NPrSg/ISg NPrSg/V/J/P D   NSg/V . NSg/V/J D   NSg/V   W?
 > occasionally ; and as    for the baby    , it        was sneezing and howling alternately
 # J/R          . V/C NSg/R C/P D   NSg/V/J . NPrSg/ISg V   V        V/C V       J/R
 > without a   moment’s pause . The only things in          the kitchen that    did not   sneeze ,
@@ -2312,12 +2312,12 @@
 # NPl  NSg/VX NSg/V . .
 >
 #
-> “ They all       can      , ” said the Duchess ; “ and most    of  ’ em      do     . ”
-# . IPl  NSg/I/J/C NPrSg/VX . . V/J  D   NSg/V   . . V/C NSg/I/J V/P . NSg/I/J NSg/VX . .
+> “ They all       can      , ” said the Duchess ; “ and most    of ’ em      do     . ”
+# . IPl  NSg/I/J/C NPrSg/VX . . V/J  D   NSg/V   . . V/C NSg/I/J P  . NSg/I/J NSg/VX . .
 >
 #
-> “ I   don’t know  of  any   that    do     , ” Alice said very politely , feeling quite pleased
-# . ISg NSg/V NSg/V V/P I/R/D N/I/C/D NSg/VX . . NPr   V/J  J    J/R      . NSg/V/J NSg   W?
+> “ I   don’t know  of any   that    do     , ” Alice said very politely , feeling quite pleased
+# . ISg NSg/V NSg/V P  I/R/D N/I/C/D NSg/VX . . NPr   V/J  J    J/R      . NSg/V/J NSg   W?
 > to have   got into a   conversation .
 # P  NSg/VX V   P    D/P NSg/V        .
 >
@@ -2326,18 +2326,18 @@
 # . IPl NSg/V NSg/V N/I/J . . V/J  D   NSg/V   . . V/C N$     D/P NSg  . .
 >
 #
-> Alice did not   at        all       like        the tone    of  this remark , and thought it        would  be     as
-# NPr   V   NSg/C NSg/I/V/P NSg/I/J/C NSg/V/J/C/P D   NSg/I/V V/P I/D  NSg/V  . V/C NSg/V   NPrSg/ISg NSg/VX NSg/VX NSg/R
-> well    to introduce some  other   subject of  conversation . While     she was trying  to
-# NSg/V/J P  V         I/J/R NSg/V/J NSg/V/J V/P NSg/V        . NSg/V/C/P ISg V   NSg/V/J P
-> fix   on  one       , the cook    took the cauldron of  soup  off       the fire    , and at        once  set       to
-# NSg/V J/P NSg/I/V/J . D   NPrSg/V V    D   NSg      V/P NSg/V NSg/V/J/P D   NSg/V/J . V/C NSg/I/V/P NSg/C NPrSg/V/J P
+> Alice did not   at        all       like        the tone    of this remark , and thought it        would  be     as
+# NPr   V   NSg/C NSg/I/V/P NSg/I/J/C NSg/V/J/C/P D   NSg/I/V P  I/D  NSg/V  . V/C NSg/V   NPrSg/ISg NSg/VX NSg/VX NSg/R
+> well    to introduce some  other   subject of conversation . While     she was trying  to
+# NSg/V/J P  V         I/J/R NSg/V/J NSg/V/J P  NSg/V        . NSg/V/C/P ISg V   NSg/V/J P
+> fix   on  one       , the cook    took the cauldron of soup  off       the fire    , and at        once  set       to
+# NSg/V J/P NSg/I/V/J . D   NPrSg/V V    D   NSg      P  NSg/V NSg/V/J/P D   NSg/V/J . V/C NSg/I/V/P NSg/C NPrSg/V/J P
 > work  throwing everything within her   reach at        the Duchess and the baby    — the
 # NSg/V V        N/I/V      N/J/P  I/J/D NSg/V NSg/I/V/P D   NSg/V   V/C D   NSg/V/J . D
-> fire    - irons came    first   ; then    followed a   shower  of  saucepans , plates , and dishes .
-# NSg/V/J . NPl   NSg/V/P NSg/V/J . NSg/J/C W?       D/P NSg/V/J V/P NPl       . NPl    . V/C NPl    .
-> The Duchess took no      notice of  them even    when    they hit       her   ; and the baby    was
-# D   NSg/V   V    NPrSg/P NSg/V  V/P N/I  NSg/V/J NSg/I/C IPl  NSg/I/V/J I/J/D . V/C D   NSg/V/J V
+> fire    - irons came    first   ; then    followed a   shower  of saucepans , plates , and dishes .
+# NSg/V/J . NPl   NSg/V/P NSg/V/J . NSg/J/C W?       D/P NSg/V/J P  NPl       . NPl    . V/C NPl    .
+> The Duchess took no      notice of them even    when    they hit       her   ; and the baby    was
+# D   NSg/V   V    NPrSg/P NSg/V  P  N/I  NSg/V/J NSg/I/C IPl  NSg/I/V/J I/J/D . V/C D   NSg/V/J V
 > howling so        much  already , that    it        was quite impossible to say   whether the blows
 # V       NSg/I/J/C N/I/J W?      . N/I/C/D NPrSg/ISg V   NSg   NSg/J      P  NSg/V I/C     D   NPl
 > hurt    it        or      not   .
@@ -2346,8 +2346,8 @@
 #
 > “ Oh      , please mind  what  you’re doing ! ” cried Alice , jumping up        and down      in          an
 # . NPrSg/V . V      NSg/V NSg/I W?     NSg/V . . W?    NPr   . V       NSg/V/J/P V/C NSg/V/J/P NPrSg/V/J/P D/P
-> agony of  terror . “ Oh      , there goes  his   precious nose  ! ” as    an  unusually large
-# NSg   V/P NSg    . . NPrSg/V . W?    NSg/V ISg/D NSg/J    NSg/V . . NSg/R D/P J/R       NSg/J
+> agony of terror . “ Oh      , there goes  his   precious nose  ! ” as    an  unusually large
+# NSg   P  NSg    . . NPrSg/V . W?    NSg/V ISg/D NSg/J    NSg/V . . NSg/R D/P J/R       NSg/J
 > saucepan flew    close   by      it        , and very nearly carried it        off       .
 # NSg/V    NSg/V/J NSg/V/J NSg/J/P NPrSg/ISg . V/C J    J/R    W?      NPrSg/ISg NSg/V/J/P .
 >
@@ -2360,16 +2360,16 @@
 #
 > “ Which would  not   be     an  advantage , ” said Alice , who     felt    very glad    to get   an
 # . I/C   NSg/VX NSg/C NSg/VX D/P NSg/V     . . V/J  NPr   . NPrSg/I NSg/V/J J    NSg/V/J P  NSg/V D/P
-> opportunity of  showing off       a   little    of  her   knowledge . “ Just think of  what  work
-# NSg         V/P NSg/V   NSg/V/J/P D/P NPrSg/I/J V/P I/J/D NSg/V     . . V/J  NSg/V V/P NSg/I NSg/V
+> opportunity of showing off       a   little    of her   knowledge . “ Just think of what  work
+# NSg         P  NSg/V   NSg/V/J/P D/P NPrSg/I/J P  I/J/D NSg/V     . . V/J  NSg/V P  NSg/I NSg/V
 > it        would  make  with the day   and night ! You see   the earth   takes twenty - four hours
 # NPrSg/ISg NSg/VX NSg/V P    D   NPrSg V/C NSg/V . IPl NSg/V D   NPrSg/V NPl   NSg    . NSg  NPl
 > to turn  round     on  its   axis  — ”
 # P  NSg/V NSg/V/J/P J/P ISg/D NPrSg . .
 >
 #
-> “ Talking of  axes , ” said the Duchess , “ chop  off       her   head      ! ”
-# . V       V/P NPl  . . V/J  D   NSg/V   . . NSg/V NSg/V/J/P I/J/D NPrSg/V/J . .
+> “ Talking of axes , ” said the Duchess , “ chop  off       her   head      ! ”
+# . V       P  NPl  . . V/J  D   NSg/V   . . NSg/V NSg/V/J/P I/J/D NPrSg/V/J . .
 >
 #
 > Alice glanced rather    anxiously at        the cook    , to see   if    she meant to take  the
@@ -2382,10 +2382,10 @@
 #
 > “ Oh      , don’t bother me        , ” said the Duchess ; “ I   never could  abide figures ! ” And with
 # . NPrSg/V . NSg/V NSg/V  NPrSg/ISg . . V/J  D   NSg/V   . . ISg V     NSg/VX V     NPl     . . V/C P
-> that    she began nursing her   child again , singing a   sort  of  lullaby to it        as    she
-# N/I/C/D ISg V     NSg/V/J I/J/D NSg/V P     . NSg/V/J D/P NSg/V V/P NSg/V   P  NPrSg/ISg NSg/R ISg
-> did so        , and giving it        a   violent shake at        the end   of  every line  :
-# V   NSg/I/J/C . V/C V      NPrSg/ISg D/P NSg/V/J NSg/V NSg/I/V/P D   NSg/V V/P D     NSg/V .
+> that    she began nursing her   child again , singing a   sort  of lullaby to it        as    she
+# N/I/C/D ISg V     NSg/V/J I/J/D NSg/V P     . NSg/V/J D/P NSg/V P  NSg/V   P  NPrSg/ISg NSg/R ISg
+> did so        , and giving it        a   violent shake at        the end   of every line  :
+# V   NSg/I/J/C . V/C V      NPrSg/ISg D/P NSg/V/J NSg/V NSg/I/V/P D   NSg/V P  D     NSg/V .
 >
 #
 > “ Speak roughly to your little    boy   , And beat    him when    he      sneezes : He      only does
@@ -2402,8 +2402,8 @@
 # . NSg/V . NSg/V . NSg/V . .
 >
 #
-> While     the Duchess sang    the second  verse of  the song , she kept tossing the baby
-# NSg/V/C/P D   NSg/V   NPrSg/V D   NSg/V/J NSg/V V/P D   NSg  . ISg V    V       D   NSg/V/J
+> While     the Duchess sang    the second  verse of the song , she kept tossing the baby
+# NSg/V/C/P D   NSg/V   NPrSg/V D   NSg/V/J NSg/V P  D   NSg  . ISg V    V       D   NSg/V/J
 > violently up        and down      , and the poor    little    thing howled so        , that    Alice could
 # J/R       NSg/V/J/P V/C NSg/V/J/P . V/C D   NSg/V/J NPrSg/I/J NSg/V W?     NSg/I/J/C . N/I/C/D NPr   NSg/VX
 > hardly hear the words : —
@@ -2428,8 +2428,8 @@
 # . NSg/J/R . IPl NPrSg/VX NSg/V NPrSg/ISg D/P NSg/V . NSg/C IPl NSg/V/J/C/P . . D   NSg/V   V/J  P  NPr   . V
 > the baby    at        her   as    she spoke . “ I   must  go      and get   ready   to play  croquet with the
 # D   NSg/V/J NSg/I/V/P I/J/D NSg/R ISg NSg/V . . ISg NSg/V NSg/V/J V/C NSg/V NSg/V/J P  NSg/V NSg/V   P    D
-> Queen   , ” and she hurried out         of  the room    . The cook    threw a   frying - pan       after her
-# NPrSg/V . . V/C ISg V/J     NSg/V/J/R/P V/P D   NSg/V/J . D   NPrSg/V V     D/P V      . NPrSg/V/J J/P   I/J/D
+> Queen   , ” and she hurried out         of the room    . The cook    threw a   frying - pan       after her
+# NPrSg/V . . V/C ISg V/J     NSg/V/J/R/P P  D   NSg/V/J . D   NPrSg/V V     D/P V      . NPrSg/V/J J/P   I/J/D
 > as    she went  out         , but     it        just missed her   .
 # NSg/R ISg NSg/V NSg/V/J/R/P . NSg/C/P NPrSg/ISg V/J  V      I/J/D .
 >
@@ -2448,10 +2448,10 @@
 # N/I/J NSg/R ISg NSg/VX NSg/VX P  NSg/V/J NPrSg/ISg .
 >
 #
-> As    soon as    she had made  out         the proper way   of  nursing it        , ( which was to twist it
-# NSg/R J/R  NSg/R ISg V   NSg/V NSg/V/J/R/P D   NSg/J  NSg/J V/P NSg/V/J NPrSg/ISg . . I/C   V   P  NSg/V NPrSg/ISg
-> up        into a   sort  of  knot  , and then    keep  tight hold    of  its   right     ear   and left      foot  ,
-# NSg/V/J/P P    D/P NSg/V V/P NSg/V . V/C NSg/J/C NSg/V V/J   NSg/V/J V/P ISg/D NPrSg/V/J NSg/V V/C NPrSg/V/J NSg/V .
+> As    soon as    she had made  out         the proper way   of nursing it        , ( which was to twist it
+# NSg/R J/R  NSg/R ISg V   NSg/V NSg/V/J/R/P D   NSg/J  NSg/J P  NSg/V/J NPrSg/ISg . . I/C   V   P  NSg/V NPrSg/ISg
+> up        into a   sort  of knot  , and then    keep  tight hold    of its   right     ear   and left      foot  ,
+# NSg/V/J/P P    D/P NSg/V P  NSg/V . V/C NSg/J/C NSg/V V/J   NSg/V/J P  ISg/D NPrSg/V/J NSg/V V/C NPrSg/V/J NSg/V .
 > so        as    to prevent its   undoing itself , ) she carried it        out         into the open    air   . “ If
 # NSg/I/J/C NSg/R P  V       ISg/D NSg/V   I      . . ISg W?      NPrSg/ISg NSg/V/J/R/P P    D   NSg/V/J NSg/V . . NSg/C
 > I   don’t take  this child away with me        , ” thought Alice , “ they’re sure to kill  it
@@ -2461,7 +2461,7 @@
 > words out         loud  , and the little    thing grunted in          reply ( it        had left      off       sneezing
 # NPl   NSg/V/J/R/P NSg/J . V/C D   NPrSg/I/J NSg/V W?      NPrSg/V/J/P NSg/V . NPrSg/ISg V   NPrSg/V/J NSg/V/J/P V
 > by      this time  ) . “ Don’t grunt , ” said Alice ; “ that’s not   at        all       a   proper way   of
-# NSg/J/P I/D  NSg/V . . . NSg/V NSg/V . . V/J  NPr   . . N$     NSg/C NSg/I/V/P NSg/I/J/C D/P NSg/J  NSg/J V/P
+# NSg/J/P I/D  NSg/V . . . NSg/V NSg/V . . V/J  NPr   . . N$     NSg/C NSg/I/V/P NSg/I/J/C D/P NSg/J  NSg/J P
 > expressing yourself . ”
 # V          I        . .
 >
@@ -2472,8 +2472,8 @@
 # NSg/I V   D   NSg/V/J P    NPrSg/ISg . W?    NSg/VX NSg/VX NPrSg/P NSg/V N/I/C/D NPrSg/ISg V   D/P J    NSg/V . NSg/V/J/P
 > nose  , much  more        like        a   snout than a   real  nose  ; also its   eyes were  getting
 # NSg/V . N/I/J NPrSg/I/V/J NSg/V/J/C/P D/P NSg/V C/P  D/P NSg/J NSg/V . W?   ISg/D NPl  NSg/V NSg/V
-> extremely small     for a   baby    : altogether Alice did not   like        the look  of  the thing
-# J/R       NPrSg/V/J C/P D/P NSg/V/J . NSg        NPr   V   NSg/C NSg/V/J/C/P D   NSg/V V/P D   NSg/V
+> extremely small     for a   baby    : altogether Alice did not   like        the look  of the thing
+# J/R       NPrSg/V/J C/P D/P NSg/V/J . NSg        NPr   V   NSg/C NSg/V/J/C/P D   NSg/V P  D   NSg/V
 > at        all       . “ But     perhaps it        was only sobbing , ” she thought , and looked into its   eyes
 # NSg/I/V/P NSg/I/J/C . . NSg/C/P NSg     NPrSg/ISg V   W?   NSg/V/J . . ISg NSg/V   . V/C W?     P    ISg/D NPl
 > again , to see   if    there were  any   tears .
@@ -2513,7 +2513,7 @@
 > and was just saying to herself , “ if    one       only knew the right     way   to change them — ”
 # V/C V   V/J  NSg/V  P  I       . . NSg/C NSg/I/V/J W?   V    D   NPrSg/V/J NSg/J P  NSg/V  N/I  . .
 > when    she was a   little    startled by      seeing    the Cheshire Cat     sitting on  a   bough of
-# NSg/I/C ISg V   D/P NPrSg/I/J W?       NSg/J/P NSg/V/J/C D   NPr      NSg/V/J NSg/V/J J/P D/P NSg   V/P
+# NSg/I/C ISg V   D/P NPrSg/I/J W?       NSg/J/P NSg/V/J/C D   NPr      NSg/V/J NSg/V/J J/P D/P NSg   P
 > a   tree  a   few yards off       .
 # D/P NSg/V D/P N/I NPl   NSg/V/J/P .
 >
@@ -2558,8 +2558,8 @@
 #
 > Alice felt    that    this could  not   be     denied , so        she tried another question . “ What
 # NPr   NSg/V/J N/I/C/D I/D  NSg/VX NSg/C NSg/VX W?     . NSg/I/J/C ISg V/J   I/D     NSg/V    . . NSg/I
-> sort  of  people live about here    ? ”
-# NSg/V V/P NSg/V  V/J  J/P   NSg/J/R . .
+> sort  of people live about here    ? ”
+# NSg/V P  NSg/V  V/J  J/P   NSg/J/R . .
 >
 #
 > “ In          that    direction , ” the Cat     said , waving its   right     paw   round     , “ lives a   Hatter :
@@ -2636,8 +2636,8 @@
 # W?       P     .
 >
 #
-> “ By      - the - bye     , what  became of  the baby    ? ” said the Cat     . “ I’d nearly forgotten to
-# . NSg/J/P . D   . NSg/J/P . NSg/I V      V/P D   NSg/V/J . . V/J  D   NSg/V/J . . W?  J/R    NSg/V/J   P
+> “ By      - the - bye     , what  became of the baby    ? ” said the Cat     . “ I’d nearly forgotten to
+# . NSg/J/P . D   . NSg/J/P . NSg/I V      P  D   NSg/V/J . . V/J  D   NSg/V/J . . W?  J/R    NSg/V/J   P
 > ask   . ”
 # NSg/V . .
 >
@@ -2662,8 +2662,8 @@
 # NSg/V/J NPrSg/VX NSg/VX N/I/J D   NSg/I/J V/J         . V/C NSg     NSg/R I/D  VL NPrSg/VX NPrSg/ISg V     NSg/VX
 > raving  mad   — at        least not   so        mad   as    it        was in          March   . ” As    she said this , she looked
 # NSg/V/J N/V/J . NSg/I/V/P NSg/J NSg/C NSg/I/J/C N/V/J NSg/R NPrSg/ISg V   NPrSg/V/J/P NPrSg/V . . NSg/R ISg V/J  I/D  . ISg W?
-> up        , and there was the Cat     again , sitting on  a   branch  of  a   tree  .
-# NSg/V/J/P . V/C W?    V   D   NSg/V/J P     . NSg/V/J J/P D/P NPrSg/V V/P D/P NSg/V .
+> up        , and there was the Cat     again , sitting on  a   branch  of a   tree  .
+# NSg/V/J/P . V/C W?    V   D   NSg/V/J P     . NSg/V/J J/P D/P NPrSg/V P  D/P NSg/V .
 >
 #
 > “ Did you say   pig   , or      fig   ? ” said the Cat     .
@@ -2678,10 +2678,10 @@
 #
 > “ All       right     , ” said the Cat     ; and this time  it        vanished quite slowly , beginning
 # . NSg/I/J/C NPrSg/V/J . . V/J  D   NSg/V/J . V/C I/D  NSg/V NPrSg/ISg W?       NSg   J/R    . NSg/V/J
-> with the end   of  the tail    , and ending with the grin  , which remained some  time
-# P    D   NSg/V V/P D   NSg/V/J . V/C NSg/V  P    D   NSg/V . I/C   W?       I/J/R NSg/V
-> after the rest  of  it        had gone  .
-# J/P   D   NSg/V V/P NPrSg/ISg V   V/J/P .
+> with the end   of the tail    , and ending with the grin  , which remained some  time
+# P    D   NSg/V P  D   NSg/V/J . V/C NSg/V  P    D   NSg/V . I/C   W?       I/J/R NSg/V
+> after the rest  of it        had gone  .
+# J/P   D   NSg/V P  NPrSg/ISg V   V/J/P .
 >
 #
 > “ Well    ! I’ve often seen  a   cat     without a   grin  , ” thought Alice ; “ but     a   grin  without
@@ -2690,14 +2690,14 @@
 # D/P NSg/V/J . W?   D   NSg/I/J J       NSg/V ISg J    NSg/V NPrSg/V/J/P D  NSg/V . .
 >
 #
-> She had not   gone  much  farther before she came    in          sight of  the house   of  the March
-# ISg V   NSg/C V/J/P N/I/J V/J     C/P    ISg NSg/V/P NPrSg/V/J/P NSg/V V/P D   NPrSg/V V/P D   NPrSg/V
+> She had not   gone  much  farther before she came    in          sight of the house   of the March
+# ISg V   NSg/C V/J/P N/I/J V/J     C/P    ISg NSg/V/P NPrSg/V/J/P NSg/V P  D   NPrSg/V P  D   NPrSg/V
 > Hare    : she thought it        must  be     the right     house   , because the chimneys were  shaped
 # NSg/V/J . ISg NSg/V   NPrSg/ISg NSg/V NSg/VX D   NPrSg/V/J NPrSg/V . C/P     D   NPl      NSg/V V/J
 > like        ears and the roof  was thatched with fur       . It        was so        large a   house   , that    she
 # NSg/V/J/C/P NPl  V/C D   NSg/V V   W?       P    NSg/V/C/P . NPrSg/ISg V   NSg/I/J/C NSg/J D/P NPrSg/V . N/I/C/D ISg
-> did not   like        to go      nearer till      she had nibbled some  more        of  the lefthand bit   of
-# V   NSg/C NSg/V/J/C/P P  NSg/V/J J      NSg/V/C/P ISg V   W?      I/J/R NPrSg/I/V/J V/P D   ?        NSg/V V/P
+> did not   like        to go      nearer till      she had nibbled some  more        of the lefthand bit   of
+# V   NSg/C NSg/V/J/C/P P  NSg/V/J J      NSg/V/C/P ISg V   W?      I/J/R NPrSg/I/V/J P  D   ?        NSg/V P
 > mushroom , and raised herself to about two feet high    : even    then    she walked up
 # NSg/V/J  . V/C W?     I       P  J/P   NSg NSg  NSg/V/J . NSg/V/J NSg/J/C ISg W?     NSg/V/J/P
 > towards it        rather    timidly , saying to herself “ Suppose it        should be     raving  mad
@@ -2710,8 +2710,8 @@
 # NSg/V   NSg . D/P N/V/J NSg/V . NSg/V/J
 >
 #
-> There was a   table set       out         under   a   tree  in          front   of  the house   , and the March   Hare
-# W?    V   D/P NSg/V NPrSg/V/J NSg/V/J/R/P NSg/J/P D/P NSg/V NPrSg/V/J/P NSg/V/J V/P D   NPrSg/V . V/C D   NPrSg/V NSg/V/J
+> There was a   table set       out         under   a   tree  in          front   of the house   , and the March   Hare
+# W?    V   D/P NSg/V NPrSg/V/J NSg/V/J/R/P NSg/J/P D/P NSg/V NPrSg/V/J/P NSg/V/J P  D   NPrSg/V . V/C D   NPrSg/V NSg/V/J
 > and the Hatter were  having tea   at        it        : a   Dormouse was sitting between them , fast
 # V/C D   NSg/V  NSg/V V      NSg/V NSg/I/V/P NPrSg/ISg . D/P NSg      V   NSg/V/J NSg/P   N/I  . NSg/V/J
 > asleep , and the other   two were  using it        as    a   cushion , resting their elbows on
@@ -2724,12 +2724,12 @@
 #
 > The table was a   large one       , but     the three were  all       crowded together at        one       corner
 # D   NSg/V V   D/P NSg/J NSg/I/V/J . NSg/C/P D   NSg   NSg/V NSg/I/J/C V/J     J        NSg/I/V/P NSg/I/V/J NSg/V/J
-> of  it        : “ No      room    ! No      room    ! ” they cried out         when    they saw   Alice coming  . “ There’s
-# V/P NPrSg/ISg . . NPrSg/P NSg/V/J . NPrSg/P NSg/V/J . . IPl  W?    NSg/V/J/R/P NSg/I/C IPl  NSg/V NPr   NSg/V/J . . W?
-> plenty  of  room    ! ” said Alice indignantly , and she sat     down      in          a   large arm     - chair
-# NSg/I/J V/P NSg/V/J . . V/J  NPr   J/R         . V/C ISg NSg/V/J NSg/V/J/P NPrSg/V/J/P D/P NSg/J NSg/V/J . NSg/V
-> at        one       end   of  the table .
-# NSg/I/V/P NSg/I/V/J NSg/V V/P D   NSg/V .
+> of it        : “ No      room    ! No      room    ! ” they cried out         when    they saw   Alice coming  . “ There’s
+# P  NPrSg/ISg . . NPrSg/P NSg/V/J . NPrSg/P NSg/V/J . . IPl  W?    NSg/V/J/R/P NSg/I/C IPl  NSg/V NPr   NSg/V/J . . W?
+> plenty  of room    ! ” said Alice indignantly , and she sat     down      in          a   large arm     - chair
+# NSg/I/J P  NSg/V/J . . V/J  NPr   J/R         . V/C ISg NSg/V/J NSg/V/J/P NPrSg/V/J/P D/P NSg/J NSg/V/J . NSg/V
+> at        one       end   of the table .
+# NSg/I/V/P NSg/I/V/J NSg/V P  D   NSg/V .
 >
 #
 > “ Have   some  wine  , ” the March   Hare    said in          an  encouraging tone    .
@@ -2746,12 +2746,12 @@
 # . W?    NSg/V I/R/D . . V/J  D   NPrSg/V NSg/V/J .
 >
 #
-> “ Then    it        wasn’t very civil of  you to offer   it        , ” said Alice angrily .
-# . NSg/J/C NPrSg/ISg V      J    J     V/P IPl P  NSg/V/J NPrSg/ISg . . V/J  NPr   R       .
+> “ Then    it        wasn’t very civil of you to offer   it        , ” said Alice angrily .
+# . NSg/J/C NPrSg/ISg V      J    J     P  IPl P  NSg/V/J NPrSg/ISg . . V/J  NPr   R       .
 >
 #
-> “ It        wasn’t very civil of  you to sit   down      without being   invited , ” said the March
-# . NPrSg/ISg V      J    J     V/P IPl P  NSg/V NSg/V/J/P C/P     NSg/V/C NSg/V/J . . V/J  D   NPrSg/V
+> “ It        wasn’t very civil of you to sit   down      without being   invited , ” said the March
+# . NPrSg/ISg V      J    J     P  IPl P  NSg/V NSg/V/J/P C/P     NSg/V/C NSg/V/J . . V/J  D   NPrSg/V
 > Hare    .
 # NSg/V/J .
 >
@@ -2834,10 +2834,10 @@
 # NSg/VX NSg/V    J/P   NPl    V/C NSg/V   . NPl   . I/C   V      N/I/J .
 >
 #
-> The Hatter was the first   to break the silence . “ What  day   of  the month is it        ? ” he
-# D   NSg/V  V   D   NSg/V/J P  NSg/V D   NSg/V   . . NSg/I NPrSg V/P D   NSg   VL NPrSg/ISg . . NPr/ISg
-> said , turning to Alice : he      had taken his   watch out         of  his   pocket  , and was
-# V/J  . NSg/V   P  NPr   . NPr/ISg V   V/J   ISg/D NSg/V NSg/V/J/R/P V/P ISg/D NSg/V/J . V/C V
+> The Hatter was the first   to break the silence . “ What  day   of the month is it        ? ” he
+# D   NSg/V  V   D   NSg/V/J P  NSg/V D   NSg/V   . . NSg/I NPrSg P  D   NSg   VL NPrSg/ISg . . NPr/ISg
+> said , turning to Alice : he      had taken his   watch out         of his   pocket  , and was
+# V/J  . NSg/V   P  NPr   . NPr/ISg V   V/J   ISg/D NSg/V NSg/V/J/R/P P  ISg/D NSg/V/J . V/C V
 > looking at        it        uneasily , shaking it        every now         and then    , and holding it        to his
 # V       NSg/I/V/P NPrSg/ISg R        . V       NPrSg/ISg D     NPrSg/V/J/C V/C NSg/J/C . V/C NSg/V   NPrSg/ISg P  ISg/D
 > ear   .
@@ -2866,16 +2866,16 @@
 #
 > The March   Hare    took the watch and looked at        it        gloomily : then    he      dipped it        into
 # D   NPrSg/V NSg/V/J V    D   NSg/V V/C W?     NSg/I/V/P NPrSg/ISg R        . NSg/J/C NPr/ISg V/J    NPrSg/ISg P
-> his   cup   of  tea   , and looked at        it        again : but     he      could  think of  nothing better   to
-# ISg/D NSg/V V/P NSg/V . V/C W?     NSg/I/V/P NPrSg/ISg P     . NSg/C/P NPr/ISg NSg/VX NSg/V V/P NSg/I/J NSg/VX/J P
+> his   cup   of tea   , and looked at        it        again : but     he      could  think of nothing better   to
+# ISg/D NSg/V P  NSg/V . V/C W?     NSg/I/V/P NPrSg/ISg P     . NSg/C/P NPr/ISg NSg/VX NSg/V P  NSg/I/J NSg/VX/J P
 > say   than his   first   remark , “ It        was the best       butter  , you know  . ”
 # NSg/V C/P  ISg/D NSg/V/J NSg/V  . . NPrSg/ISg V   D   NPrSg/VX/J NSg/V/J . IPl NSg/V . .
 >
 #
 > Alice had been  looking over      his   shoulder with some  curiosity . “ What  a   funny
 # NPr   V   NSg/V V       NSg/V/J/P ISg/D NSg/V    P    I/J/R NSg       . . NSg/I D/P NSg/J
-> watch ! ” she remarked . “ It        tells the day   of  the month , and doesn’t tell    what
-# NSg/V . . ISg V/J      . . NPrSg/ISg NPl   D   NPrSg V/P D   NSg   . V/C V       NPrSg/V NSg/I
+> watch ! ” she remarked . “ It        tells the day   of the month , and doesn’t tell    what
+# NSg/V . . ISg V/J      . . NPrSg/ISg NPl   D   NPrSg P  D   NSg   . V/C V       NPrSg/V NSg/I
 > o’clock it        is ! ”
 # W?      NPrSg/ISg VL . .
 >
@@ -2886,8 +2886,8 @@
 # VL . .
 >
 #
-> “ Of  course not   , ” Alice replied very readily : “ but     that’s because it        stays the
-# . V/P NSg/V  NSg/C . . NPr   W?      J    R       . . NSg/C/P N$     C/P     NPrSg/ISg NPl   D
+> “ Of course not   , ” Alice replied very readily : “ but     that’s because it        stays the
+# . P  NSg/V  NSg/C . . NPr   W?      J    R       . . NSg/C/P N$     C/P     NPrSg/ISg NPl   D
 > same year for such  a   long      time  together . ”
 # I/J  NSg  C/P NSg/I D/P NPrSg/V/J NSg/V J        . .
 >
@@ -2897,7 +2897,7 @@
 >
 #
 > Alice felt    dreadfully puzzled , The Hatter’s remark seemed to have   no      sort  of
-# NPr   NSg/V/J J/R        W?      . D   N$       NSg/V  W?     P  NSg/VX NPrSg/P NSg/V V/P
+# NPr   NSg/V/J J/R        W?      . D   N$       NSg/V  W?     P  NSg/VX NPrSg/P NSg/V P
 > meaning in          it        , and yet     it        was certainly English   . “ I   don’t quite understand you , ”
 # NSg/V/J NPrSg/V/J/P NPrSg/ISg . V/C NSg/V/C NPrSg/ISg V   J/R       NPrSg/V/J . . ISg NSg/V NSg   V          IPl . .
 > she said , as    politely as    she could  .
@@ -2911,9 +2911,9 @@
 >
 #
 > The Dormouse shook   its   head      impatiently , and said , without opening its   eyes , “ Of
-# D   NSg      NSg/V/J ISg/D NPrSg/V/J J/R         . V/C V/J  . C/P     NSg/V/J ISg/D NPl  . . V/P
-> course , of  course ; just what  I   was going   to remark myself . ”
-# NSg/V  . V/P NSg/V  . V/J  NSg/I ISg V   NSg/V/J P  NSg/V  I      . .
+# D   NSg      NSg/V/J ISg/D NPrSg/V/J J/R         . V/C V/J  . C/P     NSg/V/J ISg/D NPl  . . P
+> course , of course ; just what  I   was going   to remark myself . ”
+# NSg/V  . P  NSg/V  . V/J  NSg/I ISg V   NSg/V/J P  NSg/V  I      . .
 >
 #
 > “ Have   you guessed the riddle  yet     ? ” the Hatter said , turning to Alice again .
@@ -2948,8 +2948,8 @@
 # . ISg NSg/V NSg/V NSg/I IPl NSg/V/J . . V/J  NPr   .
 >
 #
-> “ Of  course you don’t ! ” the Hatter said , tossing his   head      contemptuously . “ I   dare
-# . V/P NSg/V  IPl NSg/V . . D   NSg/V  V/J  . V       ISg/D NPrSg/V/J J/R            . . ISg NPrSg/VX
+> “ Of course you don’t ! ” the Hatter said , tossing his   head      contemptuously . “ I   dare
+# . P  NSg/V  IPl NSg/V . . D   NSg/V  V/J  . V       ISg/D NPrSg/V/J J/R            . . ISg NPrSg/VX
 > say   you never even    spoke to Time  ! ”
 # NSg/V IPl V     NSg/V/J NSg/V P  NSg/V . .
 >
@@ -2996,8 +2996,8 @@
 # D   NSg/V  NSg/V/J ISg/D NPrSg/V/J J/R        . . NSg/C ISg . . NPr/ISg W?      . . IPl V/Br       NSg/V/J
 > March   — just before he      went  mad   , you know  — ” ( pointing with his   tea   spoon at        the
 # NPrSg/V . V/J  C/P    NPr/ISg NSg/V N/V/J . IPl NSg/V . . . V        P    ISg/D NSg/V NSg/V NSg/I/V/P D
-> March   Hare    , ) “ — it        was at        the great concert given     by      the Queen   of  Hearts , and I
-# NPrSg/V NSg/V/J . . . . NPrSg/ISg V   NSg/I/V/P D   NSg/J NSg/V   NSg/V/J/P NSg/J/P D   NPrSg/V V/P NPl    . V/C ISg
+> March   Hare    , ) “ — it        was at        the great concert given     by      the Queen   of Hearts , and I
+# NPrSg/V NSg/V/J . . . . NPrSg/ISg V   NSg/I/V/P D   NSg/J NSg/V   NSg/V/J/P NSg/J/P D   NPrSg/V P  NPl    . V/C ISg
 > had to sing
 # V   P  NSg/V
 >
@@ -3072,8 +3072,8 @@
 #
 > “ Suppose we  change the subject , ” the March   Hare    interrupted , yawning . “ I’m
 # . V       IPl NSg/V  D   NSg/V/J . . D   NPrSg/V NSg/V/J W?          . V       . . W?
-> getting tired of  this . I   vote  the young     lady    tells us      a   story . ”
-# NSg/V   V/J   V/P I/D  . ISg NSg/V D   NPrSg/V/J NPrSg/V NPl   NPr/ISg D/P NSg/V . .
+> getting tired of this . I   vote  the young     lady    tells us      a   story . ”
+# NSg/V   V/J   P  I/D  . ISg NSg/V D   NPrSg/V/J NPrSg/V NPl   NPr/ISg D/P NSg/V . .
 >
 #
 > “ I’m afraid I   don’t know  one       , ” said Alice , rather    alarmed at        the proposal .
@@ -3110,14 +3110,14 @@
 # . NSg/C P    D/P NSg/V W?    NSg/V NSg   NPrSg/I/J NPl     . . D   NSg      V     NPrSg/V/J/P D/P
 > great hurry ; “ and their names were  Elsie , Lacie , and Tillie ; and they lived at
 # NSg/J NSg/V . . V/C D     NPl   NSg/V NPr   . ?     . V/C ?      . V/C IPl  W?    NSg/I/V/P
-> the bottom  of  a   well    — ”
-# D   NSg/V/J V/P D/P NSg/V/J . .
+> the bottom  of a   well    — ”
+# D   NSg/V/J P  D/P NSg/V/J . .
 >
 #
 > “ What  did they live on  ? ” said Alice , who     always took a   great interest in
 # . NSg/I V   IPl  V/J  J/P . . V/J  NPr   . NPrSg/I W?     V    D/P NSg/J NSg/V    NPrSg/V/J/P
-> questions of  eating and drinking .
-# NPl       V/P V      V/C V        .
+> questions of eating and drinking .
+# NPl       P  V      V/C V        .
 >
 #
 > “ They lived on  treacle , ” said the Dormouse , after thinking a   minute  or      two .
@@ -3134,12 +3134,12 @@
 # . NSg/I/J/C IPl  NSg/V . . V/J  D   NSg      . . J    NSg/V/J . .
 >
 #
-> Alice tried to fancy   to herself what  such  an  extraordinary way   of  living  would
-# NPr   V/J   P  NSg/V/J P  I       NSg/I NSg/I D/P NSg/J         NSg/J V/P NSg/V/J NSg/VX
+> Alice tried to fancy   to herself what  such  an  extraordinary way   of living  would
+# NPr   V/J   P  NSg/V/J P  I       NSg/I NSg/I D/P NSg/J         NSg/J P  NSg/V/J NSg/VX
 > be     like        , but     it        puzzled her   too much  , so        she went  on  : “ But     why   did they live at
 # NSg/VX NSg/V/J/C/P . NSg/C/P NPrSg/ISg W?      I/J/D W?  N/I/J . NSg/I/J/C ISg NSg/V J/P . . NSg/C/P NSg/V V   IPl  V/J  NSg/I/V/P
-> the bottom  of  a   well    ? ”
-# D   NSg/V/J V/P D/P NSg/V/J . .
+> the bottom  of a   well    ? ”
+# D   NSg/V/J P  D/P NSg/V/J . .
 >
 #
 > “ Take  some  more        tea   , ” the March   Hare    said to Alice , very earnestly .
@@ -3170,8 +3170,8 @@
 # NPr   V   NSg/C NSg   NSg/V NSg/I P  NSg/V P  I/D  . NSg/I/J/C ISg W?     I       P  I/J/R NSg/V
 > and bread - and - butter  , and then    turned to the Dormouse , and repeated her
 # V/C NSg/V . V/C . NSg/V/J . V/C NSg/J/C W?     P  D   NSg      . V/C V/J      I/J/D
-> question . “ Why   did they live at        the bottom  of  a   well    ? ”
-# NSg/V    . . NSg/V V   IPl  V/J  NSg/I/V/P D   NSg/V/J V/P D/P NSg/V/J . .
+> question . “ Why   did they live at        the bottom  of a   well    ? ”
+# NSg/V    . . NSg/V V   IPl  V/J  NSg/I/V/P D   NSg/V/J P  D/P NSg/V/J . .
 >
 #
 > The Dormouse again took a   minute  or      two to think about it        , and then    said , “ It
@@ -3214,8 +3214,8 @@
 #
 > He      moved on  as    he      spoke , and the Dormouse followed him : the March   Hare    moved
 # NPr/ISg V/J   J/P NSg/R NPr/ISg NSg/V . V/C D   NSg      W?       I   . D   NPrSg/V NSg/V/J V/J
-> into the Dormouse’s place , and Alice rather    unwillingly took the place of  the
-# P    D   N$         NSg/V . V/C NPr   NPrSg/V/J J/R         V    D   NSg/V V/P D
+> into the Dormouse’s place , and Alice rather    unwillingly took the place of the
+# P    D   N$         NSg/V . V/C NPr   NPrSg/V/J J/R         V    D   NSg/V P  D
 > March   Hare    . The Hatter was the only one       who     got any   advantage from the change :
 # NPrSg/V NSg/V/J . D   NSg/V  V   D   W?   NSg/I/V/J NPrSg/I V   I/R/D NSg/V     P    D   NSg/V  .
 > and Alice was a   good      deal    worse   off       than before , as    the March   Hare    had just
@@ -3230,10 +3230,10 @@
 # . NSg/C/P ISg NSg/V V          . NSg/C V   IPl  NSg/V D   NSg/V   P    . .
 >
 #
-> “ You can      draw  water out         of  a   water - well    , ” said the Hatter ; “ so        I   should think
-# . IPl NPrSg/VX NSg/V NSg/V NSg/V/J/R/P V/P D/P NSg/V . NSg/V/J . . V/J  D   NSg/V  . . NSg/I/J/C ISg VX     NSg/V
-> you could  draw  treacle out         of  a   treacle - well    — eh  , stupid ? ”
-# IPl NSg/VX NSg/V NSg/V   NSg/V/J/R/P V/P D/P NSg/V   . NSg/V/J . V/J . NSg/J  . .
+> “ You can      draw  water out         of a   water - well    , ” said the Hatter ; “ so        I   should think
+# . IPl NPrSg/VX NSg/V NSg/V NSg/V/J/R/P P  D/P NSg/V . NSg/V/J . . V/J  D   NSg/V  . . NSg/I/J/C ISg VX     NSg/V
+> you could  draw  treacle out         of a   treacle - well    — eh  , stupid ? ”
+# IPl NSg/VX NSg/V NSg/V   NSg/V/J/R/P P  D/P NSg/V   . NSg/V/J . V/J . NSg/J  . .
 >
 #
 > “ But     they were  in          the well    , ” Alice said to the Dormouse , not   choosing to notice
@@ -3242,8 +3242,8 @@
 # I/D  NSg/V/J NSg/V  .
 >
 #
-> “ Of  course they were  , ” said the Dormouse ; “ — well    in          . ”
-# . V/P NSg/V  IPl  NSg/V . . V/J  D   NSg      . . . NSg/V/J NPrSg/V/J/P . .
+> “ Of course they were  , ” said the Dormouse ; “ — well    in          . ”
+# . P  NSg/V  IPl  NSg/V . . V/J  D   NSg      . . . NSg/V/J NPrSg/V/J/P . .
 >
 #
 > This answer so        confused poor    Alice , that    she let   the Dormouse go      on  for some
@@ -3255,7 +3255,7 @@
 > “ They were  learning to draw  , ” the Dormouse went  on  , yawning and rubbing its
 # . IPl  NSg/V V        P  NSg/V . . D   NSg      NSg/V J/P . V       V/C NSg/V   ISg/D
 > eyes , for it        was getting very sleepy ; “ and they drew  all       manner of
-# NPl  . C/P NPrSg/ISg V   NSg/V   J    NSg/J  . . V/C IPl  NPr/V NSg/I/J/C NSg    V/P
+# NPl  . C/P NPrSg/ISg V   NSg/V   J    NSg/J  . . V/C IPl  NPr/V NSg/I/J/C NSg    P
 > things — everything that    begins with an  M         — ”
 # NPl    . N/I/V      N/I/C/D NPl    P    D/P NPrSg/V/J . .
 >
@@ -3278,10 +3278,10 @@
 # NSg/C/P . J/P NSg/V/C W?      NSg/J/P D   NSg/V  . NPrSg/ISg NSg/V/J NSg/V/J/P P     P    D/P NPrSg/I/J NSg/V  . V/C
 > went  on  : “ — that    begins with an  M         , such  as    mouse - traps , and the moon    , and memory ,
 # NSg/V J/P . . . N/I/C/D NPl    P    D/P NPrSg/V/J . NSg/I NSg/R NSg/V . NPl   . V/C D   NPrSg/V . V/C NSg    .
-> and muchness — you know  you say   things are “ much  of  a   muchness ” — did you ever see
-# V/C W?       . IPl NSg/V IPl NSg/V NPl    V   . N/I/J V/P D/P W?       . . V   IPl J    NSg/V
-> such  a   thing as    a   drawing of  a   muchness ? ”
-# NSg/I D/P NSg/V NSg/R D/P NSg/V   V/P D/P W?       . .
+> and muchness — you know  you say   things are “ much  of a   muchness ” — did you ever see
+# V/C W?       . IPl NSg/V IPl NSg/V NPl    V   . N/I/J P  D/P W?       . . V   IPl J    NSg/V
+> such  a   thing as    a   drawing of a   muchness ? ”
+# NSg/I D/P NSg/V NSg/R D/P NSg/V   P  D/P W?       . .
 >
 #
 > “ Really , now         you ask   me        , ” said Alice , very much  confused , “ I   don’t think — ”
@@ -3292,12 +3292,12 @@
 # . NSg/J/C IPl NSg/V     NSg/V . . V/J  D   NSg/V  .
 >
 #
-> This piece of  rudeness was more        than Alice could  bear    : she got up        in          great
-# I/D  NSg/V V/P NSg      V   NPrSg/I/V/J C/P  NPr   NSg/VX NSg/V/J . ISg V   NSg/V/J/P NPrSg/V/J/P NSg/J
-> disgust , and walked off       ; the Dormouse fell    asleep instantly , and neither of  the
-# NSg/V   . V/C W?     NSg/V/J/P . D   NSg      NSg/V/J J      J/R       . V/C I/C     V/P D
-> others took the least notice of  her   going   , though she looked back    once  or      twice ,
-# NPl    V    D   NSg/J NSg/V  V/P I/J/D NSg/V/J . V/C    ISg W?     NSg/V/J NSg/C NPrSg/C W?    .
+> This piece of rudeness was more        than Alice could  bear    : she got up        in          great
+# I/D  NSg/V P  NSg      V   NPrSg/I/V/J C/P  NPr   NSg/VX NSg/V/J . ISg V   NSg/V/J/P NPrSg/V/J/P NSg/J
+> disgust , and walked off       ; the Dormouse fell    asleep instantly , and neither of the
+# NSg/V   . V/C W?     NSg/V/J/P . D   NSg      NSg/V/J J      J/R       . V/C I/C     P  D
+> others took the least notice of her   going   , though she looked back    once  or      twice ,
+# NPl    V    D   NSg/J NSg/V  P  I/J/D NSg/V/J . V/C    ISg W?     NSg/V/J NSg/C NPrSg/C W?    .
 > half      hoping that    they would  call  after her   : the last    time  she saw   them , they
 # NSg/V/J/P V      N/I/C/D IPl  NSg/VX NSg/V J/P   I/J/D . D   NSg/V/J NSg/V ISg NSg/V N/I  . IPl
 > were  trying  to put   the Dormouse into the teapot .
@@ -3310,8 +3310,8 @@
 # NSg/J/P D   NPrSg/V/J . . W?   D   W?        NSg/V . NSg/V/J ISg J    V   NSg/I/V/P NPrSg/V/J/P NSg/I/J/C D  NSg/V . .
 >
 #
-> Just as    she said this , she noticed that    one       of  the trees had a   door  leading
-# V/J  NSg/R ISg V/J  I/D  . ISg V       N/I/C/D NSg/I/V/J V/P D   NPl   V   D/P NSg/V NSg/V/J
+> Just as    she said this , she noticed that    one       of the trees had a   door  leading
+# V/J  NSg/R ISg V/J  I/D  . ISg V       N/I/C/D NSg/I/V/J P  D   NPl   V   D/P NSg/V NSg/V/J
 > right     into it        . “ That’s very curious ! ” she thought . “ But     everything’s curious
 # NPrSg/V/J P    NPrSg/ISg . . N$     J    J       . . ISg NSg/V   . . NSg/C/P N$           J
 > today . I   think I   may      as    well    go      in          at        once  . ” And in          she went  .
@@ -3324,8 +3324,8 @@
 # NSg/V . . NPrSg/V/J/C . W?   NSg/V  NSg/VX/J I/D  NSg/V . . ISg V/J  P  I       . V/C V     NSg/J/P
 > taking  the little    golden    key       , and unlocking the door  that    led into the garden  .
 # NSg/V/J D   NPrSg/I/J NPrSg/V/J NPrSg/V/J . V/C V         D   NSg/V N/I/C/D NSg P    D   NSg/V/J .
-> Then    she went  to work  nibbling at        the mushroom ( she had kept a   piece of  it        in
-# NSg/J/C ISg NSg/V P  NSg/V V        NSg/I/V/P D   NSg/V/J  . ISg V   V    D/P NSg/V V/P NPrSg/ISg NPrSg/V/J/P
+> Then    she went  to work  nibbling at        the mushroom ( she had kept a   piece of it        in
+# NSg/J/C ISg NSg/V P  NSg/V V        NSg/I/V/P D   NSg/V/J  . ISg V   V    D/P NSg/V P  NPrSg/ISg NPrSg/V/J/P
 > her   pocket  ) till      she was about a   foot  high    : then    she walked down      the little
 # I/J/D NSg/V/J . NSg/V/C/P ISg V   J/P   D/P NSg/V NSg/V/J . NSg/J/C ISg W?     NSg/V/J/P D   NPrSg/I/J
 > passage : and then    — she found herself at        last    in          the beautiful garden  , among the
@@ -3338,14 +3338,14 @@
 # NSg/V   W?   . D   N$      NSg/V   . NSg/V/J
 >
 #
-> A   large rose      - tree  stood near      the entrance of  the garden  : the roses growing on  it
-# D/P NSg/J NPrSg/V/J . NSg/V V     NSg/V/J/P D   NSg/V    V/P D   NSg/V/J . D   NPl   NSg/V   J/P NPrSg/ISg
+> A   large rose      - tree  stood near      the entrance of the garden  : the roses growing on  it
+# D/P NSg/J NPrSg/V/J . NSg/V V     NSg/V/J/P D   NSg/V    P  D   NSg/V/J . D   NPl   NSg/V   J/P NPrSg/ISg
 > were  white     , but     there were  three gardeners at        it        , busily painting them red   .
 # NSg/V NPrSg/V/J . NSg/C/P W?    NSg/V NSg   W?        NSg/I/V/P NPrSg/ISg . R      NSg/V    N/I  NSg/J .
 > Alice thought this a   very curious thing , and she went  nearer to watch them , and
 # NPr   NSg/V   I/D  D/P J    J       NSg/V . V/C ISg NSg/V J      P  NSg/V N/I  . V/C
-> just as    she came    up        to them she heard one       of  them say   , “ Look  out         now         , Five !
-# V/J  NSg/R ISg NSg/V/P NSg/V/J/P P  N/I  ISg V/J   NSg/I/V/J V/P N/I  NSg/V . . NSg/V NSg/V/J/R/P NPrSg/V/J/C . NSg  .
+> just as    she came    up        to them she heard one       of them say   , “ Look  out         now         , Five !
+# V/J  NSg/R ISg NSg/V/P NSg/V/J/P P  N/I  ISg V/J   NSg/I/V/J P  N/I  NSg/V . . NSg/V NSg/V/J/R/P NPrSg/V/J/C . NSg  .
 > Don’t go      splashing paint over      me        like        that    ! ”
 # NSg/V NSg/V/J V         NSg/V NSg/V/J/P NPrSg/ISg NSg/V/J/C/P N/I/C/D . .
 >
@@ -3370,22 +3370,22 @@
 # . NSg/I C/P . . V/J  D   NSg/I/V/J NPrSg/I V   V/J    NSg/V/J .
 >
 #
-> “ That’s none  of  your business , Two ! ” said Seven .
-# . N$     NSg/I V/P D    NSg/J    . NSg . . V/J  NSg   .
+> “ That’s none  of your business , Two ! ” said Seven .
+# . N$     NSg/I P  D    NSg/J    . NSg . . V/J  NSg   .
 >
 #
 > “ Yes   , it        is his   business ! ” said Five , “ and I’ll tell    him — it        was for bringing the
 # . NSg/V . NPrSg/ISg VL ISg/D NSg/J    . . V/J  NSg  . . V/C W?   NPrSg/V I   . NPrSg/ISg V   C/P V        D
-> cook    tulip - roots instead of  onions . ”
-# NPrSg/V NSg   . NPl   W?      V/P W?     . .
+> cook    tulip - roots instead of onions . ”
+# NPrSg/V NSg   . NPl   W?      P  W?     . .
 >
 #
-> Seven flung down      his   brush , and had just begun “ Well    , of  all       the unjust things — ”
-# NSg   V     NSg/V/J/P ISg/D NSg/V . V/C V   V/J  V     . NSg/V/J . V/P NSg/I/J/C D   J      NPl    . .
+> Seven flung down      his   brush , and had just begun “ Well    , of all       the unjust things — ”
+# NSg   V     NSg/V/J/P ISg/D NSg/V . V/C V   V/J  V     . NSg/V/J . P  NSg/I/J/C D   J      NPl    . .
 > when    his   eye   chanced to fall  upon Alice , as    she stood watching them , and he
 # NSg/I/C ISg/D NSg/V W?      P  NSg/V P    NPr   . NSg/R ISg V     V        N/I  . V/C NPr/ISg
-> checked himself suddenly : the others looked round     also , and all       of  them bowed
-# V/J     I       J/R      . D   NPl    W?     NSg/V/J/P W?   . V/C NSg/I/J/C V/P N/I  V/J
+> checked himself suddenly : the others looked round     also , and all       of them bowed
+# V/J     I       J/R      . D   NPl    W?     NSg/V/J/P W?   . V/C NSg/I/J/C P  N/I  V/J
 > low     .
 # NSg/V/J .
 >
@@ -3408,8 +3408,8 @@
 # ?     ISg NPl   . P  . . NSg/I/V/P I/D  NSg    NSg  . NPrSg/I V   NSg/V J/R       V       NSg/P
 > the garden  , called out         “ The Queen   ! The Queen   ! ” and the three gardeners instantly
 # D   NSg/V/J . V/J    NSg/V/J/R/P . D   NPrSg/V . D   NPrSg/V . . V/C D   NSg   W?        J/R
-> threw themselves flat    upon their faces . There was a   sound   of  many    footsteps , and
-# V     I          NSg/V/J P    D     NPl   . W?    V   D/P NSg/V/J V/P N/I/J/D NPl       . V/C
+> threw themselves flat    upon their faces . There was a   sound   of many    footsteps , and
+# V     I          NSg/V/J P    D     NPl   . W?    V   D/P NSg/V/J P  N/I/J/D NPl       . V/C
 > Alice looked round     , eager   to see   the Queen   .
 # NPr   W?     NSg/V/J/P . NSg/V/J P  NSg/V D   NPrSg/V .
 >
@@ -3421,7 +3421,7 @@
 > ten courtiers ; these were  ornamented all       over      with diamonds , and walked two and
 # NSg NPl       . I/D   NSg/V W?         NSg/I/J/C NSg/V/J/P P    NPl      . V/C W?     NSg V/C
 > two , as    the soldiers did . After these came    the royal   children ; there were  ten of
-# NSg . NSg/R D   NPl      V   . J/P   I/D   NSg/V/P D   NPrSg/J NPl      . W?    NSg/V NSg V/P
+# NSg . NSg/R D   NPl      V   . J/P   I/D   NSg/V/P D   NPrSg/J NPl      . W?    NSg/V NSg P
 > them , and the little    dears came    jumping merrily along hand  in          hand  , in          couples :
 # N/I  . V/C D   NPrSg/I/J NPl   NSg/V/P V       R       P     NSg/V NPrSg/V/J/P NSg/V . NPrSg/V/J/P NPl     .
 > they were  all       ornamented with hearts . Next    came    the guests , mostly Kings and
@@ -3430,20 +3430,20 @@
 # NPrSg  . V/C P     N/I  NPr   V/J/Br     D   NPrSg/V/J NSg/V  . NPrSg/ISg V   V       NPrSg/V/J/P D/P
 > hurried nervous manner , smiling at        everything that    was said , and went  by      without
 # V/J     J       NSg    . NSg/V/J NSg/I/V/P N/I/V      N/I/C/D V   V/J  . V/C NSg/V NSg/J/P C/P
-> noticing her   . Then    followed the Knave of  Hearts , carrying the King’s crown   on  a
-# V        I/J/D . NSg/J/C W?       D   NSg   V/P NPl    . V        D   N$     NSg/V/J J/P D/P
-> crimson velvet  cushion ; and , last    of  all       this grand procession , came    THE KING
-# NSg/V/J NSg/V/J NSg/V   . V/C . NSg/V/J V/P NSg/I/J/C I/D  NSg/J NSg/V      . NSg/V/P D   NPrSg/V
-> AND QUEEN   OF  HEARTS .
-# V/C NPrSg/V V/P NPl    .
+> noticing her   . Then    followed the Knave of Hearts , carrying the King’s crown   on  a
+# V        I/J/D . NSg/J/C W?       D   NSg   P  NPl    . V        D   N$     NSg/V/J J/P D/P
+> crimson velvet  cushion ; and , last    of all       this grand procession , came    THE KING
+# NSg/V/J NSg/V/J NSg/V   . V/C . NSg/V/J P  NSg/I/J/C I/D  NSg/J NSg/V      . NSg/V/P D   NPrSg/V
+> AND QUEEN   OF HEARTS .
+# V/C NPrSg/V P  NPl    .
 >
 #
 > Alice was rather    doubtful whether she ought    not   to lie     down      on  her   face  like        the
 # NPr   V   NPrSg/V/J NSg/J    I/C     ISg NSg/I/VX NSg/C P  NPrSg/V NSg/V/J/P J/P I/J/D NSg/V NSg/V/J/C/P D
-> three gardeners , but     she could  not   remember ever having heard of  such  a   rule  at
-# NSg   W?        . NSg/C/P ISg NSg/VX NSg/C NSg/V    J    V      V/J   V/P NSg/I D/P NSg/V NSg/I/V/P
-> processions ; “ and besides , what  would  be     the use   of  a   procession , ” thought she ,
-# NPl         . . V/C NPl     . NSg/I NSg/VX NSg/VX D   NSg/V V/P D/P NSg/V      . . NSg/V   ISg .
+> three gardeners , but     she could  not   remember ever having heard of such  a   rule  at
+# NSg   W?        . NSg/C/P ISg NSg/VX NSg/C NSg/V    J    V      V/J   P  NSg/I D/P NSg/V NSg/I/V/P
+> processions ; “ and besides , what  would  be     the use   of a   procession , ” thought she ,
+# NPl         . . V/C NPl     . NSg/I NSg/VX NSg/VX D   NSg/V P  D/P NSg/V      . . NSg/V   ISg .
 > “ if    people had all       to lie     down      upon their faces , so        that    they couldn’t see   it        ? ”
 # . NSg/C NSg/V  V   NSg/I/J/C P  NPrSg/V NSg/V/J/P P    D     NPl   . NSg/I/J/C N/I/C/D IPl  V        NSg/V NPrSg/ISg . .
 > So        she stood still   where she was , and waited .
@@ -3452,8 +3452,8 @@
 #
 > When    the procession came    opposite to Alice , they all       stopped and looked at        her   ,
 # NSg/I/C D   NSg/V      NSg/V/P NSg/J/P  P  NPr   . IPl  NSg/I/J/C V/J     V/C W?     NSg/I/V/P I/J/D .
-> and the Queen   said severely “ Who     is this ? ” She said it        to the Knave of  Hearts ,
-# V/C D   NPrSg/V V/J  J/R      . NPrSg/I VL I/D  . . ISg V/J  NPrSg/ISg P  D   NSg   V/P NPl    .
+> and the Queen   said severely “ Who     is this ? ” She said it        to the Knave of Hearts ,
+# V/C D   NPrSg/V V/J  J/R      . NPrSg/I VL I/D  . . ISg V/J  NPrSg/ISg P  D   NSg   P  NPl    .
 > who     only bowed and smiled in          reply .
 # NPrSg/I W?   V/J   V/C W?     NPrSg/V/J/P NSg/V .
 >
@@ -3466,28 +3466,28 @@
 #
 > “ My name  is Alice , so        please your Majesty , ” said Alice very politely ; but     she
 # . D  NSg/V VL NPr   . NSg/I/J/C V      D    NSg/I   . . V/J  NPr   J    J/R      . NSg/C/P ISg
-> added , to herself , “ Why   , they’re only a   pack  of  cards , after all       . I   needn’t be
-# W?    . P  I       . . NSg/V . W?      W?   D/P NSg/V V/P NPl   . J/P   NSg/I/J/C . ISg VX      NSg/VX
-> afraid of  them ! ”
-# J      V/P N/I  . .
+> added , to herself , “ Why   , they’re only a   pack  of cards , after all       . I   needn’t be
+# W?    . P  I       . . NSg/V . W?      W?   D/P NSg/V P  NPl   . J/P   NSg/I/J/C . ISg VX      NSg/VX
+> afraid of them ! ”
+# J      P  N/I  . .
 >
 #
 > “ And who     are these ? ” said the Queen   , pointing to the three gardeners who     were
 # . V/C NPrSg/I V   I/D   . . V/J  D   NPrSg/V . V        P  D   NSg   W?        NPrSg/I NSg/V
 > lying   round     the rose      - tree  ; for , you see   , as    they were  lying   on  their faces , and
 # NSg/V/J NSg/V/J/P D   NPrSg/V/J . NSg/V . C/P . IPl NSg/V . NSg/R IPl  NSg/V NSg/V/J J/P D     NPl   . V/C
-> the pattern on  their backs was the same as    the rest  of  the pack  , she could  not
-# D   NSg/V/J J/P D     NPl   V   D   I/J  NSg/R D   NSg/V V/P D   NSg/V . ISg NSg/VX NSg/C
-> tell    whether they were  gardeners , or      soldiers , or      courtiers , or      three of  her   own
-# NPrSg/V I/C     IPl  NSg/V W?        . NPrSg/C NPl      . NPrSg/C NPl       . NPrSg/C NSg   V/P I/J/D NSg/V/J
+> the pattern on  their backs was the same as    the rest  of the pack  , she could  not
+# D   NSg/V/J J/P D     NPl   V   D   I/J  NSg/R D   NSg/V P  D   NSg/V . ISg NSg/VX NSg/C
+> tell    whether they were  gardeners , or      soldiers , or      courtiers , or      three of her   own
+# NPrSg/V I/C     IPl  NSg/V W?        . NPrSg/C NPl      . NPrSg/C NPl       . NPrSg/C NSg   P  I/J/D NSg/V/J
 > children .
 # NPl      .
 >
 #
 > “ How   should I   know  ? ” said Alice , surprised at        her   own     courage . “ It’s no      business
 # . NSg/C VX     ISg NSg/V . . V/J  NPr   . W?        NSg/I/V/P I/J/D NSg/V/J NSg/V   . . W?   NPrSg/P NSg/J
-> of  mine    . ”
-# V/P NSg/I/V . .
+> of mine    . ”
+# P  NSg/I/V . .
 >
 #
 > The Queen   turned crimson with fury , and , after glaring at        her   for a   moment like
@@ -3536,8 +3536,8 @@
 #
 > “ I   see   ! ” said the Queen   , who     had meanwhile been  examining the roses . “ Off       with
 # . ISg NSg/V . . V/J  D   NPrSg/V . NPrSg/I V   NSg       NSg/V V         D   NPl   . . NSg/V/J/P P
-> their heads ! ” and the procession moved on  , three of  the soldiers remaining
-# D     NPl   . . V/C D   NSg/V      V/J   J/P . NSg   V/P D   NPl      V
+> their heads ! ” and the procession moved on  , three of the soldiers remaining
+# D     NPl   . . V/C D   NSg/V      V/J   J/P . NSg   P  D   NPl      V
 > behind  to execute the unfortunate gardeners , who     ran   to Alice for protection .
 # NSg/J/P P  V       D   NSg/J       W?        . NPrSg/I NSg/V P  NPr   C/P NSg        .
 >
@@ -3594,8 +3594,8 @@
 # . NSg/V . NSg/V . . V/J  D   NSg/V  NPrSg/V/J/P D/P NSg/V/J . V/J     NSg/I/V . NPr/ISg W?     J/R       NSg/V/J/P
 > his   shoulder as    he      spoke , and then    raised himself upon tiptoe  , put   his   mouth
 # ISg/D NSg/V    NSg/R NPr/ISg NSg/V . V/C NSg/J/C W?     I       P    NSg/V/J . NSg/V ISg/D NSg/V
-> close   to her   ear   , and whispered “ She’s under   sentence of  execution . ”
-# NSg/V/J P  I/J/D NSg/V . V/C W?        . W?    NSg/J/P NSg/V    V/P NSg       . .
+> close   to her   ear   , and whispered “ She’s under   sentence of execution . ”
+# NSg/V/J P  I/J/D NSg/V . V/C W?        . W?    NSg/J/P NSg/V    P  NSg       . .
 >
 #
 > “ What  for ? ” said Alice .
@@ -3613,15 +3613,15 @@
 >
 #
 > “ She boxed the Queen’s ears — ” the Rabbit began . Alice gave a   little    scream of
-# . ISg W?    D   N$      NPl  . . D   NSg/V  V     . NPr   V    D/P NPrSg/I/J NSg/V  V/P
+# . ISg W?    D   N$      NPl  . . D   NSg/V  V     . NPr   V    D/P NPrSg/I/J NSg/V  P
 > laughter . “ Oh      , hush  ! ” the Rabbit whispered in          a   frightened tone    . “ The Queen   will
 # NSg      . . NPrSg/V . NSg/V . . D   NSg/V  W?        NPrSg/V/J/P D/P W?         NSg/I/V . . D   NPrSg/V NPrSg/VX
 > hear you ! You see   , she came    rather    late  , and the Queen   said — ”
 # V    IPl . IPl NSg/V . ISg NSg/V/P NPrSg/V/J NSg/J . V/C D   NPrSg/V V/J  . .
 >
 #
-> “ Get   to your places ! ” shouted the Queen   in          a   voice of  thunder , and people began
-# . NSg/V P  D    NPl    . . W?      D   NPrSg/V NPrSg/V/J/P D/P NSg/V V/P NSg/V   . V/C NSg/V  V
+> “ Get   to your places ! ” shouted the Queen   in          a   voice of thunder , and people began
+# . NSg/V P  D    NPl    . . W?      D   NPrSg/V NPrSg/V/J/P D/P NSg/V P  NSg/V   . V/C NSg/V  V
 > running   about in          all       directions , tumbling up        against each other   ; however , they
 # NSg/V/J/P J/P   NPrSg/V/J/P NSg/I/J/C NSg        . NSg/V    NSg/V/J/P C/P     D    NSg/V/J . C       . IPl
 > got settled down      in          a   minute  or      two , and the game    began . Alice thought she had
@@ -3650,14 +3650,14 @@
 # N/I/C/D ISg NSg/VX NSg/C NSg/V V        NSg/V/J/R/P NSg/V    . V/C NSg/I/C ISg V   V   ISg/D NPrSg/V/J
 > down      , and was going   to begin again , it        was very provoking to find  that    the
 # NSg/V/J/P . V/C V   NSg/V/J P  NSg/V P     . NPrSg/ISg V   J    NSg/V/J   P  NSg/V N/I/C/D D
-> hedgehog had unrolled itself , and was in          the act     of  crawling away : besides all
-# NSg/V    V   W?       I      . V/C V   NPrSg/V/J/P D   NPrSg/V V/P V        V/J  . NPl     NSg/I/J/C
+> hedgehog had unrolled itself , and was in          the act     of crawling away : besides all
+# NSg/V    V   W?       I      . V/C V   NPrSg/V/J/P D   NPrSg/V P  V        V/J  . NPl     NSg/I/J/C
 > this , there was generally a   ridge or      furrow in          the way   wherever she wanted to
 # I/D  . W?    V   J/R       D/P NSg/V NPrSg/C NSg/V  NPrSg/V/J/P D   NSg/J C        ISg V/J    P
 > send  the hedgehog to , and , as    the doubled - up        soldiers were  always getting up        and
 # NSg/V D   NSg/V    P  . V/C . NSg/R D   W?      . NSg/V/J/P NPl      NSg/V W?     NSg/V   NSg/V/J/P V/C
-> walking off       to other   parts of  the ground  , Alice soon came    to the conclusion that
-# NSg/V/J NSg/V/J/P P  NSg/V/J NPl   V/P D   NSg/V/J . NPr   J/R  NSg/V/P P  D   NSg        N/I/C/D
+> walking off       to other   parts of the ground  , Alice soon came    to the conclusion that
+# NSg/V/J NSg/V/J/P P  NSg/V/J NPl   P  D   NSg/V/J . NPr   J/R  NSg/V/P P  D   NSg        N/I/C/D
 > it        was a   very difficult game    indeed .
 # NPrSg/ISg V   D/P J    V/J       NSg/V/J W?     .
 >
@@ -3676,14 +3676,14 @@
 # NPr   V     P  NSg/I/V/J J    NSg/V/J . P  NSg/VX J    . ISg V   NSg/C NSg/R NSg/V/C V   I/R/D NSg/V
 > with the Queen   , but     she knew that    it        might    happen any   minute  , “ and then    , ”
 # P    D   NPrSg/V . NSg/C/P ISg V    N/I/C/D NPrSg/ISg NSg/VX/J V      I/R/D NSg/V/J . . V/C NSg/J/C . .
-> thought she , “ what  would  become of  me        ? They’re dreadfully fond    of  beheading
-# NSg/V   ISg . . NSg/I NSg/VX V      V/P NPrSg/ISg . W?      J/R        NSg/V/J V/P NSg
+> thought she , “ what  would  become of me        ? They’re dreadfully fond    of beheading
+# NSg/V   ISg . . NSg/I NSg/VX V      P  NPrSg/ISg . W?      J/R        NSg/V/J P  NSg
 > people here    ; the great wonder is , that    there’s any   one       left      alive ! ”
 # NSg/V  NSg/J/R . D   NSg/J NSg/V  VL . N/I/C/D W?      I/R/D NSg/I/V/J NPrSg/V/J W?    . .
 >
 #
-> She was looking about for some  way   of  escape , and wondering whether she could
-# ISg V   V       J/P   C/P I/J/R NSg/J V/P NSg/V  . V/C NSg/V/J   I/C     ISg NSg/VX
+> She was looking about for some  way   of escape , and wondering whether she could
+# ISg V   V       J/P   C/P I/J/R NSg/J P  NSg/V  . V/C NSg/V/J   I/C     ISg NSg/VX
 > get   away without being   seen  , when    she noticed a   curious appearance in          the air   :
 # NSg/V V/J  C/P     NSg/V/C NSg/V . NSg/I/C ISg V       D/P J       NSg        NPrSg/V/J/P D   NSg/V .
 > it        puzzled her   very much  at        first   , but     , after watching it        a   minute  or      two , she
@@ -3702,14 +3702,14 @@
 #
 > Alice waited till      the eyes appeared , and then    nodded . “ It’s no      use   speaking to
 # NPr   W?     NSg/V/C/P D   NPl  W?       . V/C NSg/J/C V      . . W?   NPrSg/P NSg/V V        P
-> it        , ” she thought , “ till      its   ears have   come    , or      at        least one       of  them . ” In          another
-# NPrSg/ISg . . ISg NSg/V   . . NSg/V/C/P ISg/D NPl  NSg/VX NSg/V/P . NPrSg/C NSg/I/V/P NSg/J NSg/I/V/J V/P N/I  . . NPrSg/V/J/P I/D
+> it        , ” she thought , “ till      its   ears have   come    , or      at        least one       of them . ” In          another
+# NPrSg/ISg . . ISg NSg/V   . . NSg/V/C/P ISg/D NPl  NSg/VX NSg/V/P . NPrSg/C NSg/I/V/P NSg/J NSg/I/V/J P  N/I  . . NPrSg/V/J/P I/D
 > minute  the whole head      appeared , and then    Alice put   down      her   flamingo , and began
 # NSg/V/J D   NSg/J NPrSg/V/J W?       . V/C NSg/J/C NPr   NSg/V NSg/V/J/P I/J/D NSg/J    . V/C V
-> an  account of  the game    , feeling very glad    she had someone to listen to her   . The
-# D/P NSg/V   V/P D   NSg/V/J . NSg/V/J J    NSg/V/J ISg V   NSg/I   P  NSg/V  P  I/J/D . D
-> Cat     seemed to think that    there was enough of  it        now         in          sight , and no      more        of  it
-# NSg/V/J W?     P  NSg/V N/I/C/D W?    V   NSg/I  V/P NPrSg/ISg NPrSg/V/J/C NPrSg/V/J/P NSg/V . V/C NPrSg/P NPrSg/I/V/J V/P NPrSg/ISg
+> an  account of the game    , feeling very glad    she had someone to listen to her   . The
+# D/P NSg/V   P  D   NSg/V/J . NSg/V/J J    NSg/V/J ISg V   NSg/I   P  NSg/V  P  I/J/D . D
+> Cat     seemed to think that    there was enough of it        now         in          sight , and no      more        of it
+# NSg/V/J W?     P  NSg/V N/I/C/D W?    V   NSg/I  P  NPrSg/ISg NPrSg/V/J/C NPrSg/V/J/P NSg/V . V/C NPrSg/P NPrSg/I/V/J P  NPrSg/ISg
 > appeared .
 # W?       .
 >
@@ -3724,8 +3724,8 @@
 # NPl     P  N/I  . V/C W?     NPrSg/P NSg  NSg/C V/J       NPrSg/ISg VL NSg/I/J/C D   NPl    NSg/V/C
 > alive ; for instance , there’s the arch    I’ve got to go      through next    walking about
 # W?    . C/P NSg/V    . W?      D   NSg/V/J W?   V   P  NSg/V/J NSg/J/P NSg/J/P NSg/V/J J/P
-> at        the other   end   of  the ground  — and I   should have   croqueted the Queen’s hedgehog
-# NSg/I/V/P D   NSg/V/J NSg/V V/P D   NSg/V/J . V/C ISg VX     NSg/VX ?         D   N$      NSg/V
+> at        the other   end   of the ground  — and I   should have   croqueted the Queen’s hedgehog
+# NSg/I/V/P D   NSg/V/J NSg/V P  D   NSg/V/J . V/C ISg VX     NSg/VX ?         D   N$      NSg/V
 > just now         , only it        ran   away when    it        saw   mine    coming  ! ”
 # V/J  NPrSg/V/J/C . W?   NPrSg/ISg NSg/V V/J  NSg/I/C NPrSg/ISg NSg/V NSg/I/V NSg/V/J . .
 >
@@ -3752,12 +3752,12 @@
 # N$    NPrSg/V/J P    NSg/J NSg       .
 >
 #
-> “ It’s a   friend  of  mine    — a   Cheshire Cat     , ” said Alice : “ allow me        to introduce it        . ”
-# . W?   D/P NPrSg/V V/P NSg/I/V . D/P NPr      NSg/V/J . . V/J  NPr   . . V     NPrSg/ISg P  V         NPrSg/ISg . .
+> “ It’s a   friend  of mine    — a   Cheshire Cat     , ” said Alice : “ allow me        to introduce it        . ”
+# . W?   D/P NPrSg/V P  NSg/I/V . D/P NPr      NSg/V/J . . V/J  NPr   . . V     NPrSg/ISg P  V         NPrSg/ISg . .
 >
 #
-> “ I   don’t like        the look  of  it        at        all       , ” said the King    : “ however , it        may      kiss  my
-# . ISg NSg/V NSg/V/J/C/P D   NSg/V V/P NPrSg/ISg NSg/I/V/P NSg/I/J/C . . V/J  D   NPrSg/V . . C       . NPrSg/ISg NPrSg/VX NSg/V D
+> “ I   don’t like        the look  of it        at        all       , ” said the King    : “ however , it        may      kiss  my
+# . ISg NSg/V NSg/V/J/C/P D   NSg/V P  NPrSg/ISg NSg/I/V/P NSg/I/J/C . . V/J  D   NPrSg/V . . C       . NPrSg/ISg NPrSg/VX NSg/V D
 > hand  if    it        likes . ”
 # NSg/V NSg/C NPrSg/ISg NPl   . .
 >
@@ -3786,8 +3786,8 @@
 # W?      . .
 >
 #
-> The Queen   had only one       way   of  settling all       difficulties , great or      small     . “ Off
-# D   NPrSg/V V   W?   NSg/I/V/J NSg/J V/P V        NSg/I/J/C NPl          . NSg/J NPrSg/C NPrSg/V/J . . NSg/V/J/P
+> The Queen   had only one       way   of settling all       difficulties , great or      small     . “ Off
+# D   NPrSg/V V   W?   NSg/I/V/J NSg/J P  V        NSg/I/J/C NPl          . NSg/J NPrSg/C NPrSg/V/J . . NSg/V/J/P
 > with his   head      ! ” she said , without even    looking round     .
 # P    ISg/D NPrSg/V/J . . ISg V/J  . C/P     NSg/V/J V       NSg/V/J/P .
 >
@@ -3800,34 +3800,34 @@
 # NPr   NSg/V   ISg NSg/VX/J NSg/R NSg/V/J NSg/V/J NSg/V/J . V/C NSg/V NSg/C D   NSg/V/J V   NSg/V/J J/P . NSg/R
 > she heard the Queen’s voice in          the distance , screaming with passion . She had
 # ISg V/J   D   N$      NSg/V NPrSg/V/J/P D   NSg/V    . NSg/V/J   P    NPrSg/V . ISg V
-> already heard her   sentence three of  the players to be     executed for having missed
-# W?      V/J   I/J/D NSg/V    NSg   V/P D   NPl     P  NSg/VX W?       C/P V      V
-> their turns , and she did not   like        the look  of  things at        all       , as    the game    was in
-# D     NPl   . V/C ISg V   NSg/C NSg/V/J/C/P D   NSg/V V/P NPl    NSg/I/V/P NSg/I/J/C . NSg/R D   NSg/V/J V   NPrSg/V/J/P
+> already heard her   sentence three of the players to be     executed for having missed
+# W?      V/J   I/J/D NSg/V    NSg   P  D   NPl     P  NSg/VX W?       C/P V      V
+> their turns , and she did not   like        the look  of things at        all       , as    the game    was in
+# D     NPl   . V/C ISg V   NSg/C NSg/V/J/C/P D   NSg/V P  NPl    NSg/I/V/P NSg/I/J/C . NSg/R D   NSg/V/J V   NPrSg/V/J/P
 > such  confusion that    she never knew whether it        was her   turn  or      not   . So        she went
 # NSg/I NSg/V     N/I/C/D ISg V     V    I/C     NPrSg/ISg V   I/J/D NSg/V NPrSg/C NSg/C . NSg/I/J/C ISg NSg/V
-> in          search of  her   hedgehog .
-# NPrSg/V/J/P NSg/V  V/P I/J/D NSg/V    .
+> in          search of her   hedgehog .
+# NPrSg/V/J/P NSg/V  P  I/J/D NSg/V    .
 >
 #
 > The hedgehog was engaged in          a   fight with another hedgehog , which seemed to Alice
 # D   NSg/V    V   W?      NPrSg/V/J/P D/P NSg/V P    I/D     NSg/V    . I/C   W?     P  NPr
-> an  excellent opportunity for croqueting one       of  them with the other   : the only
-# D/P J         NSg         C/P ?          NSg/I/V/J V/P N/I  P    D   NSg/V/J . D   W?
-> difficulty was , that    her   flamingo was gone  across to the other   side    of  the
-# NSg        V   . N/I/C/D I/J/D NSg/J    V   V/J/P NSg/P  P  D   NSg/V/J NSg/V/J V/P D
-> garden  , where Alice could  see   it        trying  in          a   helpless sort  of  way   to fly     up        into
-# NSg/V/J . NSg/C NPr   NSg/VX NSg/V NPrSg/ISg NSg/V/J NPrSg/V/J/P D/P J        NSg/V V/P NSg/J P  NSg/V/J NSg/V/J/P P
+> an  excellent opportunity for croqueting one       of them with the other   : the only
+# D/P J         NSg         C/P ?          NSg/I/V/J P  N/I  P    D   NSg/V/J . D   W?
+> difficulty was , that    her   flamingo was gone  across to the other   side    of the
+# NSg        V   . N/I/C/D I/J/D NSg/J    V   V/J/P NSg/P  P  D   NSg/V/J NSg/V/J P  D
+> garden  , where Alice could  see   it        trying  in          a   helpless sort  of way   to fly     up        into
+# NSg/V/J . NSg/C NPr   NSg/VX NSg/V NPrSg/ISg NSg/V/J NPrSg/V/J/P D/P J        NSg/V P  NSg/J P  NSg/V/J NSg/V/J/P P
 > a   tree  .
 # D/P NSg/V .
 >
 #
 > By      the time  she had caught the flamingo and brought it        back    , the fight was over      ,
 # NSg/J/P D   NSg/V ISg V   V/J    D   NSg/J    V/C V       NPrSg/ISg NSg/V/J . D   NSg/V V   NSg/V/J/P .
-> and both the hedgehogs were  out         of  sight : “ but     it        doesn’t matter  much  , ” thought
-# V/C I/C  D   NPl       NSg/V NSg/V/J/R/P V/P NSg/V . . NSg/C/P NPrSg/ISg V       NSg/V/J N/I/J . . NSg/V
-> Alice , “ as    all       the arches are gone  from this side    of  the ground  . ” So        she tucked
-# NPr   . . NSg/R NSg/I/J/C D   NPl    V   V/J/P P    I/D  NSg/V/J V/P D   NSg/V/J . . NSg/I/J/C ISg W?
+> and both the hedgehogs were  out         of sight : “ but     it        doesn’t matter  much  , ” thought
+# V/C I/C  D   NPl       NSg/V NSg/V/J/R/P P  NSg/V . . NSg/C/P NPrSg/ISg V       NSg/V/J N/I/J . . NSg/V
+> Alice , “ as    all       the arches are gone  from this side    of the ground  . ” So        she tucked
+# NPr   . . NSg/R NSg/I/J/C D   NPl    V   V/J/P P    I/D  NSg/V/J P  D   NSg/V/J . . NSg/I/J/C ISg W?
 > it        away under   her   arm     , that    it        might    not   escape again , and went  back    for a
 # NPrSg/ISg V/J  NSg/J/P I/J/D NSg/V/J . N/I/C/D NPrSg/ISg NSg/VX/J NSg/C NSg/V  P     . V/C NSg/V NSg/V/J C/P D/P
 > little    more        conversation with her   friend  .
@@ -3856,8 +3856,8 @@
 # D   N$            NSg/V    V   . N/I/C/D IPl V        NSg/V/J NSg/V/J/P D/P NPrSg/V/J C      W?
 > was a   body  to cut     it        off       from : that    he      had never had to do     such  a   thing before ,
 # V   D/P NSg/V P  NSg/V/J NPrSg/ISg NSg/V/J/P P    . N/I/C/D NPr/ISg V   V     V   P  NSg/VX NSg/I D/P NSg/V C/P    .
-> and he      wasn’t going   to begin at        his   time  of  life  .
-# V/C NPr/ISg V      NSg/V/J P  NSg/V NSg/I/V/P ISg/D NSg/V V/P NSg/V .
+> and he      wasn’t going   to begin at        his   time  of life  .
+# V/C NPr/ISg V      NSg/V/J P  NSg/V NSg/I/V/P ISg/D NSg/V P  NSg/V .
 >
 #
 > The King’s argument was , that    anything that    had a   head      could  be     beheaded , and
@@ -3874,8 +3874,8 @@
 # NSg/V D   NSg/J NSg/V/J NSg/V NSg/I/J/C NSg/V/J V/C J       . .
 >
 #
-> Alice could  think of  nothing else  to say   but     “ It        belongs to the Duchess : you’d
-# NPr   NSg/VX NSg/V V/P NSg/I/J N/J/C P  NSg/V NSg/C/P . NPrSg/ISg NPl     P  D   NSg/V   . W?
+> Alice could  think of nothing else  to say   but     “ It        belongs to the Duchess : you’d
+# NPr   NSg/VX NSg/V P  NSg/I/J N/J/C P  NSg/V NSg/C/P . NPrSg/ISg NPl     P  D   NSg/V   . W?
 > better   ask   her   about it        . ”
 # NSg/VX/J NSg/V I/J/D J/P   NPrSg/ISg . .
 >
@@ -3890,8 +3890,8 @@
 # D   N$    NPrSg/V/J V     NSg/V  V/J  D   NSg    NPr/ISg V   V/J/P . V/C . NSg/J/P D   NSg/V NPr/ISg V
 > come    back    with the Duchess , it        had entirely disappeared ; so        the King    and the
 # NSg/V/P NSg/V/J P    D   NSg/V   . NPrSg/ISg V   J/R      W?          . NSg/I/J/C D   NPrSg/V V/C D
-> executioner ran   wildly up        and down      looking for it        , while     the rest  of  the party
-# NSg/J       NSg/V J/R    NSg/V/J/P V/C NSg/V/J/P V       C/P NPrSg/ISg . NSg/V/C/P D   NSg/V V/P D   NSg/V/J
+> executioner ran   wildly up        and down      looking for it        , while     the rest  of the party
+# NSg/J       NSg/V J/R    NSg/V/J/P V/C NSg/V/J/P V       C/P NPrSg/ISg . NSg/V/C/P D   NSg/V P  D   NSg/V/J
 > went  back    to the game    .
 # NSg/V NSg/V/J P  D   NSg/V/J .
 >
@@ -3922,8 +3922,8 @@
 # . ISg V     NSg/VX I/R/D NSg/V  NPrSg/V/J/P D  NSg/V   NSg/I/V/P NSg/I/J/C . NSg/V NSg/V J    NSg/V/J C/P     . NSg/J/R
 > it’s always pepper that    makes people hot     - tempered , ” she went  on  , very much
 # W?   W?     NSg/V  N/I/C/D NPl   NSg/V  NSg/V/J . W?       . . ISg NSg/V J/P . J    N/I/J
-> pleased at        having found out         a   new     kind  of  rule  , “ and vinegar that    makes them
-# W?      NSg/I/V/P V      NSg/V NSg/V/J/R/P D/P NSg/V/J NSg/J V/P NSg/V . . V/C NSg/V   N/I/C/D NPl   N/I
+> pleased at        having found out         a   new     kind  of rule  , “ and vinegar that    makes them
+# W?      NSg/I/V/P V      NSg/V NSg/V/J/R/P D/P NSg/V/J NSg/J P  NSg/V . . V/C NSg/V   N/I/C/D NPl   N/I
 > sour    — and camomile that    makes them bitter  — and — and barley - sugar and such  things
 # NSg/V/J . V/C ?        N/I/C/D NPl   N/I  NSg/V/J . V/C . V/C NSg    . NSg/V V/C NSg/I NPl
 > that    make  children sweet     - tempered . I   only wish  people knew that    : then    they
@@ -3937,7 +3937,7 @@
 > she heard her   voice close   to her   ear   . “ You’re thinking about something , my dear    ,
 # ISg V/J   I/J/D NSg/V NSg/V/J P  I/J/D NSg/V . . W?     V        J/P   NSg/I/V/J . D  NSg/V/J .
 > and that    makes you forget to talk  . I   can’t tell    you just now         what  the moral   of
-# V/C N/I/C/D NPl   IPl V      P  NSg/V . ISg VX    NPrSg/V IPl V/J  NPrSg/V/J/C NSg/I D   NSg/V/J V/P
+# V/C N/I/C/D NPl   IPl V      P  NSg/V . ISg VX    NPrSg/V IPl V/J  NPrSg/V/J/C NSg/I D   NSg/V/J P
 > that    is , but     I   shall remember it        in          a   bit   . ”
 # N/I/C/D VL . NSg/C/P ISg VX    NSg/V    NPrSg/ISg NPrSg/V/J/P D/P NSg/V . .
 >
@@ -3962,14 +3962,14 @@
 # V   NSg/C NSg/V/J/C/P P  NSg/VX J    . NSg/I/J/C ISg NSg/V NPrSg/ISg NSg/R NSg/V/J NSg/R ISg NSg/VX .
 >
 #
-> “ The game’s going   on  rather    better   now         , ” she said , by      way   of  keeping up        the
-# . D   N$     NSg/V/J J/P NPrSg/V/J NSg/VX/J NPrSg/V/J/C . . ISg V/J  . NSg/J/P NSg/J V/P NSg/V   NSg/V/J/P D
+> “ The game’s going   on  rather    better   now         , ” she said , by      way   of keeping up        the
+# . D   N$     NSg/V/J J/P NPrSg/V/J NSg/VX/J NPrSg/V/J/C . . ISg V/J  . NSg/J/P NSg/J P  NSg/V   NSg/V/J/P D
 > conversation a   little    .
 # NSg/V        D/P NPrSg/I/J .
 >
 #
-> “ ’ Tis so        , ” said the Duchess : “ and the moral   of  that    is — ‘          Oh      , ’ tis love    , ’ tis
-# . . ?   NSg/I/J/C . . V/J  D   NSg/V   . . V/C D   NSg/V/J V/P N/I/C/D VL . Unlintable NPrSg/V . . ?   NPrSg/V . . ?
+> “ ’ Tis so        , ” said the Duchess : “ and the moral   of that    is — ‘          Oh      , ’ tis love    , ’ tis
+# . . ?   NSg/I/J/C . . V/J  D   NSg/V   . . V/C D   NSg/V/J P  N/I/C/D VL . Unlintable NPrSg/V . . ?   NPrSg/V . . ?
 > love    , that    makes the world go      round     ! ’ ”
 # NPrSg/V . N/I/C/D NPl   D   NSg/V NSg/V/J NSg/V/J/P . . .
 >
@@ -3982,22 +3982,22 @@
 #
 > “ Ah      , well    ! It        means much  the same thing , ” said the Duchess , digging her   sharp
 # . NSg/I/V . NSg/V/J . NPrSg/ISg NPl   N/I/J D   I/J  NSg/V . . V/J  D   NSg/V   . NSg/V   I/J/D NPrSg/V/J
-> little    chin    into Alice’s shoulder as    she added , “ and the moral   of  that    is — ‘          Take
-# NPrSg/I/J NPrSg/V P    N$      NSg/V    NSg/R ISg W?    . . V/C D   NSg/V/J V/P N/I/C/D VL . Unlintable NSg/V
-> care  of  the sense , and the sounds will     take  care  of  themselves . ’ ”
-# NSg/V V/P D   NSg/V . V/C D   NPl    NPrSg/VX NSg/V NSg/V V/P I          . . .
+> little    chin    into Alice’s shoulder as    she added , “ and the moral   of that    is — ‘          Take
+# NPrSg/I/J NPrSg/V P    N$      NSg/V    NSg/R ISg W?    . . V/C D   NSg/V/J P  N/I/C/D VL . Unlintable NSg/V
+> care  of the sense , and the sounds will     take  care  of themselves . ’ ”
+# NSg/V P  D   NSg/V . V/C D   NPl    NPrSg/VX NSg/V NSg/V P  I          . . .
 >
 #
-> “ How   fond    she is of  finding morals in          things ! ” Alice thought to herself .
-# . NSg/C NSg/V/J ISg VL V/P NSg/V   NPl    NPrSg/V/J/P NPl    . . NPr   NSg/V   P  I       .
+> “ How   fond    she is of finding morals in          things ! ” Alice thought to herself .
+# . NSg/C NSg/V/J ISg VL P  NSg/V   NPl    NPrSg/V/J/P NPl    . . NPr   NSg/V   P  I       .
 >
 #
 > “ I   dare     say   you’re wondering why   I   don’t put   my arm     round     your waist , ” the
 # . ISg NPrSg/VX NSg/V W?     NSg/V/J   NSg/V ISg NSg/V NSg/V D  NSg/V/J NSg/V/J/P D    NSg   . . D
 > Duchess said after a   pause : “ the reason is , that    I’m doubtful about the temper
 # NSg/V   V/J  J/P   D/P NSg/V . . D   NSg/V  VL . N/I/C/D W?  NSg/J    J/P   D   NSg/V/J
-> of  your flamingo . Shall I   try     the experiment ? ”
-# V/P D    NSg/J    . VX    ISg NSg/V/J D   NSg/V      . .
+> of your flamingo . Shall I   try     the experiment ? ”
+# P  D    NSg/J    . VX    ISg NSg/V/J D   NSg/V      . .
 >
 #
 > “ He      might    bite  , ” Alice cautiously replied , not   feeling at        all       anxious to have
@@ -4008,16 +4008,16 @@
 #
 > “ Very true    , ” said the Duchess : “ flamingoes and mustard both bite  . And the moral
 # . J    NSg/V/J . . V/J  D   NSg/V   . . ?          V/C NSg/J   I/C  NSg/V . V/C D   NSg/V/J
-> of  that    is — ‘          Birds of  a   feather flock together . ’ ”
-# V/P N/I/C/D VL . Unlintable NPl   V/P D/P NSg/V   NSg/V J        . . .
+> of that    is — ‘          Birds of a   feather flock together . ’ ”
+# P  N/I/C/D VL . Unlintable NPl   P  D/P NSg/V   NSg/V J        . . .
 >
 #
 > “ Only mustard isn’t a   bird      , ” Alice remarked .
 # . W?   NSg/J   NSg/V D/P NPrSg/V/J . . NPr   V/J      .
 >
 #
-> “ Right     , as    usual , ” said the Duchess : “ what  a   clear   way   you have   of  putting
-# . NPrSg/V/J . NSg/R NSg/J . . V/J  D   NSg/V   . . NSg/I D/P NSg/V/J NSg/J IPl NSg/VX V/P NSg/V
+> “ Right     , as    usual , ” said the Duchess : “ what  a   clear   way   you have   of putting
+# . NPrSg/V/J . NSg/R NSg/J . . V/J  D   NSg/V   . . NSg/I D/P NSg/V/J NSg/J IPl NSg/VX P  NSg/V
 > things ! ”
 # NPl    . .
 >
@@ -4026,12 +4026,12 @@
 # . W?   D/P NSg/J   . ISg NSg/V . . V/J  NPr   .
 >
 #
-> “ Of  course it        is , ” said the Duchess , who     seemed ready   to agree to everything
-# . V/P NSg/V  NPrSg/ISg VL . . V/J  D   NSg/V   . NPrSg/I W?     NSg/V/J P  V     P  N/I/V
-> that    Alice said ; “ there’s a   large mustard - mine    near      here    . And the moral   of  that
-# N/I/C/D NPr   V/J  . . W?      D/P NSg/J NSg/J   . NSg/I/V NSg/V/J/P NSg/J/R . V/C D   NSg/V/J V/P N/I/C/D
-> is — ‘          The more        there is of  mine    , the less    there is of  yours . ’ ”
-# VL . Unlintable D   NPrSg/I/V/J W?    VL V/P NSg/I/V . D   V/J/C/P W?    VL V/P I     . . .
+> “ Of course it        is , ” said the Duchess , who     seemed ready   to agree to everything
+# . P  NSg/V  NPrSg/ISg VL . . V/J  D   NSg/V   . NPrSg/I W?     NSg/V/J P  V     P  N/I/V
+> that    Alice said ; “ there’s a   large mustard - mine    near      here    . And the moral   of that
+# N/I/C/D NPr   V/J  . . W?      D/P NSg/J NSg/J   . NSg/I/V NSg/V/J/P NSg/J/R . V/C D   NSg/V/J P  N/I/C/D
+> is — ‘          The more        there is of mine    , the less    there is of yours . ’ ”
+# VL . Unlintable D   NPrSg/I/V/J W?    VL P  NSg/I/V . D   V/J/C/P W?    VL P  I     . . .
 >
 #
 > “ Oh      , I   know  ! ” exclaimed Alice , who     had not   attended to this last    remark , “ it’s a
@@ -4040,8 +4040,8 @@
 # NSg/J     . NPrSg/ISg V       NSg/V NSg/V/J/C/P NSg/I/V/J . NSg/C/P NPrSg/ISg VL . .
 >
 #
-> “ I   quite agree with you , ” said the Duchess ; “ and the moral   of  that    is — ‘          Be     what
-# . ISg NSg   V     P    IPl . . V/J  D   NSg/V   . . V/C D   NSg/V/J V/P N/I/C/D VL . Unlintable NSg/VX NSg/I
+> “ I   quite agree with you , ” said the Duchess ; “ and the moral   of that    is — ‘          Be     what
+# . ISg NSg   V     P    IPl . . V/J  D   NSg/V   . . V/C D   NSg/V/J P  N/I/C/D VL . Unlintable NSg/VX NSg/I
 > you would  seem to be     ’ — or      if    you’d like        it        put   more        simply — ‘          Never imagine
 # IPl NSg/VX V    P  NSg/VX . . NPrSg/C NSg/C W?    NSg/V/J/C/P NPrSg/ISg NSg/V NPrSg/I/V/J R      . Unlintable V     NSg/V
 > yourself not   to be     otherwise than what  it        might    appear to others that    what  you
@@ -4069,19 +4069,19 @@
 >
 #
 > “ Oh      , don’t talk  about trouble ! ” said the Duchess . “ I   make  you a   present of
-# . NPrSg/V . NSg/V NSg/V J/P   NSg/V   . . V/J  D   NSg/V   . . ISg NSg/V IPl D/P NSg/V/J V/P
+# . NPrSg/V . NSg/V NSg/V J/P   NSg/V   . . V/J  D   NSg/V   . . ISg NSg/V IPl D/P NSg/V/J P
 > everything I’ve said as    yet     . ”
 # N/I/V      W?   V/J  NSg/R NSg/V/C . .
 >
 #
-> “ A   cheap   sort  of  present ! ” thought Alice . “ I’m glad    they don’t give  birthday
-# . D/P NSg/V/J NSg/V V/P NSg/V/J . . NSg/V   NPr   . . W?  NSg/V/J IPl  NSg/V NSg/V NSg/V
+> “ A   cheap   sort  of present ! ” thought Alice . “ I’m glad    they don’t give  birthday
+# . D/P NSg/V/J NSg/V P  NSg/V/J . . NSg/V   NPr   . . W?  NSg/V/J IPl  NSg/V NSg/V NSg/V
 > presents like        that    ! ” But     she did not   venture to say   it        out         loud  .
 # NPl      NSg/V/J/C/P N/I/C/D . . NSg/C/P ISg V   NSg/C NSg/V   P  NSg/V NPrSg/ISg NSg/V/J/R/P NSg/J .
 >
 #
-> “ Thinking again ? ” the Duchess asked , with another dig   of  her   sharp     little    chin    .
-# . V        P     . . D   NSg/V   V/J   . P    I/D     NSg/V V/P I/J/D NPrSg/V/J NPrSg/I/J NPrSg/V .
+> “ Thinking again ? ” the Duchess asked , with another dig   of her   sharp     little    chin    .
+# . V        P     . . D   NSg/V   V/J   . P    I/D     NSg/V P  I/J/D NPrSg/V/J NPrSg/I/J NPrSg/V .
 >
 #
 > “ I’ve a   right     to think , ” said Alice sharply , for she was beginning to feel      a
@@ -4096,10 +4096,10 @@
 #
 > But     here    , to Alice’s great surprise , the Duchess’s voice died away , even    in          the
 # NSg/C/P NSg/J/R . P  N$      NSg/J NSg/V    . D   N$        NSg/V W?   V/J  . NSg/V/J NPrSg/V/J/P D
-> middle  of  her   favourite  word  ‘          moral   , ’ and the arm     that    was linked into hers
-# NSg/V/J V/P I/J/D NSg/V/J/Br NSg/V Unlintable NSg/V/J . . V/C D   NSg/V/J N/I/C/D V   W?     P    ISg
-> began to tremble . Alice looked up        , and there stood the Queen   in          front   of  them ,
-# V     P  NSg/V   . NPr   W?     NSg/V/J/P . V/C W?    V     D   NPrSg/V NPrSg/V/J/P NSg/V/J V/P N/I  .
+> middle  of her   favourite  word  ‘          moral   , ’ and the arm     that    was linked into hers
+# NSg/V/J P  I/J/D NSg/V/J/Br NSg/V Unlintable NSg/V/J . . V/C D   NSg/V/J N/I/C/D V   W?     P    ISg
+> began to tremble . Alice looked up        , and there stood the Queen   in          front   of them ,
+# V     P  NSg/V   . NPr   W?     NSg/V/J/P . V/C W?    V     D   NPrSg/V NPrSg/V/J/P NSg/V/J P  N/I  .
 > with her   arms folded , frowning like        a   thunderstorm .
 # P    I/J/D NPl  W?     . V        NSg/V/J/C/P D/P NSg          .
 >
@@ -4126,8 +4126,8 @@
 # W?         P  NSg/V D/P NSg/V . NSg/C/P J/R    W?       I/J/D NSg/V/J P  D   NSg/V   . NSg/V/J .
 >
 #
-> The other   guests had taken advantage of  the Queen’s absence , and were  resting in
-# D   NSg/V/J NPl    V   V/J   NSg/V     V/P D   N$      NSg     . V/C NSg/V V       NPrSg/V/J/P
+> The other   guests had taken advantage of the Queen’s absence , and were  resting in
+# D   NSg/V/J NPl    V   V/J   NSg/V     P  D   N$      NSg     . V/C NSg/V V       NPrSg/V/J/P
 > the shade : however , the moment they saw   her   , they hurried back    to the game    , the
 # D   NSg/V . C       . D   NSg    IPl  NSg/V I/J/D . IPl  V/J     NSg/V/J P  D   NSg/V/J . D
 > Queen   merely remarking that    a   moment’s delay   would  cost  them their lives .
@@ -4138,18 +4138,18 @@
 # NSg/I/J/C D   NSg/V IPl  NSg/V V       D   NPrSg/V V     NPrSg/V/J NSg/V/J/P NSg/V/Br    P    D
 > other   players , and shouting “ Off       with his   head      ! ” or      “ Off       with her   head      ! ” Those
 # NSg/V/J NPl     . V/C V        . NSg/V/J/P P    ISg/D NPrSg/V/J . . NPrSg/C . NSg/V/J/P P    I/J/D NPrSg/V/J . . I/D
-> whom she sentenced were  taken into custody by      the soldiers , who     of  course had to
-# I    ISg W?        NSg/V V/J   P    NSg     NSg/J/P D   NPl      . NPrSg/I V/P NSg/V  V   P
-> leave off       being   arches to do     this , so        that    by      the end   of  half      an  hour or      so
-# NSg/V NSg/V/J/P NSg/V/C NPl    P  NSg/VX I/D  . NSg/I/J/C N/I/C/D NSg/J/P D   NSg/V V/P NSg/V/J/P D/P NSg  NPrSg/C NSg/I/J/C
+> whom she sentenced were  taken into custody by      the soldiers , who     of course had to
+# I    ISg W?        NSg/V V/J   P    NSg     NSg/J/P D   NPl      . NPrSg/I P  NSg/V  V   P
+> leave off       being   arches to do     this , so        that    by      the end   of half      an  hour or      so
+# NSg/V NSg/V/J/P NSg/V/C NPl    P  NSg/VX I/D  . NSg/I/J/C N/I/C/D NSg/J/P D   NSg/V P  NSg/V/J/P D/P NSg  NPrSg/C NSg/I/J/C
 > there were  no      arches left      , and all       the players , except the King    , the Queen   , and
 # W?    NSg/V NPrSg/P NPl    NPrSg/V/J . V/C NSg/I/J/C D   NPl     . V/C/P  D   NPrSg/V . D   NPrSg/V . V/C
-> Alice , were  in          custody and under   sentence of  execution .
-# NPr   . NSg/V NPrSg/V/J/P NSg     V/C NSg/J/P NSg/V    V/P NSg       .
+> Alice , were  in          custody and under   sentence of execution .
+# NPr   . NSg/V NPrSg/V/J/P NSg     V/C NSg/J/P NSg/V    P  NSg       .
 >
 #
-> Then    the Queen   left      off       , quite out         of  breath  , and said to Alice , “ Have   you seen
-# NSg/J/C D   NPrSg/V NPrSg/V/J NSg/V/J/P . NSg   NSg/V/J/R/P V/P NSg/V/J . V/C V/J  P  NPr   . . NSg/VX IPl NSg/V
+> Then    the Queen   left      off       , quite out         of breath  , and said to Alice , “ Have   you seen
+# NSg/J/C D   NPrSg/V NPrSg/V/J NSg/V/J/P . NSg   NSg/V/J/R/P P  NSg/V/J . V/C V/J  P  NPr   . . NSg/VX IPl NSg/V
 > the Mock    Turtle yet     ? ”
 # D   NSg/V/J NSg/V  NSg/V/C . .
 >
@@ -4162,8 +4162,8 @@
 # . W?   D   NSg/V NSg/V/J NSg/V  NSg/V VL NSg/V P    . . V/J  D   NPrSg/V .
 >
 #
-> “ I   never saw   one       , or      heard of  one       , ” said Alice .
-# . ISg V     NSg/V NSg/I/V/J . NPrSg/C V/J   V/P NSg/I/V/J . . V/J  NPr   .
+> “ I   never saw   one       , or      heard of one       , ” said Alice .
+# . ISg V     NSg/V NSg/I/V/J . NPrSg/C V/J   P  NSg/I/V/J . . V/J  NPr   .
 >
 #
 > “ Come    on  , then    , ” said the Queen   , “ and he      shall tell    you his   history . ”
@@ -4174,8 +4174,8 @@
 # NSg/R IPl  W?     NSg/V/J/P J        . NPr   V/J   D   NPrSg/V NSg/V NPrSg/V/J/P D/P NSg/V/J NSg/V . P  D
 > company generally , “ You are all       pardoned . ” “ Come    , that’s a   good      thing ! ” she said
 # NSg/V   J/R       . . IPl V   NSg/I/J/C W?       . . . NSg/V/P . N$     D/P NPrSg/V/J NSg/V . . ISg V/J
-> to herself , for she had felt    quite unhappy at        the number  of  executions the Queen
-# P  I       . C/P ISg V   NSg/V/J NSg   NSg/V/J NSg/I/V/P D   NSg/V/J V/P W?         D   NPrSg/V
+> to herself , for she had felt    quite unhappy at        the number  of executions the Queen
+# P  I       . C/P ISg V   NSg/V/J NSg   NSg/V/J NSg/I/V/P D   NSg/V/J P  W?         D   NPrSg/V
 > had ordered .
 # V   V/J     .
 >
@@ -4188,8 +4188,8 @@
 # . V/C NSg/V I/D  NPrSg/V/J NPrSg/V P  NSg/V D   NSg/V/J NSg/V  . V/C P  V    ISg/D NSg     . ISg
 > must  go      back    and see   after some  executions I   have   ordered ; ” and she walked off       ,
 # NSg/V NSg/V/J NSg/V/J V/C NSg/V J/P   I/J/R W?         ISg NSg/VX V/J     . . V/C ISg W?     NSg/V/J/P .
-> leaving Alice alone with the Gryphon . Alice did not   quite like        the look  of  the
-# V       NPr   J     P    D   ?       . NPr   V   NSg/C NSg   NSg/V/J/C/P D   NSg/V V/P D
+> leaving Alice alone with the Gryphon . Alice did not   quite like        the look  of the
+# V       NPr   J     P    D   ?       . NPr   V   NSg/C NSg   NSg/V/J/C/P D   NSg/V P  D
 > creature , but     on  the whole she thought it        would  be     quite as    safe    to stay    with it
 # NSg      . NSg/C/P J/P D   NSg/J ISg NSg/V   NPrSg/ISg NSg/VX NSg/VX NSg   NSg/R NSg/V/J P  NSg/V/J P    NPrSg/ISg
 > as    to go      after that    savage    Queen   : so        she waited .
@@ -4198,8 +4198,8 @@
 #
 > The Gryphon sat     up        and rubbed its   eyes : then    it        watched the Queen   till      she was
 # D   ?       NSg/V/J NSg/V/J/P V/C V/J    ISg/D NPl  . NSg/J/C NPrSg/ISg W?      D   NPrSg/V NSg/V/C/P ISg V
-> out         of  sight : then    it        chuckled . “ What  fun     ! ” said the Gryphon , half      to itself ,
-# NSg/V/J/R/P V/P NSg/V . NSg/J/C NPrSg/ISg W?       . . NSg/I NSg/V/J . . V/J  D   ?       . NSg/V/J/P P  I      .
+> out         of sight : then    it        chuckled . “ What  fun     ! ” said the Gryphon , half      to itself ,
+# NSg/V/J/R/P P  NSg/V . NSg/J/C NPrSg/ISg W?       . . NSg/I NSg/V/J . . V/J  D   ?       . NSg/V/J/P P  I      .
 > half      to Alice .
 # NSg/V/J/P P  NPr   .
 >
@@ -4222,8 +4222,8 @@
 #
 > They had not   gone  far     before they saw   the Mock    Turtle in          the distance , sitting
 # IPl  V   NSg/C V/J/P NSg/V/J C/P    IPl  NSg/V D   NSg/V/J NSg/V  NPrSg/V/J/P D   NSg/V    . NSg/V/J
-> sad     and lonely on  a   little    ledge of  rock    , and , as    they came    nearer , Alice could
-# NSg/V/J V/C J/R    J/P D/P NPrSg/I/J NSg/V V/P NPrSg/V . V/C . NSg/R IPl  NSg/V/P J      . NPr   NSg/VX
+> sad     and lonely on  a   little    ledge of rock    , and , as    they came    nearer , Alice could
+# NSg/V/J V/C J/R    J/P D/P NPrSg/I/J NSg/V P  NPrSg/V . V/C . NSg/R IPl  NSg/V/P J      . NPr   NSg/VX
 > hear him sighing as    if    his   heart would  break . She pitied him deeply . “ What  is
 # V    I   V       NSg/R NSg/C ISg/D NSg/V NSg/VX NSg/V . ISg W?     I   J/R    . . NSg/I VL
 > his   sorrow ? ” she asked the Gryphon , and the Gryphon answered , very nearly in          the
@@ -4235,7 +4235,7 @@
 >
 #
 > So        they went  up        to the Mock    Turtle , who     looked at        them with large eyes full    of
-# NSg/I/J/C IPl  NSg/V NSg/V/J/P P  D   NSg/V/J NSg/V  . NPrSg/I W?     NSg/I/V/P N/I  P    NSg/J NPl  NSg/V/J V/P
+# NSg/I/J/C IPl  NSg/V NSg/V/J/P P  D   NSg/V/J NSg/V  . NPrSg/I W?     NSg/I/V/P N/I  P    NSg/J NPl  NSg/V/J P
 > tears , but     said nothing .
 # NPl   . NSg/C/P V/J  NSg/I/J .
 >
@@ -4248,8 +4248,8 @@
 #
 > “ I’ll tell    it        her   , ” said the Mock    Turtle in          a   deep  , hollow  tone    : “ sit   down      , both
 # . W?   NPrSg/V NPrSg/ISg I/J/D . . V/J  D   NSg/V/J NSg/V  NPrSg/V/J/P D/P NSg/J . NSg/V/J NSg/I/V . . NSg/V NSg/V/J/P . I/C
-> of  you , and don’t speak a   word  till      I’ve finished . ”
-# V/P IPl . V/C NSg/V NSg/V D/P NSg/V NSg/V/C/P W?   V/J      . .
+> of you , and don’t speak a   word  till      I’ve finished . ”
+# P  IPl . V/C NSg/V NSg/V D/P NSg/V NSg/V/C/P W?   V/J      . .
 >
 #
 > So        they sat     down      , and nobody spoke for some  minutes . Alice thought to herself ,
@@ -4266,8 +4266,8 @@
 #
 > These words were  followed by      a   very long      silence , broken only by      an  occasional
 # I/D   NPl   NSg/V W?       NSg/J/P D/P J    NPrSg/V/J NSg/V   . V/J    W?   NSg/J/P D/P NSg/J
-> exclamation of  “ Hjckrrh ! ” from the Gryphon , and the constant heavy   sobbing of
-# NSg         V/P . ?       . . P    D   ?       . V/C D   NSg/J    NSg/V/J NSg/V/J V/P
+> exclamation of “ Hjckrrh ! ” from the Gryphon , and the constant heavy   sobbing of
+# NSg         P  . ?       . . P    D   ?       . V/C D   NSg/J    NSg/V/J NSg/V/J P
 > the Mock    Turtle . Alice was very nearly getting up        and saying , “ Thank you , sir     ,
 # D   NSg/V/J NSg/V  . NPr   V   J    J/R    NSg/V   NSg/V/J/P V/C NSg/V  . . NSg/V IPl . NPrSg/V .
 > for your interesting story , ” but     she could  not   help  thinking there must  be     more
@@ -4294,8 +4294,8 @@
 # . J/R    IPl V   J    V/J  . .
 >
 #
-> “ You ought    to be     ashamed of  yourself for asking such  a   simple  question , ” added
-# . IPl NSg/I/VX P  NSg/VX V/J     V/P I        C/P V      NSg/I D/P NSg/V/J NSg/V    . . W?
+> “ You ought    to be     ashamed of yourself for asking such  a   simple  question , ” added
+# . IPl NSg/I/VX P  NSg/VX V/J     P  I        C/P V      NSg/I D/P NSg/V/J NSg/V    . . W?
 > the Gryphon ; and then    they both sat     silent and looked at        poor    Alice , who     felt
 # D   ?       . V/C NSg/J/C IPl  I/C  NSg/V/J NSg/J  V/C W?     NSg/I/V/P NSg/V/J NPr   . NPrSg/I NSg/V/J
 > ready   to sink  into the earth   . At        last    the Gryphon said to the Mock    Turtle ,
@@ -4324,8 +4324,8 @@
 # NSg/V  NSg/V J/P .
 >
 #
-> “ We  had the best       of  educations — in          fact , we  went  to school every day   — ”
-# . IPl V   D   NPrSg/VX/J V/P NSg        . NPrSg/V/J/P NSg  . IPl NSg/V P  NSg/V  D     NPrSg . .
+> “ We  had the best       of educations — in          fact , we  went  to school every day   — ”
+# . IPl V   D   NPrSg/VX/J P  NSg        . NPrSg/V/J/P NSg  . IPl NSg/V P  NSg/V  D     NPrSg . .
 >
 #
 > “ I’ve been  to a   day   - school , too , ” said Alice ; “ you needn’t be     so        proud as    all
@@ -4351,15 +4351,15 @@
 >
 #
 > “ Ah      ! then    yours wasn’t a   really good      school , ” said the Mock    Turtle in          a   tone    of
-# . NSg/I/V . NSg/J/C I     V      D/P J/R    NPrSg/V/J NSg/V  . . V/J  D   NSg/V/J NSg/V  NPrSg/V/J/P D/P NSg/I/V V/P
-> great relief . “ Now         at        ours they had at        the end   of  the bill    , ‘          French    , music   , and
-# NSg/J NSg/J  . . NPrSg/V/J/C NSg/I/V/P I    IPl  V   NSg/I/V/P D   NSg/V V/P D   NPrSg/V . Unlintable NPrSg/V/J . NSg/V/J . V/C
+# . NSg/I/V . NSg/J/C I     V      D/P J/R    NPrSg/V/J NSg/V  . . V/J  D   NSg/V/J NSg/V  NPrSg/V/J/P D/P NSg/I/V P
+> great relief . “ Now         at        ours they had at        the end   of the bill    , ‘          French    , music   , and
+# NSg/J NSg/J  . . NPrSg/V/J/C NSg/I/V/P I    IPl  V   NSg/I/V/P D   NSg/V P  D   NPrSg/V . Unlintable NPrSg/V/J . NSg/V/J . V/C
 > washing — extra . ’ ”
 # NSg/V   . NSg/J . . .
 >
 #
-> “ You couldn’t have   wanted it        much  , ” said Alice ; “ living  at        the bottom  of  the
-# . IPl V        NSg/VX V/J    NPrSg/ISg N/I/J . . V/J  NPr   . . NSg/V/J NSg/I/V/P D   NSg/V/J V/P D
+> “ You couldn’t have   wanted it        much  , ” said Alice ; “ living  at        the bottom  of the
+# . IPl V        NSg/VX V/J    NPrSg/ISg N/I/J . . V/J  NPr   . . NSg/V/J NSg/I/V/P D   NSg/V/J P  D
 > sea . ”
 # NSg . .
 >
@@ -4374,20 +4374,20 @@
 # . NSg/I V   N/I/C/D . . W?       NPr   .
 >
 #
-> “ Reeling and Writhing , of  course , to begin with , ” the Mock    Turtle replied ; “ and
-# . V       V/C V        . V/P NSg/V  . P  NSg/V P    . . D   NSg/V/J NSg/V  W?      . . V/C
-> then    the different branches of  Arithmetic — Ambition , Distraction , Uglification ,
-# NSg/J/C D   NSg/J     NPl      V/P NSg/J      . NSg/V    . NSg/V       . ?            .
+> “ Reeling and Writhing , of course , to begin with , ” the Mock    Turtle replied ; “ and
+# . V       V/C V        . P  NSg/V  . P  NSg/V P    . . D   NSg/V/J NSg/V  W?      . . V/C
+> then    the different branches of Arithmetic — Ambition , Distraction , Uglification ,
+# NSg/J/C D   NSg/J     NPl      P  NSg/J      . NSg/V    . NSg/V       . ?            .
 > and Derision . ”
 # V/C NSg      . .
 >
 #
-> “ I   never heard of  ‘          Uglification , ’ ” Alice ventured to say   . “ What  is it        ? ”
-# . ISg V     V/J   V/P Unlintable ?            . . . NPr   W?       P  NSg/V . . NSg/I VL NPrSg/ISg . .
+> “ I   never heard of ‘          Uglification , ’ ” Alice ventured to say   . “ What  is it        ? ”
+# . ISg V     V/J   P  Unlintable ?            . . . NPr   W?       P  NSg/V . . NSg/I VL NPrSg/ISg . .
 >
 #
 > The Gryphon lifted up        both its   paws in          surprise . “ What  ! Never heard of
-# D   ?       W?     NSg/V/J/P I/C  ISg/D NPl  NPrSg/V/J/P NSg/V    . . NSg/I . V     V/J   V/P
+# D   ?       W?     NSg/V/J/P I/C  ISg/D NPl  NPrSg/V/J/P NSg/V    . . NSg/I . V     V/J   P
 > uglifying ! ” it        exclaimed . “ You know  what  to beautify is , I   suppose ? ”
 # ?         . . NPrSg/ISg W?        . . IPl NSg/V NSg/I P  V        VL . ISg V       . .
 >
@@ -4472,8 +4472,8 @@
 # NSg/V I/J/D NSg/J/P NSg/V  . . NSg/J/C D   NSg/J    NPrSg NSg/V NSg/VX NSg/V D/P NPrSg/V . .
 >
 #
-> “ Of  course it        was , ” said the Mock    Turtle .
-# . V/P NSg/V  NPrSg/ISg V   . . V/J  D   NSg/V/J NSg/V  .
+> “ Of course it        was , ” said the Mock    Turtle .
+# . P  NSg/V  NPrSg/ISg V   . . V/J  D   NSg/V/J NSg/V  .
 >
 #
 > “ And how   did you manage on  the twelfth ? ” Alice went  on  eagerly .
@@ -4490,8 +4490,8 @@
 # NSg/V   NPrSg/J/C . D   NSg/V/J NSg/V/J
 >
 #
-> The Mock    Turtle sighed deeply , and drew  the back    of  one       flapper across his   eyes .
-# D   NSg/V/J NSg/V  W?     J/R    . V/C NPr/V D   NSg/V/J V/P NSg/I/V/J NSg     NSg/P  ISg/D NPl  .
+> The Mock    Turtle sighed deeply , and drew  the back    of one       flapper across his   eyes .
+# D   NSg/V/J NSg/V  W?     J/R    . V/C NPr/V D   NSg/V/J P  NSg/I/V/J NSg     NSg/P  ISg/D NPl  .
 > He      looked at        Alice , and tried to speak , but     for a   minute  or      two sobs choked his
 # NPr/ISg W?     NSg/I/V/P NPr   . V/C V/J   P  NSg/V . NSg/C/P C/P D/P NSg/V/J NPrSg/C NSg NPl  W?     ISg/D
 > voice . “ Same as    if    he      had a   bone    in          his   throat , ” said the Gryphon : and it        set       to
@@ -4512,8 +4512,8 @@
 # NSg/VX NPrSg/P NSg  NSg/I D/P J          NSg/V D/P NSg/V/J NSg/V/J   VL . .
 >
 #
-> “ No      , indeed , ” said Alice . “ What  sort  of  a   dance is it        ? ”
-# . NPrSg/P . W?     . . V/J  NPr   . . NSg/I NSg/V V/P D/P NSg/V VL NPrSg/ISg . .
+> “ No      , indeed , ” said Alice . “ What  sort  of a   dance is it        ? ”
+# . NPrSg/P . W?     . . V/J  NPr   . . NSg/I NSg/V P  D/P NSg/V VL NPrSg/ISg . .
 >
 #
 > “ Why   , ” said the Gryphon , “ you first   form  into a   line  along the sea - shore — ”
@@ -4522,8 +4522,8 @@
 #
 > “ Two lines ! ” cried the Mock    Turtle . “ Seals , turtles , salmon  , and so        on  ; then    ,
 # . NSg NPl   . . W?    D   NSg/V/J NSg/V  . . NPl   . NPl     . NSg/V/J . V/C NSg/I/J/C J/P . NSg/J/C .
-> when    you’ve cleared all       the jelly   - fish  out         of  the way   — ”
-# NSg/I/C W?     W?      NSg/I/J/C D   NSg/V/J . NSg/V NSg/V/J/R/P V/P D   NSg/J . .
+> when    you’ve cleared all       the jelly   - fish  out         of the way   — ”
+# NSg/I/C W?     W?      NSg/I/J/C D   NSg/V/J . NSg/V NSg/V/J/R/P P  D   NSg/J . .
 >
 #
 > “ That    generally takes some  time  , ” interrupted the Gryphon .
@@ -4538,8 +4538,8 @@
 # . D    P    D/P NSg/V/J NSg/R D/P NSg/V   . . W?    D   ?       .
 >
 #
-> “ Of  course , ” the Mock    Turtle said : “ advance twice , set       to partners — ”
-# . V/P NSg/V  . . D   NSg/V/J NSg/V  V/J  . . NSg/V/J W?    . NPrSg/V/J P  NPl      . .
+> “ Of course , ” the Mock    Turtle said : “ advance twice , set       to partners — ”
+# . P  NSg/V  . . D   NSg/V/J NSg/V  V/J  . . NSg/V/J W?    . NPrSg/V/J P  NPl      . .
 >
 #
 > “ — change lobsters , and retire in          same order , ” continued the Gryphon .
@@ -4566,8 +4566,8 @@
 # . NSg/V D/P NSg/V      NPrSg/V/J/P D   NSg . . W?    D   NSg/V/J NSg/V  . V        J/R    J/P   .
 >
 #
-> “ Change lobsters again ! ” yelled the Gryphon at        the top     of  its   voice .
-# . NSg/V  NPl      P     . . W?     D   ?       NSg/I/V/P D   NSg/V/J V/P ISg/D NSg/V .
+> “ Change lobsters again ! ” yelled the Gryphon at        the top     of its   voice .
+# . NSg/V  NPl      P     . . W?     D   ?       NSg/I/V/P D   NSg/V/J P  ISg/D NSg/V .
 >
 #
 > “ Back    to land    again , and that’s all       the first   figure , ” said the Mock    Turtle ,
@@ -4584,8 +4584,8 @@
 # . NPrSg/ISg NSg/V NSg/VX D/P J    NSg/V/J NSg/V . . V/J  NPr   J/R     .
 >
 #
-> “ Would  you like        to see   a   little    of  it        ? ” said the Mock    Turtle .
-# . NSg/VX IPl NSg/V/J/C/P P  NSg/V D/P NPrSg/I/J V/P NPrSg/ISg . . V/J  D   NSg/V/J NSg/V  .
+> “ Would  you like        to see   a   little    of it        ? ” said the Mock    Turtle .
+# . NSg/VX IPl NSg/V/J/C/P P  NSg/V D/P NPrSg/I/J P  NPrSg/ISg . . V/J  D   NSg/V/J NSg/V  .
 >
 #
 > “ Very much  indeed , ” said Alice .
@@ -4659,7 +4659,7 @@
 >
 #
 > “ Oh      , as    to the whiting , ” said the Mock    Turtle , “ they — you’ve seen  them , of
-# . NPrSg/V . NSg/R P  D   NSg/V   . . V/J  D   NSg/V/J NSg/V  . . IPl  . W?     NSg/V N/I  . V/P
+# . NPrSg/V . NSg/R P  D   NSg/V   . . V/J  D   NSg/V/J NSg/V  . . IPl  . W?     NSg/V N/I  . P
 > course ? ”
 # NSg/V  . .
 >
@@ -4670,8 +4670,8 @@
 #
 > “ I   don’t know  where Dinn may      be     , ” said the Mock    Turtle , “ but     if    you’ve seen  them
 # . ISg NSg/V NSg/V NSg/C ?    NPrSg/VX NSg/VX . . V/J  D   NSg/V/J NSg/V  . . NSg/C/P NSg/C W?     NSg/V N/I
-> so        often , of  course you know  what  they’re like        . ”
-# NSg/I/J/C J     . V/P NSg/V  IPl NSg/V NSg/I W?      NSg/V/J/C/P . .
+> so        often , of course you know  what  they’re like        . ”
+# NSg/I/J/C J     . P  NSg/V  IPl NSg/V NSg/I W?      NSg/V/J/C/P . .
 >
 #
 > “ I   believe so        , ” Alice replied thoughtfully . “ They have   their tails in          their
@@ -4744,12 +4744,12 @@
 # P    D/P NSg/V   . NPrSg/V/J/C IPl NSg/V . .
 >
 #
-> “ And what  are they made  of  ? ” Alice asked in          a   tone    of  great curiosity .
-# . V/C NSg/I V   IPl  NSg/V V/P . . NPr   V/J   NPrSg/V/J/P D/P NSg/I/V V/P NSg/J NSg       .
+> “ And what  are they made  of ? ” Alice asked in          a   tone    of great curiosity .
+# . V/C NSg/I V   IPl  NSg/V P  . . NPr   V/J   NPrSg/V/J/P D/P NSg/I/V P  NSg/J NSg       .
 >
 #
-> “ Soles and eels , of  course , ” the Gryphon replied rather    impatiently : “ any   shrimp
-# . NPl   V/C NPl  . V/P NSg/V  . . D   ?       W?      NPrSg/V/J J/R         . . I/R/D NSg/V
+> “ Soles and eels , of course , ” the Gryphon replied rather    impatiently : “ any   shrimp
+# . NPl   V/C NPl  . P  NSg/V  . . D   ?       W?      NPrSg/V/J J/R         . . I/R/D NSg/V
 > could  have   told you that    . ”
 # NSg/VX NSg/VX V    IPl N/I/C/D . .
 >
@@ -4768,12 +4768,12 @@
 # NSg/VX NSg/V/J NSg/I    C/P     D/P NSg/V    . .
 >
 #
-> “ Wouldn’t it        really ? ” said Alice in          a   tone    of  great surprise .
-# . VX       NPrSg/ISg J/R    . . V/J  NPr   NPrSg/V/J/P D/P NSg/I/V V/P NSg/J NSg/V    .
+> “ Wouldn’t it        really ? ” said Alice in          a   tone    of great surprise .
+# . VX       NPrSg/ISg J/R    . . V/J  NPr   NPrSg/V/J/P D/P NSg/I/V P  NSg/J NSg/V    .
 >
 #
-> “ Of  course not   , ” said the Mock    Turtle : “ why   , if    a   fish  came    to me        , and told me
-# . V/P NSg/V  NSg/C . . V/J  D   NSg/V/J NSg/V  . . NSg/V . NSg/C D/P NSg/V NSg/V/P P  NPrSg/ISg . V/C V    NPrSg/ISg
+> “ Of course not   , ” said the Mock    Turtle : “ why   , if    a   fish  came    to me        , and told me
+# . P  NSg/V  NSg/C . . V/J  D   NSg/V/J NSg/V  . . NSg/V . NSg/C D/P NSg/V NSg/V/P P  NPrSg/ISg . V/C V    NPrSg/ISg
 > he      was going   a   journey , I   should say   ‘          With what  porpoise ? ’ ”
 # NPr/ISg V   NSg/V/J D/P NSg/V   . ISg VX     NSg/V Unlintable P    NSg/I NSg/V    . . .
 >
@@ -4784,8 +4784,8 @@
 #
 > “ I   mean    what  I   say   , ” the Mock    Turtle replied in          an  offended tone    . And the
 # . ISg NSg/V/J NSg/I ISg NSg/V . . D   NSg/V/J NSg/V  W?      NPrSg/V/J/P D/P W?       NSg/I/V . V/C D
-> Gryphon added “ Come    , let’s hear some  of  your adventures . ”
-# ?       W?    . NSg/V/P . N$    V    I/J/R V/P D    NPl        . .
+> Gryphon added “ Come    , let’s hear some  of your adventures . ”
+# ?       W?    . NSg/V/P . N$    V    I/J/R P  D    NPl        . .
 >
 #
 > “ I   could  tell    you my adventures — beginning from this morning , ” said Alice a
@@ -4830,26 +4830,26 @@
 # . NPrSg/ISg NSg/I/J/C NSg/V/P NSg/J     . . D   NSg/V/J NSg/V  V/J      J/R          . . ISg VX     NSg/V/J/C/P
 > to hear her   try     and repeat something now         . Tell    her   to begin . ” He      looked at        the
 # P  V    I/J/D NSg/V/J V/C NSg/V  NSg/I/V/J NPrSg/V/J/C . NPrSg/V I/J/D P  NSg/V . . NPr/ISg W?     NSg/I/V/P D
-> Gryphon as    if    he      thought it        had some  kind  of  authority over      Alice .
-# ?       NSg/R NSg/C NPr/ISg NSg/V   NPrSg/ISg V   I/J/R NSg/J V/P NSg       NSg/V/J/P NPr   .
+> Gryphon as    if    he      thought it        had some  kind  of authority over      Alice .
+# ?       NSg/R NSg/C NPr/ISg NSg/V   NPrSg/ISg V   I/J/R NSg/J P  NSg       NSg/V/J/P NPr   .
 >
 #
-> “ Stand up        and repeat ‘          ’ Tis the voice of  the sluggard , ’ ” said the Gryphon .
-# . NSg/V NSg/V/J/P V/C NSg/V  Unlintable . ?   D   NSg/V V/P D   NSg      . . . V/J  D   ?       .
+> “ Stand up        and repeat ‘          ’ Tis the voice of the sluggard , ’ ” said the Gryphon .
+# . NSg/V NSg/V/J/P V/C NSg/V  Unlintable . ?   D   NSg/V P  D   NSg      . . . V/J  D   ?       .
 >
 #
 > “ How   the creatures order one       about , and make  one       repeat lessons ! ” thought Alice ;
 # . NSg/C D   NPl       NSg/V NSg/I/V/J J/P   . V/C NSg/V NSg/I/V/J NSg/V  NPl     . . NSg/V   NPr   .
 > “ I   might    as    well    be     at        school at        once  . ” However , she got up        , and began to repeat
 # . ISg NSg/VX/J NSg/R NSg/V/J NSg/VX NSg/I/V/P NSg/V  NSg/I/V/P NSg/C . . C       . ISg V   NSg/V/J/P . V/C V     P  NSg/V
-> it        , but     her   head      was so        full    of  the Lobster Quadrille , that    she hardly knew what
-# NPrSg/ISg . NSg/C/P I/J/D NPrSg/V/J V   NSg/I/J/C NSg/V/J V/P D   NSg/V/J NSg/V/J   . N/I/C/D ISg J/R    V    NSg/I
+> it        , but     her   head      was so        full    of the Lobster Quadrille , that    she hardly knew what
+# NPrSg/ISg . NSg/C/P I/J/D NPrSg/V/J V   NSg/I/J/C NSg/V/J P  D   NSg/V/J NSg/V/J   . N/I/C/D ISg J/R    V    NSg/I
 > she was saying , and the words came    very queer   indeed : —
 # ISg V   NSg/V  . V/C D   NPl   NSg/V/P J    NSg/V/J W?     . .
 >
 #
-> “ ’ Tis the voice of  the Lobster ; I   heard him declare , “ You have   baked me        too
-# . . ?   D   NSg/V V/P D   NSg/V/J . ISg V/J   I   V       . . IPl NSg/VX V/J   NPrSg/ISg W?
+> “ ’ Tis the voice of the Lobster ; I   heard him declare , “ You have   baked me        too
+# . . ?   D   NSg/V P  D   NSg/V/J . ISg V/J   I   V       . . IPl NSg/VX V/J   NPrSg/ISg W?
 > brown     , I   must  sugar my hair  . ” As    a   duck  with its   eyelids , so        he      with his   nose
 # NPrSg/V/J . ISg NSg/V NSg/V D  NSg/V . . NSg/R D/P NSg/V P    ISg/D NPl     . NSg/I/J/C NPr/ISg P    ISg/D NSg/V
 > Trims his   belt  and his   buttons , and turns out         his   toes . ”
@@ -4858,8 +4858,8 @@
 #
 > ( later editions continued as    follows When    the sands are all       dry     , he      is gay       as
 # . J     NPl      W?        NSg/R NPl     NSg/I/C D   NPl   V   NSg/I/J/C NSg/V/J . NPr/ISg VL NPrSg/V/J NSg/R
-> a   lark  , And will     talk  in          contemptuous tones of  the Shark , But     , when    the tide
-# D/P NSg/V . V/C NPrSg/VX NSg/V NPrSg/V/J/P J            NPl   V/P D   NSg/V . NSg/C/P . NSg/I/C D   NSg/V
+> a   lark  , And will     talk  in          contemptuous tones of the Shark , But     , when    the tide
+# D/P NSg/V . V/C NPrSg/VX NSg/V NPrSg/V/J/P J            NPl   P  D   NSg/V . NSg/C/P . NSg/I/C D   NSg/V
 > rises and sharks are around , His   voice has a   timid and tremulous sound   . )
 # NPl   V/C NPl    V   J/P    . ISg/D NSg/V V   D/P J     V/C J         NSg/V/J . .
 >
@@ -4920,8 +4920,8 @@
 #
 > ( later editions continued as    follows The Panther took pie   - crust , and gravy ,
 # . J     NPl      W?        NSg/R NPl     D   NSg     V    NSg/V . NSg/V . V/C NSg/V .
-> and meat , While     the Owl   had the dish  as    its   share of  the treat . When    the pie
-# V/C NSg  . NSg/V/C/P D   NSg/V V   D   NSg/V NSg/R ISg/D NSg/V V/P D   NSg/V . NSg/I/C D   NSg/V
+> and meat , While     the Owl   had the dish  as    its   share of the treat . When    the pie
+# V/C NSg  . NSg/V/C/P D   NSg/V V   D   NSg/V NSg/R ISg/D NSg/V P  D   NSg/V . NSg/I/C D   NSg/V
 > was all       finished , the Owl   , as    a   boon  , Was kindly permitted to pocket  the
 # V   NSg/I/J/C V/J      . D   NSg/V . NSg/R D/P NSg/J . V   J/R    V/J       P  NSg/V/J D
 > spoon : While     the Panther received knife and fork  with a   growl , And concluded
@@ -4930,8 +4930,8 @@
 # D   NSg/V   . .
 >
 #
-> “ What  is the use   of  repeating all       that    stuff , ” the Mock    Turtle interrupted , “ if
-# . NSg/I VL D   NSg/V V/P NSg/V/J   NSg/I/J/C N/I/C/D NSg/V . . D   NSg/V/J NSg/V  W?          . . NSg/C
+> “ What  is the use   of repeating all       that    stuff , ” the Mock    Turtle interrupted , “ if
+# . NSg/I VL D   NSg/V P  NSg/V/J   NSg/I/J/C N/I/C/D NSg/V . . D   NSg/V/J NSg/V  W?          . . NSg/C
 > you don’t explain it        as    you go      on  ? It’s by      far     the most    confusing thing I   ever
 # IPl NSg/V V       NPrSg/ISg NSg/R IPl NSg/V/J J/P . W?   NSg/J/P NSg/V/J D   NSg/I/J V/J       NSg/V ISg J
 > heard ! ”
@@ -4944,8 +4944,8 @@
 # NSg/V/J P  NSg/VX NSg/I/J/C .
 >
 #
-> “ Shall we  try     another figure of  the Lobster Quadrille ? ” the Gryphon went  on  . “ Or
-# . VX    IPl NSg/V/J I/D     NSg/V  V/P D   NSg/V/J NSg/V/J   . . D   ?       NSg/V J/P . . NPrSg/C
+> “ Shall we  try     another figure of the Lobster Quadrille ? ” the Gryphon went  on  . “ Or
+# . VX    IPl NSg/V/J I/D     NSg/V  P  D   NSg/V/J NSg/V/J   . . D   ?       NSg/V J/P . . NPrSg/C
 > would  you like        the Mock    Turtle to sing  you a   song ? ”
 # NSg/VX IPl NSg/V/J/C/P D   NSg/V/J NSg/V  P  NSg/V IPl D/P NSg  . .
 >
@@ -4966,34 +4966,34 @@
 #
 > “ Beautiful Soup  , so        rich      and green     , Waiting in          a   hot     tureen ! Who     for such
 # . NSg/J     NSg/V . NSg/I/J/C NPrSg/V/J V/C NPrSg/V/J . NSg/V   NPrSg/V/J/P D/P NSg/V/J NSg    . NPrSg/I C/P NSg/I
-> dainties would  not   stoop ? Soup  of  the evening , beautiful Soup  ! Soup  of  the
-# NPl      NSg/VX NSg/C NSg/V . NSg/V V/P D   NSg/V   . NSg/J     NSg/V . NSg/V V/P D
+> dainties would  not   stoop ? Soup  of the evening , beautiful Soup  ! Soup  of the
+# NPl      NSg/VX NSg/C NSg/V . NSg/V P  D   NSg/V   . NSg/J     NSg/V . NSg/V P  D
 > evening , beautiful Soup  ! Beau    — ootiful Soo — oop ! Beau    — ootiful Soo — oop ! Soo — oop
 # NSg/V   . NSg/J     NSg/V . NPrSg/V . ?       ?   . ?   . NPrSg/V . ?       ?   . ?   . ?   . ?
-> of  the e       — e       — evening , Beautiful , beautiful Soup  !
-# V/P D   NPrSg/I . NPrSg/I . NSg/V   . NSg/J     . NSg/J     NSg/V .
+> of the e       — e       — evening , Beautiful , beautiful Soup  !
+# P  D   NPrSg/I . NPrSg/I . NSg/V   . NSg/J     . NSg/J     NSg/V .
 >
 #
 > “ Beautiful Soup  ! Who     cares for fish  , Game    , or      any   other   dish  ? Who     would  not
 # . NSg/J     NSg/V . NPrSg/I NPl   C/P NSg/V . NSg/V/J . NPrSg/C I/R/D NSg/V/J NSg/V . NPrSg/I NSg/VX NSg/C
-> give  all       else  for two p           ennyworth only of  beautiful Soup  ? Pennyworth only of
-# NSg/V NSg/I/J/C N/J/C C/P NSg NPrSg/V/J/P ?         W?   V/P NSg/J     NSg/V . NSg        W?   V/P
-> beautiful Soup  ? Beau    — ootiful Soo — oop ! Beau    — ootiful Soo — oop ! Soo — oop of  the
-# NSg/J     NSg/V . NPrSg/V . ?       ?   . ?   . NPrSg/V . ?       ?   . ?   . ?   . ?   V/P D
+> give  all       else  for two p           ennyworth only of beautiful Soup  ? Pennyworth only of
+# NSg/V NSg/I/J/C N/J/C C/P NSg NPrSg/V/J/P ?         W?   P  NSg/J     NSg/V . NSg        W?   P
+> beautiful Soup  ? Beau    — ootiful Soo — oop ! Beau    — ootiful Soo — oop ! Soo — oop of the
+# NSg/J     NSg/V . NPrSg/V . ?       ?   . ?   . NPrSg/V . ?       ?   . ?   . ?   . ?   P  D
 > e       — e       — evening , Beautiful , beauti — FUL SOUP  ! ”
 # NPrSg/I . NPrSg/I . NSg/V   . NSg/J     . ?      . ?   NSg/V . .
 >
 #
 > “ Chorus again ! ” cried the Gryphon , and the Mock    Turtle had just begun to repeat
 # . NSg/V  P     . . W?    D   ?       . V/C D   NSg/V/J NSg/V  V   V/J  V     P  NSg/V
-> it        , when    a   cry   of  “ The trial’s beginning ! ” was heard in          the distance .
-# NPrSg/ISg . NSg/I/C D/P NSg/V V/P . D   N$      NSg/V/J   . . V   V/J   NPrSg/V/J/P D   NSg/V    .
+> it        , when    a   cry   of “ The trial’s beginning ! ” was heard in          the distance .
+# NPrSg/ISg . NSg/I/C D/P NSg/V P  . D   N$      NSg/V/J   . . V   V/J   NPrSg/V/J/P D   NSg/V    .
 >
 #
 > “ Come    on  ! ” cried the Gryphon , and , taking  Alice by      the hand  , it        hurried off       ,
 # . NSg/V/P J/P . . W?    D   ?       . V/C . NSg/V/J NPr   NSg/J/P D   NSg/V . NPrSg/ISg V/J     NSg/V/J/P .
-> without waiting for the end   of  the song .
-# C/P     NSg/V   C/P D   NSg/V V/P D   NSg  .
+> without waiting for the end   of the song .
+# C/P     NSg/V   C/P D   NSg/V P  D   NSg  .
 >
 #
 > “ What  trial   is it        ? ” Alice panted as    she ran   ; but     the Gryphon only answered “ Come
@@ -5004,42 +5004,42 @@
 # N/I/C/D W?       N/I  . D   NSg/J      NPl   . .
 >
 #
-> “ Soo — oop of  the e       — e       — evening , Beautiful , beautiful Soup  ! ”
-# . ?   . ?   V/P D   NPrSg/I . NPrSg/I . NSg/V   . NSg/J     . NSg/J     NSg/V . .
+> “ Soo — oop of the e       — e       — evening , Beautiful , beautiful Soup  ! ”
+# . ?   . ?   P  D   NPrSg/I . NPrSg/I . NSg/V   . NSg/J     . NSg/J     NSg/V . .
 >
 #
 > CHAPTER XI  : Who     Stole the Tarts ?
 # NSg/V   NSg . NPrSg/I NSg/V D   NPl   .
 >
 #
-> The King    and Queen   of  Hearts were  seated on  their throne when    they arrived , with
-# D   NPrSg/V V/C NPrSg/V V/P NPl    NSg/V W?     J/P D     NSg/V  NSg/I/C IPl  W?      . P
-> a   great crowd assembled about them — all       sorts of  little    birds and beasts , as    well
-# D/P NSg/J NSg/V W?        J/P   N/I  . NSg/I/J/C NPl   V/P NPrSg/I/J NPl   V/C NPl    . NSg/R NSg/V/J
-> as    the whole pack  of  cards : the Knave was standing before them , in          chains , with
-# NSg/R D   NSg/J NSg/V V/P NPl   . D   NSg   V   NSg/V/J  C/P    N/I  . NPrSg/V/J/P NPl    . P
+> The King    and Queen   of Hearts were  seated on  their throne when    they arrived , with
+# D   NPrSg/V V/C NPrSg/V P  NPl    NSg/V W?     J/P D     NSg/V  NSg/I/C IPl  W?      . P
+> a   great crowd assembled about them — all       sorts of little    birds and beasts , as    well
+# D/P NSg/J NSg/V W?        J/P   N/I  . NSg/I/J/C NPl   P  NPrSg/I/J NPl   V/C NPl    . NSg/R NSg/V/J
+> as    the whole pack  of cards : the Knave was standing before them , in          chains , with
+# NSg/R D   NSg/J NSg/V P  NPl   . D   NSg   V   NSg/V/J  C/P    N/I  . NPrSg/V/J/P NPl    . P
 > a   soldier on  each side    to guard him ; and near      the King    was the White     Rabbit ,
 # D/P NSg/V   J/P D    NSg/V/J P  NSg/V I   . V/C NSg/V/J/P D   NPrSg/V V   D   NPrSg/V/J NSg/V  .
-> with a   trumpet in          one       hand  , and a   scroll of  parchment in          the other   . In          the very
-# P    D/P NSg/V   NPrSg/V/J/P NSg/I/V/J NSg/V . V/C D/P NSg/V  V/P NSg       NPrSg/V/J/P D   NSg/V/J . NPrSg/V/J/P D   J
-> middle  of  the court was a   table , with a   large dish  of  tarts upon it        : they looked
-# NSg/V/J V/P D   NSg/V V   D/P NSg/V . P    D/P NSg/J NSg/V V/P NPl   P    NPrSg/ISg . IPl  W?
+> with a   trumpet in          one       hand  , and a   scroll of parchment in          the other   . In          the very
+# P    D/P NSg/V   NPrSg/V/J/P NSg/I/V/J NSg/V . V/C D/P NSg/V  P  NSg       NPrSg/V/J/P D   NSg/V/J . NPrSg/V/J/P D   J
+> middle  of the court was a   table , with a   large dish  of tarts upon it        : they looked
+# NSg/V/J P  D   NSg/V V   D/P NSg/V . P    D/P NSg/J NSg/V P  NPl   P    NPrSg/ISg . IPl  W?
 > so        good      , that    it        made  Alice quite hungry to look  at        them — “ I   wish  they’d get   the
 # NSg/I/J/C NPrSg/V/J . N/I/C/D NPrSg/ISg NSg/V NPr   NSg   J      P  NSg/V NSg/I/V/P N/I  . . ISg NSg/V W?     NSg/V D
 > trial   done    , ” she thought , “ and hand  round     the refreshments ! ” But     there seemed to
 # NSg/V/J NSg/V/J . . ISg NSg/V   . . V/C NSg/V NSg/V/J/P D   NSg          . . NSg/C/P W?    W?     P
-> be     no      chance    of  this , so        she began looking at        everything about her   , to pass  away
-# NSg/VX NPrSg/P NPrSg/V/J V/P I/D  . NSg/I/J/C ISg V     V       NSg/I/V/P N/I/V      J/P   I/J/D . P  NSg/V V/J
+> be     no      chance    of this , so        she began looking at        everything about her   , to pass  away
+# NSg/VX NPrSg/P NPrSg/V/J P  I/D  . NSg/I/J/C ISg V     V       NSg/I/V/P N/I/V      J/P   I/J/D . P  NSg/V V/J
 > the time  .
 # D   NSg/V .
 >
 #
-> Alice had never been  in          a   court of  justice before , but     she had read  about them
-# NPr   V   V     NSg/V NPrSg/V/J/P D/P NSg/V V/P NPrSg   C/P    . NSg/C/P ISg V   NSg/V J/P   N/I
-> in          books , and she was quite pleased to find  that    she knew the name  of  nearly
-# NPrSg/V/J/P NPl   . V/C ISg V   NSg   W?      P  NSg/V N/I/C/D ISg V    D   NSg/V V/P J/R
-> everything there . “ That’s the judge , ” she said to herself , “ because of  his   great
-# N/I/V      W?    . . N$     D   NSg/V . . ISg V/J  P  I       . . C/P     V/P ISg/D NSg/J
+> Alice had never been  in          a   court of justice before , but     she had read  about them
+# NPr   V   V     NSg/V NPrSg/V/J/P D/P NSg/V P  NPrSg   C/P    . NSg/C/P ISg V   NSg/V J/P   N/I
+> in          books , and she was quite pleased to find  that    she knew the name  of nearly
+# NPrSg/V/J/P NPl   . V/C ISg V   NSg   W?      P  NSg/V N/I/C/D ISg V    D   NSg/V P  J/R
+> everything there . “ That’s the judge , ” she said to herself , “ because of his   great
+# N/I/V      W?    . . N$     D   NSg/V . . ISg V/J  P  I       . . C/P     P  ISg/D NSg/J
 > wig   . ”
 # NSg/V . .
 >
@@ -5054,14 +5054,14 @@
 #
 > “ And that’s the jury    - box   , ” thought Alice , “ and those twelve creatures , ” ( she was
 # . V/C N$     D   NSg/V/J . NSg/V . . NSg/V   NPr   . . V/C I/D   NSg    NPl       . . . ISg V
-> obliged to say   “ creatures , ” you see   , because some  of  them were  animals , and some
-# W?      P  NSg/V . NPl       . . IPl NSg/V . C/P     I/J/R V/P N/I  NSg/V NPl     . V/C I/J/R
+> obliged to say   “ creatures , ” you see   , because some  of them were  animals , and some
+# W?      P  NSg/V . NPl       . . IPl NSg/V . C/P     I/J/R P  N/I  NSg/V NPl     . V/C I/J/R
 > were  birds , ) “ I   suppose they are the jurors . ” She said this last    word  two or
 # NSg/V NPl   . . . ISg V       IPl  V   D   NPl    . . ISg V/J  I/D  NSg/V/J NSg/V NSg NPrSg/C
-> three times over      to herself , being   rather    proud of  it        : for she thought , and
-# NSg   NPl   NSg/V/J/P P  I       . NSg/V/C NPrSg/V/J J     V/P NPrSg/ISg . C/P ISg NSg/V   . V/C
-> rightly too , that    very few little    girls of  her   age   knew the meaning of  it        at
-# J/R     W?  . N/I/C/D J    N/I NPrSg/I/J NPl   V/P I/J/D NSg/V V    D   NSg/V/J V/P NPrSg/ISg NSg/I/V/P
+> three times over      to herself , being   rather    proud of it        : for she thought , and
+# NSg   NPl   NSg/V/J/P P  I       . NSg/V/C NPrSg/V/J J     P  NPrSg/ISg . C/P ISg NSg/V   . V/C
+> rightly too , that    very few little    girls of her   age   knew the meaning of it        at
+# J/R     W?  . N/I/C/D J    N/I NPrSg/I/J NPl   P  I/J/D NSg/V V    D   NSg/V/J P  NPrSg/ISg NSg/I/V/P
 > all       . However , “ jury    - men ” would  have   done    just as    well    .
 # NSg/I/J/C . C       . . NSg/V/J . NSg . NSg/VX NSg/VX NSg/V/J V/J  NSg/R NSg/V/J .
 >
@@ -5076,8 +5076,8 @@
 #
 > “ They’re putting down      their names , ” the Gryphon whispered in          reply , “ for fear
 # . W?      NSg/V   NSg/V/J/P D     NPl   . . D   ?       W?        NPrSg/V/J/P NSg/V . . C/P NSg/V
-> they should forget them before the end   of  the trial   . ”
-# IPl  VX     V      N/I  C/P    D   NSg/V V/P D   NSg/V/J . .
+> they should forget them before the end   of the trial   . ”
+# IPl  VX     V      N/I  C/P    D   NSg/V P  D   NSg/V/J . .
 >
 #
 > “ Stupid things ! ” Alice began in          a   loud  , indignant voice , but     she stopped
@@ -5092,26 +5092,26 @@
 # NPr   NSg/VX NSg/V . NSg/R NSg/V/J NSg/R NSg/C ISg NSg/V V       NSg/V/J/P D     NPl       . N/I/C/D NSg/I/J/C
 > the jurors were  writing down      “ stupid things ! ” on  their slates , and she could
 # D   NPl    NSg/V NSg/V   NSg/V/J/P . NSg/J  NPl    . . J/P D     NPl    . V/C ISg NSg/VX
-> even    make  out         that    one       of  them didn’t know  how   to spell “ stupid , ” and that    he
-# NSg/V/J NSg/V NSg/V/J/R/P N/I/C/D NSg/I/V/J V/P N/I  V      NSg/V NSg/C P  NSg/V . NSg/J  . . V/C N/I/C/D NPr/ISg
+> even    make  out         that    one       of them didn’t know  how   to spell “ stupid , ” and that    he
+# NSg/V/J NSg/V NSg/V/J/R/P N/I/C/D NSg/I/V/J P  N/I  V      NSg/V NSg/C P  NSg/V . NSg/J  . . V/C N/I/C/D NPr/ISg
 > had to ask   his   neighbour to tell    him . “ A   nice      muddle their slates’ll be     in
 # V   P  NSg/V ISg/D NSg/V/Br  P  NPrSg/V I   . . D/P NPrSg/V/J NSg/V  D     ?         NSg/VX NPrSg/V/J/P
 > before the trial’s over      ! ” thought Alice .
 # C/P    D   N$      NSg/V/J/P . . NSg/V   NPr   .
 >
 #
-> One       of  the jurors had a   pencil that    squeaked . This of  course , Alice could  not
-# NSg/I/V/J V/P D   NPl    V   D/P NSg/V  N/I/C/D W?       . I/D  V/P NSg/V  . NPr   NSg/VX NSg/C
+> One       of the jurors had a   pencil that    squeaked . This of course , Alice could  not
+# NSg/I/V/J P  D   NPl    V   D/P NSg/V  N/I/C/D W?       . I/D  P  NSg/V  . NPr   NSg/VX NSg/C
 > stand , and she went  round     the court and got behind  him , and very soon found an
 # NSg/V . V/C ISg NSg/V NSg/V/J/P D   NSg/V V/C V   NSg/J/P I   . V/C J    J/R  NSg/V D/P
-> opportunity of  taking  it        away . She did it        so        quickly that    the poor    little    juror
-# NSg         V/P NSg/V/J NPrSg/ISg V/J  . ISg V   NPrSg/ISg NSg/I/J/C J/R     N/I/C/D D   NSg/V/J NPrSg/I/J NSg
-> ( it        was Bill    , the Lizard ) could  not   make  out         at        all       what  had become of  it        ; so        ,
-# . NPrSg/ISg V   NPrSg/V . D   NSg    . NSg/VX NSg/C NSg/V NSg/V/J/R/P NSg/I/V/P NSg/I/J/C NSg/I V   V      V/P NPrSg/ISg . NSg/I/J/C .
+> opportunity of taking  it        away . She did it        so        quickly that    the poor    little    juror
+# NSg         P  NSg/V/J NPrSg/ISg V/J  . ISg V   NPrSg/ISg NSg/I/J/C J/R     N/I/C/D D   NSg/V/J NPrSg/I/J NSg
+> ( it        was Bill    , the Lizard ) could  not   make  out         at        all       what  had become of it        ; so        ,
+# . NPrSg/ISg V   NPrSg/V . D   NSg    . NSg/VX NSg/C NSg/V NSg/V/J/R/P NSg/I/V/P NSg/I/J/C NSg/I V   V      P  NPrSg/ISg . NSg/I/J/C .
 > after hunting all       about for it        , he      was obliged to write with one       finger for the
 # J/P   NSg/V   NSg/I/J/C J/P   C/P NPrSg/ISg . NPr/ISg V   W?      P  NSg/V P    NSg/I/V/J NSg/V  C/P D
-> rest  of  the day   ; and this was of  very little    use   , as    it        left      no      mark    on  the
-# NSg/V V/P D   NPrSg . V/C I/D  V   V/P J    NPrSg/I/J NSg/V . NSg/R NPrSg/ISg NPrSg/V/J NPrSg/P NPrSg/V J/P D
+> rest  of the day   ; and this was of very little    use   , as    it        left      no      mark    on  the
+# NSg/V P  D   NPrSg . V/C I/D  V   P  J    NPrSg/I/J NSg/V . NSg/R NPrSg/ISg NPrSg/V/J NPrSg/P NPrSg/V J/P D
 > slate   .
 # NSg/V/J .
 >
@@ -5126,8 +5126,8 @@
 # NSg       NSg/V  . V/C NSg/V NSg/R NPl     . .
 >
 #
-> “ The Queen   of  Hearts , she made  some  tarts , All       on  a   summer  day   : The Knave of
-# . D   NPrSg/V V/P NPl    . ISg NSg/V I/J/R NPl   . NSg/I/J/C J/P D/P NPrSg/V NPrSg . D   NSg   V/P
+> “ The Queen   of Hearts , she made  some  tarts , All       on  a   summer  day   : The Knave of
+# . D   NPrSg/V P  NPl    . ISg NSg/V I/J/R NPl   . NSg/I/J/C J/P D/P NPrSg/V NPrSg . D   NSg   P
 > Hearts , he      stole those tarts , And took them quite away ! ”
 # NPl    . NPr/ISg NSg/V I/D   NPl   . V/C V    N/I  NSg   V/J  . .
 >
@@ -5150,8 +5150,8 @@
 #
 > The first   witness was the Hatter . He      came    in          with a   teacup in          one       hand  and a
 # D   NSg/V/J NSg/V   V   D   NSg/V  . NPr/ISg NSg/V/P NPrSg/V/J/P P    D/P NSg/J  NPrSg/V/J/P NSg/I/V/J NSg/V V/C D/P
-> piece of  bread - and - butter  in          the other   . “ I   beg   pardon , your Majesty , ” he      began ,
-# NSg/V V/P NSg/V . V/C . NSg/V/J NPrSg/V/J/P D   NSg/V/J . . ISg NSg/V NSg/V  . D    NSg/I   . . NPr/ISg V     .
+> piece of bread - and - butter  in          the other   . “ I   beg   pardon , your Majesty , ” he      began ,
+# NSg/V P  NSg/V . V/C . NSg/V/J NPrSg/V/J/P D   NSg/V/J . . ISg NSg/V NSg/V  . D    NSg/I   . . NPr/ISg V     .
 > “ for bringing these in          : but     I   hadn’t quite finished my tea   when    I   was sent  for . ”
 # . C/P V        I/D   NPrSg/V/J/P . NSg/C/P ISg V      NSg   V/J      D  NSg/V NSg/I/C ISg V   NSg/V C/P . .
 >
@@ -5162,8 +5162,8 @@
 #
 > The Hatter looked at        the March   Hare    , who     had followed him into the court ,
 # D   NSg/V  W?     NSg/I/V/P D   NPrSg/V NSg/V/J . NPrSg/I V   W?       I   P    D   NSg/V .
-> arm     - in          - arm     with the Dormouse . “ Fourteenth of  March   , I   think it        was , ” he      said .
-# NSg/V/J . NPrSg/V/J/P . NSg/V/J P    D   NSg      . . NSg/J      V/P NPrSg/V . ISg NSg/V NPrSg/ISg V   . . NPr/ISg V/J  .
+> arm     - in          - arm     with the Dormouse . “ Fourteenth of March   , I   think it        was , ” he      said .
+# NSg/V/J . NPrSg/V/J/P . NSg/V/J P    D   NSg      . . NSg/J      P  NPrSg/V . ISg NSg/V NPrSg/ISg V   . . NPr/ISg V/J  .
 >
 #
 > “ Fifteenth , ” said the March   Hare    .
@@ -5192,12 +5192,12 @@
 #
 > “ Stolen  ! ” the King    exclaimed , turning to the jury    , who     instantly made  a
 # . NSg/V/J . . D   NPrSg/V W?        . NSg/V   P  D   NSg/V/J . NPrSg/I J/R       NSg/V D/P
-> memorandum of  the fact .
-# NSg        V/P D   NSg  .
+> memorandum of the fact .
+# NSg        P  D   NSg  .
 >
 #
-> “ I   keep  them to sell  , ” the Hatter added as    an  explanation ; “ I’ve none  of  my own     .
-# . ISg NSg/V N/I  P  NSg/V . . D   NSg/V  W?    NSg/R D/P NSg         . . W?   NSg/I V/P D  NSg/V/J .
+> “ I   keep  them to sell  , ” the Hatter added as    an  explanation ; “ I’ve none  of my own     .
+# . ISg NSg/V N/I  P  NSg/V . . D   NSg/V  W?    NSg/R D/P NSg         . . W?   NSg/I P  D  NSg/V/J .
 > I’m a   hatter . ”
 # W?  D/P NSg/V  . .
 >
@@ -5218,8 +5218,8 @@
 # I/D  V   NSg/C V    P  V         D   NSg/V   NSg/I/V/P NSg/I/J/C . NPr/ISg V    V        P    NSg/I/V/J
 > foot  to the other   , looking uneasily at        the Queen   , and in          his   confusion he      bit   a
 # NSg/V P  D   NSg/V/J . V       R        NSg/I/V/P D   NPrSg/V . V/C NPrSg/V/J/P ISg/D NSg/V     NPr/ISg NSg/V D/P
-> large piece out         of  his   teacup instead of  the bread - and - butter  .
-# NSg/J NSg/V NSg/V/J/R/P V/P ISg/D NSg/J  W?      V/P D   NSg/V . V/C . NSg/V/J .
+> large piece out         of his   teacup instead of the bread - and - butter  .
+# NSg/J NSg/V NSg/V/J/R/P P  ISg/D NSg/J  W?      P  D   NSg/V . V/C . NSg/V/J .
 >
 #
 > Just at        this moment Alice felt    a   very curious sensation , which puzzled her   a
@@ -5256,16 +5256,16 @@
 # . NSg/V . NSg/C/P ISg V    NSg/I/V/P D/P J          NPrSg/V/J/P . . V/J  D   NSg      . . NSg/C NPrSg/V/J/P N/I/C/D
 > ridiculous fashion . ” And he      got up        very sulkily and crossed over      to the other
 # J          NSg/V   . . V/C NPr/ISg V   NSg/V/J/P J    R       V/C W?      NSg/V/J/P P  D   NSg/V/J
-> side    of  the court .
-# NSg/V/J V/P D   NSg/V .
+> side    of the court .
+# NSg/V/J P  D   NSg/V .
 >
 #
 > All       this time  the Queen   had never left      off       staring at        the Hatter , and , just as
 # NSg/I/J/C I/D  NSg/V D   NPrSg/V V   V     NPrSg/V/J NSg/V/J/P V       NSg/I/V/P D   NSg/V  . V/C . V/J  NSg/R
-> the Dormouse crossed the court , she said to one       of  the officers of  the court ,
-# D   NSg      W?      D   NSg/V . ISg V/J  P  NSg/I/V/J V/P D   W?       V/P D   NSg/V .
-> “ Bring me        the list  of  the singers in          the last    concert ! ” on  which the wretched
-# . V     NPrSg/ISg D   NSg/V V/P D   W?      NPrSg/V/J/P D   NSg/V/J NSg/V   . . J/P I/C   D   J
+> the Dormouse crossed the court , she said to one       of the officers of the court ,
+# D   NSg      W?      D   NSg/V . ISg V/J  P  NSg/I/V/J P  D   W?       P  D   NSg/V .
+> “ Bring me        the list  of the singers in          the last    concert ! ” on  which the wretched
+# . V     NPrSg/ISg D   NSg/V P  D   W?      NPrSg/V/J/P D   NSg/V/J NSg/V   . . J/P I/C   D   J
 > Hatter trembled so        , that    he      shook   both his   shoes off       .
 # NSg/V  W?       NSg/I/J/C . N/I/C/D NPr/ISg NSg/V/J I/C  ISg/D NPl   NSg/V/J/P .
 >
@@ -5280,20 +5280,20 @@
 # . W?  D/P NSg/V/J NPrSg/I/V/J . D    NSg/I   . . D   NSg/V  V     . NPrSg/V/J/P D/P V         NSg/V . . . V/C ISg
 > hadn’t begun my tea   — not   above   a   week or      so        — and what  with the bread - and - butter
 # V      V     D  NSg/V . NSg/C NSg/J/P D/P NSg  NPrSg/C NSg/I/J/C . V/C NSg/I P    D   NSg/V . V/C . NSg/V/J
-> getting so        thin    — and the twinkling of  the tea   — ”
-# NSg/V   NSg/I/J/C NSg/V/J . V/C D   NSg/V/J   V/P D   NSg/V . .
+> getting so        thin    — and the twinkling of the tea   — ”
+# NSg/V   NSg/I/J/C NSg/V/J . V/C D   NSg/V/J   P  D   NSg/V . .
 >
 #
-> “ The twinkling of  the what  ? ” said the King    .
-# . D   NSg/V/J   V/P D   NSg/I . . V/J  D   NPrSg/V .
+> “ The twinkling of the what  ? ” said the King    .
+# . D   NSg/V/J   P  D   NSg/I . . V/J  D   NPrSg/V .
 >
 #
 > “ It        began with the tea   , ” the Hatter replied .
 # . NPrSg/ISg V     P    D   NSg/V . . D   NSg/V  W?      .
 >
 #
-> “ Of  course twinkling begins with a   T       ! ” said the King    sharply . “ Do     you take  me
-# . V/P NSg/V  NSg/V/J   NPl    P    D/P NPrSg/J . . V/J  D   NPrSg/V J/R     . . NSg/VX IPl NSg/V NPrSg/ISg
+> “ Of course twinkling begins with a   T       ! ” said the King    sharply . “ Do     you take  me
+# . P  NSg/V  NSg/V/J   NPl    P    D/P NPrSg/J . . V/J  D   NPrSg/V J/R     . . NSg/VX IPl NSg/V NPrSg/ISg
 > for a   dunce ? Go      on  ! ”
 # C/P D/P NSg   . NSg/V/J J/P . .
 >
@@ -5332,8 +5332,8 @@
 # . J/P   N/I/C/D . . W?        D   NSg/V  . . ISg NSg/V/J I/J/R NPrSg/I/V/J NSg/V . V/C . NSg/V/J . .
 >
 #
-> “ But     what  did the Dormouse say   ? ” one       of  the jury    asked .
-# . NSg/C/P NSg/I V   D   NSg      NSg/V . . NSg/I/V/J V/P D   NSg/V/J V/J   .
+> “ But     what  did the Dormouse say   ? ” one       of the jury    asked .
+# . NSg/C/P NSg/I V   D   NSg      NSg/V . . NSg/I/V/J P  D   NSg/V/J V/J   .
 >
 #
 > “ That    I   can’t remember , ” said the Hatter .
@@ -5354,10 +5354,10 @@
 # . W?     D/P J    NSg/V/J NSg/J   . . V/J  D   NPrSg/V .
 >
 #
-> Here    one       of  the guinea - pigs cheered , and was immediately suppressed by      the
-# NSg/J/R NSg/I/V/J V/P D   NPrSg  . NPl  W?      . V/C V   J/R         W?         NSg/J/P D
-> officers of  the court . ( As    that    is rather    a   hard    word  , I   will     just explain to
-# W?       V/P D   NSg/V . . NSg/R N/I/C/D VL NPrSg/V/J D/P NSg/V/J NSg/V . ISg NPrSg/VX V/J  V       P
+> Here    one       of the guinea - pigs cheered , and was immediately suppressed by      the
+# NSg/J/R NSg/I/V/J P  D   NPrSg  . NPl  W?      . V/C V   J/R         W?         NSg/J/P D
+> officers of the court . ( As    that    is rather    a   hard    word  , I   will     just explain to
+# W?       P  D   NSg/V . . NSg/R N/I/C/D VL NPrSg/V/J D/P NSg/V/J NSg/V . ISg NPrSg/VX V/J  V       P
 > you how   it        was done    . They had a   large canvas bag   , which tied up        at        the mouth
 # IPl NSg/C NPrSg/ISg V   NSg/V/J . IPl  V   D/P NSg/J NSg/V  NSg/V . I/C   W?   NSg/V/J/P NSg/I/V/P D   NSg/V
 > with strings : into this they slipped the guinea - pig   , head      first   , and then    sat
@@ -5368,10 +5368,10 @@
 #
 > “ I’m glad    I’ve seen  that    done    , ” thought Alice . “ I’ve so        often read  in          the
 # . W?  NSg/V/J W?   NSg/V N/I/C/D NSg/V/J . . NSg/V   NPr   . . W?   NSg/I/J/C J     NSg/V NPrSg/V/J/P D
-> newspapers , at        the end   of  trials , “ There was some  attempts at        applause , which
-# NPl        . NSg/I/V/P D   NSg/V V/P NPl    . . W?    V   I/J/R NPl      NSg/I/V/P NSg      . I/C
-> was immediately suppressed by      the officers of  the court , ” and I   never understood
-# V   J/R         W?         NSg/J/P D   W?       V/P D   NSg/V . . V/C ISg V     V/J
+> newspapers , at        the end   of trials , “ There was some  attempts at        applause , which
+# NPl        . NSg/I/V/P D   NSg/V P  NPl    . . W?    V   I/J/R NPl      NSg/I/V/P NSg      . I/C
+> was immediately suppressed by      the officers of the court , ” and I   never understood
+# V   J/R         W?         NSg/J/P D   W?       P  D   NSg/V . . V/C ISg V     V/J
 > what  it        meant till      now         . ”
 # NSg/I NPrSg/ISg V     NSg/V/C/P NPrSg/V/J/C . .
 >
@@ -5400,8 +5400,8 @@
 #
 > “ I’d rather    finish my tea   , ” said the Hatter , with an  anxious look  at        the Queen   ,
 # . W?  NPrSg/V/J NSg/V  D  NSg/V . . V/J  D   NSg/V  . P    D/P J       NSg/V NSg/I/V/P D   NPrSg/V .
-> who     was reading the list  of  singers .
-# NPrSg/I V   NPrSg/V D   NSg/V V/P W?      .
+> who     was reading the list  of singers .
+# NPrSg/I V   NPrSg/V D   NSg/V P  W?      .
 >
 #
 > “ You may      go      , ” said the King    , and the Hatter hurriedly left      the court , without
@@ -5410,10 +5410,10 @@
 # NSg/V/J NSg/V   P  NSg/V ISg/D NPl   J/P .
 >
 #
-> “ — and just take  his   head      off       outside   , ” the Queen   added to one       of  the officers :
-# . . V/C V/J  NSg/V ISg/D NPrSg/V/J NSg/V/J/P NSg/V/J/P . . D   NPrSg/V W?    P  NSg/I/V/J V/P D   W?       .
-> but     the Hatter was out         of  sight before the officer could  get   to the door  .
-# NSg/C/P D   NSg/V  V   NSg/V/J/R/P V/P NSg/V C/P    D   NSg/V/J NSg/VX NSg/V P  D   NSg/V .
+> “ — and just take  his   head      off       outside   , ” the Queen   added to one       of the officers :
+# . . V/C V/J  NSg/V ISg/D NPrSg/V/J NSg/V/J/P NSg/V/J/P . . D   NPrSg/V W?    P  NSg/I/V/J P  D   W?       .
+> but     the Hatter was out         of sight before the officer could  get   to the door  .
+# NSg/C/P D   NSg/V  V   NSg/V/J/R/P P  NSg/V C/P    D   NSg/V/J NSg/VX NSg/V P  D   NSg/V .
 >
 #
 > “ Call  the next    witness ! ” said the King    .
@@ -5445,9 +5445,9 @@
 > “ Well    , if    I   must  , I   must  , ” the King    said , with a   melancholy air   , and , after
 # . NSg/V/J . NSg/C ISg NSg/V . ISg NSg/V . . D   NPrSg/V V/J  . P    D/P NSg/J      NSg/V . V/C . J/P
 > folding his   arms and frowning at        the cook    till      his   eyes were  nearly out         of
-# V       ISg/D NPl  V/C V        NSg/I/V/P D   NPrSg/V NSg/V/C/P ISg/D NPl  NSg/V J/R    NSg/V/J/R/P V/P
-> sight , he      said in          a   deep  voice , “ What  are tarts made  of  ? ”
-# NSg/V . NPr/ISg V/J  NPrSg/V/J/P D/P NSg/J NSg/V . . NSg/I V   NPl   NSg/V V/P . .
+# V       ISg/D NPl  V/C V        NSg/I/V/P D   NPrSg/V NSg/V/C/P ISg/D NPl  NSg/V J/R    NSg/V/J/R/P P
+> sight , he      said in          a   deep  voice , “ What  are tarts made  of ? ”
+# NSg/V . NPr/ISg V/J  NPrSg/V/J/P D/P NSg/J NSg/V . . NSg/I V   NPl   NSg/V P  . .
 >
 #
 > “ Pepper , mostly , ” said the cook    .
@@ -5460,8 +5460,8 @@
 #
 > “ Collar that    Dormouse , ” the Queen   shrieked out         . “ Behead that    Dormouse ! Turn  that
 # . NSg/V  N/I/C/D NSg      . . D   NPrSg/V W?       NSg/V/J/R/P . . V      N/I/C/D NSg      . NSg/V N/I/C/D
-> Dormouse out         of  court ! Suppress him ! Pinch him ! Off       with his   whiskers ! ”
-# NSg      NSg/V/J/R/P V/P NSg/V . V        I   . NSg/V I   . NSg/V/J/P P    ISg/D W?       . .
+> Dormouse out         of court ! Suppress him ! Pinch him ! Off       with his   whiskers ! ”
+# NSg      NSg/V/J/R/P P  NSg/V . V        I   . NSg/V I   . NSg/V/J/P P    ISg/D W?       . .
 >
 #
 > For some  minutes the whole court was in          confusion , getting the Dormouse turned
@@ -5470,8 +5470,8 @@
 # NSg/V/J/R/P . V/C . NSg/J/P D   NSg/V IPl  V   W?      NSg/V/J/P P     . D   NPrSg/V V   W?          .
 >
 #
-> “ Never mind  ! ” said the King    , with an  air   of  great relief . “ Call  the next
-# . V     NSg/V . . V/J  D   NPrSg/V . P    D/P NSg/V V/P NSg/J NSg/J  . . NSg/V D   NSg/J/P
+> “ Never mind  ! ” said the King    , with an  air   of great relief . “ Call  the next
+# . V     NSg/V . . V/J  D   NPrSg/V . P    D/P NSg/V P  NSg/J NSg/J  . . NSg/V D   NSg/J/P
 > witness . ” And he      added in          an  undertone to the Queen   , “ Really , my dear    , you must
 # NSg/V   . . V/C NPr/ISg W?    NPrSg/V/J/P D/P NSg/V     P  D   NPrSg/V . . J/R    . D  NSg/V/J . IPl NSg/V
 > cross       - examine the next    witness . It        quite makes my forehead ache  ! ”
@@ -5484,34 +5484,34 @@
 # P  NSg/V NSg/I D   NSg/J/P NSg/V   NSg/VX NSg/VX NSg/V/J/C/P . . . C/P IPl  V       V   N/I/J NSg/V
 > yet     , ” she said to herself . Imagine her   surprise , when    the White     Rabbit read  out         ,
 # NSg/V/C . . ISg V/J  P  I       . NSg/V   I/J/D NSg/V    . NSg/I/C D   NPrSg/V/J NSg/V  NSg/V NSg/V/J/R/P .
-> at        the top     of  his   shrill  little    voice , the name  “ Alice ! ”
-# NSg/I/V/P D   NSg/V/J V/P ISg/D NSg/V/J NPrSg/I/J NSg/V . D   NSg/V . NPr   . .
+> at        the top     of his   shrill  little    voice , the name  “ Alice ! ”
+# NSg/I/V/P D   NSg/V/J P  ISg/D NSg/V/J NPrSg/I/J NSg/V . D   NSg/V . NPr   . .
 >
 #
 > CHAPTER XII : Alice’s Evidence
 # NSg/V   W?  . N$      NSg/V
 >
 #
-> “ Here    ! ” cried Alice , quite forgetting in          the flurry of  the moment how   large she
-# . NSg/J/R . . W?    NPr   . NSg   NSg/V      NPrSg/V/J/P D   NSg/V  V/P D   NSg    NSg/C NSg/J ISg
+> “ Here    ! ” cried Alice , quite forgetting in          the flurry of the moment how   large she
+# . NSg/J/R . . W?    NPr   . NSg   NSg/V      NPrSg/V/J/P D   NSg/V  P  D   NSg    NSg/C NSg/J ISg
 > had grown in          the last    few minutes , and she jumped up        in          such  a   hurry that    she
 # V   V/J   NPrSg/V/J/P D   NSg/V/J N/I NPl     . V/C ISg W?     NSg/V/J/P NPrSg/V/J/P NSg/I D/P NSg/V N/I/C/D ISg
-> tipped over      the jury    - box   with the edge  of  her   skirt , upsetting all       the jurymen
-# V      NSg/V/J/P D   NSg/V/J . NSg/V P    D   NSg/V V/P I/J/D NSg/V . NSg/V/J   NSg/I/J/C D   NPl
-> on  to the heads of  the crowd below , and there they lay     sprawling about ,
-# J/P P  D   NPl   V/P D   NSg/V P     . V/C W?    IPl  NSg/V/J V         J/P   .
-> reminding her   very much  of  a   globe of  goldfish she had accidentally upset   the
-# V         I/J/D J    N/I/J V/P D/P NSg/V V/P NSg      ISg V   J/R          NSg/V/J D
+> tipped over      the jury    - box   with the edge  of her   skirt , upsetting all       the jurymen
+# V      NSg/V/J/P D   NSg/V/J . NSg/V P    D   NSg/V P  I/J/D NSg/V . NSg/V/J   NSg/I/J/C D   NPl
+> on  to the heads of the crowd below , and there they lay     sprawling about ,
+# J/P P  D   NPl   P  D   NSg/V P     . V/C W?    IPl  NSg/V/J V         J/P   .
+> reminding her   very much  of a   globe of goldfish she had accidentally upset   the
+# V         I/J/D J    N/I/J P  D/P NSg/V P  NSg      ISg V   J/R          NSg/V/J D
 > week before .
 # NSg  C/P    .
 >
 #
-> “ Oh      , I   beg   your pardon ! ” she exclaimed in          a   tone    of  great dismay , and began
-# . NPrSg/V . ISg NSg/V D    NSg/V  . . ISg W?        NPrSg/V/J/P D/P NSg/I/V V/P NSg/J NSg/V  . V/C V
-> picking them up        again as    quickly as    she could  , for the accident of  the goldfish
-# V       N/I  NSg/V/J/P P     NSg/R J/R     NSg/R ISg NSg/VX . C/P D   NSg/J    V/P D   NSg
-> kept running   in          her   head      , and she had a   vague   sort  of  idea that    they must  be
-# V    NSg/V/J/P NPrSg/V/J/P I/J/D NPrSg/V/J . V/C ISg V   D/P NSg/V/J NSg/V V/P NSg  N/I/C/D IPl  NSg/V NSg/VX
+> “ Oh      , I   beg   your pardon ! ” she exclaimed in          a   tone    of great dismay , and began
+# . NPrSg/V . ISg NSg/V D    NSg/V  . . ISg W?        NPrSg/V/J/P D/P NSg/I/V P  NSg/J NSg/V  . V/C V
+> picking them up        again as    quickly as    she could  , for the accident of the goldfish
+# V       N/I  NSg/V/J/P P     NSg/R J/R     NSg/R ISg NSg/VX . C/P D   NSg/J    P  D   NSg
+> kept running   in          her   head      , and she had a   vague   sort  of idea that    they must  be
+# V    NSg/V/J/P NPrSg/V/J/P I/J/D NPrSg/V/J . V/C ISg V   D/P NSg/V/J NSg/V P  NSg  N/I/C/D IPl  NSg/V NSg/VX
 > collected at        once  and put   back    into the jury    - box   , or      they would  die   .
 # V/J       NSg/I/V/P NSg/C V/C NSg/V NSg/V/J P    D   NSg/V/J . NSg/V . NPrSg/C IPl  NSg/VX NSg/V .
 >
@@ -5536,16 +5536,16 @@
 # NSg/VX NSg/VX NSg   NSg/R N/I/J NSg/V NPrSg/V/J/P D   NSg/V/J NSg/I/V/J NSg/J NSg/V/J/P NSg/R D   NSg/V/J . .
 >
 #
-> As    soon as    the jury    had a   little    recovered from the shock   of  being   upset   , and
-# NSg/R J/R  NSg/R D   NSg/V/J V   D/P NPrSg/I/J W?        P    D   NSg/V/J V/P NSg/V/C NSg/V/J . V/C
+> As    soon as    the jury    had a   little    recovered from the shock   of being   upset   , and
+# NSg/R J/R  NSg/R D   NSg/V/J V   D/P NPrSg/I/J W?        P    D   NSg/V/J P  NSg/V/C NSg/V/J . V/C
 > their slates and pencils had been  found and handed back    to them , they set       to
 # D     NPl    V/C NPl     V   NSg/V NSg/V V/C V/J    NSg/V/J P  N/I  . IPl  NPrSg/V/J P
-> work  very diligently to write out         a   history of  the accident , all       except the
-# NSg/V J    J/R        P  NSg/V NSg/V/J/R/P D/P NSg     V/P D   NSg/J    . NSg/I/J/C V/C/P  D
+> work  very diligently to write out         a   history of the accident , all       except the
+# NSg/V J    J/R        P  NSg/V NSg/V/J/R/P D/P NSg     P  D   NSg/J    . NSg/I/J/C V/C/P  D
 > Lizard , who     seemed too much  overcome to do     anything but     sit   with its   mouth open    ,
 # NSg    . NPrSg/I W?     W?  N/I/J NSg/V    P  NSg/VX NSg/I/V  NSg/C/P NSg/V P    ISg/D NSg/V NSg/V/J .
-> gazing up        into the roof  of  the court .
-# V      NSg/V/J/P P    D   NSg/V V/P D   NSg/V .
+> gazing up        into the roof  of the court .
+# V      NSg/V/J/P P    D   NSg/V P  D   NSg/V .
 >
 #
 > “ What  do     you know  about this business ? ” the King    said to Alice .
@@ -5568,14 +5568,14 @@
 # . N$     J    J         . . D   NPrSg/V V/J  . NSg/V   P  D   NSg/V/J . IPl  NSg/V V/J
 > beginning to write this down      on  their slates , when    the White     Rabbit interrupted :
 # NSg/V/J   P  NSg/V I/D  NSg/V/J/P J/P D     NPl    . NSg/I/C D   NPrSg/V/J NSg/V  W?          .
-> “ Unimportant , your Majesty means , of  course , ” he      said in          a   very respectful tone    ,
-# . J           . D    NSg/I   NPl   . V/P NSg/V  . . NPr/ISg V/J  NPrSg/V/J/P D/P J    J          NSg/I/V .
+> “ Unimportant , your Majesty means , of course , ” he      said in          a   very respectful tone    ,
+# . J           . D    NSg/I   NPl   . P  NSg/V  . . NPr/ISg V/J  NPrSg/V/J/P D/P J    J          NSg/I/V .
 > but     frowning and making faces at        him as    he      spoke .
 # NSg/C/P V        V/C NSg/V  NPl   NSg/I/V/P I   NSg/R NPr/ISg NSg/V .
 >
 #
-> “ Unimportant , of  course , I   meant , ” the King    hastily said , and went  on  to himself
-# . J           . V/P NSg/V  . ISg V     . . D   NPrSg/V R       V/J  . V/C NSg/V J/P P  I
+> “ Unimportant , of course , I   meant , ” the King    hastily said , and went  on  to himself
+# . J           . P  NSg/V  . ISg V     . . D   NPrSg/V R       V/J  . V/C NSg/V J/P P  I
 > in          an  undertone ,
 # NPrSg/V/J/P D/P NSg/V     .
 >
@@ -5586,8 +5586,8 @@
 # W?      NPrSg/VX/J .
 >
 #
-> Some  of  the jury    wrote it        down      “ important , ” and some  “ unimportant . ” Alice could
-# I/J/R V/P D   NSg/V/J V     NPrSg/ISg NSg/V/J/P . J         . . V/C I/J/R . J           . . NPr   NSg/VX
+> Some  of the jury    wrote it        down      “ important , ” and some  “ unimportant . ” Alice could
+# I/J/R P  D   NSg/V/J V     NPrSg/ISg NSg/V/J/P . J         . . V/C I/J/R . J           . . NPr   NSg/VX
 > see   this , as    she was near      enough to look  over      their slates ; “ but     it        doesn’t
 # NSg/V I/D  . NSg/R ISg V   NSg/V/J/P NSg/I  P  NSg/V NSg/V/J/P D     NPl    . . NSg/C/P NPrSg/ISg V
 > matter  a   bit   , ” she thought to herself .
@@ -5660,20 +5660,20 @@
 # NSg/V NSg/J . IPl NSg/V . .
 >
 #
-> “ Who     is it        directed to ? ” said one       of  the jurymen .
-# . NPrSg/I VL NPrSg/ISg W?       P  . . V/J  NSg/I/V/J V/P D   NPl     .
+> “ Who     is it        directed to ? ” said one       of the jurymen .
+# . NPrSg/I VL NPrSg/ISg W?       P  . . V/J  NSg/I/V/J P  D   NPl     .
 >
 #
 > “ It        isn’t directed at        all       , ” said the White     Rabbit ; “ in          fact , there’s nothing
 # . NPrSg/ISg NSg/V W?       NSg/I/V/P NSg/I/J/C . . V/J  D   NPrSg/V/J NSg/V  . . NPrSg/V/J/P NSg  . W?      NSg/I/J
 > written on  the outside   . ” He      unfolded the paper   as    he      spoke , and added “ It        isn’t
 # V/J     J/P D   NSg/V/J/P . . NPr/ISg W?       D   NSg/V/J NSg/R NPr/ISg NSg/V . V/C W?    . NPrSg/ISg NSg/V
-> a   letter , after all       : it’s a   set       of  verses . ”
-# D/P NSg/V  . J/P   NSg/I/J/C . W?   D/P NPrSg/V/J V/P NPl    . .
+> a   letter , after all       : it’s a   set       of verses . ”
+# D/P NSg/V  . J/P   NSg/I/J/C . W?   D/P NPrSg/V/J P  NPl    . .
 >
 #
-> “ Are they in          the prisoner’s handwriting ? ” asked another of  the jurymen .
-# . V   IPl  NPrSg/V/J/P D   N$         NSg/V       . . V/J   I/D     V/P D   NPl     .
+> “ Are they in          the prisoner’s handwriting ? ” asked another of the jurymen .
+# . V   IPl  NPrSg/V/J/P D   N$         NSg/V       . . V/J   I/D     P  D   NPl     .
 >
 #
 > “ No      , they’re not   , ” said the White     Rabbit , “ and that’s the queerest thing about
@@ -5702,8 +5702,8 @@
 # V/J    NPrSg/I/V/J . .
 >
 #
-> There was a   general clapping of  hands at        this : it        was the first   really clever
-# W?    V   D/P NSg/V/J NSg/V    V/P NPl   NSg/I/V/P I/D  . NPrSg/ISg V   D   NSg/V/J J/R    J
+> There was a   general clapping of hands at        this : it        was the first   really clever
+# W?    V   D/P NSg/V/J NSg/V    P  NPl   NSg/I/V/P I/D  . NPrSg/ISg V   D   NSg/V/J J/R    J
 > thing the King    had said that    day   .
 # NSg/V D   NPrSg/V V   V/J  N/I/C/D NPrSg .
 >
@@ -5712,8 +5712,8 @@
 # . N/I/C/D NPl    ISg/D NSg/V . . V/J  D   NPrSg/V .
 >
 #
-> “ It        proves nothing of  the sort  ! ” said Alice . “ Why   , you don’t even    know  what
-# . NPrSg/ISg NPl    NSg/I/J V/P D   NSg/V . . V/J  NPr   . . NSg/V . IPl NSg/V NSg/V/J NSg/V NSg/I
+> “ It        proves nothing of the sort  ! ” said Alice . “ Why   , you don’t even    know  what
+# . NPrSg/ISg NPl    NSg/I/J P  D   NSg/V . . V/J  NPr   . . NSg/V . IPl NSg/V NSg/V/J NSg/V NSg/I
 > they’re about ! ”
 # W?      J/P   . .
 >
@@ -5746,8 +5746,8 @@
 #
 > He      sent  them word  I   had not   gone  ( We  know  it        to be     true    ) : If    she should push
 # NPr/ISg NSg/V N/I  NSg/V ISg V   NSg/C V/J/P . IPl NSg/V NPrSg/ISg P  NSg/VX NSg/V/J . . NSg/C ISg VX     NSg/V
-> the matter  on  , What  would  become of  you ?
-# D   NSg/V/J J/P . NSg/I NSg/VX V      V/P IPl .
+> the matter  on  , What  would  become of you ?
+# D   NSg/V/J J/P . NSg/I NSg/VX V      P  IPl .
 >
 #
 > I   gave her   one       , they gave him two , You gave us      three or      more        ; They all
@@ -5774,28 +5774,28 @@
 # P    NSg/I/J/C D   NSg/V . NSg/P   I        V/C NPrSg/ISg . .
 >
 #
-> “ That’s the most    important piece of  evidence we’ve heard yet     , ” said the King    ,
-# . N$     D   NSg/I/J J         NSg/V V/P NSg/V    W?    V/J   NSg/V/C . . V/J  D   NPrSg/V .
+> “ That’s the most    important piece of evidence we’ve heard yet     , ” said the King    ,
+# . N$     D   NSg/I/J J         NSg/V P  NSg/V    W?    V/J   NSg/V/C . . V/J  D   NPrSg/V .
 > rubbing his   hands ; “ so        now         let   the jury    — ”
 # NSg/V   ISg/D NPl   . . NSg/I/J/C NPrSg/V/J/C NSg/V D   NSg/V/J . .
 >
 #
-> “ If    any   one       of  them can      explain it        , ” said Alice , ( she had grown so        large in          the
-# . NSg/C I/R/D NSg/I/V/J V/P N/I  NPrSg/VX V       NPrSg/ISg . . V/J  NPr   . . ISg V   V/J   NSg/I/J/C NSg/J NPrSg/V/J/P D
-> last    few minutes that    she wasn’t a   bit   afraid of  interrupting him , ) “ I’ll give
-# NSg/V/J N/I NPl     N/I/C/D ISg V      D/P NSg/V J      V/P V            I   . . . W?   NSg/V
-> him sixpence . I   don’t believe there’s an  atom of  meaning in          it        . ”
-# I   NSg      . ISg NSg/V V       W?      D/P NSg  V/P NSg/V/J NPrSg/V/J/P NPrSg/ISg . .
+> “ If    any   one       of them can      explain it        , ” said Alice , ( she had grown so        large in          the
+# . NSg/C I/R/D NSg/I/V/J P  N/I  NPrSg/VX V       NPrSg/ISg . . V/J  NPr   . . ISg V   V/J   NSg/I/J/C NSg/J NPrSg/V/J/P D
+> last    few minutes that    she wasn’t a   bit   afraid of interrupting him , ) “ I’ll give
+# NSg/V/J N/I NPl     N/I/C/D ISg V      D/P NSg/V J      P  V            I   . . . W?   NSg/V
+> him sixpence . I   don’t believe there’s an  atom of meaning in          it        . ”
+# I   NSg      . ISg NSg/V V       W?      D/P NSg  P  NSg/V/J NPrSg/V/J/P NPrSg/ISg . .
 >
 #
 > The jury    all       wrote down      on  their slates , “ She doesn’t believe there’s an  atom of
-# D   NSg/V/J NSg/I/J/C V     NSg/V/J/P J/P D     NPl    . . ISg V       V       W?      D/P NSg  V/P
-> meaning in          it        , ” but     none  of  them attempted to explain the paper   .
-# NSg/V/J NPrSg/V/J/P NPrSg/ISg . . NSg/C/P NSg/I V/P N/I  W?        P  V       D   NSg/V/J .
+# D   NSg/V/J NSg/I/J/C V     NSg/V/J/P J/P D     NPl    . . ISg V       V       W?      D/P NSg  P
+> meaning in          it        , ” but     none  of them attempted to explain the paper   .
+# NSg/V/J NPrSg/V/J/P NPrSg/ISg . . NSg/C/P NSg/I P  N/I  W?        P  V       D   NSg/V/J .
 >
 #
-> “ If    there’s no      meaning in          it        , ” said the King    , “ that    saves a   world of  trouble ,
-# . NSg/C W?      NPrSg/P NSg/V/J NPrSg/V/J/P NPrSg/ISg . . V/J  D   NPrSg/V . . N/I/C/D NPl   D/P NSg/V V/P NSg/V   .
+> “ If    there’s no      meaning in          it        , ” said the King    , “ that    saves a   world of trouble ,
+# . NSg/C W?      NPrSg/P NSg/V/J NPrSg/V/J/P NPrSg/ISg . . V/J  D   NPrSg/V . . N/I/C/D NPl   D/P NSg/V P  NSg/V   .
 > you know  , as    we  needn’t try     to find  any   . And yet     I   don’t know  , ” he      went  on  ,
 # IPl NSg/V . NSg/R IPl VX      NSg/V/J P  NSg/V I/R/D . V/C NSg/V/C ISg NSg/V NSg/V . . NPr/ISg NSg/V J/P .
 > spreading out         the verses on  his   knee  , and looking at        them with one       eye   ; “ I   seem
@@ -5808,14 +5808,14 @@
 #
 > The Knave shook   his   head      sadly . “ Do     I   look  like        it        ? ” he      said . ( Which he
 # D   NSg   NSg/V/J ISg/D NPrSg/V/J J/R   . . NSg/VX ISg NSg/V NSg/V/J/C/P NPrSg/ISg . . NPr/ISg V/J  . . I/C   NPr/ISg
-> certainly did not   , being   made  entirely of  cardboard . )
-# J/R       V   NSg/C . NSg/V/C NSg/V J/R      V/P NSg/J     . .
+> certainly did not   , being   made  entirely of cardboard . )
+# J/R       V   NSg/C . NSg/V/C NSg/V J/R      P  NSg/J     . .
 >
 #
 > “ All       right     , so        far     , ” said the King    , and he      went  on  muttering over      the verses to
 # . NSg/I/J/C NPrSg/V/J . NSg/I/J/C NSg/V/J . . V/J  D   NPrSg/V . V/C NPr/ISg NSg/V J/P NSg/V     NSg/V/J/P D   NPl    P
-> himself : “ ‘          We  know  it        to be     true    — ’ that’s the jury    , of  course — ‘          I   gave her   one       ,
-# I       . . Unlintable IPl NSg/V NPrSg/ISg P  NSg/VX NSg/V/J . . N$     D   NSg/V/J . V/P NSg/V  . Unlintable ISg V    I/J/D NSg/I/V/J .
+> himself : “ ‘          We  know  it        to be     true    — ’ that’s the jury    , of course — ‘          I   gave her   one       ,
+# I       . . Unlintable IPl NSg/V NPrSg/ISg P  NSg/VX NSg/V/J . . N$     D   NSg/V/J . P  NSg/V  . Unlintable ISg V    I/J/D NSg/I/V/J .
 > they gave him two — ’ why   , that    must  be     what  he      did with the tarts , you know  — ”
 # IPl  V    I   NSg . . NSg/V . N/I/C/D NSg/V NSg/VX NSg/I NPr/ISg V   P    D   NPl   . IPl NSg/V . .
 >
@@ -5860,8 +5860,8 @@
 # . NPrSg/P . NPrSg/P . . V/J  D   NPrSg/V . . NSg/V    NSg/V/J . NSg     R/Br       . .
 >
 #
-> “ Stuff and nonsense ! ” said Alice loudly . “ The idea of  having the sentence
-# . NSg/V V/C NSg/V/J  . . V/J  NPr   J/R    . . D   NSg  V/P V      D   NSg/V
+> “ Stuff and nonsense ! ” said Alice loudly . “ The idea of having the sentence
+# . NSg/V V/C NSg/V/J  . . V/J  NPr   J/R    . . D   NSg  P  V      D   NSg/V
 > first   ! ”
 # NSg/V/J . .
 >
@@ -5874,22 +5874,22 @@
 # . ISg V     . . V/J  NPr   .
 >
 #
-> “ Off       with her   head      ! ” the Queen   shouted at        the top     of  her   voice . Nobody moved .
-# . NSg/V/J/P P    I/J/D NPrSg/V/J . . D   NPrSg/V W?      NSg/I/V/P D   NSg/V/J V/P I/J/D NSg/V . NSg/I  V/J   .
+> “ Off       with her   head      ! ” the Queen   shouted at        the top     of her   voice . Nobody moved .
+# . NSg/V/J/P P    I/J/D NPrSg/V/J . . D   NPrSg/V W?      NSg/I/V/P D   NSg/V/J P  I/J/D NSg/V . NSg/I  V/J   .
 >
 #
 > “ Who     cares for you ? ” said Alice , ( she had grown to her   full    size  by      this time  . )
 # . NPrSg/I NPl   C/P IPl . . V/J  NPr   . . ISg V   V/J   P  I/J/D NSg/V/J NSg/V NSg/J/P I/D  NSg/V . .
-> “ You’re nothing but     a   pack  of  cards ! ”
-# . W?     NSg/I/J NSg/C/P D/P NSg/V V/P NPl   . .
+> “ You’re nothing but     a   pack  of cards ! ”
+# . W?     NSg/I/J NSg/C/P D/P NSg/V P  NPl   . .
 >
 #
 > At        this the whole pack  rose      up        into the air   , and came    flying  down      upon her   : she
 # NSg/I/V/P I/D  D   NSg/J NSg/V NPrSg/V/J NSg/V/J/P P    D   NSg/V . V/C NSg/V/P NSg/V/J NSg/V/J/P P    I/J/D . ISg
-> gave a   little    scream , half      of  fright  and half      of  anger , and tried to beat    them
-# V    D/P NPrSg/I/J NSg/V  . NSg/V/J/P V/P NSg/V/J V/C NSg/V/J/P V/P NSg/V . V/C V/J   P  NSg/V/J N/I
-> off       , and found herself lying   on  the bank  , with her   head      in          the lap     of  her
-# NSg/V/J/P . V/C NSg/V I       NSg/V/J J/P D   NSg/V . P    I/J/D NPrSg/V/J NPrSg/V/J/P D   NSg/V/J V/P I/J/D
+> gave a   little    scream , half      of fright  and half      of anger , and tried to beat    them
+# V    D/P NPrSg/I/J NSg/V  . NSg/V/J/P P  NSg/V/J V/C NSg/V/J/P P  NSg/V . V/C V/J   P  NSg/V/J N/I
+> off       , and found herself lying   on  the bank  , with her   head      in          the lap     of her
+# NSg/V/J/P . V/C NSg/V I       NSg/V/J J/P D   NSg/V . P    I/J/D NPrSg/V/J NPrSg/V/J/P D   NSg/V/J P  I/J/D
 > sister , who     was gently brushing away some  dead    leaves that    had fluttered down
 # NSg/V  . NPrSg/I V   R      V        V/J  I/J/R NSg/V/J NPl    N/I/C/D V   W?        NSg/V/J/P
 > from the trees upon her   face  .
@@ -5902,8 +5902,8 @@
 #
 > “ Oh      , I’ve had such  a   curious dream   ! ” said Alice , and she told her   sister , as
 # . NPrSg/V . W?   V   NSg/I D/P J       NSg/V/J . . V/J  NPr   . V/C ISg V    I/J/D NSg/V  . NSg/R
-> well    as    she could  remember them , all       these strange Adventures of  hers that    you
-# NSg/V/J NSg/R ISg NSg/VX NSg/V    N/I  . NSg/I/J/C I/D   NSg/V/J NPl        V/P ISg  N/I/C/D IPl
+> well    as    she could  remember them , all       these strange Adventures of hers that    you
+# NSg/V/J NSg/R ISg NSg/VX NSg/V    N/I  . NSg/I/J/C I/D   NSg/V/J NPl        P  ISg  N/I/C/D IPl
 > have   just been  reading about ; and when    she had finished , her   sister kissed her   ,
 # NSg/VX V/J  NSg/V NPrSg/V J/P   . V/C NSg/I/C ISg V   V/J      . I/J/D NSg/V  W?     I/J/D .
 > and said , “ It        was a   curious dream   , dear    , certainly : but     now         run   in          to your tea   ;
@@ -5916,44 +5916,44 @@
 #
 > But     her   sister sat     still   just as    she left      her   , leaning her   head      on  her   hand  ,
 # NSg/C/P I/J/D NSg/V  NSg/V/J NSg/V/J V/J  NSg/R ISg NPrSg/V/J I/J/D . NSg/V   I/J/D NPrSg/V/J J/P I/J/D NSg/V .
-> watching the setting sun     , and thinking of  little    Alice and all       her   wonderful
-# V        D   NSg/V/J NPrSg/V . V/C V        V/P NPrSg/I/J NPr   V/C NSg/I/J/C I/J/D J
+> watching the setting sun     , and thinking of little    Alice and all       her   wonderful
+# V        D   NSg/V/J NPrSg/V . V/C V        P  NPrSg/I/J NPr   V/C NSg/I/J/C I/J/D J
 > Adventures , till      she too began dreaming after a   fashion , and this was her
 # NPl        . NSg/V/C/P ISg W?  V     V        J/P   D/P NSg/V   . V/C I/D  V   I/J/D
 > dream   : —
 # NSg/V/J . .
 >
 #
-> First   , she dreamed of  little    Alice herself , and once  again the tiny  hands were
-# NSg/V/J . ISg V       V/P NPrSg/I/J NPr   I       . V/C NSg/C P     D   NSg/J NPl   NSg/V
+> First   , she dreamed of little    Alice herself , and once  again the tiny  hands were
+# NSg/V/J . ISg V       P  NPrSg/I/J NPr   I       . V/C NSg/C P     D   NSg/J NPl   NSg/V
 > clasped upon her   knee  , and the bright    eager   eyes were  looking up        into hers — she
 # W?      P    I/J/D NSg/V . V/C D   NPrSg/V/J NSg/V/J NPl  NSg/V V       NSg/V/J/P P    ISg  . ISg
-> could  hear the very tones of  her   voice , and see   that    queer   little    toss  of  her
-# NSg/VX V    D   J    NPl   V/P I/J/D NSg/V . V/C NSg/V N/I/C/D NSg/V/J NPrSg/I/J NSg/V V/P I/J/D
+> could  hear the very tones of her   voice , and see   that    queer   little    toss  of her
+# NSg/VX V    D   J    NPl   P  I/J/D NSg/V . V/C NSg/V N/I/C/D NSg/V/J NPrSg/I/J NSg/V P  I/J/D
 > head      to keep  back    the wandering hair  that    would  always get   into her   eyes — and
 # NPrSg/V/J P  NSg/V NSg/V/J D   V         NSg/V N/I/C/D NSg/VX W?     NSg/V P    I/J/D NPl  . V/C
 > still   as    she listened , or      seemed to listen , the whole place around her   became
 # NSg/V/J NSg/R ISg W?       . NPrSg/C W?     P  NSg/V  . D   NSg/J NSg/V J/P    I/J/D V
-> alive with the strange creatures of  her   little    sister’s dream   .
-# W?    P    D   NSg/V/J NPl       V/P I/J/D NPrSg/I/J N$       NSg/V/J .
+> alive with the strange creatures of her   little    sister’s dream   .
+# W?    P    D   NSg/V/J NPl       P  I/J/D NPrSg/I/J N$       NSg/V/J .
 >
 #
 > The long      grass   rustled at        her   feet as    the White     Rabbit hurried by      — the frightened
 # D   NPrSg/V/J NPrSg/V W?      NSg/I/V/P I/J/D NSg  NSg/R D   NPrSg/V/J NSg/V  V/J     NSg/J/P . D   W?
 > Mouse splashed his   way   through the neighbouring pool  — she could  hear the rattle
 # NSg/V W?       ISg/D NSg/J NSg/J/P D   V            NSg/V . ISg NSg/VX V    D   NSg/V
-> of  the teacups as    the March   Hare    and his   friends shared their never - ending meal  ,
-# V/P D   NPl     NSg/R D   NPrSg/V NSg/V/J V/C ISg/D NPl     W?     D     V     . NSg/V  NSg/V .
-> and the shrill  voice of  the Queen   ordering off       her   unfortunate guests to
-# V/C D   NSg/V/J NSg/V V/P D   NPrSg/V V        NSg/V/J/P I/J/D NSg/J       NPl    P
+> of the teacups as    the March   Hare    and his   friends shared their never - ending meal  ,
+# P  D   NPl     NSg/R D   NPrSg/V NSg/V/J V/C ISg/D NPl     W?     D     V     . NSg/V  NSg/V .
+> and the shrill  voice of the Queen   ordering off       her   unfortunate guests to
+# V/C D   NSg/V/J NSg/V P  D   NPrSg/V V        NSg/V/J/P I/J/D NSg/J       NPl    P
 > execution — once  more        the pig   - baby    was sneezing on  the Duchess’s knee  , while
 # NSg       . NSg/C NPrSg/I/V/J D   NSg/V . NSg/V/J V   V        J/P D   N$        NSg/V . NSg/V/C/P
-> plates and dishes crashed around it        — once  more        the shriek of  the Gryphon , the
-# NPl    V/C NPl    W?      J/P    NPrSg/ISg . NSg/C NPrSg/I/V/J D   NSg/V  V/P D   ?       . D
-> squeaking of  the Lizard’s slate   - pencil , and the choking of  the suppressed
-# V         V/P D   N$       NSg/V/J . NSg/V  . V/C D   V       V/P D   W?
-> guinea - pigs , filled the air   , mixed up        with the distant sobs of  the miserable
-# NPrSg  . NPl  . V/J    D   NSg/V . V/J   NSg/V/J/P P    D   J       NPl  V/P D   W?
+> plates and dishes crashed around it        — once  more        the shriek of the Gryphon , the
+# NPl    V/C NPl    W?      J/P    NPrSg/ISg . NSg/C NPrSg/I/V/J D   NSg/V  P  D   ?       . D
+> squeaking of the Lizard’s slate   - pencil , and the choking of the suppressed
+# V         P  D   N$       NSg/V/J . NSg/V  . V/C D   V       P  D   W?
+> guinea - pigs , filled the air   , mixed up        with the distant sobs of the miserable
+# NPrSg  . NPl  . V/J    D   NSg/V . V/J   NSg/V/J/P P    D   J       NPl  P  D   W?
 > Mock    Turtle .
 # NSg/V/J NSg/V  .
 >
@@ -5964,30 +5964,30 @@
 # ISg V    ISg V   NSg/C/P P  NSg/V/J N/I  P     . V/C NSg/I/J/C NSg/VX NSg/V  P  V/J
 > reality — the grass   would  be     only rustling in          the wind  , and the pool  rippling to
 # NSg     . D   NPrSg/V NSg/VX NSg/VX W?   V        NPrSg/V/J/P D   NSg/V . V/C D   NSg/V V        P
-> the waving of  the reeds — the rattling teacups would  change to tinkling
-# D   V      V/P D   NPl   . D   V        NPl     NSg/VX NSg/V  P  V
-> sheep - bells , and the Queen’s shrill  cries to the voice of  the shepherd boy   — and
-# NSg   . NPl   . V/C D   N$      NSg/V/J NPl   P  D   NSg/V V/P D   NPrSg/V  NSg/V . V/C
-> the sneeze of  the baby    , the shriek of  the Gryphon , and all       the other   queer
-# D   NSg/V  V/P D   NSg/V/J . D   NSg/V  V/P D   ?       . V/C NSg/I/J/C D   NSg/V/J NSg/V/J
-> noises , would  change ( she knew ) to the confused clamour  of  the busy
-# NPl    . NSg/VX NSg/V  . ISg V    . P  D   V/J      NSg/V/Br V/P D   NSg/V/J
-> farm  - yard  — while     the lowing of  the cattle in          the distance would  take  the place of
-# NSg/V . NSg/V . NSg/V/C/P D   V      V/P D   NSg/V  NPrSg/V/J/P D   NSg/V    NSg/VX NSg/V D   NSg/V V/P
+> the waving of the reeds — the rattling teacups would  change to tinkling
+# D   V      P  D   NPl   . D   V        NPl     NSg/VX NSg/V  P  V
+> sheep - bells , and the Queen’s shrill  cries to the voice of the shepherd boy   — and
+# NSg   . NPl   . V/C D   N$      NSg/V/J NPl   P  D   NSg/V P  D   NPrSg/V  NSg/V . V/C
+> the sneeze of the baby    , the shriek of the Gryphon , and all       the other   queer
+# D   NSg/V  P  D   NSg/V/J . D   NSg/V  P  D   ?       . V/C NSg/I/J/C D   NSg/V/J NSg/V/J
+> noises , would  change ( she knew ) to the confused clamour  of the busy
+# NPl    . NSg/VX NSg/V  . ISg V    . P  D   V/J      NSg/V/Br P  D   NSg/V/J
+> farm  - yard  — while     the lowing of the cattle in          the distance would  take  the place of
+# NSg/V . NSg/V . NSg/V/C/P D   V      P  D   NSg/V  NPrSg/V/J/P D   NSg/V    NSg/VX NSg/V D   NSg/V P
 > the Mock    Turtle’s heavy   sobs .
 # D   NSg/V/J N$       NSg/V/J NPl  .
 >
 #
-> Lastly , she pictured to herself how   this same little    sister of  hers would  , in
-# J/R    . ISg W?       P  I       NSg/C I/D  I/J  NPrSg/I/J NSg/V  V/P ISg  NSg/VX . NPrSg/V/J/P
+> Lastly , she pictured to herself how   this same little    sister of hers would  , in
+# J/R    . ISg W?       P  I       NSg/C I/D  I/J  NPrSg/I/J NSg/V  P  ISg  NSg/VX . NPrSg/V/J/P
 > the after - time  , be     herself a   grown woman ; and how   she would  keep  , through all
 # D   J/P   . NSg/V . NSg/VX I       D/P V/J   NSg/V . V/C NSg/C ISg NSg/VX NSg/V . NSg/J/P NSg/I/J/C
-> her   riper years , the simple  and loving  heart of  her   childhood : and how   she would
-# I/J/D J     NPl   . D   NSg/V/J V/C NSg/V/J NSg/V V/P I/J/D NSg       . V/C NSg/C ISg NSg/VX
+> her   riper years , the simple  and loving  heart of her   childhood : and how   she would
+# I/J/D J     NPl   . D   NSg/V/J V/C NSg/V/J NSg/V P  I/J/D NSg       . V/C NSg/C ISg NSg/VX
 > gather about her   other   little    children , and make  their eyes bright    and eager
 # NSg/V  J/P   I/J/D NSg/V/J NPrSg/I/J NPl      . V/C NSg/V D     NPl  NPrSg/V/J V/C NSg/V/J
-> with many    a   strange tale  , perhaps even    with the dream   of  Wonderland of  long      ago :
-# P    N/I/J/D D/P NSg/V/J NSg/V . NSg     NSg/V/J P    D   NSg/V/J V/P NSg        V/P NPrSg/V/J J/P .
+> with many    a   strange tale  , perhaps even    with the dream   of Wonderland of long      ago :
+# P    N/I/J/D D/P NSg/V/J NSg/V . NSg     NSg/V/J P    D   NSg/V/J P  NSg        P  NPrSg/V/J J/P .
 > and how   she would  feel      with all       their simple  sorrows , and find  a   pleasure in          all
 # V/C NSg/C ISg NSg/VX NSg/I/V/J P    NSg/I/J/C D     NSg/V/J NPl     . V/C NSg/V D/P NSg/V    NPrSg/V/J/P NSg/I/J/C
 > their simple  joys , remembering her   own     child - life  , and the happy   summer  days .

--- a/harper-core/tests/text/tagged/Computer science.md
+++ b/harper-core/tests/text/tagged/Computer science.md
@@ -10,32 +10,32 @@
 # Unlintable NSg/V    NSg/V
 >
 #
-> Computer science is the study of  computation , information , and automation .
-# NSg/V    NSg/V   VL D   NSg/V V/P NSg         . NSg         . V/C NSg        .
+> Computer science is the study of computation , information , and automation .
+# NSg/V    NSg/V   VL D   NSg/V P  NSg         . NSg         . V/C NSg        .
 > Computer science spans theoretical disciplines ( such  as    algorithms , theory of
-# NSg/V    NSg/V   NPl   J           NPl         . NSg/I NSg/R NPl        . NSg    V/P
+# NSg/V    NSg/V   NPl   J           NPl         . NSg/I NSg/R NPl        . NSg    P
 > computation , and information theory ) to applied disciplines ( including the
 # NSg         . V/C NSg         NSg    . P  W?      NPl         . V         D
-> design and implementation of  hardware and software ) .
-# NSg/V  V/C NSg            V/P NSg      V/C NSg      . .
+> design and implementation of hardware and software ) .
+# NSg/V  V/C NSg            P  NSg      V/C NSg      . .
 >
 #
 > Algorithms and data structures are central to computer science . The theory of
-# NPl        V/C NSg  NPl        V   NPrSg/J P  NSg/V    NSg/V   . D   NSg    V/P
-> computation concerns abstract models of  computation and general classes of
-# NSg         NSg/V    NSg/V/J  NPl    V/P NSg         V/C NSg/V/J NPl     V/P
-> problems that    can      be     solved using them . The fields of  cryptography and computer
-# NPl      N/I/C/D NPrSg/VX NSg/VX V/J    V     N/I  . D   NPrPl  V/P NSg          V/C NSg/V
+# NPl        V/C NSg  NPl        V   NPrSg/J P  NSg/V    NSg/V   . D   NSg    P
+> computation concerns abstract models of computation and general classes of
+# NSg         NSg/V    NSg/V/J  NPl    P  NSg         V/C NSg/V/J NPl     P
+> problems that    can      be     solved using them . The fields of cryptography and computer
+# NPl      N/I/C/D NPrSg/VX NSg/VX V/J    V     N/I  . D   NPrPl  P  NSg          V/C NSg/V
 > security involve studying the means for secure communication and preventing
 # NSg      V       V        D   NPl   C/P V/J    NSg           V/C V
 > security vulnerabilities . Computer graphics and computational geometry address
 # NSg      NSg             . NSg/V    NPl      V/C J             NSg      NSg/V
-> the generation of  images . Programming language theory considers different ways
-# D   NSg        V/P NPl    . NSg/V       NSg/V    NSg    NPl       NSg/J     NPl
+> the generation of images . Programming language theory considers different ways
+# D   NSg        P  NPl    . NSg/V       NSg/V    NSg    NPl       NSg/J     NPl
 > to describe computational processes , and database theory concerns the management
 # P  NSg/V    J             NPl       . V/C NSg/V    NSg    NSg/V    D   NSg
-> of  repositories of  data . Human   – computer interaction investigates the interfaces
-# V/P NPl          V/P NSg  . NSg/V/J . NSg/V    NSg         NPl          D   NPl
+> of repositories of data . Human   – computer interaction investigates the interfaces
+# P  NPl          P  NSg  . NSg/V/J . NSg/V    NSg         NPl          D   NPl
 > through which humans and computers interact , and software engineering focuses on
 # NSg/J/P I/C   NPl    V/C NPl       NSg/V    . V/C NSg      NSg/V       NPl     J/P
 > the design and principles behind  developing software . Areas such  as    operating
@@ -43,7 +43,7 @@
 > systems , networks and embedded systems investigate the principles and design
 # NPl     . NPl      V/C V/J      NPl     V           D   NPl        V/C NSg/V
 > behind  complex systems . Computer architecture describes the construction of
-# NSg/J/P NSg/V/J NPl     . NSg/V    NSg          NPl       D   NSg          V/P
+# NSg/J/P NSg/V/J NPl     . NSg/V    NSg          NPl       D   NSg          P
 > computer components and computer - operated equipment . Artificial intelligence and
 # NSg/V    NPl        V/C NSg/V    . W?       NSg       . J          NSg          V/C
 > machine learning aim   to synthesize goal  - orientated processes such  as
@@ -58,8 +58,8 @@
 # NSg/V    V          NPl  P  V          V/C NSg/V   J       V/C J          NSg  .
 >
 #
-> The fundamental concern of  computer science is determining what  can      and cannot
-# D   NSg/J       NSg/V   V/P NSg/V    NSg/V   VL V           NSg/I NPrSg/VX V/C NSg/V
+> The fundamental concern of computer science is determining what  can      and cannot
+# D   NSg/J       NSg/V   P  NSg/V    NSg/V   VL V           NSg/I NPrSg/VX V/C NSg/V
 > be     automated . The Turing Award is generally recognized as    the highest
 # NSg/VX W?        . D   NPr    NSg/V VL J/R       V/J        NSg/R D   W?
 > distinction in          computer science .
@@ -70,16 +70,16 @@
 # NSg
 >
 #
-> The earliest foundations of  what  would  become computer science predate the
-# D   W?       NPl         V/P NSg/I NSg/VX V      NSg/V    NSg/V   NSg/V   D
-> invention of  the modern digital computer . Machines for calculating fixed
-# NSg       V/P D   NSg/J  NSg/J   NSg/V    . NPl      C/P V/J         V/J
+> The earliest foundations of what  would  become computer science predate the
+# D   W?       NPl         P  NSg/I NSg/VX V      NSg/V    NSg/V   NSg/V   D
+> invention of the modern digital computer . Machines for calculating fixed
+# NSg       P  D   NSg/J  NSg/J   NSg/V    . NPl      C/P V/J         V/J
 > numerical tasks such  as    the abacus have   existed since antiquity , aiding in
 # J         NPl   NSg/I NSg/R D   NSg    NSg/VX W?      C/P   NSg       . V      NPrSg/V/J/P
 > computations such  as    multiplication and division . Algorithms for performing
 # NPl          NSg/I NSg/R NSg            V/C NSg      . NPl        C/P V
 > computations have   existed since antiquity , even    before the development of
-# NPl          NSg/VX W?      C/P   NSg       . NSg/V/J C/P    D   NSg         V/P
+# NPl          NSg/VX W?      C/P   NSg       . NSg/V/J C/P    D   NSg         P
 > sophisticated computing equipment .
 # V/J           NSg/V     NSg       .
 >
@@ -90,8 +90,8 @@
 # NSg        NPrSg/V/J/P #    . NPrSg/V/J/P #    . ?         NPr     W?           D/P NSg/J   NSg/J
 > calculator , called the Stepped Reckoner . Leibniz may      be     considered the first
 # NSg        . V/J    D   W?      ?        . NPr     NPrSg/VX NSg/VX V/J        D   NSg/V/J
-> computer scientist and information theorist , because of  various reasons ,
-# NSg/V    NSg       V/C NSg         NSg      . C/P     V/P J       NPl     .
+> computer scientist and information theorist , because of various reasons ,
+# NSg/V    NSg       V/C NSg         NSg      . C/P     P  J       NPl     .
 > including the fact that    he      documented the binary number  system . In          1820 , Thomas
 # V         D   NSg  N/I/C/D NPr/ISg V          D   NSg/J  NSg/V/J NSg    . NPrSg/V/J/P #    . NPrSg
 > de    Colmar launched the mechanical calculator industry [ note  1 ] when    he      invented
@@ -100,54 +100,54 @@
 # ISg/D W?         ?            . D   NSg/V/J V/J         NSg/V   NPr/J  NSg/I  V/C
 > reliable enough to be     used daily   in          an  office environment . Charles Babbage
 # NSg/J    NSg/I  P  NSg/VX V/J  NSg/V/J NPrSg/V/J/P D/P NSg/V  NSg         . NPr     NPr
-> started the design of  the first   automatic mechanical calculator , his   Difference
-# W?      D   NSg/V  V/P D   NSg/V/J NSg/J     NSg/J      NSg        . ISg/D NSg/V
-> Engine , in          1822 , which eventually gave him the idea of  the first   programmable
-# NSg/V  . NPrSg/V/J/P #    . I/C   J/R        V    I   D   NSg  V/P D   NSg/V/J NSg/J
+> started the design of the first   automatic mechanical calculator , his   Difference
+# W?      D   NSg/V  P  D   NSg/V/J NSg/J     NSg/J      NSg        . ISg/D NSg/V
+> Engine , in          1822 , which eventually gave him the idea of the first   programmable
+# NSg/V  . NPrSg/V/J/P #    . I/C   J/R        V    I   D   NSg  P  D   NSg/V/J NSg/J
 > mechanical calculator , his   Analytical Engine . He      started developing this machine
 # NSg/J      NSg        . ISg/D J          NSg/V  . NPr/ISg W?      V          I/D  NSg/V
-> in          1834 , and " in          less    than two years , he      had sketched out         many    of  the salient
-# NPrSg/V/J/P #    . V/C . NPrSg/V/J/P V/J/C/P C/P  NSg NPl   . NPr/ISg V   W?       NSg/V/J/R/P N/I/J/D V/P D   NSg/J
-> features of  the modern computer " . " A   crucial step  was the adoption of  a   punched
-# NPl      V/P D   NSg/J  NSg/V    . . . D/P J       NSg/V V   D   NSg      V/P D/P W?
+> in          1834 , and " in          less    than two years , he      had sketched out         many    of the salient
+# NPrSg/V/J/P #    . V/C . NPrSg/V/J/P V/J/C/P C/P  NSg NPl   . NPr/ISg V   W?       NSg/V/J/R/P N/I/J/D P  D   NSg/J
+> features of the modern computer " . " A   crucial step  was the adoption of a   punched
+# NPl      P  D   NSg/J  NSg/V    . . . D/P J       NSg/V V   D   NSg      P  D/P W?
 > card  system derived from the Jacquard loom  " making it        infinitely
 # NSg/V NSg    W?      P    D   NPrSg    NSg/V . NSg/V  NPrSg/ISg J/R
-> programmable . [ note  2 ] In          1843 , during the translation of  a   French    article on  the
-# NSg/J        . . NSg/V # . NPrSg/V/J/P #    . V/P    D   NSg         V/P D/P NPrSg/V/J NSg/V   J/P D
-> Analytical Engine , Ada Lovelace wrote , in          one       of  the many    notes she included , an
-# J          NSg/V  . NPr NPrSg    V     . NPrSg/V/J/P NSg/I/V/J V/P D   N/I/J/D NPl   ISg W?       . D/P
+> programmable . [ note  2 ] In          1843 , during the translation of a   French    article on  the
+# NSg/J        . . NSg/V # . NPrSg/V/J/P #    . V/P    D   NSg         P  D/P NPrSg/V/J NSg/V   J/P D
+> Analytical Engine , Ada Lovelace wrote , in          one       of the many    notes she included , an
+# J          NSg/V  . NPr NPrSg    V     . NPrSg/V/J/P NSg/I/V/J P  D   N/I/J/D NPl   ISg W?       . D/P
 > algorithm to compute the Bernoulli numbers , which is considered to be     the first
 # NSg       P  NSg/V   D   NPr       NPrPl   . I/C   VL V/J        P  NSg/VX D   NSg/V/J
 > published algorithm ever specifically tailored for implementation on  a   computer .
 # V/J       NSg       J    W?           W?       C/P NSg            J/P D/P NSg/V    .
 > Around 1885 , Herman Hollerith invented the tabulator , which used punched cards
 # J/P    #    . NPr    NPr       W?       D   NSg       . I/C   V/J  W?      NPl
-> to process statistical information ; eventually his   company became part    of  IBM   .
-# P  NSg/V   J           NSg         . J/R        ISg/D NSg/V   V      NSg/V/J V/P NPrSg .
-> Following Babbage , although unaware of  his   earlier work  , Percy Ludgate in          1909
-# NSg/V/J/P NPr     . C        V/J     V/P ISg/D J       NSg/V . NPr   ?       NPrSg/V/J/P #
-> published the 2nd of  the only two designs for mechanical analytical engines in
-# V/J       D   #   V/P D   W?   NSg NPl     C/P NSg/J      J          NPl     NPrSg/V/J/P
+> to process statistical information ; eventually his   company became part    of IBM   .
+# P  NSg/V   J           NSg         . J/R        ISg/D NSg/V   V      NSg/V/J P  NPrSg .
+> Following Babbage , although unaware of his   earlier work  , Percy Ludgate in          1909
+# NSg/V/J/P NPr     . C        V/J     P  ISg/D J       NSg/V . NPr   ?       NPrSg/V/J/P #
+> published the 2nd of the only two designs for mechanical analytical engines in
+# V/J       D   #   P  D   W?   NSg NPl     C/P NSg/J      J          NPl     NPrSg/V/J/P
 > history . In          1914 , the Spanish engineer Leonardo Torres Quevedo published his
 # NSg     . NPrSg/V/J/P #    . D   NPrSg/J NSg/V    NPrSg    NPr    ?       V/J       ISg/D
 > Essays on  Automatics , and designed , inspired by      Babbage , a   theoretical
 # NPl    J/P NPl        . V/C W?       . V/J      NSg/J/P NPr     . D/P J
 > electromechanical calculating machine which was to be     controlled by      a   read  - only
 # ?                 V/J         NSg/V   I/C   V   P  NSg/VX V/J        NSg/J/P D/P NSg/V . W?
-> program . The paper   also introduced the idea of  floating - point arithmetic . In
-# NPrSg/V . D   NSg/V/J W?   W?         D   NSg  V/P V        . NSg/V NSg/J      . NPrSg/V/J/P
-> 1920 , to celebrate the 100th anniversary of  the invention of  the arithmometer ,
-# #    . P  V         D   #     NSg         V/P D   NSg       V/P D   ?            .
+> program . The paper   also introduced the idea of floating - point arithmetic . In
+# NPrSg/V . D   NSg/V/J W?   W?         D   NSg  P  V        . NSg/V NSg/J      . NPrSg/V/J/P
+> 1920 , to celebrate the 100th anniversary of the invention of the arithmometer ,
+# #    . P  V         D   #     NSg         P  D   NSg       P  D   ?            .
 > Torres presented in          Paris the Electromechanical Arithmometer , a   prototype that
 # NPr    W?        NPrSg/V/J/P NPr   D   ?                 ?            . D/P NSg/V     N/I/C/D
-> demonstrated the feasibility of  an  electromechanical analytical engine , on  which
-# W?           D   NSg         V/P D/P ?                 J          NSg/V  . J/P I/C
+> demonstrated the feasibility of an  electromechanical analytical engine , on  which
+# W?           D   NSg         P  D/P ?                 J          NSg/V  . J/P I/C
 > commands could  be     typed and the results printed automatically . In          1937 , one
 # NPl      NSg/VX NSg/VX W?    V/C D   NPl     W?      W?            . NPrSg/V/J/P #    . NSg/I/V/J
 > hundred years after Babbage's impossible dream   , Howard Aiken convinced IBM   ,
 # NSg     NPl   J/P   N$        NSg/J      NSg/V/J . NPr    NPr   V/J       NPrSg .
-> which was making all       kinds of  punched card  equipment and was also in          the
-# I/C   V   NSg/V  NSg/I/J/C NSg   V/P W?      NSg/V NSg       V/C V   W?   NPrSg/V/J/P D
+> which was making all       kinds of punched card  equipment and was also in          the
+# I/C   V   NSg/V  NSg/I/J/C NSg   P  W?      NSg/V NSg       V/C V   W?   NPrSg/V/J/P D
 > calculator business to develop his   giant programmable calculator , the
 # NSg        NSg/J    P  V       ISg/D NSg/J NSg/J        NSg        . D
 > ASCC / Harvard Mark    I   , based on  Babbage's Analytical Engine , which itself used
@@ -158,44 +158,44 @@
 # NPrSg/ISg NSg/R . N$        NSg/V/J NSg/V/P NSg/V/J . .
 >
 #
-> During the 1940s , with the development of  new     and more        powerful computing
-# V/P    D   #d    . P    D   NSg         V/P NSg/V/J V/C NPrSg/I/V/J J        NSg/V
+> During the 1940s , with the development of new     and more        powerful computing
+# V/P    D   #d    . P    D   NSg         P  NSg/V/J V/C NPrSg/I/V/J J        NSg/V
 > machines such  as    the Atanasoff – Berry   computer and ENIAC , the term    computer came
 # NPl      NSg/I NSg/R D   ?         . NPrSg/V NSg/V    V/C ?     . D   NSg/V/J NSg/V    NSg/V/P
 > to refer   to the machines rather    than their human   predecessors . As    it        became
 # P  NSg/V/J P  D   NPl      NPrSg/V/J C/P  D     NSg/V/J NPl          . NSg/R NPrSg/ISg V
 > clear   that    computers could  be     used for more        than just mathematical calculations ,
 # NSg/V/J N/I/C/D NPl       NSg/VX NSg/VX V/J  C/P NPrSg/I/V/J C/P  V/J  J            W?           .
-> the field of  computer science broadened to study computation in          general . In
-# D   NSg/V V/P NSg/V    NSg/V   W?        P  NSg/V NSg         NPrSg/V/J/P NSg/V/J . NPrSg/V/J/P
+> the field of computer science broadened to study computation in          general . In
+# D   NSg/V P  NSg/V    NSg/V   W?        P  NSg/V NSg         NPrSg/V/J/P NSg/V/J . NPrSg/V/J/P
 > 1945 , IBM   founded the Watson Scientific Computing Laboratory at        Columbia
 # #    . NPrSg V/J     D   NPr    J          NSg/V     NSg        NSg/I/V/P NPr
 > University in          New     York City . The renovated fraternity house   on  Manhattan's West
 # NSg        NPrSg/V/J/P NSg/V/J NPr  NSg  . D   W?        NSg        NPrSg/V J/P N$          NPrSg/V/J
 > Side    was IBM's first   laboratory devoted to pure    science . The lab   is the
 # NSg/V/J V   N$    NSg/V/J NSg        V/J     P  NSg/V/J NSg/V   . D   NPrSg VL D
-> forerunner of  IBM's Research Division , which today operates research facilities
-# NSg        V/P N$    NSg/V    NSg      . I/C   NSg/J NPl      NSg/V    NPl
+> forerunner of IBM's Research Division , which today operates research facilities
+# NSg        P  N$    NSg/V    NSg      . I/C   NSg/J NPl      NSg/V    NPl
 > around the world . Ultimately , the close   relationship between IBM   and Columbia
 # J/P    D   NSg/V . J/R        . D   NSg/V/J NSg          NSg/P   NPrSg V/C NPr
-> University was instrumental in          the emergence of  a   new     scientific discipline ,
-# NSg        V   NSg/J        NPrSg/V/J/P D   NSg       V/P D/P NSg/V/J J          NSg/V      .
-> with Columbia offering one       of  the first   academic - credit courses in          computer
-# P    NPr      NSg/V    NSg/I/V/J V/P D   NSg/V/J NSg/J    . NSg/V  NPl     NPrSg/V/J/P NSg/V
+> University was instrumental in          the emergence of a   new     scientific discipline ,
+# NSg        V   NSg/J        NPrSg/V/J/P D   NSg       P  D/P NSg/V/J J          NSg/V      .
+> with Columbia offering one       of the first   academic - credit courses in          computer
+# P    NPr      NSg/V    NSg/I/V/J P  D   NSg/V/J NSg/J    . NSg/V  NPl     NPrSg/V/J/P NSg/V
 > science in          1946 . Computer science began to be     established as    a   distinct academic
 # NSg/V   NPrSg/V/J/P #    . NSg/V    NSg/V   V     P  NSg/VX W?          NSg/R D/P V/J      NSg/J
 > discipline in          the 1950s and early   1960s . The world's first   computer science
 # NSg/V      NPrSg/V/J/P D   #d    V/C NSg/J/R #d    . D   N$      NSg/V/J NSg/V    NSg/V
 > degree program , the Cambridge Diploma in          Computer Science , began at        the
 # NSg    NPrSg/V . D   NPr       NSg     NPrSg/V/J/P NSg/V    NSg/V   . V     NSg/I/V/P D
-> University of  Cambridge Computer Laboratory in          1953 . The first   computer science
-# NSg        V/P NPr       NSg/V    NSg        NPrSg/V/J/P #    . D   NSg/V/J NSg/V    NSg/V
+> University of Cambridge Computer Laboratory in          1953 . The first   computer science
+# NSg        P  NPr       NSg/V    NSg        NPrSg/V/J/P #    . D   NSg/V/J NSg/V    NSg/V
 > department in          the United States was formed at        Purdue University in          1962 . Since
 # NSg        NPrSg/V/J/P D   W?     NPrSg  V   V      NSg/I/V/P NPr    NSg        NPrSg/V/J/P #    . C/P
-> practical computers became available , many    applications of  computing have   become
-# NSg/J     NPl       V      J         . N/I/J/D W?           V/P NSg/V     NSg/VX V
-> distinct areas of  study in          their own     rights .
-# V/J      NPl   V/P NSg/V NPrSg/V/J/P D     NSg/V/J NPl    .
+> practical computers became available , many    applications of computing have   become
+# NSg/J     NPl       V      J         . N/I/J/D W?           P  NSg/V     NSg/VX V
+> distinct areas of study in          their own     rights .
+# V/J      NPl   P  NSg/V NPrSg/V/J/P D     NSg/V/J NPl    .
 >
 #
 > Etymology and scope
@@ -204,26 +204,26 @@
 #
 > Although first   proposed in          1956 , the term    " computer science " appears in          a   1959
 # C        NSg/V/J W?       NPrSg/V/J/P #    . D   NSg/V/J . NSg/V    NSg/V   . NPl     NPrSg/V/J/P D/P #
-> article in          Communications of  the ACM , in          which Louis Fein argues for the
-# NSg/V   NPrSg/V/J/P W?             V/P D   NSg . NPrSg/V/J/P I/C   NPrSg ?    NPl    C/P D
-> creation of  a   Graduate School in          Computer Sciences analogous to the creation of
-# NSg      V/P D/P NSg/V/J  NSg/V  NPrSg/V/J/P NSg/V    NPl      J         P  D   NSg      V/P
+> article in          Communications of the ACM , in          which Louis Fein argues for the
+# NSg/V   NPrSg/V/J/P W?             P  D   NSg . NPrSg/V/J/P I/C   NPrSg ?    NPl    C/P D
+> creation of a   Graduate School in          Computer Sciences analogous to the creation of
+# NSg      P  D/P NSg/V/J  NSg/V  NPrSg/V/J/P NSg/V    NPl      J         P  D   NSg      P
 > Harvard Business School in          1921 . Louis justifies the name  by      arguing that    , like
 # NPr     NSg/J    NSg/V  NPrSg/V/J/P #    . NPrSg NPl       D   NSg/V NSg/J/P V       N/I/C/D . NSg/V/J/C/P
 > management science , the subject is applied and interdisciplinary in          nature ,
 # NSg        NSg/V   . D   NSg/V/J VL W?      V/C J                 NPrSg/V/J/P NSg/V  .
-> while     having the characteristics typical of  an  academic discipline . His   efforts ,
-# NSg/V/C/P V      D   NPl             NSg/J   V/P D/P NSg/J    NSg/V      . ISg/D NPl     .
-> and those of  others such  as    numerical analyst George Forsythe , were  rewarded :
-# V/C I/D   V/P NPl    NSg/I NSg/R J         NSg     NPrSg  ?        . NSg/V V        .
+> while     having the characteristics typical of an  academic discipline . His   efforts ,
+# NSg/V/C/P V      D   NPl             NSg/J   P  D/P NSg/J    NSg/V      . ISg/D NPl     .
+> and those of others such  as    numerical analyst George Forsythe , were  rewarded :
+# V/C I/D   P  NPl    NSg/I NSg/R J         NSg     NPrSg  ?        . NSg/V V        .
 > universities went  on  to create such  departments , starting with Purdue in          1962 .
 # NPl          NSg/V J/P P  V/J    NSg/I NPl         . V        P    NPr    NPrSg/V/J/P #    .
-> Despite its   name  , a   significant amount of  computer science does  not   involve the
-# NSg/V/P ISg/D NSg/V . D/P NSg/J       NSg/V  V/P NSg/V    NSg/V   NSg/V NSg/C V       D
-> study of  computers themselves . Because of  this , several alternative names have
-# NSg/V V/P NPl       I          . C/P     V/P I/D  . J/D     NSg/J       NPl   NSg/VX
-> been  proposed . Certain departments of  major     universities prefer the term
-# NSg/V W?       . I/J     NPl         V/P NPrSg/V/J NPl          V      D   NSg/V/J
+> Despite its   name  , a   significant amount of computer science does  not   involve the
+# NSg/V/P ISg/D NSg/V . D/P NSg/J       NSg/V  P  NSg/V    NSg/V   NSg/V NSg/C V       D
+> study of computers themselves . Because of this , several alternative names have
+# NSg/V P  NPl       I          . C/P     P  I/D  . J/D     NSg/J       NPl   NSg/VX
+> been  proposed . Certain departments of major     universities prefer the term
+# NSg/V W?       . I/J     NPl         P  NPrSg/V/J NPl          V      D   NSg/V/J
 > computing science , to emphasize precisely that    difference . Danish  scientist
 # NSg/V     NSg/V   . P  V         J/R       N/I/C/D NSg/V      . NPrSg/J NSg
 > Peter     Naur suggested the term    datalogy , to reflect the fact that    the scientific
@@ -232,30 +232,30 @@
 # NSg/V      NPl      J/P    NSg  V/C NSg  NSg       . NSg/V/C/P NSg/C R
 > involving computers . The first   scientific institution to use   the term    was the
 # V         NPl       . D   NSg/V/J J          NSg         P  NSg/V D   NSg/V/J V   D
-> Department of  Datalogy at        the University of  Copenhagen , founded in          1969 , with
-# NSg        V/P ?        NSg/I/V/P D   NSg        V/P NPrSg      . V/J     NPrSg/V/J/P #    . P
+> Department of Datalogy at        the University of Copenhagen , founded in          1969 , with
+# NSg        P  ?        NSg/I/V/P D   NSg        P  NPrSg      . V/J     NPrSg/V/J/P #    . P
 > Peter     Naur being   the first   professor in          datalogy . The term    is used mainly in          the
 # NPrSg/V/J ?    NSg/V/C D   NSg/V/J NSg       NPrSg/V/J/P ?        . D   NSg/V/J VL V/J  J/R    NPrSg/V/J/P D
 > Scandinavian countries . An  alternative term    , also proposed by      Naur , is data
 # NSg/J        NPl       . D/P NSg/J       NSg/V/J . W?   W?       NSg/J/P ?    . VL NSg
-> science ; this is now         used for a   multi - disciplinary field of  data analysis ,
-# NSg/V   . I/D  VL NPrSg/V/J/C V/J  C/P D/P NSg   . NSg/J        NSg/V V/P NSg  NSg      .
+> science ; this is now         used for a   multi - disciplinary field of data analysis ,
+# NSg/V   . I/D  VL NPrSg/V/J/C V/J  C/P D/P NSg   . NSg/J        NSg/V P  NSg  NSg      .
 > including statistics and databases .
 # V         NPl        V/C NPl       .
 >
 #
-> In          the early   days of  computing , a   number  of  terms for the practitioners of  the
-# NPrSg/V/J/P D   NSg/J/R NPl  V/P NSg/V     . D/P NSg/V/J V/P NPl   C/P D   NPl           V/P D
-> field of  computing were  suggested ( albeit facetiously ) in          the Communications of
-# NSg/V V/P NSg/V     NSg/V W?        . C      J/R         . NPrSg/V/J/P D   W?             V/P
+> In          the early   days of computing , a   number  of terms for the practitioners of the
+# NPrSg/V/J/P D   NSg/J/R NPl  P  NSg/V     . D/P NSg/V/J P  NPl   C/P D   NPl           P  D
+> field of computing were  suggested ( albeit facetiously ) in          the Communications of
+# NSg/V P  NSg/V     NSg/V W?        . C      J/R         . NPrSg/V/J/P D   W?             P
 > the ACM — turingineer , turologist , flow  - charts - man         , applied meta  - mathematician ,
 # D   NSg . ?           . ?          . NSg/V . NPl    . NPrSg/I/V/J . W?      NSg/J . NSg           .
 > and applied epistemologist . Three months later in          the same journal , comptologist
 # V/C W?      ?              . NSg   NSg    J     NPrSg/V/J/P D   I/J  NSg/V/J . ?
 > was suggested , followed next    year by      hypologist . The term    computics has also
 # V   W?        . W?       NSg/J/P NSg  NSg/J/P ?          . D   NSg/V/J ?         V   W?
-> been  suggested . In          Europe , terms derived from contracted translations of  the
-# NSg/V W?        . NPrSg/V/J/P NPr    . NPl   W?      P    W?         W?           V/P D
+> been  suggested . In          Europe , terms derived from contracted translations of the
+# NSg/V W?        . NPrSg/V/J/P NPr    . NPl   W?      P    W?         W?           P  D
 > expression " automatic information " ( e.g. " informazione automatica " in          Italian )
 # NSg        . NSg/J     NSg         . . NSg  . ?            ?          . NPrSg/V/J/P NSg/J   .
 > or      " information and mathematics " are often used , e.g. informatique ( French    ) ,
@@ -266,12 +266,12 @@
 # NPrSg/J    . . ?           . NSg/J  NPl       V/C NSg/J     . NPrSg/C ?
 > ( π          λ          η          ρ          ο          φ          ο          ρ          ι          κ          ή          , which means informatics ) in          Greek     . Similar words have   also been
 # . Unlintable Unlintable Unlintable Unlintable Unlintable Unlintable Unlintable Unlintable Unlintable Unlintable Unlintable . I/C   NPl   NSg         . NPrSg/V/J/P NPrSg/V/J . NSg/J   NPl   NSg/VX W?   NSg/V
-> adopted in          the UK  ( as    in          the School of  Informatics , University of  Edinburgh ) .
-# W?      NPrSg/V/J/P D   NPr . NSg/R NPrSg/V/J/P D   NSg/V  V/P NSg         . NSg        V/P NPr       . .
+> adopted in          the UK  ( as    in          the School of Informatics , University of Edinburgh ) .
+# W?      NPrSg/V/J/P D   NPr . NSg/R NPrSg/V/J/P D   NSg/V  P  NSg         . NSg        P  NPr       . .
 > " In          the U.S. , however , informatics is linked with applied computing , or
 # . NPrSg/V/J/P D   ?    . C       . NSg         VL W?     P    W?      NSg/V     . NPrSg/C
-> computing in          the context of  another domain . "
-# NSg/V     NPrSg/V/J/P D   NSg/V   V/P I/D     NSg    . .
+> computing in          the context of another domain . "
+# NSg/V     NPrSg/V/J/P D   NSg/V   P  I/D     NSg    . .
 >
 #
 > A   folkloric quotation , often attributed to — but     almost certainly not   first
@@ -280,16 +280,16 @@
 # V          NSg/J/P . ?      N        . NPrSg  N/I/C/D . NSg/V    NSg/V   VL NPrSg/P NPrSg/I/V/J J/P
 > computers than astronomy is about telescopes . " [ note  3 ] The design and deployment
 # NPl       C/P  NSg       VL J/P   NPl        . . . NSg/V # . D   NSg/V  V/C NSg
-> of  computers and computer systems is generally considered the province of
-# V/P NPl       V/C NSg/V    NPl     VL J/R       V/J        D   NSg      V/P
-> disciplines other   than computer science . For example , the study of  computer
-# NPl         NSg/V/J C/P  NSg/V    NSg/V   . C/P NSg/V   . D   NSg/V V/P NSg/V
-> hardware is usually considered part    of  computer engineering , while     the study of
-# NSg      VL J/R     V/J        NSg/V/J V/P NSg/V    NSg/V       . NSg/V/C/P D   NSg/V V/P
+> of computers and computer systems is generally considered the province of
+# P  NPl       V/C NSg/V    NPl     VL J/R       V/J        D   NSg      P
+> disciplines other   than computer science . For example , the study of computer
+# NPl         NSg/V/J C/P  NSg/V    NSg/V   . C/P NSg/V   . D   NSg/V P  NSg/V
+> hardware is usually considered part    of computer engineering , while     the study of
+# NSg      VL J/R     V/J        NSg/V/J P  NSg/V    NSg/V       . NSg/V/C/P D   NSg/V P
 > commercial computer systems and their deployment is often called information
 # NSg/J      NSg/V    NPl     V/C D     NSg        VL J     V/J    NSg
-> technology or      information systems . However , there has been  exchange of  ideas
-# NSg        NPrSg/C NSg         NPl     . C       . W?    V   NSg/V NSg/V    V/P NPl
+> technology or      information systems . However , there has been  exchange of ideas
+# NSg        NPrSg/C NSg         NPl     . C       . W?    V   NSg/V NSg/V    P  NPl
 > between the various computer - related disciplines . Computer science research also
 # NSg/P   D   J       NSg/V    . J       NPl         . NSg/V    NSg/V   NSg/V    W?
 > often intersects other   disciplines , such  as    cognitive science , linguistics ,
@@ -304,12 +304,12 @@
 # NSg         C/P  N/I/J/D J          NPl         . P    I/J/R W?        NSg/V  N/I/C/D
 > computing is a   mathematical science . Early   computer science was strongly
 # NSg/V     VL D/P J            NSg/V   . NSg/J/R NSg/V    NSg/V   V   J/R
-> influenced by      the work  of  mathematicians such  as    Kurt Gödel , Alan  Turing , John
-# V/J        NSg/J/P D   NSg/V V/P NPl            NSg/I NSg/R NPr  ?     . NPrSg NPr    . NPrSg
+> influenced by      the work  of mathematicians such  as    Kurt Gödel , Alan  Turing , John
+# V/J        NSg/J/P D   NSg/V P  NPl            NSg/I NSg/R NPr  ?     . NPrSg NPr    . NPrSg
 > von Neumann , Rózsa Péter and Alonzo Church  and there continues to be     a   useful
 # ?   ?       . ?     ?     V/C NPr    NPrSg/V V/C W?    NPl       P  NSg/VX D/P J
-> interchange of  ideas between the two fields in          areas such  as    mathematical logic   ,
-# NSg/V       V/P NPl   NSg/P   D   NSg NPrPl  NPrSg/V/J/P NPl   NSg/I NSg/R J            NSg/V/J .
+> interchange of ideas between the two fields in          areas such  as    mathematical logic   ,
+# NSg/V       P  NPl   NSg/P   D   NSg NPrPl  NPrSg/V/J/P NPl   NSg/I NSg/R J            NSg/V/J .
 > category theory , domain theory , and algebra .
 # NSg      NSg    . NSg    NSg    . V/C NSg     .
 >
@@ -322,26 +322,26 @@
 # . NSg      NSg/V       . NPl   . V/C NSg/C NSg/V    NSg/V   VL V/J     . NPr   ?      .
 > taking  a   cue   from the relationship between other   engineering and science
 # NSg/V/J D/P NSg/V P    D   NSg          NSg/P   NSg/V/J NSg/V       V/C NSg/V
-> disciplines , has claimed that    the principal focus of  computer science is
-# NPl         . V   V       N/I/C/D D   NSg/J     NSg/V V/P NSg/V    NSg/V   VL
-> studying the properties of  computation in          general , while     the principal focus of
-# V        D   NPl        V/P NSg         NPrSg/V/J/P NSg/V/J . NSg/V/C/P D   NSg/J     NSg/V V/P
-> software engineering is the design of  specific computations to achieve practical
-# NSg      NSg/V       VL D   NSg/V  V/P NSg/J    NPl          P  V       NSg/J
+> disciplines , has claimed that    the principal focus of computer science is
+# NPl         . V   V       N/I/C/D D   NSg/J     NSg/V P  NSg/V    NSg/V   VL
+> studying the properties of computation in          general , while     the principal focus of
+# V        D   NPl        P  NSg         NPrSg/V/J/P NSg/V/J . NSg/V/C/P D   NSg/J     NSg/V P
+> software engineering is the design of specific computations to achieve practical
+# NSg      NSg/V       VL D   NSg/V  P  NSg/J    NPl          P  V       NSg/J
 > goals , making the two separate but     complementary disciplines .
 # NPl   . NSg/V  D   NSg NSg/V/J  NSg/C/P NSg/J         NPl         .
 >
 #
-> The academic , political , and funding aspects of  computer science tend to depend
-# D   NSg/J    . NSg/J     . V/C NSg/V   NPl     V/P NSg/V    NSg/V   V    P  NSg/V
+> The academic , political , and funding aspects of computer science tend to depend
+# D   NSg/J    . NSg/J     . V/C NSg/V   NPl     P  NSg/V    NSg/V   V    P  NSg/V
 > on  whether a   department is formed with a   mathematical emphasis or      with an
 # J/P I/C     D/P NSg        VL V      P    D/P J            NSg      NPrSg/C P    D/P
 > engineering emphasis . Computer science departments with a   mathematics emphasis
 # NSg/V       NSg      . NSg/V    NSg/V   NPl         P    D/P NSg         NSg
 > and with a   numerical orientation consider alignment with computational science .
 # V/C P    D/P J         NSg         V        NSg       P    J             NSg/V   .
-> Both types of  departments tend to make  efforts to bridge the field educationally
-# I/C  NPl   V/P NPl         V    P  NSg/V NPl     P  NSg/V  D   NSg/V J/R
+> Both types of departments tend to make  efforts to bridge the field educationally
+# I/C  NPl   P  NPl         V    P  NSg/V NPl     P  NSg/V  D   NSg/V J/R
 > if    not   across all       research .
 # NSg/C NSg/C NSg/P  NSg/I/J/C NSg/V    .
 >
@@ -350,24 +350,24 @@
 # NSg/V
 >
 #
-> Epistemology of  computer science
-# NSg          V/P NSg/V    NSg/V
+> Epistemology of computer science
+# NSg          P  NSg/V    NSg/V
 >
 #
 > Despite the word  science in          its   name  , there is debate over      whether or      not
 # NSg/V/P D   NSg/V NSg/V   NPrSg/V/J/P ISg/D NSg/V . W?    VL NSg/V  NSg/V/J/P I/C     NPrSg/C NSg/C
-> computer science is a   discipline of  science , mathematics , or      engineering . Allen
-# NSg/V    NSg/V   VL D/P NSg/V      V/P NSg/V   . NSg         . NPrSg/C NSg/V       . NPrSg
+> computer science is a   discipline of science , mathematics , or      engineering . Allen
+# NSg/V    NSg/V   VL D/P NSg/V      P  NSg/V   . NSg         . NPrSg/C NSg/V       . NPrSg
 > Newell and Herbert A. Simon argued in          1975 ,
 # ?      V/C NPr     ?  NPrSg W?     NPrSg/V/J/P #    .
 >
 #
 > Computer science is an  empirical discipline . We  would  have   called it        an
 # NSg/V    NSg/V   VL D/P NSg/J     NSg/V      . IPl NSg/VX NSg/VX V/J    NPrSg/ISg D/P
-> experimental science , but     like        astronomy , economics , and geology , some  of  its
-# NSg/J        NSg/V   . NSg/C/P NSg/V/J/C/P NSg       . NSg       . V/C NSg     . I/J/R V/P ISg/D
-> unique forms of  observation and experience do     not   fit     a   narrow  stereotype of
-# NSg/J  NPl   V/P NSg         V/C NSg/V      NSg/VX NSg/C NSg/V/J D/P NSg/V/J NSg/V      V/P
+> experimental science , but     like        astronomy , economics , and geology , some  of its
+# NSg/J        NSg/V   . NSg/C/P NSg/V/J/C/P NSg       . NSg       . V/C NSg     . I/J/R P  ISg/D
+> unique forms of observation and experience do     not   fit     a   narrow  stereotype of
+# NSg/J  NPl   P  NSg         V/C NSg/V      NSg/VX NSg/C NSg/V/J D/P NSg/V/J NSg/V      P
 > the experimental method . Nonetheless , they are experiments . Each new     machine
 # D   NSg/J        NSg/V  . W?          . IPl  V   NPl         . D    NSg/V/J NSg/V
 > that    is built   is an  experiment . Actually constructing the machine poses a
@@ -380,16 +380,16 @@
 #
 > It        has since been  argued that    computer science can      be     classified as    an  empirical
 # NPrSg/ISg V   C/P   NSg/V W?     N/I/C/D NSg/V    NSg/V   NPrSg/VX NSg/VX NSg/V/J    NSg/R D/P NSg/J
-> science since it        makes use   of  empirical testing to evaluate the correctness of
-# NSg/V   C/P   NPrSg/ISg NPl   NSg/V V/P NSg/J     V       P  V        D   NSg         V/P
-> programs , but     a   problem remains in          defining the laws and theorems of  computer
-# NPl      . NSg/C/P D/P NSg/J   NPl     NPrSg/V/J/P V        D   NPl  V/C NPl      V/P NSg/V
-> science ( if    any   exist ) and defining the nature of  experiments in          computer
-# NSg/V   . NSg/C I/R/D V     . V/C V        D   NSg/V  V/P NPl         NPrSg/V/J/P NSg/V
-> science . Proponents of  classifying computer science as    an  engineering discipline
-# NSg/V   . NPl        V/P V           NSg/V    NSg/V   NSg/R D/P NSg/V       NSg/V
-> argue that    the reliability of  computational systems is investigated in          the same
-# V     N/I/C/D D   NSg         V/P J             NPl     VL W?           NPrSg/V/J/P D   I/J
+> science since it        makes use   of empirical testing to evaluate the correctness of
+# NSg/V   C/P   NPrSg/ISg NPl   NSg/V P  NSg/J     V       P  V        D   NSg         P
+> programs , but     a   problem remains in          defining the laws and theorems of computer
+# NPl      . NSg/C/P D/P NSg/J   NPl     NPrSg/V/J/P V        D   NPl  V/C NPl      P  NSg/V
+> science ( if    any   exist ) and defining the nature of experiments in          computer
+# NSg/V   . NSg/C I/R/D V     . V/C V        D   NSg/V  P  NPl         NPrSg/V/J/P NSg/V
+> science . Proponents of classifying computer science as    an  engineering discipline
+# NSg/V   . NPl        P  V           NSg/V    NSg/V   NSg/R D/P NSg/V       NSg/V
+> argue that    the reliability of computational systems is investigated in          the same
+# V     N/I/C/D D   NSg         P  J             NPl     VL W?           NPrSg/V/J/P D   I/J
 > way   as    bridges in          civil engineering and airplanes in          aerospace engineering . They
 # NSg/J NSg/R NPrPl   NPrSg/V/J/P J     NSg/V       V/C NPl       NPrSg/V/J/P NSg/J     NSg/V       . IPl
 > also argue that    while     empirical sciences observe what  presently exists , computer
@@ -402,10 +402,10 @@
 # W?      V/J       P    V        NSg       .
 >
 #
-> Proponents of  classifying computer science as    a   mathematical discipline argue
-# NPl        V/P V           NSg/V    NSg/V   NSg/R D/P J            NSg/V      V
-> that    computer programs are physical realizations of  mathematical entities and
-# N/I/C/D NSg/V    NPl      V   NSg/J    NPl          V/P J            NPl      V/C
+> Proponents of classifying computer science as    a   mathematical discipline argue
+# NPl        P  V           NSg/V    NSg/V   NSg/R D/P J            NSg/V      V
+> that    computer programs are physical realizations of mathematical entities and
+# N/I/C/D NSg/V    NPl      V   NSg/J    NPl          P  J            NPl      V/C
 > programs that    can      be     deductively reasoned through mathematical formal methods .
 # NPl      N/I/C/D NPrSg/VX NSg/VX J/R         W?       NSg/J/P J            NSg/J  NPl     .
 > Computer scientists Edsger W. Dijkstra and Tony    Hoare regard instructions for
@@ -416,12 +416,12 @@
 # NSg/V       NPl       NSg/R J            J         NPl     .
 >
 #
-> Paradigms of  computer science
-# NPl       V/P NSg/V    NSg/V
+> Paradigms of computer science
+# NPl       P  NSg/V    NSg/V
 >
 #
-> A   number  of  computer scientists have   argued for the distinction of  three
-# D/P NSg/V/J V/P NSg/V    NPl        NSg/VX W?     C/P D   NSg         V/P NSg
+> A   number  of computer scientists have   argued for the distinction of three
+# D/P NSg/V/J P  NSg/V    NPl        NSg/VX W?     C/P D   NSg         P  NSg
 > separate paradigms in          computer science . Peter     Wegner argued that    those paradigms
 # NSg/V/J  NPl       NPrSg/V/J/P NSg/V    NSg/V   . NPrSg/V/J ?      W?     N/I/C/D I/D   NPl
 > are science , technology , and mathematics . Peter     Denning's working group argued
@@ -430,20 +430,20 @@
 # N/I/C/D IPl  V   NSg    . NSg         . NSg/V    . . V/C NSg/V  . ?     ?  NPrSg
 > described them as    the " rationalist paradigm " ( which treats computer science as    a
 # W?        N/I  NSg/R D   . NSg         NSg      . . I/C   NPl    NSg/V    NSg/V   NSg/R D/P
-> branch  of  mathematics , which is prevalent in          theoretical computer science , and
-# NPrSg/V V/P NSg         . I/C   VL NSg/J     NPrSg/V/J/P J           NSg/V    NSg/V   . V/C
+> branch  of mathematics , which is prevalent in          theoretical computer science , and
+# NPrSg/V P  NSg         . I/C   VL NSg/J     NPrSg/V/J/P J           NSg/V    NSg/V   . V/C
 > mainly employs deductive reasoning ) , the " technocratic paradigm " ( which might    be
 # J/R    NPl     J         NSg/V     . . D   . J            NSg      . . I/C   NSg/VX/J NSg/VX
 > found in          engineering approaches , most    prominently in          software engineering ) , and
 # NSg/V NPrSg/V/J/P NSg/V       NPl        . NSg/I/J J/R         NPrSg/V/J/P NSg      NSg/V       . . V/C
 > the " scientific paradigm " ( which approaches computer - related artifacts from the
 # D   . J          NSg      . . I/C   NPl        NSg/V    . J       NPl       P    D
-> empirical perspective of  natural sciences , identifiable in          some  branches of
-# NSg/J     NSg/J       V/P NSg/J   NPl      . J            NPrSg/V/J/P I/J/R NPl      V/P
+> empirical perspective of natural sciences , identifiable in          some  branches of
+# NSg/J     NSg/J       P  NSg/J   NPl      . J            NPrSg/V/J/P I/J/R NPl      P
 > artificial intelligence ) . Computer science focuses on  methods involved in
 # J          NSg          . . NSg/V    NSg/V   NPl     J/P NPl     V/J      NPrSg/V/J/P
 > design , specification , programming , verification , implementation and testing of
-# NSg/V  . NSg           . NSg/V       . NSg          . NSg            V/C V       V/P
+# NSg/V  . NSg           . NSg/V       . NSg          . NSg            V/C V       P
 > human   - made  computing systems .
 # NSg/V/J . NSg/V NSg/V     NPl     .
 >
@@ -452,20 +452,20 @@
 # NPrPl
 >
 #
-> As    a   discipline , computer science spans a   range of  topics from theoretical
-# NSg/R D/P NSg/V      . NSg/V    NSg/V   NPl   D/P NSg/V V/P NPl    P    J
-> studies of  algorithms and the limits of  computation to the practical issues of
-# NPl     V/P NPl        V/C D   NPl    V/P NSg         P  D   NSg/J     NPl    V/P
+> As    a   discipline , computer science spans a   range of topics from theoretical
+# NSg/R D/P NSg/V      . NSg/V    NSg/V   NPl   D/P NSg/V P  NPl    P    J
+> studies of algorithms and the limits of computation to the practical issues of
+# NPl     P  NPl        V/C D   NPl    P  NSg         P  D   NSg/J     NPl    P
 > implementing computing systems in          hardware and software . CSAB , formerly called
 # V            NSg/V     NPl     NPrSg/V/J/P NSg      V/C NSg      . ?    . R        V/J
-> Computing Sciences Accreditation Board — which is made  up        of  representatives of
-# NSg/V     NPl      NSg           NSg/V . I/C   VL NSg/V NSg/V/J/P V/P NPl             V/P
+> Computing Sciences Accreditation Board — which is made  up        of representatives of
+# NSg/V     NPl      NSg           NSg/V . I/C   VL NSg/V NSg/V/J/P P  NPl             P
 > the Association for Computing Machinery ( ACM ) , and the IEEE Computer Society
 # D   NSg         C/P NSg/V     NSg       . NSg . . V/C D   NPr  NSg/V    NSg
 > ( IEEE CS  ) — identifies four areas that    it        considers crucial to the discipline of
-# . NPr  NPl . . NPl        NSg  NPl   N/I/C/D NPrSg/ISg NPl       J       P  D   NSg/V      V/P
-> computer science : theory of  computation , algorithms and data structures ,
-# NSg/V    NSg/V   . NSg    V/P NSg         . NPl        V/C NSg  NPl        .
+# . NPr  NPl . . NPl        NSg  NPl   N/I/C/D NPrSg/ISg NPl       J       P  D   NSg/V      P
+> computer science : theory of computation , algorithms and data structures ,
+# NSg/V    NSg/V   . NSg    P  NSg         . NPl        V/C NSg  NPl        .
 > programming methodology and languages , and computer elements and architecture .
 # NSg/V       NSg         V/C NPl       . V/C NSg/V    NPl      V/C NSg          .
 > In          addition to these four areas , CSAB also identifies fields such  as    software
@@ -476,8 +476,8 @@
 # NSg/V    NPl     . NSg/V/J  NSg         . V/J         NSg         . NSg/V/J . NSg/V
 > interaction , computer graphics , operating systems , and numerical and symbolic
 # NSg         . NSg/V    NPl      . V         NPl     . V/C J         V/C J
-> computation as    being   important areas of  computer science .
-# NSg         NSg/R NSg/V/C J         NPl   V/P NSg/V    NSg/V   .
+> computation as    being   important areas of computer science .
+# NSg         NSg/R NSg/V/C J         NPl   P  NSg/V    NSg/V   .
 >
 #
 > Theoretical computer science
@@ -488,40 +488,40 @@
 # J           NSg/V    NSg/V   VL J            V/C NSg/V/J  NPrSg/V/J/P NSg/V  . NSg/C/P NPrSg/ISg
 > derives its   motivation from practical and everyday computation . It        aims to
 # NPl     ISg/D NSg        P    NSg/J     V/C NSg/J    NSg         . NPrSg/ISg NPl  P
-> understand the nature of  computation and , as    a   consequence of  this
-# V          D   NSg/V  V/P NSg         V/C . NSg/R D/P NSg/V       V/P I/D
+> understand the nature of computation and , as    a   consequence of this
+# V          D   NSg/V  P  NSg         V/C . NSg/R D/P NSg/V       P  I/D
 > understanding , provide more        efficient methodologies .
 # NSg/V/J       . V       NPrSg/I/V/J NSg/J     NPl           .
 >
 #
-> Theory of  computation
-# NSg    V/P NSg
+> Theory of computation
+# NSg    P  NSg
 >
 #
 > According to Peter     Denning , the fundamental question underlying computer science
 # V/J       P  NPrSg/V/J ?       . D   NSg/J       NSg/V    NSg/V/J    NSg/V    NSg/V
-> is , " What  can      be     automated ? " Theory of  computation is focused on  answering
-# VL . . NSg/I NPrSg/VX NSg/VX W?        . . NSg    V/P NSg         VL V/J     J/P V
-> fundamental questions about what  can      be     computed and what  amount of  resources
-# NSg/J       NPl       J/P   NSg/I NPrSg/VX NSg/VX W?       V/C NSg/I NSg/V  V/P NPl
+> is , " What  can      be     automated ? " Theory of computation is focused on  answering
+# VL . . NSg/I NPrSg/VX NSg/VX W?        . . NSg    P  NSg         VL V/J     J/P V
+> fundamental questions about what  can      be     computed and what  amount of resources
+# NSg/J       NPl       J/P   NSg/I NPrSg/VX NSg/VX W?       V/C NSg/I NSg/V  P  NPl
 > are required to perform those computations . In          an  effort to answer the first
 # V   W?       P  V       I/D   NPl          . NPrSg/V/J/P D/P NSg/V  P  NSg/V  D   NSg/V/J
 > question , computability theory examines which computational problems are
 # NSg/V    . ?             NSg    NPl      I/C   J             NPl      V
-> solvable on  various theoretical models of  computation . The second  question is
-# J        J/P J       J           NPl    V/P NSg         . D   NSg/V/J NSg/V    VL
+> solvable on  various theoretical models of computation . The second  question is
+# J        J/P J       J           NPl    P  NSg         . D   NSg/V/J NSg/V    VL
 > addressed by      computational complexity theory , which studies the time  and space
 # V/J       NSg/J/P J             NSg        NSg    . I/C   NPl     D   NSg/V V/C NSg/V
 > costs associated with different approaches to solving a   multitude of
-# NPl   W?         P    NSg/J     NPl        P  V       D/P NSg       V/P
+# NPl   W?         P    NSg/J     NPl        P  V       D/P NSg       P
 > computational problems .
 # J             NPl      .
 >
 #
-> The famous P           = NP    ? problem , one       of  the Millennium Prize   Problems , is an  open
-# D   V/J    NPrSg/V/J/P . NPrSg . NSg/J   . NSg/I/V/J V/P D   NSg        NSg/V/J NPl      . VL D/P NSg/V/J
-> problem in          the theory of  computation .
-# NSg/J   NPrSg/V/J/P D   NSg    V/P NSg         .
+> The famous P           = NP    ? problem , one       of the Millennium Prize   Problems , is an  open
+# D   V/J    NPrSg/V/J/P . NPrSg . NSg/J   . NSg/I/V/J P  D   NSg        NSg/V/J NPl      . VL D/P NSg/V/J
+> problem in          the theory of computation .
+# NSg/J   NPrSg/V/J/P D   NSg    P  NSg         .
 >
 #
 > Information and coding theory
@@ -530,20 +530,20 @@
 #
 > Information theory , closely related to probability and statistics , is related to
 # NSg         NSg    . J/R     J       P  NSg         V/C NPl        . VL J       P
-> the quantification of  information . This was developed by      Claude Shannon to find
-# D   NSg            V/P NSg         . I/D  V   V/J       NSg/J/P NPr    NPr     P  NSg/V
+> the quantification of information . This was developed by      Claude Shannon to find
+# D   NSg            P  NSg         . I/D  V   V/J       NSg/J/P NPr    NPr     P  NSg/V
 > fundamental limits on  signal  processing operations such  as    compressing data and
 # NSg/J       NPl    J/P NSg/V/J V          W?         NSg/I NSg/R V           NSg  V/C
-> on  reliably storing and communicating data . Coding theory is the study of  the
-# J/P R        V       V/C V             NSg  . V      NSg    VL D   NSg/V V/P D
-> properties of  codes ( systems for converting information from one       form  to
-# NPl        V/P NPl   . NPl     C/P V          NSg         P    NSg/I/V/J NSg/V P
+> on  reliably storing and communicating data . Coding theory is the study of the
+# J/P R        V       V/C V             NSg  . V      NSg    VL D   NSg/V P  D
+> properties of codes ( systems for converting information from one       form  to
+# NPl        P  NPl   . NPl     C/P V          NSg         P    NSg/I/V/J NSg/V P
 > another ) and their fitness for a   specific application . Codes are used for data
 # I/D     . V/C D     NSg     C/P D/P NSg/J    NSg         . NPl   V   V/J  C/P NSg
 > compression , cryptography , error detection and correction , and more        recently
 # NSg         . NSg          . NSg/V NSg       V/C NSg        . V/C NPrSg/I/V/J J/R
-> also for network coding . Codes are studied for the purpose of  designing
-# W?   C/P NSg/V   V      . NPl   V   V/J     C/P D   NSg/V   V/P V
+> also for network coding . Codes are studied for the purpose of designing
+# W?   C/P NSg/V   V      . NPl   V   V/J     C/P D   NSg/V   P  V
 > efficient and reliable data transmission methods .
 # NSg/J     V/C NSg/J    NSg  NSg          NPl     .
 >
@@ -552,8 +552,8 @@
 # NSg  NPl        V/C NPl
 >
 #
-> Data structures and algorithms are the studies of  commonly used computational
-# NSg  NPl        V/C NPl        V   D   NPl     V/P J/R      V/J  J
+> Data structures and algorithms are the studies of commonly used computational
+# NSg  NPl        V/C NPl        V   D   NPl     P  J/R      V/J  J
 > methods and their computational efficiency .
 # NPl     V/C D     J             NSg        .
 >
@@ -562,30 +562,30 @@
 # NSg/V       NSg/V    NSg    V/C NSg/J  NPl
 >
 #
-> Programming language theory is a   branch  of  computer science that    deals with the
-# NSg/V       NSg/V    NSg    VL D/P NPrSg/V V/P NSg/V    NSg/V   N/I/C/D NPl   P    D
+> Programming language theory is a   branch  of computer science that    deals with the
+# NSg/V       NSg/V    NSg    VL D/P NPrSg/V P  NSg/V    NSg/V   N/I/C/D NPl   P    D
 > design , implementation , analysis , characterization , and classification of
-# NSg/V  . NSg            . NSg      . NSg              . V/C NSg            V/P
+# NSg/V  . NSg            . NSg      . NSg              . V/C NSg            P
 > programming languages and their individual features . It        falls within the
 # NSg/V       NPl       V/C D     NSg/J      NPl      . NPrSg/ISg NPl   N/J/P  D
-> discipline of  computer science , both depending on  and affecting mathematics ,
-# NSg/V      V/P NSg/V    NSg/V   . I/C  V         J/P V/C V/J       NSg         .
+> discipline of computer science , both depending on  and affecting mathematics ,
+# NSg/V      P  NSg/V    NSg/V   . I/C  V         J/P V/C V/J       NSg         .
 > software engineering , and linguistics . It        is an  active research area , with
 # NSg      NSg/V       . V/C NSg         . NPrSg/ISg VL D/P NSg/J  NSg/V    NSg  . P
 > numerous dedicated academic journals .
 # J        W?        NSg/J    NPl      .
 >
 #
-> Formal methods are a   particular kind  of  mathematically based technique for the
-# NSg/J  NPl     V   D/P NSg/J      NSg/J V/P J/R            W?    NSg       C/P D
-> specification , development and verification of  software and hardware systems .
-# NSg           . NSg         V/C NSg          V/P NSg      V/C NSg      NPl     .
-> The use   of  formal methods for software and hardware design is motivated by      the
-# D   NSg/V V/P NSg/J  NPl     C/P NSg      V/C NSg      NSg/V  VL V/J       NSg/J/P D
+> Formal methods are a   particular kind  of mathematically based technique for the
+# NSg/J  NPl     V   D/P NSg/J      NSg/J P  J/R            W?    NSg       C/P D
+> specification , development and verification of software and hardware systems .
+# NSg           . NSg         V/C NSg          P  NSg      V/C NSg      NPl     .
+> The use   of formal methods for software and hardware design is motivated by      the
+# D   NSg/V P  NSg/J  NPl     C/P NSg      V/C NSg      NSg/V  VL V/J       NSg/J/P D
 > expectation that    , as    in          other   engineering disciplines , performing appropriate
 # NSg         N/I/C/D . NSg/R NPrSg/V/J/P NSg/V/J NSg/V       NPl         . V          V/J
-> mathematical analysis can      contribute to the reliability and robustness of  a
-# J            NSg      NPrSg/VX NSg/V      P  D   NSg         V/C NSg        V/P D/P
+> mathematical analysis can      contribute to the reliability and robustness of a
+# J            NSg      NPrSg/VX NSg/V      P  D   NSg         V/C NSg        P  D/P
 > design . They form  an  important theoretical underpinning for software
 # NSg/V  . IPl  NSg/V D/P J         J           NSg/V        C/P NSg
 > engineering , especially where safety or      security is involved . Formal methods are
@@ -594,14 +594,14 @@
 # D/P J      NSg/V/J P  NSg      V       C/P   IPl  NSg/V V     NPl    V/C NPrSg/VX W?
 > give  a   framework for testing . For industrial use   , tool  support is required .
 # NSg/V D/P NSg       C/P V       . C/P NSg/J      NSg/V . NSg/V NSg/V   VL W?       .
-> However , the high    cost  of  using formal methods means that    they are usually only
-# C       . D   NSg/V/J NSg/V V/P V     NSg/J  NPl     NPl   N/I/C/D IPl  V   J/R     W?
-> used in          the development of  high    - integrity and life  - critical systems , where
-# V/J  NPrSg/V/J/P D   NSg         V/P NSg/V/J . NSg       V/C NSg/V . NSg/J    NPl     . NSg/C
-> safety or      security is of  utmost importance . Formal methods are best       described as
-# NSg/V  NPrSg/C NSg      VL V/P NSg/J  NSg        . NSg/J  NPl     V   NPrSg/VX/J W?        NSg/R
-> the application of  a   fairly broad variety of  theoretical computer science
-# D   NSg         V/P D/P J/R    NSg/J NSg     V/P J           NSg/V    NSg/V
+> However , the high    cost  of using formal methods means that    they are usually only
+# C       . D   NSg/V/J NSg/V P  V     NSg/J  NPl     NPl   N/I/C/D IPl  V   J/R     W?
+> used in          the development of high    - integrity and life  - critical systems , where
+# V/J  NPrSg/V/J/P D   NSg         P  NSg/V/J . NSg       V/C NSg/V . NSg/J    NPl     . NSg/C
+> safety or      security is of utmost importance . Formal methods are best       described as
+# NSg/V  NPrSg/C NSg      VL P  NSg/J  NSg        . NSg/J  NPl     V   NPrSg/VX/J W?        NSg/R
+> the application of a   fairly broad variety of theoretical computer science
+# D   NSg         P  D/P J/R    NSg/J NSg     P  J           NSg/V    NSg/V
 > fundamentals , in          particular logic   calculi , formal languages , automata theory ,
 # NPl          . NPrSg/V/J/P NSg/J      NSg/V/J NSg     . NSg/J  NPl       . NSg      NSg    .
 > and program semantics , but     also type  systems and algebraic data types to
@@ -618,14 +618,14 @@
 # NSg/V    NPl      V/C NSg
 >
 #
-> Computer graphics is the study of  digital visual contents and involves the
-# NSg/V    NPl      VL D   NSg/V V/P NSg/J   NSg/J  NPl      V/C NPl      D
-> synthesis and manipulation of  image data . The study is connected to many    other
-# NSg       V/C NSg          V/P NSg/V NSg  . D   NSg/V VL V/J       P  N/I/J/D NSg/V/J
+> Computer graphics is the study of digital visual contents and involves the
+# NSg/V    NPl      VL D   NSg/V P  NSg/J   NSg/J  NPl      V/C NPl      D
+> synthesis and manipulation of image data . The study is connected to many    other
+# NSg       V/C NSg          P  NSg/V NSg  . D   NSg/V VL V/J       P  N/I/J/D NSg/V/J
 > fields in          computer science , including computer vision , image processing , and
 # NPrPl  NPrSg/V/J/P NSg/V    NSg/V   . V         NSg/V    NSg/V  . NSg/V V          . V/C
-> computational geometry , and is heavily applied in          the fields of  special effects
-# J             NSg      . V/C VL R       W?      NPrSg/V/J/P D   NPrPl  V/P NSg/V/J NPl
+> computational geometry , and is heavily applied in          the fields of special effects
+# J             NSg      . V/C VL R       W?      NPrSg/V/J/P D   NPrPl  P  NSg/V/J NPl
 > and video games .
 # V/C NSg/V NPl   .
 >
@@ -634,48 +634,48 @@
 # NSg/V V/C NSg/V/J V
 >
 #
-> Information can      take  the form  of  images , sound   , video or      other   multimedia . Bits
-# NSg         NPrSg/VX NSg/V D   NSg/V V/P NPl    . NSg/V/J . NSg/V NPrSg/C NSg/V/J NSg/J      . NPl
-> of  information can      be     streamed via   signals . Its   processing is the central notion
-# V/P NSg         NPrSg/VX NSg/VX W?       NSg/P NPl     . ISg/D V          VL D   NPrSg/J NSg
-> of  informatics , the European view  on  computing , which studies information
-# V/P NSg         . D   NSg/J    NSg/V J/P NSg/V     . I/C   NPl     NSg
-> processing algorithms independently of  the type  of  information carrier – whether
-# V          NPl        J/R           V/P D   NSg/V V/P NSg         NPrSg/J . I/C
+> Information can      take  the form  of images , sound   , video or      other   multimedia . Bits
+# NSg         NPrSg/VX NSg/V D   NSg/V P  NPl    . NSg/V/J . NSg/V NPrSg/C NSg/V/J NSg/J      . NPl
+> of information can      be     streamed via   signals . Its   processing is the central notion
+# P  NSg         NPrSg/VX NSg/VX W?       NSg/P NPl     . ISg/D V          VL D   NPrSg/J NSg
+> of informatics , the European view  on  computing , which studies information
+# P  NSg         . D   NSg/J    NSg/V J/P NSg/V     . I/C   NPl     NSg
+> processing algorithms independently of the type  of information carrier – whether
+# V          NPl        J/R           P  D   NSg/V P  NSg         NPrSg/J . I/C
 > it        is electrical , mechanical or      biological . This field plays important role in
 # NPrSg/ISg VL NSg/J      . NSg/J      NPrSg/C NSg/J      . I/D  NSg/V NPl   J         NSg  NPrSg/V/J/P
 > information theory , telecommunications , information engineering and has
 # NSg         NSg    . NSg                . NSg         NSg/V       V/C V
 > applications in          medical image computing and speech synthesis , among others . What
 # W?           NPrSg/V/J/P NSg/J   NSg/V NSg/V     V/C NSg/V  NSg       . P     NPl    . NSg/I
-> is the lower bound   on  the complexity of  fast    Fourier transform algorithms ? is
-# VL D   V/J   NSg/V/J J/P D   NSg        V/P NSg/V/J NPr     NSg/V     NPl        . VL
-> one       of  the unsolved problems in          theoretical computer science .
-# NSg/I/V/J V/P D   V/J      NPl      NPrSg/V/J/P J           NSg/V    NSg/V   .
+> is the lower bound   on  the complexity of fast    Fourier transform algorithms ? is
+# VL D   V/J   NSg/V/J J/P D   NSg        P  NSg/V/J NPr     NSg/V     NPl        . VL
+> one       of the unsolved problems in          theoretical computer science .
+# NSg/I/V/J P  D   V/J      NPl      NPrSg/V/J/P J           NSg/V    NSg/V   .
 >
 #
 > Computational science , finance and engineering
 # J             NSg/V   . NSg/V   V/C NSg/V
 >
 #
-> Scientific computing ( or      computational science ) is the field of  study concerned
-# J          NSg/V     . NPrSg/C J             NSg/V   . VL D   NSg/V V/P NSg/V V/J
+> Scientific computing ( or      computational science ) is the field of study concerned
+# J          NSg/V     . NPrSg/C J             NSg/V   . VL D   NSg/V P  NSg/V V/J
 > with constructing mathematical models and quantitative analysis techniques and
 # P    V            J            NPl    V/C J            NSg      NPl        V/C
 > using computers to analyze and solve scientific problems . A   major     usage of
-# V     NPl       P  V       V/C NSg/V J          NPl      . D/P NPrSg/V/J NSg   V/P
-> scientific computing is simulation of  various processes , including computational
-# J          NSg/V     VL NSg        V/P J       NPl       . V         J
+# V     NPl       P  V       V/C NSg/V J          NPl      . D/P NPrSg/V/J NSg   P
+> scientific computing is simulation of various processes , including computational
+# J          NSg/V     VL NSg        P  J       NPl       . V         J
 > fluid dynamics , physical , electrical , and electronic systems and circuits , as
 # NSg/J NSg      . NSg/J    . NSg/J      . V/C J          NPl     V/C NPl      . NSg/R
 > well    as    societies and social situations ( notably war   games ) along with their
 # NSg/V/J NSg/R NPl       V/C NSg/J  W?         . R       NSg/V NPl   . P     P    D
-> habitats , among many    others . Modern computers enable optimization of  such
-# NPl      . P     N/I/J/D NPl    . NSg/J  NPl       V      NSg          V/P NSg/I
+> habitats , among many    others . Modern computers enable optimization of such
+# NPl      . P     N/I/J/D NPl    . NSg/J  NPl       V      NSg          P  NSg/I
 > designs as    complete aircraft . Notable in          electrical and electronic circuit
 # NPl     NSg/R NSg/V/J  NSg      . NSg/J   NPrSg/V/J/P NSg/J      V/C J          NSg/V
-> design are SPICE , as    well    as    software for physical realization of  new     ( or
-# NSg/V  V   NSg/V . NSg/R NSg/V/J NSg/R NSg      C/P NSg/J    NSg         V/P NSg/V/J . NPrSg/C
+> design are SPICE , as    well    as    software for physical realization of new     ( or
+# NSg/V  V   NSg/V . NSg/R NSg/V/J NSg/R NSg      C/P NSg/J    NSg         P  NSg/V/J . NPrSg/C
 > modified ) designs . The latter includes essential design software for integrated
 # NSg/V/J  . NPl     . D   N/J    NPl      NSg/J     NSg/V  NSg      C/P W?
 > circuits .
@@ -686,10 +686,10 @@
 # NSg/V/J . NSg/V    NSg
 >
 #
-> Human   – computer interaction ( HCI ) is the field of  study and research concerned
-# NSg/V/J . NSg/V    NSg         . ?   . VL D   NSg/V V/P NSg/V V/C NSg/V    V/J
-> with the design and use   of  computer systems , mainly based on  the analysis of  the
-# P    D   NSg/V  V/C NSg/V V/P NSg/V    NPl     . J/R    W?    J/P D   NSg      V/P D
+> Human   – computer interaction ( HCI ) is the field of study and research concerned
+# NSg/V/J . NSg/V    NSg         . ?   . VL D   NSg/V P  NSg/V V/C NSg/V    V/J
+> with the design and use   of computer systems , mainly based on  the analysis of the
+# P    D   NSg/V  V/C NSg/V P  NSg/V    NPl     . J/R    W?    J/P D   NSg      P  D
 > interaction between humans and computer interfaces . HCI has several subfields
 # NSg         NSg/P   NPl    V/C NSg/V    NPl        . ?   V   J/D     NPl
 > that    focus on  the relationship between emotions , social behavior and brain
@@ -702,18 +702,18 @@
 # NSg      NSg/V
 >
 #
-> Software engineering is the study of  designing , implementing , and modifying the
-# NSg      NSg/V       VL D   NSg/V V/P V         . V            . V/C V         D
-> software in          order to ensure it        is of  high    quality , affordable , maintainable , and
-# NSg      NPrSg/V/J/P NSg/V P  V      NPrSg/ISg VL V/P NSg/V/J NSg/J   . W?         . J            . V/C
+> Software engineering is the study of designing , implementing , and modifying the
+# NSg      NSg/V       VL D   NSg/V P  V         . V            . V/C V         D
+> software in          order to ensure it        is of high    quality , affordable , maintainable , and
+# NSg      NPrSg/V/J/P NSg/V P  V      NPrSg/ISg VL P  NSg/V/J NSg/J   . W?         . J            . V/C
 > fast    to build . It        is a   systematic approach to software design , involving the
 # NSg/V/J P  NSg/V . NPrSg/ISg VL D/P J          NSg/V    P  NSg      NSg/V  . V         D
-> application of  engineering practices to software . Software engineering deals
-# NSg         V/P NSg/V       NPl       P  NSg      . NSg      NSg/V       NPl
-> with the organizing and analyzing of  software — it        does  not   just deal    with the
-# P    D   V          V/C V         V/P NSg      . NPrSg/ISg NSg/V NSg/C V/J  NSg/V/J P    D
-> creation or      manufacture of  new     software , but     its   internal arrangement and
-# NSg      NPrSg/C NSg/V       V/P NSg/V/J NSg      . NSg/C/P ISg/D J        NSg         V/C
+> application of engineering practices to software . Software engineering deals
+# NSg         P  NSg/V       NPl       P  NSg      . NSg      NSg/V       NPl
+> with the organizing and analyzing of software — it        does  not   just deal    with the
+# P    D   V          V/C V         P  NSg      . NPrSg/ISg NSg/V NSg/C V/J  NSg/V/J P    D
+> creation or      manufacture of new     software , but     its   internal arrangement and
+# NSg      NPrSg/C NSg/V       P  NSg/V/J NSg      . NSg/C/P ISg/D J        NSg         V/C
 > maintenance . For example software testing , systems engineering , technical debt
 # NSg         . C/P NSg/V   NSg      V       . NPl     NSg/V       . NSg/J     NSg
 > and software development processes .
@@ -734,28 +734,28 @@
 # NPl     . P    ISg/D NPl     NPrSg/V/J/P NSg         V/C NPrSg/V/J/P D   NPr       NSg/V      . #    . .
 > artificial intelligence research has been  necessarily cross       - disciplinary ,
 # J          NSg          NSg/V    V   NSg/V R           NPrSg/V/J/P . NSg/J        .
-> drawing on  areas of  expertise such  as    applied mathematics , symbolic logic   ,
-# NSg/V   J/P NPl   V/P NSg/V     NSg/I NSg/R W?      NSg         . J        NSg/V/J .
-> semiotics , electrical engineering , philosophy of  mind  , neurophysiology , and
-# NSg       . NSg/J      NSg/V       . NSg/V      V/P NSg/V . ?               . V/C
+> drawing on  areas of expertise such  as    applied mathematics , symbolic logic   ,
+# NSg/V   J/P NPl   P  NSg/V     NSg/I NSg/R W?      NSg         . J        NSg/V/J .
+> semiotics , electrical engineering , philosophy of mind  , neurophysiology , and
+# NSg       . NSg/J      NSg/V       . NSg/V      P  NSg/V . ?               . V/C
 > social intelligence . AI    is associated in          the popular mind  with robotic
 # NSg/J  NSg          . NPrSg VL W?         NPrSg/V/J/P D   NSg/J   NSg/V P    J
-> development , but     the main    field of  practical application has been  as    an  embedded
-# NSg         . NSg/C/P D   NSg/V/J NSg/V V/P NSg/J     NSg         V   NSg/V NSg/R D/P V/J
-> component in          areas of  software development , which require computational
-# NSg/J     NPrSg/V/J/P NPl   V/P NSg      NSg         . I/C   NSg/V   J
+> development , but     the main    field of practical application has been  as    an  embedded
+# NSg         . NSg/C/P D   NSg/V/J NSg/V P  NSg/J     NSg         V   NSg/V NSg/R D/P V/J
+> component in          areas of software development , which require computational
+# NSg/J     NPrSg/V/J/P NPl   P  NSg      NSg         . I/C   NSg/V   J
 > understanding . The starting point in          the late  1940s was Alan  Turing's question
 # NSg/V/J       . D   V        NSg/V NPrSg/V/J/P D   NSg/J #d    V   NPrSg N$       NSg/V
 > " Can      computers think ? " , and the question remains effectively unanswered ,
 # . NPrSg/VX NPl       NSg/V . . . V/C D   NSg/V    NPl     J/R         V/J        .
 > although the Turing test  is still   used to assess computer output on  the scale of
-# C        D   NPr    NSg/V VL NSg/V/J V/J  P  V      NSg/V    NSg/V  J/P D   NSg/V V/P
-> human   intelligence . But     the automation of  evaluative and predictive tasks has
-# NSg/V/J NSg          . NSg/C/P D   NSg        V/P W?         V/C W?         NPl   V
+# C        D   NPr    NSg/V VL NSg/V/J V/J  P  V      NSg/V    NSg/V  J/P D   NSg/V P
+> human   intelligence . But     the automation of evaluative and predictive tasks has
+# NSg/V/J NSg          . NSg/C/P D   NSg        P  W?         V/C W?         NPl   V
 > been  increasingly successful as    a   substitute for human   monitoring and
 # NSg/V J/R          J          NSg/R D/P NSg/V      C/P NSg/V/J V          V/C
-> intervention in          domains of  computer application involving complex real  - world
-# NSg          NPrSg/V/J/P NPl     V/P NSg/V    NSg         V         NSg/V/J NSg/J . NSg/V
+> intervention in          domains of computer application involving complex real  - world
+# NSg          NPrSg/V/J/P NPl     P  NSg/V    NSg         V         NSg/V/J NSg/J . NSg/V
 > data .
 # NSg  .
 >
@@ -770,20 +770,20 @@
 #
 > Computer architecture , or      digital computer organization , is the conceptual
 # NSg/V    NSg          . NPrSg/C NSg/J   NSg/V    NSg          . VL D   J
-> design and fundamental operational structure of  a   computer system . It        focuses
-# NSg/V  V/C NSg/J       J           NSg/V     V/P D/P NSg/V    NSg    . NPrSg/ISg NPl
+> design and fundamental operational structure of a   computer system . It        focuses
+# NSg/V  V/C NSg/J       J           NSg/V     P  D/P NSg/V    NSg    . NPrSg/ISg NPl
 > largely on  the way   by      which the central processing unit performs internally and
 # J/R     J/P D   NSg/J NSg/J/P I/C   D   NPrSg/J V          NSg  NPl      J/R        V/C
 > accesses addresses in          memory . Computer engineers study computational logic   and
 # NPl      NPl       NPrSg/V/J/P NSg    . NSg/V    NPl       NSg/V J             NSg/V/J V/C
-> design of  computer hardware , from individual processor components ,
-# NSg/V  V/P NSg/V    NSg      . P    NSg/J      NSg       NPl        .
+> design of computer hardware , from individual processor components ,
+# NSg/V  P  NSg/V    NSg      . P    NSg/J      NSg       NPl        .
 > microcontrollers , personal computers to supercomputers and embedded systems . The
 # NPl              . NSg/J    NPl       P  NPl            V/C V/J      NPl     . D
-> term    " architecture " in          computer literature can      be     traced to the work  of  Lyle R.
-# NSg/V/J . NSg          . NPrSg/V/J/P NSg/V    NSg        NPrSg/VX NSg/VX W?     P  D   NSg/V V/P NPr  ?
-> Johnson and Frederick P. Brooks Jr  . , members of  the Machine Organization
-# NPrSg   V/C NPr       ?  NPrPl  N/J . . NPl     V/P D   NSg/V   NSg
+> term    " architecture " in          computer literature can      be     traced to the work  of Lyle R.
+# NSg/V/J . NSg          . NPrSg/V/J/P NSg/V    NSg        NPrSg/VX NSg/VX W?     P  D   NSg/V P  NPr  ?
+> Johnson and Frederick P. Brooks Jr  . , members of the Machine Organization
+# NPrSg   V/C NPr       ?  NPrPl  N/J . . NPl     P  D   NSg/V   NSg
 > department in          IBM's main    research center  in          1959 .
 # NSg        NPrSg/V/J/P N$    NSg/V/J NSg/V    NSg/V/J NPrSg/V/J/P #    .
 >
@@ -792,10 +792,10 @@
 # NSg/J      . NSg/V/J  V/C V/J         NSg/V
 >
 #
-> Concurrency is a   property of  systems in          which several computations are executing
-# NSg         VL D/P NSg/V    V/P NPl     NPrSg/V/J/P I/C   J/D     NPl          V   V
+> Concurrency is a   property of systems in          which several computations are executing
+# NSg         VL D/P NSg/V    P  NPl     NPrSg/V/J/P I/C   J/D     NPl          V   V
 > simultaneously , and potentially interacting with each other   . A   number  of
-# J/R            . V/C J/R         V           P    D    NSg/V/J . D/P NSg/V/J V/P
+# J/R            . V/C J/R         V           P    D    NSg/V/J . D/P NSg/V/J P
 > mathematical models have   been  developed for general concurrent computation
 # J            NPl    NSg/VX NSg/V V/J       C/P NSg/V/J NSg/J      NSg
 > including Petri nets , process calculi and the parallel random  access machine
@@ -814,8 +814,8 @@
 # NSg/V    NPl
 >
 #
-> This branch  of  computer science aims to manage networks between computers
-# I/D  NPrSg/V V/P NSg/V    NSg/V   NPl  P  NSg/V  NPl      NSg/P   NPl
+> This branch  of computer science aims to manage networks between computers
+# I/D  NPrSg/V P  NSg/V    NSg/V   NPl  P  NSg/V  NPl      NSg/P   NPl
 > worldwide .
 # J         .
 >
@@ -824,20 +824,20 @@
 # NSg/V    NSg      V/C NSg
 >
 #
-> Computer security is a   branch  of  computer technology with the objective of
-# NSg/V    NSg      VL D/P NPrSg/V V/P NSg/V    NSg        P    D   NSg/J     V/P
+> Computer security is a   branch  of computer technology with the objective of
+# NSg/V    NSg      VL D/P NPrSg/V P  NSg/V    NSg        P    D   NSg/J     P
 > protecting information from unauthorized access , disruption , or      modification
 # V          NSg         P    V/J          NSg/V  . NSg        . NPrSg/C NSg
-> while     maintaining the accessibility and usability of  the system for its   intended
-# NSg/V/C/P V           D   NSg           V/C NSg       V/P D   NSg    C/P ISg/D NSg/V/J
+> while     maintaining the accessibility and usability of the system for its   intended
+# NSg/V/C/P V           D   NSg           V/C NSg       P  D   NSg    C/P ISg/D NSg/V/J
 > users .
 # NPl   .
 >
 #
-> Historical cryptography is the art     of  writing and deciphering secret  messages .
-# NSg/J      NSg          VL D   NPrSg/V V/P NSg/V   V/C V           NSg/V/J NPl      .
-> Modern cryptography is the scientific study of  problems relating to distributed
-# NSg/J  NSg          VL D   J          NSg/V V/P NPl      V        P  V/J
+> Historical cryptography is the art     of writing and deciphering secret  messages .
+# NSg/J      NSg          VL D   NPrSg/V P  NSg/V   V/C V           NSg/V/J NPl      .
+> Modern cryptography is the scientific study of problems relating to distributed
+# NSg/J  NSg          VL D   J          NSg/V P  NPl      V        P  V/J
 > computations that    can      be     attacked . Technologies studied in          modern cryptography
 # NPl          N/I/C/D NPrSg/VX NSg/VX W?       . NPl          V/J     NPrSg/V/J/P NSg/J  NSg
 > include symmetric and asymmetric encryption , digital signatures , cryptographic
@@ -852,22 +852,22 @@
 # NPl       V/C NSg  NSg/V
 >
 #
-> A   database is intended to organize , store , and retrieve large amounts of  data
-# D/P NSg/V    VL NSg/V/J  P  V        . NSg/V . V/C NSg/V    NSg/J NPl     V/P NSg
+> A   database is intended to organize , store , and retrieve large amounts of data
+# D/P NSg/V    VL NSg/V/J  P  V        . NSg/V . V/C NSg/V    NSg/J NPl     P  NSg
 > easily . Digital databases are managed using database management systems to
 # R      . NSg/J   NPl       V   W?      V     NSg/V    NSg        NPl     P
 > store , create , maintain , and search data , through database models and query
 # NSg/V . V/J    . V        . V/C NSg/V  NSg  . NSg/J/P NSg/V    NPl    V/C NSg/V
-> languages . Data mining is a   process of  discovering patterns in          large data sets .
-# NPl       . NSg  NSg/V  VL D/P NSg/V   V/P V           NPl      NPrSg/V/J/P NSg/J NSg  NPl  .
+> languages . Data mining is a   process of discovering patterns in          large data sets .
+# NPl       . NSg  NSg/V  VL D/P NSg/V   P  V           NPl      NPrSg/V/J/P NSg/J NSg  NPl  .
 >
 #
 > Discoveries
 # NPl
 >
 #
-> The philosopher of  computing Bill    Rapaport noted three Great Insights of
-# D   NSg         V/P NSg/V     NPrSg/V ?        W?    NSg   NSg/J NPl      V/P
+> The philosopher of computing Bill    Rapaport noted three Great Insights of
+# D   NSg         P  NSg/V     NPrSg/V ?        W?    NSg   NSg/J NPl      P
 > Computer Science :
 # NSg/V    NSg/V   .
 >
@@ -905,7 +905,7 @@
 >
 #
 > Every algorithm can      be     expressed in          a   language for a   computer consisting of
-# D     NSg       NPrSg/VX NSg/VX V/J       NPrSg/V/J/P D/P NSg/V    C/P D/P NSg/V    V          V/P
+# D     NSg       NPrSg/VX NSg/VX V/J       NPrSg/V/J/P D/P NSg/V    C/P D/P NSg/V    V          P
 > only five basic   instructions :
 # W?   NSg  NPrSg/J NPl          .
 >
@@ -939,15 +939,15 @@
 >
 #
 > Corrado Böhm and Giuseppe Jacopini's insight : there are only three ways of
-# ?       ?    V/C N        ?          NSg     . W?    V   W?   NSg   NPl  V/P
+# ?       ?    V/C N        ?          NSg     . W?    V   W?   NSg   NPl  P
 > combining these actions ( into more        complex ones ) that    are needed in          order for
 # V         I/D   NPl     . P    NPrSg/I/V/J NSg/V/J NPl  . N/I/C/D V   V/J    NPrSg/V/J/P NSg/V C/P
 > a   computer to do     " anything " .
 # D/P NSg/V    P  NSg/VX . NSg/I/V  . .
 >
 #
-> Only three rules are needed to combine any   set       of  basic   instructions into more
-# W?   NSg   NPl   V   V/J    P  NSg/V   I/R/D NPrSg/V/J V/P NPrSg/J NPl          P    NPrSg/I/V/J
+> Only three rules are needed to combine any   set       of basic   instructions into more
+# W?   NSg   NPl   V   V/J    P  NSg/V   I/R/D NPrSg/V/J P  NPrSg/J NPl          P    NPrSg/I/V/J
 > complex ones :
 # NSg/V/J NPl  .
 >
@@ -965,9 +965,9 @@
 >
 #
 > repetition : WHILE     such  - and - such  is the case    , DO     this . The three rules of
-# NSg/V      . NSg/V/C/P NSg/I . V/C . NSg/I VL D   NPrSg/V . NSg/VX I/D  . D   NSg   NPl   V/P
+# NSg/V      . NSg/V/C/P NSg/I . V/C . NSg/I VL D   NPrSg/V . NSg/VX I/D  . D   NSg   NPl   P
 > Boehm's and Jacopini's insight can      be     further simplified with the use   of
-# ?       V/C ?          NSg     NPrSg/VX NSg/VX V/J     W?         P    D   NSg/V V/P
+# ?       V/C ?          NSg     NPrSg/VX NSg/VX V/J     W?         P    D   NSg/V P
 > goto ( which means it        is more        elementary than structured programming ) .
 # ?    . I/C   NPl   NPrSg/ISg VL NPrSg/I/V/J NSg/J      C/P  V/J        NSg/V       . .
 >
@@ -990,16 +990,16 @@
 #
 >
 #
-> Functional programming , a   style of  building the structure and elements of
-# NSg/J      NSg/V       . D/P NSg/V V/P NSg/V    D   NSg/V     V/C NPl      V/P
-> computer programs that    treats computation as    the evaluation of  mathematical
-# NSg/V    NPl      N/I/C/D NPl    NSg         NSg/R D   NSg        V/P J
+> Functional programming , a   style of building the structure and elements of
+# NSg/J      NSg/V       . D/P NSg/V P  NSg/V    D   NSg/V     V/C NPl      P
+> computer programs that    treats computation as    the evaluation of mathematical
+# NSg/V    NPl      N/I/C/D NPl    NSg         NSg/R D   NSg        P  J
 > functions and avoids state and mutable data . It        is a   declarative programming
 # NPl       V/C NPl    NSg/V V/C W?      NSg  . NPrSg/ISg VL D/P NSg/J       NSg/V
 > paradigm , which means programming is done    with expressions or      declarations
 # NSg      . I/C   NPl   NSg/V       VL NSg/V/J P    NPl         NPrSg/C NPl
-> instead of  statements .
-# W?      V/P NPl        .
+> instead of statements .
+# W?      P  NPl        .
 >
 #
 > Imperative programming , a   programming paradigm that    uses statements that
@@ -1007,7 +1007,7 @@
 > change a   program's state . In          much  the same way   that    the imperative mood in
 # NSg/V  D/P N$        NSg/V . NPrSg/V/J/P N/I/J D   I/J  NSg/J N/I/C/D D   NSg/J      NSg  NPrSg/V/J/P
 > natural languages expresses commands , an  imperative program consists of
-# NSg/J   NPl       NPl       NPl      . D/P NSg/J      NPrSg/V NPl      V/P
+# NSg/J   NPl       NPl       NPl      . D/P NSg/J      NPrSg/V NPl      P
 > commands for the computer to perform . Imperative programming focuses on
 # NPl      C/P D   NSg/V    P  V       . NSg/J      NSg/V       NPl     J/P
 > describing how   a   program operates .
@@ -1015,33 +1015,33 @@
 >
 #
 > Object - oriented programming , a   programming paradigm based on  the concept of
-# NSg/V  . W?       NSg/V       . D/P NSg/V       NSg      W?    J/P D   NSg/V   V/P
-> " objects " , which may      contain data , in          the form  of  fields , often known   as
-# . NPl     . . I/C   NPrSg/VX V       NSg  . NPrSg/V/J/P D   NSg/V V/P NPrPl  . J     NSg/V/J NSg/R
-> attributes ; and code  , in          the form  of  procedures , often known   as    methods . A
-# NPl        . V/C NSg/V . NPrSg/V/J/P D   NSg/V V/P NPl        . J     NSg/V/J NSg/R NPl     . D/P
-> feature of  objects is that    an  object's procedures can      access and often modify
-# NSg/V   V/P NPl     VL N/I/C/D D/P N$       NPl        NPrSg/VX NSg/V  V/C J     V
-> the data fields of  the object with which they are associated . Thus
-# D   NSg  NPrPl  V/P D   NSg/V  P    I/C   IPl  V   W?         . NSg
-> object - oriented computer programs are made  out         of  objects that    interact with
-# NSg/V  . W?       NSg/V    NPl      V   NSg/V NSg/V/J/R/P V/P NPl     N/I/C/D NSg/V    P
+# NSg/V  . W?       NSg/V       . D/P NSg/V       NSg      W?    J/P D   NSg/V   P
+> " objects " , which may      contain data , in          the form  of fields , often known   as
+# . NPl     . . I/C   NPrSg/VX V       NSg  . NPrSg/V/J/P D   NSg/V P  NPrPl  . J     NSg/V/J NSg/R
+> attributes ; and code  , in          the form  of procedures , often known   as    methods . A
+# NPl        . V/C NSg/V . NPrSg/V/J/P D   NSg/V P  NPl        . J     NSg/V/J NSg/R NPl     . D/P
+> feature of objects is that    an  object's procedures can      access and often modify
+# NSg/V   P  NPl     VL N/I/C/D D/P N$       NPl        NPrSg/VX NSg/V  V/C J     V
+> the data fields of the object with which they are associated . Thus
+# D   NSg  NPrPl  P  D   NSg/V  P    I/C   IPl  V   W?         . NSg
+> object - oriented computer programs are made  out         of objects that    interact with
+# NSg/V  . W?       NSg/V    NPl      V   NSg/V NSg/V/J/R/P P  NPl     N/I/C/D NSg/V    P
 > one       another .
 # NSg/I/V/J I/D     .
 >
 #
 > Service - oriented programming , a   programming paradigm that    uses " services " as
 # NSg/V   . W?       NSg/V       . D/P NSg/V       NSg      N/I/C/D NPl  . NPl      . NSg/R
-> the unit of  computer work  , to design and implement integrated business
-# D   NSg  V/P NSg/V    NSg/V . P  NSg/V  V/C NSg/V     W?         NSg/J
+> the unit of computer work  , to design and implement integrated business
+# D   NSg  P  NSg/V    NSg/V . P  NSg/V  V/C NSg/V     W?         NSg/J
 > applications and mission critical software programs .
 # W?           V/C NSg/V   NSg/J    NSg      NPl      .
 >
 #
 > Many    languages offer   support for multiple paradigms , making the distinction more
 # N/I/J/D NPl       NSg/V/J NSg/V   C/P NSg/J    NPl       . NSg/V  D   NSg         NPrSg/I/V/J
-> a   matter  of  style than of  technical capabilities .
-# D/P NSg/V/J V/P NSg/V C/P  V/P NSg/J     NSg          .
+> a   matter  of style than of technical capabilities .
+# D/P NSg/V/J P  NSg/V C/P  P  NSg/J     NSg          .
 >
 #
 > Research
@@ -1054,11 +1054,11 @@
 # NPl         . W?          P    D   NSg/V/J V/C NSg/V/J NPl     NSg/V/J D
 > recent work  and meet    . Unlike    in          most    other   academic fields , in          computer science ,
 # NSg/J  NSg/V V/C NSg/V/J . NSg/V/J/P NPrSg/V/J/P NSg/I/J NSg/V/J NSg/J    NPrPl  . NPrSg/V/J/P NSg/V    NSg/V   .
-> the prestige of  conference papers is greater than that    of  journal publications .
-# D   NSg/V/J  V/P NSg/V      NPl    VL J       C/P  N/I/C/D V/P NSg/V/J NPl          .
-> One       proposed explanation for this is the quick   development of  this relatively
-# NSg/I/V/J W?       NSg         C/P I/D  VL D   NSg/V/J NSg         V/P I/D  J/R
-> new     field requires rapid review and distribution of  results , a   task  better
-# NSg/V/J NSg/V NPl      NSg/J NSg/V  V/C NSg          V/P NPl     . D/P NSg/V NSg/VX/J
+> the prestige of conference papers is greater than that    of journal publications .
+# D   NSg/V/J  P  NSg/V      NPl    VL J       C/P  N/I/C/D P  NSg/V/J NPl          .
+> One       proposed explanation for this is the quick   development of this relatively
+# NSg/I/V/J W?       NSg         C/P I/D  VL D   NSg/V/J NSg         P  I/D  J/R
+> new     field requires rapid review and distribution of results , a   task  better
+# NSg/V/J NSg/V NPl      NSg/J NSg/V  V/C NSg          P  NPl     . D/P NSg/V NSg/VX/J
 > handled by      conferences than by      journals .
 # W?      NSg/J/P NPl         C/P  NSg/J/P NPl      .

--- a/harper-core/tests/text/tagged/Part-of-speech tagging.md
+++ b/harper-core/tests/text/tagged/Part-of-speech tagging.md
@@ -6,32 +6,32 @@
 # Unlintable Unlintable
 >            -->
 # Unlintable Unlintable
->            Part    - of  - speech tagging
-# Unlintable NSg/V/J . V/P . NSg/V  NSg/V
+>            Part    - of - speech tagging
+# Unlintable NSg/V/J . P  . NSg/V  NSg/V
 >
 #
-> In          corpus linguistics , part    - of  - speech tagging ( POS tagging or      PoS tagging or
-# NPrSg/V/J/P NSg    NSg         . NSg/V/J . V/P . NSg/V  NSg/V   . ?   NSg/V   NPrSg/C ?   NSg/V   NPrSg/C
-> POST      ) , also called grammatical tagging is the process of  marking up        a   word  in          a
-# NPrSg/V/P . . W?   V/J    J           NSg/V   VL D   NSg/V   V/P NSg/V   NSg/V/J/P D/P NSg/V NPrSg/V/J/P D/P
-> text  ( corpus ) as    corresponding to a   particular part    of  speech , based on  both its
-# NSg/V . NSg    . NSg/R NSg/V/J       P  D/P NSg/J      NSg/V/J V/P NSg/V  . W?    J/P I/C  ISg/D
-> definition and its   context . A   simplified form  of  this is commonly taught to
-# NSg        V/C ISg/D NSg/V   . D/P W?         NSg/V V/P I/D  VL J/R      V      P
-> school - age   children , in          the identification of  words as    nouns , verbs , adjectives ,
-# NSg/V  . NSg/V NPl      . NPrSg/V/J/P D   NSg            V/P NPl   NSg/R NPl   . NPl   . NPl        .
+> In          corpus linguistics , part    - of - speech tagging ( POS tagging or      PoS tagging or
+# NPrSg/V/J/P NSg    NSg         . NSg/V/J . P  . NSg/V  NSg/V   . ?   NSg/V   NPrSg/C ?   NSg/V   NPrSg/C
+> POST      ) , also called grammatical tagging is the process of marking up        a   word  in          a
+# NPrSg/V/P . . W?   V/J    J           NSg/V   VL D   NSg/V   P  NSg/V   NSg/V/J/P D/P NSg/V NPrSg/V/J/P D/P
+> text  ( corpus ) as    corresponding to a   particular part    of speech , based on  both its
+# NSg/V . NSg    . NSg/R NSg/V/J       P  D/P NSg/J      NSg/V/J P  NSg/V  . W?    J/P I/C  ISg/D
+> definition and its   context . A   simplified form  of this is commonly taught to
+# NSg        V/C ISg/D NSg/V   . D/P W?         NSg/V P  I/D  VL J/R      V      P
+> school - age   children , in          the identification of words as    nouns , verbs , adjectives ,
+# NSg/V  . NSg/V NPl      . NPrSg/V/J/P D   NSg            P  NPl   NSg/R NPl   . NPl   . NPl        .
 > adverbs , etc.
 # NPl     . W?
 >
 #
-> Once  performed by      hand  , POS tagging is now         done    in          the context of  computational
-# NSg/C V         NSg/J/P NSg/V . ?   NSg/V   VL NPrSg/V/J/C NSg/V/J NPrSg/V/J/P D   NSg/V   V/P J
+> Once  performed by      hand  , POS tagging is now         done    in          the context of computational
+# NSg/C V         NSg/J/P NSg/V . ?   NSg/V   VL NPrSg/V/J/C NSg/V/J NPrSg/V/J/P D   NSg/V   P  J
 > linguistics , using algorithms which associate discrete terms , as    well    as    hidden
 # NSg         . V     NPl        I/C   NSg/V/J   J        NPl   . NSg/R NSg/V/J NSg/R V/J
-> parts of  speech , by      a   set       of  descriptive tags . POS - tagging algorithms fall  into
-# NPl   V/P NSg/V  . NSg/J/P D/P NPrSg/V/J V/P NSg/J       NPl  . ?   . NSg/V   NPl        NSg/V P
-> two distinctive groups : rule  - based and stochastic . E. Brill's tagger , one       of  the
-# NSg NSg/J       NPl    . NSg/V . W?    V/C J          . ?  ?       NSg    . NSg/I/V/J V/P D
+> parts of speech , by      a   set       of descriptive tags . POS - tagging algorithms fall  into
+# NPl   P  NSg/V  . NSg/J/P D/P NPrSg/V/J P  NSg/J       NPl  . ?   . NSg/V   NPl        NSg/V P
+> two distinctive groups : rule  - based and stochastic . E. Brill's tagger , one       of the
+# NSg NSg/J       NPl    . NSg/V . W?    V/C J          . ?  ?       NSg    . NSg/I/V/J P  D
 > first   and most    widely used English   POS - taggers , employs rule  - based algorithms .
 # NSg/V/J V/C NSg/I/J J/R    V/J  NPrSg/V/J ?   . NPl     . NPl     NSg/V . W?    NPl        .
 >
@@ -40,18 +40,18 @@
 # NSg/V
 >
 #
-> Part    - of  - speech tagging is harder than just having a   list  of  words and their
-# NSg/V/J . V/P . NSg/V  NSg/V   VL J      C/P  V/J  V      D/P NSg/V V/P NPl   V/C D
-> parts of  speech , because some  words can      represent more        than one       part    of  speech
-# NPl   V/P NSg/V  . C/P     I/J/R NPl   NPrSg/VX V         NPrSg/I/V/J C/P  NSg/I/V/J NSg/V/J V/P NSg/V
-> at        different times , and because some  parts of  speech are complex . This is not
-# NSg/I/V/P NSg/J     NPl   . V/C C/P     I/J/R NPl   V/P NSg/V  V   NSg/V/J . I/D  VL NSg/C
+> Part    - of - speech tagging is harder than just having a   list  of words and their
+# NSg/V/J . P  . NSg/V  NSg/V   VL J      C/P  V/J  V      D/P NSg/V P  NPl   V/C D
+> parts of speech , because some  words can      represent more        than one       part    of speech
+# NPl   P  NSg/V  . C/P     I/J/R NPl   NPrSg/VX V         NPrSg/I/V/J C/P  NSg/I/V/J NSg/V/J P  NSg/V
+> at        different times , and because some  parts of speech are complex . This is not
+# NSg/I/V/P NSg/J     NPl   . V/C C/P     I/J/R NPl   P  NSg/V  V   NSg/V/J . I/D  VL NSg/C
 > rare    — in          natural languages ( as    opposed to many    artificial languages ) , a   large
 # NSg/V/J . NPrSg/V/J/P NSg/J   NPl       . NSg/R V/J     P  N/I/J/D J          NPl       . . D/P NSg/J
-> percentage of  word  - forms are ambiguous . For example , even    " dogs " , which is
-# NSg        V/P NSg/V . NPl   V   J         . C/P NSg/V   . NSg/V/J . NPl  . . I/C   VL
-> usually thought of  as    just a   plural noun  , can      also be     a   verb  :
-# J/R     NSg/V   V/P NSg/R V/J  D/P NSg/J  NSg/V . NPrSg/VX W?   NSg/VX D/P NSg/V .
+> percentage of word  - forms are ambiguous . For example , even    " dogs " , which is
+# NSg        P  NSg/V . NPl   V   J         . C/P NSg/V   . NSg/V/J . NPl  . . I/C   VL
+> usually thought of as    just a   plural noun  , can      also be     a   verb  :
+# J/R     NSg/V   P  NSg/R V/J  D/P NSg/J  NSg/V . NPrSg/VX W?   NSg/VX D/P NSg/V .
 >
 #
 > The sailor dogs the hatch .
@@ -76,8 +76,8 @@
 # NSg/V NPl
 >
 #
-> Schools commonly teach that    there are 9 parts of  speech in          English   : noun  , verb  ,
-# NPl     J/R      NSg/V N/I/C/D W?    V   # NPl   V/P NSg/V  NPrSg/V/J/P NPrSg/V/J . NSg/V . NSg/V .
+> Schools commonly teach that    there are 9 parts of speech in          English   : noun  , verb  ,
+# NPl     J/R      NSg/V N/I/C/D W?    V   # NPl   P  NSg/V  NPrSg/V/J/P NPrSg/V/J . NSg/V . NSg/V .
 > article , adjective , preposition , pronoun , adverb , conjunction , and interjection .
 # NSg/V   . NSg/V/J   . NSg/V       . NSg/V   . NSg/V  . NSg/V       . V/C NSg          .
 > However , there are clearly many    more        categories and sub     - categories . For nouns ,
@@ -88,30 +88,30 @@
 # NPl       NPl   V   W?   V/J    C/P D     . NPrSg/V . . NSg  NSg/R NSg/V/J . NSg/V  .
 > etc. ) , grammatical gender  , and so        on  ; while     verbs are marked for tense   , aspect ,
 # W?   . . J           NSg/V/J . V/C NSg/I/J/C J/P . NSg/V/C/P NPl   V   V/J    C/P NSg/V/J . NSg/V  .
-> and other   things . In          some  tagging systems , different inflections of  the same
-# V/C NSg/V/J NPl    . NPrSg/V/J/P I/J/R NSg/V   NPl     . NSg/J     NPl         V/P D   I/J
-> root    word  will     get   different parts of  speech , resulting in          a   large number  of
-# NPrSg/V NSg/V NPrSg/VX NSg/V NSg/J     NPl   V/P NSg/V  . V         NPrSg/V/J/P D/P NSg/J NSg/V/J V/P
+> and other   things . In          some  tagging systems , different inflections of the same
+# V/C NSg/V/J NPl    . NPrSg/V/J/P I/J/R NSg/V   NPl     . NSg/J     NPl         P  D   I/J
+> root    word  will     get   different parts of speech , resulting in          a   large number  of
+# NPrSg/V NSg/V NPrSg/VX NSg/V NSg/J     NPl   P  NSg/V  . V         NPrSg/V/J/P D/P NSg/J NSg/V/J P
 > tags . For example , NN for singular common  nouns , NNS for plural common  nouns , NP
 # NPl  . C/P NSg/V   . ?  C/P NSg/J    NSg/V/J NPl   . ?   C/P NSg/J  NSg/V/J NPl   . NPrSg
 > for singular proper nouns ( see   the POS tags used in          the Brown     Corpus ) . Other
 # C/P NSg/J    NSg/J  NPl   . NSg/V D   ?   NPl  V/J  NPrSg/V/J/P D   NPrSg/V/J NSg    . . NSg/V/J
-> tagging systems use   a   smaller number  of  tags and ignore fine    differences or
-# NSg/V   NPl     NSg/V D/P J       NSg/V/J V/P NPl  V/C V      NSg/V/J NSg/V       NPrSg/C
-> model   them as    features somewhat independent from part    - of  - speech .
-# NSg/V/J N/I  NSg/R NPl      NSg/I    NSg/J       P    NSg/V/J . V/P . NSg/V  .
+> tagging systems use   a   smaller number  of tags and ignore fine    differences or
+# NSg/V   NPl     NSg/V D/P J       NSg/V/J P  NPl  V/C V      NSg/V/J NSg/V       NPrSg/C
+> model   them as    features somewhat independent from part    - of - speech .
+# NSg/V/J N/I  NSg/R NPl      NSg/I    NSg/J       P    NSg/V/J . P  . NSg/V  .
 >
 #
-> In          part    - of  - speech tagging by      computer , it        is typical to distinguish from 50 to
-# NPrSg/V/J/P NSg/V/J . V/P . NSg/V  NSg/V   NSg/J/P NSg/V    . NPrSg/ISg VL NSg/J   P  V           P    #  P
-> 150 separate parts of  speech for English   . Work  on  stochastic methods for tagging
-# #   NSg/V/J  NPl   V/P NSg/V  C/P NPrSg/V/J . NSg/V J/P J          NPl     C/P NSg/V
-> Koine Greek     ( DeRose 1990 ) has used over      1 , 000 parts of  speech and found that
-# ?     NPrSg/V/J . ?      #    . V   V/J  NSg/V/J/P # . #   NPl   V/P NSg/V  V/C NSg/V N/I/C/D
+> In          part    - of - speech tagging by      computer , it        is typical to distinguish from 50 to
+# NPrSg/V/J/P NSg/V/J . P  . NSg/V  NSg/V   NSg/J/P NSg/V    . NPrSg/ISg VL NSg/J   P  V           P    #  P
+> 150 separate parts of speech for English   . Work  on  stochastic methods for tagging
+# #   NSg/V/J  NPl   P  NSg/V  C/P NPrSg/V/J . NSg/V J/P J          NPl     C/P NSg/V
+> Koine Greek     ( DeRose 1990 ) has used over      1 , 000 parts of speech and found that
+# ?     NPrSg/V/J . ?      #    . V   V/J  NSg/V/J/P # . #   NPl   P  NSg/V  V/C NSg/V N/I/C/D
 > about as    many    words were  ambiguous in          that    language as    in          English   . A
 # J/P   NSg/R N/I/J/D NPl   NSg/V J         NPrSg/V/J/P N/I/C/D NSg/V    NSg/R NPrSg/V/J/P NPrSg/V/J . D/P
-> morphosyntactic descriptor in          the case    of  morphologically rich      languages is
-# ?               NSg        NPrSg/V/J/P D   NPrSg/V V/P ?               NPrSg/V/J NPl       VL
+> morphosyntactic descriptor in          the case    of morphologically rich      languages is
+# ?               NSg        NPrSg/V/J/P D   NPrSg/V P  ?               NPrSg/V/J NPl       VL
 > commonly expressed using very short       mnemonics , such  as    Ncmsan for Category = Noun  ,
 # J/R      V/J       V     J    NPrSg/V/J/P NPl       . NSg/I NSg/R ?      C/P NSg      . NSg/V .
 > Type  = common  , Gender  = masculine , Number  = singular , Case    = accusative , Animate
@@ -132,8 +132,8 @@
 # C/P NSg/J    NPl       .
 >
 #
-> POS tagging work  has been  done    in          a   variety of  languages , and the set       of  POS
-# ?   NSg/V   NSg/V V   NSg/V NSg/V/J NPrSg/V/J/P D/P NSg     V/P NPl       . V/C D   NPrSg/V/J V/P ?
+> POS tagging work  has been  done    in          a   variety of languages , and the set       of POS
+# ?   NSg/V   NSg/V V   NSg/V NSg/V/J NPrSg/V/J/P D/P NSg     P  NPl       . V/C D   NPrSg/V/J P  ?
 > tags used varies greatly with language . Tags usually are designed to include
 # NPl  V/J  NPl    J/R     P    NSg/V    . NPl  J/R     V   W?       P  NSg/V
 > overt morphological distinctions , although this leads to inconsistencies such  as
@@ -148,10 +148,10 @@
 # NSg/R NPrSg/J NPl       NPrSg/VX NSg/VX J/R       NSg/J      . NSg/I/V/P D   NSg/V/J NSg/J   . ?      ?
 > al. have   proposed a   " universal " tag   set       , with 12 categories ( for example , no
 # ?   NSg/VX W?       D/P . NSg/J     . NSg/V NPrSg/V/J . P    #  NPl        . C/P NSg/V   . NPrSg/P
-> subtypes of  nouns , verbs , punctuation , and so        on  ) . Whether a   very small     set       of
-# NPl      V/P NPl   . NPl   . NSg         . V/C NSg/I/J/C J/P . . I/C     D/P J    NPrSg/V/J NPrSg/V/J V/P
-> very broad tags or      a   much  larger set       of  more        precise ones is preferable , depends
-# J    NSg/J NPl  NPrSg/C D/P N/I/J J      NPrSg/V/J V/P NPrSg/I/V/J V/J     NPl  VL W?         . NPl
+> subtypes of nouns , verbs , punctuation , and so        on  ) . Whether a   very small     set       of
+# NPl      P  NPl   . NPl   . NSg         . V/C NSg/I/J/C J/P . . I/C     D/P J    NPrSg/V/J NPrSg/V/J P
+> very broad tags or      a   much  larger set       of more        precise ones is preferable , depends
+# J    NSg/J NPl  NPrSg/C D/P N/I/J J      NPrSg/V/J P  NPrSg/I/V/J V/J     NPl  VL W?         . NPl
 > on  the purpose at        hand  . Automatic tagging is easier on  smaller tag   - sets .
 # J/P D   NSg/V   NSg/I/V/P NSg/V . NSg/J     NSg/V   VL J      J/P J       NSg/V . NPl  .
 >
@@ -164,28 +164,28 @@
 # D   NPrSg/V/J NSg
 >
 #
-> Research on  part    - of  - speech tagging has been  closely tied to corpus linguistics .
-# NSg/V    J/P NSg/V/J . V/P . NSg/V  NSg/V   V   NSg/V J/R     W?   P  NSg    NSg         .
-> The first   major     corpus of  English   for computer analysis was the Brown     Corpus
-# D   NSg/V/J NPrSg/V/J NSg    V/P NPrSg/V/J C/P NSg/V    NSg      V   D   NPrSg/V/J NSg
+> Research on  part    - of - speech tagging has been  closely tied to corpus linguistics .
+# NSg/V    J/P NSg/V/J . P  . NSg/V  NSg/V   V   NSg/V J/R     W?   P  NSg    NSg         .
+> The first   major     corpus of English   for computer analysis was the Brown     Corpus
+# D   NSg/V/J NPrSg/V/J NSg    P  NPrSg/V/J C/P NSg/V    NSg      V   D   NPrSg/V/J NSg
 > developed at        Brown     University by      Henry Kučera and W. Nelson Francis , in          the
 # V/J       NSg/I/V/P NPrSg/V/J NSg        NSg/J/P NPrSg ?      V/C ?  NPrSg  NPr     . NPrSg/V/J/P D
-> mid     - 1960s . It        consists of  about 1 , 000 , 000 words of  running   English   prose text  ,
-# NSg/J/P . #d    . NPrSg/ISg NPl      V/P J/P   # . #   . #   NPl   V/P NSg/V/J/P NPrSg/V/J NSg/V NSg/V .
-> made  up        of  500 samples from randomly chosen publications . Each sample is 2 , 000
-# NSg/V NSg/V/J/P V/P #   NPl     P    J/R      V/J    NPl          . D    NSg/V  VL # . #
+> mid     - 1960s . It        consists of about 1 , 000 , 000 words of running   English   prose text  ,
+# NSg/J/P . #d    . NPrSg/ISg NPl      P  J/P   # . #   . #   NPl   P  NSg/V/J/P NPrSg/V/J NSg/V NSg/V .
+> made  up        of 500 samples from randomly chosen publications . Each sample is 2 , 000
+# NSg/V NSg/V/J/P P  #   NPl     P    J/R      V/J    NPl          . D    NSg/V  VL # . #
 > or      more        words ( ending at        the first   sentence - end   after 2 , 000 words , so        that    the
 # NPrSg/C NPrSg/I/V/J NPl   . NSg/V  NSg/I/V/P D   NSg/V/J NSg/V    . NSg/V J/P   # . #   NPl   . NSg/I/J/C N/I/C/D D
 > corpus contains only complete sentences ) .
 # NSg    NPl      W?   NSg/V/J  NPl       . .
 >
 #
-> The Brown     Corpus was painstakingly " tagged " with part    - of  - speech markers over
-# D   NPrSg/V/J NSg    V   J/R           . V/J    . P    NSg/V/J . V/P . NSg/V  NPl     NSg/V/J/P
+> The Brown     Corpus was painstakingly " tagged " with part    - of - speech markers over
+# D   NPrSg/V/J NSg    V   J/R           . V/J    . P    NSg/V/J . P  . NSg/V  NPl     NSg/V/J/P
 > many    years . A   first   approximation was done    with a   program by      Greene and Rubin ,
 # N/I/J/D NPl   . D/P NSg/V/J NSg           V   NSg/V/J P    D/P NPrSg/V NSg/J/P NPr    V/C NPr   .
-> which consisted of  a   huge handmade list  of  what  categories could  co        - occur at
-# I/C   W?        V/P D/P J    NSg/J    NSg/V V/P NSg/I NPl        NSg/VX NPrSg/I/V . V     NSg/I/V/P
+> which consisted of a   huge handmade list  of what  categories could  co        - occur at
+# I/C   W?        P  D/P J    NSg/J    NSg/V P  NSg/I NPl        NSg/VX NPrSg/I/V . V     NSg/I/V/P
 > all       . For example , article then    noun  can      occur , but     article then    verb  ( arguably )
 # NSg/I/J/C . C/P NSg/V   . NSg/V   NSg/J/C NSg/V NPrSg/VX V     . NSg/C/P NSg/V   NSg/J/C NSg/V . R        .
 > cannot . The program got about 70 % correct . Its   results were  repeatedly reviewed
@@ -198,14 +198,14 @@
 # W?       NSg/VX/J NSg/C V     . .
 >
 #
-> This corpus has been  used for innumerable studies of  word  - frequency and of
-# I/D  NSg    V   NSg/V V/J  C/P J           NPl     V/P NSg/V . NSg       V/C V/P
-> part    - of  - speech and inspired the development of  similar " tagged " corpora in          many
-# NSg/V/J . V/P . NSg/V  V/C V/J      D   NSg         V/P NSg/J   . V/J    . NPl     NPrSg/V/J/P N/I/J/D
+> This corpus has been  used for innumerable studies of word  - frequency and of
+# I/D  NSg    V   NSg/V V/J  C/P J           NPl     P  NSg/V . NSg       V/C P
+> part    - of - speech and inspired the development of similar " tagged " corpora in          many
+# NSg/V/J . P  . NSg/V  V/C V/J      D   NSg         P  NSg/J   . V/J    . NPl     NPrSg/V/J/P N/I/J/D
 > other   languages . Statistics derived by      analyzing it        formed the basis for most
 # NSg/V/J NPl       . NPl        W?      NSg/J/P V         NPrSg/ISg V      D   NSg   C/P NSg/I/J
-> later part    - of  - speech tagging systems , such  as    CLAWS and VOLSUNGA . However , by
-# J     NSg/V/J . V/P . NSg/V  NSg/V   NPl     . NSg/I NSg/R NPl   V/C ?        . C       . NSg/J/P
+> later part    - of - speech tagging systems , such  as    CLAWS and VOLSUNGA . However , by
+# J     NSg/V/J . P  . NSg/V  NSg/V   NPl     . NSg/I NSg/R NPl   V/C ?        . C       . NSg/J/P
 > this time  ( 2005 ) it        has been  superseded by      larger corpora such  as    the 100
 # I/D  NSg/V . #    . NPrSg/ISg V   NSg/V W?         NSg/J/P J      NPl     NSg/I NSg/R D   #
 > million word  British National Corpus , even    though larger corpora are rarely so
@@ -214,46 +214,46 @@
 # J/R        W?      .
 >
 #
-> For some  time  , part    - of  - speech tagging was considered an  inseparable part    of
-# C/P I/J/R NSg/V . NSg/V/J . V/P . NSg/V  NSg/V   V   V/J        D/P NSg/J       NSg/V/J V/P
+> For some  time  , part    - of - speech tagging was considered an  inseparable part    of
+# C/P I/J/R NSg/V . NSg/V/J . P  . NSg/V  NSg/V   V   V/J        D/P NSg/J       NSg/V/J P
 > natural language processing , because there are certain cases where the correct
 # NSg/J   NSg/V    V          . C/P     W?    V   I/J     NPl   NSg/C D   NSg/V/J
-> part    of  speech cannot be     decided without understanding the semantics or      even    the
-# NSg/V/J V/P NSg/V  NSg/V  NSg/VX NSg/V/J C/P     NSg/V/J       D   NSg       NPrSg/C NSg/V/J D
-> pragmatics of  the context . This is extremely expensive , especially because
-# NPl        V/P D   NSg/V   . I/D  VL J/R       J         . J/R        C/P
-> analyzing the higher levels is much  harder when    multiple part    - of  - speech
-# V         D   J      NPl    VL N/I/J J      NSg/I/C NSg/J    NSg/V/J . V/P . NSg/V
+> part    of speech cannot be     decided without understanding the semantics or      even    the
+# NSg/V/J P  NSg/V  NSg/V  NSg/VX NSg/V/J C/P     NSg/V/J       D   NSg       NPrSg/C NSg/V/J D
+> pragmatics of the context . This is extremely expensive , especially because
+# NPl        P  D   NSg/V   . I/D  VL J/R       J         . J/R        C/P
+> analyzing the higher levels is much  harder when    multiple part    - of - speech
+# V         D   J      NPl    VL N/I/J J      NSg/I/C NSg/J    NSg/V/J . P  . NSg/V
 > possibilities must  be     considered for each word  .
 # NPl           NSg/V NSg/VX V/J        C/P D    NSg/V .
 >
 #
-> Use   of  hidden Markov models
-# NSg/V V/P V/J    NPr    NPl
+> Use   of hidden Markov models
+# NSg/V P  V/J    NPr    NPl
 >
 #
 > In          the mid     - 1980s , researchers in          Europe began to use   hidden Markov models ( HMMs )
 # NPrSg/V/J/P D   NSg/J/P . #d    . W?          NPrSg/V/J/P NPr    V     P  NSg/V V/J    NPr    NPl    . ?    .
-> to disambiguate parts of  speech , when    working to tag   the Lancaster - Oslo - Bergen
-# P  V            NPl   V/P NSg/V  . NSg/I/C V       P  NSg/V D   NPr       . NPr  . NPr
-> Corpus of  British English   . HMMs involve counting cases ( such  as    from the Brown
-# NSg    V/P NPrSg/J NPrSg/V/J . ?    V       V        NPl   . NSg/I NSg/R P    D   NPrSg/V/J
-> Corpus ) and making a   table of  the probabilities of  certain sequences . For
-# NSg    . V/C NSg/V  D/P NSg/V V/P D   NPl           V/P I/J     NPl       . C/P
+> to disambiguate parts of speech , when    working to tag   the Lancaster - Oslo - Bergen
+# P  V            NPl   P  NSg/V  . NSg/I/C V       P  NSg/V D   NPr       . NPr  . NPr
+> Corpus of British English   . HMMs involve counting cases ( such  as    from the Brown
+# NSg    P  NPrSg/J NPrSg/V/J . ?    V       V        NPl   . NSg/I NSg/R P    D   NPrSg/V/J
+> Corpus ) and making a   table of the probabilities of certain sequences . For
+# NSg    . V/C NSg/V  D/P NSg/V P  D   NPl           P  I/J     NPl       . C/P
 > example , once  you've seen  an  article such  as    ' the ' , perhaps the next    word  is a
 # NSg/V   . NSg/C W?     NSg/V D/P NSg/V   NSg/I NSg/R . D   . . NSg     D   NSg/J/P NSg/V VL D/P
-> noun  40 % of  the time  , an  adjective 40 % , and a   number  20 % . Knowing   this , a
-# NSg/V #  . V/P D   NSg/V . D/P NSg/V/J   #  . . V/C D/P NSg/V/J #  . . NSg/V/J/P I/D  . D/P
+> noun  40 % of the time  , an  adjective 40 % , and a   number  20 % . Knowing   this , a
+# NSg/V #  . P  D   NSg/V . D/P NSg/V/J   #  . . V/C D/P NSg/V/J #  . . NSg/V/J/P I/D  . D/P
 > program can      decide that    " can      " in          " the can      " is far     more        likely to be     a   noun  than
 # NPrSg/V NPrSg/VX V      N/I/C/D . NPrSg/VX . NPrSg/V/J/P . D   NPrSg/VX . VL NSg/V/J NPrSg/I/V/J NSg/J  P  NSg/VX D/P NSg/V C/P
-> a   verb  or      a   modal . The same method can      , of  course , be     used to benefit from
-# D/P NSg/V NPrSg/C D/P NSg/J . D   I/J  NSg/V  NPrSg/VX . V/P NSg/V  . NSg/VX V/J  P  NSg/V   P
+> a   verb  or      a   modal . The same method can      , of course , be     used to benefit from
+# D/P NSg/V NPrSg/C D/P NSg/J . D   I/J  NSg/V  NPrSg/VX . P  NSg/V  . NSg/VX V/J  P  NSg/V   P
 > knowledge about the following words .
 # NSg/V     J/P   D   NSg/V/J/P NPl   .
 >
 #
-> More        advanced ( " higher - order " ) HMMs learn the probabilities not   only of  pairs
-# NPrSg/I/V/J W?       . . J      . NSg/V . . ?    NSg/V D   NPl           NSg/C W?   V/P NPl
+> More        advanced ( " higher - order " ) HMMs learn the probabilities not   only of pairs
+# NPrSg/I/V/J W?       . . J      . NSg/V . . ?    NSg/V D   NPl           NSg/C W?   P  NPl
 > but     triples or      even    larger sequences . So        , for example , if    you've just seen  a
 # NSg/C/P NPl     NPrSg/C NSg/V/J J      NPl       . NSg/I/J/C . C/P NSg/V   . NSg/C W?     V/J  NSg/V D/P
 > noun  followed by      a   verb  , the next    item  may      be     very likely a   preposition ,
@@ -266,8 +266,8 @@
 # NSg/I/C J/D     J         NPl   V     J        . D   NPl           NSg/V    .
 > However , it        is easy    to enumerate every combination and to assign a   relative
 # C       . NPrSg/ISg VL NSg/V/J P  V         D     NSg         V/C P  NSg/V  D/P NSg/J
-> probability to each one       , by      multiplying together the probabilities of  each
-# NSg         P  D    NSg/I/V/J . NSg/J/P V           J        D   NPl           V/P D
+> probability to each one       , by      multiplying together the probabilities of each
+# NSg         P  D    NSg/I/V/J . NSg/J/P V           J        D   NPl           P  D
 > choice in          turn  . The combination with the highest probability is then    chosen . The
 # NSg/J  NPrSg/V/J/P NSg/V . D   NSg         P    D   W?      NSg         VL NSg/J/C V/J    . D
 > European group developed CLAWS , a   tagging program that    did exactly this and
@@ -284,26 +284,26 @@
 # D   NSg/V . NSg/J  NSg/V . P  NSg/I/J/C NPl      NPrSg/VX NSg/V    #  . NSg      C/P     N/I/J/D
 > words are unambiguous , and many    others only rarely represent their less    - common
 # NPl   V   J           . V/C N/I/J/D NPl    W?   J/R    V         D     V/J/C/P . NSg/V/J
-> parts of  speech .
-# NPl   V/P NSg/V  .
+> parts of speech .
+# NPl   P  NSg/V  .
 >
 #
-> CLAWS pioneered the field of  HMM - based part    of  speech tagging but     was quite
-# NPl   W?        D   NSg/V V/P V   . W?    NSg/V/J V/P NSg/V  NSg/V   NSg/C/P V   NSg
+> CLAWS pioneered the field of HMM - based part    of speech tagging but     was quite
+# NPl   W?        D   NSg/V P  V   . W?    NSg/V/J P  NSg/V  NSg/V   NSg/C/P V   NSg
 > expensive since it        enumerated all       possibilities . It        sometimes had to resort to
 # J         C/P   NPrSg/ISg W?         NSg/I/J/C NPl           . NPrSg/ISg R         V   P  NSg/V  P
 > backup methods when    there were  simply too many    options ( the Brown     Corpus
 # NSg/J  NPl     NSg/I/C W?    NSg/V R      W?  N/I/J/D NPl     . D   NPrSg/V/J NSg
 > contains a   case    with 17 ambiguous words in          a   row   , and there are words such  as
 # NPl      D/P NPrSg/V P    #  J         NPl   NPrSg/V/J/P D/P NSg/V . V/C W?    V   NPl   NSg/I NSg/R
-> " still   " that    can      represent as    many    as    7 distinct parts of  speech .
-# . NSg/V/J . N/I/C/D NPrSg/VX V         NSg/R N/I/J/D NSg/R # V/J      NPl   V/P NSg/V  .
+> " still   " that    can      represent as    many    as    7 distinct parts of speech .
+# . NSg/V/J . N/I/C/D NPrSg/VX V         NSg/R N/I/J/D NSg/R # V/J      NPl   P  NSg/V  .
 >
 #
-> HMMs underlie the functioning of  stochastic taggers and are used in          various
-# ?    V        D   V           V/P J          NPl     V/C V   V/J  NPrSg/V/J/P J
-> algorithms one       of  the most    widely used being   the bi    - directional inference
-# NPl        NSg/I/V/J V/P D   NSg/I/J J/R    V/J  NSg/V/C D   NSg/J . NSg/J       NSg
+> HMMs underlie the functioning of stochastic taggers and are used in          various
+# ?    V        D   V           P  J          NPl     V/C V   V/J  NPrSg/V/J/P J
+> algorithms one       of the most    widely used being   the bi    - directional inference
+# NPl        NSg/I/V/J P  D   NSg/I/J J/R    V/J  NSg/V/C D   NSg/J . NSg/J       NSg
 > algorithm .
 # NSg       .
 >
@@ -318,44 +318,44 @@
 # NSg/V       NPl        P  NSg/V D   I/J  NSg/J   NPrSg/V/J/P J/R    V/J/C/P NSg/V . D
 > methods were  similar to the Viterbi algorithm known   for some  time  in          other
 # NPl     NSg/V NSg/J   P  D   ?       NSg       NSg/V/J C/P I/J/R NSg/V NPrSg/V/J/P NSg/V/J
-> fields . DeRose used a   table of  pairs , while     Church  used a   table of  triples and a
-# NPrPl  . ?      V/J  D/P NSg/V V/P NPl   . NSg/V/C/P NPrSg/V V/J  D/P NSg/V V/P NPl     V/C D/P
-> method of  estimating the values for triples that    were  rare    or      nonexistent in          the
-# NSg/V  V/P V          D   NPl    C/P NPl     N/I/C/D NSg/V NSg/V/J NPrSg/C NSg/J       NPrSg/V/J/P D
-> Brown     Corpus ( an  actual measurement of  triple  probabilities would  require a   much
-# NPrSg/V/J NSg    . D/P NSg/J  NSg         V/P NSg/V/J NPl           NSg/VX NSg/V   D/P N/I/J
-> larger corpus ) . Both methods achieved an  accuracy of  over      95 % . DeRose's 1990
-# J      NSg    . . I/C  NPl     W?       D/P NSg      V/P NSg/V/J/P #  . . ?        #
-> dissertation at        Brown     University included analyses of  the specific error types ,
-# NSg          NSg/I/V/P NPrSg/V/J NSg        W?       NSg/V    V/P D   NSg/J    NSg/V NPl   .
+> fields . DeRose used a   table of pairs , while     Church  used a   table of triples and a
+# NPrPl  . ?      V/J  D/P NSg/V P  NPl   . NSg/V/C/P NPrSg/V V/J  D/P NSg/V P  NPl     V/C D/P
+> method of estimating the values for triples that    were  rare    or      nonexistent in          the
+# NSg/V  P  V          D   NPl    C/P NPl     N/I/C/D NSg/V NSg/V/J NPrSg/C NSg/J       NPrSg/V/J/P D
+> Brown     Corpus ( an  actual measurement of triple  probabilities would  require a   much
+# NPrSg/V/J NSg    . D/P NSg/J  NSg         P  NSg/V/J NPl           NSg/VX NSg/V   D/P N/I/J
+> larger corpus ) . Both methods achieved an  accuracy of over      95 % . DeRose's 1990
+# J      NSg    . . I/C  NPl     W?       D/P NSg      P  NSg/V/J/P #  . . ?        #
+> dissertation at        Brown     University included analyses of the specific error types ,
+# NSg          NSg/I/V/P NPrSg/V/J NSg        W?       NSg/V    P  D   NSg/J    NSg/V NPl   .
 > probabilities , and other   related data , and replicated his   work  for Greek     , where
 # NPl           . V/C NSg/V/J J       NSg  . V/C W?         ISg/D NSg/V C/P NPrSg/V/J . NSg/C
 > it        proved similarly effective .
 # NPrSg/ISg V      J/R       NSg/J     .
 >
 #
-> These findings were  surprisingly disruptive to the field of  natural language
-# I/D   NSg      NSg/V J/R          J          P  D   NSg/V V/P NSg/J   NSg/V
-> processing . The accuracy reported was higher than the typical accuracy of  very
-# V          . D   NSg      V        V   J      C/P  D   NSg/J   NSg      V/P J
-> sophisticated algorithms that    integrated part    of  speech choice with many    higher
-# V/J           NPl        N/I/C/D W?         NSg/V/J V/P NSg/V  NSg/J  P    N/I/J/D J
-> levels of  linguistic analysis : syntax , morphology , semantics , and so        on  . CLAWS ,
-# NPl    V/P J          NSg      . NSg    . NSg        . NSg       . V/C NSg/I/J/C J/P . NPl   .
-> DeRose's and Church's methods did fail    for some  of  the known   cases where
-# ?        V/C N$       NPl     V   NSg/V/J C/P I/J/R V/P D   NSg/V/J NPl   NSg/C
+> These findings were  surprisingly disruptive to the field of natural language
+# I/D   NSg      NSg/V J/R          J          P  D   NSg/V P  NSg/J   NSg/V
+> processing . The accuracy reported was higher than the typical accuracy of very
+# V          . D   NSg      V        V   J      C/P  D   NSg/J   NSg      P  J
+> sophisticated algorithms that    integrated part    of speech choice with many    higher
+# V/J           NPl        N/I/C/D W?         NSg/V/J P  NSg/V  NSg/J  P    N/I/J/D J
+> levels of linguistic analysis : syntax , morphology , semantics , and so        on  . CLAWS ,
+# NPl    P  J          NSg      . NSg    . NSg        . NSg       . V/C NSg/I/J/C J/P . NPl   .
+> DeRose's and Church's methods did fail    for some  of the known   cases where
+# ?        V/C N$       NPl     V   NSg/V/J C/P I/J/R P  D   NSg/V/J NPl   NSg/C
 > semantics is required , but     those proved negligibly rare    . This convinced many    in
 # NSg       VL W?       . NSg/C/P I/D   V      R          NSg/V/J . I/D  V/J       N/I/J/D NPrSg/V/J/P
-> the field that    part    - of  - speech tagging could  usefully be     separated from the other
-# D   NSg/V N/I/C/D NSg/V/J . V/P . NSg/V  NSg/V   NSg/VX J/R      NSg/VX W?        P    D   NSg/V/J
-> levels of  processing ; this , in          turn  , simplified the theory and practice of
-# NPl    V/P V          . I/D  . NPrSg/V/J/P NSg/V . W?         D   NSg    V/C NSg/V    V/P
+> the field that    part    - of - speech tagging could  usefully be     separated from the other
+# D   NSg/V N/I/C/D NSg/V/J . P  . NSg/V  NSg/V   NSg/VX J/R      NSg/VX W?        P    D   NSg/V/J
+> levels of processing ; this , in          turn  , simplified the theory and practice of
+# NPl    P  V          . I/D  . NPrSg/V/J/P NSg/V . W?         D   NSg    V/C NSg/V    P
 > computerized language analysis and encouraged researchers to find  ways to
 # W?           NSg/V    NSg      V/C W?         W?          P  NSg/V NPl  P
 > separate other   pieces as    well    . Markov Models became the standard method for the
 # NSg/V/J  NSg/V/J NPl    NSg/R NSg/V/J . NPr    NPl    V      D   NSg/J    NSg/V  C/P D
-> part    - of  - speech assignment .
-# NSg/V/J . V/P . NSg/V  NSg        .
+> part    - of - speech assignment .
+# NSg/V/J . P  . NSg/V  NSg        .
 >
 #
 > Unsupervised taggers
@@ -370,14 +370,14 @@
 # . V/J          . NSg/V   . V/J          NSg/V   NPl        NSg/V D/P ?        NSg
 > for their training data and produce the tagset by      induction . That    is , they
 # C/P D     NSg/V    NSg  V/C NSg/V   D   ?      NSg/J/P NSg       . N/I/C/D VL . IPl
-> observe patterns in          word  use   , and derive part    - of  - speech categories themselves .
-# NSg/V   NPl      NPrSg/V/J/P NSg/V NSg/V . V/C NSg/V  NSg/V/J . V/P . NSg/V  NPl        I          .
+> observe patterns in          word  use   , and derive part    - of - speech categories themselves .
+# NSg/V   NPl      NPrSg/V/J/P NSg/V NSg/V . V/C NSg/V  NSg/V/J . P  . NSg/V  NPl        I          .
 > For example , statistics readily reveal that    " the " , " a   " , and " an  " occur in
 # C/P NSg/V   . NPl        R       NSg/V  N/I/C/D . D   . . . D/P . . V/C . D/P . V     NPrSg/V/J/P
 > similar contexts , while     " eat   " occurs in          very different ones . With sufficient
 # NSg/J   NPl      . NSg/V/C/P . NSg/V . NPl    NPrSg/V/J/P J    NSg/J     NPl  . P    J
-> iteration , similarity classes of  words emerge that    are remarkably similar to
-# NSg       . NSg        NPl     V/P NPl   NSg/V  N/I/C/D V   R          NSg/J   P
+> iteration , similarity classes of words emerge that    are remarkably similar to
+# NSg       . NSg        NPl     P  NPl   NSg/V  N/I/C/D V   R          NSg/J   P
 > those human   linguists would  expect ; and the differences themselves sometimes
 # I/D   NSg/V/J NPl       NSg/VX V      . V/C D   NSg/V       I          R
 > suggest valuable new     insights .
@@ -394,22 +394,22 @@
 # NSg/V/J NPl     V/C NPl
 >
 #
-> Some  current major     algorithms for part    - of  - speech tagging include the Viterbi
-# I/J/R NSg/J   NPrSg/V/J NPl        C/P NSg/V/J . V/P . NSg/V  NSg/V   NSg/V   D   ?
+> Some  current major     algorithms for part    - of - speech tagging include the Viterbi
+# I/J/R NSg/J   NPrSg/V/J NPl        C/P NSg/V/J . P  . NSg/V  NSg/V   NSg/V   D   ?
 > algorithm , Brill tagger , Constraint Grammar , and the Baum - Welch algorithm ( also
 # NSg       . NSg/J NSg    . NSg        NSg/V   . V/C D   NPr  . ?     NSg       . W?
 > known   as    the forward - backward algorithm ) . Hidden Markov model   and visible Markov
 # NSg/V/J NSg/R D   NSg/V/J . NSg/J    NSg       . . V/J    NPr    NSg/V/J V/C J       NPr
 > model   taggers can      both be     implemented using the Viterbi algorithm . The
 # NSg/V/J NPl     NPrSg/VX I/C  NSg/VX V           V     D   ?       NSg       . D
-> rule  - based Brill tagger is unusual in          that    it        learns a   set       of  rule  patterns , and
-# NSg/V . W?    NSg/J NSg    VL NSg/J   NPrSg/V/J/P N/I/C/D NPrSg/ISg NPl    D/P NPrSg/V/J V/P NSg/V NPl      . V/C
+> rule  - based Brill tagger is unusual in          that    it        learns a   set       of rule  patterns , and
+# NSg/V . W?    NSg/J NSg    VL NSg/J   NPrSg/V/J/P N/I/C/D NPrSg/ISg NPl    D/P NPrSg/V/J P  NSg/V NPl      . V/C
 > then    applies those patterns rather    than optimizing a   statistical quantity .
 # NSg/J/C NPl     I/D   NPl      NPrSg/V/J C/P  V          D/P J           NSg      .
 >
 #
-> Many    machine learning methods have   also been  applied to the problem of  POS
-# N/I/J/D NSg/V   V        NPl     NSg/VX W?   NSg/V W?      P  D   NSg/J   V/P ?
+> Many    machine learning methods have   also been  applied to the problem of POS
+# N/I/J/D NSg/V   V        NPl     NSg/VX W?   NSg/V W?      P  D   NSg/J   P  ?
 > tagging . Methods such  as    SVM , maximum entropy classifier , perceptron , and
 # NSg/V   . NPl     NSg/I NSg/R ?   . NSg/J   NSg     NSg        . N          . V/C
 > nearest - neighbor have   all       been  tried , and most    can      achieve accuracy above
@@ -418,14 +418,14 @@
 # #  . . . NSg      V/J    .
 >
 #
-> A   direct comparison of  several methods is reported ( with references ) at        the ACL
-# D/P V/J    NSg        V/P J/D     NPl     VL V        . P    NPl        . NSg/I/V/P D   NSg
-> Wiki  . This comparison uses the Penn tag   set       on  some  of  the Penn Treebank data ,
-# NSg/V . I/D  NSg        NPl  D   NPr  NSg/V NPrSg/V/J J/P I/J/R V/P D   NPr  ?        NSg  .
+> A   direct comparison of several methods is reported ( with references ) at        the ACL
+# D/P V/J    NSg        P  J/D     NPl     VL V        . P    NPl        . NSg/I/V/P D   NSg
+> Wiki  . This comparison uses the Penn tag   set       on  some  of the Penn Treebank data ,
+# NSg/V . I/D  NSg        NPl  D   NPr  NSg/V NPrSg/V/J J/P I/J/R P  D   NPr  ?        NSg  .
 > so        the results are directly comparable . However , many    significant taggers are
 # NSg/I/J/C D   NPl     V   R/C      NSg/J      . C       . N/I/J/D NSg/J       NPl     V
-> not   included ( perhaps because of  the labor      involved in          reconfiguring them for
-# NSg/C W?       . NSg     C/P     V/P D   NPrSg/V/Am V/J      NPrSg/V/J/P V             N/I  C/P
+> not   included ( perhaps because of the labor      involved in          reconfiguring them for
+# NSg/C W?       . NSg     C/P     P  D   NPrSg/V/Am V/J      NPrSg/V/J/P V             N/I  C/P
 > this particular dataset ) . Thus , it        should not   be     assumed that    the results
 # I/D  NSg/J      NSg     . . NSg  . NPrSg/ISg VX     NSg/C NSg/VX W?      N/I/C/D D   NPl
 > reported here    are the best       that    can      be     achieved with a   given     approach ; nor   even
@@ -436,5 +436,5 @@
 #
 > In          2014 , a   paper   reporting using the structure regularization method for
 # NPrSg/V/J/P #    . D/P NSg/V/J V         V     D   NSg/V     NSg            NSg/V  C/P
-> part    - of  - speech tagging , achieving 97.36 % on  a   standard benchmark dataset .
-# NSg/V/J . V/P . NSg/V  NSg/V   . V         #     . J/P D/P NSg/J    NSg/V     NSg     .
+> part    - of - speech tagging , achieving 97.36 % on  a   standard benchmark dataset .
+# NSg/V/J . P  . NSg/V  NSg/V   . V         #     . J/P D/P NSg/J    NSg/V     NSg     .

--- a/harper-core/tests/text/tagged/The Constitution of the United States.md
+++ b/harper-core/tests/text/tagged/The Constitution of the United States.md
@@ -1,19 +1,19 @@
 > <!-- source: https://github.com/JesseKPhillips/USA-Constitution/blob/4cfdd130709fa7e8db998383b6917ba33b402ec6/Constitution.md -->
 # Unlintable
->            The Constitution Of  The United States Of  America
-# Unlintable D   NPrSg        V/P D   W?     NPrSg  V/P NPr
+>            The Constitution Of The United States Of America
+# Unlintable D   NPrSg        P  D   W?     NPrSg  P  NPr
 >
 #
-> We  the People of  the United States , in          Order to form  a   more        perfect Union     ,
-# IPl D   NSg/V  V/P D   W?     NPrSg  . NPrSg/V/J/P NSg/V P  NSg/V D/P NPrSg/I/V/J NSg/V/J NPrSg/V/J .
+> We  the People of the United States , in          Order to form  a   more        perfect Union     ,
+# IPl D   NSg/V  P  D   W?     NPrSg  . NPrSg/V/J/P NSg/V P  NSg/V D/P NPrSg/I/V/J NSg/V/J NPrSg/V/J .
 > establish Justice , insure domestic Tranquility , provide for the common  defence ,
 # V         NPrSg   . V      NSg/J    NSg         . V       C/P D   NSg/V/J ?       .
-> promote the general Welfare , and secure the Blessings of  Liberty to ourselves
-# NSg/V   D   NSg/V/J NSg/V   . V/C V/J    D   W?        V/P NSg     P  I
+> promote the general Welfare , and secure the Blessings of Liberty to ourselves
+# NSg/V   D   NSg/V/J NSg/V   . V/C V/J    D   W?        P  NSg     P  I
 > and our Posterity , do     ordain and establish this Constitution for the United
 # V/C D   NSg       . NSg/VX V      V/C V         I/D  NPrSg        C/P D   W?
-> States of  America .
-# NPrSg  V/P NPr     .
+> States of America .
+# NPrSg  P  NPr     .
 >
 #
 > Article . I.
@@ -26,42 +26,42 @@
 #
 > All       legislative Powers herein granted shall be     vested in          a
 # NSg/I/J/C NSg/J       NPrSg  W?     W?      VX    NSg/VX W?     NPrSg/V/J/P D/P
-> Congress of  the United States , which shall consist of  a   Senate and House   of
-# NPrSg/V  V/P D   W?     NPrSg  . I/C   VX    NSg/V   V/P D/P NPrSg  V/C NPrSg/V V/P
+> Congress of the United States , which shall consist of a   Senate and House   of
+# NPrSg/V  P  D   W?     NPrSg  . I/C   VX    NSg/V   P  D/P NPrSg  V/C NPrSg/V P
 > Representatives . Congress shall make  no      law   respecting an  establishment of
-# NPl             . NPrSg/V  VX    NSg/V NPrSg/P NSg/V V          D/P NSg           V/P
+# NPl             . NPrSg/V  VX    NSg/V NPrSg/P NSg/V V          D/P NSg           P
 > religion , or      prohibiting the free    exercise thereof ; or      abridging the freedom of
-# NSg/V    . NPrSg/C V           D   NSg/V/J NSg/V    W?      . NPrSg/C V         D   NSg     V/P
-> speech , or      of  the press ; or      the right     of  the people peaceably to assemble , and
-# NSg/V  . NPrSg/C V/P D   NSg/V . NPrSg/C D   NPrSg/V/J V/P D   NSg/V  R         P  V        . V/C
-> to petition the government for a   redress of  grievances .
-# P  NSg/V    D   NSg        C/P D/P NSg/V   V/P NPl        .
+# NSg/V    . NPrSg/C V           D   NSg/V/J NSg/V    W?      . NPrSg/C V         D   NSg     P
+> speech , or      of the press ; or      the right     of the people peaceably to assemble , and
+# NSg/V  . NPrSg/C P  D   NSg/V . NPrSg/C D   NPrSg/V/J P  D   NSg/V  R         P  V        . V/C
+> to petition the government for a   redress of grievances .
+# P  NSg/V    D   NSg        C/P D/P NSg/V   P  NPl        .
 >
 #
 > No      person shall be     a   Senator or      Representative in          Congress , or      elector of
-# NPrSg/P NSg/V  VX    NSg/VX D/P NSg     NPrSg/C NSg/J          NPrSg/V/J/P NPrSg/V  . NPrSg/C NSg     V/P
+# NPrSg/P NSg/V  VX    NSg/VX D/P NSg     NPrSg/C NSg/J          NPrSg/V/J/P NPrSg/V  . NPrSg/C NSg     P
 > President and Vice      President , or      hold    any   office , civil or      military , under   the
 # NSg/V     V/C NSg/V/J/P NSg/V     . NPrSg/C NSg/V/J I/R/D NSg/V  . J     NPrSg/C NSg/J    . NSg/J/P D
 > United States , or      under   any   State , who     , having previously taken an  oath  , as    a
 # W?     NPrSg  . NPrSg/C NSg/J/P I/R/D NSg/V . NPrSg/I . V      J/R        V/J   D/P NSg/V . NSg/R D/P
-> member of  Congress , or      as    an  officer of  the United States , or      as    a   member of
-# NSg/V  V/P NPrSg/V  . NPrSg/C NSg/R D/P NSg/V/J V/P D   W?     NPrSg  . NPrSg/C NSg/R D/P NSg/V  V/P
-> any   State legislature , or      as    an  executive or      judicial officer of  any   State , to
-# I/R/D NSg/V NSg         . NPrSg/C NSg/R D/P NSg/J     NPrSg/C NSg/J    NSg/V/J V/P I/R/D NSg/V . P
-> support the Constitution of  the United States , shall have   engaged in
-# NSg/V   D   NPrSg        V/P D   W?     NPrSg  . VX    NSg/VX W?      NPrSg/V/J/P
+> member of Congress , or      as    an  officer of the United States , or      as    a   member of
+# NSg/V  P  NPrSg/V  . NPrSg/C NSg/R D/P NSg/V/J P  D   W?     NPrSg  . NPrSg/C NSg/R D/P NSg/V  P
+> any   State legislature , or      as    an  executive or      judicial officer of any   State , to
+# I/R/D NSg/V NSg         . NPrSg/C NSg/R D/P NSg/J     NPrSg/C NSg/J    NSg/V/J P  I/R/D NSg/V . P
+> support the Constitution of the United States , shall have   engaged in
+# NSg/V   D   NPrSg        P  D   W?     NPrSg  . VX    NSg/VX W?      NPrSg/V/J/P
 > insurrection or      rebellion against the same , or      given     aid   or      comfort to the
 # NSg          NPrSg/C NSg       C/P     D   I/J  . NPrSg/C NSg/V/J/P NSg/V NPrSg/C NSg/V   P  D
-> enemies thereof . But     Congress may      , by      a   vote  of  two - thirds of  each House   ,
-# NPl     W?      . NSg/C/P NPrSg/V  NPrSg/VX . NSg/J/P D/P NSg/V V/P NSg . NPl    V/P D    NPrSg/V .
+> enemies thereof . But     Congress may      , by      a   vote  of two - thirds of each House   ,
+# NPl     W?      . NSg/C/P NPrSg/V  NPrSg/VX . NSg/J/P D/P NSg/V P  NSg . NPl    P  D    NPrSg/V .
 > remove such  disability .
 # NSg/V  NSg/I NSg        .
 >
 #
-> The terms of  Senators and Representatives shall end   at        noon  on  the 3 d       day   of
-# D   NPl   V/P NPl      V/C NPl             VX    NSg/V NSg/I/V/P NSg/V J/P D   # NPrSg/J NPrSg V/P
-> January , of  the years in          which such  terms end   ; and the terms of  their
-# NPr     . V/P D   NPl   NPrSg/V/J/P I/C   NSg/I NPl   NSg/V . V/C D   NPl   V/P D
+> The terms of Senators and Representatives shall end   at        noon  on  the 3 d       day   of
+# D   NPl   P  NPl      V/C NPl             VX    NSg/V NSg/I/V/P NSg/V J/P D   # NPrSg/J NPrSg P
+> January , of the years in          which such  terms end   ; and the terms of their
+# NPr     . P  D   NPl   NPrSg/V/J/P I/C   NSg/I NPl   NSg/V . V/C D   NPl   P  D
 > successors shall then    begin .
 # NPl        VX    NSg/J/C NSg/V .
 >
@@ -70,58 +70,58 @@
 # NSg/V   . # .
 >
 #
-> The House   of  Representatives shall be     composed of  Members
-# D   NPrSg/V V/P NPl             VX    NSg/VX W?       V/P NPl
-> chosen every second  Year by      the People of  the several States , and the Electors
-# V/J    D     NSg/V/J NSg  NSg/J/P D   NSg/V  V/P D   J/D     NPrSg  . V/C D   NPl
-> in          each State shall have   the Qualifications requisite for Electors of  the most
-# NPrSg/V/J/P D    NSg/V VX    NSg/VX D   W?             NSg/J     C/P NPl      V/P D   NSg/I/J
-> numerous Branch  of  the State Legislature .
-# J        NPrSg/V V/P D   NSg/V NSg         .
+> The House   of Representatives shall be     composed of Members
+# D   NPrSg/V P  NPl             VX    NSg/VX W?       P  NPl
+> chosen every second  Year by      the People of the several States , and the Electors
+# V/J    D     NSg/V/J NSg  NSg/J/P D   NSg/V  P  D   J/D     NPrSg  . V/C D   NPl
+> in          each State shall have   the Qualifications requisite for Electors of the most
+# NPrSg/V/J/P D    NSg/V VX    NSg/VX D   W?             NSg/J     C/P NPl      P  D   NSg/I/J
+> numerous Branch  of the State Legislature .
+# J        NPrSg/V P  D   NSg/V NSg         .
 >
 #
 > No      Person shall be     a   Representative who     shall not   have   attained to the Age   of
-# NPrSg/P NSg/V  VX    NSg/VX D/P NSg/J          NPrSg/I VX    NSg/C NSg/VX W?       P  D   NSg/V V/P
-> twenty five Years , and been  seven Years a   Citizen of  the United States , and who
-# NSg    NSg  NPl   . V/C NSg/V NSg   NPl   D/P NSg     V/P D   W?     NPrSg  . V/C NPrSg/I
-> shall not   , when    elected , be     an  Inhabitant of  that    State in          which he      shall be
-# VX    NSg/C . NSg/I/C NSg/V/J . NSg/VX D/P NSg/J      V/P N/I/C/D NSg/V NPrSg/V/J/P I/C   NPr/ISg VX    NSg/VX
+# NPrSg/P NSg/V  VX    NSg/VX D/P NSg/J          NPrSg/I VX    NSg/C NSg/VX W?       P  D   NSg/V P
+> twenty five Years , and been  seven Years a   Citizen of the United States , and who
+# NSg    NSg  NPl   . V/C NSg/V NSg   NPl   D/P NSg     P  D   W?     NPrSg  . V/C NPrSg/I
+> shall not   , when    elected , be     an  Inhabitant of that    State in          which he      shall be
+# VX    NSg/C . NSg/I/C NSg/V/J . NSg/VX D/P NSg/J      P  N/I/C/D NSg/V NPrSg/V/J/P I/C   NPr/ISg VX    NSg/VX
 > chosen .
 # V/J    .
 >
 #
 > Representatives shall be     apportioned among the several States according to
 # NPl             VX    NSg/VX W?          P     D   J/D     NPrSg  V/J       P
-> their respective numbers , counting the whole number  of  persons in          each State ,
-# D     J          NPrPl   . V        D   NSg/J NSg/V/J V/P NPl     NPrSg/V/J/P D    NSg/V .
+> their respective numbers , counting the whole number  of persons in          each State ,
+# D     J          NPrPl   . V        D   NSg/J NSg/V/J P  NPl     NPrSg/V/J/P D    NSg/V .
 > excluding Indians not   taxed . But     when    the right     to vote  at        any   election for the
 # V         NPl     NSg/C W?    . NSg/C/P NSg/I/C D   NPrSg/V/J P  NSg/V NSg/I/V/P I/R/D NSg      C/P D
-> choice of  electors for President and Vice      President of  the United States ,
-# NSg/J  V/P NPl      C/P NSg/V     V/C NSg/V/J/P NSg/V     V/P D   W?     NPrSg  .
-> Representatives in          Congress , the Executive and Judicial officers of  a   State , or
-# NPl             NPrSg/V/J/P NPrSg/V  . D   NSg/J     V/C NSg/J    W?       V/P D/P NSg/V . NPrSg/C
-> the members of  the Legislature thereof , is denied to any   of  the male
-# D   NPl     V/P D   NSg         W?      . VL W?     P  I/R/D V/P D   NPrSg/J
-> inhabitants of  such  State , being   twenty - one       years of  age   , and citizens of  the
-# NPl         V/P NSg/I NSg/V . NSg/V/C NSg    . NSg/I/V/J NPl   V/P NSg/V . V/C NPl      V/P D
+> choice of electors for President and Vice      President of the United States ,
+# NSg/J  P  NPl      C/P NSg/V     V/C NSg/V/J/P NSg/V     P  D   W?     NPrSg  .
+> Representatives in          Congress , the Executive and Judicial officers of a   State , or
+# NPl             NPrSg/V/J/P NPrSg/V  . D   NSg/J     V/C NSg/J    W?       P  D/P NSg/V . NPrSg/C
+> the members of the Legislature thereof , is denied to any   of the male
+# D   NPl     P  D   NSg         W?      . VL W?     P  I/R/D P  D   NPrSg/J
+> inhabitants of such  State , being   twenty - one       years of age   , and citizens of the
+# NPl         P  NSg/I NSg/V . NSg/V/C NSg    . NSg/I/V/J NPl   P  NSg/V . V/C NPl      P  D
 > United States , or      in          any   way   abridged , except for participation in          rebellion ,
 # W?     NPrSg  . NPrSg/C NPrSg/V/J/P I/R/D NSg/J W?       . V/C/P  C/P NSg           NPrSg/V/J/P NSg       .
-> or      other   crime , the basis of  representation therein shall be     reduced in          the
-# NPrSg/C NSg/V/J NSg/V . D   NSg   V/P NSg            W?      VX    NSg/VX W?      NPrSg/V/J/P D
-> proportion which the number  of  such  male    citizens shall bear    to the whole
-# NSg/V      I/C   D   NSg/V/J V/P NSg/I NPrSg/J NPl      VX    NSg/V/J P  D   NSg/J
-> number  of  male    citizens twenty - one       years of  age   in          such  State . The actual
-# NSg/V/J V/P NPrSg/J NPl      NSg    . NSg/I/V/J NPl   V/P NSg/V NPrSg/V/J/P NSg/I NSg/V . D   NSg/J
-> Enumeration shall be     made  within three Years after the first   Meeting of  the
-# NSg         VX    NSg/VX NSg/V N/J/P  NSg   NPl   J/P   D   NSg/V/J NSg/V   V/P D
-> Congress of  the United States , and within every subsequent Term    of  ten Years ,
-# NPrSg/V  V/P D   W?     NPrSg  . V/C N/J/P  D     NSg/J      NSg/V/J V/P NSg NPl   .
-> in          such  Manner as    they shall by      Law   direct . The Number  of  Representatives shall
-# NPrSg/V/J/P NSg/I NSg    NSg/R IPl  VX    NSg/J/P NSg/V V/J    . D   NSg/V/J V/P NPl             VX
+> or      other   crime , the basis of representation therein shall be     reduced in          the
+# NPrSg/C NSg/V/J NSg/V . D   NSg   P  NSg            W?      VX    NSg/VX W?      NPrSg/V/J/P D
+> proportion which the number  of such  male    citizens shall bear    to the whole
+# NSg/V      I/C   D   NSg/V/J P  NSg/I NPrSg/J NPl      VX    NSg/V/J P  D   NSg/J
+> number  of male    citizens twenty - one       years of age   in          such  State . The actual
+# NSg/V/J P  NPrSg/J NPl      NSg    . NSg/I/V/J NPl   P  NSg/V NPrSg/V/J/P NSg/I NSg/V . D   NSg/J
+> Enumeration shall be     made  within three Years after the first   Meeting of the
+# NSg         VX    NSg/VX NSg/V N/J/P  NSg   NPl   J/P   D   NSg/V/J NSg/V   P  D
+> Congress of the United States , and within every subsequent Term    of ten Years ,
+# NPrSg/V  P  D   W?     NPrSg  . V/C N/J/P  D     NSg/J      NSg/V/J P  NSg NPl   .
+> in          such  Manner as    they shall by      Law   direct . The Number  of Representatives shall
+# NPrSg/V/J/P NSg/I NSg    NSg/R IPl  VX    NSg/J/P NSg/V V/J    . D   NSg/V/J P  NPl             VX
 > not   exceed one       for every thirty Thousand , but     each State shall have   at        Least
 # NSg/C V      NSg/I/V/J C/P D     NSg    NSg      . NSg/C/P D    NSg/V VX    NSg/VX NSg/I/V/P NSg/J
-> one       Representative ; and until such  enumeration shall be     made  , the State of  New
-# NSg/I/V/J NSg/J          . V/C C/P   NSg/I NSg         VX    NSg/VX NSg/V . D   NSg/V V/P NSg/V/J
+> one       Representative ; and until such  enumeration shall be     made  , the State of New
+# NSg/I/V/J NSg/J          . V/C C/P   NSg/I NSg         VX    NSg/VX NSg/V . D   NSg/V P  NSg/V/J
 > Hampshire shall be     entitled to chuse three , Massachusetts eight , Rhode - Island
 # NPrSg     VX    NSg/VX W?       P  ?     NSg   . NPr           NSg/J . NPr   . NSg/V
 > and Providence Plantations one       , Connecticut five , New     - York six , New     Jersey
@@ -134,90 +134,90 @@
 #
 > When    vacancies happen in          the Representation from any   State , the Executive
 # NSg/I/C NPl       V      NPrSg/V/J/P D   NSg            P    I/R/D NSg/V . D   NSg/J
-> Authority thereof shall issue Writs of  Election to fill  such  Vacancies .
-# NSg       W?      VX    NSg/V NPl   V/P NSg      P  NSg/V NSg/I NPl       .
+> Authority thereof shall issue Writs of Election to fill  such  Vacancies .
+# NSg       W?      VX    NSg/V NPl   P  NSg      P  NSg/V NSg/I NPl       .
 >
 #
-> The House   of  Representatives shall chuse their Speaker and other   Officers ; and
-# D   NPrSg/V V/P NPl             VX    ?     D     NSg/J   V/C NSg/V/J W?       . V/C
-> shall have   the sole    Power   of  Impeachment .
-# VX    NSg/VX D   NSg/V/J NSg/V/J V/P NSg         .
+> The House   of Representatives shall chuse their Speaker and other   Officers ; and
+# D   NPrSg/V P  NPl             VX    ?     D     NSg/J   V/C NSg/V/J W?       . V/C
+> shall have   the sole    Power   of Impeachment .
+# VX    NSg/VX D   NSg/V/J NSg/V/J P  NSg         .
 >
 #
 > Section . 3 .
 # NSg/V   . # .
 >
 #
-> The Senate of  the United States shall be     composed of  two
-# D   NPrSg  V/P D   W?     NPrSg  VX    NSg/VX W?       V/P NSg
+> The Senate of the United States shall be     composed of two
+# D   NPrSg  P  D   W?     NPrSg  VX    NSg/VX W?       P  NSg
 > Senators from each State , elected by      the people thereof , for six years ; and
 # NPl      P    D    NSg/V . NSg/V/J NSg/J/P D   NSg/V  W?      . C/P NSg NPl   . V/C
 > each Senator shall have   one       vote  . The electors in          each State shall have   the
 # D    NSg     VX    NSg/VX NSg/I/V/J NSg/V . D   NPl      NPrSg/V/J/P D    NSg/V VX    NSg/VX D
-> qualifications requisite for electors of  the most    numerous branch  of  the State
-# W?             NSg/J     C/P NPl      V/P D   NSg/I/J J        NPrSg/V V/P D   NSg/V
+> qualifications requisite for electors of the most    numerous branch  of the State
+# W?             NSg/J     C/P NPl      P  D   NSg/I/J J        NPrSg/V P  D   NSg/V
 > legislatures .
 # NPl          .
 >
 #
-> Immediately after they shall be     assembled in          Consequence of  the first   Election ,
-# J/R         J/P   IPl  VX    NSg/VX W?        NPrSg/V/J/P NSg/V       V/P D   NSg/V/J NSg      .
-> they shall be     divided as    equally as    may      be     into three Classes . The Seats of  the
-# IPl  VX    NSg/VX V/J     NSg/R J/R     NSg/R NPrSg/VX NSg/VX P    NSg   NPl     . D   NPl   V/P D
-> Senators of  the first   Class   shall be     vacated at        the Expiration of  the second
-# NPl      V/P D   NSg/V/J NSg/V/J VX    NSg/VX W?      NSg/I/V/P D   NSg        V/P D   NSg/V/J
-> Year , of  the second  Class   at        the Expiration of  the fourth    Year , and of  the
-# NSg  . V/P D   NSg/V/J NSg/V/J NSg/I/V/P D   NSg        V/P D   NPrSg/V/J NSg  . V/C V/P D
-> third   Class   at        the Expiration of  the sixth   Year , so        that    one       third   may      be
-# NSg/V/J NSg/V/J NSg/I/V/P D   NSg        V/P D   NSg/V/J NSg  . NSg/I/J/C N/I/C/D NSg/I/V/J NSg/V/J NPrSg/VX NSg/VX
+> Immediately after they shall be     assembled in          Consequence of the first   Election ,
+# J/R         J/P   IPl  VX    NSg/VX W?        NPrSg/V/J/P NSg/V       P  D   NSg/V/J NSg      .
+> they shall be     divided as    equally as    may      be     into three Classes . The Seats of the
+# IPl  VX    NSg/VX V/J     NSg/R J/R     NSg/R NPrSg/VX NSg/VX P    NSg   NPl     . D   NPl   P  D
+> Senators of the first   Class   shall be     vacated at        the Expiration of the second
+# NPl      P  D   NSg/V/J NSg/V/J VX    NSg/VX W?      NSg/I/V/P D   NSg        P  D   NSg/V/J
+> Year , of the second  Class   at        the Expiration of the fourth    Year , and of the
+# NSg  . P  D   NSg/V/J NSg/V/J NSg/I/V/P D   NSg        P  D   NPrSg/V/J NSg  . V/C P  D
+> third   Class   at        the Expiration of the sixth   Year , so        that    one       third   may      be
+# NSg/V/J NSg/V/J NSg/I/V/P D   NSg        P  D   NSg/V/J NSg  . NSg/I/J/C N/I/C/D NSg/I/V/J NSg/V/J NPrSg/VX NSg/VX
 > chosen every second  Year ; and when    vacancies happen in          the representation of
-# V/J    D     NSg/V/J NSg  . V/C NSg/I/C NPl       V      NPrSg/V/J/P D   NSg            V/P
-> any   State in          the Senate , the executive authority of  such  State shall issue
-# I/R/D NSg/V NPrSg/V/J/P D   NPrSg  . D   NSg/J     NSg       V/P NSg/I NSg/V VX    NSg/V
-> writs of  election to fill  such  vacancies : Provided , That    the legislature of  any
-# NPl   V/P NSg      P  NSg/V NSg/I NPl       . V/C      . N/I/C/D D   NSg         V/P I/R/D
+# V/J    D     NSg/V/J NSg  . V/C NSg/I/C NPl       V      NPrSg/V/J/P D   NSg            P
+> any   State in          the Senate , the executive authority of such  State shall issue
+# I/R/D NSg/V NPrSg/V/J/P D   NPrSg  . D   NSg/J     NSg       P  NSg/I NSg/V VX    NSg/V
+> writs of election to fill  such  vacancies : Provided , That    the legislature of any
+# NPl   P  NSg      P  NSg/V NSg/I NPl       . V/C      . N/I/C/D D   NSg         P  I/R/D
 > State may      empower the executive thereof to make  temporary appointments until
 # NSg/V NPrSg/VX V       D   NSg/J     W?      P  NSg/V NSg/J     NPl          C/P
 > the people fill  the vacancies by      election as    the legislature may      direct .
 # D   NSg/V  NSg/V D   NPl       NSg/J/P NSg      NSg/R D   NSg         NPrSg/VX V/J    .
 >
 #
-> No      Person shall be     a   Senator who     shall not   have   attained to the Age   of  thirty
-# NPrSg/P NSg/V  VX    NSg/VX D/P NSg     NPrSg/I VX    NSg/C NSg/VX W?       P  D   NSg/V V/P NSg
-> Years , and been  nine Years a   Citizen of  the United States , and who     shall not   ,
-# NPl   . V/C NSg/V NSg  NPl   D/P NSg     V/P D   W?     NPrSg  . V/C NPrSg/I VX    NSg/C .
-> when    elected , be     an  Inhabitant of  that    State for which he      shall be     chosen .
-# NSg/I/C NSg/V/J . NSg/VX D/P NSg/J      V/P N/I/C/D NSg/V C/P I/C   NPr/ISg VX    NSg/VX V/J    .
+> No      Person shall be     a   Senator who     shall not   have   attained to the Age   of thirty
+# NPrSg/P NSg/V  VX    NSg/VX D/P NSg     NPrSg/I VX    NSg/C NSg/VX W?       P  D   NSg/V P  NSg
+> Years , and been  nine Years a   Citizen of the United States , and who     shall not   ,
+# NPl   . V/C NSg/V NSg  NPl   D/P NSg     P  D   W?     NPrSg  . V/C NPrSg/I VX    NSg/C .
+> when    elected , be     an  Inhabitant of that    State for which he      shall be     chosen .
+# NSg/I/C NSg/V/J . NSg/VX D/P NSg/J      P  N/I/C/D NSg/V C/P I/C   NPr/ISg VX    NSg/VX V/J    .
 >
 #
-> The Vice      President of  the United States shall be     President of  the Senate , but
-# D   NSg/V/J/P NSg/V     V/P D   W?     NPrSg  VX    NSg/VX NSg/V     V/P D   NPrSg  . NSg/C/P
+> The Vice      President of the United States shall be     President of the Senate , but
+# D   NSg/V/J/P NSg/V     P  D   W?     NPrSg  VX    NSg/VX NSg/V     P  D   NPrSg  . NSg/C/P
 > shall have   no      Vote  , unless they be     equally divided .
 # VX    NSg/VX NPrSg/P NSg/V . C      IPl  NSg/VX J/R     V/J     .
 >
 #
 > The Senate shall chuse their other   Officers , and also a   President pro     tempore ,
 # D   NPrSg  VX    ?     D     NSg/V/J W?       . V/C W?   D/P NSg/V     NSg/J/P ?       .
-> in          the Absence of  the Vice      President , or      when    he      shall exercise the Office of
-# NPrSg/V/J/P D   NSg     V/P D   NSg/V/J/P NSg/V     . NPrSg/C NSg/I/C NPr/ISg VX    NSg/V    D   NSg/V  V/P
-> President of  the United States .
-# NSg/V     V/P D   W?     NPrSg  .
+> in          the Absence of the Vice      President , or      when    he      shall exercise the Office of
+# NPrSg/V/J/P D   NSg     P  D   NSg/V/J/P NSg/V     . NPrSg/C NSg/I/C NPr/ISg VX    NSg/V    D   NSg/V  P
+> President of the United States .
+# NSg/V     P  D   W?     NPrSg  .
 >
 #
 > The Senate shall have   the sole    Power   to try     all       Impeachments . When    sitting for
 # D   NPrSg  VX    NSg/VX D   NSg/V/J NSg/V/J P  NSg/V/J NSg/I/J/C NPl          . NSg/I/C NSg/V/J C/P
-> that    Purpose , they shall be     on  Oath  or      Affirmation . When    the President of  the
-# N/I/C/D NSg/V   . IPl  VX    NSg/VX J/P NSg/V NPrSg/C NSg         . NSg/I/C D   NSg/V     V/P D
+> that    Purpose , they shall be     on  Oath  or      Affirmation . When    the President of the
+# N/I/C/D NSg/V   . IPl  VX    NSg/VX J/P NSg/V NPrSg/C NSg         . NSg/I/C D   NSg/V     P  D
 > United States is tried , the Chief   Justice shall preside : And no      Person shall be
 # W?     NPrSg  VL V/J   . D   NSg/V/J NPrSg   VX    V       . V/C NPrSg/P NSg/V  VX    NSg/VX
-> convicted without the Concurrence of  two thirds of  the Members present .
-# W?        C/P     D   NSg         V/P NSg NPl    V/P D   NPl     NSg/V/J .
+> convicted without the Concurrence of two thirds of the Members present .
+# W?        C/P     D   NSg         P  NSg NPl    P  D   NPl     NSg/V/J .
 >
 #
-> Judgment in          Cases of  impeachment shall not   extend further than to removal from
-# NSg      NPrSg/V/J/P NPl   V/P NSg         VX    NSg/C NSg/V  V/J     C/P  P  NSg     P
-> Office , and disqualification to hold    and enjoy any   Office of  honor    , Trust   or
-# NSg/V  . V/C NSg              P  NSg/V/J V/C V     I/R/D NSg/V  V/P NSg/V/Am . NSg/V/J NPrSg/C
+> Judgment in          Cases of impeachment shall not   extend further than to removal from
+# NSg      NPrSg/V/J/P NPl   P  NSg         VX    NSg/C NSg/V  V/J     C/P  P  NSg     P
+> Office , and disqualification to hold    and enjoy any   Office of honor    , Trust   or
+# NSg/V  . V/C NSg              P  NSg/V/J V/C V     I/R/D NSg/V  P  NSg/V/Am . NSg/V/J NPrSg/C
 > Profit  under   the United States : but     the Party   convicted shall nevertheless be
 # NSg/V/J NSg/J/P D   W?     NPrSg  . NSg/C/P D   NSg/V/J W?        VX    W?           NSg/VX
 > liable and subject to Indictment , Trial   , Judgment and Punishment , according to
@@ -230,20 +230,20 @@
 # NSg/V   . # .
 >
 #
-> The Times , Places and Manner of  holding Elections for Senators
-# D   NPl   . NPl    V/C NSg    V/P NSg/V   NPl       C/P NPl
+> The Times , Places and Manner of holding Elections for Senators
+# D   NPl   . NPl    V/C NSg    P  NSg/V   NPl       C/P NPl
 > and Representatives , shall be     prescribed in          each State by      the Legislature
 # V/C NPl             . VX    NSg/VX W?         NPrSg/V/J/P D    NSg/V NSg/J/P D   NSg
 > thereof ; but     the Congress may      at        any   time  by      Law   make  or      alter such
 # W?      . NSg/C/P D   NPrSg/V  NPrSg/VX NSg/I/V/P I/R/D NSg/V NSg/J/P NSg/V NSg/V NPrSg/C NSg/V NSg/I
-> Regulations , except as    to the Places of  chusing Senators .
-# NSg         . V/C/P  NSg/R P  D   NPl    V/P ?       NPl      .
+> Regulations , except as    to the Places of chusing Senators .
+# NSg         . V/C/P  NSg/R P  D   NPl    P  ?       NPl      .
 >
 #
 > The Congress shall assemble at        least once  in          every year , and such  meeting shall
 # D   NPrSg/V  VX    V        NSg/I/V/P NSg/J NSg/C NPrSg/V/J/P D     NSg  . V/C NSg/I NSg/V   VX
-> begin at        noon  on  the 3 d       day   of  January , unless they shall by      law   appoint a
-# NSg/V NSg/I/V/P NSg/V J/P D   # NPrSg/J NPrSg V/P NPr     . C      IPl  VX    NSg/J/P NSg/V V       D/P
+> begin at        noon  on  the 3 d       day   of January , unless they shall by      law   appoint a
+# NSg/V NSg/I/V/P NSg/V J/P D   # NPrSg/J NPrSg P  NPr     . C      IPl  VX    NSg/J/P NSg/V V       D/P
 > different day   .
 # NSg/J     NPrSg .
 >
@@ -252,36 +252,36 @@
 # NSg/V   . # .
 >
 #
-> Each House   shall be     the Judge of  the Elections , Returns and
-# D    NPrSg/V VX    NSg/VX D   NSg/V V/P D   NPl       . NPl     V/C
-> Qualifications of  its   own     Members , and a   Majority of  each shall constitute a
-# W?             V/P ISg/D NSg/V/J NPl     . V/C D/P NSg      V/P D    VX    NSg/V      D/P
+> Each House   shall be     the Judge of the Elections , Returns and
+# D    NPrSg/V VX    NSg/VX D   NSg/V P  D   NPl       . NPl     V/C
+> Qualifications of its   own     Members , and a   Majority of each shall constitute a
+# W?             P  ISg/D NSg/V/J NPl     . V/C D/P NSg      P  D    VX    NSg/V      D/P
 > Quorum to do     Business ; but     a   smaller Number  may      adjourn from day   to day   , and
 # NSg    P  NSg/VX NSg/J    . NSg/C/P D/P J       NSg/V/J NPrSg/VX V       P    NPrSg P  NPrSg . V/C
-> may      be     authorized to compel the Attendance of  absent    Members , in          such  Manner ,
-# NPrSg/VX NSg/VX V/J        P  V      D   NSg        V/P NSg/V/J/P NPl     . NPrSg/V/J/P NSg/I NSg    .
+> may      be     authorized to compel the Attendance of absent    Members , in          such  Manner ,
+# NPrSg/VX NSg/VX V/J        P  V      D   NSg        P  NSg/V/J/P NPl     . NPrSg/V/J/P NSg/I NSg    .
 > and under   such  Penalties as    each House   may      provide .
 # V/C NSg/J/P NSg/I NPl       NSg/R D    NPrSg/V NPrSg/VX V       .
 >
 #
-> Each House   may      determine the Rules of  its   Proceedings , punish its   Members for
-# D    NPrSg/V NPrSg/VX V         D   NPl   V/P ISg/D W?          . V      ISg/D NPl     C/P
-> disorderly Behaviour , and , with the Concurrence of  two thirds , expel a   Member .
-# J/R        NSg/Br    . V/C . P    D   NSg         V/P NSg NPl    . V     D/P NSg/V  .
+> Each House   may      determine the Rules of its   Proceedings , punish its   Members for
+# D    NPrSg/V NPrSg/VX V         D   NPl   P  ISg/D W?          . V      ISg/D NPl     C/P
+> disorderly Behaviour , and , with the Concurrence of two thirds , expel a   Member .
+# J/R        NSg/Br    . V/C . P    D   NSg         P  NSg NPl    . V     D/P NSg/V  .
 >
 #
-> Each House   shall keep  a   Journal of  its   Proceedings , and from time  to time
-# D    NPrSg/V VX    NSg/V D/P NSg/V/J V/P ISg/D W?          . V/C P    NSg/V P  NSg/V
+> Each House   shall keep  a   Journal of its   Proceedings , and from time  to time
+# D    NPrSg/V VX    NSg/V D/P NSg/V/J P  ISg/D W?          . V/C P    NSg/V P  NSg/V
 > publish the same , excepting such  Parts as    may      in          their Judgment require
 # V       D   I/J  . V         NSg/I NPl   NSg/R NPrSg/VX NPrSg/V/J/P D     NSg      NSg/V
-> Secrecy ; and the Yeas and Nays of  the Members of  either House   on  any   question
-# NSg     . V/C D   NPl  V/C NPl  V/P D   NPl     V/P I/C    NPrSg/V J/P I/R/D NSg/V
-> shall , at        the Desire of  one       fifth   of  those Present , be     entered on  the Journal .
-# VX    . NSg/I/V/P D   NSg/V  V/P NSg/I/V/J NSg/V/J V/P I/D   NSg/V/J . NSg/VX W?      J/P D   NSg/V/J .
+> Secrecy ; and the Yeas and Nays of the Members of either House   on  any   question
+# NSg     . V/C D   NPl  V/C NPl  P  D   NPl     P  I/C    NPrSg/V J/P I/R/D NSg/V
+> shall , at        the Desire of one       fifth   of those Present , be     entered on  the Journal .
+# VX    . NSg/I/V/P D   NSg/V  P  NSg/I/V/J NSg/V/J P  I/D   NSg/V/J . NSg/VX W?      J/P D   NSg/V/J .
 >
 #
-> Neither House   , during the Session of  Congress , shall , without the Consent of
-# I/C     NPrSg/V . V/P    D   NSg/V   V/P NPrSg/V  . VX    . C/P     D   NSg/V   V/P
+> Neither House   , during the Session of Congress , shall , without the Consent of
+# I/C     NPrSg/V . V/P    D   NSg/V   P  NPrSg/V  . VX    . C/P     D   NSg/V   P
 > the other   , adjourn for more        than three days , nor   to any   other   Place than that
 # D   NSg/V/J . V       C/P NPrSg/I/V/J C/P  NSg   NPl  . NSg/C P  I/R/D NSg/V/J NSg/V C/P  N/I/C/D
 > in          which the two Houses shall be     sitting .
@@ -294,14 +294,14 @@
 #
 > The Senators and Representatives shall receive a   Compensation
 # D   NPl      V/C NPl             VX    NSg/V   D/P NSg
-> for their Services , to be     ascertained by      Law   , and paid out         of  the Treasury of
-# C/P D     NPl      . P  NSg/VX W?          NSg/J/P NSg/V . V/C V/J  NSg/V/J/R/P V/P D   NPrSg    V/P
+> for their Services , to be     ascertained by      Law   , and paid out         of the Treasury of
+# C/P D     NPl      . P  NSg/VX W?          NSg/J/P NSg/V . V/C V/J  NSg/V/J/R/P P  D   NPrSg    P
 > the United States . They shall in          all       Cases , except Treason , Felony and Breach
 # D   W?     NPrSg  . IPl  VX    NPrSg/V/J/P NSg/I/J/C NPl   . V/C/P  NSg     . NSg    V/C NSg/V
-> of  the Peace   , be     privileged from Arrest during their Attendance at        the Session
-# V/P D   NPrSg/V . NSg/VX V/J        P    NSg/V  V/P    D     NSg        NSg/I/V/P D   NSg/V
-> of  their respective Houses , and in          going   to and returning from the same ; and
-# V/P D     J          NPl    . V/C NPrSg/V/J/P NSg/V/J P  V/C V         P    D   I/J  . V/C
+> of the Peace   , be     privileged from Arrest during their Attendance at        the Session
+# P  D   NPrSg/V . NSg/VX V/J        P    NSg/V  V/P    D     NSg        NSg/I/V/P D   NSg/V
+> of their respective Houses , and in          going   to and returning from the same ; and
+# P  D     J          NPl    . V/C NPrSg/V/J/P NSg/V/J P  V/C V         P    D   I/J  . V/C
 > for any   Speech or      Debate in          either House   , they shall not   be     questioned in          any
 # C/P I/R/D NSg/V  NPrSg/C NSg/V  NPrSg/V/J/P I/C    NPrSg/V . IPl  VX    NSg/C NSg/VX V          NPrSg/V/J/P I/R/D
 > other   Place .
@@ -310,18 +310,18 @@
 #
 > No      Senator or      Representative shall , during the Time  for which he      was elected ,
 # NPrSg/P NSg     NPrSg/C NSg/J          VX    . V/P    D   NSg/V C/P I/C   NPr/ISg V   NSg/V/J .
-> be     appointed to any   civil Office under   the Authority of  the United States ,
-# NSg/VX W?        P  I/R/D J     NSg/V  NSg/J/P D   NSg       V/P D   W?     NPrSg  .
+> be     appointed to any   civil Office under   the Authority of the United States ,
+# NSg/VX W?        P  I/R/D J     NSg/V  NSg/J/P D   NSg       P  D   W?     NPrSg  .
 > which shall have   been  created , or      the Emoluments whereof shall have   been
 # I/C   VX    NSg/VX NSg/V W?      . NPrSg/C D   NPl        C       VX    NSg/VX NSg/V
 > encreased during such  time  ; and no      Person holding any   Office under   the United
 # ?         V/P    NSg/I NSg/V . V/C NPrSg/P NSg/V  NSg/V   I/R/D NSg/V  NSg/J/P D   W?
-> States , shall be     a   Member of  either House   during his   Continuance in          Office . No
-# NPrSg  . VX    NSg/VX D/P NSg/V  V/P I/C    NPrSg/V V/P    ISg/D NSg         NPrSg/V/J/P NSg/V  . NPrSg/P
-> law   , varying the compensation for the services of  the Senators and
-# NSg/V . NSg/V   D   NSg          C/P D   NPl      V/P D   NPl      V/C
-> Representatives , shall take  effect , until an  election of  Representatives shall
-# NPl             . VX    NSg/V NSg/V  . C/P   D/P NSg      V/P NPl             VX
+> States , shall be     a   Member of either House   during his   Continuance in          Office . No
+# NPrSg  . VX    NSg/VX D/P NSg/V  P  I/C    NPrSg/V V/P    ISg/D NSg         NPrSg/V/J/P NSg/V  . NPrSg/P
+> law   , varying the compensation for the services of the Senators and
+# NSg/V . NSg/V   D   NSg          C/P D   NPl      P  D   NPl      V/C
+> Representatives , shall take  effect , until an  election of Representatives shall
+# NPl             . VX    NSg/V NSg/V  . C/P   D/P NSg      P  NPl             VX
 > have   intervened .
 # NSg/VX W?         .
 >
@@ -331,35 +331,35 @@
 >
 #
 > All       Bills for raising Revenue shall originate in          the House   of
-# NSg/I/J/C NPl   C/P V       NSg     VX    V         NPrSg/V/J/P D   NPrSg/V V/P
+# NSg/I/J/C NPl   C/P V       NSg     VX    V         NPrSg/V/J/P D   NPrSg/V P
 > Representatives ; but     the Senate may      propose or      concur with Amendments as    on
 # NPl             . NSg/C/P D   NPrSg  NPrSg/VX NSg/V   NPrSg/C V      P    NPl        NSg/R J/P
 > other   Bills .
 # NSg/V/J NPl   .
 >
 #
-> Every Bill    which shall have   passed the House   of  Representatives and the Senate ,
-# D     NPrSg/V I/C   VX    NSg/VX W?     D   NPrSg/V V/P NPl             V/C D   NPrSg  .
-> shall , before it        become a   Law   , be     presented to the President of  the United
-# VX    . C/P    NPrSg/ISg V      D/P NSg/V . NSg/VX W?        P  D   NSg/V     V/P D   W?
+> Every Bill    which shall have   passed the House   of Representatives and the Senate ,
+# D     NPrSg/V I/C   VX    NSg/VX W?     D   NPrSg/V P  NPl             V/C D   NPrSg  .
+> shall , before it        become a   Law   , be     presented to the President of the United
+# VX    . C/P    NPrSg/ISg V      D/P NSg/V . NSg/VX W?        P  D   NSg/V     P  D   W?
 > States ; If    he      approve he      shall sign  it        , but     if    not   he      shall return it        , with his
 # NPrSg  . NSg/C NPr/ISg V       NPr/ISg VX    NSg/V NPrSg/ISg . NSg/C/P NSg/C NSg/C NPr/ISg VX    NSg/V  NPrSg/ISg . P    ISg/D
 > Objections to that    House   in          which it        shall have   originated , who     shall enter the
 # NPl        P  N/I/C/D NPrSg/V NPrSg/V/J/P I/C   NPrSg/ISg VX    NSg/VX W?         . NPrSg/I VX    NSg/V D
 > Objections at        large on  their Journal , and proceed to reconsider it        . If    after
 # NPl        NSg/I/V/P NSg/J J/P D     NSg/V/J . V/C V       P  V          NPrSg/ISg . NSg/C J/P
-> such  Reconsideration two thirds of  that    House   shall agree to pass  the Bill    , it
-# NSg/I NSg             NSg NPl    V/P N/I/C/D NPrSg/V VX    V     P  NSg/V D   NPrSg/V . NPrSg/ISg
+> such  Reconsideration two thirds of that    House   shall agree to pass  the Bill    , it
+# NSg/I NSg             NSg NPl    P  N/I/C/D NPrSg/V VX    V     P  NSg/V D   NPrSg/V . NPrSg/ISg
 > shall be     sent  , together with the Objections , to the other   House   , by      which it
 # VX    NSg/VX NSg/V . J        P    D   NPl        . P  D   NSg/V/J NPrSg/V . NSg/J/P I/C   NPrSg/ISg
-> shall likewise be     reconsidered , and if    approved by      two thirds of  that    House   , it
-# VX    W?       NSg/VX W?           . V/C NSg/C V/J      NSg/J/P NSg NPl    V/P N/I/C/D NPrSg/V . NPrSg/ISg
-> shall become a   Law   . But     in          all       such  Cases the Votes of  both Houses shall be
-# VX    V      D/P NSg/V . NSg/C/P NPrSg/V/J/P NSg/I/J/C NSg/I NPl   D   NPl   V/P I/C  NPl    VX    NSg/VX
-> determined by      yeas and Nays , and the Names of  the Persons voting for and
-# V/J        NSg/J/P NPl  V/C NPl  . V/C D   NPl   V/P D   NPl     V      C/P V/C
-> against the Bill    shall be     entered on  the Journal of  each House   respectively . If
-# C/P     D   NPrSg/V VX    NSg/VX W?      J/P D   NSg/V/J V/P D    NPrSg/V J/R          . NSg/C
+> shall likewise be     reconsidered , and if    approved by      two thirds of that    House   , it
+# VX    W?       NSg/VX W?           . V/C NSg/C V/J      NSg/J/P NSg NPl    P  N/I/C/D NPrSg/V . NPrSg/ISg
+> shall become a   Law   . But     in          all       such  Cases the Votes of both Houses shall be
+# VX    V      D/P NSg/V . NSg/C/P NPrSg/V/J/P NSg/I/J/C NSg/I NPl   D   NPl   P  I/C  NPl    VX    NSg/VX
+> determined by      yeas and Nays , and the Names of the Persons voting for and
+# V/J        NSg/J/P NPl  V/C NPl  . V/C D   NPl   P  D   NPl     V      C/P V/C
+> against the Bill    shall be     entered on  the Journal of each House   respectively . If
+# C/P     D   NPrSg/V VX    NSg/VX W?      J/P D   NSg/V/J P  D    NPrSg/V J/R          . NSg/C
 > any   Bill    shall not   be     returned by      the President within ten Days ( Sundays
 # I/R/D NPrSg/V VX    NSg/C NSg/VX W?       NSg/J/P D   NSg/V     N/J/P  NSg NPl  . NPl
 > excepted ) after it        shall have   been  presented to him , the Same shall be     a   Law   ,
@@ -370,18 +370,18 @@
 # V       ISg/D NSg/V  . NPrSg/V/J/P I/C   NPrSg/V NPrSg/ISg VX    NSg/C NSg/VX D/P NSg/V .
 >
 #
-> Every Order , Resolution , or      Vote  to which the Concurrence of  the Senate and
-# D     NSg/V . W?         . NPrSg/C NSg/V P  I/C   D   NSg         V/P D   NPrSg  V/C
-> House   of  Representatives may      be     necessary ( except on  a   question of  Adjournment )
-# NPrSg/V V/P NPl             NPrSg/VX NSg/VX NSg/J     . V/C/P  J/P D/P NSg/V    V/P NSg         .
-> shall be     presented to the President of  the United States ; and before the Same
-# VX    NSg/VX W?        P  D   NSg/V     V/P D   W?     NPrSg  . V/C C/P    D   I/J
+> Every Order , Resolution , or      Vote  to which the Concurrence of the Senate and
+# D     NSg/V . W?         . NPrSg/C NSg/V P  I/C   D   NSg         P  D   NPrSg  V/C
+> House   of Representatives may      be     necessary ( except on  a   question of Adjournment )
+# NPrSg/V P  NPl             NPrSg/VX NSg/VX NSg/J     . V/C/P  J/P D/P NSg/V    P  NSg         .
+> shall be     presented to the President of the United States ; and before the Same
+# VX    NSg/VX W?        P  D   NSg/V     P  D   W?     NPrSg  . V/C C/P    D   I/J
 > shall take  Effect , shall be     approved by      him , or      being   disapproved by      him , shall
 # VX    NSg/V NSg/V  . VX    NSg/VX V/J      NSg/J/P I   . NPrSg/C NSg/V/C W?          NSg/J/P I   . VX
-> be     repassed by      two thirds of  the Senate and House   of  Representatives , according
-# NSg/VX ?        NSg/J/P NSg NPl    V/P D   NPrSg  V/C NPrSg/V V/P NPl             . V/J
-> to the Rules and Limitations prescribed in          the Case    of  a   Bill    .
-# P  D   NPl   V/C NSg         W?         NPrSg/V/J/P D   NPrSg/V V/P D/P NPrSg/V .
+> be     repassed by      two thirds of the Senate and House   of Representatives , according
+# NSg/VX ?        NSg/J/P NSg NPl    P  D   NPrSg  V/C NPrSg/V P  NPl             . V/J
+> to the Rules and Limitations prescribed in          the Case    of a   Bill    .
+# P  D   NPl   V/C NSg         W?         NPrSg/V/J/P D   NPrSg/V P  D/P NPrSg/V .
 >
 #
 > Section . 8 .
@@ -392,8 +392,8 @@
 # D   NPrSg/V  VX    NSg/VX NSg/V/J P  NSg/V/J V/C NSg/V/J NPl   . NPl    .
 > Imposts and Excises , to pay     the Debts and provide for the common  Defence and
 # NPl     V/C NPl     . P  NSg/V/J D   NPl   V/C V       C/P D   NSg/V/J ?       V/C
-> general Welfare of  the United States ; but     all       Duties , Imposts and Excises shall
-# NSg/V/J NSg/V   V/P D   W?     NPrSg  . NSg/C/P NSg/I/J/C NPl    . NPl     V/C NPl     VX
+> general Welfare of the United States ; but     all       Duties , Imposts and Excises shall
+# NSg/V/J NSg/V   P  D   W?     NPrSg  . NSg/C/P NSg/I/J/C NPl    . NPl     V/C NPl     VX
 > be     uniform throughout the United States ;
 # NSg/VX NSg/V/J P          D   W?     NPrSg  .
 >
@@ -402,8 +402,8 @@
 #
 >
 #
-> To borrow Money on  the credit of  the United States ;
-# P  NSg/V  NSg/J J/P D   NSg/V  V/P D   W?     NPrSg  .
+> To borrow Money on  the credit of the United States ;
+# P  NSg/V  NSg/J J/P D   NSg/V  P  D   W?     NPrSg  .
 >
 #
 >
@@ -420,30 +420,30 @@
 #
 >
 #
-> To establish an  uniform Rule  of  Naturalization , and uniform Laws on  the subject
-# P  V         D/P NSg/V/J NSg/V V/P NSg            . V/C NSg/V/J NPl  J/P D   NSg/V/J
-> of  Bankruptcies throughout the United States ;
-# V/P NPl          P          D   W?     NPrSg  .
+> To establish an  uniform Rule  of Naturalization , and uniform Laws on  the subject
+# P  V         D/P NSg/V/J NSg/V P  NSg            . V/C NSg/V/J NPl  J/P D   NSg/V/J
+> of Bankruptcies throughout the United States ;
+# P  NPl          P          D   W?     NPrSg  .
 >
 #
 >
 #
 >
 #
-> To coin  Money , regulate the Value thereof , and of  foreign Coin  , and fix   the
-# P  NSg/V NSg/J . V        D   NSg/V W?      . V/C V/P NSg/J   NSg/V . V/C NSg/V D
-> Standard of  Weights and Measures ;
-# NSg/J    V/P NPl     V/C NPl      .
+> To coin  Money , regulate the Value thereof , and of foreign Coin  , and fix   the
+# P  NSg/V NSg/J . V        D   NSg/V W?      . V/C P  NSg/J   NSg/V . V/C NSg/V D
+> Standard of Weights and Measures ;
+# NSg/J    P  NPl     V/C NPl      .
 >
 #
 >
 #
 >
 #
-> To provide for the Punishment of  counterfeiting the Securities and current Coin
-# P  V       C/P D   NSg        V/P V              D   NPl        V/C NSg/J   NSg/V
-> of  the United States ;
-# V/P D   W?     NPrSg  .
+> To provide for the Punishment of counterfeiting the Securities and current Coin
+# P  V       C/P D   NSg        P  V              D   NPl        V/C NSg/J   NSg/V
+> of the United States ;
+# P  D   W?     NPrSg  .
 >
 #
 >
@@ -458,8 +458,8 @@
 #
 >
 #
-> To promote the Progress of  Science and useful Arts , by      securing for limited
-# P  NSg/V   D   NSg/V    V/P NSg/V   V/C J      NPl  . NSg/J/P V        C/P NSg/V/J
+> To promote the Progress of Science and useful Arts , by      securing for limited
+# P  NSg/V   D   NSg/V    P  NSg/V   V/C J      NPl  . NSg/J/P V        C/P NSg/V/J
 > Times to Authors and Inventors the exclusive Right     to their respective Writings
 # NPl   P  NPl     V/C NPl       D   NSg/J     NPrSg/V/J P  D     J          W?
 > and Discoveries ;
@@ -480,16 +480,16 @@
 #
 > To define  and punish Piracies and Felonies committed on  the high    Seas , and
 # P  NSg/V/J V/C V      ?        V/C NPl      V/J       J/P D   NSg/V/J NPl  . V/C
-> Offences against the Law   of  Nations ;
-# NPl      C/P     D   NSg/V V/P NPl     .
+> Offences against the Law   of Nations ;
+# NPl      C/P     D   NSg/V P  NPl     .
 >
 #
 >
 #
 >
 #
-> To declare War   , grant   Letters of  Marque and Reprisal , and make  Rules concerning
-# P  V       NSg/V . NPrSg/V NPl     V/P NSg    V/C NSg      . V/C NSg/V NPl   NSg/V/J/P
+> To declare War   , grant   Letters of Marque and Reprisal , and make  Rules concerning
+# P  V       NSg/V . NPrSg/V NPl     P  NSg    V/C NSg      . V/C NSg/V NPl   NSg/V/J/P
 > Captures on  Land    and Water ;
 # NPl      J/P NPrSg/V V/C NSg/V .
 >
@@ -498,8 +498,8 @@
 #
 >
 #
-> To raise and support Armies , but     no      Appropriation of  Money to that    Use   shall be
-# P  NSg/V V/C NSg/V   NPl    . NSg/C/P NPrSg/P NSg           V/P NSg/J P  N/I/C/D NSg/V VX    NSg/VX
+> To raise and support Armies , but     no      Appropriation of Money to that    Use   shall be
+# P  NSg/V V/C NSg/V   NPl    . NSg/C/P NPrSg/P NSg           P  NSg/J P  N/I/C/D NSg/V VX    NSg/VX
 > for a   longer Term    than two Years ;
 # C/P D/P NSg/J  NSg/V/J C/P  NSg NPl   .
 >
@@ -516,16 +516,16 @@
 #
 >
 #
-> To make  Rules for the Government and Regulation of  the land    and naval Forces ;
-# P  NSg/V NPl   C/P D   NSg        V/C NSg/J      V/P D   NPrSg/V V/C J     NPl    .
+> To make  Rules for the Government and Regulation of the land    and naval Forces ;
+# P  NSg/V NPl   C/P D   NSg        V/C NSg/J      P  D   NPrSg/V V/C J     NPl    .
 >
 #
 >
 #
 >
 #
-> To provide for calling forth the Militia to execute the Laws of  the Union     ,
-# P  V       C/P NSg/V   W?    D   NSg     P  V       D   NPl  V/P D   NPrSg/V/J .
+> To provide for calling forth the Militia to execute the Laws of the Union     ,
+# P  V       C/P NSg/V   W?    D   NSg     P  V       D   NPl  P  D   NPrSg/V/J .
 > suppress Insurrections and repel Invasions ;
 # V        NPl           V/C V     NPl       .
 >
@@ -536,12 +536,12 @@
 #
 > To provide for organizing , arming , and disciplining , the Militia , and for
 # P  V       C/P V          . V      . V/C V            . D   NSg     . V/C C/P
-> governing such  Part    of  them as    may      be     employed in          the Service of  the United
-# V         NSg/I NSg/V/J V/P N/I  NSg/R NPrSg/VX NSg/VX W?       NPrSg/V/J/P D   NSg/V   V/P D   W?
-> States , reserving to the States respectively , the Appointment of  the Officers ,
-# NPrSg  . V         P  D   NPrSg  J/R          . D   NSg         V/P D   W?       .
-> and the Authority of  training the Militia according to the discipline
-# V/C D   NSg       V/P NSg/V    D   NSg     V/J       P  D   NSg/V
+> governing such  Part    of them as    may      be     employed in          the Service of the United
+# V         NSg/I NSg/V/J P  N/I  NSg/R NPrSg/VX NSg/VX W?       NPrSg/V/J/P D   NSg/V   P  D   W?
+> States , reserving to the States respectively , the Appointment of the Officers ,
+# NPrSg  . V         P  D   NPrSg  J/R          . D   NSg         P  D   W?       .
+> and the Authority of training the Militia according to the discipline
+# V/C D   NSg       P  NSg/V    D   NSg     V/J       P  D   NSg/V
 > prescribed by      Congress ;
 # W?         NSg/J/P NPrSg/V  .
 >
@@ -552,14 +552,14 @@
 #
 > To exercise exclusive Legislation in          all       Cases whatsoever , over      such  District
 # P  NSg/V    NSg/J     NSg         NPrSg/V/J/P NSg/I/J/C NPl   I          . NSg/V/J/P NSg/I NSg/V/J
-> ( not   exceeding ten Miles square  ) as    may      , by      Cession of  particular States , and
-# . NSg/C NSg/V/J   NSg NPrPl NSg/V/J . NSg/R NPrSg/VX . NSg/J/P NSg     V/P NSg/J      NPrSg  . V/C
-> the Acceptance of  Congress , become the Seat  of  the Government of  the United
-# D   NSg        V/P NPrSg/V  . V      D   NSg/V V/P D   NSg        V/P D   W?
+> ( not   exceeding ten Miles square  ) as    may      , by      Cession of particular States , and
+# . NSg/C NSg/V/J   NSg NPrPl NSg/V/J . NSg/R NPrSg/VX . NSg/J/P NSg     P  NSg/J      NPrSg  . V/C
+> the Acceptance of Congress , become the Seat  of the Government of the United
+# D   NSg        P  NPrSg/V  . V      D   NSg/V P  D   NSg        P  D   W?
 > States , and to exercise like        Authority over      all       Places purchased by      the Consent
 # NPrSg  . V/C P  NSg/V    NSg/V/J/C/P NSg       NSg/V/J/P NSg/I/J/C NPl    W?        NSg/J/P D   NSg/V
-> of  the Legislature of  the State in          which the Same shall be     , for the Erection of
-# V/P D   NSg         V/P D   NSg/V NPrSg/V/J/P I/C   D   I/J  VX    NSg/VX . C/P D   NSg      V/P
+> of the Legislature of the State in          which the Same shall be     , for the Erection of
+# P  D   NSg         P  D   NSg/V NPrSg/V/J/P I/C   D   I/J  VX    NSg/VX . C/P D   NSg      P
 > Forts , Magazines , Arsenals , dock  - Yards , and other   needful Buildings ; — And
 # NPl   . NPl       . NPl      . NSg/V . NPl   . V/C NSg/V/J NSg/J   W?        . . V/C
 >
@@ -572,8 +572,8 @@
 # P  NSg/V NSg/I/J/C NPl  I/C   VX    NSg/VX NSg/J     V/C NSg/J  C/P V        P
 > Execution the foregoing Powers , and all       other   Powers vested by      this
 # NSg       D   V         NPrSg  . V/C NSg/I/J/C NSg/V/J NPrSg  W?     NSg/J/P I/D
-> Constitution in          the Government of  the United States , or      in          any   Department or
-# NPrSg        NPrSg/V/J/P D   NSg        V/P D   W?     NPrSg  . NPrSg/C NPrSg/V/J/P I/R/D NSg        NPrSg/C
+> Constitution in          the Government of the United States , or      in          any   Department or
+# NPrSg        NPrSg/V/J/P D   NSg        P  D   W?     NPrSg  . NPrSg/C NPrSg/V/J/P I/R/D NSg        NPrSg/C
 > Officer thereof .
 # NSg/V/J W?      .
 >
@@ -586,8 +586,8 @@
 # NSg/V   . # .
 >
 #
-> The Migration or      Importation of  such  Persons as    any   of  the
-# D   NSg       NPrSg/C NSg         V/P NSg/I NPl     NSg/R I/R/D V/P D
+> The Migration or      Importation of such  Persons as    any   of the
+# D   NSg       NPrSg/C NSg         P  NSg/I NPl     NSg/R I/R/D P  D
 > States now         existing shall think proper to admit , shall not   be     prohibited by      the
 # NPrSg  NPrSg/V/J/C V        VX    NSg/V NSg/J  P  V     . VX    NSg/C NSg/VX W?         NSg/J/P D
 > Congress prior to the Year one       thousand eight hundred and eight , but     a   Tax   or
@@ -598,14 +598,14 @@
 # NSg/V  .
 >
 #
-> The Privilege of  the Writ  of  Habeas Corpus shall not   be     suspended , unless when
-# D   NSg/V     V/P D   NSg/V V/P ?      NSg    VX    NSg/C NSg/VX W?        . C      NSg/I/C
-> in          Cases of  Rebellion or      Invasion the public  Safety may      require it        .
-# NPrSg/V/J/P NPl   V/P NSg       NPrSg/C NSg      D   NSg/V/J NSg/V  NPrSg/VX NSg/V   NPrSg/ISg .
+> The Privilege of the Writ  of Habeas Corpus shall not   be     suspended , unless when
+# D   NSg/V     P  D   NSg/V P  ?      NSg    VX    NSg/C NSg/VX W?        . C      NSg/I/C
+> in          Cases of Rebellion or      Invasion the public  Safety may      require it        .
+# NPrSg/V/J/P NPl   P  NSg       NPrSg/C NSg      D   NSg/V/J NSg/V  NPrSg/VX NSg/V   NPrSg/ISg .
 >
 #
-> No      Bill    of  Attainder or      ex      post      facto Law   shall be     passed .
-# NPrSg/P NPrSg/V V/P NSg       NPrSg/C NSg/V/J NPrSg/V/P ?     NSg/V VX    NSg/VX W?     .
+> No      Bill    of Attainder or      ex      post      facto Law   shall be     passed .
+# NPrSg/P NPrSg/V P  NSg       NPrSg/C NSg/V/J NPrSg/V/P ?     NSg/V VX    NSg/VX W?     .
 >
 #
 > No      Capitation , or      other   direct , Tax   shall be     laid , unless in          Proportion to the
@@ -624,40 +624,40 @@
 # NPrSg/P NSg/V NPrSg/C NSg  VX    NSg/VX V/J  J/P NPl      W?       P    I/R/D NSg/V .
 >
 #
-> No      Preference shall be     given     by      any   Regulation of  Commerce or      Revenue to the
-# NPrSg/P NSg/V      VX    NSg/VX NSg/V/J/P NSg/J/P I/R/D NSg/J      V/P NSg/V    NPrSg/C NSg     P  D
-> Ports of  one       State over      those of  another : nor   shall Vessels bound   to , or      from ,
-# NPl   V/P NSg/I/V/J NSg/V NSg/V/J/P I/D   V/P I/D     . NSg/C VX    NPl     NSg/V/J P  . NPrSg/C P    .
+> No      Preference shall be     given     by      any   Regulation of Commerce or      Revenue to the
+# NPrSg/P NSg/V      VX    NSg/VX NSg/V/J/P NSg/J/P I/R/D NSg/J      P  NSg/V    NPrSg/C NSg     P  D
+> Ports of one       State over      those of another : nor   shall Vessels bound   to , or      from ,
+# NPl   P  NSg/I/V/J NSg/V NSg/V/J/P I/D   P  I/D     . NSg/C VX    NPl     NSg/V/J P  . NPrSg/C P    .
 > one       State , be     obliged to enter , clear   , or      pay     Duties in          another .
 # NSg/I/V/J NSg/V . NSg/VX W?      P  NSg/V . NSg/V/J . NPrSg/C NSg/V/J NPl    NPrSg/V/J/P I/D     .
 >
 #
-> No      Money shall be     drawn from the Treasury , but     in          Consequence of  Appropriations
-# NPrSg/P NSg/J VX    NSg/VX V/J   P    D   NPrSg    . NSg/C/P NPrSg/V/J/P NSg/V       V/P W?
-> made  by      Law   ; and a   regular Statement and Account of  the Receipts and
-# NSg/V NSg/J/P NSg/V . V/C D/P NSg/J   NSg/V/J   V/C NSg/V   V/P D   NPl      V/C
-> Expenditures of  all       public  Money shall be     published from time  to time  .
-# NPl          V/P NSg/I/J/C NSg/V/J NSg/J VX    NSg/VX V/J       P    NSg/V P  NSg/V .
+> No      Money shall be     drawn from the Treasury , but     in          Consequence of Appropriations
+# NPrSg/P NSg/J VX    NSg/VX V/J   P    D   NPrSg    . NSg/C/P NPrSg/V/J/P NSg/V       P  W?
+> made  by      Law   ; and a   regular Statement and Account of the Receipts and
+# NSg/V NSg/J/P NSg/V . V/C D/P NSg/J   NSg/V/J   V/C NSg/V   P  D   NPl      V/C
+> Expenditures of all       public  Money shall be     published from time  to time  .
+# NPl          P  NSg/I/J/C NSg/V/J NSg/J VX    NSg/VX V/J       P    NSg/V P  NSg/V .
 >
 #
-> No      Title of  Nobility shall be     granted by      the United States : And no      Person
-# NPrSg/P NSg/V V/P NSg      VX    NSg/VX W?      NSg/J/P D   W?     NPrSg  . V/C NPrSg/P NSg/V
-> holding any   Office of  Profit  or      Trust   under   them , shall , without the Consent of
-# NSg/V   I/R/D NSg/V  V/P NSg/V/J NPrSg/C NSg/V/J NSg/J/P N/I  . VX    . C/P     D   NSg/V   V/P
-> the Congress , accept  of  any   present , Emolument , Office , or      Title , of  any   kind
-# D   NPrSg/V  . NSg/V/J V/P I/R/D NSg/V/J . NSg       . NSg/V  . NPrSg/C NSg/V . V/P I/R/D NSg/J
+> No      Title of Nobility shall be     granted by      the United States : And no      Person
+# NPrSg/P NSg/V P  NSg      VX    NSg/VX W?      NSg/J/P D   W?     NPrSg  . V/C NPrSg/P NSg/V
+> holding any   Office of Profit  or      Trust   under   them , shall , without the Consent of
+# NSg/V   I/R/D NSg/V  P  NSg/V/J NPrSg/C NSg/V/J NSg/J/P N/I  . VX    . C/P     D   NSg/V   P
+> the Congress , accept  of any   present , Emolument , Office , or      Title , of any   kind
+# D   NPrSg/V  . NSg/V/J P  I/R/D NSg/V/J . NSg       . NSg/V  . NPrSg/C NSg/V . P  I/R/D NSg/J
 > whatever , from any   King    , Prince  , or      foreign State .
 # NSg/I/J  . P    I/R/D NPrSg/V . NPrSg/V . NPrSg/C NSg/J   NSg/V .
 >
 #
-> The right     of  citizens of  the United States to vote  in          any   primary or      other
-# D   NPrSg/V/J V/P NPl      V/P D   W?     NPrSg  P  NSg/V NPrSg/V/J/P I/R/D NSg/V/J NPrSg/C NSg/V/J
+> The right     of citizens of the United States to vote  in          any   primary or      other
+# D   NPrSg/V/J P  NPl      P  D   W?     NPrSg  P  NSg/V NPrSg/V/J/P I/R/D NSg/V/J NPrSg/C NSg/V/J
 > election for President or      Vice      President , for electors for President or      Vice
 # NSg      C/P NSg/V     NPrSg/C NSg/V/J/P NSg/V     . C/P NPl      C/P NSg/V     NPrSg/C NSg/V/J/P
 > President , or      for Senator or      Representative in          Congress , shall not   be     denied or
 # NSg/V     . NPrSg/C C/P NSg     NPrSg/C NSg/J          NPrSg/V/J/P NPrSg/V  . VX    NSg/C NSg/VX W?     NPrSg/C
-> abridged by      the United States or      any   State by      reason of  failure to pay     any   poll
-# W?       NSg/J/P D   W?     NPrSg  NPrSg/C I/R/D NSg/V NSg/J/P NSg/V  V/P NSg     P  NSg/V/J I/R/D NSg/V/J
+> abridged by      the United States or      any   State by      reason of failure to pay     any   poll
+# W?       NSg/J/P D   W?     NPrSg  NPrSg/C I/R/D NSg/V NSg/J/P NSg/V  P  NSg     P  NSg/V/J I/R/D NSg/V/J
 > tax   or      other   tax   .
 # NSg/V NPrSg/C NSg/V/J NSg/V .
 >
@@ -668,38 +668,38 @@
 #
 > No      State shall enter into any   Treaty , Alliance , or
 # NPrSg/P NSg/V VX    NSg/V P    I/R/D NSg/V  . NSg/V    . NPrSg/C
-> Confederation ; grant   Letters of  Marque and Reprisal ; coin  Money ; emit Bills of
-# NSg/J         . NPrSg/V NPl     V/P NSg    V/C NSg      . NSg/V NSg/J . V    NPl   V/P
-> Credit ; make  any   Thing but     gold    and silver  Coin  a   Tender  in          Payment of  Debts ;
-# NSg/V  . NSg/V I/R/D NSg/V NSg/C/P NSg/V/J V/C NSg/V/J NSg/V D/P NSg/V/J NPrSg/V/J/P NSg     V/P NPl   .
-> pass  any   Bill    of  Attainder , ex      post      facto Law   , or      Law   impairing the Obligation
-# NSg/V I/R/D NPrSg/V V/P NSg       . NSg/V/J NPrSg/V/P ?     NSg/V . NPrSg/C NSg/V V         D   NSg
-> of  Contracts , or      grant   any   Title of  Nobility .
-# V/P NPl       . NPrSg/C NPrSg/V I/R/D NSg/V V/P NSg      .
+> Confederation ; grant   Letters of Marque and Reprisal ; coin  Money ; emit Bills of
+# NSg/J         . NPrSg/V NPl     P  NSg    V/C NSg      . NSg/V NSg/J . V    NPl   P
+> Credit ; make  any   Thing but     gold    and silver  Coin  a   Tender  in          Payment of Debts ;
+# NSg/V  . NSg/V I/R/D NSg/V NSg/C/P NSg/V/J V/C NSg/V/J NSg/V D/P NSg/V/J NPrSg/V/J/P NSg     P  NPl   .
+> pass  any   Bill    of Attainder , ex      post      facto Law   , or      Law   impairing the Obligation
+# NSg/V I/R/D NPrSg/V P  NSg       . NSg/V/J NPrSg/V/P ?     NSg/V . NPrSg/C NSg/V V         D   NSg
+> of Contracts , or      grant   any   Title of Nobility .
+# P  NPl       . NPrSg/C NPrSg/V I/R/D NSg/V P  NSg      .
 >
 #
-> No      State shall , without the Consent of  the Congress , lay     any   Imposts or      Duties
-# NPrSg/P NSg/V VX    . C/P     D   NSg/V   V/P D   NPrSg/V  . NSg/V/J I/R/D NPl     NPrSg/C NPl
+> No      State shall , without the Consent of the Congress , lay     any   Imposts or      Duties
+# NPrSg/P NSg/V VX    . C/P     D   NSg/V   P  D   NPrSg/V  . NSg/V/J I/R/D NPl     NPrSg/C NPl
 > on  Imports or      Exports , except what  may      be     absolutely necessary for executing
 # J/P NPl     NPrSg/C NPl     . V/C/P  NSg/I NPrSg/VX NSg/VX J/R        NSg/J     C/P V
-> it's inspection Laws : and the net     Produce of  all       Duties and Imposts , laid by
-# W?   NSg        NPl  . V/C D   NSg/V/J NSg/V   V/P NSg/I/J/C NPl    V/C NPl     . V/J  NSg/J/P
-> any   State on  Imports or      Exports , shall be     for the Use   of  the Treasury of  the
-# I/R/D NSg/V J/P NPl     NPrSg/C NPl     . VX    NSg/VX C/P D   NSg/V V/P D   NPrSg    V/P D
+> it's inspection Laws : and the net     Produce of all       Duties and Imposts , laid by
+# W?   NSg        NPl  . V/C D   NSg/V/J NSg/V   P  NSg/I/J/C NPl    V/C NPl     . V/J  NSg/J/P
+> any   State on  Imports or      Exports , shall be     for the Use   of the Treasury of the
+# I/R/D NSg/V J/P NPl     NPrSg/C NPl     . VX    NSg/VX C/P D   NSg/V P  D   NPrSg    P  D
 > United States ; and all       such  Laws shall be     subject to the Revision and Controul
 # W?     NPrSg  . V/C NSg/I/J/C NSg/I NPl  VX    NSg/VX NSg/V/J P  D   NSg/V    V/C ?
-> of  the Congress .
-# V/P D   NPrSg/V  .
+> of the Congress .
+# P  D   NPrSg/V  .
 >
 #
-> No      State shall , without the Consent of  Congress , lay     any   Duty of  Tonnage , keep
-# NPrSg/P NSg/V VX    . C/P     D   NSg/V   V/P NPrSg/V  . NSg/V/J I/R/D NSg  V/P NSg     . NSg/V
-> Troops , or      Ships of  War   in          time  of  Peace   , enter into any   Agreement or      Compact
-# NPl    . NPrSg/C NPl   V/P NSg/V NPrSg/V/J/P NSg/V V/P NPrSg/V . NSg/V P    I/R/D NSg       NPrSg/C NSg/V/J
+> No      State shall , without the Consent of Congress , lay     any   Duty of Tonnage , keep
+# NPrSg/P NSg/V VX    . C/P     D   NSg/V   P  NPrSg/V  . NSg/V/J I/R/D NSg  P  NSg     . NSg/V
+> Troops , or      Ships of War   in          time  of Peace   , enter into any   Agreement or      Compact
+# NPl    . NPrSg/C NPl   P  NSg/V NPrSg/V/J/P NSg/V P  NPrSg/V . NSg/V P    I/R/D NSg       NPrSg/C NSg/V/J
 > with another State , or      with a   foreign Power   , or      engage in          War   , unless actually
 # P    I/D     NSg/V . NPrSg/C P    D/P NSg/J   NSg/V/J . NPrSg/C V      NPrSg/V/J/P NSg/V . C      J/R
-> invaded , or      in          such  imminent Danger  as    will     not   admit of  delay   .
-# W?      . NPrSg/C NPrSg/V/J/P NSg/I J        NSg/V/J NSg/R NPrSg/VX NSg/C V     V/P NSg/V/J .
+> invaded , or      in          such  imminent Danger  as    will     not   admit of delay   .
+# W?      . NPrSg/C NPrSg/V/J/P NSg/I J        NSg/V/J NSg/R NPrSg/VX NSg/C V     P  NSg/V/J .
 >
 #
 > Article . II .
@@ -710,24 +710,24 @@
 # NSg/V   . # .
 >
 #
-> The executive Power   shall be     vested in          a   President of  the
-# D   NSg/J     NSg/V/J VX    NSg/VX W?     NPrSg/V/J/P D/P NSg/V     V/P D
-> United States of  America . He      shall hold    his   Office during the Term    of  four
-# W?     NPrSg  V/P NPr     . NPr/ISg VX    NSg/V/J ISg/D NSg/V  V/P    D   NSg/V/J V/P NSg
-> Years ending at        noon  on  the 20th day   of  January , and , together with the Vice
-# NPl   NSg/V  NSg/I/V/P NSg/V J/P D   #    NPrSg V/P NPr     . V/C . J        P    D   NSg/V/J/P
+> The executive Power   shall be     vested in          a   President of the
+# D   NSg/J     NSg/V/J VX    NSg/VX W?     NPrSg/V/J/P D/P NSg/V     P  D
+> United States of America . He      shall hold    his   Office during the Term    of four
+# W?     NPrSg  P  NPr     . NPr/ISg VX    NSg/V/J ISg/D NSg/V  V/P    D   NSg/V/J P  NSg
+> Years ending at        noon  on  the 20th day   of January , and , together with the Vice
+# NPl   NSg/V  NSg/I/V/P NSg/V J/P D   #    NPrSg P  NPr     . V/C . J        P    D   NSg/V/J/P
 > President , chosen for the same Term    , be     elected , as    follows
 # NSg/V     . V/J    C/P D   I/J  NSg/V/J . NSg/VX NSg/V/J . NSg/R NPl
 >
 #
 > Each State shall appoint , in          such  Manner as    the Legislature thereof may      direct ,
 # D    NSg/V VX    V       . NPrSg/V/J/P NSg/I NSg    NSg/R D   NSg         W?      NPrSg/VX V/J    .
-> a   Number  of  Electors , equal   to the whole Number  of  Senators and Representatives
-# D/P NSg/V/J V/P NPl      . NSg/V/J P  D   NSg/J NSg/V/J V/P NPl      V/C NPl
+> a   Number  of Electors , equal   to the whole Number  of Senators and Representatives
+# D/P NSg/V/J P  NPl      . NSg/V/J P  D   NSg/J NSg/V/J P  NPl      V/C NPl
 > to which the State may      be     entitled in          the Congress : but     no      Senator or
 # P  I/C   D   NSg/V NPrSg/VX NSg/VX W?       NPrSg/V/J/P D   NPrSg/V  . NSg/C/P NPrSg/P NSg     NPrSg/C
-> Representative , or      Person holding an  Office of  Trust   or      Profit  under   the United
-# NSg/J          . NPrSg/C NSg/V  NSg/V   D/P NSg/V  V/P NSg/V/J NPrSg/C NSg/V/J NSg/J/P D   W?
+> Representative , or      Person holding an  Office of Trust   or      Profit  under   the United
+# NSg/J          . NPrSg/C NSg/V  NSg/V   D/P NSg/V  P  NSg/V/J NPrSg/C NSg/V/J NSg/J/P D   W?
 > States , shall be     appointed an  Elector .
 # NPrSg  . VX    NSg/VX W?        D/P NSg     .
 >
@@ -738,48 +738,48 @@
 #
 > The Electors shall meet    in          their respective states , and vote
 # D   NPl      VX    NSg/V/J NPrSg/V/J/P D     J          NPrSg  . V/C NSg/V
-> by      ballot for President and Vice      - President , one       of  whom , at        least , shall not   be
-# NSg/J/P NSg/V  C/P NSg/V     V/C NSg/V/J/P . NSg/V     . NSg/I/V/J V/P I    . NSg/I/V/P NSg/J . VX    NSg/C NSg/VX
-> an  inhabitant of  the same state with themselves ; they shall name  in          their
-# D/P NSg/J      V/P D   I/J  NSg/V P    I          . IPl  VX    NSg/V NPrSg/V/J/P D
+> by      ballot for President and Vice      - President , one       of whom , at        least , shall not   be
+# NSg/J/P NSg/V  C/P NSg/V     V/C NSg/V/J/P . NSg/V     . NSg/I/V/J P  I    . NSg/I/V/P NSg/J . VX    NSg/C NSg/VX
+> an  inhabitant of the same state with themselves ; they shall name  in          their
+# D/P NSg/J      P  D   I/J  NSg/V P    I          . IPl  VX    NSg/V NPrSg/V/J/P D
 > ballots the person voted for as    President , and in          distinct ballots the person
 # NPl     D   NSg/V  W?    C/P NSg/R NSg/V     . V/C NPrSg/V/J/P V/J      NPl     D   NSg/V
-> voted for as    Vice      - President , and they shall make  distinct lists of  all       persons
-# W?    C/P NSg/R NSg/V/J/P . NSg/V     . V/C IPl  VX    NSg/V V/J      NPl   V/P NSg/I/J/C NPl
-> voted for as    President , and all       persons voted for as    Vice      - President and of  the
-# W?    C/P NSg/R NSg/V     . V/C NSg/I/J/C NPl     W?    C/P NSg/R NSg/V/J/P . NSg/V     V/C V/P D
-> number  of  votes for each , which lists they shall sign  and certify , and transmit
-# NSg/V/J V/P NPl   C/P D    . I/C   NPl   IPl  VX    NSg/V V/C V       . V/C V
-> sealed to the seat  of  the government of  the United States , directed to the
-# W?     P  D   NSg/V V/P D   NSg        V/P D   W?     NPrSg  . W?       P  D
-> President of  the Senate ; — The President of  the Senate shall , in          the presence of
-# NSg/V     V/P D   NPrSg  . . D   NSg/V     V/P D   NPrSg  VX    . NPrSg/V/J/P D   NSg/V    V/P
-> the Senate and House   of  Representatives , open    all       the certificates and the
-# D   NPrSg  V/C NPrSg/V V/P NPl             . NSg/V/J NSg/I/J/C D   NPl          V/C D
-> votes shall then    be     counted ; — The person having the greatest Number  of  votes for
-# NPl   VX    NSg/J/C NSg/VX V       . . D   NSg/V  V      D   W?       NSg/V/J V/P NPl   C/P
-> President , shall be     the President , if    such  number  be     a   majority of  the whole
-# NSg/V     . VX    NSg/VX D   NSg/V     . NSg/C NSg/I NSg/V/J NSg/VX D/P NSg      V/P D   NSg/J
-> number  of  Electors appointed ; and if    no      person have   such  majority , then    from
-# NSg/V/J V/P NPl      W?        . V/C NSg/C NPrSg/P NSg/V  NSg/VX NSg/I NSg      . NSg/J/C P
-> the persons having the highest numbers not   exceeding three on  the list  of  those
-# D   NPl     V      D   W?      NPrPl   NSg/C NSg/V/J   NSg   J/P D   NSg/V V/P I/D
-> voted for as    President , the House   of  Representatives shall choose  immediately ,
-# W?    C/P NSg/R NSg/V     . D   NPrSg/V V/P NPl             VX    NSg/V/C J/R         .
+> voted for as    Vice      - President , and they shall make  distinct lists of all       persons
+# W?    C/P NSg/R NSg/V/J/P . NSg/V     . V/C IPl  VX    NSg/V V/J      NPl   P  NSg/I/J/C NPl
+> voted for as    President , and all       persons voted for as    Vice      - President and of the
+# W?    C/P NSg/R NSg/V     . V/C NSg/I/J/C NPl     W?    C/P NSg/R NSg/V/J/P . NSg/V     V/C P  D
+> number  of votes for each , which lists they shall sign  and certify , and transmit
+# NSg/V/J P  NPl   C/P D    . I/C   NPl   IPl  VX    NSg/V V/C V       . V/C V
+> sealed to the seat  of the government of the United States , directed to the
+# W?     P  D   NSg/V P  D   NSg        P  D   W?     NPrSg  . W?       P  D
+> President of the Senate ; — The President of the Senate shall , in          the presence of
+# NSg/V     P  D   NPrSg  . . D   NSg/V     P  D   NPrSg  VX    . NPrSg/V/J/P D   NSg/V    P
+> the Senate and House   of Representatives , open    all       the certificates and the
+# D   NPrSg  V/C NPrSg/V P  NPl             . NSg/V/J NSg/I/J/C D   NPl          V/C D
+> votes shall then    be     counted ; — The person having the greatest Number  of votes for
+# NPl   VX    NSg/J/C NSg/VX V       . . D   NSg/V  V      D   W?       NSg/V/J P  NPl   C/P
+> President , shall be     the President , if    such  number  be     a   majority of the whole
+# NSg/V     . VX    NSg/VX D   NSg/V     . NSg/C NSg/I NSg/V/J NSg/VX D/P NSg      P  D   NSg/J
+> number  of Electors appointed ; and if    no      person have   such  majority , then    from
+# NSg/V/J P  NPl      W?        . V/C NSg/C NPrSg/P NSg/V  NSg/VX NSg/I NSg      . NSg/J/C P
+> the persons having the highest numbers not   exceeding three on  the list  of those
+# D   NPl     V      D   W?      NPrPl   NSg/C NSg/V/J   NSg   J/P D   NSg/V P  I/D
+> voted for as    President , the House   of Representatives shall choose  immediately ,
+# W?    C/P NSg/R NSg/V     . D   NPrSg/V P  NPl             VX    NSg/V/C J/R         .
 > by      ballot , the President . But     in          choosing the President , the votes shall be
 # NSg/J/P NSg/V  . D   NSg/V     . NSg/C/P NPrSg/V/J/P V        D   NSg/V     . D   NPl   VX    NSg/VX
 > taken by      states , the representation from each state having one       vote  ; a   quorum
 # V/J   NSg/J/P NPrSg  . D   NSg            P    D    NSg/V V      NSg/I/V/J NSg/V . D/P NSg
-> for this purpose shall consist of  a   member or      members from two - thirds of  the
-# C/P I/D  NSg/V   VX    NSg/V   V/P D/P NSg/V  NPrSg/C NPl     P    NSg . NPl    V/P D
-> states , and a   majority of  all       the states shall be     necessary to a   choice . [ If    ,
-# NPrSg  . V/C D/P NSg      V/P NSg/I/J/C D   NPrSg  VX    NSg/VX NSg/J     P  D/P NSg/J  . . NSg/C .
-> at        the time  fixed for the beginning of  the term    of  the President , the President
-# NSg/I/V/P D   NSg/V V/J   C/P D   NSg/V/J   V/P D   NSg/V/J V/P D   NSg/V     . D   NSg/V
+> for this purpose shall consist of a   member or      members from two - thirds of the
+# C/P I/D  NSg/V   VX    NSg/V   P  D/P NSg/V  NPrSg/C NPl     P    NSg . NPl    P  D
+> states , and a   majority of all       the states shall be     necessary to a   choice . [ If    ,
+# NPrSg  . V/C D/P NSg      P  NSg/I/J/C D   NPrSg  VX    NSg/VX NSg/J     P  D/P NSg/J  . . NSg/C .
+> at        the time  fixed for the beginning of the term    of the President , the President
+# NSg/I/V/P D   NSg/V V/J   C/P D   NSg/V/J   P  D   NSg/V/J P  D   NSg/V     . D   NSg/V
 > elect   shall have   died , the Vice      President elect   shall become President . If    a
 # NSg/V/J VX    NSg/VX W?   . D   NSg/V/J/P NSg/V     NSg/V/J VX    V      NSg/V     . NSg/C D/P
 > President shall not   have   been  chosen before the time  fixed for the beginning of
-# NSg/V     VX    NSg/C NSg/VX NSg/V V/J    C/P    D   NSg/V V/J   C/P D   NSg/V/J   V/P
+# NSg/V     VX    NSg/C NSg/VX NSg/V V/J    C/P    D   NSg/V V/J   C/P D   NSg/V/J   P
 > his   term    , or      if    the President elect   shall have   failed to qualify , then    the Vice
 # ISg/D NSg/V/J . NPrSg/C NSg/C D   NSg/V     NSg/V/J VX    NSg/VX W?     P  NSg/V   . NSg/J/C D   NSg/V/J/P
 > President elect   shall act     as    President until a   President shall have   qualified ;
@@ -792,36 +792,36 @@
 # NPrSg/V NSg/R NSg/V     . NPrSg/C D   NSg    NPrSg/V/J/P I/C   NSg/I/V/J NPrSg/I VL P  NPrSg/V VX    NSg/VX W?       .
 > and such  person shall act     accordingly until a   President or      Vice      President shall
 # V/C NSg/I NSg/V  VX    NPrSg/V J/R         C/P   D/P NSg/V     NPrSg/C NSg/V/J/P NSg/V     VX
-> have   qualified.The Congress may      by      law   provide for the case    of  the death of  any
-# NSg/VX Hostname      NPrSg/V  NPrSg/VX NSg/J/P NSg/V V       C/P D   NPrSg/V V/P D   NPrSg V/P I/R/D
-> of  the persons from whom the House   of  Representatives may      choose  a   President
-# V/P D   NPl     P    I    D   NPrSg/V V/P NPl             NPrSg/VX NSg/V/C D/P NSg/V
-> whenever the right     of  choice shall have   devolved upon them , and for the case    of
-# C        D   NPrSg/V/J V/P NSg/J  VX    NSg/VX W?       P    N/I  . V/C C/P D   NPrSg/V V/P
-> the death of  any   of  the persons from whom the Senate may      choose  a   Vice
-# D   NPrSg V/P I/R/D V/P D   NPl     P    I    D   NPrSg  NPrSg/VX NSg/V/C D/P NSg/V/J/P
-> President whenever the right     of  choice shall have   devolved upon them . ] The
-# NSg/V     C        D   NPrSg/V/J V/P NSg/J  VX    NSg/VX W?       P    N/I  . . D
-> person having the greatest number  of  votes as    Vice      - President , shall be     the
-# NSg/V  V      D   W?       NSg/V/J V/P NPl   NSg/R NSg/V/J/P . NSg/V     . VX    NSg/VX D
-> Vice      - President , if    such  number  be     a   majority of  the whole number  of  Electors
-# NSg/V/J/P . NSg/V     . NSg/C NSg/I NSg/V/J NSg/VX D/P NSg      V/P D   NSg/J NSg/V/J V/P NPl
+> have   qualified.The Congress may      by      law   provide for the case    of the death of any
+# NSg/VX Hostname      NPrSg/V  NPrSg/VX NSg/J/P NSg/V V       C/P D   NPrSg/V P  D   NPrSg P  I/R/D
+> of the persons from whom the House   of Representatives may      choose  a   President
+# P  D   NPl     P    I    D   NPrSg/V P  NPl             NPrSg/VX NSg/V/C D/P NSg/V
+> whenever the right     of choice shall have   devolved upon them , and for the case    of
+# C        D   NPrSg/V/J P  NSg/J  VX    NSg/VX W?       P    N/I  . V/C C/P D   NPrSg/V P
+> the death of any   of the persons from whom the Senate may      choose  a   Vice
+# D   NPrSg P  I/R/D P  D   NPl     P    I    D   NPrSg  NPrSg/VX NSg/V/C D/P NSg/V/J/P
+> President whenever the right     of choice shall have   devolved upon them . ] The
+# NSg/V     C        D   NPrSg/V/J P  NSg/J  VX    NSg/VX W?       P    N/I  . . D
+> person having the greatest number  of votes as    Vice      - President , shall be     the
+# NSg/V  V      D   W?       NSg/V/J P  NPl   NSg/R NSg/V/J/P . NSg/V     . VX    NSg/VX D
+> Vice      - President , if    such  number  be     a   majority of the whole number  of Electors
+# NSg/V/J/P . NSg/V     . NSg/C NSg/I NSg/V/J NSg/VX D/P NSg      P  D   NSg/J NSg/V/J P  NPl
 > appointed , and if    no      person have   a   majority , then    from the two highest numbers
 # W?        . V/C NSg/C NPrSg/P NSg/V  NSg/VX D/P NSg      . NSg/J/C P    D   NSg W?      NPrPl
 > on  the list  , the Senate shall choose  the Vice      - President ; a   quorum for the
 # J/P D   NSg/V . D   NPrSg  VX    NSg/V/C D   NSg/V/J/P . NSg/V     . D/P NSg    C/P D
-> purpose shall consist of  two - thirds of  the whole number  of  Senators , and a
-# NSg/V   VX    NSg/V   V/P NSg . NPl    V/P D   NSg/J NSg/V/J V/P NPl      . V/C D/P
-> majority of  the whole number  shall be     necessary to a   choice . But     no      person
-# NSg      V/P D   NSg/J NSg/V/J VX    NSg/VX NSg/J     P  D/P NSg/J  . NSg/C/P NPrSg/P NSg/V
-> constitutionally ineligible to the office of  President shall be     eligible to
-# J/R              NSg/J      P  D   NSg/V  V/P NSg/V     VX    NSg/VX NSg/J    P
-> that    of  Vice      - President of  the United States .
-# N/I/C/D V/P NSg/V/J/P . NSg/V     V/P D   W?     NPrSg  .
+> purpose shall consist of two - thirds of the whole number  of Senators , and a
+# NSg/V   VX    NSg/V   P  NSg . NPl    P  D   NSg/J NSg/V/J P  NPl      . V/C D/P
+> majority of the whole number  shall be     necessary to a   choice . But     no      person
+# NSg      P  D   NSg/J NSg/V/J VX    NSg/VX NSg/J     P  D/P NSg/J  . NSg/C/P NPrSg/P NSg/V
+> constitutionally ineligible to the office of President shall be     eligible to
+# J/R              NSg/J      P  D   NSg/V  P  NSg/V     VX    NSg/VX NSg/J    P
+> that    of Vice      - President of the United States .
+# N/I/C/D P  NSg/V/J/P . NSg/V     P  D   W?     NPrSg  .
 >
 #
-> The Congress may      determine the Time  of  chusing the Electors , and the Day   on
-# D   NPrSg/V  NPrSg/VX V         D   NSg/V V/P ?       D   NPl      . V/C D   NPrSg J/P
+> The Congress may      determine the Time  of chusing the Electors , and the Day   on
+# D   NPrSg/V  NPrSg/VX V         D   NSg/V P  ?       D   NPl      . V/C D   NPrSg J/P
 > which they shall give  their Votes ; which Day   shall be     the same throughout the
 # I/C   IPl  VX    NSg/V D     NPl   . I/C   NPrSg VX    NSg/VX D   I/J  P          D
 > United States .
@@ -832,114 +832,114 @@
 # NSg/V      . #
 >
 #
-> No      Person except a   natural born      Citizen , or      a   Citizen of  the
-# NPrSg/P NSg/V  V/C/P  D/P NSg/J   NPrSg/V/J NSg     . NPrSg/C D/P NSg     V/P D
-> United States , at        the time  of  the Adoption of  this Constitution , shall be
-# W?     NPrSg  . NSg/I/V/P D   NSg/V V/P D   NSg      V/P I/D  NPrSg        . VX    NSg/VX
-> eligible to the Office of  President ; neither shall any   Person be     eligible to
-# NSg/J    P  D   NSg/V  V/P NSg/V     . I/C     VX    I/R/D NSg/V  NSg/VX NSg/J    P
-> that    Office who     shall not   have   attained to the Age   of  thirty five Years , and
-# N/I/C/D NSg/V  NPrSg/I VX    NSg/C NSg/VX W?       P  D   NSg/V V/P NSg    NSg  NPl   . V/C
+> No      Person except a   natural born      Citizen , or      a   Citizen of the
+# NPrSg/P NSg/V  V/C/P  D/P NSg/J   NPrSg/V/J NSg     . NPrSg/C D/P NSg     P  D
+> United States , at        the time  of the Adoption of this Constitution , shall be
+# W?     NPrSg  . NSg/I/V/P D   NSg/V P  D   NSg      P  I/D  NPrSg        . VX    NSg/VX
+> eligible to the Office of President ; neither shall any   Person be     eligible to
+# NSg/J    P  D   NSg/V  P  NSg/V     . I/C     VX    I/R/D NSg/V  NSg/VX NSg/J    P
+> that    Office who     shall not   have   attained to the Age   of thirty five Years , and
+# N/I/C/D NSg/V  NPrSg/I VX    NSg/C NSg/VX W?       P  D   NSg/V P  NSg    NSg  NPl   . V/C
 > been  fourteen Years a   Resident within the United States .
 # NSg/V N        NPl   D/P NSg/J    N/J/P  D   W?     NPrSg  .
 >
 #
-> No      person shall be     elected to the office of  the President more        than twice , and
-# NPrSg/P NSg/V  VX    NSg/VX NSg/V/J P  D   NSg/V  V/P D   NSg/V     NPrSg/I/V/J C/P  W?    . V/C
-> no      person who     has held the office of  President , or      acted as    President , for more
-# NPrSg/P NSg/V  NPrSg/I V   V    D   NSg/V  V/P NSg/V     . NPrSg/C W?    NSg/R NSg/V     . C/P NPrSg/I/V/J
-> than two years of  a   term    to which some  other   person was elected President shall
-# C/P  NSg NPl   V/P D/P NSg/V/J P  I/C   I/J/R NSg/V/J NSg/V  V   NSg/V/J NSg/V     VX
-> be     elected to the office of  the President more        than once  . But     this article
-# NSg/VX NSg/V/J P  D   NSg/V  V/P D   NSg/V     NPrSg/I/V/J C/P  NSg/C . NSg/C/P I/D  NSg/V
-> shall not   apply to any   person holding the office of  President when    this article
-# VX    NSg/C V/J   P  I/R/D NSg/V  NSg/V   D   NSg/V  V/P NSg/V     NSg/I/C I/D  NSg/V
+> No      person shall be     elected to the office of the President more        than twice , and
+# NPrSg/P NSg/V  VX    NSg/VX NSg/V/J P  D   NSg/V  P  D   NSg/V     NPrSg/I/V/J C/P  W?    . V/C
+> no      person who     has held the office of President , or      acted as    President , for more
+# NPrSg/P NSg/V  NPrSg/I V   V    D   NSg/V  P  NSg/V     . NPrSg/C W?    NSg/R NSg/V     . C/P NPrSg/I/V/J
+> than two years of a   term    to which some  other   person was elected President shall
+# C/P  NSg NPl   P  D/P NSg/V/J P  I/C   I/J/R NSg/V/J NSg/V  V   NSg/V/J NSg/V     VX
+> be     elected to the office of the President more        than once  . But     this article
+# NSg/VX NSg/V/J P  D   NSg/V  P  D   NSg/V     NPrSg/I/V/J C/P  NSg/C . NSg/C/P I/D  NSg/V
+> shall not   apply to any   person holding the office of President when    this article
+# VX    NSg/C V/J   P  I/R/D NSg/V  NSg/V   D   NSg/V  P  NSg/V     NSg/I/C I/D  NSg/V
 > was proposed by      the Congress , and shall not   prevent any   person who     may      be
 # V   W?       NSg/J/P D   NPrSg/V  . V/C VX    NSg/C V       I/R/D NSg/V  NPrSg/I NPrSg/VX NSg/VX
-> holding the office of  President , or      acting  as    President , during the term    within
-# NSg/V   D   NSg/V  V/P NSg/V     . NPrSg/C NSg/V/J NSg/R NSg/V     . V/P    D   NSg/V/J N/J/P
-> which this article becomes operative from holding the office of  President or
-# I/C   I/D  NSg/V   NPl     NSg/J     P    NSg/V   D   NSg/V  V/P NSg/V     NPrSg/C
-> acting  as    President during the remainder of  such  term    .
-# NSg/V/J NSg/R NSg/V     V/P    D   NSg/V/J   V/P NSg/I NSg/V/J .
+> holding the office of President , or      acting  as    President , during the term    within
+# NSg/V   D   NSg/V  P  NSg/V     . NPrSg/C NSg/V/J NSg/R NSg/V     . V/P    D   NSg/V/J N/J/P
+> which this article becomes operative from holding the office of President or
+# I/C   I/D  NSg/V   NPl     NSg/J     P    NSg/V   D   NSg/V  P  NSg/V     NPrSg/C
+> acting  as    President during the remainder of such  term    .
+# NSg/V/J NSg/R NSg/V     V/P    D   NSg/V/J   P  NSg/I NSg/V/J .
 >
 #
 > SubSection 3 .
 # NSg/V      # .
 >
 #
-> In          case    of  the removal of  the President from office or      of  his
-# NPrSg/V/J/P NPrSg/V V/P D   NSg     V/P D   NSg/V     P    NSg/V  NPrSg/C V/P ISg/D
+> In          case    of the removal of the President from office or      of his
+# NPrSg/V/J/P NPrSg/V P  D   NSg     P  D   NSg/V     P    NSg/V  NPrSg/C P  ISg/D
 > death or      resignation , the Vice      President shall become President .
 # NPrSg NPrSg/C NSg         . D   NSg/V/J/P NSg/V     VX    V      NSg/V     .
 >
 #
-> Whenever there is a   vacancy in          the office of  the Vice      President , the President
-# C        W?    VL D/P NSg     NPrSg/V/J/P D   NSg/V  V/P D   NSg/V/J/P NSg/V     . D   NSg/V
+> Whenever there is a   vacancy in          the office of the Vice      President , the President
+# C        W?    VL D/P NSg     NPrSg/V/J/P D   NSg/V  P  D   NSg/V/J/P NSg/V     . D   NSg/V
 > shall nominate a   Vice      President who     shall take  office upon confirmation by      a
 # VX    V/J      D/P NSg/V/J/P NSg/V     NPrSg/I VX    NSg/V NSg/V  P    NSg          NSg/J/P D/P
-> majority vote  of  both Houses of  Congress .
-# NSg      NSg/V V/P I/C  NPl    V/P NPrSg/V  .
+> majority vote  of both Houses of Congress .
+# NSg      NSg/V P  I/C  NPl    P  NPrSg/V  .
 >
 #
-> Whenever the President transmits to the President pro     tempore of  the Senate and
-# C        D   NSg/V     NPl       P  D   NSg/V     NSg/J/P ?       V/P D   NPrSg  V/C
-> the Speaker of  the House   of  Representatives his   written declaration that    he      is
-# D   NSg/J   V/P D   NPrSg/V V/P NPl             ISg/D V/J     NSg         N/I/C/D NPr/ISg VL
-> unable  to discharge the powers and duties of  his   office , and until he      transmits
-# NSg/V/J P  NSg/V     D   NPrSg  V/C NPl    V/P ISg/D NSg/V  . V/C C/P   NPr/ISg NPl
+> Whenever the President transmits to the President pro     tempore of the Senate and
+# C        D   NSg/V     NPl       P  D   NSg/V     NSg/J/P ?       P  D   NPrSg  V/C
+> the Speaker of the House   of Representatives his   written declaration that    he      is
+# D   NSg/J   P  D   NPrSg/V P  NPl             ISg/D V/J     NSg         N/I/C/D NPr/ISg VL
+> unable  to discharge the powers and duties of his   office , and until he      transmits
+# NSg/V/J P  NSg/V     D   NPrSg  V/C NPl    P  ISg/D NSg/V  . V/C C/P   NPr/ISg NPl
 > to them a   written declaration to the contrary , such  powers and duties shall be
 # P  N/I  D/P V/J     NSg         P  D   NSg/V/J  . NSg/I NPrSg  V/C NPl    VX    NSg/VX
 > discharged by      the Vice      President as    Acting  President .
 # V          NSg/J/P D   NSg/V/J/P NSg/V     NSg/R NSg/V/J NSg/V     .
 >
 #
-> Whenever the Vice      President and a   majority of  either the principal officers of
-# C        D   NSg/V/J/P NSg/V     V/C D/P NSg      V/P I/C    D   NSg/J     W?       V/P
-> the executive departments or      of  such  other   body  as    Congress may      by      law   provide ,
-# D   NSg/J     NPl         NPrSg/C V/P NSg/I NSg/V/J NSg/V NSg/R NPrSg/V  NPrSg/VX NSg/J/P NSg/V V       .
-> transmit to the President pro     tempore of  the Senate and the Speaker of  the
-# V        P  D   NSg/V     NSg/J/P ?       V/P D   NPrSg  V/C D   NSg/J   V/P D
-> House   of  Representatives their written declaration that    the President is unable
-# NPrSg/V V/P NPl             D     V/J     NSg         N/I/C/D D   NSg/V     VL NSg/V/J
-> to discharge the powers and duties of  his   office , the Vice      President shall
-# P  NSg/V     D   NPrSg  V/C NPl    V/P ISg/D NSg/V  . D   NSg/V/J/P NSg/V     VX
-> immediately assume the powers and duties of  the office as    Acting  President .
-# J/R         V      D   NPrSg  V/C NPl    V/P D   NSg/V  NSg/R NSg/V/J NSg/V     .
+> Whenever the Vice      President and a   majority of either the principal officers of
+# C        D   NSg/V/J/P NSg/V     V/C D/P NSg      P  I/C    D   NSg/J     W?       P
+> the executive departments or      of such  other   body  as    Congress may      by      law   provide ,
+# D   NSg/J     NPl         NPrSg/C P  NSg/I NSg/V/J NSg/V NSg/R NPrSg/V  NPrSg/VX NSg/J/P NSg/V V       .
+> transmit to the President pro     tempore of the Senate and the Speaker of the
+# V        P  D   NSg/V     NSg/J/P ?       P  D   NPrSg  V/C D   NSg/J   P  D
+> House   of Representatives their written declaration that    the President is unable
+# NPrSg/V P  NPl             D     V/J     NSg         N/I/C/D D   NSg/V     VL NSg/V/J
+> to discharge the powers and duties of his   office , the Vice      President shall
+# P  NSg/V     D   NPrSg  V/C NPl    P  ISg/D NSg/V  . D   NSg/V/J/P NSg/V     VX
+> immediately assume the powers and duties of the office as    Acting  President .
+# J/R         V      D   NPrSg  V/C NPl    P  D   NSg/V  NSg/R NSg/V/J NSg/V     .
 >
 #
-> Thereafter , when    the President transmits to the President pro     tempore of  the
-# NSg        . NSg/I/C D   NSg/V     NPl       P  D   NSg/V     NSg/J/P ?       V/P D
-> Senate and the Speaker of  the House   of  Representatives his   written declaration
-# NPrSg  V/C D   NSg/J   V/P D   NPrSg/V V/P NPl             ISg/D V/J     NSg
-> that    no      inability exists , he      shall resume the powers and duties of  his   office
-# N/I/C/D NPrSg/P NSg       NPl    . NPr/ISg VX    NSg/V  D   NPrSg  V/C NPl    V/P ISg/D NSg/V
-> unless the Vice      President and a   majority of  either the principal officers of
-# C      D   NSg/V/J/P NSg/V     V/C D/P NSg      V/P I/C    D   NSg/J     W?       V/P
-> the executive department or      of  such  other   body  as    Congress may      by      law   provide ,
-# D   NSg/J     NSg        NPrSg/C V/P NSg/I NSg/V/J NSg/V NSg/R NPrSg/V  NPrSg/VX NSg/J/P NSg/V V       .
-> transmit within four days to the President pro     tempore of  the Senate and the
-# V        N/J/P  NSg  NPl  P  D   NSg/V     NSg/J/P ?       V/P D   NPrSg  V/C D
-> Speaker of  the House   of  Representatives their written declaration that    the
-# NSg/J   V/P D   NPrSg/V V/P NPl             D     V/J     NSg         N/I/C/D D
-> President is unable  to discharge the powers and duties of  his   office . Thereupon
-# NSg/V     VL NSg/V/J P  NSg/V     D   NPrSg  V/C NPl    V/P ISg/D NSg/V  . W?
+> Thereafter , when    the President transmits to the President pro     tempore of the
+# NSg        . NSg/I/C D   NSg/V     NPl       P  D   NSg/V     NSg/J/P ?       P  D
+> Senate and the Speaker of the House   of Representatives his   written declaration
+# NPrSg  V/C D   NSg/J   P  D   NPrSg/V P  NPl             ISg/D V/J     NSg
+> that    no      inability exists , he      shall resume the powers and duties of his   office
+# N/I/C/D NPrSg/P NSg       NPl    . NPr/ISg VX    NSg/V  D   NPrSg  V/C NPl    P  ISg/D NSg/V
+> unless the Vice      President and a   majority of either the principal officers of
+# C      D   NSg/V/J/P NSg/V     V/C D/P NSg      P  I/C    D   NSg/J     W?       P
+> the executive department or      of such  other   body  as    Congress may      by      law   provide ,
+# D   NSg/J     NSg        NPrSg/C P  NSg/I NSg/V/J NSg/V NSg/R NPrSg/V  NPrSg/VX NSg/J/P NSg/V V       .
+> transmit within four days to the President pro     tempore of the Senate and the
+# V        N/J/P  NSg  NPl  P  D   NSg/V     NSg/J/P ?       P  D   NPrSg  V/C D
+> Speaker of the House   of Representatives their written declaration that    the
+# NSg/J   P  D   NPrSg/V P  NPl             D     V/J     NSg         N/I/C/D D
+> President is unable  to discharge the powers and duties of his   office . Thereupon
+# NSg/V     VL NSg/V/J P  NSg/V     D   NPrSg  V/C NPl    P  ISg/D NSg/V  . W?
 > Congress shall decide the issue , assembling within forty - eight hours for that
 # NPrSg/V  VX    V      D   NSg/V . V          N/J/P  NSg/J . NSg/J NPl   C/P N/I/C/D
 > purpose if    not   in          session . If    the Congress , within twenty - one       days after
 # NSg/V   NSg/C NSg/C NPrSg/V/J/P NSg/V   . NSg/C D   NPrSg/V  . N/J/P  NSg    . NSg/I/V/J NPl  J/P
-> receipt of  the latter written declaration , or      , if    Congress is not   in          session ,
-# NSg/V   V/P D   N/J    V/J     NSg         . NPrSg/C . NSg/C NPrSg/V  VL NSg/C NPrSg/V/J/P NSg/V   .
+> receipt of the latter written declaration , or      , if    Congress is not   in          session ,
+# NSg/V   P  D   N/J    V/J     NSg         . NPrSg/C . NSg/C NPrSg/V  VL NSg/C NPrSg/V/J/P NSg/V   .
 > within twenty - one       days after Congress is required to assemble , determines by
 # N/J/P  NSg    . NSg/I/V/J NPl  J/P   NPrSg/V  VL W?       P  V        . NPl        NSg/J/P
-> two - thirds vote  of  both Houses that    the President is unable  to discharge the
-# NSg . NPl    NSg/V V/P I/C  NPl    N/I/C/D D   NSg/V     VL NSg/V/J P  NSg/V     D
-> powers and duties of  his   office , the Vice      President shall continue to discharge
-# NPrSg  V/C NPl    V/P ISg/D NSg/V  . D   NSg/V/J/P NSg/V     VX    NSg/V    P  NSg/V
+> two - thirds vote  of both Houses that    the President is unable  to discharge the
+# NSg . NPl    NSg/V P  I/C  NPl    N/I/C/D D   NSg/V     VL NSg/V/J P  NSg/V     D
+> powers and duties of his   office , the Vice      President shall continue to discharge
+# NPrSg  V/C NPl    P  ISg/D NSg/V  . D   NSg/V/J/P NSg/V     VX    NSg/V    P  NSg/V
 > the same as    Acting  President ; otherwise , the President shall resume the powers
 # D   I/J  NSg/R NSg/V/J NSg/V     . J         . D   NSg/V     VX    NSg/V  D   NPrSg
-> and duties of  his   office .
-# V/C NPl    V/P ISg/D NSg/V  .
+> and duties of his   office .
+# V/C NPl    P  ISg/D NSg/V  .
 >
 #
 > SubSection 4 .
@@ -954,18 +954,18 @@
 # V/P    D   NSg/V/J C/P I/C   NPr/ISg VX    NSg/VX NSg/V NSg/V/J . V/C NPr/ISg VX    NSg/C
 > receive within that    Period  any   other   Emolument from the United States , or      any
 # NSg/V   N/J/P  N/I/C/D NSg/V/J I/R/D NSg/V/J NSg       P    D   W?     NPrSg  . NPrSg/C I/R/D
-> of  them .
-# V/P N/I  .
+> of them .
+# P  N/I  .
 >
 #
-> Before he      enter on  the Execution of  his   Office , he      shall take  the following
-# C/P    NPr/ISg NSg/V J/P D   NSg       V/P ISg/D NSg/V  . NPr/ISg VX    NSg/V D   NSg/V/J/P
+> Before he      enter on  the Execution of his   Office , he      shall take  the following
+# C/P    NPr/ISg NSg/V J/P D   NSg       P  ISg/D NSg/V  . NPr/ISg VX    NSg/V D   NSg/V/J/P
 > Oath  or      Affirmation : - - " I   do     solemnly swear   ( or      affirm ) that    I   will     faithfully
 # NSg/V NPrSg/C NSg         . . . . ISg NSg/VX J/R      NSg/V/J . NPrSg/C V      . N/I/C/D ISg NPrSg/VX J/R
-> execute the Office of  President of  the United States , and will     to the best       of
-# V       D   NSg/V  V/P NSg/V     V/P D   W?     NPrSg  . V/C NPrSg/VX P  D   NPrSg/VX/J V/P
-> my Ability , preserve , protect and defend the Constitution of  the United
-# D  NSg     . NSg/V    . V       V/C NSg/V  D   NPrSg        V/P D   W?
+> execute the Office of President of the United States , and will     to the best       of
+# V       D   NSg/V  P  NSg/V     P  D   W?     NPrSg  . V/C NPrSg/VX P  D   NPrSg/VX/J P
+> my Ability , preserve , protect and defend the Constitution of the United
+# D  NSg     . NSg/V    . V       V/C NSg/V  D   NPrSg        P  D   W?
 > States . "
 # NPrSg  . .
 >
@@ -974,26 +974,26 @@
 # NSg/V      # .
 >
 #
-> The District constituting the seat  of  Government of  the
-# D   NSg/V/J  V            D   NSg/V V/P NSg        V/P D
+> The District constituting the seat  of Government of the
+# D   NSg/V/J  V            D   NSg/V P  NSg        P  D
 > United States shall appoint in          such  manner as    the Congress may      direct :
 # W?     NPrSg  VX    V       NPrSg/V/J/P NSg/I NSg    NSg/R D   NPrSg/V  NPrSg/VX V/J    .
 >
 #
-> A   number  of  electors of  President and Vice      President equal   to the whole number
-# D/P NSg/V/J V/P NPl      V/P NSg/V     V/C NSg/V/J/P NSg/V     NSg/V/J P  D   NSg/J NSg/V/J
-> of  Senators and Representatives in          Congress to which the District would  be
-# V/P NPl      V/C NPl             NPrSg/V/J/P NPrSg/V  P  I/C   D   NSg/V/J  NSg/VX NSg/VX
+> A   number  of electors of President and Vice      President equal   to the whole number
+# D/P NSg/V/J P  NPl      P  NSg/V     V/C NSg/V/J/P NSg/V     NSg/V/J P  D   NSg/J NSg/V/J
+> of Senators and Representatives in          Congress to which the District would  be
+# P  NPl      V/C NPl             NPrSg/V/J/P NPrSg/V  P  I/C   D   NSg/V/J  NSg/VX NSg/VX
 > entitled if    it        were  a   State , but     in          no      event more        than the least populous
 # W?       NSg/C NPrSg/ISg NSg/V D/P NSg/V . NSg/C/P NPrSg/V/J/P NPrSg/P NSg/V NPrSg/I/V/J C/P  D   NSg/J J
 > State ; they shall be     in          addition to those appointed by      the States , but     they
 # NSg/V . IPl  VX    NSg/VX NPrSg/V/J/P NSg      P  I/D   W?        NSg/J/P D   NPrSg  . NSg/C/P IPl
-> shall be     considered , for the purposes of  the election of  President and Vice
-# VX    NSg/VX V/J        . C/P D   NPl      V/P D   NSg      V/P NSg/V     V/C NSg/V/J/P
+> shall be     considered , for the purposes of the election of President and Vice
+# VX    NSg/VX V/J        . C/P D   NPl      P  D   NSg      P  NSg/V     V/C NSg/V/J/P
 > President , to be     electors appointed by      a   State ; and they shall meet    in          the
 # NSg/V     . P  NSg/VX NPl      W?        NSg/J/P D/P NSg/V . V/C IPl  VX    NSg/V/J NPrSg/V/J/P D
-> District and perform such  duties as    provided by      this article of  the
-# NSg/V/J  V/C V       NSg/I NPl    NSg/R V/C      NSg/J/P I/D  NSg/V   V/P D
+> District and perform such  duties as    provided by      this article of the
+# NSg/V/J  V/C V       NSg/I NPl    NSg/R V/C      NSg/J/P I/D  NSg/V   P  D
 > Constitution .
 # NPrSg        .
 >
@@ -1002,54 +1002,54 @@
 # NSg/V   . # .
 >
 #
-> The President shall be     Commander in          Chief   of  the Army and Navy
-# D   NSg/V     VX    NSg/VX NSg/J     NPrSg/V/J/P NSg/V/J V/P D   NSg  V/C NSg/J
-> of  the United States , and of  the Militia of  the several States , when    called
-# V/P D   W?     NPrSg  . V/C V/P D   NSg     V/P D   J/D     NPrSg  . NSg/I/C V/J
-> into the actual Service of  the United States ; he      may      require the Opinion , in
-# P    D   NSg/J  NSg/V   V/P D   W?     NPrSg  . NPr/ISg NPrSg/VX NSg/V   D   NSg/V   . NPrSg/V/J/P
-> writing , of  the principal Officer in          each of  the executive Departments , upon
-# NSg/V   . V/P D   NSg/J     NSg/V/J NPrSg/V/J/P D    V/P D   NSg/J     NPl         . P
-> any   Subject relating to the Duties of  their respective Offices , and he      shall
-# I/R/D NSg/V/J V        P  D   NPl    V/P D     J          NPl     . V/C NPr/ISg VX
+> The President shall be     Commander in          Chief   of the Army and Navy
+# D   NSg/V     VX    NSg/VX NSg/J     NPrSg/V/J/P NSg/V/J P  D   NSg  V/C NSg/J
+> of the United States , and of the Militia of the several States , when    called
+# P  D   W?     NPrSg  . V/C P  D   NSg     P  D   J/D     NPrSg  . NSg/I/C V/J
+> into the actual Service of the United States ; he      may      require the Opinion , in
+# P    D   NSg/J  NSg/V   P  D   W?     NPrSg  . NPr/ISg NPrSg/VX NSg/V   D   NSg/V   . NPrSg/V/J/P
+> writing , of the principal Officer in          each of the executive Departments , upon
+# NSg/V   . P  D   NSg/J     NSg/V/J NPrSg/V/J/P D    P  D   NSg/J     NPl         . P
+> any   Subject relating to the Duties of their respective Offices , and he      shall
+# I/R/D NSg/V/J V        P  D   NPl    P  D     J          NPl     . V/C NPr/ISg VX
 > have   Power   to grant   Reprieves and Pardons for Offences against the United
 # NSg/VX NSg/V/J P  NPrSg/V NPl       V/C NPl     C/P NPl      C/P     D   W?
-> States , except in          Cases of  Impeachment .
-# NPrSg  . V/C/P  NPrSg/V/J/P NPl   V/P NSg         .
+> States , except in          Cases of Impeachment .
+# NPrSg  . V/C/P  NPrSg/V/J/P NPl   P  NSg         .
 >
 #
-> He      shall have   Power   , by      and with the Advice and Consent of  the Senate , to make
-# NPr/ISg VX    NSg/VX NSg/V/J . NSg/J/P V/C P    D   NSg/V  V/C NSg/V   V/P D   NPrSg  . P  NSg/V
-> Treaties , provided two thirds of  the Senators present concur ; and he      shall
-# NPl      . V/C      NSg NPl    V/P D   NPl      NSg/V/J V      . V/C NPr/ISg VX
-> nominate , and by      and with the Advice and Consent of  the Senate , shall appoint
-# V/J      . V/C NSg/J/P V/C P    D   NSg/V  V/C NSg/V   V/P D   NPrSg  . VX    V
-> Ambassadors , other   public  Ministers and Consuls , Judges of  the supreme Court ,
-# NPl         . NSg/V/J NSg/V/J NPl       V/C NPl     . NPrPl  V/P D   NSg/V/J NSg/V .
-> and all       other   Officers of  the United States , whose Appointments are not   herein
-# V/C NSg/I/J/C NSg/V/J W?       V/P D   W?     NPrSg  . I     NPl          V   NSg/C W?
+> He      shall have   Power   , by      and with the Advice and Consent of the Senate , to make
+# NPr/ISg VX    NSg/VX NSg/V/J . NSg/J/P V/C P    D   NSg/V  V/C NSg/V   P  D   NPrSg  . P  NSg/V
+> Treaties , provided two thirds of the Senators present concur ; and he      shall
+# NPl      . V/C      NSg NPl    P  D   NPl      NSg/V/J V      . V/C NPr/ISg VX
+> nominate , and by      and with the Advice and Consent of the Senate , shall appoint
+# V/J      . V/C NSg/J/P V/C P    D   NSg/V  V/C NSg/V   P  D   NPrSg  . VX    V
+> Ambassadors , other   public  Ministers and Consuls , Judges of the supreme Court ,
+# NPl         . NSg/V/J NSg/V/J NPl       V/C NPl     . NPrPl  P  D   NSg/V/J NSg/V .
+> and all       other   Officers of the United States , whose Appointments are not   herein
+# V/C NSg/I/J/C NSg/V/J W?       P  D   W?     NPrSg  . I     NPl          V   NSg/C W?
 > otherwise provided for , and which shall be     established by      Law   : but     the Congress
 # J         V/C      C/P . V/C I/C   VX    NSg/VX W?          NSg/J/P NSg/V . NSg/C/P D   NPrSg/V
-> may      by      Law   vest  the Appointment of  such  inferior Officers , as    they think
-# NPrSg/VX NSg/J/P NSg/V NSg/V D   NSg         V/P NSg/I NSg/J    W?       . NSg/R IPl  NSg/V
-> proper , in          the President alone , in          the Courts of  Law   , or      in          the Heads of
-# NSg/J  . NPrSg/V/J/P D   NSg/V     J     . NPrSg/V/J/P D   NPl    V/P NSg/V . NPrSg/C NPrSg/V/J/P D   NPl   V/P
+> may      by      Law   vest  the Appointment of such  inferior Officers , as    they think
+# NPrSg/VX NSg/J/P NSg/V NSg/V D   NSg         P  NSg/I NSg/J    W?       . NSg/R IPl  NSg/V
+> proper , in          the President alone , in          the Courts of Law   , or      in          the Heads of
+# NSg/J  . NPrSg/V/J/P D   NSg/V     J     . NPrSg/V/J/P D   NPl    P  NSg/V . NPrSg/C NPrSg/V/J/P D   NPl   P
 > Departments .
 # NPl         .
 >
 #
 > The President shall have   Power   to fill  up        all       Vacancies that    may      happen during
 # D   NSg/V     VX    NSg/VX NSg/V/J P  NSg/V NSg/V/J/P NSg/I/J/C NPl       N/I/C/D NPrSg/VX V      V/P
-> the Recess  of  the Senate , by      granting Commissions which shall expire at        the End
-# D   NSg/V/J V/P D   NPrSg  . NSg/J/P V        NPl         I/C   VX    V      NSg/I/V/P D   NSg/V
-> of  their next    Session .
-# V/P D     NSg/J/P NSg/V   .
+> the Recess  of the Senate , by      granting Commissions which shall expire at        the End
+# D   NSg/V/J P  D   NPrSg  . NSg/J/P V        NPl         I/C   VX    V      NSg/I/V/P D   NSg/V
+> of their next    Session .
+# P  D     NSg/J/P NSg/V   .
 >
 #
-> No      soldier shall , in          time  of  peace   be     quartered in          any   house   , without the
-# NPrSg/P NSg/V   VX    . NPrSg/V/J/P NSg/V V/P NPrSg/V NSg/VX W?        NPrSg/V/J/P I/R/D NPrSg/V . C/P     D
-> consent of  the owner , nor   in          time  of  war   , but     in          a   manner to be     prescribed by
-# NSg/V   V/P D   NSg   . NSg/C NPrSg/V/J/P NSg/V V/P NSg/V . NSg/C/P NPrSg/V/J/P D/P NSg    P  NSg/VX W?         NSg/J/P
+> No      soldier shall , in          time  of peace   be     quartered in          any   house   , without the
+# NPrSg/P NSg/V   VX    . NPrSg/V/J/P NSg/V P  NPrSg/V NSg/VX W?        NPrSg/V/J/P I/R/D NPrSg/V . C/P     D
+> consent of the owner , nor   in          time  of war   , but     in          a   manner to be     prescribed by
+# NSg/V   P  D   NSg   . NSg/C NPrSg/V/J/P NSg/V P  NSg/V . NSg/C/P NPrSg/V/J/P D/P NSg    P  NSg/VX W?         NSg/J/P
 > law   .
 # NSg/V .
 >
@@ -1059,33 +1059,33 @@
 >
 #
 > He      shall from time  to time  give  to the Congress Information of
-# NPr/ISg VX    P    NSg/V P  NSg/V NSg/V P  D   NPrSg/V  NSg         V/P
-> the State of  the Union     , and recommend to their Consideration such  Measures as
-# D   NSg/V V/P D   NPrSg/V/J . V/C NSg/V     P  D     NSg           NSg/I NPl      NSg/R
+# NPr/ISg VX    P    NSg/V P  NSg/V NSg/V P  D   NPrSg/V  NSg         P
+> the State of the Union     , and recommend to their Consideration such  Measures as
+# D   NSg/V P  D   NPrSg/V/J . V/C NSg/V     P  D     NSg           NSg/I NPl      NSg/R
 > he      shall judge necessary and expedient ; he      may      , on  extraordinary Occasions ,
 # NPr/ISg VX    NSg/V NSg/J     V/C NSg/J     . NPr/ISg NPrSg/VX . J/P NSg/J         NPl       .
-> convene both Houses , or      either of  them , and in          Case    of  Disagreement between
-# V       I/C  NPl    . NPrSg/C I/C    V/P N/I  . V/C NPrSg/V/J/P NPrSg/V V/P NSg          NSg/P
-> them , with Respect to the Time  of  Adjournment , he      may      adjourn them to such  Time
-# N/I  . P    NSg/V   P  D   NSg/V V/P NSg         . NPr/ISg NPrSg/VX V       N/I  P  NSg/I NSg/V
+> convene both Houses , or      either of them , and in          Case    of Disagreement between
+# V       I/C  NPl    . NPrSg/C I/C    P  N/I  . V/C NPrSg/V/J/P NPrSg/V P  NSg          NSg/P
+> them , with Respect to the Time  of Adjournment , he      may      adjourn them to such  Time
+# N/I  . P    NSg/V   P  D   NSg/V P  NSg         . NPr/ISg NPrSg/VX V       N/I  P  NSg/I NSg/V
 > as    he      shall think proper ; he      shall receive Ambassadors and other   public
 # NSg/R NPr/ISg VX    NSg/V NSg/J  . NPr/ISg VX    NSg/V   NPl         V/C NSg/V/J NSg/V/J
 > Ministers ; he      shall take  Care  that    the Laws be     faithfully executed , and shall
 # NPl       . NPr/ISg VX    NSg/V NSg/V N/I/C/D D   NPl  NSg/VX J/R        W?       . V/C VX
-> Commission all       the Officers of  the United States .
-# NSg/V      NSg/I/J/C D   W?       V/P D   W?     NPrSg  .
+> Commission all       the Officers of the United States .
+# NSg/V      NSg/I/J/C D   W?       P  D   W?     NPrSg  .
 >
 #
 > Section . 4 .
 # NSg/V   . # .
 >
 #
-> The President , Vice      President and all       civil Officers of  the
-# D   NSg/V     . NSg/V/J/P NSg/V     V/C NSg/I/J/C J     W?       V/P D
+> The President , Vice      President and all       civil Officers of the
+# D   NSg/V     . NSg/V/J/P NSg/V     V/C NSg/I/J/C J     W?       P  D
 > United States , shall be     removed from Office on  Impeachment for , and Conviction
 # W?     NPrSg  . VX    NSg/VX W?      P    NSg/V  J/P NSg         C/P . V/C NSg
-> of  , Treason , Bribery , or      other   high    Crimes and Misdemeanors .
-# V/P . NSg     . NSg     . NPrSg/C NSg/V/J NSg/V/J NPl    V/C NPl          .
+> of , Treason , Bribery , or      other   high    Crimes and Misdemeanors .
+# P  . NSg     . NSg     . NPrSg/C NSg/V/J NSg/V/J NPl    V/C NPl          .
 >
 #
 > Article . III .
@@ -1096,12 +1096,12 @@
 # NSg/V   . # .
 >
 #
-> The judicial Power   of  the United States , shall be     vested in
-# D   NSg/J    NSg/V/J V/P D   W?     NPrSg  . VX    NSg/VX W?     NPrSg/V/J/P
+> The judicial Power   of the United States , shall be     vested in
+# D   NSg/J    NSg/V/J P  D   W?     NPrSg  . VX    NSg/VX W?     NPrSg/V/J/P
 > one       supreme Court , and in          such  inferior Courts as    the Congress may      from time  to
 # NSg/I/V/J NSg/V/J NSg/V . V/C NPrSg/V/J/P NSg/I NSg/J    NPl    NSg/R D   NPrSg/V  NPrSg/VX P    NSg/V P
-> time  ordain and establish . The Judges , both of  the supreme and inferior Courts ,
-# NSg/V V      V/C V         . D   NPrPl  . I/C  V/P D   NSg/V/J V/C NSg/J    NPl    .
+> time  ordain and establish . The Judges , both of the supreme and inferior Courts ,
+# NSg/V V      V/C V         . D   NPrPl  . I/C  P  D   NSg/V/J V/C NSg/J    NPl    .
 > shall hold    their Offices during good      Behaviour , and shall , at        stated Times ,
 # VX    NSg/V/J D     NPl     V/P    NPrSg/V/J NSg/Br    . V/C VX    . NSg/I/V/P V/J    NPl   .
 > receive for their Services , a   Compensation , which shall not   be     diminished
@@ -1116,20 +1116,20 @@
 #
 > The judicial Power   shall extend to all       Cases , in          Law   and
 # D   NSg/J    NSg/V/J VX    NSg/V  P  NSg/I/J/C NPl   . NPrSg/V/J/P NSg/V V/C
-> Equity , arising under   this Constitution , the Laws of  the United States , and
-# NSg    . V       NSg/J/P I/D  NPrSg        . D   NPl  V/P D   W?     NPrSg  . V/C
+> Equity , arising under   this Constitution , the Laws of the United States , and
+# NSg    . V       NSg/J/P I/D  NPrSg        . D   NPl  P  D   W?     NPrSg  . V/C
 > Treaties made  , or      which shall be     made  , under   their Authority ; — to all       Cases
 # NPl      NSg/V . NPrSg/C I/C   VX    NSg/VX NSg/V . NSg/J/P D     NSg       . . P  NSg/I/J/C NPl
 > affecting Ambassadors , other   public  Ministers and Consuls ; — to all       Cases of
-# V/J       NPl         . NSg/V/J NSg/V/J NPl       V/C NPl     . . P  NSg/I/J/C NPl   V/P
+# V/J       NPl         . NSg/V/J NSg/V/J NPl       V/C NPl     . . P  NSg/I/J/C NPl   P
 > admiralty and maritime Jurisdiction ; — to Controversies to which the United
 # NPrSg     V/C J        NSg          . . P  NPl           P  I/C   D   W?
 > States shall be     a   Party   ; — to Controversies between two or      more        States ; — between
 # NPrSg  VX    NSg/VX D/P NSg/V/J . . P  NPl           NSg/P   NSg NPrSg/C NPrSg/I/V/J NPrSg  . . NSg/P
-> Citizens of  different States , — between Citizens of  the same State claiming
-# NPl      V/P NSg/J     NPrSg  . . NSg/P   NPl      V/P D   I/J  NSg/V V
-> Lands under   Grants of  different States .
-# NPl   NSg/J/P NPl    V/P NSg/J     NPrSg  .
+> Citizens of different States , — between Citizens of the same State claiming
+# NPl      P  NSg/J     NPrSg  . . NSg/P   NPl      P  D   I/J  NSg/V V
+> Lands under   Grants of different States .
+# NPl   NSg/J/P NPl    P  NSg/J     NPrSg  .
 >
 #
 > In          all       Cases affecting Ambassadors , other   public  Ministers and Consuls , and
@@ -1144,8 +1144,8 @@
 # NSg/J/P NSg/I NSg         NSg/R D   NPrSg/V  VX    NSg/V .
 >
 #
-> The Trial   of  all       Crimes , except in          Cases of  Impeachment , shall be     by      Jury    ; and
-# D   NSg/V/J V/P NSg/I/J/C NPl    . V/C/P  NPrSg/V/J/P NPl   V/P NSg         . VX    NSg/VX NSg/J/P NSg/V/J . V/C
+> The Trial   of all       Crimes , except in          Cases of Impeachment , shall be     by      Jury    ; and
+# D   NSg/V/J P  NSg/I/J/C NPl    . V/C/P  NPrSg/V/J/P NPl   P  NSg         . VX    NSg/VX NSg/J/P NSg/V/J . V/C
 > such  Trial   shall be     held in          the State where the said Crimes shall have   been
 # NSg/I NSg/V/J VX    NSg/VX V    NPrSg/V/J/P D   NSg/V NSg/C D   V/J  NPl    VX    NSg/VX NSg/V
 > committed ; but     when    not   committed within any   State , the Trial   shall be     at        such
@@ -1162,26 +1162,26 @@
 # NSg     C/P     D   W?     NPrSg  . VX    NSg/V   W?   NPrSg/V/J/P
 > levying War   against them , or      in          adhering to their Enemies , giving them Aid   and
 # V       NSg/V C/P     N/I  . NPrSg/C NPrSg/V/J/P V        P  D     NPl     . V      N/I  NSg/V V/C
-> Comfort . No      Person shall be     convicted of  Treason unless on  the Testimony of  two
-# NSg/V   . NPrSg/P NSg/V  VX    NSg/VX W?        V/P NSg     C      J/P D   NSg       V/P NSg
+> Comfort . No      Person shall be     convicted of Treason unless on  the Testimony of two
+# NSg/V   . NPrSg/P NSg/V  VX    NSg/VX W?        P  NSg     C      J/P D   NSg       P  NSg
 > Witnesses to the same overt Act     , or      on  Confession in          open    Court .
 # NPl       P  D   I/J  NSg/J NPrSg/V . NPrSg/C J/P NSg        NPrSg/V/J/P NSg/V/J NSg/V .
 >
 #
-> The Congress shall have   Power   to declare the Punishment of  Treason , but     no
-# D   NPrSg/V  VX    NSg/VX NSg/V/J P  V       D   NSg        V/P NSg     . NSg/C/P NPrSg/P
-> Attainder of  Treason shall work  Corruption of  Blood , or      Forfeiture except
-# NSg       V/P NSg     VX    NSg/V NSg        V/P NSg/V . NPrSg/C NSg        V/C/P
-> during the Life  of  the Person attainted .
-# V/P    D   NSg/V V/P D   NSg/V  ?         .
+> The Congress shall have   Power   to declare the Punishment of Treason , but     no
+# D   NPrSg/V  VX    NSg/VX NSg/V/J P  V       D   NSg        P  NSg     . NSg/C/P NPrSg/P
+> Attainder of Treason shall work  Corruption of Blood , or      Forfeiture except
+# NSg       P  NSg     VX    NSg/V NSg        P  NSg/V . NPrSg/C NSg        V/C/P
+> during the Life  of the Person attainted .
+# V/P    D   NSg/V P  D   NSg/V  ?         .
 >
 #
 > Section . 4 .
 # NSg/V   . # .
 >
 #
-> The right     of  the people to be     secure in          their persons , houses ,
-# D   NPrSg/V/J V/P D   NSg/V  P  NSg/VX V/J    NPrSg/V/J/P D     NPl     . NPl    .
+> The right     of the people to be     secure in          their persons , houses ,
+# D   NPrSg/V/J P  D   NSg/V  P  NSg/VX V/J    NPrSg/V/J/P D     NPl     . NPl    .
 > papers , and effects , against unreasonable searches and seizures , shall not   be
 # NPl    . V/C NPl     . C/P     J            NPl      V/C NPl      . VX    NSg/C NSg/VX
 > violated , and no      warrants shall issue , but     upon probable cause   , supported by
@@ -1194,46 +1194,46 @@
 #
 > No      person shall be     held to answer for a   capital , or      otherwise infamous crime ,
 # NPrSg/P NSg/V  VX    NSg/VX V    P  NSg/V  C/P D/P NSg/J   . NPrSg/C J         V/J      NSg/V .
-> unless on  a   presentment or      indictment of  a   grand jury    , except in          cases arising
-# C      J/P D/P NSg         NPrSg/C NSg        V/P D/P NSg/J NSg/V/J . V/C/P  NPrSg/V/J/P NPl   V
+> unless on  a   presentment or      indictment of a   grand jury    , except in          cases arising
+# C      J/P D/P NSg         NPrSg/C NSg        P  D/P NSg/J NSg/V/J . V/C/P  NPrSg/V/J/P NPl   V
 > in          the land    or      naval forces , or      in          the militia , when    in          actual service in          time
 # NPrSg/V/J/P D   NPrSg/V NPrSg/C J     NPl    . NPrSg/C NPrSg/V/J/P D   NSg     . NSg/I/C NPrSg/V/J/P NSg/J  NSg/V   NPrSg/V/J/P NSg/V
-> of  war   or      public  danger  ; nor   shall any   person be     subject for the same offense
-# V/P NSg/V NPrSg/C NSg/V/J NSg/V/J . NSg/C VX    I/R/D NSg/V  NSg/VX NSg/V/J C/P D   I/J  NSg
-> to be     twice put   in          jeopardy of  life  or      limb  ; nor   shall be     compelled in          any
-# P  NSg/VX W?    NSg/V NPrSg/V/J/P NSg/V    V/P NSg/V NPrSg/C NSg/V . NSg/C VX    NSg/VX V/J       NPrSg/V/J/P I/R/D
-> criminal case    to be     a   witness against himself , nor   be     deprived of  life  ,
-# NSg/J    NPrSg/V P  NSg/VX D/P NSg/V   C/P     I       . NSg/C NSg/VX W?       V/P NSg/V .
-> liberty , or      property , without due   process of  law   ; nor   shall private property be
-# NSg     . NPrSg/C NSg/V    . C/P     NSg/J NSg/V   V/P NSg/V . NSg/C VX    NSg/V/J NSg/V    NSg/VX
+> of war   or      public  danger  ; nor   shall any   person be     subject for the same offense
+# P  NSg/V NPrSg/C NSg/V/J NSg/V/J . NSg/C VX    I/R/D NSg/V  NSg/VX NSg/V/J C/P D   I/J  NSg
+> to be     twice put   in          jeopardy of life  or      limb  ; nor   shall be     compelled in          any
+# P  NSg/VX W?    NSg/V NPrSg/V/J/P NSg/V    P  NSg/V NPrSg/C NSg/V . NSg/C VX    NSg/VX V/J       NPrSg/V/J/P I/R/D
+> criminal case    to be     a   witness against himself , nor   be     deprived of life  ,
+# NSg/J    NPrSg/V P  NSg/VX D/P NSg/V   C/P     I       . NSg/C NSg/VX W?       P  NSg/V .
+> liberty , or      property , without due   process of law   ; nor   shall private property be
+# NSg     . NPrSg/C NSg/V    . C/P     NSg/J NSg/V   P  NSg/V . NSg/C VX    NSg/V/J NSg/V    NSg/VX
 > taken for public  use   , without just compensation .
 # V/J   C/P NSg/V/J NSg/V . C/P     V/J  NSg          .
 >
 #
 > In          all       criminal prosecutions , the accused shall enjoy the right     to a   speedy and
 # NPrSg/V/J/P NSg/I/J/C NSg/J    W?           . D   W?      VX    V     D   NPrSg/V/J P  D/P V/J    V/C
-> public  trial   , by      an  impartial jury    of  the state and district wherein the crime
-# NSg/V/J NSg/V/J . NSg/J/P D/P J         NSg/V/J V/P D   NSg/V V/C NSg/V/J  C       D   NSg/V
+> public  trial   , by      an  impartial jury    of the state and district wherein the crime
+# NSg/V/J NSg/V/J . NSg/J/P D/P J         NSg/V/J P  D   NSg/V V/C NSg/V/J  C       D   NSg/V
 > shall have   been  committed , which district shall have   been  previously
 # VX    NSg/VX NSg/V V/J       . I/C   NSg/V/J  VX    NSg/VX NSg/V J/R
-> ascertained by      law   , and to be     informed of  the nature and cause   of  the
-# W?          NSg/J/P NSg/V . V/C P  NSg/VX V/J      V/P D   NSg/V  V/C NSg/V/C V/P D
+> ascertained by      law   , and to be     informed of the nature and cause   of the
+# W?          NSg/J/P NSg/V . V/C P  NSg/VX V/J      P  D   NSg/V  V/C NSg/V/C P  D
 > accusation ; to be     confronted with the witnesses against him ; to have   compulsory
 # NSg        . P  NSg/VX W?         P    D   NPl       C/P     I   . P  NSg/VX NSg/J
 > process for obtaining witnesses in          his   favor , and to have   the assistance of
-# NSg/V   C/P V         NPl       NPrSg/V/J/P ISg/D NSg/V . V/C P  NSg/VX D   NSg        V/P
+# NSg/V   C/P V         NPl       NPrSg/V/J/P ISg/D NSg/V . V/C P  NSg/VX D   NSg        P
 > counsel for his   defense .
 # NSg/V   C/P ISg/D NSg/V   .
 >
 #
 > In          suits at        common  law   , where the value in          controversy shall exceed twenty
 # NPrSg/V/J/P NPl   NSg/I/V/P NSg/V/J NSg/V . NSg/C D   NSg/V NPrSg/V/J/P NSg         VX    V      NSg
-> dollars , the right     of  trial   by      jury    shall be     preserved , and no      fact tried by      a
-# NPl     . D   NPrSg/V/J V/P NSg/V/J NSg/J/P NSg/V/J VX    NSg/VX W?        . V/C NPrSg/P NSg  V/J   NSg/J/P D/P
-> jury    , shall be     otherwise reexamined in          any   court of  the United States , than
-# NSg/V/J . VX    NSg/VX J         W?         NPrSg/V/J/P I/R/D NSg/V V/P D   W?     NPrSg  . C/P
-> according to the rules of  the common  law   .
-# V/J       P  D   NPl   V/P D   NSg/V/J NSg/V .
+> dollars , the right     of trial   by      jury    shall be     preserved , and no      fact tried by      a
+# NPl     . D   NPrSg/V/J P  NSg/V/J NSg/J/P NSg/V/J VX    NSg/VX W?        . V/C NPrSg/P NSg  V/J   NSg/J/P D/P
+> jury    , shall be     otherwise reexamined in          any   court of the United States , than
+# NSg/V/J . VX    NSg/VX J         W?         NPrSg/V/J/P I/R/D NSg/V P  D   W?     NPrSg  . C/P
+> according to the rules of the common  law   .
+# V/J       P  D   NPl   P  D   NSg/V/J NSg/V .
 >
 #
 > Excessive bail  shall not   be     required , nor   excessive fines imposed , nor   cruel
@@ -1252,8 +1252,8 @@
 #
 > Full    Faith and Credit shall be     given     in          each State to the
 # NSg/V/J NPrSg V/C NSg/V  VX    NSg/VX NSg/V/J/P NPrSg/V/J/P D    NSg/V P  D
-> public  Acts  , Records , and judicial Proceedings of  every other   State . And the
-# NSg/V/J NPrSg . NPl     . V/C NSg/J    W?          V/P D     NSg/V/J NSg/V . V/C D
+> public  Acts  , Records , and judicial Proceedings of every other   State . And the
+# NSg/V/J NPrSg . NPl     . V/C NSg/J    W?          P  D     NSg/V/J NSg/V . V/C D
 > Congress may      by      general Laws prescribe the Manner in          which such  Acts  , Records
 # NPrSg/V  NPrSg/VX NSg/J/P NSg/V/J NPl  V         D   NSg    NPrSg/V/J/P I/C   NSg/I NPrSg . NPl
 > and Proceedings shall be     proved , and the Effect thereof .
@@ -1266,36 +1266,36 @@
 #
 > All       persons born      or      naturalized in          the United States , and
 # NSg/I/J/C NPl     NPrSg/V/J NPrSg/C W?          NPrSg/V/J/P D   W?     NPrSg  . V/C
-> subject to the jurisdiction thereof , are citizens of  the United States and of
-# NSg/V/J P  D   NSg          W?      . V   NPl      V/P D   W?     NPrSg  V/C V/P
+> subject to the jurisdiction thereof , are citizens of the United States and of
+# NSg/V/J P  D   NSg          W?      . V   NPl      P  D   W?     NPrSg  V/C P
 > the State wherein they reside  . No      State shall make  or      enforce any   law   which
 # D   NSg/V C       IPl  NSg/V/J . NPrSg/P NSg/V VX    NSg/V NPrSg/C V       I/R/D NSg/V I/C
-> shall abridge the privileges or      immunities of  citizens of  the United States ;
-# VX    V       D   NPl        NPrSg/C ?          V/P NPl      V/P D   W?     NPrSg  .
-> nor   shall any   State deprive any   person of  life  , liberty , or      property , without
-# NSg/C VX    I/R/D NSg/V V       I/R/D NSg/V  V/P NSg/V . NSg     . NPrSg/C NSg/V    . C/P
-> due   process of  law   ; nor   deny to any   person within its   jurisdiction the equal
-# NSg/J NSg/V   V/P NSg/V . NSg/C V    P  I/R/D NSg/V  N/J/P  ISg/D NSg          D   NSg/V/J
-> protection of  the laws .
-# NSg        V/P D   NPl  .
+> shall abridge the privileges or      immunities of citizens of the United States ;
+# VX    V       D   NPl        NPrSg/C ?          P  NPl      P  D   W?     NPrSg  .
+> nor   shall any   State deprive any   person of life  , liberty , or      property , without
+# NSg/C VX    I/R/D NSg/V V       I/R/D NSg/V  P  NSg/V . NSg     . NPrSg/C NSg/V    . C/P
+> due   process of law   ; nor   deny to any   person within its   jurisdiction the equal
+# NSg/J NSg/V   P  NSg/V . NSg/C V    P  I/R/D NSg/V  N/J/P  ISg/D NSg          D   NSg/V/J
+> protection of the laws .
+# NSg        P  D   NPl  .
 >
 #
-> The right     of  citizens of  the United States , who     are eighteen years of  age   or
-# D   NPrSg/V/J V/P NPl      V/P D   W?     NPrSg  . NPrSg/I V   N        NPl   V/P NSg/V NPrSg/C
+> The right     of citizens of the United States , who     are eighteen years of age   or
+# D   NPrSg/V/J P  NPl      P  D   W?     NPrSg  . NPrSg/I V   N        NPl   P  NSg/V NPrSg/C
 > older , to vote  shall not   be     denied or      abridged by      the United States or      by      any
 # J     . P  NSg/V VX    NSg/C NSg/VX W?     NPrSg/C W?       NSg/J/P D   W?     NPrSg  NPrSg/C NSg/J/P I/R/D
-> State on  account of  age   , sex   , race  , color      , or      previous condition of  servitude .
-# NSg/V J/P NSg/V   V/P NSg/V . NSg/V . NSg/V . NSg/V/J/Am . NPrSg/C NSg/J    NSg/V     V/P NSg       .
+> State on  account of age   , sex   , race  , color      , or      previous condition of servitude .
+# NSg/V J/P NSg/V   P  NSg/V . NSg/V . NSg/V . NSg/V/J/Am . NPrSg/C NSg/J    NSg/V     P  NSg       .
 >
 #
 > A   Person charged in          any   State with Treason , Felony , or      other   Crime , who     shall
 # D/P NSg/V  V/J     NPrSg/V/J/P I/R/D NSg/V P    NSg     . NSg    . NPrSg/C NSg/V/J NSg/V . NPrSg/I VX
-> flee from Justice , and be     found in          another State , shall on  Demand of  the
-# V    P    NPrSg   . V/C NSg/VX NSg/V NPrSg/V/J/P I/D     NSg/V . VX    J/P NSg/V  V/P D
-> executive Authority of  the State from which he      fled , be     delivered up        , to be
-# NSg/J     NSg       V/P D   NSg/V P    I/C   NPr/ISg W?   . NSg/VX V/J       NSg/V/J/P . P  NSg/VX
-> removed to the State having Jurisdiction of  the Crime .
-# W?      P  D   NSg/V V      NSg          V/P D   NSg/V .
+> flee from Justice , and be     found in          another State , shall on  Demand of the
+# V    P    NPrSg   . V/C NSg/VX NSg/V NPrSg/V/J/P I/D     NSg/V . VX    J/P NSg/V  P  D
+> executive Authority of the State from which he      fled , be     delivered up        , to be
+# NSg/J     NSg       P  D   NSg/V P    I/C   NPr/ISg W?   . NSg/VX V/J       NSg/V/J/P . P  NSg/VX
+> removed to the State having Jurisdiction of the Crime .
+# W?      P  D   NSg/V V      NSg          P  D   NSg/V .
 >
 #
 > Neither slavery nor   involuntary servitude , except as    a   punishment for crime
@@ -1306,10 +1306,10 @@
 # NPrSg  . NPrSg/C I/R/D NSg/V NSg/V/J P  D     NSg          . NPrSg/P NSg/V  V    P  NSg/V
 > or      Labour     in          one       State , under   the Laws thereof , escaping into another , shall ,
 # NPrSg/C NPrSg/V/Br NPrSg/V/J/P NSg/I/V/J NSg/V . NSg/J/P D   NPl  W?      . V        P    I/D     . VX    .
-> in          Consequence of  any   Law   or      Regulation therein , be     discharged from such
-# NPrSg/V/J/P NSg/V       V/P I/R/D NSg/V NPrSg/C NSg/J      W?      . NSg/VX V          P    NSg/I
-> Service or      Labour     , but     shall be     delivered up        on  Claim of  the Party   to whom such
-# NSg/V   NPrSg/C NPrSg/V/Br . NSg/C/P VX    NSg/VX V/J       NSg/V/J/P J/P NSg/V V/P D   NSg/V/J P  I    NSg/I
+> in          Consequence of any   Law   or      Regulation therein , be     discharged from such
+# NPrSg/V/J/P NSg/V       P  I/R/D NSg/V NPrSg/C NSg/J      W?      . NSg/VX V          P    NSg/I
+> Service or      Labour     , but     shall be     delivered up        on  Claim of the Party   to whom such
+# NSg/V   NPrSg/C NPrSg/V/Br . NSg/C/P VX    NSg/VX V/J       NSg/V/J/P J/P NSg/V P  D   NSg/V/J P  I    NSg/I
 > Service or      Labour     may      be     due   .
 # NSg/V   NPrSg/C NPrSg/V/Br NPrSg/VX NSg/VX NSg/J .
 >
@@ -1320,24 +1320,24 @@
 #
 > New     States may      be     admitted by      the Congress into this Union     ; but
 # NSg/V/J NPrSg  NPrSg/VX NSg/VX V        NSg/J/P D   NPrSg/V  P    I/D  NPrSg/V/J . NSg/C/P
-> no      new     State shall be     formed or      erected within the Jurisdiction of  any   other
-# NPrSg/P NSg/V/J NSg/V VX    NSg/VX V      NPrSg/C W?      N/J/P  D   NSg          V/P I/R/D NSg/V/J
-> State ; nor   any   State be     formed by      the Junction of  two or      more        States , or      Parts
-# NSg/V . NSg/C I/R/D NSg/V NSg/VX V      NSg/J/P D   NSg/V    V/P NSg NPrSg/C NPrSg/I/V/J NPrSg  . NPrSg/C NPl
-> of  States , without the Consent of  the Legislatures of  the States concerned as
-# V/P NPrSg  . C/P     D   NSg/V   V/P D   NPl          V/P D   NPrSg  V/J       NSg/R
-> well    as    of  the Congress .
-# NSg/V/J NSg/R V/P D   NPrSg/V  .
+> no      new     State shall be     formed or      erected within the Jurisdiction of any   other
+# NPrSg/P NSg/V/J NSg/V VX    NSg/VX V      NPrSg/C W?      N/J/P  D   NSg          P  I/R/D NSg/V/J
+> State ; nor   any   State be     formed by      the Junction of two or      more        States , or      Parts
+# NSg/V . NSg/C I/R/D NSg/V NSg/VX V      NSg/J/P D   NSg/V    P  NSg NPrSg/C NPrSg/I/V/J NPrSg  . NPrSg/C NPl
+> of States , without the Consent of the Legislatures of the States concerned as
+# P  NPrSg  . C/P     D   NSg/V   P  D   NPl          P  D   NPrSg  V/J       NSg/R
+> well    as    of the Congress .
+# NSg/V/J NSg/R P  D   NPrSg/V  .
 >
 #
-> The Congress shall have   Power   to dispose of  and make  all       needful Rules and
-# D   NPrSg/V  VX    NSg/VX NSg/V/J P  NSg/V   V/P V/C NSg/V NSg/I/J/C NSg/J   NPl   V/C
+> The Congress shall have   Power   to dispose of and make  all       needful Rules and
+# D   NPrSg/V  VX    NSg/VX NSg/V/J P  NSg/V   P  V/C NSg/V NSg/I/J/C NSg/J   NPl   V/C
 > Regulations respecting the Territory or      other   Property belonging to the United
 # NSg         V          D   NSg       NPrSg/C NSg/V/J NSg/V    NSg/V     P  D   W?
 > States ; and nothing in          this Constitution shall be     so        construed as    to Prejudice
 # NPrSg  . V/C NSg/I/J NPrSg/V/J/P I/D  NPrSg        VX    NSg/VX NSg/I/J/C W?        NSg/R P  NSg/V/J
-> any   Claims of  the United States , or      of  any   particular State .
-# I/R/D NPl    V/P D   W?     NPrSg  . NPrSg/C V/P I/R/D NSg/J      NSg/V .
+> any   Claims of the United States , or      of any   particular State .
+# I/R/D NPl    P  D   W?     NPrSg  . NPrSg/C P  I/R/D NSg/J      NSg/V .
 >
 #
 > Section . 4 .
@@ -1346,10 +1346,10 @@
 #
 > The United States shall guarantee to every State in          this Union
 # D   W?     NPrSg  VX    NSg/V     P  D     NSg/V NPrSg/V/J/P I/D  NPrSg/V/J
-> a   Republican Form  of  Government , and shall protect each of  them against
-# D/P NSg/J      NSg/V V/P NSg        . V/C VX    V       D    V/P N/I  C/P
-> Invasion ; and on  Application of  the Legislature , or      of  the Executive ( when    the
-# NSg      . V/C J/P NSg         V/P D   NSg         . NPrSg/C V/P D   NSg/J     . NSg/I/C D
+> a   Republican Form  of Government , and shall protect each of them against
+# D/P NSg/J      NSg/V P  NSg        . V/C VX    V       D    P  N/I  C/P
+> Invasion ; and on  Application of the Legislature , or      of the Executive ( when    the
+# NSg      . V/C J/P NSg         P  D   NSg         . NPrSg/C P  D   NSg/J     . NSg/I/C D
 > Legislature cannot be     convened ) against domestic Violence .
 # NSg         NSg/V  NSg/VX W?       . C/P     NSg/J    NSg/V    .
 >
@@ -1358,18 +1358,18 @@
 # NSg/V   . # .
 >
 #
-> The validity of  the public  debt of  the United States ,
-# D   NSg      V/P D   NSg/V/J NSg  V/P D   W?     NPrSg  .
-> authorized by      law   , including debts incurred for payment of  pensions and
-# V/J        NSg/J/P NSg/V . V         NPl   V        C/P NSg     V/P NPl      V/C
+> The validity of the public  debt of the United States ,
+# D   NSg      P  D   NSg/V/J NSg  P  D   W?     NPrSg  .
+> authorized by      law   , including debts incurred for payment of pensions and
+# V/J        NSg/J/P NSg/V . V         NPl   V        C/P NSg     P  NPl      V/C
 > bounties for services in          suppressing insurrection or      rebellion , shall not   be
 # NPl      C/P NPl      NPrSg/V/J/P V           NSg          NPrSg/C NSg       . VX    NSg/C NSg/VX
 > questioned . But     neither the United States nor   any   State shall assume or      pay     any
 # V          . NSg/C/P I/C     D   W?     NPrSg  NSg/C I/R/D NSg/V VX    V      NPrSg/C NSg/V/J I/R/D
-> debt or      obligation incurred in          aid   of  insurrection or      rebellion against the
-# NSg  NPrSg/C NSg        V        NPrSg/V/J/P NSg/V V/P NSg          NPrSg/C NSg       C/P     D
-> United States , or      any   claim for the loss  or      emancipation of  any   slave ; but     all
-# W?     NPrSg  . NPrSg/C I/R/D NSg/V C/P D   NSg/V NPrSg/C NSg          V/P I/R/D NSg/V . NSg/C/P NSg/I/J/C
+> debt or      obligation incurred in          aid   of insurrection or      rebellion against the
+# NSg  NPrSg/C NSg        V        NPrSg/V/J/P NSg/V P  NSg          NPrSg/C NSg       C/P     D
+> United States , or      any   claim for the loss  or      emancipation of any   slave ; but     all
+# W?     NPrSg  . NPrSg/C I/R/D NSg/V C/P D   NSg/V NPrSg/C NSg          P  I/R/D NSg/V . NSg/C/P NSg/I/J/C
 > such  debts , obligations and claims shall be     held illegal and void    .
 # NSg/I NPl   . W?          V/C NPl    VX    NSg/VX V    NSg/J   V/C NSg/V/J .
 >
@@ -1378,60 +1378,60 @@
 # NSg/V   . ?
 >
 #
-> The Congress , whenever two thirds of  both Houses shall deem  it        necessary , shall
-# D   NPrSg/V  . C        NSg NPl    V/P I/C  NPl    VX    NSg/V NPrSg/ISg NSg/J     . VX
-> propose Amendments to this Constitution , or      , on  the Application of  the
-# NSg/V   NPl        P  I/D  NPrSg        . NPrSg/C . J/P D   NSg         V/P D
-> Legislatures of  two thirds of  the several States , shall call  a   Convention for
-# NPl          V/P NSg NPl    V/P D   J/D     NPrSg  . VX    NSg/V D/P NSg        C/P
+> The Congress , whenever two thirds of both Houses shall deem  it        necessary , shall
+# D   NPrSg/V  . C        NSg NPl    P  I/C  NPl    VX    NSg/V NPrSg/ISg NSg/J     . VX
+> propose Amendments to this Constitution , or      , on  the Application of the
+# NSg/V   NPl        P  I/D  NPrSg        . NPrSg/C . J/P D   NSg         P  D
+> Legislatures of two thirds of the several States , shall call  a   Convention for
+# NPl          P  NSg NPl    P  D   J/D     NPrSg  . VX    NSg/V D/P NSg        C/P
 > proposing Amendments , which , in          either Case    , shall be     valid to all       Intents and
 # V         NPl        . I/C   . NPrSg/V/J/P I/C    NPrSg/V . VX    NSg/VX J     P  NSg/I/J/C NPl     V/C
-> Purposes , as    Part    of  this Constitution , when    ratified by      the Legislatures of
-# NPl      . NSg/R NSg/V/J V/P I/D  NPrSg        . NSg/I/C W?       NSg/J/P D   NPl          V/P
-> three fourths of  the several States , or      by      Conventions in          three fourths
-# NSg   NSg     V/P D   J/D     NPrSg  . NPrSg/C NSg/J/P NPl         NPrSg/V/J/P NSg   NSg
-> thereof , as    the one       or      the other   Mode of  Ratification may      be     proposed by      the
-# W?      . NSg/R D   NSg/I/V/J NPrSg/C D   NSg/V/J NSg  V/P NSg          NPrSg/VX NSg/VX W?       NSg/J/P D
+> Purposes , as    Part    of this Constitution , when    ratified by      the Legislatures of
+# NPl      . NSg/R NSg/V/J P  I/D  NPrSg        . NSg/I/C W?       NSg/J/P D   NPl          P
+> three fourths of the several States , or      by      Conventions in          three fourths
+# NSg   NSg     P  D   J/D     NPrSg  . NPrSg/C NSg/J/P NPl         NPrSg/V/J/P NSg   NSg
+> thereof , as    the one       or      the other   Mode of Ratification may      be     proposed by      the
+# W?      . NSg/R D   NSg/I/V/J NPrSg/C D   NSg/V/J NSg  P  NSg          NPrSg/VX NSg/VX W?       NSg/J/P D
 > Congress ; Provided that    no      Amendment which may      be     made  prior to the Year One
 # NPrSg/V  . V/C      N/I/C/D NPrSg/P NSg       I/C   NPrSg/VX NSg/VX NSg/V NSg/J P  D   NSg  NSg/I/V/J
 > thousand eight hundred and eight shall in          any   Manner affect the first   and
 # NSg      NSg/J NSg     V/C NSg/J VX    NPrSg/V/J/P I/R/D NSg    NSg/V  D   NSg/V/J V/C
-> fourth    Clauses in          the Ninth   Section of  the first   Article ; and that    no      State ,
-# NPrSg/V/J NPl     NPrSg/V/J/P D   NSg/V/J NSg/V   V/P D   NSg/V/J NSg/V   . V/C N/I/C/D NPrSg/P NSg/V .
-> without its   Consent , shall be     deprived of  its   equal   Suffrage in          the Senate .
-# C/P     ISg/D NSg/V   . VX    NSg/VX W?       V/P ISg/D NSg/V/J NSg      NPrSg/V/J/P D   NPrSg  .
+> fourth    Clauses in          the Ninth   Section of the first   Article ; and that    no      State ,
+# NPrSg/V/J NPl     NPrSg/V/J/P D   NSg/V/J NSg/V   P  D   NSg/V/J NSg/V   . V/C N/I/C/D NPrSg/P NSg/V .
+> without its   Consent , shall be     deprived of its   equal   Suffrage in          the Senate .
+# C/P     ISg/D NSg/V   . VX    NSg/VX W?       P  ISg/D NSg/V/J NSg      NPrSg/V/J/P D   NPrSg  .
 >
 #
 > Article . VI    .
 # NSg/V   . NPrSg .
 >
 #
-> All       Debts contracted and Engagements entered into , before the Adoption of  this
-# NSg/I/J/C NPl   W?         V/C NPl         W?      P    . C/P    D   NSg      V/P I/D
+> All       Debts contracted and Engagements entered into , before the Adoption of this
+# NSg/I/J/C NPl   W?         V/C NPl         W?      P    . C/P    D   NSg      P  I/D
 > Constitution , shall be     as    valid against the United States under   this
 # NPrSg        . VX    NSg/VX NSg/R J     C/P     D   W?     NPrSg  NSg/J/P I/D
 > Constitution , as    under   the Confederation .
 # NPrSg        . NSg/R NSg/J/P D   NSg/J         .
 >
 #
-> This Constitution , and the Laws of  the United States which shall be     made  in
-# I/D  NPrSg        . V/C D   NPl  V/P D   W?     NPrSg  I/C   VX    NSg/VX NSg/V NPrSg/V/J/P
+> This Constitution , and the Laws of the United States which shall be     made  in
+# I/D  NPrSg        . V/C D   NPl  P  D   W?     NPrSg  I/C   VX    NSg/VX NSg/V NPrSg/V/J/P
 > Pursuance thereof ; and all       Treaties made  , or      which shall be     made  , under   the
 # NSg       W?      . V/C NSg/I/J/C NPl      NSg/V . NPrSg/C I/C   VX    NSg/VX NSg/V . NSg/J/P D
-> Authority of  the United States , shall be     the supreme Law   of  the Land    ; and the
-# NSg       V/P D   W?     NPrSg  . VX    NSg/VX D   NSg/V/J NSg/V V/P D   NPrSg/V . V/C D
+> Authority of the United States , shall be     the supreme Law   of the Land    ; and the
+# NSg       P  D   W?     NPrSg  . VX    NSg/VX D   NSg/V/J NSg/V P  D   NPrSg/V . V/C D
 > Judges in          every State shall be     bound   thereby , any   Thing in          the Constitution or
 # NPrPl  NPrSg/V/J/P D     NSg/V VX    NSg/VX NSg/V/J W?      . I/R/D NSg/V NPrSg/V/J/P D   NPrSg        NPrSg/C
-> Laws of  any   State to the Contrary notwithstanding .
-# NPl  V/P I/R/D NSg/V P  D   NSg/V/J  C/P             .
+> Laws of any   State to the Contrary notwithstanding .
+# NPl  P  I/R/D NSg/V P  D   NSg/V/J  C/P             .
 >
 #
-> The Senators and Representatives before mentioned , and the Members of  the
-# D   NPl      V/C NPl             C/P    V         . V/C D   NPl     V/P D
+> The Senators and Representatives before mentioned , and the Members of the
+# D   NPl      V/C NPl             C/P    V         . V/C D   NPl     P  D
 > several State Legislatures , and all       executive and judicial Officers , both of
-# J/D     NSg/V NPl          . V/C NSg/I/J/C NSg/J     V/C NSg/J    W?       . I/C  V/P
-> the United States and of  the several States , shall be     bound   by      Oath  or
-# D   W?     NPrSg  V/C V/P D   J/D     NPrSg  . VX    NSg/VX NSg/V/J NSg/J/P NSg/V NPrSg/C
+# J/D     NSg/V NPl          . V/C NSg/I/J/C NSg/J     V/C NSg/J    W?       . I/C  P
+> the United States and of the several States , shall be     bound   by      Oath  or
+# D   W?     NPrSg  V/C P  D   J/D     NPrSg  . VX    NSg/VX NSg/V/J NSg/J/P NSg/V NPrSg/C
 > Affirmation , to support this Constitution ; but     no      religious Test  shall ever be
 # NSg         . P  NSg/V   I/D  NPrSg        . NSg/C/P NPrSg/P NSg/J     NSg/V VX    J    NSg/VX
 > required as    a   Qualification to any   Office or      public  Trust   under   the United
@@ -1440,18 +1440,18 @@
 # NPrSg  .
 >
 #
-> A   well    regulated militia , being   necessary to the security of  a   free    state , the
-# D/P NSg/V/J V/J       NSg     . NSg/V/C NSg/J     P  D   NSg      V/P D/P NSg/V/J NSg/V . D
-> right     of  the people to keep  and bear    arms , shall not   be     infringed .
-# NPrSg/V/J V/P D   NSg/V  P  NSg/V V/C NSg/V/J NPl  . VX    NSg/C NSg/VX W?        .
+> A   well    regulated militia , being   necessary to the security of a   free    state , the
+# D/P NSg/V/J V/J       NSg     . NSg/V/C NSg/J     P  D   NSg      P  D/P NSg/V/J NSg/V . D
+> right     of the people to keep  and bear    arms , shall not   be     infringed .
+# NPrSg/V/J P  D   NSg/V  P  NSg/V V/C NSg/V/J NPl  . VX    NSg/C NSg/VX W?        .
 >
 #
 > Section . 1 .
 # NSg/V   . # .
 >
 #
-> The enumeration in          the Constitution , of  certain rights , shall
-# D   NSg         NPrSg/V/J/P D   NPrSg        . V/P I/J     NPl    . VX
+> The enumeration in          the Constitution , of certain rights , shall
+# D   NSg         NPrSg/V/J/P D   NPrSg        . P  I/J     NPl    . VX
 > not   be     construed to deny or      disparage others retained by      the people .
 # NSg/C NSg/VX W?        P  V    NPrSg/C NSg/V     NPl    W?       NSg/J/P D   NSg/V  .
 >
@@ -1468,32 +1468,32 @@
 # NSg/V   . NSg .
 >
 #
-> The Ratification of  the Conventions of  nine States , shall be     sufficient for the
-# D   NSg          V/P D   NPl         V/P NSg  NPrSg  . VX    NSg/VX J          C/P D
-> Establishment of  this Constitution between the States so        ratifying the Same .
-# NSg           V/P I/D  NPrSg        NSg/P   D   NPrSg  NSg/I/J/C V         D   I/J  .
+> The Ratification of the Conventions of nine States , shall be     sufficient for the
+# D   NSg          P  D   NPl         P  NSg  NPrSg  . VX    NSg/VX J          C/P D
+> Establishment of this Constitution between the States so        ratifying the Same .
+# NSg           P  I/D  NPrSg        NSg/P   D   NPrSg  NSg/I/J/C V         D   I/J  .
 >
 #
-> The Word  " the " , being   interlined between the seventh and eight Lines of  the
-# D   NSg/V . D   . . NSg/V/C W?         NSg/P   D   NSg/J   V/C NSg/J NPl   V/P D
+> The Word  " the " , being   interlined between the seventh and eight Lines of the
+# D   NSg/V . D   . . NSg/V/C W?         NSg/P   D   NSg/J   V/C NSg/J NPl   P  D
 > first   Page    , The Word  " Thirty " being   partly written on  an  Erazure in          the
 # NSg/V/J NPrSg/V . D   NSg/V . NSg    . NSg/V/C W?     V/J     J/P D/P ?       NPrSg/V/J/P D
-> fifteenth Line  of  the first   Page    . The Words " is tried " being   interlined between
-# NSg/J     NSg/V V/P D   NSg/V/J NPrSg/V . D   NPl   . VL V/J   . NSg/V/C W?         NSg/P
-> the thirty second  and thirty third   Lines of  the first   Page    and the Word  " the "
-# D   NSg    NSg/V/J V/C NSg    NSg/V/J NPl   V/P D   NSg/V/J NPrSg/V V/C D   NSg/V . D   .
-> being   interlined between the forty third   and forty fourth    Lines of  the second
-# NSg/V/C W?         NSg/P   D   NSg/J NSg/V/J V/C NSg/J NPrSg/V/J NPl   V/P D   NSg/V/J
+> fifteenth Line  of the first   Page    . The Words " is tried " being   interlined between
+# NSg/J     NSg/V P  D   NSg/V/J NPrSg/V . D   NPl   . VL V/J   . NSg/V/C W?         NSg/P
+> the thirty second  and thirty third   Lines of the first   Page    and the Word  " the "
+# D   NSg    NSg/V/J V/C NSg    NSg/V/J NPl   P  D   NSg/V/J NPrSg/V V/C D   NSg/V . D   .
+> being   interlined between the forty third   and forty fourth    Lines of the second
+# NSg/V/C W?         NSg/P   D   NSg/J NSg/V/J V/C NSg/J NPrSg/V/J NPl   P  D   NSg/V/J
 > Page    .
 # NPrSg/V .
 >
 #
-> done    in          Convention by      the Unanimous Consent of  the States present the
-# NSg/V/J NPrSg/V/J/P NSg        NSg/J/P D   J         NSg/V   V/P D   NPrSg  NSg/V/J D
-> Seventeenth Day   of  September in          the Year of  our Lord    one       thousand seven hundred
-# NSg/J       NPrSg V/P NPr       NPrSg/V/J/P D   NSg  V/P D   NPrSg/V NSg/I/V/J NSg      NSg   NSg
-> and Eighty seven and of  the Independence of  the United States of  America the
-# V/C N      NSg   V/C V/P D   NPrSg        V/P D   W?     NPrSg  V/P NPr     D
+> done    in          Convention by      the Unanimous Consent of the States present the
+# NSg/V/J NPrSg/V/J/P NSg        NSg/J/P D   J         NSg/V   P  D   NPrSg  NSg/V/J D
+> Seventeenth Day   of September in          the Year of our Lord    one       thousand seven hundred
+# NSg/J       NPrSg P  NPr       NPrSg/V/J/P D   NSg  P  D   NPrSg/V NSg/I/V/J NSg      NSg   NSg
+> and Eighty seven and of the Independence of the United States of America the
+# V/C N      NSg   V/C P  D   NPrSg        P  D   W?     NPrSg  P  NPr     D
 > Twelfth In          witness whereof We  have   hereunto subscribed our Names ,
 # NSg/J   NPrSg/V/J/P NSg/V   C       IPl NSg/VX W?       W?         D   NPl   .
 >
@@ -1508,7 +1508,7 @@
 #
 > The transportation or      importation into any   State , Territory , or
 # D   NSg            NPrSg/C NSg         P    I/R/D NSg/V . NSg       . NPrSg/C
-> possession of  the United States for delivery or      use   therein of  intoxicating
-# NSg/V      V/P D   W?     NPrSg  C/P NSg/V/J  NPrSg/C NSg/V W?      V/P V
-> liquors , in          violation of  the laws thereof , is hereby prohibited .
-# NPl     . NPrSg/V/J/P NSg       V/P D   NPl  W?      . VL W?     W?         .
+> possession of the United States for delivery or      use   therein of intoxicating
+# NSg/V      P  D   W?     NPrSg  C/P NSg/V/J  NPrSg/C NSg/V W?      P  V
+> liquors , in          violation of the laws thereof , is hereby prohibited .
+# NPl     . NPrSg/V/J/P NSg       P  D   NPl  W?      . VL W?     W?         .

--- a/harper-core/tests/text/tagged/The Great Gatsby.md
+++ b/harper-core/tests/text/tagged/The Great Gatsby.md
@@ -28,80 +28,80 @@
 # V/J      NSg/J . V/C ISg V/J        N/I/C/D NPr/ISg V     D/P NSg/J NSg/V/J NPrSg/I/V/J C/P  N/I/C/D . NPrSg/V/J/P
 > consequence , I’m inclined to reserve all       judgments , a   habit that    has opened up
 # NSg/V       . W?  W?       P  NSg/V   NSg/I/J/C NPl       . D/P NSg/V N/I/C/D V   V/J    NSg/V/J/P
-> many    curious natures to me        and also made  me        the victim of  not   a   few veteran
-# N/I/J/D J       NPl     P  NPrSg/ISg V/C W?   NSg/V NPrSg/ISg D   NSg/V  V/P NSg/C D/P N/I NSg/J
+> many    curious natures to me        and also made  me        the victim of not   a   few veteran
+# N/I/J/D J       NPl     P  NPrSg/ISg V/C W?   NSg/V NPrSg/ISg D   NSg/V  P  NSg/C D/P N/I NSg/J
 > bores . The abnormal mind  is quick   to detect and attach itself to this quality
 # NPl   . D   NSg/J    NSg/V VL NSg/V/J P  V/J    V/C V      I      P  I/D  NSg/J
 > when    it        appears in          a   normal person , and so        it        came    about that    in          college I   was
 # NSg/I/C NPrSg/ISg NPl     NPrSg/V/J/P D/P NSg/J  NSg/V  . V/C NSg/I/J/C NPrSg/ISg NSg/V/P J/P   N/I/C/D NPrSg/V/J/P NSg     ISg V
-> unjustly accused of  being   a   politician , because I   was privy to the secret  griefs
-# J/R      W?      V/P NSg/V/C D/P NSg        . C/P     ISg V   NSg/J P  D   NSg/V/J NPl
-> of  wild    , unknown men . Most    of  the confidences were  unsought — frequently I   have
-# V/P NSg/V/J . NSg/V/J NSg . NSg/I/J V/P D   NPl         NSg/V V        . J/R        ISg NSg/VX
+> unjustly accused of being   a   politician , because I   was privy to the secret  griefs
+# J/R      W?      P  NSg/V/C D/P NSg        . C/P     ISg V   NSg/J P  D   NSg/V/J NPl
+> of wild    , unknown men . Most    of the confidences were  unsought — frequently I   have
+# P  NSg/V/J . NSg/V/J NSg . NSg/I/J P  D   NPl         NSg/V V        . J/R        ISg NSg/VX
 > feigned sleep , preoccupation , or      a   hostile levity when    I   realized by      some
 # V/J     NSg/V . NSg           . NPrSg/C D/P NSg/J   NSg    NSg/I/C ISg V        NSg/J/P I/J/R
 > unmistakable sign  that    an  intimate revelation was quivering on  the horizon ; for
 # J            NSg/V N/I/C/D D/P NSg/V/J  NPrSg      V   V         J/P D   NSg     . C/P
-> the intimate revelations of  young     men , or      at        least the terms in          which they
-# D   NSg/V/J  NPrPl       V/P NPrSg/V/J NSg . NPrSg/C NSg/I/V/P NSg/J D   NPl   NPrSg/V/J/P I/C   IPl
+> the intimate revelations of young     men , or      at        least the terms in          which they
+# D   NSg/V/J  NPrPl       P  NPrSg/V/J NSg . NPrSg/C NSg/I/V/P NSg/J D   NPl   NPrSg/V/J/P I/C   IPl
 > express them , are usually plagiaristic and marred by      obvious suppressions .
 # NSg/V/J N/I  . V   J/R     ?            V/C V/J    NSg/J/P J       ?            .
-> Reserving judgments is a   matter  of  infinite hope    . I   am        still   a   little    afraid of
-# V         NPl       VL D/P NSg/V/J V/P NSg/J    NPrSg/V . ISg NPrSg/V/J NSg/V/J D/P NPrSg/I/J J      V/P
+> Reserving judgments is a   matter  of infinite hope    . I   am        still   a   little    afraid of
+# V         NPl       VL D/P NSg/V/J P  NSg/J    NPrSg/V . ISg NPrSg/V/J NSg/V/J D/P NPrSg/I/J J      P
 > missing something if    I   forget that    , as    my father  snobbishly suggested , and I
 # V       NSg/I/V/J NSg/C ISg V      N/I/C/D . NSg/R D  NPrSg/V J/R        W?        . V/C ISg
-> snobbishly repeat , a   sense of  the fundamental decencies is parcelled out
-# J/R        NSg/V  . D/P NSg/V V/P D   NSg/J       NPl       VL V/Br      NSg/V/J/R/P
+> snobbishly repeat , a   sense of the fundamental decencies is parcelled out
+# J/R        NSg/V  . D/P NSg/V P  D   NSg/J       NPl       VL V/Br      NSg/V/J/R/P
 > unequally at        birth   .
 # J/R       NSg/I/V/P NSg/V/J .
 >
 #
-> And , after boasting this way   of  my tolerance , I   come    to the admission that    it
-# V/C . J/P   V        I/D  NSg/J V/P D  NSg/V     . ISg NSg/V/P P  D   NSg       N/I/C/D NPrSg/ISg
+> And , after boasting this way   of my tolerance , I   come    to the admission that    it
+# V/C . J/P   V        I/D  NSg/J P  D  NSg/V     . ISg NSg/V/P P  D   NSg       N/I/C/D NPrSg/ISg
 > has a   limit   . Conduct may      be     founded on  the hard    rock    or      the wet     marshes , but
 # V   D/P NSg/V/J . NSg/V   NPrSg/VX NSg/VX V/J     J/P D   NSg/V/J NPrSg/V NPrSg/C D   NSg/V/J NPl     . NSg/C/P
 > after a   certain point I   don’t care  what  it’s founded on  . When    I   came    back    from
 # J/P   D/P I/J     NSg/V ISg NSg/V NSg/V NSg/I W?   V/J     J/P . NSg/I/C ISg NSg/V/P NSg/V/J P
 > the East    last    autumn  I   felt    that    I   wanted the world to be     in          uniform and at        a
 # D   NPrSg/J NSg/V/J NPrSg/V ISg NSg/V/J N/I/C/D ISg V/J    D   NSg/V P  NSg/VX NPrSg/V/J/P NSg/V/J V/C NSg/I/V/P D/P
-> sort  of  moral   attention forever ; I   wanted no      more        riotous excursions with
-# NSg/V V/P NSg/V/J NSg       NSg/J   . ISg V/J    NPrSg/P NPrSg/I/V/J J       NPl        P
+> sort  of moral   attention forever ; I   wanted no      more        riotous excursions with
+# NSg/V P  NSg/V/J NSg       NSg/J   . ISg V/J    NPrSg/P NPrSg/I/V/J J       NPl        P
 > privileged glimpses into the human   heart . Only Gatsby , the man         who     gives his
 # V/J        NPl      P    D   NSg/V/J NSg/V . W?   NPr    . D   NPrSg/I/V/J NPrSg/I NPl   ISg/D
 > name  to this book  , was exempt  from my reaction — Gatsby , who     represented
 # NSg/V P  I/D  NSg/V . V   NSg/V/J P    D  NSg/V/J  . NPr    . NPrSg/I V
 > everything for which I   have   an  unaffected scorn . If    personality is an  unbroken
 # N/I/V      C/P I/C   ISg NSg/VX D/P NSg/V/J    NSg/V . NSg/C NSg         VL D/P V/J
-> series of  successful gestures , then    there was something gorgeous about him , some
-# NSg    V/P J          NPl      . NSg/J/C W?    V   NSg/I/V/J J        J/P   I   . I/J/R
-> heightened sensitivity to the promises of  life  , as    if    he      were  related to one       of
-# W?         NSg         P  D   NPl      V/P NSg/V . NSg/R NSg/C NPr/ISg NSg/V J       P  NSg/I/V/J V/P
+> series of successful gestures , then    there was something gorgeous about him , some
+# NSg    P  J          NPl      . NSg/J/C W?    V   NSg/I/V/J J        J/P   I   . I/J/R
+> heightened sensitivity to the promises of life  , as    if    he      were  related to one       of
+# W?         NSg         P  D   NPl      P  NSg/V . NSg/R NSg/C NPr/ISg NSg/V J       P  NSg/I/V/J P
 > those intricate machines that    register earthquakes ten thousand miles away . This
 # I/D   V/J       NPl      N/I/C/D NSg/V    NPl         NSg NSg      NPrPl V/J  . I/D
 > responsiveness had nothing to do     with that    flabby impressionability which is
 # NSg            V   NSg/I/J P  NSg/VX P    N/I/C/D J      NSg               I/C   VL
-> dignified under   the name  of  the “ creative temperament ” — it        was an  extraordinary
-# V/J       NSg/J/P D   NSg/V V/P D   . NSg/J    NSg         . . NPrSg/ISg V   D/P NSg/J
+> dignified under   the name  of the “ creative temperament ” — it        was an  extraordinary
+# V/J       NSg/J/P D   NSg/V P  D   . NSg/J    NSg         . . NPrSg/ISg V   D/P NSg/J
 > gift  for hope    , a   romantic readiness such  as    I   have   never found in          any   other
 # NSg/V C/P NPrSg/V . D/P NSg/J    NSg       NSg/I NSg/R ISg NSg/VX V     NSg/V NPrSg/V/J/P I/R/D NSg/V/J
 > person and which it        is not   likely I   shall ever find  again . No      — Gatsby turned out
 # NSg/V  V/C I/C   NPrSg/ISg VL NSg/C NSg/J  ISg VX    J    NSg/V P     . NPrSg/P . NPr    W?     NSg/V/J/R/P
 > all       right     at        the end   ; it        is what  preyed on  Gatsby , what  foul    dust  floated in          the
 # NSg/I/J/C NPrSg/V/J NSg/I/V/P D   NSg/V . NPrSg/ISg VL NSg/I W?     J/P NPr    . NSg/I NSg/V/J NSg/V W?      NPrSg/V/J/P D
-> wake    of  his   dreams that    temporarily closed out         my interest in          the abortive
-# NPrSg/V V/P ISg/D NPl    N/I/C/D R           W?     NSg/V/J/R/P D  NSg/V    NPrSg/V/J/P D   NSg/V/J
-> sorrows and short       - winded elations of  men .
-# NPl     V/C NPrSg/V/J/P . V/J    ?        V/P NSg .
+> wake    of his   dreams that    temporarily closed out         my interest in          the abortive
+# NPrSg/V P  ISg/D NPl    N/I/C/D R           W?     NSg/V/J/R/P D  NSg/V    NPrSg/V/J/P D   NSg/V/J
+> sorrows and short       - winded elations of men .
+# NPl     V/C NPrSg/V/J/P . V/J    ?        P  NSg .
 >
 #
 > My family have   been  prominent , well    - to - do     people in          this Middle  Western city for
 # D  NSg/J  NSg/VX NSg/V NSg/J     . NSg/V/J . P  . NSg/VX NSg/V  NPrSg/V/J/P I/D  NSg/V/J NPrSg/J NSg  C/P
-> three generations . The Carraways are something of  a   clan , and we  have   a
-# NSg   NSg         . D   ?         V   NSg/I/V/J V/P D/P NSg  . V/C IPl NSg/VX D/P
-> tradition that    we’re descended from the Dukes of  Buccleuch , but     the actual
-# NSg/V     N/I/C/D W?    W?        P    D   NPl   V/P ?         . NSg/C/P D   NSg/J
-> founder of  my line  was my grandfather’s brother , who     came    here    in          fifty - one       ,
-# NSg/V   V/P D  NSg/V V   D  N$            NSg/V/J . NPrSg/I NSg/V/P NSg/J/R NPrSg/V/J/P NSg   . NSg/I/V/J .
+> three generations . The Carraways are something of a   clan , and we  have   a
+# NSg   NSg         . D   ?         V   NSg/I/V/J P  D/P NSg  . V/C IPl NSg/VX D/P
+> tradition that    we’re descended from the Dukes of Buccleuch , but     the actual
+# NSg/V     N/I/C/D W?    W?        P    D   NPl   P  ?         . NSg/C/P D   NSg/J
+> founder of my line  was my grandfather’s brother , who     came    here    in          fifty - one       ,
+# NSg/V   P  D  NSg/V V   D  N$            NSg/V/J . NPrSg/I NSg/V/P NSg/J/R NPrSg/V/J/P NSg   . NSg/I/V/J .
 > sent  a   substitute to the Civil War   , and started the wholesale hardware business
 # NSg/V D/P NSg/V      P  D   J     NSg/V . V/C W?      D   NSg/V/J   NSg      NSg/J
 > that    my father  carries on  to - day   .
@@ -112,16 +112,16 @@
 # ISg V     NSg/V I/D  NSg/J . NSg/V . NSg/C/P W?  V/J      P  NSg/V NSg/V/J/C/P I   . P    NSg/V/J
 > reference to the rather    hard    - boiled painting that    hangs in          father’s office . I
 # NSg/V     P  D   NPrSg/V/J NSg/V/J . W?     NSg/V    N/I/C/D NPl   NPrSg/V/J/P N$       NSg/V  . ISg
-> graduated from New     Haven in          1915 , just a   quarter of  a   century after my father  ,
-# W?        P    NSg/V/J NSg/V NPrSg/V/J/P #    . V/J  D/P NSg/V/J V/P D/P NSg     J/P   D  NPrSg/V .
+> graduated from New     Haven in          1915 , just a   quarter of a   century after my father  ,
+# W?        P    NSg/V/J NSg/V NPrSg/V/J/P #    . V/J  D/P NSg/V/J P  D/P NSg     J/P   D  NPrSg/V .
 > and a   little    later I   participated in          that    delayed Teutonic migration known   as
 # V/C D/P NPrSg/I/J J     ISg W?           NPrSg/V/J/P N/I/C/D W?      NSg/J    NSg       NSg/V/J NSg/R
 > the Great War   . I   enjoyed the counter - raid  so        thoroughly that    I   came    back
 # D   NSg/J NSg/V . ISg W?      D   NSg/V/J . NSg/V NSg/I/J/C J/R        N/I/C/D ISg NSg/V/P NSg/V/J
-> restless . Instead of  being   the warm    centre   of  the world , the Middle  West      now
-# J        . W?      V/P NSg/V/C D   NSg/V/J NSg/V/Br V/P D   NSg/V . D   NSg/V/J NPrSg/V/J NPrSg/V/J/C
-> seemed like        the ragged edge  of  the universe — so        I   decided to go      East    and learn
-# W?     NSg/V/J/C/P D   V/J    NSg/V V/P D   NPrSg    . NSg/I/J/C ISg NSg/V/J P  NSg/V/J NPrSg/J V/C NSg/V
+> restless . Instead of being   the warm    centre   of the world , the Middle  West      now
+# J        . W?      P  NSg/V/C D   NSg/V/J NSg/V/Br P  D   NSg/V . D   NSg/V/J NPrSg/V/J NPrSg/V/J/C
+> seemed like        the ragged edge  of the universe — so        I   decided to go      East    and learn
+# W?     NSg/V/J/C/P D   V/J    NSg/V P  D   NPrSg    . NSg/I/J/C ISg NSg/V/J P  NSg/V/J NPrSg/J V/C NSg/V
 > the bond      business . Everybody I   knew was in          the bond      business , so        I   supposed it
 # D   NPrSg/V/J NSg/J    . N/I       ISg V    V   NPrSg/V/J/P D   NPrSg/V/J NSg/J    . NSg/I/J/C ISg V/J      NPrSg/ISg
 > could  support one       more        single  man         . All       my aunts and uncles talked it        over      as    if
@@ -130,14 +130,14 @@
 # IPl  NSg/V V        D/P NSg/V NSg/V  C/P NPrSg/ISg . V/C J/R     V/J  . . NSg/V . NSg/I/D . NPl . . P
 > very grave   , hesitant faces . Father  agreed to finance me        for a   year , and after
 # J    NSg/V/J . J        NPl   . NPrSg/V W?     P  NSg/V   NPrSg/ISg C/P D/P NSg  . V/C J/P
-> various delays I   came    East    , permanently , I   thought , in          the spring of  twenty - two .
-# J       NPl    ISg NSg/V/P NPrSg/J . J/R         . ISg NSg/V   . NPrSg/V/J/P D   NSg/V  V/P NSg    . NSg .
+> various delays I   came    East    , permanently , I   thought , in          the spring of twenty - two .
+# J       NPl    ISg NSg/V/P NPrSg/J . J/R         . ISg NSg/V   . NPrSg/V/J/P D   NSg/V  P  NSg    . NSg .
 >
 #
 > The practical thing was to find  rooms in          the city , but     it        was a   warm    season , and
 # D   NSg/J     NSg/V V   P  NSg/V NPl   NPrSg/V/J/P D   NSg  . NSg/C/P NPrSg/ISg V   D/P NSg/V/J NSg/V  . V/C
-> I   had just left      a   country of  wide  lawns and friendly trees , so        when    a   young     man
-# ISg V   V/J  NPrSg/V/J D/P NSg/J   V/P NSg/J NPl   V/C NSg/J/R  NPl   . NSg/I/J/C NSg/I/C D/P NPrSg/V/J NPrSg/I/V/J
+> I   had just left      a   country of wide  lawns and friendly trees , so        when    a   young     man
+# ISg V   V/J  NPrSg/V/J D/P NSg/J   P  NSg/J NPl   V/C NSg/J/R  NPl   . NSg/I/J/C NSg/I/C D/P NPrSg/V/J NPrSg/I/V/J
 > at        the office suggested that    we  take  a   house   together in          a   commuting town , it
 # NSg/I/V/P D   NSg/V  W?        N/I/C/D IPl NSg/V D/P NPrSg/V J        NPrSg/V/J/P D/P V         NSg  . NPrSg/ISg
 > sounded like        a   great idea . He      found the house   , a   weatherbeaten cardboard
@@ -167,13 +167,13 @@
 > I   told him . And as    I   walked on  I   was lonely no      longer . I   was a   guide , a
 # ISg V    I   . V/C NSg/R ISg W?     J/P ISg V   J/R    NPrSg/P NSg/J  . ISg V   D/P NSg/V . D/P
 > pathfinder , an  original settler . He      had casually conferred on  me        the freedom of
-# NSg        . D/P NSg/J    NSg     . NPr/ISg V   J/R      V         J/P NPrSg/ISg D   NSg     V/P
+# NSg        . D/P NSg/J    NSg     . NPr/ISg V   J/R      V         J/P NPrSg/ISg D   NSg     P
 > the neighborhood .
 # D   NSg          .
 >
 #
-> And so        with the sunshine and the great bursts of  leaves growing on  the trees ,
-# V/C NSg/I/J/C P    D   NSg/J    V/C D   NSg/J NPl    V/P NPl    NSg/V   J/P D   NPl   .
+> And so        with the sunshine and the great bursts of leaves growing on  the trees ,
+# V/C NSg/I/J/C P    D   NSg/J    V/C D   NSg/J NPl    P  NPl    NSg/V   J/P D   NPl   .
 > just as    things grow in          fast    movies , I   had that    familiar conviction that    life  was
 # V/J  NSg/R NPl    V    NPrSg/V/J/P NSg/V/J NPl    . ISg V   N/I/C/D NSg/J    NSg        N/I/C/D NSg/V V
 > beginning over      again with the summer  .
@@ -182,82 +182,82 @@
 #
 > There was so        much  to read  , for one       thing , and so        much  fine    health to be     pulled
 # W?    V   NSg/I/J/C N/I/J P  NSg/V . C/P NSg/I/V/J NSg/V . V/C NSg/I/J/C N/I/J NSg/V/J NSg    P  NSg/VX W?
-> down      out         of  the young     breath  - giving air   . I   bought a   dozen volumes on  banking and
-# NSg/V/J/P NSg/V/J/R/P V/P D   NPrSg/V/J NSg/V/J . V      NSg/V . ISg NSg/V  D/P NSg   NPl     J/P NSg/V   V/C
+> down      out         of the young     breath  - giving air   . I   bought a   dozen volumes on  banking and
+# NSg/V/J/P NSg/V/J/R/P P  D   NPrSg/V/J NSg/V/J . V      NSg/V . ISg NSg/V  D/P NSg   NPl     J/P NSg/V   V/C
 > credit and investment securities , and they stood on  my shelf in          red   and gold
 # NSg/V  V/C NSg        NPl        . V/C IPl  V     J/P D  NSg   NPrSg/V/J/P NSg/J V/C NSg/V/J
 > like        new     money from the mint    , promising to unfold the shining secrets that    only
 # NSg/V/J/C/P NSg/V/J NSg/J P    D   NSg/V/J . NSg/V/J   P  NSg/V  D   V       NPl     N/I/C/D W?
-> Midas and Morgan and Mæcenas knew . And I   had the high    intention of  reading many
-# NPrSg V/C NPrSg  V/C ?       V    . V/C ISg V   D   NSg/V/J NSg/V     V/P NPrSg/V N/I/J/D
+> Midas and Morgan and Mæcenas knew . And I   had the high    intention of reading many
+# NPrSg V/C NPrSg  V/C ?       V    . V/C ISg V   D   NSg/V/J NSg/V     P  NPrSg/V N/I/J/D
 > other   books besides . I   was rather    literary in          college — one       year I   wrote a   series
 # NSg/V/J NPl   NPl     . ISg V   NPrSg/V/J J        NPrSg/V/J/P NSg     . NSg/I/V/J NSg  ISg V     D/P NSg
-> of  very solemn and obvious editorials for the Yale News  — and now         I   was going   to
-# V/P J    J      V/C J       NPl        C/P D   NPr  NSg/V . V/C NPrSg/V/J/C ISg V   NSg/V/J P
+> of very solemn and obvious editorials for the Yale News  — and now         I   was going   to
+# P  J    J      V/C J       NPl        C/P D   NPr  NSg/V . V/C NPrSg/V/J/C ISg V   NSg/V/J P
 > bring back    all       such  things into my life  and become again that    most    limited of
-# V     NSg/V/J NSg/I/J/C NSg/I NPl    P    D  NSg/V V/C V      P     N/I/C/D NSg/I/J NSg/V/J V/P
+# V     NSg/V/J NSg/I/J/C NSg/I NPl    P    D  NSg/V V/C V      P     N/I/C/D NSg/I/J NSg/V/J P
 > all       specialists , the “ well    - rounded man         . ” This isn’t just an  epigram — life  is much
 # NSg/I/J/C NPl         . D   . NSg/V/J . W?      NPrSg/I/V/J . . I/D  NSg/V V/J  D/P NSg     . NSg/V VL N/I/J
 > more        successfully looked at        from a   single  window , after all       .
 # NPrSg/I/V/J J/R          W?     NSg/I/V/P P    D/P NSg/V/J NSg/V  . J/P   NSg/I/J/C .
 >
 #
-> It        was a   matter  of  chance    that    I   should have   rented a   house   in          one       of  the
-# NPrSg/ISg V   D/P NSg/V/J V/P NPrSg/V/J N/I/C/D ISg VX     NSg/VX W?     D/P NPrSg/V NPrSg/V/J/P NSg/I/V/J V/P D
+> It        was a   matter  of chance    that    I   should have   rented a   house   in          one       of the
+# NPrSg/ISg V   D/P NSg/V/J P  NPrSg/V/J N/I/C/D ISg VX     NSg/VX W?     D/P NPrSg/V NPrSg/V/J/P NSg/I/V/J P  D
 > strangest communities in          North     America . It        was on  that    slender riotous island
 # W?        NPl         NPrSg/V/J/P NPrSg/V/J NPr     . NPrSg/ISg V   J/P N/I/C/D J       J       NSg/V
-> which extends itself due   east    of  New     York — and where there are , among other
-# I/C   NPl     I      NSg/J NPrSg/J V/P NSg/V/J NPr  . V/C NSg/C W?    V   . P     NSg/V/J
-> natural curiosities , two unusual formations of  land    . Twenty miles from the city
-# NSg/J   NPl         . NSg NSg/J   NPl        V/P NPrSg/V . NSg    NPrPl P    D   NSg
-> a   pair  of  enormous eggs , identical in          contour and separated only by      a   courtesy
-# D/P NSg/V V/P J        NPl  . NSg/J     NPrSg/V/J/P NSg/V   V/C W?        W?   NSg/J/P D/P NSg/V/J
-> bay     , jut   out         into the most    domesticated body  of  salt      water in          the Western
-# NSg/V/J . NSg/V NSg/V/J/R/P P    D   NSg/I/J V/J          NSg/V V/P NPrSg/V/J NSg/V NPrSg/V/J/P D   NPrSg/J
-> hemisphere , the great wet     barnyard of  Long      Island Sound   . They are not   perfect
-# NSg        . D   NSg/J NSg/V/J NSg/J    V/P NPrSg/V/J NSg/V  NSg/V/J . IPl  V   NSg/C NSg/V/J
+> which extends itself due   east    of New     York — and where there are , among other
+# I/C   NPl     I      NSg/J NPrSg/J P  NSg/V/J NPr  . V/C NSg/C W?    V   . P     NSg/V/J
+> natural curiosities , two unusual formations of land    . Twenty miles from the city
+# NSg/J   NPl         . NSg NSg/J   NPl        P  NPrSg/V . NSg    NPrPl P    D   NSg
+> a   pair  of enormous eggs , identical in          contour and separated only by      a   courtesy
+# D/P NSg/V P  J        NPl  . NSg/J     NPrSg/V/J/P NSg/V   V/C W?        W?   NSg/J/P D/P NSg/V/J
+> bay     , jut   out         into the most    domesticated body  of salt      water in          the Western
+# NSg/V/J . NSg/V NSg/V/J/R/P P    D   NSg/I/J V/J          NSg/V P  NPrSg/V/J NSg/V NPrSg/V/J/P D   NPrSg/J
+> hemisphere , the great wet     barnyard of Long      Island Sound   . They are not   perfect
+# NSg        . D   NSg/J NSg/V/J NSg/J    P  NPrSg/V/J NSg/V  NSg/V/J . IPl  V   NSg/C NSg/V/J
 > ovals — like        the egg   in          the Columbus story , they are both crushed flat    at        the
 # NPl   . NSg/V/J/C/P D   NSg/V NPrSg/V/J/P D   NPrSg/V  NSg/V . IPl  V   I/C  W?      NSg/V/J NSg/I/V/P D
-> contact end   — but     their physical resemblance must  be     a   source of  perpetual wonder
-# NSg/V   NSg/V . NSg/C/P D     NSg/J    NSg         NSg/V NSg/VX D/P NSg/V  V/P NSg/J     NSg/V
+> contact end   — but     their physical resemblance must  be     a   source of perpetual wonder
+# NSg/V   NSg/V . NSg/C/P D     NSg/J    NSg         NSg/V NSg/VX D/P NSg/V  P  NSg/J     NSg/V
 > to the gulls that    fly     overhead . To the wingless a   more        interesting phenomenon is
 # P  D   NPl   N/I/C/D NSg/V/J NSg/J/P  . P  D   J        D/P NPrSg/I/V/J V/J         NSg        VL
 > their dissimilarity in          every particular except shape and size  .
 # D     NSg           NPrSg/V/J/P D     NSg/J      V/C/P  NSg/V V/C NSg/V .
 >
 #
-> I   lived at        West      Egg   , the — well    , the less    fashionable of  the two , though this is a
-# ISg W?    NSg/I/V/P NPrSg/V/J NSg/V . D   . NSg/V/J . D   V/J/C/P NSg/J       V/P D   NSg . V/C    I/D  VL D/P
+> I   lived at        West      Egg   , the — well    , the less    fashionable of the two , though this is a
+# ISg W?    NSg/I/V/P NPrSg/V/J NSg/V . D   . NSg/V/J . D   V/J/C/P NSg/J       P  D   NSg . V/C    I/D  VL D/P
 > most    superficial tag   to express the bizarre and not   a   little    sinister contrast
 # NSg/I/J NSg/J       NSg/V P  NSg/V/J D   J       V/C NSg/C D/P NPrSg/I/J J        NSg/V
-> between them . My house   was at        the very tip   of  the egg   , only fifty yards from the
-# NSg/P   N/I  . D  NPrSg/V V   NSg/I/V/P D   J    NSg/V V/P D   NSg/V . W?   NSg   NPl   P    D
+> between them . My house   was at        the very tip   of the egg   , only fifty yards from the
+# NSg/P   N/I  . D  NPrSg/V V   NSg/I/V/P D   J    NSg/V P  D   NSg/V . W?   NSg   NPl   P    D
 > Sound   , and squeezed between two huge places that    rented for twelve or      fifteen
 # NSg/V/J . V/C W?       NSg/P   NSg J    NPl    N/I/C/D W?     C/P NSg    NPrSg/C NSg
 > thousand a   season . The one       on  my right     was a   colossal affair by      any   standard — it
 # NSg      D/P NSg/V  . D   NSg/I/V/J J/P D  NPrSg/V/J V   D/P J        NSg    NSg/J/P I/R/D NSg/J    . NPrSg/ISg
-> was a   factual imitation of  some  Hôtel de    Ville in          Normandy , with a   tower   on  one
-# V   D/P NSg/J   NSg       V/P I/J/R ?     NPrSg ?     NPrSg/V/J/P NPr      . P    D/P NSg/V/J J/P NSg/I/V/J
-> side    , spanking new     under   a   thin    beard   of  raw     ivy   , and a   marble  swimming pool  ,
-# NSg/V/J . NSg/V/J  NSg/V/J NSg/J/P D/P NSg/V/J NPrSg/V V/P NSg/V/J NPrSg . V/C D/P NSg/V/J NSg/V    NSg/V .
-> and more        than forty acres of  lawn  and garden  . It        was Gatsby’s mansion . Or      ,
-# V/C NPrSg/I/V/J C/P  NSg/J NPl   V/P NSg/V V/C NSg/V/J . NPrSg/ISg V   N$       NSg     . NPrSg/C .
+> was a   factual imitation of some  Hôtel de    Ville in          Normandy , with a   tower   on  one
+# V   D/P NSg/J   NSg       P  I/J/R ?     NPrSg ?     NPrSg/V/J/P NPr      . P    D/P NSg/V/J J/P NSg/I/V/J
+> side    , spanking new     under   a   thin    beard   of raw     ivy   , and a   marble  swimming pool  ,
+# NSg/V/J . NSg/V/J  NSg/V/J NSg/J/P D/P NSg/V/J NPrSg/V P  NSg/V/J NPrSg . V/C D/P NSg/V/J NSg/V    NSg/V .
+> and more        than forty acres of lawn  and garden  . It        was Gatsby’s mansion . Or      ,
+# V/C NPrSg/I/V/J C/P  NSg/J NPl   P  NSg/V V/C NSg/V/J . NPrSg/ISg V   N$       NSg     . NPrSg/C .
 > rather    , as    I   didn’t know  Mr  . Gatsby , it        was a   mansion inhabited by      a   gentleman
 # NPrSg/V/J . NSg/R ISg V      NSg/V NSg . NPr    . NPrSg/ISg V   D/P NSg     J         NSg/J/P D/P NSg
-> of  that    name  . My own     house   was an  eyesore , but     it        was a   small     eyesore , and it
-# V/P N/I/C/D NSg/V . D  NSg/V/J NPrSg/V V   D/P NSg     . NSg/C/P NPrSg/ISg V   D/P NPrSg/V/J NSg     . V/C NPrSg/ISg
-> had been  overlooked , so        I   had a   view  of  the water , a   partial view  of  my
-# V   NSg/V W?         . NSg/I/J/C ISg V   D/P NSg/V V/P D   NSg/V . D/P NSg/V/J NSg/V V/P D
-> neighbor’s lawn  , and the consoling proximity of  millionaires — all       for eighty
-# N$         NSg/V . V/C D   NSg/V/J   NSg       V/P NPl          . NSg/I/J/C C/P N
+> of that    name  . My own     house   was an  eyesore , but     it        was a   small     eyesore , and it
+# P  N/I/C/D NSg/V . D  NSg/V/J NPrSg/V V   D/P NSg     . NSg/C/P NPrSg/ISg V   D/P NPrSg/V/J NSg     . V/C NPrSg/ISg
+> had been  overlooked , so        I   had a   view  of the water , a   partial view  of my
+# V   NSg/V W?         . NSg/I/J/C ISg V   D/P NSg/V P  D   NSg/V . D/P NSg/V/J NSg/V P  D
+> neighbor’s lawn  , and the consoling proximity of millionaires — all       for eighty
+# N$         NSg/V . V/C D   NSg/V/J   NSg       P  NPl          . NSg/I/J/C C/P N
 > dollars a   month .
 # NPl     D/P NSg   .
 >
 #
-> Across the courtesy bay     the white     palaces of  fashionable East    Egg   glittered
-# NSg/P  D   NSg/V/J  NSg/V/J D   NPrSg/V/J NPl     V/P NSg/J       NPrSg/J NSg/V W?
-> along the water , and the history of  the summer  really begins on  the evening I
-# P     D   NSg/V . V/C D   NSg     V/P D   NPrSg/V J/R    NPl    J/P D   NSg/V   ISg
+> Across the courtesy bay     the white     palaces of fashionable East    Egg   glittered
+# NSg/P  D   NSg/V/J  NSg/V/J D   NPrSg/V/J NPl     P  NSg/J       NPrSg/J NSg/V W?
+> along the water , and the history of the summer  really begins on  the evening I
+# P     D   NSg/V . V/C D   NSg     P  D   NPrSg/V J/R    NPl    J/P D   NSg/V   ISg
 > drove over      there to have   dinner with the Tom     Buchanans . Daisy was my second
 # NSg/V NSg/V/J/P W?    P  NSg/VX NSg/V  P    D   NPrSg/V ?         . NPrSg V   D  NSg/V/J
 > cousin once  removed , and I’d known   Tom     in          college . And just after the war   I
@@ -266,20 +266,20 @@
 # V/J   NSg NPl  P    N/I  NPrSg/V/J/P NPr     .
 >
 #
-> Her   husband , among various physical accomplishments , had been  one       of  the most
-# I/J/D NSg/V   . P     J       NSg/J    NPl             . V   NSg/V NSg/I/V/J V/P D   NSg/I/J
+> Her   husband , among various physical accomplishments , had been  one       of the most
+# I/J/D NSg/V   . P     J       NSg/J    NPl             . V   NSg/V NSg/I/V/J P  D   NSg/I/J
 > powerful ends that    ever played football at        New     Haven — a   national figure in          a   way   ,
 # J        NPl  N/I/C/D J    W?     NSg/V    NSg/I/V/P NSg/V/J NSg/V . D/P NSg/J    NSg/V  NPrSg/V/J/P D/P NSg/J .
-> one       of  those men who     reach such  an  acute   limited excellence at        twenty - one       that
-# NSg/I/V/J V/P I/D   NSg NPrSg/I NSg/V NSg/I D/P NSg/V/J NSg/V/J NSg        NSg/I/V/P NSg    . NSg/I/V/J N/I/C/D
-> everything afterward savors of  anti    - climax . His   family were  enormously
-# N/I/V      R/Am      NPl    V/P NSg/J/P . NSg/V  . ISg/D NSg/J  NSg/V J/R
+> one       of those men who     reach such  an  acute   limited excellence at        twenty - one       that
+# NSg/I/V/J P  I/D   NSg NPrSg/I NSg/V NSg/I D/P NSg/V/J NSg/V/J NSg        NSg/I/V/P NSg    . NSg/I/V/J N/I/C/D
+> everything afterward savors of anti    - climax . His   family were  enormously
+# N/I/V      R/Am      NPl    P  NSg/J/P . NSg/V  . ISg/D NSg/J  NSg/V J/R
 > wealthy — even    in          college his   freedom with money was a   matter  for reproach — but     now
 # NSg/J   . NSg/V/J NPrSg/V/J/P NSg     ISg/D NSg     P    NSg/J V   D/P NSg/V/J C/P NSg/V    . NSg/C/P NPrSg/V/J/C
 > he’d left      Chicago and come    East    in          a   fashion that    rather    took your breath  away :
 # W?   NPrSg/V/J NPr     V/C NSg/V/P NPrSg/J NPrSg/V/J/P D/P NSg/V   N/I/C/D NPrSg/V/J V    D    NSg/V/J V/J  .
-> for instance , he’d brought down      a   string of  polo  ponies from Lake  Forest  . It        was
-# C/P NSg/V    . W?   V       NSg/V/J/P D/P NSg/V  V/P NPrSg NPl    P    NSg/V NPrSg/V . NPrSg/ISg V
+> for instance , he’d brought down      a   string of polo  ponies from Lake  Forest  . It        was
+# C/P NSg/V    . W?   V       NSg/V/J/P D/P NSg/V  P  NPrSg NPl    P    NSg/V NPrSg/V . NPrSg/ISg V
 > hard    to realize that    a   man         in          my own     generation was wealthy enough to do     that    .
 # NSg/V/J P  V       N/I/C/D D/P NPrSg/I/V/J NPrSg/V/J/P D  NSg/V/J NSg        V   NSg/J   NSg/I  P  NSg/VX N/I/C/D .
 >
@@ -294,8 +294,8 @@
 # D   NSg/V     . NSg/C/P ISg V      V       NPrSg/ISg . ISg V   NPrSg/P NSg/V P    N$      NSg/V . NSg/C/P ISg
 > felt    that    Tom     would  drift on  forever seeking , a   little    wistfully , for the
 # NSg/V/J N/I/C/D NPrSg/V NSg/VX NSg/V J/P NSg/J   V       . D/P NPrSg/I/J J/R       . C/P D
-> dramatic turbulence of  some  irrecoverable football game    .
-# J        NSg        V/P I/J/R J             NSg/V    NSg/V/J .
+> dramatic turbulence of some  irrecoverable football game    .
+# J        NSg        P  I/J/R J             NSg/V    NSg/V/J .
 >
 #
 > And so        it        happened that    on  a   warm    windy evening I   drove over      to East    Egg   to see
@@ -306,12 +306,12 @@
 # C/P  ISg NSg/J    . D/P J        NSg/J . V/C . NPrSg/V/J NSg/J    NSg/J    NSg     . V
 > the bay     . The lawn  started at        the beach   and ran   toward the front   door  for a
 # D   NSg/V/J . D   NSg/V W?      NSg/I/V/P D   NPrSg/V V/C NSg/V J/P    D   NSg/V/J NSg/V C/P D/P
-> quarter of  a   mile , jumping over      sun     - dials and brick   walks and burning
-# NSg/V/J V/P D/P NSg  . V       NSg/V/J/P NPrSg/V . NPl   V/C NSg/V/J NPl   V/C V
+> quarter of a   mile , jumping over      sun     - dials and brick   walks and burning
+# NSg/V/J P  D/P NSg  . V       NSg/V/J/P NPrSg/V . NPl   V/C NSg/V/J NPl   V/C V
 > gardens — finally when    it        reached the house   drifting up        the side    in          bright    vines
 # NPl     . J/R     NSg/I/C NPrSg/ISg W?      D   NPrSg/V V        NSg/V/J/P D   NSg/V/J NPrSg/V/J/P NPrSg/V/J NPl
-> as    though from the momentum of  its   run   . The front   was broken by      a   line  of  French
-# NSg/R V/C    P    D   NSg      V/P ISg/D NSg/V . D   NSg/V/J V   V/J    NSg/J/P D/P NSg/V V/P NPrSg/V/J
+> as    though from the momentum of its   run   . The front   was broken by      a   line  of French
+# NSg/R V/C    P    D   NSg      P  ISg/D NSg/V . D   NSg/V/J V   V/J    NSg/J/P D/P NSg/V P  NPrSg/V/J
 > windows , glowing now         with reflected gold    and wide  open    to the warm    windy
 # NPrPl   . NSg/V/J NPrSg/V/J/C P    W?        NSg/V/J V/C NSg/J NSg/V/J P  D   NSg/V/J NSg/J
 > afternoon , and Tom     Buchanan in          riding clothes was standing with his   legs apart
@@ -322,38 +322,38 @@
 #
 > He      had changed since his   New     Haven years . Now         he      was a   sturdy straw   - haired man
 # NPr/ISg V   V/J     C/P   ISg/D NSg/V/J NSg/V NPl   . NPrSg/V/J/C NPr/ISg V   D/P NSg/J  NSg/V/J . W?     NPrSg/I/V/J
-> of  thirty with a   rather    hard    mouth and a   supercilious manner . Two shining
-# V/P NSg    P    D/P NPrSg/V/J NSg/V/J NSg/V V/C D/P J            NSg    . NSg V
+> of thirty with a   rather    hard    mouth and a   supercilious manner . Two shining
+# P  NSg    P    D/P NPrSg/V/J NSg/V/J NSg/V V/C D/P J            NSg    . NSg V
 > arrogant eyes had established dominance over      his   face  and gave him the
 # J        NPl  V   W?          NSg       NSg/V/J/P ISg/D NSg/V V/C V    I   D
-> appearance of  always leaning aggressively forward . Not   even    the effeminate swank
-# NSg        V/P W?     NSg/V   J/R          NSg/V/J . NSg/C NSg/V/J D   NSg/V/J    NSg/V/J
-> of  his   riding clothes could  hide  the enormous power   of  that    body  — he      seemed to
-# V/P ISg/D NSg/V  NPl     NSg/VX NSg/V D   J        NSg/V/J V/P N/I/C/D NSg/V . NPr/ISg W?     P
+> appearance of always leaning aggressively forward . Not   even    the effeminate swank
+# NSg        P  W?     NSg/V   J/R          NSg/V/J . NSg/C NSg/V/J D   NSg/V/J    NSg/V/J
+> of his   riding clothes could  hide  the enormous power   of that    body  — he      seemed to
+# P  ISg/D NSg/V  NPl     NSg/VX NSg/V D   J        NSg/V/J P  N/I/C/D NSg/V . NPr/ISg W?     P
 > fill  those glistening boots until he      strained the top     lacing , and you could  see
 # NSg/V I/D   V          NPl   C/P   NPr/ISg W?       D   NSg/V/J V      . V/C IPl NSg/VX NSg/V
-> a   great pack  of  muscle shifting when    his   shoulder moved under   his   thin    coat  . It
-# D/P NSg/J NSg/V V/P NSg/V  V        NSg/I/C ISg/D NSg/V    V/J   NSg/J/P ISg/D NSg/V/J NSg/V . NPrSg/ISg
-> was a   body  capable of  enormous leverage — a   cruel   body  .
-# V   D/P NSg/V J       V/P J        NSg/V    . D/P NSg/V/J NSg/V .
+> a   great pack  of muscle shifting when    his   shoulder moved under   his   thin    coat  . It
+# D/P NSg/J NSg/V P  NSg/V  V        NSg/I/C ISg/D NSg/V    V/J   NSg/J/P ISg/D NSg/V/J NSg/V . NPrSg/ISg
+> was a   body  capable of enormous leverage — a   cruel   body  .
+# V   D/P NSg/V J       P  J        NSg/V    . D/P NSg/V/J NSg/V .
 >
 #
 > His   speaking voice , a   gruff   husky tenor , added to the impression of
-# ISg/D V        NSg/V . D/P NSg/V/J NSg/J NSg/J . W?    P  D   NSg/V      V/P
-> fractiousness he      conveyed . There was a   touch of  paternal contempt in          it        , even
-# NSg           NPr/ISg W?       . W?    V   D/P NSg/V V/P J        NSg      NPrSg/V/J/P NPrSg/ISg . NSg/V/J
+# ISg/D V        NSg/V . D/P NSg/V/J NSg/J NSg/J . W?    P  D   NSg/V      P
+> fractiousness he      conveyed . There was a   touch of paternal contempt in          it        , even
+# NSg           NPr/ISg W?       . W?    V   D/P NSg/V P  J        NSg      NPrSg/V/J/P NPrSg/ISg . NSg/V/J
 > toward people he      liked — and there were  men at        New     Haven who     had hated his   guts .
 # J/P    NSg/V  NPr/ISg W?    . V/C W?    NSg/V NSg NSg/I/V/P NSg/V/J NSg/V NPrSg/I V   W?    ISg/D NPl  .
 >
 #
 > “ Now         , don’t think my opinion on  these matters is final   , ” he      seemed to say   , “ just
 # . NPrSg/V/J/C . NSg/V NSg/V D  NSg/V   J/P I/D   W?      VL NSg/V/J . . NPr/ISg W?     P  NSg/V . . V/J
-> because I’m stronger and more        of  a   man         than you are . ” We  were  in          the same senior
-# C/P     W?  J        V/C NPrSg/I/V/J V/P D/P NPrSg/I/V/J C/P  IPl V   . . IPl NSg/V NPrSg/V/J/P D   I/J  NPrSg/J
+> because I’m stronger and more        of a   man         than you are . ” We  were  in          the same senior
+# C/P     W?  J        V/C NPrSg/I/V/J P  D/P NPrSg/I/V/J C/P  IPl V   . . IPl NSg/V NPrSg/V/J/P D   I/J  NPrSg/J
 > society , and while     we  were  never intimate I   always had the impression that    he
 # NSg     . V/C NSg/V/C/P IPl NSg/V V     NSg/V/J  ISg W?     V   D   NSg/V      N/I/C/D NPr/ISg
-> approved of  me        and wanted me        to like        him with some  harsh , defiant wistfulness of
-# V/J      V/P NPrSg/ISg V/C V/J    NPrSg/ISg P  NSg/V/J/C/P I   P    I/J/R V/J   . NSg/J   NSg         V/P
+> approved of me        and wanted me        to like        him with some  harsh , defiant wistfulness of
+# V/J      P  NPrSg/ISg V/C V/J    NPrSg/ISg P  NSg/V/J/C/P I   P    I/J/R V/J   . NSg/J   NSg         P
 > his   own     .
 # ISg/D NSg/V/J .
 >
@@ -368,8 +368,8 @@
 #
 > Turning me        around by      one       arm     , he      moved a   broad flat    hand  along the front   vista ,
 # NSg/V   NPrSg/ISg J/P    NSg/J/P NSg/I/V/J NSg/V/J . NPr/ISg V/J   D/P NSg/J NSg/V/J NSg/V P     D   NSg/V/J NSg/V .
-> including in          its   sweep a   sunken Italian garden  , a   half      acre of  deep  , pungent
-# V         NPrSg/V/J/P ISg/D NSg/V D/P W?     NSg/J   NSg/V/J . D/P NSg/V/J/P NSg  V/P NSg/J . J
+> including in          its   sweep a   sunken Italian garden  , a   half      acre of deep  , pungent
+# V         NPrSg/V/J/P ISg/D NSg/V D/P W?     NSg/J   NSg/V/J . D/P NSg/V/J/P NSg  P  NSg/J . J
 > roses , and a   snub    - nosed motor   - boat  that    bumped the tide  offshore .
 # NPl   . V/C D/P NSg/V/J . W?    NSg/V/J . NSg/V N/I/C/D W?     D   NSg/V NSg/V/J  .
 >
@@ -390,8 +390,8 @@
 # P    D   NPrSg/V . D/P NSg/V  NSg/V/J NSg/J/P D   NSg/V/J . NSg/V/J NPl      NPrSg/V/J/P NSg/I/V/P NSg/I/V/J NSg/V V/C
 > out         the other   like        pale    flags , twisting them up        toward the frosted wedding - cake
 # NSg/V/J/R/P D   NSg/V/J NSg/V/J/C/P NSg/V/J NPl   . V        N/I  NSg/V/J/P J/P    D   W?      NSg/V   . NSg/V
-> of  the ceiling , and then    rippled over      the wine  - colored    rug     , making a   shadow  on
-# V/P D   NSg/V   . V/C NSg/J/C W?      NSg/V/J/P D   NSg/V . NSg/V/J/Am NSg/V/J . NSg/V  D/P NSg/V/J J/P
+> of the ceiling , and then    rippled over      the wine  - colored    rug     , making a   shadow  on
+# P  D   NSg/V   . V/C NSg/J/C W?      NSg/V/J/P D   NSg/V . NSg/V/J/Am NSg/V/J . NSg/V  D/P NSg/V/J J/P
 > it        as    wind  does  on  the sea .
 # NPrSg/ISg NSg/R NSg/V NSg/V J/P D   NSg .
 >
@@ -404,24 +404,24 @@
 # I/C  NPrSg/V/J/P NPrSg/V/J . V/C D     NPl     NSg/V V        V/C V          NSg/R NSg/C IPl  V
 > just been  blown back    in          after a   short       flight  around the house   . I   must  have   stood
 # V/J  NSg/V V/J   NSg/V/J NPrSg/V/J/P J/P   D/P NPrSg/V/J/P NSg/V/J J/P    D   NPrSg/V . ISg NSg/V NSg/VX V
-> for a   few moments listening to the whip  and snap    of  the curtains and the groan
-# C/P D/P N/I NPl     V         P  D   NSg/V V/C NSg/V/J V/P D   NPl      V/C D   NSg/V
-> of  a   picture on  the wall    . Then    there was a   boom  as    Tom     Buchanan shut    the rear
-# V/P D/P NSg/V   J/P D   NPrSg/V . NSg/J/C W?    V   D/P NSg/V NSg/R NPrSg/V NPr      NSg/V/J D   NSg/V/J
+> for a   few moments listening to the whip  and snap    of the curtains and the groan
+# C/P D/P N/I NPl     V         P  D   NSg/V V/C NSg/V/J P  D   NPl      V/C D   NSg/V
+> of a   picture on  the wall    . Then    there was a   boom  as    Tom     Buchanan shut    the rear
+# P  D/P NSg/V   J/P D   NPrSg/V . NSg/J/C W?    V   D/P NSg/V NSg/R NPrSg/V NPr      NSg/V/J D   NSg/V/J
 > windows and the caught wind  died out         about the room    , and the curtains and the
 # NPrPl   V/C D   V/J    NSg/V W?   NSg/V/J/R/P J/P   D   NSg/V/J . V/C D   NPl      V/C D
 > rugs and the two young     women ballooned slowly to the floor .
 # NPl  V/C D   NSg NPrSg/V/J NPl   W?        J/R    P  D   NSg/V .
 >
 #
-> The younger of  the two was a   stranger to me        . She was extended full    length at        her
-# D   J       V/P D   NSg V   D/P NSg/V/J  P  NPrSg/ISg . ISg V   W?       NSg/V/J NSg/V  NSg/I/V/P I/J/D
-> end   of  the divan , completely motionless , and with her   chin    raised a   little    , as
-# NSg/V V/P D   NSg   . J/R        J          . V/C P    I/J/D NPrSg/V W?     D/P NPrSg/I/J . NSg/R
+> The younger of the two was a   stranger to me        . She was extended full    length at        her
+# D   J       P  D   NSg V   D/P NSg/V/J  P  NPrSg/ISg . ISg V   W?       NSg/V/J NSg/V  NSg/I/V/P I/J/D
+> end   of the divan , completely motionless , and with her   chin    raised a   little    , as
+# NSg/V P  D   NSg   . J/R        J          . V/C P    I/J/D NPrSg/V W?     D/P NPrSg/I/J . NSg/R
 > if    she were  balancing something on  it        which was quite likely to fall  . If    she saw
 # NSg/C ISg NSg/V V         NSg/I/V/J J/P NPrSg/ISg I/C   V   NSg   NSg/J  P  NSg/V . NSg/C ISg NSg/V
-> me        out         of  the corner  of  her   eyes she gave no      hint  of  it        — indeed , I   was almost
-# NPrSg/ISg NSg/V/J/R/P V/P D   NSg/V/J V/P I/J/D NPl  ISg V    NPrSg/P NSg/V V/P NPrSg/ISg . W?     . ISg V   NSg
+> me        out         of the corner  of her   eyes she gave no      hint  of it        — indeed , I   was almost
+# NPrSg/ISg NSg/V/J/R/P P  D   NSg/V/J P  I/J/D NPl  ISg V    NPrSg/P NSg/V P  NPrSg/ISg . W?     . ISg V   NSg
 > surprised into murmuring an  apology for having disturbed her   by      coming  in          .
 # W?        P    NSg/V     D/P NSg     C/P V      V/J       I/J/D NSg/J/P NSg/V/J NPrSg/V/J/P .
 >
@@ -444,8 +444,8 @@
 # NSg    . V       NSg/V/J/P P    D  NSg/V . NSg/V/J   N/I/C/D W?    V   NPrSg/P NSg/I/V/J NPrSg/V/J/P D   NSg/V
 > she so        much  wanted to see   . That    was a   way   she had . She hinted in          a   murmur that
 # ISg NSg/I/J/C N/I/J V/J    P  NSg/V . N/I/C/D V   D/P NSg/J ISg V   . ISg W?     NPrSg/V/J/P D/P NSg/V  N/I/C/D
-> the surname of  the balancing girl  was Baker   . ( I’ve heard it        said that    Daisy’s
-# D   NSg/V   V/P D   V         NSg/V V   NPrSg/J . . W?   V/J   NPrSg/ISg V/J  N/I/C/D N$
+> the surname of the balancing girl  was Baker   . ( I’ve heard it        said that    Daisy’s
+# D   NSg/V   P  D   V         NSg/V V   NPrSg/J . . W?   V/J   NPrSg/ISg V/J  N/I/C/D N$
 > murmur was only to make  people lean      toward her   ; an  irrelevant criticism that
 # NSg/V  V   W?   P  NSg/V NSg/V  NPrSg/V/J J/P    I/J/D . D/P J          NSg       N/I/C/D
 > made  it        no      less    charming . )
@@ -456,20 +456,20 @@
 # NSg/I/V/P I/R/D NSg/V . NSg/V N$      NPl  W?        . ISg V      NSg/I/V/P NPrSg/ISg NSg    R             .
 > and then    quickly tipped her   head      back    again — the object she was balancing had
 # V/C NSg/J/C J/R     V      I/J/D NPrSg/V/J NSg/V/J P     . D   NSg/V  ISg V   V         V
-> obviously tottered a   little    and given     her   something of  a   fright  . Again a   sort  of
-# J/R       W?       D/P NPrSg/I/J V/C NSg/V/J/P I/J/D NSg/I/V/J V/P D/P NSg/V/J . P     D/P NSg/V V/P
-> apology arose to my lips . Almost any   exhibition of  complete self      - sufficiency
-# NSg     V     P  D  NPl  . NSg    I/R/D NSg        V/P NSg/V/J  NSg/I/V/J . NSg
+> obviously tottered a   little    and given     her   something of a   fright  . Again a   sort  of
+# J/R       W?       D/P NPrSg/I/J V/C NSg/V/J/P I/J/D NSg/I/V/J P  D/P NSg/V/J . P     D/P NSg/V P
+> apology arose to my lips . Almost any   exhibition of complete self      - sufficiency
+# NSg     V     P  D  NPl  . NSg    I/R/D NSg        P  NSg/V/J  NSg/I/V/J . NSg
 > draws a   stunned tribute from me        .
 # NPl   D/P V/J     NSg/V   P    NPrSg/ISg .
 >
 #
 > I   looked back    at        my cousin , who     began to ask   me        questions in          her   low     , thrilling
 # ISg W?     NSg/V/J NSg/I/V/P D  NSg/V  . NPrSg/I V     P  NSg/V NPrSg/ISg NPl       NPrSg/V/J/P I/J/D NSg/V/J . NSg/V/J
-> voice . It        was the kind  of  voice that    the ear   follows up        and down      , as    if    each
-# NSg/V . NPrSg/ISg V   D   NSg/J V/P NSg/V N/I/C/D D   NSg/V NPl     NSg/V/J/P V/C NSg/V/J/P . NSg/R NSg/C D
-> speech is an  arrangement of  notes that    will     never be     played again . Her   face  was
-# NSg/V  VL D/P NSg         V/P NPl   N/I/C/D NPrSg/VX V     NSg/VX W?     P     . I/J/D NSg/V V
+> voice . It        was the kind  of voice that    the ear   follows up        and down      , as    if    each
+# NSg/V . NPrSg/ISg V   D   NSg/J P  NSg/V N/I/C/D D   NSg/V NPl     NSg/V/J/P V/C NSg/V/J/P . NSg/R NSg/C D
+> speech is an  arrangement of notes that    will     never be     played again . Her   face  was
+# NSg/V  VL D/P NSg         P  NPl   N/I/C/D NPrSg/VX V     NSg/VX W?     P     . I/J/D NSg/V V
 > sad     and lovely  with bright    things in          it        , bright    eyes and a   bright    passionate
 # NSg/V/J V/C NSg/J/R P    NPrSg/V/J NPl    NPrSg/V/J/P NPrSg/ISg . NPrSg/V/J NPl  V/C D/P NPrSg/V/J NSg/V/J
 > mouth , but     there was an  excitement in          her   voice that    men who     had cared for her
@@ -544,8 +544,8 @@
 # ISg V    I   .
 >
 #
-> “ Never heard of  them , ” he      remarked decisively .
-# . V     V/J   V/P N/I  . . NPr/ISg V/J      J/R        .
+> “ Never heard of them , ” he      remarked decisively .
+# . V     V/J   P  N/I  . . NPr/ISg V/J      J/R        .
 >
 #
 > This annoyed me        .
@@ -570,8 +570,8 @@
 # W?      . NPrSg/ISg V   D   NSg/V/J NSg/V ISg V   W?      C/P   ISg NSg/V/P P    D   NSg/V/J .
 > Evidently it        surprised her   as    much  as    it        did me        , for she yawned and with a
 # J/R       NPrSg/ISg W?        I/J/D NSg/R N/I/J NSg/R NPrSg/ISg V   NPrSg/ISg . C/P ISg W?     V/C P    D/P
-> series of  rapid , deft movements stood up        into the room    .
-# NSg    V/P NSg/J . J    NPl       V     NSg/V/J/P P    D   NSg/V/J .
+> series of rapid , deft movements stood up        into the room    .
+# NSg    P  NSg/J . J    NPl       V     NSg/V/J/P P    D   NSg/V/J .
 >
 #
 > “ I’m stiff   , ” she complained , “ I’ve been  lying   on  that    sofa  for as    long      as    I   can
@@ -596,8 +596,8 @@
 # I/J/D NSg/V W?     NSg/I/V/P I/J/D J/R           .
 >
 #
-> “ You are ! ” He      took down      his   drink as    if    it        were  a   drop  in          the bottom  of  a   glass   .
-# . IPl V   . . NPr/ISg V    NSg/V/J/P ISg/D NSg/V NSg/R NSg/C NPrSg/ISg NSg/V D/P NSg/V NPrSg/V/J/P D   NSg/V/J V/P D/P NPrSg/V .
+> “ You are ! ” He      took down      his   drink as    if    it        were  a   drop  in          the bottom  of a   glass   .
+# . IPl V   . . NPr/ISg V    NSg/V/J/P ISg/D NSg/V NSg/R NSg/C NPrSg/ISg NSg/V D/P NSg/V NPrSg/V/J/P D   NSg/V/J P  D/P NPrSg/V .
 > “ How   you ever get   anything done    is beyond me        . ”
 # . NSg/C IPl J    NSg/V NSg/I/V  NSg/V/J VL NSg/P  NPrSg/ISg . .
 >
@@ -610,10 +610,10 @@
 # ISg W?          NSg/J/P V        I/J/D NSg/V NSg/J    NSg/I/V/P D   NPl       NSg/V/J/C/P D/P NPrSg/V/J
 > cadet . Her   gray         sun     - strained eyes looked back    at        me        with polite reciprocal
 # NSg   . I/J/D NPrSg/V/J/Am NPrSg/V . W?       NPl  W?     NSg/V/J NSg/I/V/P NPrSg/ISg P    V/J    NSg/J
-> curiosity out         of  a   wan     , charming , discontented face  . It        occurred to me        now         that
-# NSg       NSg/V/J/R/P V/P D/P NSg/V/J . NSg/V/J  . V/J          NSg/V . NPrSg/ISg V        P  NPrSg/ISg NPrSg/V/J/C N/I/C/D
-> I   had seen  her   , or      a   picture of  her   , somewhere before .
-# ISg V   NSg/V I/J/D . NPrSg/C D/P NSg/V   V/P I/J/D . NSg       C/P    .
+> curiosity out         of a   wan     , charming , discontented face  . It        occurred to me        now         that
+# NSg       NSg/V/J/R/P P  D/P NSg/V/J . NSg/V/J  . V/J          NSg/V . NPrSg/ISg V        P  NPrSg/ISg NPrSg/V/J/C N/I/C/D
+> I   had seen  her   , or      a   picture of her   , somewhere before .
+# ISg V   NSg/V I/J/D . NPrSg/C D/P NSg/V   P  I/J/D . NSg       C/P    .
 >
 #
 > “ You live in          West      Egg   , ” she remarked contemptuously . “ I   know  somebody there . ”
@@ -652,8 +652,8 @@
 # . NSg/V NPl     . . W?       NPrSg . V        . ISg V       N/I  NSg/V/J/R/P P    I/J/D NPl     .
 > “ In          two weeks it’ll be     the longest day   in          the year . ” She looked at        us      all
 # . NPrSg/V/J/P NSg NPrPl W?    NSg/VX D   W?      NPrSg NPrSg/V/J/P D   NSg  . . ISg W?     NSg/I/V/P NPr/ISg NSg/I/J/C
-> radiantly . “ Do     you always watch for the longest day   of  the year and then    miss
-# J/R       . . NSg/VX IPl W?     NSg/V C/P D   W?      NPrSg V/P D   NSg  V/C NSg/J/C NSg/V
+> radiantly . “ Do     you always watch for the longest day   of the year and then    miss
+# J/R       . . NSg/VX IPl W?     NSg/V C/P D   W?      NPrSg P  D   NSg  V/C NSg/J/C NSg/V
 > it        ? I   always watch for the longest day   in          the year and then    miss  it        . ”
 # NPrSg/ISg . ISg W?     NSg/V C/P D   W?      NPrSg NPrSg/V/J/P D   NSg  V/C NSg/J/C NSg/V NPrSg/ISg . .
 >
@@ -686,10 +686,10 @@
 #
 > “ You did it        , Tom     , ” she said accusingly . “ I   know  you didn’t mean    to , but     you did
 # . IPl V   NPrSg/ISg . NPrSg/V . . ISg V/J  J/R        . . ISg NSg/V IPl V      NSg/V/J P  . NSg/C/P IPl V
-> do     it        . That’s what  I   get   for marrying a   brute   of  a   man         , a   great , big     , hulking
-# NSg/VX NPrSg/ISg . N$     NSg/I ISg NSg/V C/P V        D/P NSg/V/J V/P D/P NPrSg/I/V/J . D/P NSg/J . NSg/V/J . V
-> physical specimen of  a   — ” ’
-# NSg/J    NSg      V/P D/P . . .
+> do     it        . That’s what  I   get   for marrying a   brute   of a   man         , a   great , big     , hulking
+# NSg/VX NPrSg/ISg . N$     NSg/I ISg NSg/V C/P V        D/P NSg/V/J P  D/P NPrSg/I/V/J . D/P NSg/J . NSg/V/J . V
+> physical specimen of a   — ” ’
+# NSg/J    NSg      P  D/P . . .
 >
 #
 > “ I   hate  that    word  hulking , ” objected Tom     crossly , “ even    in          kidding . ”
@@ -704,8 +704,8 @@
 # R         ISg V/C NSg/V NPrSg/J W?     NSg/I/V/P NSg/C . J/R           V/C P    D/P NSg/V/J
 > inconsequence that    was never quite chatter , that    was as    cool    as    their white
 # ?             N/I/C/D V   V     NSg   NSg/V   . N/I/C/D V   NSg/R NSg/V/J NSg/R D     NPrSg/V/J
-> dresses and their impersonal eyes in          the absence of  all       desire . They were  here    ,
-# NPl     V/C D     NSg/J      NPl  NPrSg/V/J/P D   NSg     V/P NSg/I/J/C NSg/V  . IPl  NSg/V NSg/J/R .
+> dresses and their impersonal eyes in          the absence of all       desire . They were  here    ,
+# NPl     V/C D     NSg/J      NPl  NPrSg/V/J/P D   NSg     P  NSg/I/J/C NSg/V  . IPl  NSg/V NSg/J/R .
 > and they accepted Tom     and me        , making only a   polite pleasant effort to entertain
 # V/C IPl  V/J      NPrSg/V V/C NPrSg/ISg . NSg/V  W?   D/P V/J    NSg/J    NSg/V  P  NSg/V
 > or      to be     entertained . They knew that    presently dinner would  be     over      and a   little
@@ -716,12 +716,12 @@
 # NSg/J     P    D   NPrSg/V/J . NSg/C D/P NSg/V   V   V/J     P    NPrSg/V P  NPrSg/V J/P
 > its   close   , in          a   continually disappointed anticipation or      else  in          sheer   nervous
 # ISg/D NSg/V/J . NPrSg/V/J/P D/P J/R         W?           NSg          NPrSg/C N/J/C NPrSg/V/J/P NSg/V/J J
-> dread   of  the moment itself .
-# NSg/V/J V/P D   NSg    I      .
+> dread   of the moment itself .
+# NSg/V/J P  D   NSg    I      .
 >
 #
-> “ You make  me        feel      uncivilized , Daisy , ” I   confessed on  my second  glass   of  corky
-# . IPl NSg/V NPrSg/ISg NSg/I/V/J V/J         . NPrSg . . ISg V/J       J/P D  NSg/V/J NPrSg/V V/P ?
+> “ You make  me        feel      uncivilized , Daisy , ” I   confessed on  my second  glass   of corky
+# . IPl NSg/V NPrSg/ISg NSg/I/V/J V/J         . NPrSg . . ISg V/J       J/P D  NSg/V/J NPrSg/V P  ?
 > but     rather    impressive claret  . “ Can’t you talk  about crops or      something ? ”
 # NSg/C/P NPrSg/V/J J          NSg/V/J . . VX    IPl NSg/V J/P   NPl   NPrSg/C NSg/I/V/J . .
 >
@@ -734,8 +734,8 @@
 #
 > “ Civilization’s going   to pieces , ” broke   out         Tom     violently . “ I’ve gotten to be     a
 # . N$             NSg/V/J P  NPl    . . NSg/V/J NSg/V/J/R/P NPrSg/V J/R       . . W?   V/J    P  NSg/VX D/P
-> terrible pessimist about things . Have   you read  ‘          The Rise  of  the Colored    Empires ’
-# J        NSg       J/P   NPl    . NSg/VX IPl NSg/V Unlintable D   NSg/V V/P D   NSg/V/J/Am NPl     .
+> terrible pessimist about things . Have   you read  ‘          The Rise  of the Colored    Empires ’
+# J        NSg       J/P   NPl    . NSg/VX IPl NSg/V Unlintable D   NSg/V P  D   NSg/V/J/Am NPl     .
 > by      this man         Goddard ? ”
 # NSg/J/P I/D  NPrSg/I/V/J NPr     . .
 >
@@ -752,8 +752,8 @@
 # NSg/V . W?   NSg/V V      . .
 >
 #
-> “ Tom’s getting very profound , ” said Daisy , with an  expression of  unthoughtful
-# . N$    NSg/V   J    NSg/V/J  . . V/J  NPrSg . P    D/P NSg        V/P ?
+> “ Tom’s getting very profound , ” said Daisy , with an  expression of unthoughtful
+# . N$    NSg/V   J    NSg/V/J  . . V/J  NPrSg . P    D/P NSg        P  ?
 > sadness . “ He      reads deep  books with long      words in          them . What  was that    word  we  — — — ”
 # NSg     . . NPr/ISg NPl   NSg/J NPl   P    NPrSg/V/J NPl   NPrSg/V/J/P N/I  . NSg/I V   N/I/C/D NSg/V IPl . . . .
 >
@@ -763,7 +763,7 @@
 > impatiently . “ This fellow has worked out         the whole thing . It’s up        to us      , who     are
 # J/R         . . I/D  NSg/V  V   W?     NSg/V/J/R/P D   NSg/J NSg/V . W?   NSg/V/J/P P  NPr/ISg . NPrSg/I V
 > the dominant race  , to watch out         or      these other   races will     have   control of
-# D   NSg/J    NSg/V . P  NSg/V NSg/V/J/R/P NPrSg/C I/D   NSg/V/J NPl   NPrSg/VX NSg/VX NSg/V   V/P
+# D   NSg/J    NSg/V . P  NSg/V NSg/V/J/R/P NPrSg/C I/D   NSg/V/J NPl   NPrSg/VX NSg/VX NSg/V   P
 > things . ”
 # NPl    . .
 >
@@ -792,8 +792,8 @@
 #
 > There was something pathetic in          his   concentration , as    if    his   complacency , more
 # W?    V   NSg/I/V/J J        NPrSg/V/J/P ISg/D NSg           . NSg/R NSg/C ISg/D NSg         . NPrSg/I/V/J
-> acute   than of  old   , was not   enough to him any   more        . When    , almost immediately , the
-# NSg/V/J C/P  V/P NSg/J . V   NSg/C NSg/I  P  I   I/R/D NPrSg/I/V/J . NSg/I/C . NSg    J/R         . D
+> acute   than of old   , was not   enough to him any   more        . When    , almost immediately , the
+# NSg/V/J C/P  P  NSg/J . V   NSg/C NSg/I  P  I   I/R/D NPrSg/I/V/J . NSg/I/C . NSg    J/R         . D
 > telephone rang inside  and the butler  left      the porch Daisy seized upon the
 # NSg/V     V    NSg/J/P V/C D   NPrSg/V NPrSg/V/J D   NSg   NPrSg W?     P    D
 > momentary interruption and leaned toward me        .
@@ -848,8 +848,8 @@
 # NSg/V/J V/C NSg/V/J .
 >
 #
-> “ I   love    to see   you at        my table , Nick    . You remind me        of  a   — of  a   rose      , an  absolute
-# . ISg NPrSg/V P  NSg/V IPl NSg/I/V/P D  NSg/V . NPrSg/V . IPl NSg/V  NPrSg/ISg V/P D/P . V/P D/P NPrSg/V/J . D/P NSg/J
+> “ I   love    to see   you at        my table , Nick    . You remind me        of a   — of a   rose      , an  absolute
+# . ISg NPrSg/V P  NSg/V IPl NSg/I/V/P D  NSg/V . NPrSg/V . IPl NSg/V  NPrSg/ISg P  D/P . P  D/P NPrSg/V/J . D/P NSg/J
 > rose      . Doesn’t he      ? ” She turned to Miss  Baker   for confirmation : “ An  absolute
 # NPrSg/V/J . V       NPr/ISg . . ISg W?     P  NSg/V NPrSg/J C/P NSg          . . D/P NSg/J
 > rose      ? ”
@@ -860,26 +860,26 @@
 # I/D  V   J      . ISg NPrSg/V/J NSg/C NSg/V/J J/R     NSg/V/J/C/P D/P NPrSg/V/J . ISg V   W?   V             .
 > but     a   stirring warmth flowed from her   , as    if    her   heart was trying  to come    out         to
 # NSg/C/P D/P NSg/V/J  NSg    W?     P    I/J/D . NSg/R NSg/C I/J/D NSg/V V   NSg/V/J P  NSg/V/P NSg/V/J/R/P P
-> you concealed in          one       of  those breathless , thrilling words . Then    suddenly she
-# IPl V/J       NPrSg/V/J/P NSg/I/V/J V/P I/D   J          . NSg/V/J   NPl   . NSg/J/C J/R      ISg
+> you concealed in          one       of those breathless , thrilling words . Then    suddenly she
+# IPl V/J       NPrSg/V/J/P NSg/I/V/J P  I/D   J          . NSg/V/J   NPl   . NSg/J/C J/R      ISg
 > threw her   napkin on  the table and excused herself and went  into the house   .
 # V     I/J/D NSg    J/P D   NSg/V V/C V       I       V/C NSg/V P    D   NPrSg/V .
 >
 #
-> Miss  Baker   and I   exchanged a   short       glance consciously devoid of  meaning . I   was
-# NSg/V NPrSg/J V/C ISg W?        D/P NPrSg/V/J/P NSg/V  J/R         V/J    V/P NSg/V/J . ISg V
+> Miss  Baker   and I   exchanged a   short       glance consciously devoid of meaning . I   was
+# NSg/V NPrSg/J V/C ISg W?        D/P NPrSg/V/J/P NSg/V  J/R         V/J    P  NSg/V/J . ISg V
 > about to speak when    she sat     up        alertly and said “ Sh ! ” in          a   warning voice . A
 # J/P   P  NSg/V NSg/I/C ISg NSg/V/J NSg/V/J/P J/R     V/C V/J  . W? . . NPrSg/V/J/P D/P NSg/V   NSg/V . D/P
 > subdued impassioned murmur was audible in          the room    beyond , and Miss  Baker   leaned
 # W?      J           NSg/V  V   NSg/V/J NPrSg/V/J/P D   NSg/V/J NSg/P  . V/C NSg/V NPrSg/J W?
 > forward unashamed , trying  to hear . The murmur trembled on  the verge of
-# NSg/V/J V/J       . NSg/V/J P  V    . D   NSg/V  W?       J/P D   NSg/V V/P
+# NSg/V/J V/J       . NSg/V/J P  V    . D   NSg/V  W?       J/P D   NSg/V P
 > coherence , sank down      , mounted excitedly , and then    ceased altogether .
 # NSg       . V    NSg/V/J/P . V/J     J/R       . V/C NSg/J/C W?     NSg        .
 >
 #
-> “ This Mr  . Gatsby you spoke of  is my neighbor — ” ’ I   began .
-# . I/D  NSg . NPr    IPl NSg/V V/P VL D  NSg/V    . . . ISg V     .
+> “ This Mr  . Gatsby you spoke of is my neighbor — ” ’ I   began .
+# . I/D  NSg . NPr    IPl NSg/V P  VL D  NSg/V    . . . ISg V     .
 >
 #
 > “ Don’t talk  . I   want  to hear what  happens . ”
@@ -918,10 +918,10 @@
 # NSg/V . .
 >
 #
-> Almost before I   had grasped her   meaning there was the flutter of  a   dress and the
-# NSg    C/P    ISg V   W?      I/J/D NSg/V/J W?    V   D   NSg/V   V/P D/P NSg/V V/C D
-> crunch of  leather boots , and Tom     and Daisy were  back    at        the table .
-# NSg/V  V/P NSg/V/J NPl   . V/C NPrSg/V V/C NPrSg NSg/V NSg/V/J NSg/I/V/P D   NSg/V .
+> Almost before I   had grasped her   meaning there was the flutter of a   dress and the
+# NSg    C/P    ISg V   W?      I/J/D NSg/V/J W?    V   D   NSg/V   P  D/P NSg/V V/C D
+> crunch of leather boots , and Tom     and Daisy were  back    at        the table .
+# NSg/V  P  NSg/V/J NPl   . V/C NPrSg/V V/C NPrSg NSg/V NSg/V/J NSg/I/V/P D   NSg/V .
 >
 #
 > “ It        couldn’t be     helped ! ” cried Daisy with tense   gayety .
@@ -946,32 +946,32 @@
 #
 > The telephone rang inside  , startingly , and as    Daisy shook   her   head      decisively at
 # D   NSg/V     V    NSg/J/P . ?          . V/C NSg/R NPrSg NSg/V/J I/J/D NPrSg/V/J J/R        NSg/I/V/P
-> Tom     the subject of  the stables , in          fact all       subjects , vanished into air   . Among
-# NPrSg/V D   NSg/V/J V/P D   NPl     . NPrSg/V/J/P NSg  NSg/I/J/C NPl      . W?       P    NSg/V . P
-> the broken fragments of  the last    five minutes at        table I   remember the candles
-# D   V/J    NPl       V/P D   NSg/V/J NSg  NPl     NSg/I/V/P NSg/V ISg NSg/V    D   NPl
-> being   lit     again , pointlessly , and I   was conscious of  wanting to look  squarely at
-# NSg/V/C NSg/V/J P     . J/R         . V/C ISg V   NSg/J     V/P V       P  NSg/V J/R      NSg/I/V/P
+> Tom     the subject of the stables , in          fact all       subjects , vanished into air   . Among
+# NPrSg/V D   NSg/V/J P  D   NPl     . NPrSg/V/J/P NSg  NSg/I/J/C NPl      . W?       P    NSg/V . P
+> the broken fragments of the last    five minutes at        table I   remember the candles
+# D   V/J    NPl       P  D   NSg/V/J NSg  NPl     NSg/I/V/P NSg/V ISg NSg/V    D   NPl
+> being   lit     again , pointlessly , and I   was conscious of wanting to look  squarely at
+# NSg/V/C NSg/V/J P     . J/R         . V/C ISg V   NSg/J     P  V       P  NSg/V J/R      NSg/I/V/P
 > every one       , and yet     to avoid all       eyes . I   couldn’t guess what  Daisy and Tom     were
 # D     NSg/I/V/J . V/C NSg/V/C P  V     NSg/I/J/C NPl  . ISg V        NSg/V NSg/I NPrSg V/C NPrSg/V NSg/V
 > thinking , but     I   doubt if    even    Miss  Baker   , who     seemed to have   mastered a   certain
 # V        . NSg/C/P ISg NSg/V NSg/C NSg/V/J NSg/V NPrSg/J . NPrSg/I W?     P  NSg/VX W?       D/P I/J
 > hardy   scepticism , was able    utterly to put   this fifth   guest’s shrill  metallic
 # NPrSg/J NSg/Br     . V   NSg/V/J J/R     P  NSg/V I/D  NSg/V/J N$      NSg/V/J NSg/J
-> urgency out         of  mind  . To a   certain temperament the situation might    have   seemed
-# NSg     NSg/V/J/R/P V/P NSg/V . P  D/P I/J     NSg         D   NSg       NSg/VX/J NSg/VX W?
+> urgency out         of mind  . To a   certain temperament the situation might    have   seemed
+# NSg     NSg/V/J/R/P P  NSg/V . P  D/P I/J     NSg         D   NSg       NSg/VX/J NSg/VX W?
 > intriguing — my own     instinct was to telephone immediately for the police .
 # NSg/V/J    . D  NSg/V/J NSg/J    V   P  NSg/V     J/R         C/P D   NSg/V  .
 >
 #
 > The horses , needless to say   , were  not   mentioned again . Tom     and Miss  Baker   , with
 # D   NPl    . J        P  NSg/V . NSg/V NSg/C V         P     . NPrSg/V V/C NSg/V NPrSg/J . P
-> several feet of  twilight between them , strolled back    into the library , as    if    to
-# J/D     NSg  V/P NSg/V/J  NSg/P   N/I  . W?       NSg/V/J P    D   NSg     . NSg/R NSg/C P
+> several feet of twilight between them , strolled back    into the library , as    if    to
+# J/D     NSg  P  NSg/V/J  NSg/P   N/I  . W?       NSg/V/J P    D   NSg     . NSg/R NSg/C P
 > a   vigil beside a   perfectly tangible body  , while     , trying  to look  pleasantly
 # D/P NSg/V P      D/P J/R       NSg/J    NSg/V . NSg/V/C/P . NSg/V/J P  NSg/V J/R
-> interested and a   little    deaf    , I   followed Daisy around a   chain of  connecting
-# V/J        V/C D/P NPrSg/I/J NSg/V/J . ISg W?       NPrSg J/P    D/P NSg/V V/P V
+> interested and a   little    deaf    , I   followed Daisy around a   chain of connecting
+# V/J        V/C D/P NPrSg/I/J NSg/V/J . ISg W?       NPrSg J/P    D/P NSg/V P  V
 > verandas to the porch in          front   . In          its   deep  gloom we  sat     down      side    by      side    on  a
 # NPl      P  D   NSg   NPrSg/V/J/P NSg/V/J . NPrSg/V/J/P ISg/D NSg/J NSg/V IPl NSg/V/J NSg/V/J/P NSg/V/J NSg/J/P NSg/V/J J/P D/P
 > wicker settee .
@@ -1006,8 +1006,8 @@
 #
 > Evidently she had reason to be     . I   waited but     she didn’t say   any   more        , and after
 # J/R       ISg V   NSg/V  P  NSg/VX . ISg W?     NSg/C/P ISg V      NSg/V I/R/D NPrSg/I/V/J . V/C J/P
-> a   moment I   returned rather    feebly to the subject of  her   daughter .
-# D/P NSg    ISg W?       NPrSg/V/J R      P  D   NSg/V/J V/P I/J/D NSg      .
+> a   moment I   returned rather    feebly to the subject of her   daughter .
+# D/P NSg    ISg W?       NPrSg/V/J R      P  D   NSg/V/J P  I/J/D NSg      .
 >
 #
 > “ I   suppose she talks , and — eats , and everything . ”
@@ -1026,8 +1026,8 @@
 #
 > “ I’ll show  you how   I’ve gotten to feel      about — things . Well    , she was less    than an
 # . W?   NSg/V IPl NSg/C W?   V/J    P  NSg/I/V/J J/P   . NPl    . NSg/V/J . ISg V   V/J/C/P C/P  D/P
-> hour old   and Tom     was God     knows where . I   woke    up        out         of  the ether with an  utterly
-# NSg  NSg/J V/C NPrSg/V V   NPrSg/V NPl   NSg/C . ISg NSg/V/J NSg/V/J/P NSg/V/J/R/P V/P D   NSg/V P    D/P J/R
+> hour old   and Tom     was God     knows where . I   woke    up        out         of the ether with an  utterly
+# NSg  NSg/J V/C NPrSg/V V   NPrSg/V NPl   NSg/C . ISg NSg/V/J NSg/V/J/P NSg/V/J/R/P P  D   NSg/V P    D/P J/R
 > abandoned feeling , and asked the nurse right     away if    it        was a   boy   or      a   girl  . She
 # W?        NSg/V/J . V/C V/J   D   NSg/V NPrSg/V/J V/J  NSg/C NPrSg/ISg V   D/P NSg/V NPrSg/C D/P NSg/V . ISg
 > told me        it        was a   girl  , and so        I   turned my head      away and wept . ‘          All       right     , ’ I
@@ -1052,10 +1052,10 @@
 #
 > The instant her   voice broke   off       , ceasing to compel my attention , my belief , I
 # D   NSg/V/J I/J/D NSg/V NSg/V/J NSg/V/J/P . V       P  V      D  NSg       . D  NSg    . ISg
-> felt    the basic   insincerity of  what  she had said . It        made  me        uneasy  , as    though
-# NSg/V/J D   NPrSg/J NSg         V/P NSg/I ISg V   V/J  . NPrSg/ISg NSg/V NPrSg/ISg NSg/V/J . NSg/R V/C
-> the whole evening had been  a   trick   of  some  sort  to exact a   contributary emotion
-# D   NSg/J NSg/V   V   NSg/V D/P NSg/V/J V/P I/J/R NSg/V P  V/J   D/P ?            NSg
+> felt    the basic   insincerity of what  she had said . It        made  me        uneasy  , as    though
+# NSg/V/J D   NPrSg/J NSg         P  NSg/I ISg V   V/J  . NPrSg/ISg NSg/V NPrSg/ISg NSg/V/J . NSg/R V/C
+> the whole evening had been  a   trick   of some  sort  to exact a   contributary emotion
+# D   NSg/J NSg/V   V   NSg/V D/P NSg/V/J P  I/J/R NSg/V P  V/J   D/P ?            NSg
 > from me        . I   waited , and sure enough , in          a   moment she looked at        me        with an
 # P    NPrSg/ISg . ISg W?     . V/C J    NSg/I  . NPrSg/V/J/P D/P NSg    ISg W?     NSg/I/V/P NPrSg/ISg P    D/P
 > absolute smirk   on  her   lovely  face  , as    if    she had asserted her   membership in          a
@@ -1066,14 +1066,14 @@
 #
 > Inside  , the crimson room    bloomed with light   . Tom     and Miss  Baker   sat     at        either
 # NSg/J/P . D   NSg/V/J NSg/V/J W?      P    NSg/V/J . NPrSg/V V/C NSg/V NPrSg/J NSg/V/J NSg/I/V/P I/C
-> end   of  the long      couch and she read  aloud to him from the Saturday Evening
-# NSg/V V/P D   NPrSg/V/J NSg/V V/C ISg NSg/V J     P  I   P    D   NSg/V    NSg/V
+> end   of the long      couch and she read  aloud to him from the Saturday Evening
+# NSg/V P  D   NPrSg/V/J NSg/V V/C ISg NSg/V J     P  I   P    D   NSg/V    NSg/V
 > Post      — the words , murmurous and uninflected , running   together in          a   soothing tune  .
 # NPrSg/V/P . D   NPl   . J         V/C ?           . NSg/V/J/P J        NPrSg/V/J/P D/P NSg/V/J  NSg/V .
-> The lamp  - light   , bright    on  his   boots and dull on  the autumn  - leaf  yellow  of  her
-# D   NSg/V . NSg/V/J . NPrSg/V/J J/P ISg/D NPl   V/C V/J  J/P D   NPrSg/V . NSg/V NSg/V/J V/P I/J/D
-> hair  , glinted along the paper   as    she turned a   page    with a   flutter of  slender
-# NSg/V . W?      P     D   NSg/V/J NSg/R ISg W?     D/P NPrSg/V P    D/P NSg/V   V/P J
+> The lamp  - light   , bright    on  his   boots and dull on  the autumn  - leaf  yellow  of her
+# D   NSg/V . NSg/V/J . NPrSg/V/J J/P ISg/D NPl   V/C V/J  J/P D   NPrSg/V . NSg/V NSg/V/J P  I/J/D
+> hair  , glinted along the paper   as    she turned a   page    with a   flutter of slender
+# NSg/V . W?      P     D   NSg/V/J NSg/R ISg W?     D/P NPrSg/V P    D/P NSg/V   P  J
 > muscles in          her   arms .
 # NPl     NPrSg/V/J/P I/J/D NPl  .
 >
@@ -1088,8 +1088,8 @@
 # NSg/J/P NSg/V . .
 >
 #
-> Her   body  asserted itself with a   restless movement of  her   knee  , and she stood up        .
-# I/J/D NSg/V W?       I      P    D/P J        NSg      V/P I/J/D NSg/V . V/C ISg V     NSg/V/J/P .
+> Her   body  asserted itself with a   restless movement of her   knee  , and she stood up        .
+# I/J/D NSg/V W?       I      P    D/P J        NSg      P  I/J/D NSg/V . V/C ISg V     NSg/V/J/P .
 >
 #
 > “ Ten o’clock , ” she remarked , apparently finding the time  on  the ceiling . “ Time
@@ -1110,10 +1110,10 @@
 #
 > I   knew now         why   her   face  was familiar — its   pleasing contemptuous expression had
 # ISg V    NPrSg/V/J/C NSg/V I/J/D NSg/V V   NSg/J    . ISg/D NSg/V/J  J            NSg        V
-> looked out         at        me        from many    rotogravure pictures of  the sporting life  at
-# W?     NSg/V/J/R/P NSg/I/V/P NPrSg/ISg P    N/I/J/D NSg         NPl      V/P D   NSg/V/J  NSg/V NSg/I/V/P
-> Asheville and Hot     Springs and Palm  Beach   . I   had heard some  story of  her   too , a
-# NPr       V/C NSg/V/J NPl     V/C NSg/V NPrSg/V . ISg V   V/J   I/J/R NSg/V V/P I/J/D W?  . D/P
+> looked out         at        me        from many    rotogravure pictures of the sporting life  at
+# W?     NSg/V/J/R/P NSg/I/V/P NPrSg/ISg P    N/I/J/D NSg         NPl      P  D   NSg/V/J  NSg/V NSg/I/V/P
+> Asheville and Hot     Springs and Palm  Beach   . I   had heard some  story of her   too , a
+# NPr       V/C NSg/V/J NPl     V/C NSg/V NPrSg/V . ISg V   V/J   I/J/R NSg/V P  I/J/D W?  . D/P
 > critical , unpleasant story , but     what  it        was I   had forgotten long      ago .
 # NSg/J    . NSg/J      NSg/V . NSg/C/P NSg/I NPrSg/ISg V   ISg V   NSg/V/J   NPrSg/V/J J/P .
 >
@@ -1130,14 +1130,14 @@
 # . ISg NPrSg/VX . NPrSg/V/J NSg/V . NSg . ?        . NSg/V IPl NSg/J . .
 >
 #
-> “ Of  course you will     , ” confirmed Daisy . “ In          fact I   think I’ll arrange a   marriage .
-# . V/P NSg/V  IPl NPrSg/VX . . V/J       NPrSg . . NPrSg/V/J/P NSg  ISg NSg/V W?   NSg/V   D/P NSg      .
-> Come    over      often , Nick    , and I’ll sort  of  — oh      — fling you together . You know  — lock  you
-# NSg/V/P NSg/V/J/P J     . NPrSg/V . V/C W?   NSg/V V/P . NPrSg/V . NSg/V IPl J        . IPl NSg/V . NSg/V IPl
+> “ Of course you will     , ” confirmed Daisy . “ In          fact I   think I’ll arrange a   marriage .
+# . P  NSg/V  IPl NPrSg/VX . . V/J       NPrSg . . NPrSg/V/J/P NSg  ISg NSg/V W?   NSg/V   D/P NSg      .
+> Come    over      often , Nick    , and I’ll sort  of — oh      — fling you together . You know  — lock  you
+# NSg/V/P NSg/V/J/P J     . NPrSg/V . V/C W?   NSg/V P  . NPrSg/V . NSg/V IPl J        . IPl NSg/V . NSg/V IPl
 > up        accidentally in          linen closets and push  you out         to sea in          a   boat  , and all       that
 # NSg/V/J/P J/R          NPrSg/V/J/P NSg/J NPl     V/C NSg/V IPl NSg/V/J/R/P P  NSg NPrSg/V/J/P D/P NSg/V . V/C NSg/I/J/C N/I/C/D
-> sort  of  thing — — — ”
-# NSg/V V/P NSg/V . . . .
+> sort  of thing — — — ”
+# NSg/V P  NSg/V . . . .
 >
 #
 > “ Good      night , ” called Miss  Baker   from the stairs . “ I   haven’t heard a   word  . ”
@@ -1160,8 +1160,8 @@
 #
 > “ Her   family is one       aunt about a   thousand years old   . Besides , Nick’s going   to
 # . I/J/D NSg/J  VL NSg/I/V/J NSg  J/P   D/P NSg      NPl   NSg/J . NPl     . N$     NSg/V/J P
-> look  after her   , aren’t you , Nick    ? She’s going   to spend lots of  week - ends out
-# NSg/V J/P   I/J/D . V      IPl . NPrSg/V . W?    NSg/V/J P  NSg/V NPl  V/P NSg  . NPl  NSg/V/J/R/P
+> look  after her   , aren’t you , Nick    ? She’s going   to spend lots of week - ends out
+# NSg/V J/P   I/J/D . V      IPl . NPrSg/V . W?    NSg/V/J P  NSg/V NPl  P  NSg  . NPl  NSg/V/J/R/P
 > here    this summer  . I   think the home    influence will     be     very good      for her   . ”
 # NSg/J/R I/D  NPrSg/V . ISg NSg/V D   NSg/V/J NSg/V     NPrSg/VX NSg/VX J    NPrSg/V/J C/P I/J/D . .
 >
@@ -1188,8 +1188,8 @@
 #
 > “ Did I   ? ” She looked at        me        . “ I   can’t seem to remember , but     I   think we  talked
 # . V   ISg . . ISg W?     NSg/I/V/P NPrSg/ISg . . ISg VX    V    P  NSg/V    . NSg/C/P ISg NSg/V IPl W?
-> about the Nordic race  . Yes   , I’m sure we  did . It        sort  of  crept up        on  us      and first
-# J/P   D   NSg/J  NSg/V . NSg/V . W?  J    IPl V   . NPrSg/ISg NSg/V V/P V     NSg/V/J/P J/P NPr/ISg V/C NSg/V/J
+> about the Nordic race  . Yes   , I’m sure we  did . It        sort  of crept up        on  us      and first
+# J/P   D   NSg/J  NSg/V . NSg/V . W?  J    IPl V   . NPrSg/ISg NSg/V P  V     NSg/V/J/P J/P NPr/ISg V/C NSg/V/J
 > thing you know  — — — ”
 # NSg/V IPl NSg/V . . . .
 >
@@ -1202,8 +1202,8 @@
 # ISg V/J  R       N/I/C/D ISg V   V/J   NSg/I/J NSg/I/V/P NSg/I/J/C . V/C D/P N/I NPl     J     ISg V   NSg/V/J/P
 > to go      home    . They came    to the door  with me        and stood side    by      side    in          a   cheerful
 # P  NSg/V/J NSg/V/J . IPl  NSg/V/P P  D   NSg/V P    NPrSg/ISg V/C V     NSg/V/J NSg/J/P NSg/V/J NPrSg/V/J/P D/P J
-> square  of  light   . As    I   started my motor   Daisy peremptorily called : “ Wait  !
-# NSg/V/J V/P NSg/V/J . NSg/R ISg W?      D  NSg/V/J NPrSg R            V/J    . . NSg/V .
+> square  of light   . As    I   started my motor   Daisy peremptorily called : “ Wait  !
+# NSg/V/J P  NSg/V/J . NSg/R ISg W?      D  NSg/V/J NPrSg R            V/J    . . NSg/V .
 >
 #
 > “ I   forgot to ask   you something , and it’s important . We  heard you were  engaged to
@@ -1226,56 +1226,56 @@
 # NSg/V  . NSg/V/J/C/P NSg/J . . IPl V/J   NPrSg/ISg P    NSg   NSg/V  . NSg/I/J/C NPrSg/ISg NSg/V NSg/VX NSg/V/J . .
 >
 #
-> Of  course I   knew what  they were  referring to , but     I   wasn’t even    vaguely engaged .
-# V/P NSg/V  ISg V    NSg/I IPl  NSg/V NSg/V     P  . NSg/C/P ISg V      NSg/V/J J/R     W?      .
-> The fact that    gossip had published the banns was one       of  the reasons I   had come
-# D   NSg  N/I/C/D NSg/V  V   V/J       D   NSg   V   NSg/I/V/J V/P D   NPl     ISg V   NSg/V/P
-> East    . You can’t stop  going   with an  old   friend  on  account of  rumors , and on  the
-# NPrSg/J . IPl VX    NSg/V NSg/V/J P    D/P NSg/J NPrSg/V J/P NSg/V   V/P NPl    . V/C J/P D
-> other   hand  I   had no      intention of  being   rumored into marriage .
-# NSg/V/J NSg/V ISg V   NPrSg/P NSg/V     V/P NSg/V/C W?      P    NSg      .
+> Of course I   knew what  they were  referring to , but     I   wasn’t even    vaguely engaged .
+# P  NSg/V  ISg V    NSg/I IPl  NSg/V NSg/V     P  . NSg/C/P ISg V      NSg/V/J J/R     W?      .
+> The fact that    gossip had published the banns was one       of the reasons I   had come
+# D   NSg  N/I/C/D NSg/V  V   V/J       D   NSg   V   NSg/I/V/J P  D   NPl     ISg V   NSg/V/P
+> East    . You can’t stop  going   with an  old   friend  on  account of rumors , and on  the
+# NPrSg/J . IPl VX    NSg/V NSg/V/J P    D/P NSg/J NPrSg/V J/P NSg/V   P  NPl    . V/C J/P D
+> other   hand  I   had no      intention of being   rumored into marriage .
+# NSg/V/J NSg/V ISg V   NPrSg/P NSg/V     P  NSg/V/C W?      P    NSg      .
 >
 #
 > Their interest rather    touched me        and made  them less    remotely rich      — nevertheless ,
 # D     NSg/V    NPrSg/V/J V/J     NPrSg/ISg V/C NSg/V N/I  V/J/C/P J/R      NPrSg/V/J . W?           .
 > I   was confused and a   little    disgusted as    I   drove away . It        seemed to me        that    the
 # ISg V   V/J      V/C D/P NPrSg/I/J V/J       NSg/R ISg NSg/V V/J  . NPrSg/ISg W?     P  NPrSg/ISg N/I/C/D D
-> thing for Daisy to do     was to rush      out         of  the house   , child in          arms — but     apparently
-# NSg/V C/P NPrSg P  NSg/VX V   P  NPrSg/V/J NSg/V/J/R/P V/P D   NPrSg/V . NSg/V NPrSg/V/J/P NPl  . NSg/C/P J/R
+> thing for Daisy to do     was to rush      out         of the house   , child in          arms — but     apparently
+# NSg/V C/P NPrSg P  NSg/VX V   P  NPrSg/V/J NSg/V/J/R/P P  D   NPrSg/V . NSg/V NPrSg/V/J/P NPl  . NSg/C/P J/R
 > there were  no      such  intentions in          her   head      . As    for Tom     , the fact that    he      “ had
 # W?    NSg/V NPrSg/P NSg/I NPl        NPrSg/V/J/P I/J/D NPrSg/V/J . NSg/R C/P NPrSg/V . D   NSg  N/I/C/D NPr/ISg . V
 > some  woman in          New     York ” was really less    surprising than that    he      had been
 # I/J/R NSg/V NPrSg/V/J/P NSg/V/J NPr  . V   J/R    V/J/C/P NSg/V/J    C/P  N/I/C/D NPr/ISg V   NSg/V
-> depressed by      a   book  . Something was making him nibble at        the edge  of  stale   ideas
-# W?        NSg/J/P D/P NSg/V . NSg/I/V/J V   NSg/V  I   NSg/V  NSg/I/V/P D   NSg/V V/P NSg/V/J NPl
+> depressed by      a   book  . Something was making him nibble at        the edge  of stale   ideas
+# W?        NSg/J/P D/P NSg/V . NSg/I/V/J V   NSg/V  I   NSg/V  NSg/I/V/P D   NSg/V P  NSg/V/J NPl
 > as    if    his   sturdy physical egotism no      longer nourished his   peremptory heart .
 # NSg/R NSg/C ISg/D NSg/J  NSg/J    NSg     NPrSg/P NSg/J  W?        ISg/D NSg/J      NSg/V .
 >
 #
-> Already it        was deep  summer  on  roadhouse roofs and in          front   of  wayside garages ,
-# W?      NPrSg/ISg V   NSg/J NPrSg/V J/P NSg       NPl   V/C NPrSg/V/J/P NSg/V/J V/P NSg/J   NPl     .
-> where new     red   gaspumps sat     out         in          pools of  light   , and when    I   reached my estate
-# NSg/C NSg/V/J NSg/J ?        NSg/V/J NSg/V/J/R/P NPrSg/V/J/P NPl   V/P NSg/V/J . V/C NSg/I/C ISg W?      D  NSg/V/J
+> Already it        was deep  summer  on  roadhouse roofs and in          front   of wayside garages ,
+# W?      NPrSg/ISg V   NSg/J NPrSg/V J/P NSg       NPl   V/C NPrSg/V/J/P NSg/V/J P  NSg/J   NPl     .
+> where new     red   gaspumps sat     out         in          pools of light   , and when    I   reached my estate
+# NSg/C NSg/V/J NSg/J ?        NSg/V/J NSg/V/J/R/P NPrSg/V/J/P NPl   P  NSg/V/J . V/C NSg/I/C ISg W?      D  NSg/V/J
 > at        West      Egg   I   ran   the car under   its   shed  and sat     for a   while     on  an  abandoned
 # NSg/I/V/P NPrSg/V/J NSg/V ISg NSg/V D   NSg NSg/J/P ISg/D NSg/V V/C NSg/V/J C/P D/P NSg/V/C/P J/P D/P W?
 > grass   roller  in          the yard  . The wind  had blown off       , leaving a   loud  , bright    night ,
 # NPrSg/V NSg/V/J NPrSg/V/J/P D   NSg/V . D   NSg/V V   V/J   NSg/V/J/P . V       D/P NSg/J . NPrSg/V/J NSg/V .
 > with wings beating in          the trees and a   persistent organ sound   as    the full    bellows
 # P    NPl   NSg/V   NPrSg/V/J/P D   NPl   V/C D/P J          NSg/V NSg/V/J NSg/R D   NSg/V/J NPl
-> of  the earth   blew    the frogs full    of  life  . The silhouette of  a   moving  cat     wavered
-# V/P D   NPrSg/V NSg/V/J D   NPl   NSg/V/J V/P NSg/V . D   NSg/V      V/P D/P NSg/V/J NSg/V/J W?
+> of the earth   blew    the frogs full    of life  . The silhouette of a   moving  cat     wavered
+# P  D   NPrSg/V NSg/V/J D   NPl   NSg/V/J P  NSg/V . D   NSg/V      P  D/P NSg/V/J NSg/V/J W?
 > across the moonlight , and turning my head      to watch it        , I   saw   that    I   was not
 # NSg/P  D   NSg/V     . V/C NSg/V   D  NPrSg/V/J P  NSg/V NPrSg/ISg . ISg NSg/V N/I/C/D ISg V   NSg/C
-> alone — fifty feet away a   figure had emerged from the shadow  of  my neighbor’s
-# J     . NSg   NSg  V/J  D/P NSg/V  V   W?      P    D   NSg/V/J V/P D  N$
+> alone — fifty feet away a   figure had emerged from the shadow  of my neighbor’s
+# J     . NSg   NSg  V/J  D/P NSg/V  V   W?      P    D   NSg/V/J P  D  N$
 > mansion and was standing with his   hands in          his   pockets regarding the silver
 # NSg     V/C V   NSg/V/J  P    ISg/D NPl   NPrSg/V/J/P ISg/D NPl     V         D   NSg/V/J
-> pepper of  the stars . Something in          his   leisurely movements and the secure
-# NSg/V  V/P D   NPl   . NSg/I/V/J NPrSg/V/J/P ISg/D J/R       NPl       V/C D   V/J
-> position of  his   feet upon the lawn  suggested that    it        was Mr  . Gatsby himself ,
-# NSg/V    V/P ISg/D NSg  P    D   NSg/V W?        N/I/C/D NPrSg/ISg V   NSg . NPr    I       .
-> come    out         to determine what  share was his   of  our local heavens .
-# NSg/V/P NSg/V/J/R/P P  V         NSg/I NSg/V V   ISg/D V/P D   NSg/J NSg/V   .
+> pepper of the stars . Something in          his   leisurely movements and the secure
+# NSg/V  P  D   NPl   . NSg/I/V/J NPrSg/V/J/P ISg/D J/R       NPl       V/C D   V/J
+> position of his   feet upon the lawn  suggested that    it        was Mr  . Gatsby himself ,
+# NSg/V    P  ISg/D NSg  P    D   NSg/V W?        N/I/C/D NPrSg/ISg V   NSg . NPr    I       .
+> come    out         to determine what  share was his   of our local heavens .
+# NSg/V/P NSg/V/J/R/P P  V         NSg/I NSg/V V   ISg/D P  D   NSg/J NSg/V   .
 >
 #
 > I   decided to call  to him . Miss  Baker   had mentioned him at        dinner , and that    would
@@ -1288,8 +1288,8 @@
 # NSg/V/J NSg/V NPrSg/V/J/P D/P J       NSg/J . V/C . NSg/V/J NSg/R ISg V   P    I   . ISg NSg/VX NSg/VX V/J   NPr/ISg
 > was trembling . Involuntarily I   glanced seaward — and distinguished nothing except
 # V   V         . R             ISg W?      N/J     . V/C V/J           NSg/I/J V/C/P
-> a   single  green     light   , minute  and far     away , that    might    have   been  the end   of  a
-# D/P NSg/V/J NPrSg/V/J NSg/V/J . NSg/V/J V/C NSg/V/J V/J  . N/I/C/D NSg/VX/J NSg/VX NSg/V D   NSg/V V/P D/P
+> a   single  green     light   , minute  and far     away , that    might    have   been  the end   of a
+# D/P NSg/V/J NPrSg/V/J NSg/V/J . NSg/V/J V/C NSg/V/J V/J  . N/I/C/D NSg/VX/J NSg/VX NSg/V D   NSg/V P  D/P
 > dock  . When    I   looked once  more        for Gatsby he      had vanished , and I   was alone again
 # NSg/V . NSg/I/C ISg W?     NSg/C NPrSg/I/V/J C/P NPr    NPr/ISg V   W?       . V/C ISg V   J     P
 > in          the unquiet darkness .
@@ -1302,18 +1302,18 @@
 #
 > About half      way   between West      Egg   and New     York the motor   road  hastily joins the
 # J/P   NSg/V/J/P NSg/J NSg/P   NPrSg/V/J NSg/V V/C NSg/V/J NPr  D   NSg/V/J NSg/J R       NPl   D
-> railroad and runs beside it        for a   quarter of  a   mile , so        as    to shrink away from a
-# NSg/V    V/C NPl  P      NPrSg/ISg C/P D/P NSg/V/J V/P D/P NSg  . NSg/I/J/C NSg/R P  NSg/V  V/J  P    D/P
-> certain desolate area of  land    . This is a   valley of  ashes — a   fantastic farm  where
-# I/J     V/J      NSg  V/P NPrSg/V . I/D  VL D/P NSg/V  V/P NPl   . D/P NSg/J     NSg/V NSg/C
+> railroad and runs beside it        for a   quarter of a   mile , so        as    to shrink away from a
+# NSg/V    V/C NPl  P      NPrSg/ISg C/P D/P NSg/V/J P  D/P NSg  . NSg/I/J/C NSg/R P  NSg/V  V/J  P    D/P
+> certain desolate area of land    . This is a   valley of ashes — a   fantastic farm  where
+# I/J     V/J      NSg  P  NPrSg/V . I/D  VL D/P NSg/V  P  NPl   . D/P NSg/J     NSg/V NSg/C
 > ashes grow like        wheat into ridges and hills and grotesque gardens ; where ashes
 # NPl   V    NSg/V/J/C/P NSg/J P    NPl    V/C NPl   V/C NSg/J     NPl     . NSg/C NPl
-> take  the forms of  houses and chimneys and rising    smoke and , finally , with a
-# NSg/V D   NPl   V/P NPl    V/C NPl      V/C NSg/V/J/P NSg/V V/C . J/R     . P    D/P
-> transcendent effort , of  ash   - gray         men , who     move  dimly and already crumbling
-# NSg/J        NSg/V  . V/P NSg/V . NPrSg/V/J/Am NSg . NPrSg/I NSg/V J/R   V/C W?      V
-> through the powdery air   . Occasionally a   line  of  gray         cars crawls along an
-# NSg/J/P D   J       NSg/V . J/R          D/P NSg/V V/P NPrSg/V/J/Am NPl  NPl    P     D/P
+> take  the forms of houses and chimneys and rising    smoke and , finally , with a
+# NSg/V D   NPl   P  NPl    V/C NPl      V/C NSg/V/J/P NSg/V V/C . J/R     . P    D/P
+> transcendent effort , of ash   - gray         men , who     move  dimly and already crumbling
+# NSg/J        NSg/V  . P  NSg/V . NPrSg/V/J/Am NSg . NPrSg/I NSg/V J/R   V/C W?      V
+> through the powdery air   . Occasionally a   line  of gray         cars crawls along an
+# NSg/J/P D   J       NSg/V . J/R          D/P NSg/V P  NPrSg/V/J/Am NPl  NPl    P     D/P
 > invisible track , gives out         a   ghastly creak , and comes to rest  , and immediately
 # J         NSg/V . NPl   NSg/V/J/R/P D/P J       NSg/V . V/C NPl   P  NSg/V . V/C J/R
 > the ash   - gray         men swarm up        with leaden spades and stir  up        an  impenetrable cloud ,
@@ -1322,18 +1322,18 @@
 # I/C   NPl     D     V/J     W?         P    D    NSg/V .
 >
 #
-> But     above   the gray         land    and the spasms of  bleak dust  which drift endlessly over
-# NSg/C/P NSg/J/P D   NPrSg/V/J/Am NPrSg/V V/C D   NPl    V/P NSg/J NSg/V I/C   NSg/V J/R       NSg/V/J/P
-> it        , you perceive , after a   moment , the eyes of  Doctor T. J. Eckleburg . The eyes
-# NPrSg/ISg . IPl V        . J/P   D/P NSg    . D   NPl  V/P NSg/V  ?  ?  ?         . D   NPl
-> of  Doctor T. J. Eckleburg are blue    and gigantic — their retinas are one       yard  high    .
-# V/P NSg/V  ?  ?  ?         V   NSg/V/J V/C J        . D     NPl     V   NSg/I/V/J NSg/V NSg/V/J .
-> They look  out         of  no      face  , but     , instead , from a   pair  of  enormous yellow
-# IPl  NSg/V NSg/V/J/R/P V/P NPrSg/P NSg/V . NSg/C/P . W?      . P    D/P NSg/V V/P J        NSg/V/J
-> spectacles which pass  over      a   nonexistent nose  . Evidently some  wild    wag   of  an
-# NSg        I/C   NSg/V NSg/V/J/P D/P NSg/J       NSg/V . J/R       I/J/R NSg/V/J NSg/V V/P D/P
-> oculist set       them there to fatten his   practice in          the borough of  Queens , and then
-# NSg     NPrSg/V/J N/I  W?    P  V      ISg/D NSg/V    NPrSg/V/J/P D   NSg     V/P NPrSg  . V/C NSg/J/C
+> But     above   the gray         land    and the spasms of bleak dust  which drift endlessly over
+# NSg/C/P NSg/J/P D   NPrSg/V/J/Am NPrSg/V V/C D   NPl    P  NSg/J NSg/V I/C   NSg/V J/R       NSg/V/J/P
+> it        , you perceive , after a   moment , the eyes of Doctor T. J. Eckleburg . The eyes
+# NPrSg/ISg . IPl V        . J/P   D/P NSg    . D   NPl  P  NSg/V  ?  ?  ?         . D   NPl
+> of Doctor T. J. Eckleburg are blue    and gigantic — their retinas are one       yard  high    .
+# P  NSg/V  ?  ?  ?         V   NSg/V/J V/C J        . D     NPl     V   NSg/I/V/J NSg/V NSg/V/J .
+> They look  out         of no      face  , but     , instead , from a   pair  of enormous yellow
+# IPl  NSg/V NSg/V/J/R/P P  NPrSg/P NSg/V . NSg/C/P . W?      . P    D/P NSg/V P  J        NSg/V/J
+> spectacles which pass  over      a   nonexistent nose  . Evidently some  wild    wag   of an
+# NSg        I/C   NSg/V NSg/V/J/P D/P NSg/J       NSg/V . J/R       I/J/R NSg/V/J NSg/V P  D/P
+> oculist set       them there to fatten his   practice in          the borough of Queens , and then
+# NSg     NPrSg/V/J N/I  W?    P  V      ISg/D NSg/V    NPrSg/V/J/P D   NSg     P  NPrSg  . V/C NSg/J/C
 > sank down      himself into eternal blindness , or      forgot them and moved away . But     his
 # V    NSg/V/J/P I       P    NSg/J   NSg       . NPrSg/C V      N/I  V/C V/J   V/J  . NSg/C/P ISg/D
 > eyes , dimmed a   little    by      many    paintless days , under   sun     and rain  , brood   on  over
@@ -1342,14 +1342,14 @@
 # D   J      V       NSg/V/J .
 >
 #
-> The valley of  ashes is bounded on  one       side    by      a   small     foul    river   , and , when    the
-# D   NSg/V  V/P NPl   VL W?      J/P NSg/I/V/J NSg/V/J NSg/J/P D/P NPrSg/V/J NSg/V/J NSg/V/J . V/C . NSg/I/C D
+> The valley of ashes is bounded on  one       side    by      a   small     foul    river   , and , when    the
+# D   NSg/V  P  NPl   VL W?      J/P NSg/I/V/J NSg/V/J NSg/J/P D/P NPrSg/V/J NSg/V/J NSg/V/J . V/C . NSg/I/C D
 > drawbridge is up        to let   barges through , the passengers on  waiting trains can
 # NSg        VL NSg/V/J/P P  NSg/V NPl    NSg/J/P . D   NPl        J/P NSg/V   NPl    NPrSg/VX
 > stare at        the dismal scene for as    long      as    half      an  hour . There is always a   halt
 # NSg/V NSg/I/V/P D   NSg/J  NSg/V C/P NSg/R NPrSg/V/J NSg/R NSg/V/J/P D/P NSg  . W?    VL W?     D/P NSg/V/J
-> there of  at        least a   minute  , and it        was because of  this that    I   first   met Tom
-# W?    V/P NSg/I/V/P NSg/J D/P NSg/V/J . V/C NPrSg/ISg V   C/P     V/P I/D  N/I/C/D ISg NSg/V/J V   NPrSg/V
+> there of at        least a   minute  , and it        was because of this that    I   first   met Tom
+# W?    P  NSg/I/V/P NSg/J D/P NSg/V/J . V/C NPrSg/ISg V   C/P     P  I/D  N/I/C/D ISg NSg/V/J V   NPrSg/V
 > Buchanan’s mistress .
 # N$         NSg/V    .
 >
@@ -1364,8 +1364,8 @@
 # V/C    ISg V   J       P  NSg/V I/J/D . ISg V   NPrSg/P NSg/V  P  NSg/V/J I/J/D . NSg/C/P ISg V   . ISg NSg/V
 > up        to New     York with Tom     on  the train one       afternoon , and when    we  stopped by      the
 # NSg/V/J/P P  NSg/V/J NPr  P    NPrSg/V J/P D   NSg/V NSg/I/V/J NSg       . V/C NSg/I/C IPl V/J     NSg/J/P D
-> ashheaps he      jumped to his   feet and , taking  hold    of  my elbow , literally forced me
-# ?        NPr/ISg W?     P  ISg/D NSg  V/C . NSg/V/J NSg/V/J V/P D  NSg/V . J/R       V/J    NPrSg/ISg
+> ashheaps he      jumped to his   feet and , taking  hold    of my elbow , literally forced me
+# ?        NPr/ISg W?     P  ISg/D NSg  V/C . NSg/V/J NSg/V/J P  D  NSg/V . J/R       V/J    NPrSg/ISg
 > from the car .
 # P    D   NSg .
 >
@@ -1386,14 +1386,14 @@
 # ISg W?       I   NSg/V/J/P D/P NSg/V/J W?          NSg/V    NSg/V . V/C IPl W?     NSg/V/J D/P
 > hundred yards along the road  under   Doctor Eckleburg’s persistent stare . The only
 # NSg     NPl   P     D   NSg/J NSg/J/P NSg/V  ?           J          NSg/V . D   W?
-> building in          sight was a   small     block of  yellow  brick   sitting on  the edge  of  the
-# NSg/V    NPrSg/V/J/P NSg/V V   D/P NPrSg/V/J NSg/V V/P NSg/V/J NSg/V/J NSg/V/J J/P D   NSg/V V/P D
-> waste   land    , a   sort  of  compact Main    Street  ministering to it        , and contiguous to
-# NSg/V/J NPrSg/V . D/P NSg/V V/P NSg/V/J NSg/V/J NSg/V/J V           P  NPrSg/ISg . V/C J          P
-> absolutely nothing . One       of  the three shops it        contained was for rent    and another
-# J/R        NSg/I/J . NSg/I/V/J V/P D   NSg   NPl   NPrSg/ISg W?        V   C/P NSg/V/J V/C I/D
-> was an  all       - night restaurant , approached by      a   trail of  ashes ; the third   was a
-# V   D/P NSg/I/J/C . NSg/V NSg        . W?         NSg/J/P D/P NSg/V V/P NPl   . D   NSg/V/J V   D/P
+> building in          sight was a   small     block of yellow  brick   sitting on  the edge  of the
+# NSg/V    NPrSg/V/J/P NSg/V V   D/P NPrSg/V/J NSg/V P  NSg/V/J NSg/V/J NSg/V/J J/P D   NSg/V P  D
+> waste   land    , a   sort  of compact Main    Street  ministering to it        , and contiguous to
+# NSg/V/J NPrSg/V . D/P NSg/V P  NSg/V/J NSg/V/J NSg/V/J V           P  NPrSg/ISg . V/C J          P
+> absolutely nothing . One       of the three shops it        contained was for rent    and another
+# J/R        NSg/I/J . NSg/I/V/J P  D   NSg   NPl   NPrSg/ISg W?        V   C/P NSg/V/J V/C I/D
+> was an  all       - night restaurant , approached by      a   trail of ashes ; the third   was a
+# V   D/P NSg/I/J/C . NSg/V NSg        . W?         NSg/J/P D/P NSg/V P  NPl   . D   NSg/V/J V   D/P
 > garage — Repairs . George B. Wilson . Cars bought and sold  . — and I   followed Tom
 # NSg/V  . NPl     . NPrSg  ?  NPr    . NPl  NSg/V  V/C NSg/V . . V/C ISg W?       NPrSg/V
 > inside  .
@@ -1402,16 +1402,16 @@
 #
 > The interior was unprosperous and bare    ; the only car visible was the
 # D   NSg/J    V   ?            V/C NSg/V/J . D   W?   NSg J       V   D
-> dust  - covered wreck of  a   Ford    which crouched in          a   dim     corner  . It        had occurred to
-# NSg/V . W?      NSg/V V/P D/P NPrSg/V I/C   W?       NPrSg/V/J/P D/P NSg/V/J NSg/V/J . NPrSg/ISg V   V        P
-> me        that    this shadow  of  a   garage must  be     a   blind   , and that    sumptuous and romantic
-# NPrSg/ISg N/I/C/D I/D  NSg/V/J V/P D/P NSg/V  NSg/V NSg/VX D/P NSg/V/J . V/C N/I/C/D J         V/C NSg/J
+> dust  - covered wreck of a   Ford    which crouched in          a   dim     corner  . It        had occurred to
+# NSg/V . W?      NSg/V P  D/P NPrSg/V I/C   W?       NPrSg/V/J/P D/P NSg/V/J NSg/V/J . NPrSg/ISg V   V        P
+> me        that    this shadow  of a   garage must  be     a   blind   , and that    sumptuous and romantic
+# NPrSg/ISg N/I/C/D I/D  NSg/V/J P  D/P NSg/V  NSg/V NSg/VX D/P NSg/V/J . V/C N/I/C/D J         V/C NSg/J
 > apartments were  concealed overhead , when    the proprietor himself appeared in          the
 # NPl        NSg/V V/J       NSg/J/P  . NSg/I/C D   NSg        I       W?       NPrSg/V/J/P D
-> door  of  an  office , wiping his   hands on  a   piece of  waste   . He      was a   blond   ,
-# NSg/V V/P D/P NSg/V  . V      ISg/D NPl   J/P D/P NSg/V V/P NSg/V/J . NPr/ISg V   D/P NSg/V/J .
+> door  of an  office , wiping his   hands on  a   piece of waste   . He      was a   blond   ,
+# NSg/V P  D/P NSg/V  . V      ISg/D NPl   J/P D/P NSg/V P  NSg/V/J . NPr/ISg V   D/P NSg/V/J .
 > spiritless man         , anæmic , and faintly handsome . When    he      saw   us      a   damp    gleam of
-# J          NPrSg/I/V/J . ?      . V/C J/R     V/J      . NSg/I/C NPr/ISg NSg/V NPr/ISg D/P NSg/V/J NSg/V V/P
+# J          NPrSg/I/V/J . ?      . V/C J/R     V/J      . NSg/I/C NPr/ISg NSg/V NPr/ISg D/P NSg/V/J NSg/V P
 > hope    sprang into his   light   blue    eyes .
 # NPrSg/V V      P    ISg/D NSg/V/J NSg/V/J NPl  .
 >
@@ -1448,18 +1448,18 @@
 #
 > His   voice faded off       and Tom     glanced impatiently around the garage . Then    I   heard
 # ISg/D NSg/V W?    NSg/V/J/P V/C NPrSg/V W?      J/R         J/P    D   NSg/V  . NSg/J/C ISg V/J
-> footsteps on  a   stairs , and in          a   moment the thickish figure of  a   woman blocked
-# NPl       J/P D/P NPl    . V/C NPrSg/V/J/P D/P NSg    D   ?        NSg/V  V/P D/P NSg/V W?
+> footsteps on  a   stairs , and in          a   moment the thickish figure of a   woman blocked
+# NPl       J/P D/P NPl    . V/C NPrSg/V/J/P D/P NSg    D   ?        NSg/V  P  D/P NSg/V W?
 > out         the light   from the office door  . She was in          the middle  thirties , and faintly
 # NSg/V/J/R/P D   NSg/V/J P    D   NSg/V  NSg/V . ISg V   NPrSg/V/J/P D   NSg/V/J NPl      . V/C J/R
 > stout     , but     she carried her   flesh sensuously as    some  women can      . Her   face  , above   a
 # NPrSg/V/J . NSg/C/P ISg W?      I/J/D NSg/V J/R        NSg/R I/J/R NPl   NPrSg/VX . I/J/D NSg/V . NSg/J/P D/P
-> spotted dress of  dark    blue    crêpe - de    - chine , contained no      facet or      gleam of
-# V/J     NSg/V V/P NSg/V/J NSg/V/J ?     . NPrSg . NSg/V . W?        NPrSg/P NSg/V NPrSg/C NSg/V V/P
+> spotted dress of dark    blue    crêpe - de    - chine , contained no      facet or      gleam of
+# V/J     NSg/V P  NSg/V/J NSg/V/J ?     . NPrSg . NSg/V . W?        NPrSg/P NSg/V NPrSg/C NSg/V P
 > beauty  , but     there was an  immediately perceptible vitality about her   as    if    the
 # NSg/V/J . NSg/C/P W?    V   D/P J/R         NSg/J       NSg      J/P   I/J/D NSg/R NSg/C D
-> nerves of  her   body  were  continually smouldering . She smiled slowly and , walking
-# NPl    V/P I/J/D NSg/V NSg/V J/R         V           . ISg W?     J/R    V/C . NSg/V/J
+> nerves of her   body  were  continually smouldering . She smiled slowly and , walking
+# NPl    P  I/J/D NSg/V NSg/V J/R         V           . ISg W?     J/R    V/C . NSg/V/J
 > through her   husband as    if    he      were  a   ghost , shook   hands with Tom     , looking him
 # NSg/J/P I/J/D NSg/V   NSg/R NSg/C NPr/ISg NSg/V D/P NSg/V . NSg/V/J NPl   P    NPrSg/V . V       I
 > flush   in          the eye   . Then    she wet     her   lips , and without turning around spoke to her
@@ -1474,8 +1474,8 @@
 #
 > “ Oh      , sure , ” agreed Wilson hurriedly , and went  toward the little    office , mingling
 # . NPrSg/V . J    . . W?     NPr    J/R       . V/C NSg/V J/P    D   NPrSg/I/J NSg/V  . V
-> immediately with the cement color      of  the walls . A   white     ashen dust  veiled his
-# J/R         P    D   NSg/V  NSg/V/J/Am V/P D   NPrPl . D/P NPrSg/V/J W?    NSg/V W?     ISg/D
+> immediately with the cement color      of the walls . A   white     ashen dust  veiled his
+# J/R         P    D   NSg/V  NSg/V/J/Am P  D   NPrPl . D/P NPrSg/V/J W?    NSg/V W?     ISg/D
 > dark    suit  and his   pale    hair  as    it        veiled everything in          the vicinity — except his
 # NSg/V/J NSg/V V/C ISg/D NSg/V/J NSg/V NSg/R NPrSg/ISg W?     N/I/V      NPrSg/V/J/P D   NSg      . V/C/P  ISg/D
 > wife  , who     moved close   to Tom     .
@@ -1500,10 +1500,10 @@
 # P    ISg/D NSg/V  NSg/V .
 >
 #
-> We  waited for her   down      the road  and out         of  sight . It        was a   few days before the
-# IPl W?     C/P I/J/D NSg/V/J/P D   NSg/J V/C NSg/V/J/R/P V/P NSg/V . NPrSg/ISg V   D/P N/I NPl  C/P    D
-> Fourth    of  July , and a   gray         , scrawny Italian child was setting torpedoes in          a   row
-# NPrSg/V/J V/P NPr  . V/C D/P NPrSg/V/J/Am . J       NSg/J   NSg/V V   NSg/V/J NSg/V     NPrSg/V/J/P D/P NSg/V
+> We  waited for her   down      the road  and out         of sight . It        was a   few days before the
+# IPl W?     C/P I/J/D NSg/V/J/P D   NSg/J V/C NSg/V/J/R/P P  NSg/V . NPrSg/ISg V   D/P N/I NPl  C/P    D
+> Fourth    of July , and a   gray         , scrawny Italian child was setting torpedoes in          a   row
+# NPrSg/V/J P  NPr  . V/C D/P NPrSg/V/J/Am . J       NSg/J   NSg/V V   NSg/V/J NSg/V     NPrSg/V/J/P D/P NSg/V
 > along the railroad track .
 # P     D   NSg/V    NSg/V .
 >
@@ -1534,32 +1534,32 @@
 # NSg/I/J/C NPrSg/V NPr      V/C ISg/D NSg/V V/C ISg NSg/V NSg/V/J/P J        P  NSg/V/J NPr  . NPrSg/C NSg/C NSg
 > together , for Mrs . Wilson sat     discreetly in          another car . Tom     deferred that    much
 # J        . C/P NPl . NPr    NSg/V/J J/R        NPrSg/V/J/P I/D     NSg . NPrSg/V NSg/V/J  N/I/C/D N/I/J
-> to the sensibilities of  those East    Eggers who     might    be     on  the train .
-# P  D   NSg           V/P I/D   NPrSg/J ?      NPrSg/I NSg/VX/J NSg/VX J/P D   NSg/V .
+> to the sensibilities of those East    Eggers who     might    be     on  the train .
+# P  D   NSg           P  I/D   NPrSg/J ?      NPrSg/I NSg/VX/J NSg/VX J/P D   NSg/V .
 >
 #
 > She had changed her   dress to a   brown     figured muslin , which stretched tight over
 # ISg V   V/J     I/J/D NSg/V P  D/P NPrSg/V/J W?      NSg    . I/C   W?        V/J   NSg/V/J/P
 > her   rather    wide  hips as    Tom     helped her   to the platform in          New     York . At        the
 # I/J/D NPrSg/V/J NSg/J NPl  NSg/R NPrSg/V W?     I/J/D P  D   NSg/V    NPrSg/V/J/P NSg/V/J NPr  . NSg/I/V/P D
-> news  - stand she bought a   copy  of  Town Tattle and a   moving  - picture magazine , and
-# NSg/V . NSg/V ISg NSg/V  D/P NSg/V V/P NSg  NSg/V  V/C D/P NSg/V/J . NSg/V   NSg      . V/C
-> in          the station drug  - store some  cold  cream   and a   small     flask of  perfume .
-# NPrSg/V/J/P D   NSg/V   NSg/V . NSg/V I/J/R NSg/J NSg/V/J V/C D/P NPrSg/V/J NSg/V V/P NSg/V   .
+> news  - stand she bought a   copy  of Town Tattle and a   moving  - picture magazine , and
+# NSg/V . NSg/V ISg NSg/V  D/P NSg/V P  NSg  NSg/V  V/C D/P NSg/V/J . NSg/V   NSg      . V/C
+> in          the station drug  - store some  cold  cream   and a   small     flask of perfume .
+# NPrSg/V/J/P D   NSg/V   NSg/V . NSg/V I/J/R NSg/J NSg/V/J V/C D/P NPrSg/V/J NSg/V P  NSg/V   .
 > Up        - stairs , in          the solemn echoing drive she let   four taxicabs drive away before
 # NSg/V/J/P . NPl    . NPrSg/V/J/P D   J      V       NSg/V ISg NSg/V NSg  NPl      NSg/V V/J  C/P
 > she selected a   new     one       , lavender - colored    with gray         upholstery , and in          this we
 # ISg W?       D/P NSg/V/J NSg/I/V/J . NSg/V/J  . NSg/V/J/Am P    NPrSg/V/J/Am NSg        . V/C NPrSg/V/J/P I/D  IPl
-> slid out         from the mass      of  the station into the glowing sunshine . But     immediately
-# V    NSg/V/J/R/P P    D   NPrSg/V/J V/P D   NSg/V   P    D   NSg/V/J NSg/J    . NSg/C/P J/R
+> slid out         from the mass      of the station into the glowing sunshine . But     immediately
+# V    NSg/V/J/R/P P    D   NPrSg/V/J P  D   NSg/V   P    D   NSg/V/J NSg/J    . NSg/C/P J/R
 > she turned sharply from the window and , leaning forward , tapped on  the front
 # ISg W?     J/R     P    D   NSg/V  V/C . NSg/V   NSg/V/J . V/J    J/P D   NSg/V/J
 > glass   .
 # NPrSg/V .
 >
 #
-> “ I   want  to get   one       of  those dogs , ” she said earnestly . “ I   want  to get   one       for
-# . ISg NSg/V P  NSg/V NSg/I/V/J V/P I/D   NPl  . . ISg V/J  J/R       . . ISg NSg/V P  NSg/V NSg/I/V/J C/P
+> “ I   want  to get   one       of those dogs , ” she said earnestly . “ I   want  to get   one       for
+# . ISg NSg/V P  NSg/V NSg/I/V/J P  I/D   NPl  . . ISg V/J  J/R       . . ISg NSg/V P  NSg/V NSg/I/V/J C/P
 > the apartment . They’re nice      to have   — a   dog     . ”
 # D   NSg       . W?      NPrSg/V/J P  NSg/VX . D/P NSg/V/J . .
 >
@@ -1568,8 +1568,8 @@
 # IPl W?     NSg/V/J/P P  D/P NPrSg/V/J/Am NSg/J NPrSg/I/V/J NPrSg/I NSg/V D/P NSg/J  NSg         P  NPrSg ?
 > Rockefeller . In          a   basket swung from his   neck  cowered a   dozen very recent puppies
 # NPr         . NPrSg/V/J/P D/P NSg/V  V     P    ISg/D NSg/V W?      D/P NSg   J    NSg/J  NPl
-> of  an  indeterminate breed .
-# V/P D/P NSg/J         NSg/V .
+> of an  indeterminate breed .
+# P  D/P NSg/J         NSg/V .
 >
 #
 > “ What  kind  are they ? ” asked Mrs . Wilson eagerly , as    he      came    to the taxi  - window .
@@ -1580,14 +1580,14 @@
 # . NSg/I/J/C NSg   . NSg/I NSg/J NSg/VX IPl NSg/V . NPrSg/V . .
 >
 #
-> “ I’d like        to get   one       of  those police dogs ; I   don’t suppose you got that    kind  ? ”
-# . W?  NSg/V/J/C/P P  NSg/V NSg/I/V/J V/P I/D   NSg/V  NPl  . ISg NSg/V V       IPl V   N/I/C/D NSg/J . .
+> “ I’d like        to get   one       of those police dogs ; I   don’t suppose you got that    kind  ? ”
+# . W?  NSg/V/J/C/P P  NSg/V NSg/I/V/J P  I/D   NSg/V  NPl  . ISg NSg/V V       IPl V   N/I/C/D NSg/J . .
 >
 #
 > The man         peered doubtfully into the basket , plunged in          his   hand  and drew  one       up        ,
 # D   NPrSg/I/V/J W?     J/R        P    D   NSg/V  . W?      NPrSg/V/J/P ISg/D NSg/V V/C NPr/V NSg/I/V/J NSg/V/J/P .
-> wriggling , by      the back    of  the neck  .
-# V         . NSg/J/P D   NSg/V/J V/P D   NSg/V .
+> wriggling , by      the back    of the neck  .
+# V         . NSg/J/P D   NSg/V/J P  D   NSg/V .
 >
 #
 > “ That’s no      police dog     , ” said Tom     .
@@ -1596,8 +1596,8 @@
 #
 > “ No      , it’s not   exactly a   police dog     , ” said the man         with disappointment in          his
 # . NPrSg/P . W?   NSg/C J/R     D/P NSg/V  NSg/V/J . . V/J  D   NPrSg/I/V/J P    NSg            NPrSg/V/J/P ISg/D
-> voice . “ It’s more        of  an  Airedale . ” He      passed his   hand  over      the brown     washrag of
-# NSg/V . . W?   NPrSg/I/V/J V/P D/P NPrSg    . . NPr/ISg W?     ISg/D NSg/V NSg/V/J/P D   NPrSg/V/J NSg     V/P
+> voice . “ It’s more        of an  Airedale . ” He      passed his   hand  over      the brown     washrag of
+# NSg/V . . W?   NPrSg/I/V/J P  D/P NPrSg    . . NPr/ISg W?     ISg/D NSg/V NSg/V/J/P D   NPrSg/V/J NSg     P
 > a   back    . “ Look  at        that    coat  . Some  coat  . That’s a   dog     that’ll never bother you
 # D/P NSg/V/J . . NSg/V NSg/I/V/P N/I/C/D NSg/V . I/J/R NSg/V . N$     D/P NSg/V/J W?      V     NSg/V  IPl
 > with catching cold  . ”
@@ -1636,8 +1636,8 @@
 #
 > We  drove over      to Fifth   Avenue , warm    and soft  , almost pastoral , on  the summer
 # IPl NSg/V NSg/V/J/P P  NSg/V/J NSg    . NSg/V/J V/C NSg/J . NSg    NSg/J    . J/P D   NPrSg/V
-> Sunday afternoon . I   wouldn’t have   been  surprised to see   a   great flock of  white
-# NSg/V  NSg       . ISg VX       NSg/VX NSg/V W?        P  NSg/V D/P NSg/J NSg/V V/P NPrSg/V/J
+> Sunday afternoon . I   wouldn’t have   been  surprised to see   a   great flock of white
+# NSg/V  NSg       . ISg VX       NSg/VX NSg/V W?        P  NSg/V D/P NSg/J NSg/V P  NPrSg/V/J
 > sheep turn  the corner  .
 # NSg   NSg/V D   NSg/V/J .
 >
@@ -1664,8 +1664,8 @@
 #
 > We  went  on  , cutting back    again over      the Park    toward the West      Hundreds . At        158th
 # IPl NSg/V J/P . NSg/V/J NSg/V/J P     NSg/V/J/P D   NPrSg/V J/P    D   NPrSg/V/J NPl      . NSg/I/V/P #
-> Street  the cab   stopped at        one       slice   in          a   long      white     cake  of  apartment - houses .
-# NSg/V/J D   NSg/V V/J     NSg/I/V/P NSg/I/V/J NSg/V/J NPrSg/V/J/P D/P NPrSg/V/J NPrSg/V/J NSg/V V/P NSg       . NPl    .
+> Street  the cab   stopped at        one       slice   in          a   long      white     cake  of apartment - houses .
+# NSg/V/J D   NSg/V V/J     NSg/I/V/P NSg/I/V/J NSg/V/J NPrSg/V/J/P D/P NPrSg/V/J NPrSg/V/J NSg/V P  NSg       . NPl    .
 > Throwing a   regal homecoming glance around the neighborhood , Mrs . Wilson gathered
 # V        D/P NSg/J NSg        NSg/V  J/P    D   NSg          . NPl . NPr    W?
 > up        her   dog     and her   other   purchases , and went  haughtily in          .
@@ -1674,36 +1674,36 @@
 #
 > “ I’m going   to have   the McKees come    up        , ” she announced as    we  rose      in          the
 # . W?  NSg/V/J P  NSg/VX D   ?      NSg/V/P NSg/V/J/P . . ISg V/J       NSg/R IPl NPrSg/V/J NPrSg/V/J/P D
-> elevator . “ And , of  course , I   got to call  up        my sister , too . ”
-# NSg/V    . . V/C . V/P NSg/V  . ISg V   P  NSg/V NSg/V/J/P D  NSg/V  . W?  . .
+> elevator . “ And , of course , I   got to call  up        my sister , too . ”
+# NSg/V    . . V/C . P  NSg/V  . ISg V   P  NSg/V NSg/V/J/P D  NSg/V  . W?  . .
 >
 #
 > The apartment was on  the top     floor — a   small     living  - room    , a   small     dining - room    , a
 # D   NSg       V   J/P D   NSg/V/J NSg/V . D/P NPrSg/V/J NSg/V/J . NSg/V/J . D/P NPrSg/V/J V      . NSg/V/J . D/P
 > small     bedroom , and a   bath  . The living  - room    was crowded to the doors with a   set
 # NPrSg/V/J NSg     . V/C D/P NSg/V . D   NSg/V/J . NSg/V/J V   V/J     P  D   NPl   P    D/P NPrSg/V/J
-> of  tapestried furniture entirely too large for it        , so        that    to move  about was to
-# V/P ?          NSg       J/R      W?  NSg/J C/P NPrSg/ISg . NSg/I/J/C N/I/C/D P  NSg/V J/P   V   P
-> stumble continually over      scenes of  ladies swinging in          the gardens of  Versailles .
-# NSg/V   J/R         NSg/V/J/P NPl    V/P NPl    V        NPrSg/V/J/P D   NPl     V/P NPr        .
+> of tapestried furniture entirely too large for it        , so        that    to move  about was to
+# P  ?          NSg       J/R      W?  NSg/J C/P NPrSg/ISg . NSg/I/J/C N/I/C/D P  NSg/V J/P   V   P
+> stumble continually over      scenes of ladies swinging in          the gardens of Versailles .
+# NSg/V   J/R         NSg/V/J/P NPl    P  NPl    V        NPrSg/V/J/P D   NPl     P  NPr        .
 > The only picture was an  over      - enlarged photograph , apparently a   hen   sitting on  a
 # D   W?   NSg/V   V   D/P NSg/V/J/P . W?       NSg/V      . J/R        D/P NSg/V NSg/V/J J/P D/P
 > blurred rock    . Looked at        from a   distance , however , the hen   resolved itself into a
 # V/J     NPrSg/V . W?     NSg/I/V/P P    D/P NSg/V    . C       . D   NSg/V V/J      I      P    D/P
-> bonnet , and the countenance of  a   stout     old   lady    beamed down      into the room    .
-# NSg/V  . V/C D   NSg/V       V/P D/P NPrSg/V/J NSg/J NPrSg/V W?     NSg/V/J/P P    D   NSg/V/J .
-> Several old   copies of  Town Tattle lay     on  the table together with a   copy  of
-# J/D     NSg/J NPl    V/P NSg  NSg/V  NSg/V/J J/P D   NSg/V J        P    D/P NSg/V V/P
-> “ Simon Called Peter     , ” and some  of  the small     scandal magazines of  Broadway . Mrs .
-# . NPrSg V/J    NPrSg/V/J . . V/C I/J/R V/P D   NPrSg/V/J NSg/V   NPl       V/P NPrSg/J  . NPl .
+> bonnet , and the countenance of a   stout     old   lady    beamed down      into the room    .
+# NSg/V  . V/C D   NSg/V       P  D/P NPrSg/V/J NSg/J NPrSg/V W?     NSg/V/J/P P    D   NSg/V/J .
+> Several old   copies of Town Tattle lay     on  the table together with a   copy  of
+# J/D     NSg/J NPl    P  NSg  NSg/V  NSg/V/J J/P D   NSg/V J        P    D/P NSg/V P
+> “ Simon Called Peter     , ” and some  of the small     scandal magazines of Broadway . Mrs .
+# . NPrSg V/J    NPrSg/V/J . . V/C I/J/R P  D   NPrSg/V/J NSg/V   NPl       P  NPrSg/J  . NPl .
 > Wilson was first   concerned with the dog     . A   reluctant elevator - boy   went  for a   box
 # NPr    V   NSg/V/J V/J       P    D   NSg/V/J . D/P J         NSg/V    . NSg/V NSg/V C/P D/P NSg/V
-> full    of  straw   and some  milk  , to which he      added on  his   own     initiative a   tin     of
-# NSg/V/J V/P NSg/V/J V/C I/J/R NSg/V . P  I/C   NPr/ISg W?    J/P ISg/D NSg/V/J NSg/J      D/P NSg/V/J V/P
-> large , hard    dog     - biscuits — one       of  which decomposed apathetically in          the saucer  of
-# NSg/J . NSg/V/J NSg/V/J . NPl      . NSg/I/V/J V/P I/C   W?         W?            NPrSg/V/J/P D   NSg/V/J V/P
-> milk  all       afternoon . Meanwhile Tom     brought out         a   bottle of  whiskey from a   locked
-# NSg/V NSg/I/J/C NSg       . NSg       NPrSg/V V       NSg/V/J/R/P D/P NSg/V  V/P NSg     P    D/P W?
+> full    of straw   and some  milk  , to which he      added on  his   own     initiative a   tin     of
+# NSg/V/J P  NSg/V/J V/C I/J/R NSg/V . P  I/C   NPr/ISg W?    J/P ISg/D NSg/V/J NSg/J      D/P NSg/V/J P
+> large , hard    dog     - biscuits — one       of which decomposed apathetically in          the saucer  of
+# NSg/J . NSg/V/J NSg/V/J . NPl      . NSg/I/V/J P  I/C   W?         W?            NPrSg/V/J/P D   NSg/V/J P
+> milk  all       afternoon . Meanwhile Tom     brought out         a   bottle of whiskey from a   locked
+# NSg/V NSg/I/J/C NSg       . NSg       NPrSg/V V       NSg/V/J/R/P D/P NSg/V  P  NSg     P    D/P W?
 > bureau door  .
 # NSg    NSg/V .
 >
@@ -1712,16 +1712,16 @@
 # ISg NSg/VX NSg/V NSg/V/J V/J  W?    NPrSg/V/J/P D  NSg/V . V/C D   NSg/V/J NSg/V V   N/I/C/D NSg       .
 > so        everything that    happened has a   dim     , hazy  cast    over      it        , although until after
 # NSg/I/J/C N/I/V      N/I/C/D W?       V   D/P NSg/V/J . NSg/J NSg/V/J NSg/V/J/P NPrSg/ISg . C        C/P   J/P
-> eight o’clock the apartment was full    of  cheerful sun     . Sitting on  Tom’s lap     Mrs .
-# NSg/J W?      D   NSg       V   NSg/V/J V/P J        NPrSg/V . NSg/V/J J/P N$    NSg/V/J NPl .
+> eight o’clock the apartment was full    of cheerful sun     . Sitting on  Tom’s lap     Mrs .
+# NSg/J W?      D   NSg       V   NSg/V/J P  J        NPrSg/V . NSg/V/J J/P N$    NSg/V/J NPl .
 > Wilson called up        several people on  the telephone ; then    there were  no      cigarettes ,
 # NPr    V/J    NSg/V/J/P J/D     NSg/V  J/P D   NSg/V     . NSg/J/C W?    NSg/V NPrSg/P NPl        .
 > and I   went  out         to buy   some  at        the drugstore on  the corner  . When    I   came    back    they
 # V/C ISg NSg/V NSg/V/J/R/P P  NSg/V I/J/R NSg/I/V/P D   NSg       J/P D   NSg/V/J . NSg/I/C ISg NSg/V/P NSg/V/J IPl
 > had both disappeared , so        I   sat     down      discreetly in          the living  - room    and read  a
 # V   I/C  W?          . NSg/I/J/C ISg NSg/V/J NSg/V/J/P J/R        NPrSg/V/J/P D   NSg/V/J . NSg/V/J V/C NSg/V D/P
-> chapter of  “ Simon Called Peter     ” — either it        was terrible stuff or      the whiskey
-# NSg/V   V/P . NPrSg V/J    NPrSg/V/J . . I/C    NPrSg/ISg V   J        NSg/V NPrSg/C D   NSg
+> chapter of “ Simon Called Peter     ” — either it        was terrible stuff or      the whiskey
+# NSg/V   P  . NPrSg V/J    NPrSg/V/J . . I/C    NPrSg/ISg V   J        NSg/V NPrSg/C D   NSg
 > distorted things , because it        didn’t make  any   sense to me        .
 # W?        NPl    . C/P     NPrSg/ISg V      NSg/V I/R/D NSg/V P  NPrSg/ISg .
 >
@@ -1734,14 +1734,14 @@
 # NSg       . NSg/V .
 >
 #
-> The sister , Catherine , was a   slender , worldly girl  of  about thirty , with a
-# D   NSg/V  . NPr       . V   D/P J       . J       NSg/V V/P J/P   NSg    . P    D/P
-> solid , sticky  bob     of  red   hair  , and a   complexion powdered milky white     . Her
-# NSg/J . NSg/V/J NPrSg/V V/P NSg/J NSg/V . V/C D/P NSg/V      W?       J     NPrSg/V/J . I/J/D
+> The sister , Catherine , was a   slender , worldly girl  of about thirty , with a
+# D   NSg/V  . NPr       . V   D/P J       . J       NSg/V P  J/P   NSg    . P    D/P
+> solid , sticky  bob     of red   hair  , and a   complexion powdered milky white     . Her
+# NSg/J . NSg/V/J NPrSg/V P  NSg/J NSg/V . V/C D/P NSg/V      W?       J     NPrSg/V/J . I/J/D
 > eyebrows had been  plucked and then    drawn on  again at        a   more        rakish angle , but
 # NPl      V   NSg/V W?      V/C NSg/J/C V/J   J/P P     NSg/I/V/P D/P NPrSg/I/V/J J      NSg/V . NSg/C/P
-> the efforts of  nature toward the restoration of  the old   alignment gave a   blurred
-# D   NPl     V/P NSg/V  J/P    D   NPrSg       V/P D   NSg/J NSg       V    D/P V/J
+> the efforts of nature toward the restoration of the old   alignment gave a   blurred
+# D   NPl     P  NSg/V  J/P    D   NPrSg       P  D   NSg/J NSg       V    D/P V/J
 > air   to her   face  . When    she moved about there was an  incessant clicking as
 # NSg/V P  I/J/D NSg/V . NSg/I/C ISg V/J   J/P   W?    V   D/P J         V        NSg/R
 > innumerable pottery bracelets jingled up        and down      upon her   arms . She came    in
@@ -1758,14 +1758,14 @@
 #
 > Mr  . McKee was a   pale    , feminine man         from the flat    below . He      had just shaved , for
 # NSg . NPr   V   D/P NSg/V/J . NSg/J    NPrSg/I/V/J P    D   NSg/V/J P     . NPr/ISg V   V/J  W?     . C/P
-> there was a   white     spot    of  lather  on  his   cheekbone , and he      was most    respectful in
-# W?    V   D/P NPrSg/V/J NSg/V/J V/P NSg/V/J J/P ISg/D NSg       . V/C NPr/ISg V   NSg/I/J J          NPrSg/V/J/P
+> there was a   white     spot    of lather  on  his   cheekbone , and he      was most    respectful in
+# W?    V   D/P NPrSg/V/J NSg/V/J P  NSg/V/J J/P ISg/D NSg       . V/C NPr/ISg V   NSg/I/J J          NPrSg/V/J/P
 > his   greeting to every one       in          the room    . He      informed me        that    he      was in          the
 # ISg/D NSg/V    P  D     NSg/I/V/J NPrSg/V/J/P D   NSg/V/J . NPr/ISg V/J      NPrSg/ISg N/I/C/D NPr/ISg V   NPrSg/V/J/P D
 > “ artistic game    , ” and I   gathered later that    he      was a   photographer and had made
 # . J        NSg/V/J . . V/C ISg W?       J     N/I/C/D NPr/ISg V   D/P NSg/J        V/C V   NSg/V
-> the dim     enlargement of  Mrs . Wilson’s mother which hovered like        an  ectoplasm on
-# D   NSg/V/J NSg         V/P NPl . N$       NSg/V  I/C   W?      NSg/V/J/C/P D/P NSg       J/P
+> the dim     enlargement of Mrs . Wilson’s mother which hovered like        an  ectoplasm on
+# D   NSg/V/J NSg         P  NPl . N$       NSg/V  I/C   W?      NSg/V/J/C/P D/P NSg       J/P
 > the wall    . His   wife  was shrill  , languid , handsome , and horrible . She told me        with
 # D   NPrSg/V . ISg/D NSg/V V   NSg/V/J . NSg/J   . V/J      . V/C NSg/J    . ISg V    NPrSg/ISg P
 > pride that    her   husband had photographed her   a   hundred and twenty - seven times
@@ -1776,10 +1776,10 @@
 #
 > Mrs . Wilson had changed her   costume some  time  before , and was now         attired in          an
 # NPl . NPr    V   V/J     I/J/D NSg/V   I/J/R NSg/V C/P    . V/C V   NPrSg/V/J/C W?      NPrSg/V/J/P D/P
-> elaborate afternoon dress of  cream   - colored    chiffon , which gave out         a   continual
-# V/J       NSg       NSg/V V/P NSg/V/J . NSg/V/J/Am NSg     . I/C   V    NSg/V/J/R/P D/P J
-> rustle as    she swept about the room    . With the influence of  the dress her
-# NSg/V  NSg/R ISg V/J   J/P   D   NSg/V/J . P    D   NSg/V     V/P D   NSg/V I/J/D
+> elaborate afternoon dress of cream   - colored    chiffon , which gave out         a   continual
+# V/J       NSg       NSg/V P  NSg/V/J . NSg/V/J/Am NSg     . I/C   V    NSg/V/J/R/P D/P J
+> rustle as    she swept about the room    . With the influence of the dress her
+# NSg/V  NSg/R ISg V/J   J/P   D   NSg/V/J . P    D   NSg/V     P  D   NSg/V I/J/D
 > personality had also undergone a   change . The intense vitality that    had been  so
 # NSg         V   W?   V         D/P NSg/V  . D   J       NSg      N/I/C/D V   NSg/V NSg/I/J/C
 > remarkable in          the garage was converted into impressive hauteur . Her   laughter ,
@@ -1792,18 +1792,18 @@
 # V         J/P D/P J     . V        NSg/V NSg/J/P D   J     NSg/V .
 >
 #
-> “ My dear    , ” she told her   sister in          a   high    , mincing shout , “ most    of  these fellas
-# . D  NSg/V/J . . ISg V    I/J/D NSg/V  NPrSg/V/J/P D/P NSg/V/J . V       NSg/V . . NSg/I/J V/P I/D   NPl
-> will     cheat you every time  . All       they think of  is money . I   had a   woman up        here
-# NPrSg/VX NSg/V IPl D     NSg/V . NSg/I/J/C IPl  NSg/V V/P VL NSg/J . ISg V   D/P NSg/V NSg/V/J/P NSg/J/R
-> last    week to look  at        my feet , and when    she gave me        the bill    you’d of  thought she
-# NSg/V/J NSg  P  NSg/V NSg/I/V/P D  NSg  . V/C NSg/I/C ISg V    NPrSg/ISg D   NPrSg/V W?    V/P NSg/V   ISg
+> “ My dear    , ” she told her   sister in          a   high    , mincing shout , “ most    of these fellas
+# . D  NSg/V/J . . ISg V    I/J/D NSg/V  NPrSg/V/J/P D/P NSg/V/J . V       NSg/V . . NSg/I/J P  I/D   NPl
+> will     cheat you every time  . All       they think of is money . I   had a   woman up        here
+# NPrSg/VX NSg/V IPl D     NSg/V . NSg/I/J/C IPl  NSg/V P  VL NSg/J . ISg V   D/P NSg/V NSg/V/J/P NSg/J/R
+> last    week to look  at        my feet , and when    she gave me        the bill    you’d of thought she
+# NSg/V/J NSg  P  NSg/V NSg/I/V/P D  NSg  . V/C NSg/I/C ISg V    NPrSg/ISg D   NPrSg/V W?    P  NSg/V   ISg
 > had my appendicitus out         . ”
 # V   D  ?            NSg/V/J/R/P . .
 >
 #
-> “ What  was the name  of  the woman ? ” asked Mrs . McKee .
-# . NSg/I V   D   NSg/V V/P D   NSg/V . . V/J   NPl . NPr   .
+> “ What  was the name  of the woman ? ” asked Mrs . McKee .
+# . NSg/I V   D   NSg/V P  D   NSg/V . . V/J   NPl . NPr   .
 >
 #
 > “ Mrs . Eberhardt . She goes  around looking at        people’s feet in          their own     homes . ”
@@ -1827,29 +1827,29 @@
 > “ But     it        looks wonderful on  you , if    you know  what  I   mean    , ” pursued Mrs . McKee .
 # . NSg/C/P NPrSg/ISg NPl   J         J/P IPl . NSg/C IPl NSg/V NSg/I ISg NSg/V/J . . W?      NPl . NPr   .
 > “ If    Chester could  only get   you in          that    pose  I   think he      could  make  something of
-# . NSg/C NPrSg   NSg/VX W?   NSg/V IPl NPrSg/V/J/P N/I/C/D NSg/V ISg NSg/V NPr/ISg NSg/VX NSg/V NSg/I/V/J V/P
+# . NSg/C NPrSg   NSg/VX W?   NSg/V IPl NPrSg/V/J/P N/I/C/D NSg/V ISg NSg/V NPr/ISg NSg/VX NSg/V NSg/I/V/J P
 > it        . ”
 # NPrSg/ISg . .
 >
 #
-> We  all       looked in          silence at        Mrs . Wilson , who     removed a   strand of  hair  from over
-# IPl NSg/I/J/C W?     NPrSg/V/J/P NSg/V   NSg/I/V/P NPl . NPr    . NPrSg/I W?      D/P NSg/V  V/P NSg/V P    NSg/V/J/P
+> We  all       looked in          silence at        Mrs . Wilson , who     removed a   strand of hair  from over
+# IPl NSg/I/J/C W?     NPrSg/V/J/P NSg/V   NSg/I/V/P NPl . NPr    . NPrSg/I W?      D/P NSg/V  P  NSg/V P    NSg/V/J/P
 > her   eyes and looked back    at        us      with a   brilliant smile . Mr  . McKee regarded her
 # I/J/D NPl  V/C W?     NSg/V/J NSg/I/V/P NPr/ISg P    D/P NSg/J     NSg/V . NSg . NPr   W?       I/J/D
 > intently with his   head      on  one       side    , and then    moved his   hand  back    and forth
 # J/R      P    ISg/D NPrSg/V/J J/P NSg/I/V/J NSg/V/J . V/C NSg/J/C V/J   ISg/D NSg/V NSg/V/J V/C W?
-> slowly in          front   of  his   face  .
-# J/R    NPrSg/V/J/P NSg/V/J V/P ISg/D NSg/V .
+> slowly in          front   of his   face  .
+# J/R    NPrSg/V/J/P NSg/V/J P  ISg/D NSg/V .
 >
 #
 > “ I   should change the light   , ” he      said after a   moment . “ I’d like        to bring out         the
 # . ISg VX     NSg/V  D   NSg/V/J . . NPr/ISg V/J  J/P   D/P NSg    . . W?  NSg/V/J/C/P P  V     NSg/V/J/R/P D
-> modelling of  the features . And I’d try     to get   hold    of  all       the back    hair  . ”
-# NSg/V/Br  V/P D   NPl      . V/C W?  NSg/V/J P  NSg/V NSg/V/J V/P NSg/I/J/C D   NSg/V/J NSg/V . .
+> modelling of the features . And I’d try     to get   hold    of all       the back    hair  . ”
+# NSg/V/Br  P  D   NPl      . V/C W?  NSg/V/J P  NSg/V NSg/V/J P  NSg/I/J/C D   NSg/V/J NSg/V . .
 >
 #
-> “ I   wouldn’t think of  changing the light   , ” cried Mrs . McKee . “ I   think it’s — — — ”
-# . ISg VX       NSg/V V/P NSg/V    D   NSg/V/J . . W?    NPl . NPr   . . ISg NSg/V W?   . . . .
+> “ I   wouldn’t think of changing the light   , ” cried Mrs . McKee . “ I   think it’s — — — ”
+# . ISg VX       NSg/V P  NSg/V    D   NSg/V/J . . W?    NPl . NPr   . . ISg NSg/V W?   . . . .
 >
 #
 > Her   husband said “ Sh ! ” and we  all       looked at        the subject again , whereupon Tom
@@ -1866,8 +1866,8 @@
 #
 > “ I   told that    boy   about the ice     . ” Myrtle raised her   eyebrows in          despair at        the
 # . ISg V    N/I/C/D NSg/V J/P   D   NPrSg/V . . NPrSg  W?     I/J/D NPl      NPrSg/V/J/P NSg/V   NSg/I/V/P D
-> shiftlessness of  the lower orders . “ These people ! You have   to keep  after them
-# NSg           V/P D   V/J   NPl    . . I/D   NSg/V  . IPl NSg/VX P  NSg/V J/P   N/I
+> shiftlessness of the lower orders . “ These people ! You have   to keep  after them
+# NSg           P  D   V/J   NPl    . . I/D   NSg/V  . IPl NSg/VX P  NSg/V J/P   N/I
 > all       the time  . ”
 # NSg/I/J/C D   NSg/V . .
 >
@@ -1888,16 +1888,16 @@
 # NPrSg/V W?     NSg/I/V/P I   J/R     .
 >
 #
-> “ Two of  them we  have   framed down      - stairs . ”
-# . NSg V/P N/I  IPl NSg/VX V      NSg/V/J/P . NPl    . .
+> “ Two of them we  have   framed down      - stairs . ”
+# . NSg P  N/I  IPl NSg/VX V      NSg/V/J/P . NPl    . .
 >
 #
 > “ Two what  ? ” demanded Tom     .
 # . NSg NSg/I . . W?       NPrSg/V .
 >
 #
-> “ Two studies . One       of  them I   call  ‘          Montauk Point — The Gulls , ’ and the other   I   call
-# . NSg NPl     . NSg/I/V/J V/P N/I  ISg NSg/V Unlintable ?       NSg/V . D   NPl   . . V/C D   NSg/V/J ISg NSg/V
+> “ Two studies . One       of them I   call  ‘          Montauk Point — The Gulls , ’ and the other   I   call
+# . NSg NPl     . NSg/I/V/J P  N/I  ISg NSg/V Unlintable ?       NSg/V . D   NPl   . . V/C D   NSg/V/J ISg NSg/V
 > ‘          Montauk Point — The Sea . ’ ”
 # Unlintable ?       NSg/V . D   NSg . . .
 >
@@ -1924,8 +1924,8 @@
 # . ISg V/J  NSg/J/P NSg/V P  I   . .
 >
 #
-> “ Well    , they say   he’s a   nephew or      a   cousin of  Kaiser Wilhelm’s . That’s where all
-# . NSg/V/J . IPl  NSg/V N$   D/P NSg    NPrSg/C D/P NSg/V  V/P NPrSg  N$        . N$     NSg/C NSg/I/J/C
+> “ Well    , they say   he’s a   nephew or      a   cousin of Kaiser Wilhelm’s . That’s where all
+# . NSg/V/J . IPl  NSg/V N$   D/P NSg    NPrSg/C D/P NSg/V  P  NPrSg  N$        . N$     NSg/C NSg/I/J/C
 > his   money comes from . ”
 # ISg/D NSg/J NPl   P    . .
 >
@@ -1938,8 +1938,8 @@
 # ISg V      .
 >
 #
-> “ I’m scared of  him . I’d hate  to have   him get   anything on  me        . ”
-# . W?  W?     V/P I   . W?  NSg/V P  NSg/VX I   NSg/V NSg/I/V  J/P NPrSg/ISg . .
+> “ I’m scared of him . I’d hate  to have   him get   anything on  me        . ”
+# . W?  W?     P  I   . W?  NSg/V P  NSg/VX I   NSg/V NSg/I/V  J/P NPrSg/ISg . .
 >
 #
 > This absorbing information about my neighbor was interrupted by      Mrs . McKee’s
@@ -1960,10 +1960,10 @@
 # N/I/C/D IPl  VX     NSg/V NPrSg/ISg D/P NSg/V . .
 >
 #
-> “ Ask   Myrtle , ” said Tom     , breaking into a   short       shout of  laughter as    Mrs . Wilson
-# . NSg/V NPrSg  . . V/J  NPrSg/V . V        P    D/P NPrSg/V/J/P NSg/V V/P NSg      NSg/R NPl . NPr
-> entered with a   tray  . “ She'll give  you a   letter of  introduction , won’t you ,
-# W?      P    D/P NSg/V . . W?     NSg/V IPl D/P NSg/V  V/P NSg          . V     IPl .
+> “ Ask   Myrtle , ” said Tom     , breaking into a   short       shout of laughter as    Mrs . Wilson
+# . NSg/V NPrSg  . . V/J  NPrSg/V . V        P    D/P NPrSg/V/J/P NSg/V P  NSg      NSg/R NPl . NPr
+> entered with a   tray  . “ She'll give  you a   letter of introduction , won’t you ,
+# W?      P    D/P NSg/V . . W?     NSg/V IPl D/P NSg/V  P  NSg          . V     IPl .
 > Myrtle ? ”
 # NPrSg  . .
 >
@@ -1972,10 +1972,10 @@
 # . NSg/VX NSg/I . . ISg V/J   . W?       .
 >
 #
-> “ You'll give  McKee a   letter of  introduction to your husband , so        he      can      do     some
-# . W?     NSg/V NPr   D/P NSg/V  V/P NSg          P  D    NSg/V   . NSg/I/J/C NPr/ISg NPrSg/VX NSg/VX I/J/R
-> studies of  him . ” His   lips moved silently for a   moment as    he      invented . “ ‘          George
-# NPl     V/P I   . . ISg/D NPl  V/J   J/R      C/P D/P NSg    NSg/R NPr/ISg W?       . . Unlintable NPrSg
+> “ You'll give  McKee a   letter of introduction to your husband , so        he      can      do     some
+# . W?     NSg/V NPr   D/P NSg/V  P  NSg          P  D    NSg/V   . NSg/I/J/C NPr/ISg NPrSg/VX NSg/VX I/J/R
+> studies of him . ” His   lips moved silently for a   moment as    he      invented . “ ‘          George
+# NPl     P  I   . . ISg/D NPl  V/J   J/R      C/P D/P NSg    NSg/R NPr/ISg W?       . . Unlintable NPrSg
 > B. Wilson at        the Gasoline Pump  , ’ or      something like        that    . ”
 # ?  NPr    NSg/I/V/P D   NSg/J    NSg/V . . NPrSg/C NSg/I/V/J NSg/V/J/C/P N/I/C/D . .
 >
@@ -1984,8 +1984,8 @@
 # NPr       W?     NSg/V/J P  NPrSg/ISg V/C W?        NPrSg/V/J/P D  NSg/V .
 >
 #
-> “ Neither of  them can      stand the person they’re married to . ”
-# . I/C     V/P N/I  NPrSg/VX NSg/V D   NSg/V  W?      NSg/V/J P  . .
+> “ Neither of them can      stand the person they’re married to . ”
+# . I/C     P  N/I  NPrSg/VX NSg/V D   NSg/V  W?      NSg/V/J P  . .
 >
 #
 > “ Can’t they ? ”
@@ -2018,8 +2018,8 @@
 # V       NPrSg/V/J/P NSg/V   . .
 >
 #
-> Daisy was not   a   Catholic , and I   was a   little    shocked at        the elaborateness of  the
-# NPrSg V   NSg/C D/P NSg/J    . V/C ISg V   D/P NPrSg/I/J W?      NSg/I/V/P D   NSg           V/P D
+> Daisy was not   a   Catholic , and I   was a   little    shocked at        the elaborateness of the
+# NPrSg V   NSg/C D/P NSg/J    . V/C ISg V   D/P NPrSg/I/J W?      NSg/I/V/P D   NSg           P  D
 > lie     .
 # NPrSg/V .
 >
@@ -2052,10 +2052,10 @@
 # . NSg/V/J NPrSg/V/J . .
 >
 #
-> “ No      , we  just went  to Monte Carlo and back    . We  went  by      way   of  Marseilles . We  had
-# . NPrSg/P . IPl V/J  NSg/V P  NPr   NPr   V/C NSg/V/J . IPl NSg/V NSg/J/P NSg/J V/P NPrSg      . IPl V
-> over      twelve hundred dollars when    we  started , but     we  got gyped out         of  it        all       in
-# NSg/V/J/P NSg    NSg     NPl     NSg/I/C IPl W?      . NSg/C/P IPl V   ?     NSg/V/J/R/P V/P NPrSg/ISg NSg/I/J/C NPrSg/V/J/P
+> “ No      , we  just went  to Monte Carlo and back    . We  went  by      way   of Marseilles . We  had
+# . NPrSg/P . IPl V/J  NSg/V P  NPr   NPr   V/C NSg/V/J . IPl NSg/V NSg/J/P NSg/J P  NPrSg      . IPl V
+> over      twelve hundred dollars when    we  started , but     we  got gyped out         of it        all       in
+# NSg/V/J/P NSg    NSg     NPl     NSg/I/C IPl W?      . NSg/C/P IPl V   ?     NSg/V/J/R/P P  NPrSg/ISg NSg/I/J/C NPrSg/V/J/P
 > two days in          the private rooms . We  had an  awful time  getting back    , I   can      tell
 # NSg NPl  NPrSg/V/J/P D   NSg/V/J NPl   . IPl V   D/P J     NSg/V NSg/V   NSg/V/J . ISg NPrSg/VX NPrSg/V
 > you . God     , how   I   hated that    town ! ”
@@ -2063,9 +2063,9 @@
 >
 #
 > The late  afternoon sky   bloomed in          the window for a   moment like        the blue    honey   of
-# D   NSg/J NSg       NSg/V W?      NPrSg/V/J/P D   NSg/V  C/P D/P NSg    NSg/V/J/C/P D   NSg/V/J NSg/V/J V/P
-> the Mediterranean — then    the shrill  voice of  Mrs . McKee called me        back    into the
-# D   NPrSg/J       . NSg/J/C D   NSg/V/J NSg/V V/P NPl . NPr   V/J    NPrSg/ISg NSg/V/J P    D
+# D   NSg/J NSg       NSg/V W?      NPrSg/V/J/P D   NSg/V  C/P D/P NSg    NSg/V/J/C/P D   NSg/V/J NSg/V/J P
+> the Mediterranean — then    the shrill  voice of Mrs . McKee called me        back    into the
+# D   NPrSg/J       . NSg/J/C D   NSg/V/J NSg/V P  NPl . NPr   V/J    NPrSg/ISg NSg/V/J P    D
 > room    .
 # NSg/V/J .
 >
@@ -2076,8 +2076,8 @@
 # NPrSg/I/J ?    W?    NSg/V J/P   NPrSg/ISg C/P NPl   . ISg V    NPr/ISg V   P     NPrSg/ISg . N/I
 > kept saying to me        : ‘          Lucille , that    man’s        ’ way   below you ! ’ But     if    I   hadn’t met
 # V    NSg/V  P  NPrSg/ISg . Unlintable NPr     . N/I/C/D NPrSg$/I/V/J . NSg/J P     IPl . . NSg/C/P NSg/C ISg V      V
-> Chester , he’d of  got me        sure . ”
-# NPrSg   . W?   V/P V   NPrSg/ISg J    . .
+> Chester , he’d of got me        sure . ”
+# NPrSg   . W?   P  V   NPrSg/ISg J    . .
 >
 #
 > “ Yes   , but     listen , ” said Myrtle Wilson , nodding her   head      up        and down      , “ at        least
@@ -2146,8 +2146,8 @@
 # V   . .
 >
 #
-> The bottle of  whiskey — a   second  one       — was now         in          constant demand by      all       present ,
-# D   NSg/V  V/P NSg     . D/P NSg/V/J NSg/I/V/J . V   NPrSg/V/J/C NPrSg/V/J/P NSg/J    NSg/V  NSg/J/P NSg/I/J/C NSg/V/J .
+> The bottle of whiskey — a   second  one       — was now         in          constant demand by      all       present ,
+# D   NSg/V  P  NSg     . D/P NSg/V/J NSg/I/V/J . V   NPrSg/V/J/C NPrSg/V/J/P NSg/J    NSg/V  NSg/J/P NSg/I/J/C NSg/V/J .
 > excepting Catherine , who     “ felt    just as    good      on  nothing at        all       . ” Tom     rang for the
 # V         NPr       . NPrSg/I . NSg/V/J V/J  NSg/R NPrSg/V/J J/P NSg/I/J NSg/I/V/P NSg/I/J/C . . NPrSg/V V    C/P D
 > janitor and sent  him for some  celebrated sandwiches , which were  a   complete
@@ -2158,20 +2158,20 @@
 # NSg/J/P D   NSg/J NSg/V/J  . NSg/C/P D    NSg/V ISg V/J   P  NSg/V/J ISg V      W?        NPrSg/V/J/P
 > some  wild    , strident argument which pulled me        back    , as    if    with ropes , into my
 # I/J/R NSg/V/J . NSg/J    NSg/V    I/C   W?     NPrSg/ISg NSg/V/J . NSg/R NSg/C P    NPl   . P    D
-> chair . Yet     high    over      the city our line  of  yellow  windows must  have   contributed
-# NSg/V . NSg/V/C NSg/V/J NSg/V/J/P D   NSg  D   NSg/V V/P NSg/V/J NPrPl   NSg/V NSg/VX W?
-> their share of  human   secrecy to the casual watcher in          the darkening streets , and
-# D     NSg/V V/P NSg/V/J NSg     P  D   NSg/J  NSg/J   NPrSg/V/J/P D   V         NPl     . V/C
+> chair . Yet     high    over      the city our line  of yellow  windows must  have   contributed
+# NSg/V . NSg/V/C NSg/V/J NSg/V/J/P D   NSg  D   NSg/V P  NSg/V/J NPrPl   NSg/V NSg/VX W?
+> their share of human   secrecy to the casual watcher in          the darkening streets , and
+# D     NSg/V P  NSg/V/J NSg     P  D   NSg/J  NSg/J   NPrSg/V/J/P D   V         NPl     . V/C
 > I   saw   him too , looking up        and wondering . I   was within and without ,
 # ISg NSg/V I   W?  . V       NSg/V/J/P V/C NSg/V/J   . ISg V   N/J/P  V/C C/P     .
-> simultaneously enchanted and repelled by      the inexhaustible variety of  life  .
-# J/R            W?        V/C V        NSg/J/P D   J             NSg     V/P NSg/V .
+> simultaneously enchanted and repelled by      the inexhaustible variety of life  .
+# J/R            W?        V/C V        NSg/J/P D   J             NSg     P  NSg/V .
 >
 #
 > Myrtle pulled her   chair close   to mine    , and suddenly her   warm    breath  poured over
 # NPrSg  W?     I/J/D NSg/V NSg/V/J P  NSg/I/V . V/C J/R      I/J/D NSg/V/J NSg/V/J W?     NSg/V/J/P
-> me        the story of  her   first   meeting with Tom     .
-# NPrSg/ISg D   NSg/V V/P I/J/D NSg/V/J NSg/V   P    NPrSg/V .
+> me        the story of her   first   meeting with Tom     .
+# NPrSg/ISg D   NSg/V P  I/J/D NSg/V/J NSg/V   P    NPrSg/V .
 >
 #
 > “ It        was on  the two little    seats facing  each other   that    are always the last    ones
@@ -2196,18 +2196,18 @@
 # NSg/J   . . .
 >
 #
-> She turned to Mrs . McKee and the room    rang full    of  her   artificial laughter .
-# ISg W?     P  NPl . NPr   V/C D   NSg/V/J V    NSg/V/J V/P I/J/D J          NSg      .
+> She turned to Mrs . McKee and the room    rang full    of her   artificial laughter .
+# ISg W?     P  NPl . NPr   V/C D   NSg/V/J V    NSg/V/J P  I/J/D J          NSg      .
 >
 #
 > “ My dear    , ” she cried , “ I’m going   to give  you this dress as    soon as    I’m through
 # . D  NSg/V/J . . ISg W?    . . W?  NSg/V/J P  NSg/V IPl I/D  NSg/V NSg/R J/R  NSg/R W?  NSg/J/P
-> with it        . I’ve got to get   another one       to - morrow  . I’m going   to make  a   list  of  all
-# P    NPrSg/ISg . W?   V   P  NSg/V I/D     NSg/I/V/J P  . NPrSg/V . W?  NSg/V/J P  NSg/V D/P NSg/V V/P NSg/I/J/C
+> with it        . I’ve got to get   another one       to - morrow  . I’m going   to make  a   list  of all
+# P    NPrSg/ISg . W?   V   P  NSg/V I/D     NSg/I/V/J P  . NPrSg/V . W?  NSg/V/J P  NSg/V D/P NSg/V P  NSg/I/J/C
 > the things I’ve got to get   . A   massage and a   wave  , and a   collar for the dog     , and
 # D   NPl    W?   V   P  NSg/V . D/P NSg/V   V/C D/P NSg/V . V/C D/P NSg/V  C/P D   NSg/V/J . V/C
-> one       of  those cute little    ash   - trays where you touch a   spring , and a   wreath with a
-# NSg/I/V/J V/P I/D   J    NPrSg/I/J NSg/V . NPl   NSg/C IPl NSg/V D/P NSg/V  . V/C D/P NSg/V  P    D/P
+> one       of those cute little    ash   - trays where you touch a   spring , and a   wreath with a
+# NSg/I/V/J P  I/D   J    NPrSg/I/J NSg/V . NPl   NSg/C IPl NSg/V D/P NSg/V  . V/C D/P NSg/V  P    D/P
 > black   silk  bow   for mother’s grave   that’ll last    all       summer  . I   got to write down      a
 # NSg/V/J NSg/V NSg/V C/P N$       NSg/V/J W?      NSg/V/J NSg/I/J/C NPrSg/V . ISg V   P  NSg/V NSg/V/J/P D/P
 > list  so        I   won’t forget all       the things I   got to do     . ”
@@ -2218,10 +2218,10 @@
 # NPrSg/ISg V   NSg  W?      . NSg    J/R         R/Am      ISg W?     NSg/I/V/P D  NSg/V V/C NSg/V
 > it        was ten . Mr  . McKee was asleep on  a   chair with his   fists clenched in          his   lap     ,
 # NPrSg/ISg V   NSg . NSg . NPr   V   J      J/P D/P NSg/V P    ISg/D NPl   W?       NPrSg/V/J/P ISg/D NSg/V/J .
-> like        a   photograph of  a   man         of  action  . Taking  out         my handkerchief I   wiped from
-# NSg/V/J/C/P D/P NSg/V      V/P D/P NPrSg/I/V/J V/P NSg/V/J . NSg/V/J NSg/V/J/R/P D  NSg          ISg W?    P
-> his   cheek the spot    of  dried lather  that    had worried me        all       the afternoon .
-# ISg/D NSg/V D   NSg/V/J V/P W?    NSg/V/J N/I/C/D V   V/J     NPrSg/ISg NSg/I/J/C D   NSg       .
+> like        a   photograph of a   man         of action  . Taking  out         my handkerchief I   wiped from
+# NSg/V/J/C/P D/P NSg/V      P  D/P NPrSg/I/V/J P  NSg/V/J . NSg/V/J NSg/V/J/R/P D  NSg          ISg W?    P
+> his   cheek the spot    of dried lather  that    had worried me        all       the afternoon .
+# ISg/D NSg/V D   NSg/V/J P  W?    NSg/V/J N/I/C/D V   V/J     NPrSg/ISg NSg/I/J/C D   NSg       .
 >
 #
 > The little    dog     was sitting on  the table looking with blind   eyes through the
@@ -2250,18 +2250,18 @@
 #
 > Then    there were  bloody  towels upon the bathroom floor , and women’s voices
 # NSg/J/C W?    NSg/V NSg/V/J NPl    P    D   NSg/V    NSg/V . V/C N$      NPl
-> scolding , and high    over      the confusion a   long      broken wail  of  pain  . Mr  . McKee
-# NSg/V    . V/C NSg/V/J NSg/V/J/P D   NSg/V     D/P NPrSg/V/J V/J    NSg/V V/P NSg/V . NSg . NPr
+> scolding , and high    over      the confusion a   long      broken wail  of pain  . Mr  . McKee
+# NSg/V    . V/C NSg/V/J NSg/V/J/P D   NSg/V     D/P NPrSg/V/J V/J    NSg/V P  NSg/V . NSg . NPr
 > awoke from his   doze  and started in          a   daze  toward the door  . When    he      had gone  half
 # V     P    ISg/D NSg/V V/C W?      NPrSg/V/J/P D/P NSg/V J/P    D   NSg/V . NSg/I/C NPr/ISg V   V/J/P NSg/V/J/P
 > way   he      turned around and stared at        the scene — his   wife  and Catherine scolding and
 # NSg/J NPr/ISg W?     J/P    V/C W?     NSg/I/V/P D   NSg/V . ISg/D NSg/V V/C NPr       NSg/V    V/C
 > consoling as    they stumbled here    and there among the crowded furniture with
 # NSg/V/J   NSg/R IPl  W?       NSg/J/R V/C W?    P     D   V/J     NSg       P
-> articles of  aid   , and the despairing figure on  the couch , bleeding fluently , and
-# NPl      V/P NSg/V . V/C D   NSg/V/J    NSg/V  J/P D   NSg/V . NSg/V/J  J/R      . V/C
-> trying  to spread a   copy  of  Town Tattle over      the tapestry scenes of  Versailles .
-# NSg/V/J P  NSg/V  D/P NSg/V V/P NSg  NSg/V  NSg/V/J/P D   NSg/V    NPl    V/P NPr        .
+> articles of aid   , and the despairing figure on  the couch , bleeding fluently , and
+# NPl      P  NSg/V . V/C D   NSg/V/J    NSg/V  J/P D   NSg/V . NSg/V/J  J/R      . V/C
+> trying  to spread a   copy  of Town Tattle over      the tapestry scenes of Versailles .
+# NSg/V/J P  NSg/V  D/P NSg/V P  NSg  NSg/V  NSg/V/J/P D   NSg/V    NPl    P  NPr        .
 > Then    Mr  . McKee turned and continued on  out         the door  . Taking  my hat   from the
 # NSg/J/C NSg . NPr   W?     V/C W?        J/P NSg/V/J/R/P D   NSg/V . NSg/V/J D  NSg/V P    D
 > chandelier , I   followed .
@@ -2302,8 +2302,8 @@
 #
 > “ Beauty  and the Beast   . . . Loneliness . . . Old   Grocery Horse . . . Brook’n
 # . NSg/V/J V/C D   NSg/V/J . . . NSg        . . . NSg/J NSg/V   NSg/V . . . ?
-> Bridge . . . ” Then    I   was lying   half      asleep in          the cold  lower level   of  the
-# NSg/V  . . . . NSg/J/C ISg V   NSg/V/J NSg/V/J/P J      NPrSg/V/J/P D   NSg/J V/J   NSg/V/J V/P D
+> Bridge . . . ” Then    I   was lying   half      asleep in          the cold  lower level   of the
+# NSg/V  . . . . NSg/J/C ISg V   NSg/V/J NSg/V/J/P J      NPrSg/V/J/P D   NSg/J V/J   NSg/V/J P  D
 > Pennsylvania Station , staring at        the morning Tribune , and waiting for the four
 # NPr          NSg/V   . V       NSg/I/V/P D   NSg/V   NSg     . V/C NSg/V   C/P D   NSg
 > o’clock train .
@@ -2320,12 +2320,12 @@
 # NPl     NSg V/C NPl   NSg/V/P V/C NSg/V NSg/V/J/C/P NSg/V P     D   ?           V/C D
 > champagne and the stars . At        high    tide  in          the afternoon I   watched his   guests
 # NSg/V/J   V/C D   NPl   . NSg/I/V/P NSg/V/J NSg/V NPrSg/V/J/P D   NSg       ISg W?      ISg/D NPl
-> diving  from the tower   of  his   raft  , or      taking  the sun     on  the hot     sand    of  his
-# NSg/V/J P    D   NSg/V/J V/P ISg/D NSg/V . NPrSg/C NSg/V/J D   NPrSg/V J/P D   NSg/V/J NSg/V/J V/P ISg/D
-> beach   while     his   two motor   - boats slit    the waters  of  the Sound   , drawing aquaplanes
-# NPrSg/V NSg/V/C/P ISg/D NSg NSg/V/J . NPl   NSg/V/J D   NPrSg/V V/P D   NSg/V/J . NSg/V   NPl
-> over      cataracts of  foam  . On  week - ends his   Rolls - Royce became an  omnibus , bearing
-# NSg/V/J/P NPl       V/P NSg/V . J/P NSg  . NPl  ISg/D NPl   . NPr   V      D/P NSg/V/J . NSg/V/J
+> diving  from the tower   of his   raft  , or      taking  the sun     on  the hot     sand    of his
+# NSg/V/J P    D   NSg/V/J P  ISg/D NSg/V . NPrSg/C NSg/V/J D   NPrSg/V J/P D   NSg/V/J NSg/V/J P  ISg/D
+> beach   while     his   two motor   - boats slit    the waters  of the Sound   , drawing aquaplanes
+# NPrSg/V NSg/V/C/P ISg/D NSg NSg/V/J . NPl   NSg/V/J D   NPrSg/V P  D   NSg/V/J . NSg/V   NPl
+> over      cataracts of foam  . On  week - ends his   Rolls - Royce became an  omnibus , bearing
+# NSg/V/J/P NPl       P  NSg/V . J/P NSg  . NPl  ISg/D NPl   . NPr   V      D/P NSg/V/J . NSg/V/J
 > parties to and from the city between nine in          the morning and long      past      midnight ,
 # NPl     P  V/C P    D   NSg  NSg/P   NSg  NPrSg/V/J/P D   NSg/V   V/C NPrSg/V/J NSg/V/J/P NSg/J    .
 > while     his   station wagon scampered like        a   brisk yellow  bug   to meet    all       trains .
@@ -2334,44 +2334,44 @@
 # V/C J/P NPl     NSg/J NPl      . V         D/P NSg/J NSg/J    . W?     NSg/I/J/C NPrSg P
 > mops and scrubbing - brushes and hammers and garden  - shears , repairing the ravages
 # NPl  V/C NSg/V     . NPl     V/C NPl     V/C NSg/V/J . NPl    . V         D   NSg/V
-> of  the night before .
-# V/P D   NSg/V C/P    .
+> of the night before .
+# P  D   NSg/V C/P    .
 >
 #
-> Every Friday five crates of  oranges and lemons arrived from a   fruiterer in          New
-# D     NSg    NSg  NPl    V/P NPl     V/C NPl    W?      P    D/P NSg       NPrSg/V/J/P NSg/V/J
+> Every Friday five crates of oranges and lemons arrived from a   fruiterer in          New
+# D     NSg    NSg  NPl    P  NPl     V/C NPl    W?      P    D/P NSg       NPrSg/V/J/P NSg/V/J
 > York — every Monday these same oranges and lemons left      his   back    door  in          a   pyramid
 # NPr  . D     NSg    I/D   I/J  NPl     V/C NPl    NPrSg/V/J ISg/D NSg/V/J NSg/V NPrSg/V/J/P D/P NSg/V
-> of  pulpless halves . There was a   machine in          the kitchen which could  extract the
-# V/P ?        NPl    . W?    V   D/P NSg/V   NPrSg/V/J/P D   NSg/V   I/C   NSg/VX NSg/V   D
-> juice   of  two hundred oranges in          half      an  hour if    a   little    button was pressed two
-# NSg/V/J V/P NSg NSg     NPl     NPrSg/V/J/P NSg/V/J/P D/P NSg  NSg/C D/P NPrSg/I/J NSg/V  V   V/J     NSg
+> of pulpless halves . There was a   machine in          the kitchen which could  extract the
+# P  ?        NPl    . W?    V   D/P NSg/V   NPrSg/V/J/P D   NSg/V   I/C   NSg/VX NSg/V   D
+> juice   of two hundred oranges in          half      an  hour if    a   little    button was pressed two
+# NSg/V/J P  NSg NSg     NPl     NPrSg/V/J/P NSg/V/J/P D/P NSg  NSg/C D/P NPrSg/I/J NSg/V  V   V/J     NSg
 > hundred times by      a   butler’s thumb .
 # NSg     NPl   NSg/J/P D/P N$       NSg/V .
 >
 #
-> At        least once  a   fortnight a   corps of  caterers came    down      with several hundred
-# NSg/I/V/P NSg/J NSg/C D/P NSg       D/P NSg   V/P W?       NSg/V/P NSg/V/J/P P    J/D     NSg
-> feet of  canvas and enough colored    lights to make  a   Christmas tree  of  Gatsby’s
-# NSg  V/P NSg/V  V/C NSg/I  NSg/V/J/Am NPl    P  NSg/V D/P NPrSg/V/J NSg/V V/P N$
+> At        least once  a   fortnight a   corps of caterers came    down      with several hundred
+# NSg/I/V/P NSg/J NSg/C D/P NSg       D/P NSg   P  W?       NSg/V/P NSg/V/J/P P    J/D     NSg
+> feet of canvas and enough colored    lights to make  a   Christmas tree  of Gatsby’s
+# NSg  P  NSg/V  V/C NSg/I  NSg/V/J/Am NPl    P  NSg/V D/P NPrSg/V/J NSg/V P  N$
 > enormous garden  . On  buffet  tables , garnished with glistening hors - d’œuvre ,
 # J        NSg/V/J . J/P NPrSg/V NPl    . W?        P    V          ?    . ?       .
-> spiced baked hams crowded against salads of  harlequin designs and pastry pigs
-# W?     V/J   NPl  V/J     C/P     NPl    V/P NPrSg/V/J NPl     V/C NSg    NPl
+> spiced baked hams crowded against salads of harlequin designs and pastry pigs
+# W?     V/J   NPl  V/J     C/P     NPl    P  NPrSg/V/J NPl     V/C NSg    NPl
 > and turkeys bewitched to a   dark    gold    . In          the main    hall  a   bar     with a   real  brass
 # V/C NPl     W?        P  D/P NSg/V/J NSg/V/J . NPrSg/V/J/P D   NSg/V/J NPrSg D/P NSg/V/P P    D/P NSg/J NSg/V/J
 > rail  was set       up        , and stocked with gins and liquors and with cordials so        long
 # NSg/V V   NPrSg/V/J NSg/V/J/P . V/C W?      P    NPl  V/C NPl     V/C P    NPl      NSg/I/J/C NPrSg/V/J
-> forgotten that    most    of  his   female guests were  too young     to know  one       from
-# NSg/V/J   N/I/C/D NSg/I/J V/P ISg/D NSg/J  NPl    NSg/V W?  NPrSg/V/J P  NSg/V NSg/I/V/J P
+> forgotten that    most    of his   female guests were  too young     to know  one       from
+# NSg/V/J   N/I/C/D NSg/I/J P  ISg/D NSg/J  NPl    NSg/V W?  NPrSg/V/J P  NSg/V NSg/I/V/J P
 > another .
 # I/D     .
 >
 #
 > By      seven o’clock the orchestra has arrived , no      thin    five - piece affair , but     a
 # NSg/J/P NSg   W?      D   NSg       V   W?      . NPrSg/P NSg/V/J NSg  . NSg/V NSg    . NSg/C/P D/P
-> whole pitful of  oboes and trombones and saxophones and viols and cornets and
-# NSg/J ?      V/P NPl   V/C NPl       V/C NPl        V/C NPl   V/C NPl     V/C
+> whole pitful of oboes and trombones and saxophones and viols and cornets and
+# NSg/J ?      P  NPl   V/C NPl       V/C NPl        V/C NPl   V/C NPl     V/C
 > piccolos , and low     and high    drums . The last    swimmers have   come    in          from the beach
 # NPl      . V/C NSg/V/J V/C NSg/V/J NPl   . D   NSg/V/J NPl      NSg/VX NSg/V/P NPrSg/V/J/P P    D   NPrSg/V
 > now         and are dressing up        - stairs ; the cars from New     York are parked five deep  in
@@ -2379,9 +2379,9 @@
 > the drive , and already the halls and salons and verandas are gaudy with primary
 # D   NSg/V . V/C W?      D   NPl   V/C NPl    V/C NPl      V   NSg/J P    NSg/V/J
 > colors , and hair  bobbed in          strange new     ways , and shawls beyond the dreams of
-# NPl    . V/C NSg/V V/J    NPrSg/V/J/P NSg/V/J NSg/V/J NPl  . V/C NPl    NSg/P  D   NPl    V/P
-> Castile . The bar     is in          full    swing , and floating rounds of  cocktails permeate the
-# ?       . D   NSg/V/P VL NPrSg/V/J/P NSg/V/J NSg/V . V/C V        NPl    V/P NPl       NSg/V    D
+# NPl    . V/C NSg/V V/J    NPrSg/V/J/P NSg/V/J NSg/V/J NPl  . V/C NPl    NSg/P  D   NPl    P
+> Castile . The bar     is in          full    swing , and floating rounds of cocktails permeate the
+# ?       . D   NSg/V/P VL NPrSg/V/J/P NSg/V/J NSg/V . V/C V        NPl    P  NPl       NSg/V    D
 > garden  outside   , until the air   is alive with chatter and laughter , and casual
 # NSg/V/J NSg/V/J/P . C/P   D   NSg/V VL W?    P    NSg/V   V/C NSg      . V/C NSg/J
 > innuendo and introductions forgotten on  the spot    , and enthusiastic meetings
@@ -2392,8 +2392,8 @@
 #
 > The lights grow brighter as    the earth   lurches away from the sun     , and now         the
 # D   NPl    V    J        NSg/R D   NPrSg/V NPl     V/J  P    D   NPrSg/V . V/C NPrSg/V/J/C D
-> orchestra is playing yellow  cocktail music   , and the opera of  voices pitches a
-# NSg       VL V       NSg/V/J NSg/V/J  NSg/V/J . V/C D   NSg   V/P NPl    NPl     D/P
+> orchestra is playing yellow  cocktail music   , and the opera of voices pitches a
+# NSg       VL V       NSg/V/J NSg/V/J  NSg/V/J . V/C D   NSg   P  NPl    NPl     D/P
 > key       higher . Laughter is easier minute  by      minute  , spilled with prodigality ,
 # NPrSg/V/J J      . NSg      VL J      NSg/V/J NSg/J/P NSg/V/J . W?      P    NSg         .
 > tipped out         at        a   cheerful word  . The groups change more        swiftly , swell   with new
@@ -2402,30 +2402,30 @@
 # NPl      . NSg/V    V/C NSg/V NPrSg/V/J/P D   I/J  NSg/V/J . W?      W?    V   W?        .
 > confident girls who     weave here    and there among the stouter and more        stable  ,
 # NSg/J     NPl   NPrSg/I NSg/V NSg/J/R V/C W?    P     D   J       V/C NPrSg/I/V/J NSg/V/J .
-> become for a   sharp     , joyous moment the centre   of  a   group , and then    , excited with
-# V      C/P D/P NPrSg/V/J . J      NSg    D   NSg/V/Br V/P D/P NSg/V . V/C NSg/J/C . V/J     P
-> triumph , glide on  through the sea - change of  faces and voices and color      under   the
-# NSg/V   . NSg/V J/P NSg/J/P D   NSg . NSg/V  V/P NPl   V/C NPl    V/C NSg/V/J/Am NSg/J/P D
+> become for a   sharp     , joyous moment the centre   of a   group , and then    , excited with
+# V      C/P D/P NPrSg/V/J . J      NSg    D   NSg/V/Br P  D/P NSg/V . V/C NSg/J/C . V/J     P
+> triumph , glide on  through the sea - change of faces and voices and color      under   the
+# NSg/V   . NSg/V J/P NSg/J/P D   NSg . NSg/V  P  NPl   V/C NPl    V/C NSg/V/J/Am NSg/J/P D
 > constantly changing light   .
 # J/R        NSg/V    NSg/V/J .
 >
 #
-> Suddenly one       of  these gypsies , in          trembling opal  , seizes a   cocktail out         of  the
-# J/R      NSg/I/V/J V/P I/D   NPl     . NPrSg/V/J/P V         NPrSg . NPl    D/P NSg/V/J  NSg/V/J/R/P V/P D
+> Suddenly one       of these gypsies , in          trembling opal  , seizes a   cocktail out         of the
+# J/R      NSg/I/V/J P  I/D   NPl     . NPrSg/V/J/P V         NPrSg . NPl    D/P NSg/V/J  NSg/V/J/R/P P  D
 > air   , dumps it        down      for courage and , moving  her   hands like        Frisco , dances out
 # NSg/V . NPl   NPrSg/ISg NSg/V/J/P C/P NSg/V   V/C . NSg/V/J I/J/D NPl   NSg/V/J/C/P NPr    . NPl    NSg/V/J/R/P
 > alone on  the canvas platform . A   momentary hush  ; the orchestra leader varies his
 # J     J/P D   NSg/V  NSg/V    . D/P J         NSg/V . D   NSg       NSg/J  NPl    ISg/D
-> rhythm obligingly for her   , and there is a   burst of  chatter as    the erroneous news
-# NSg/V  J/R        C/P I/J/D . V/C W?    VL D/P NSg/V V/P NSg/V   NSg/R D   J         NSg/V
+> rhythm obligingly for her   , and there is a   burst of chatter as    the erroneous news
+# NSg/V  J/R        C/P I/J/D . V/C W?    VL D/P NSg/V P  NSg/V   NSg/R D   J         NSg/V
 > goes  around that    she is Gilda Gray’s understudy from the Follies . The party   has
 # NSg/V J/P    N/I/C/D ISg VL NPr   N$     NSg/V      P    D   NPl     . D   NSg/V/J V
 > begun .
 # V     .
 >
 #
-> I   believe that    on  the first   night I   went  to Gatsby’s house   I   was one       of  the few
-# ISg V       N/I/C/D J/P D   NSg/V/J NSg/V ISg NSg/V P  N$       NPrSg/V ISg V   NSg/I/V/J V/P D   N/I
+> I   believe that    on  the first   night I   went  to Gatsby’s house   I   was one       of the few
+# ISg V       N/I/C/D J/P D   NSg/V/J NSg/V ISg NSg/V P  N$       NPrSg/V ISg V   NSg/I/V/J P  D   N/I
 > guests who     had actually been  invited . People were  not   invited — they went  there .
 # NPl    NPrSg/I V   J/R      NSg/V NSg/V/J . NSg/V  NSg/V NSg/C NSg/V/J . IPl  NSg/V W?    .
 > They got into automobiles which bore  them out         to Long      Island , and somehow they
@@ -2433,43 +2433,43 @@
 > ended up        at        Gatsby’s door  . Once  there they were  introduced by      somebody who     knew
 # W?    NSg/V/J/P NSg/I/V/P N$       NSg/V . NSg/C W?    IPl  NSg/V W?         NSg/J/P NSg/I    NPrSg/I V
 > Gatsby , and after that    they conducted themselves according to the rules of
-# NPr    . V/C J/P   N/I/C/D IPl  W?        I          V/J       P  D   NPl   V/P
+# NPr    . V/C J/P   N/I/C/D IPl  W?        I          V/J       P  D   NPl   P
 > behavior associated with an  amusement park    . Sometimes they came    and went  without
 # NSg      W?         P    D/P NSg       NPrSg/V . R         IPl  NSg/V/P V/C NSg/V C/P
-> having met Gatsby at        all       , came    for the party   with a   simplicity of  heart that    was
-# V      V   NPr    NSg/I/V/P NSg/I/J/C . NSg/V/P C/P D   NSg/V/J P    D/P NSg        V/P NSg/V N/I/C/D V
-> its   own     ticket of  admission .
-# ISg/D NSg/V/J NSg/V  V/P NSg       .
+> having met Gatsby at        all       , came    for the party   with a   simplicity of heart that    was
+# V      V   NPr    NSg/I/V/P NSg/I/J/C . NSg/V/P C/P D   NSg/V/J P    D/P NSg        P  NSg/V N/I/C/D V
+> its   own     ticket of admission .
+# ISg/D NSg/V/J NSg/V  P  NSg       .
 >
 #
-> I   had been  actually invited . A   chauffeur in          a   uniform of  robin’s - egg   blue
-# ISg V   NSg/V J/R      NSg/V/J . D/P NSg/V     NPrSg/V/J/P D/P NSg/V/J V/P N$      . NSg/V NSg/V/J
+> I   had been  actually invited . A   chauffeur in          a   uniform of robin’s - egg   blue
+# ISg V   NSg/V J/R      NSg/V/J . D/P NSg/V     NPrSg/V/J/P D/P NSg/V/J P  N$      . NSg/V NSg/V/J
 > crossed my lawn  early   that    Saturday morning with a   surprisingly formal note  from
 # W?      D  NSg/V NSg/J/R N/I/C/D NSg/V    NSg/V   P    D/P J/R          NSg/J  NSg/V P
 > his   employer : the honor    would  be     entirely Gatsby’s , it        said , if    I   would  attend
 # ISg/D NSg      . D   NSg/V/Am NSg/VX NSg/VX J/R      N$       . NPrSg/ISg V/J  . NSg/C ISg NSg/VX V
 > his   “ little    party   ” that    night . He      had seen  me        several times , and had intended to
 # ISg/D . NPrSg/I/J NSg/V/J . N/I/C/D NSg/V . NPr/ISg V   NSg/V NPrSg/ISg J/D     NPl   . V/C V   NSg/V/J  P
-> call  on  me        long      before , but     a   peculiar combination of  circumstances had
-# NSg/V J/P NPrSg/ISg NPrSg/V/J C/P    . NSg/C/P D/P NSg/J    NSg         V/P NPl           V
+> call  on  me        long      before , but     a   peculiar combination of circumstances had
+# NSg/V J/P NPrSg/ISg NPrSg/V/J C/P    . NSg/C/P D/P NSg/J    NSg         P  NPl           V
 > prevented it        — signed Jay   Gatsby , in          a   majestic hand  .
 # W?        NPrSg/ISg . V/J    NPrSg NPr    . NPrSg/V/J/P D/P J        NSg/V .
 >
 #
 > Dressed up        in          white     flannels I   went  over      to his   lawn  a   little    after seven , and
 # W?      NSg/V/J/P NPrSg/V/J/P NPrSg/V/J NPl      ISg NSg/V NSg/V/J/P P  ISg/D NSg/V D/P NPrSg/I/J J/P   NSg   . V/C
-> wandered around rather    ill     at        ease  among swirls and eddies of  people I   didn’t
-# W?       J/P    NPrSg/V/J NSg/V/J NSg/I/V/P NSg/V P     NPl    V/C NPl    V/P NSg/V  ISg V
+> wandered around rather    ill     at        ease  among swirls and eddies of people I   didn’t
+# W?       J/P    NPrSg/V/J NSg/V/J NSg/I/V/P NSg/V P     NPl    V/C NPl    P  NSg/V  ISg V
 > know  — though here    and there was a   face  I   had noticed on  the commuting train . I
 # NSg/V . V/C    NSg/J/R V/C W?    V   D/P NSg/V ISg V   V       J/P D   V         NSg/V . ISg
-> was immediately struck by      the number  of  young     Englishmen dotted about ; all       well
-# V   J/R         V      NSg/J/P D   NSg/V/J V/P NPrSg/V/J NPl        V/J    J/P   . NSg/I/J/C NSg/V/J
+> was immediately struck by      the number  of young     Englishmen dotted about ; all       well
+# V   J/R         V      NSg/J/P D   NSg/V/J P  NPrSg/V/J NPl        V/J    J/P   . NSg/I/J/C NSg/V/J
 > dressed , all       looking a   little    hungry , and all       talking in          low     , earnest   voices to
 # W?      . NSg/I/J/C V       D/P NPrSg/I/J J      . V/C NSg/I/J/C V       NPrSg/V/J/P NSg/V/J . NPrSg/V/J NPl    P
 > solid and prosperous Americans . I   was sure that    they were  selling something :
 # NSg/J V/C J          NPl       . ISg V   J    N/I/C/D IPl  NSg/V V       NSg/I/V/J .
-> bonds or      insurance or      automobiles . They were  at        least agonizingly aware of  the
-# NPl   NPrSg/C NSg       NPrSg/C NPl         . IPl  NSg/V NSg/I/V/P NSg/J J/R         V/J   V/P D
+> bonds or      insurance or      automobiles . They were  at        least agonizingly aware of the
+# NPl   NPrSg/C NSg       NPrSg/C NPl         . IPl  NSg/V NSg/I/V/P NSg/J J/R         V/J   P  D
 > easy    money in          the vicinity and convinced that    it        was theirs for a   few words in
 # NSg/V/J NSg/J NPrSg/V/J/P D   NSg      V/C V/J       N/I/C/D NPrSg/ISg V   I      C/P D/P N/I NPl   NPrSg/V/J/P
 > the right     key       .
@@ -2478,20 +2478,20 @@
 #
 > As    soon as    I   arrived I   made  an  attempt to find  my host  , but     the two or      three
 # NSg/R J/R  NSg/R ISg W?      ISg NSg/V D/P NSg/V   P  NSg/V D  NSg/V . NSg/C/P D   NSg NPrSg/C NSg
-> people of  whom I   asked his   whereabouts stared at        me        in          such  an  amazed way   , and
-# NSg/V  V/P I    ISg V/J   ISg/D NSg         W?     NSg/I/V/P NPrSg/ISg NPrSg/V/J/P NSg/I D/P W?     NSg/J . V/C
-> denied so        vehemently any   knowledge of  his   movements , that    I   slunk off       in          the
-# W?     NSg/I/J/C J/R        I/R/D NSg/V     V/P ISg/D NPl       . N/I/C/D ISg NSg/V NSg/V/J/P NPrSg/V/J/P D
-> direction of  the cocktail table — the only place in          the garden  where a   single  man
-# NSg       V/P D   NSg/V/J  NSg/V . D   W?   NSg/V NPrSg/V/J/P D   NSg/V/J NSg/C D/P NSg/V/J NPrSg/I/V/J
+> people of whom I   asked his   whereabouts stared at        me        in          such  an  amazed way   , and
+# NSg/V  P  I    ISg V/J   ISg/D NSg         W?     NSg/I/V/P NPrSg/ISg NPrSg/V/J/P NSg/I D/P W?     NSg/J . V/C
+> denied so        vehemently any   knowledge of his   movements , that    I   slunk off       in          the
+# W?     NSg/I/J/C J/R        I/R/D NSg/V     P  ISg/D NPl       . N/I/C/D ISg NSg/V NSg/V/J/P NPrSg/V/J/P D
+> direction of the cocktail table — the only place in          the garden  where a   single  man
+# NSg       P  D   NSg/V/J  NSg/V . D   W?   NSg/V NPrSg/V/J/P D   NSg/V/J NSg/C D/P NSg/V/J NPrSg/I/V/J
 > could  linger without looking purposeless and alone .
 # NSg/VX V      C/P     V       J           V/C J     .
 >
 #
 > I   was on  my way   to get   roaring drunk   from sheer   embarrassment when    Jordan Baker
 # ISg V   J/P D  NSg/J P  NSg/V NSg/V/J NSg/V/J P    NSg/V/J NSg           NSg/I/C NPr    NPrSg/J
-> came    out         of  the house   and stood at        the head      of  the marble  steps , leaning a
-# NSg/V/P NSg/V/J/R/P V/P D   NPrSg/V V/C V     NSg/I/V/P D   NPrSg/V/J V/P D   NSg/V/J NPl   . NSg/V   D/P
+> came    out         of the house   and stood at        the head      of the marble  steps , leaning a
+# NSg/V/P NSg/V/J/R/P P  D   NPrSg/V V/C V     NSg/I/V/P D   NPrSg/V/J P  D   NSg/V/J NPl   . NSg/V   D/P
 > little    backward and looking with contemptuous interest down      into the garden  .
 # NPrSg/I/J NSg/J    V/C V       P    J            NSg/V    NSg/V/J/P P    D   NSg/V/J .
 >
@@ -2514,12 +2514,12 @@
 # V          IPl W?    NSg/J/P NSg/V P  . . .
 >
 #
-> She held my hand  impersonally , as    a   promise that    she’d take  care  of  me        in          a
-# ISg V    D  NSg/V J/R          . NSg/R D/P NSg/V   N/I/C/D W?    NSg/V NSg/V V/P NPrSg/ISg NPrSg/V/J/P D/P
+> She held my hand  impersonally , as    a   promise that    she’d take  care  of me        in          a
+# ISg V    D  NSg/V J/R          . NSg/R D/P NSg/V   N/I/C/D W?    NSg/V NSg/V P  NPrSg/ISg NPrSg/V/J/P D/P
 > minute  , and gave ear   to two girls in          twin    yellow  dresses , who     stopped at        the
 # NSg/V/J . V/C V    NSg/V P  NSg NPl   NPrSg/V/J/P NSg/V/J NSg/V/J NPl     . NPrSg/I V/J     NSg/I/V/P D
-> foot  of  the steps .
-# NSg/V V/P D   NPl   .
+> foot  of the steps .
+# NSg/V P  D   NPl   .
 >
 #
 > “ Hello ! ” they cried together . “ Sorry   you didn’t win   . ”
@@ -2530,8 +2530,8 @@
 # N/I/C/D V   C/P D   NSg/V NSg        . ISg V   V/J  NPrSg/V/J/P D   NPl    D   NSg  C/P    .
 >
 #
-> “ You don’t know  who     we  are , ” said one       of  the girls in          yellow  , “ but     we  met you
-# . IPl NSg/V NSg/V NPrSg/I IPl V   . . V/J  NSg/I/V/J V/P D   NPl   NPrSg/V/J/P NSg/V/J . . NSg/C/P IPl V   IPl
+> “ You don’t know  who     we  are , ” said one       of the girls in          yellow  , “ but     we  met you
+# . IPl NSg/V NSg/V NPrSg/I IPl V   . . V/J  NSg/I/V/J P  D   NPl   NPrSg/V/J/P NSg/V/J . . NSg/C/P IPl V   IPl
 > here    about a   month ago . ”
 # NSg/J/R J/P   D/P NSg   J/P . .
 >
@@ -2540,20 +2540,20 @@
 # . W?     W?   D    NSg/V C/P   NSg/J/C . . V/J      NPr    . V/C ISg W?      . NSg/C/P D
 > girls had moved casually on  and her   remark was addressed to the premature moon    ,
 # NPl   V   V/J   J/R      J/P V/C I/J/D NSg/V  V   V/J       P  D   NSg/J     NPrSg/V .
-> produced like        the supper  , no      doubt , out         of  a   caterer’s basket . With Jordan’s
-# W?       NSg/V/J/C/P D   NSg/V/J . NPrSg/P NSg/V . NSg/V/J/R/P V/P D/P N$        NSg/V  . P    N$
+> produced like        the supper  , no      doubt , out         of a   caterer’s basket . With Jordan’s
+# W?       NSg/V/J/C/P D   NSg/V/J . NPrSg/P NSg/V . NSg/V/J/R/P P  D/P N$        NSg/V  . P    N$
 > slender golden    arm     resting in          mine    , we  descended the steps and sauntered about
 # J       NPrSg/V/J NSg/V/J V       NPrSg/V/J/P NSg/I/V . IPl W?        D   NPl   V/C W?        J/P
-> the garden  . A   tray  of  cocktails floated at        us      through the twilight , and we  sat
-# D   NSg/V/J . D/P NSg/V V/P NPl       W?      NSg/I/V/P NPr/ISg NSg/J/P D   NSg/V/J  . V/C IPl NSg/V/J
+> the garden  . A   tray  of cocktails floated at        us      through the twilight , and we  sat
+# D   NSg/V/J . D/P NSg/V P  NPl       W?      NSg/I/V/P NPr/ISg NSg/J/P D   NSg/V/J  . V/C IPl NSg/V/J
 > down      at        a   table with the two girls in          yellow  and three men , each one       introduced
 # NSg/V/J/P NSg/I/V/P D/P NSg/V P    D   NSg NPl   NPrSg/V/J/P NSg/V/J V/C NSg   NSg . D    NSg/I/V/J W?
 > to us      as    Mr  . Mumble .
 # P  NPr/ISg NSg/R NSg . NSg/V  .
 >
 #
-> “ Do     you come    to these parties often ? ” inquired Jordan of  the girl  beside her   .
-# . NSg/VX IPl NSg/V/P P  I/D   NPl     J     . . W?       NPr    V/P D   NSg/V P      I/J/D .
+> “ Do     you come    to these parties often ? ” inquired Jordan of the girl  beside her   .
+# . NSg/VX IPl NSg/V/P P  I/D   NPl     J     . . W?       NPr    P  D   NSg/V P      I/J/D .
 >
 #
 > “ The last    one       was the one       I   met you at        , ” answered the girl  , in          an  alert
@@ -2570,8 +2570,8 @@
 # . ISg NSg/V/J/C/P P  NSg/V/P . . NPr     V/J  . . ISg V     NSg/V NSg/I ISg NSg/VX . NSg/I/J/C ISg W?     NSg/VX D/P NPrSg/V/J
 > time  . When    I   was here    last    I   tore    my gown  on  a   chair , and he      asked me        my name
 # NSg/V . NSg/I/C ISg V   NSg/J/R NSg/V/J ISg NSg/V/J D  NSg/V J/P D/P NSg/V . V/C NPr/ISg V/J   NPrSg/ISg D  NSg/V
-> and address — inside  of  a   week I   got a   package from Croirier’s with a   new     evening
-# V/C NSg/V   . NSg/J/P V/P D/P NSg  ISg V   D/P NSg/V   P    ?          P    D/P NSg/V/J NSg/V
+> and address — inside  of a   week I   got a   package from Croirier’s with a   new     evening
+# V/C NSg/V   . NSg/J/P P  D/P NSg  ISg V   D/P NSg/V   P    ?          P    D/P NSg/V/J NSg/V
 > gown  in          it        . ”
 # NSg/V NPrSg/V/J/P NPrSg/ISg . .
 >
@@ -2610,8 +2610,8 @@
 # . NSg/I    V    NPrSg/ISg IPl  NSg/V   NPr/ISg W?     D/P NPrSg/I/V/J NSg/C . .
 >
 #
-> A   thrill passed over      all       of  us      . The three Mr  . Mumbles bent    forward and listened
-# D/P NSg/V  W?     NSg/V/J/P NSg/I/J/C V/P NPr/ISg . D   NSg   NSg . NPl     NSg/V/J NSg/V/J V/C W?
+> A   thrill passed over      all       of us      . The three Mr  . Mumbles bent    forward and listened
+# D/P NSg/V  W?     NSg/V/J/P NSg/I/J/C P  NPr/ISg . D   NSg   NSg . NPl     NSg/V/J NSg/V/J V/C W?
 > eagerly .
 # J/R     .
 >
@@ -2622,8 +2622,8 @@
 # NPr/ISg V   D/P NPrSg/J NSg/V V/P    D   NSg/V . .
 >
 #
-> One       of  the men nodded in          confirmation .
-# NSg/I/V/J V/P D   NSg V      NPrSg/V/J/P NSg          .
+> One       of the men nodded in          confirmation .
+# NSg/I/V/J P  D   NSg V      NPrSg/V/J/P NSg          .
 >
 #
 > “ I   heard that    from a   man         who     knew all       about him , grew up        with him in          Germany , ”
@@ -2656,18 +2656,18 @@
 # D   NSg/V/J NSg/V/J . W?    NSg/VX NSg/VX I/D     NSg/I/V/J J/P   NSg/J    . V   NPrSg/V/J/C NSg/V/C W?     .
 > and Jordan invited me        to join  her   own     party   , who     were  spread around a   table on
 # V/C NPr    NSg/V/J NPrSg/ISg P  NSg/V I/J/D NSg/V/J NSg/V/J . NPrSg/I NSg/V NSg/V  J/P    D/P NSg/V J/P
-> the other   side    of  the garden  . There were  three married couples and Jordan’s
-# D   NSg/V/J NSg/V/J V/P D   NSg/V/J . W?    NSg/V NSg   NSg/V/J NPl     V/C N$
+> the other   side    of the garden  . There were  three married couples and Jordan’s
+# D   NSg/V/J NSg/V/J P  D   NSg/V/J . W?    NSg/V NSg   NSg/V/J NPl     V/C N$
 > escort , a   persistent undergraduate given     to violent innuendo , and obviously
 # NSg/V  . D/P J          NSg/J         NSg/V/J/P P  NSg/V/J NSg/V    . V/C J/R
 > under   the impression that    sooner or      later Jordan was going   to yield him up        her
 # NSg/J/P D   NSg/V      N/I/C/D J      NPrSg/C J     NPr    V   NSg/V/J P  NSg/V I   NSg/V/J/P I/J/D
-> person to a   greater or      lesser degree . Instead of  rambling this party   had
-# NSg/V  P  D/P J       NPrSg/C J      NSg    . W?      V/P V        I/D  NSg/V/J V
+> person to a   greater or      lesser degree . Instead of rambling this party   had
+# NSg/V  P  D/P J       NPrSg/C J      NSg    . W?      P  V        I/D  NSg/V/J V
 > preserved a   dignified homogeneity , and assumed to itself the function of
-# W?        D/P V/J       NSg         . V/C W?      P  I      D   NSg/V    V/P
-> representing the staid nobility of  the country - side    — East    Egg   condescending to
-# V            D   V/J   NSg      V/P D   NSg/J   . NSg/V/J . NPrSg/J NSg/V V/J           P
+# W?        D/P V/J       NSg         . V/C W?      P  I      D   NSg/V    P
+> representing the staid nobility of the country - side    — East    Egg   condescending to
+# V            D   V/J   NSg      P  D   NSg/J   . NSg/V/J . NPrSg/J NSg/V V/J           P
 > West      Egg   , and carefully on  guard against its   spectroscopic gayety .
 # NPrSg/V/J NSg/V . V/C J/R       J/P NSg/V C/P     ISg/D J             ?      .
 >
@@ -2688,8 +2688,8 @@
 #
 > The bar     , where we  glanced first   , was crowded , but     Gatsby was not   there . She
 # D   NSg/V/P . NSg/C IPl W?      NSg/V/J . V   V/J     . NSg/C/P NPr    V   NSg/C W?    . ISg
-> couldn’t find  him from the top     of  the steps , and he      wasn’t on  the veranda . On  a
-# V        NSg/V I   P    D   NSg/V/J V/P D   NPl   . V/C NPr/ISg V      J/P D   NSg/Br  . J/P D/P
+> couldn’t find  him from the top     of the steps , and he      wasn’t on  the veranda . On  a
+# V        NSg/V I   P    D   NSg/V/J P  D   NPl   . V/C NPr/ISg V      J/P D   NSg/Br  . J/P D/P
 > chance    we  tried an  important - looking door  , and walked into a   high    Gothic
 # NPrSg/V/J IPl V/J   D/P J         . V       NSg/V . V/C W?     P    D/P NSg/V/J NPrSg/J
 > library , panelled with carved English   oak     , and probably transported complete
@@ -2700,10 +2700,10 @@
 #
 > A   stout     , middle  - aged man         , with enormous owl   - eyed spectacles , was sitting
 # D/P NPrSg/V/J . NSg/V/J . W?   NPrSg/I/V/J . P    J        NSg/V . W?   NSg        . V   NSg/V/J
-> somewhat drunk   on  the edge  of  a   great table , staring with unsteady concentration
-# NSg/I    NSg/V/J J/P D   NSg/V V/P D/P NSg/J NSg/V . V       P    V/J      NSg
-> at        the shelves of  books . As    we  entered he      wheeled excitedly around and examined
-# NSg/I/V/P D   NPl     V/P NPl   . NSg/R IPl W?      NPr/ISg W?      J/R       J/P    V/C W?
+> somewhat drunk   on  the edge  of a   great table , staring with unsteady concentration
+# NSg/I    NSg/V/J J/P D   NSg/V P  D/P NSg/J NSg/V . V       P    V/J      NSg
+> at        the shelves of books . As    we  entered he      wheeled excitedly around and examined
+# NSg/I/V/P D   NPl     P  NPl   . NSg/R IPl W?      NPr/ISg W?      J/R       J/P    V/C W?
 > Jordan from head      to foot  .
 # NPr    P    NPrSg/V/J P  NSg/V .
 >
@@ -2720,8 +2720,8 @@
 # NPr/ISg W?    ISg/D NSg/V J/P    D   NSg/V . NPl     .
 >
 #
-> “ About that    . As    a   matter  of  fact you needn’t bother to ascertain . I   ascertained .
-# . J/P   N/I/C/D . NSg/R D/P NSg/V/J V/P NSg  IPl VX      NSg/V  P  V         . ISg W?          .
+> “ About that    . As    a   matter  of fact you needn’t bother to ascertain . I   ascertained .
+# . J/P   N/I/C/D . NSg/R D/P NSg/V/J P  NSg  IPl VX      NSg/V  P  V         . ISg W?          .
 > They’re real  . ”
 # W?      NSg/J . .
 >
@@ -2736,20 +2736,20 @@
 #
 > “ Absolutely real  — have   pages and everything . I   thought they’d be     a   nice      durable
 # . J/R        NSg/J . NSg/VX NPl   V/C N/I/V      . ISg NSg/V   W?     NSg/VX D/P NPrSg/V/J NSg/J
-> cardboard . Matter  of  fact , they’re absolutely real  . Pages and — Here    ! Lemme show
-# NSg/J     . NSg/V/J V/P NSg  . W?      J/R        NSg/J . NPl   V/C . NSg/J/R . W?    NSg/V
+> cardboard . Matter  of fact , they’re absolutely real  . Pages and — Here    ! Lemme show
+# NSg/J     . NSg/V/J P  NSg  . W?      J/R        NSg/J . NPl   V/C . NSg/J/R . W?    NSg/V
 > you . ”
 # IPl . .
 >
 #
 > Taking  our scepticism for granted , he      rushed to the bookcases and returned with
 # NSg/V/J D   NSg/Br     C/P W?      . NPr/ISg W?     P  D   NPl       V/C W?       P
-> Volume One       of  the “ Stoddard Lectures . ”
-# NSg/V  NSg/I/V/J V/P D   . ?        NPl      . .
+> Volume One       of the “ Stoddard Lectures . ”
+# NSg/V  NSg/I/V/J P  D   . ?        NPl      . .
 >
 #
-> “ See   ! ” he      cried triumphantly . “ It’s a   bona - fide piece of  printed matter  . It
-# . NSg/V . . NPr/ISg W?    J/R          . . W?   D/P ?    . ?    NSg/V V/P W?      NSg/V/J . NPrSg/ISg
+> “ See   ! ” he      cried triumphantly . “ It’s a   bona - fide piece of printed matter  . It
+# . NSg/V . . NPr/ISg W?    J/R          . . W?   D/P ?    . ?    NSg/V P  W?      NSg/V/J . NPrSg/ISg
 > fooled me        . This fella’s a   regular Belasco . It’s a   triumph . What  thoroughness !
 # W?     NPrSg/ISg . I/D  ?       D/P NSg/J   ?       . W?   D/P NSg/V   . NSg/I NSg          .
 > What  realism ! Knew when    to stop  , too — didn’t cut     the pages . But     what  do     you want  ?
@@ -2804,36 +2804,36 @@
 # W?    V   NSg/V   NPrSg/V/J/C J/P D   NSg/V  NPrSg/V/J/P D   NSg/V/J . NSg/J NSg V       NPrSg/V/J NPl
 > backward in          eternal graceless circles , superior couples holding each other
 # NSg/J    NPrSg/V/J/P NSg/J   J         NPl     . NPrSg/J  NPl     NSg/V   D    NSg/V/J
-> tortuously , fashionably , and keeping in          the corners — and a   great number  of  single
-# J/R        . R           . V/C NSg/V   NPrSg/V/J/P D   W?      . V/C D/P NSg/J NSg/V/J V/P NSg/V/J
-> girls dancing individualistically or      relieving the orchestra for a   moment of  the
-# NPl   NSg/V   W?                  NPrSg/C V         D   NSg       C/P D/P NSg    V/P D
-> burden of  the banjo or      the traps . By      midnight the hilarity had increased . A
-# NSg/V  V/P D   NSg/V NPrSg/C D   NPl   . NSg/J/P NSg/J    D   NSg      V   W?        . D/P
+> tortuously , fashionably , and keeping in          the corners — and a   great number  of single
+# J/R        . R           . V/C NSg/V   NPrSg/V/J/P D   W?      . V/C D/P NSg/J NSg/V/J P  NSg/V/J
+> girls dancing individualistically or      relieving the orchestra for a   moment of the
+# NPl   NSg/V   W?                  NPrSg/C V         D   NSg       C/P D/P NSg    P  D
+> burden of the banjo or      the traps . By      midnight the hilarity had increased . A
+# NSg/V  P  D   NSg/V NPrSg/C D   NPl   . NSg/J/P NSg/J    D   NSg      V   W?        . D/P
 > celebrated tenor had sung  in          Italian , and a   notorious contralto had sung  in
 # W?         NSg/J V   NPr/V NPrSg/V/J/P NSg/J   . V/C D/P J         NSg       V   NPr/V NPrSg/V/J/P
 > jazz  , and between the numbers people were  doing ‘          ‘          stunts ” all       over      the garden  ,
 # NSg/V . V/C NSg/P   D   NPrPl   NSg/V  NSg/V NSg/V Unlintable Unlintable NPl    . NSg/I/J/C NSg/V/J/P D   NSg/V/J .
-> while     happy   , vacuous bursts of  laughter rose      toward the summer  sky   . A   pair  of
-# NSg/V/C/P NSg/V/J . J       NPl    V/P NSg      NPrSg/V/J J/P    D   NPrSg/V NSg/V . D/P NSg/V V/P
+> while     happy   , vacuous bursts of laughter rose      toward the summer  sky   . A   pair  of
+# NSg/V/C/P NSg/V/J . J       NPl    P  NSg      NPrSg/V/J J/P    D   NPrSg/V NSg/V . D/P NSg/V P
 > stage twins , who     turned out         to be     the girls in          yellow  , did a   baby    act     in
 # NSg/V NPl   . NPrSg/I W?     NSg/V/J/R/P P  NSg/VX D   NPl   NPrSg/V/J/P NSg/V/J . V   D/P NSg/V/J NPrSg/V NPrSg/V/J/P
 > costume , and champagne was served in          glasses bigger than finger - bowls . The moon
 # NSg/V   . V/C NSg/V/J   V   W?     NPrSg/V/J/P NPl     V/J    C/P  NSg/V  . NPl   . D   NPrSg/V
-> had risen higher , and floating in          the Sound   was a   triangle of  silver  scales ,
-# V   V/J   J      . V/C V        NPrSg/V/J/P D   NSg/V/J V   D/P NSg      V/P NSg/V/J NPl    .
-> trembling a   little    to the stiff   , tinny drip  of  the banjoes on  the lawn  .
-# V         D/P NPrSg/I/J P  D   NSg/V/J . NSg/J NSg/V V/P D   ?       J/P D   NSg/V .
+> had risen higher , and floating in          the Sound   was a   triangle of silver  scales ,
+# V   V/J   J      . V/C V        NPrSg/V/J/P D   NSg/V/J V   D/P NSg      P  NSg/V/J NPl    .
+> trembling a   little    to the stiff   , tinny drip  of the banjoes on  the lawn  .
+# V         D/P NPrSg/I/J P  D   NSg/V/J . NSg/J NSg/V P  D   ?       J/P D   NSg/V .
 >
 #
-> I   was still   with Jordan Baker   . We  were  sitting at        a   table with a   man         of  about my
-# ISg V   NSg/V/J P    NPr    NPrSg/J . IPl NSg/V NSg/V/J NSg/I/V/P D/P NSg/V P    D/P NPrSg/I/V/J V/P J/P   D
+> I   was still   with Jordan Baker   . We  were  sitting at        a   table with a   man         of about my
+# ISg V   NSg/V/J P    NPr    NPrSg/J . IPl NSg/V NSg/V/J NSg/I/V/P D/P NSg/V P    D/P NPrSg/I/V/J P  J/P   D
 > age   and a   rowdy little    girl  , who     gave way   upon the slightest provocation to
 # NSg/V V/C D/P NSg/J NPrSg/I/J NSg/V . NPrSg/I V    NSg/J P    D   W?        NSg         P
 > uncontrollable laughter . I   was enjoying myself now         . I   had taken two finger - bowls
 # NSg/J          NSg      . ISg V   V        I      NPrSg/V/J/C . ISg V   V/J   NSg NSg/V  . NPl
-> of  champagne , and the scene had changed before my eyes into something
-# V/P NSg/V/J   . V/C D   NSg/V V   V/J     C/P    D  NPl  P    NSg/I/V/J
+> of champagne , and the scene had changed before my eyes into something
+# P  NSg/V/J   . V/C D   NSg/V V   V/J     C/P    D  NPl  P    NSg/I/V/J
 > significant , elemental , and profound .
 # NSg/J       . NSg/J     . V/C NSg/V/J  .
 >
@@ -2878,8 +2878,8 @@
 # . I/R/D NSg/V N/I/C/D NPl   IPl NPrSg/VX/J . .
 >
 #
-> It        was on  the tip   of  my tongue to ask   his   name  when    Jordan looked around and
-# NPrSg/ISg V   J/P D   NSg/V V/P D  NSg/V  P  NSg/V ISg/D NSg/V NSg/I/C NPr    W?     J/P    V/C
+> It        was on  the tip   of my tongue to ask   his   name  when    Jordan looked around and
+# NPrSg/ISg V   J/P D   NSg/V P  D  NSg/V  P  NSg/V ISg/D NSg/V NSg/I/C NPr    W?     J/P    V/C
 > smiled .
 # W?     .
 >
@@ -2914,10 +2914,10 @@
 # . ISg NSg/V   IPl V    . NSg/J NSg/V . W?  J      W?  NSg/C D/P J    NPrSg/V/J NSg/V . .
 >
 #
-> He      smiled understandingly — much  more        than understandingly . It        was one       of  those
-# NPr/ISg W?     J/R             . N/I/J NPrSg/I/V/J C/P  J/R             . NPrSg/ISg V   NSg/I/V/J V/P I/D
-> rare    smiles with a   quality of  eternal reassurance in          it        , that    you may      come
-# NSg/V/J NPl    P    D/P NSg/J   V/P NSg/J   NSg         NPrSg/V/J/P NPrSg/ISg . N/I/C/D IPl NPrSg/VX NSg/V/P
+> He      smiled understandingly — much  more        than understandingly . It        was one       of those
+# NPr/ISg W?     J/R             . N/I/J NPrSg/I/V/J C/P  J/R             . NPrSg/ISg V   NSg/I/V/J P  I/D
+> rare    smiles with a   quality of eternal reassurance in          it        , that    you may      come
+# NSg/V/J NPl    P    D/P NSg/J   P  NSg/J   NSg         NPrSg/V/J/P NPrSg/ISg . N/I/C/D IPl NPrSg/VX NSg/V/P
 > across four or      five times in          life  . It        faced — or      seemed to face  — the whole eternal
 # NSg/P  NSg  NPrSg/C NSg  NPl   NPrSg/V/J/P NSg/V . NPrSg/ISg W?    . NPrSg/C W?     P  NSg/V . D   NSg/J NSg/J
 > world for an  instant , and then    concentrated on  you with an  irresistible
@@ -2926,14 +2926,14 @@
 # NSg/V/J   NPrSg/V/J/P D    NSg/V . NPrSg/ISg V/J        IPl V/J  NSg/I/J/C NSg/V/J NSg/R IPl V/J    P  NSg/VX
 > understood , believed in          you as    you would  like        to believe in          yourself , and
 # V/J        . W?       NPrSg/V/J/P IPl NSg/R IPl NSg/VX NSg/V/J/C/P P  V       NPrSg/V/J/P I        . V/C
-> assured you that    it        had precisely the impression of  you that    , at        your best       , you
-# NSg/V/J IPl N/I/C/D NPrSg/ISg V   J/R       D   NSg/V      V/P IPl N/I/C/D . NSg/I/V/P D    NPrSg/VX/J . IPl
+> assured you that    it        had precisely the impression of you that    , at        your best       , you
+# NSg/V/J IPl N/I/C/D NPrSg/ISg V   J/R       D   NSg/V      P  IPl N/I/C/D . NSg/I/V/P D    NPrSg/VX/J . IPl
 > hoped to convey . Precisely at        that    point it        vanished — and I   was looking at        an
 # W?    P  V      . J/R       NSg/I/V/P N/I/C/D NSg/V NPrSg/ISg W?       . V/C ISg V   V       NSg/I/V/P D/P
 > elegant young     rough   - neck  , a   year or      two over      thirty , whose elaborate formality
 # NSg/J   NPrSg/V/J NSg/V/J . NSg/V . D/P NSg  NPrSg/C NSg NSg/V/J/P NSg    . I     V/J       NSg
-> of  speech just missed being   absurd . Some  time  before he      introduced himself I’d
-# V/P NSg/V  V/J  V      NSg/V/C NSg/J  . I/J/R NSg/V C/P    NPr/ISg W?         I       W?
+> of speech just missed being   absurd . Some  time  before he      introduced himself I’d
+# P  NSg/V  V/J  V      NSg/V/C NSg/J  . I/J/R NSg/V C/P    NPr/ISg W?         I       W?
 > got a   strong impression that    he      was picking his   words with care  .
 # V   D/P NPr/J  NSg/V      N/I/C/D NPr/ISg V   V       ISg/D NPl   P    NSg/V .
 >
@@ -2942,8 +2942,8 @@
 # NSg    NSg/I/V/P D   NSg    NSg/I/C NSg . NPr    V          I       D/P NPrSg/V V/J     J/P
 > him with the information that    Chicago was calling him on  the wire  . He      excused
 # I   P    D   NSg         N/I/C/D NPr     V   NSg/V   I   J/P D   NSg/V . NPr/ISg V
-> himself with a   small     bow   that    included each of  us      in          turn  .
-# I       P    D/P NPrSg/V/J NSg/V N/I/C/D W?       D    V/P NPr/ISg NPrSg/V/J/P NSg/V .
+> himself with a   small     bow   that    included each of us      in          turn  .
+# I       P    D/P NPrSg/V/J NSg/V N/I/C/D W?       D    P  NPr/ISg NPrSg/V/J/P NSg/V .
 >
 #
 > “ If    you want  anything just ask   for it        , old   sport , ” he      urged me        . “ Excuse me        . I
@@ -2952,8 +2952,8 @@
 # NPrSg/VX NSg/V  IPl J     . .
 >
 #
-> When    he      was gone  I   turned immediately to Jordan — constrained to assure her   of  my
-# NSg/I/C NPr/ISg V   V/J/P ISg W?     J/R         P  NPr    . V/J         P  V      I/J/D V/P D
+> When    he      was gone  I   turned immediately to Jordan — constrained to assure her   of my
+# NSg/I/C NPr/ISg V   V/J/P ISg W?     J/R         P  NPr    . V/J         P  V      I/J/D P  D
 > surprise . I   had expected that    Mr  . Gatsby would  be     a   florid and corpulent person
 # NSg/V    . ISg V   NSg/J    N/I/C/D NSg . NPr    NSg/VX NSg/VX D/P J      V/C J         NSg/V
 > in          his   middle  years .
@@ -2996,18 +2996,18 @@
 # . ISg NSg/V NSg/V . . ISg W?       . . ISg V/J  NSg/V NSg/V NPr/ISg NSg/V W?    . .
 >
 #
-> Something in          her   tone    reminded me        of  the other   girl’s “ I   think he      killed a   man         , ”
-# NSg/I/V/J NPrSg/V/J/P I/J/D NSg/I/V W?       NPrSg/ISg V/P D   NSg/V/J N$     . ISg NSg/V NPr/ISg W?     D/P NPrSg/I/V/J . .
-> and had the effect of  stimulating my curiosity . I   would  have   accepted without
-# V/C V   D   NSg/V  V/P V           D  NSg       . ISg NSg/VX NSg/VX V/J      C/P
-> question the information that    Gatsby sprang from the swamps of  Louisiana or      from
-# NSg/V    D   NSg         N/I/C/D NPr    V      P    D   NPl    V/P NPr       NPrSg/C P
-> the lower East    Side    of  New     York . That    was comprehensible . But     young     men
-# D   V/J   NPrSg/J NSg/V/J V/P NSg/V/J NPr  . N/I/C/D V   J              . NSg/C/P NPrSg/V/J NSg
+> Something in          her   tone    reminded me        of the other   girl’s “ I   think he      killed a   man         , ”
+# NSg/I/V/J NPrSg/V/J/P I/J/D NSg/I/V W?       NPrSg/ISg P  D   NSg/V/J N$     . ISg NSg/V NPr/ISg W?     D/P NPrSg/I/V/J . .
+> and had the effect of stimulating my curiosity . I   would  have   accepted without
+# V/C V   D   NSg/V  P  V           D  NSg       . ISg NSg/VX NSg/VX V/J      C/P
+> question the information that    Gatsby sprang from the swamps of Louisiana or      from
+# NSg/V    D   NSg         N/I/C/D NPr    V      P    D   NPl    P  NPr       NPrSg/C P
+> the lower East    Side    of New     York . That    was comprehensible . But     young     men
+# D   V/J   NPrSg/J NSg/V/J P  NSg/V/J NPr  . N/I/C/D V   J              . NSg/C/P NPrSg/V/J NSg
 > didn’t — at        least in          my provincial inexperience I   believed they didn’t — drift
 # V      . NSg/I/V/P NSg/J NPrSg/V/J/P D  NSg/J      NSg/V        ISg W?       IPl  V      . NSg/V
-> coolly out         of  nowhere and buy   a   palace on  Long      Island Sound   .
-# J/R    NSg/V/J/R/P V/P NSg/J   V/C NSg/V D/P NSg/V  J/P NPrSg/V/J NSg/V  NSg/V/J .
+> coolly out         of nowhere and buy   a   palace on  Long      Island Sound   .
+# J/R    NSg/V/J/R/P P  NSg/J   V/C NSg/V D/P NSg/V  J/P NPrSg/V/J NSg/V  NSg/V/J .
 >
 #
 > “ Anyhow , he      gives large parties , ” said Jordan , changing the subject with an
@@ -3018,14 +3018,14 @@
 # NSg/I/V/P NPrSg/V/J NPl     W?    NSg/V I/R/D NSg     . .
 >
 #
-> There was the boom  of  a   bass      drum  , and the voice of  the orchestra leader rang
-# W?    V   D   NSg/V V/P D/P NPrSg/V/J NSg/V . V/C D   NSg/V V/P D   NSg       NSg/J  V
-> out         suddenly above   the chatter of  the garden  .
-# NSg/V/J/R/P J/R      NSg/J/P D   NSg/V   V/P D   NSg/V/J .
+> There was the boom  of a   bass      drum  , and the voice of the orchestra leader rang
+# W?    V   D   NSg/V P  D/P NPrSg/V/J NSg/V . V/C D   NSg/V P  D   NSg       NSg/J  V
+> out         suddenly above   the chatter of the garden  .
+# NSg/V/J/R/P J/R      NSg/J/P D   NSg/V   P  D   NSg/V/J .
 >
 #
-> “ Ladies and gentlemen , ” he      cried . “ At        the request of  Mr  . Gatsby we  are going   to
-# . NPl    V/C NPl       . . NPr/ISg W?    . . NSg/I/V/P D   NSg/V   V/P NSg . NPr    IPl V   NSg/V/J P
+> “ Ladies and gentlemen , ” he      cried . “ At        the request of Mr  . Gatsby we  are going   to
+# . NPl    V/C NPl       . . NPr/ISg W?    . . NSg/I/V/P D   NSg/V   P  NSg . NPr    IPl V   NSg/V/J P
 > play  for you Mr  . Vladmir Tostoff’s latest work  , which attracted so        much
 # NSg/V C/P IPl NSg . ?       ?         NSg/J  NSg/V . I/C   W?        NSg/I/J/C N/I/J
 > attention at        Carnegie Hall  last    May      . If    you read  the papers you know  there was a
@@ -3038,12 +3038,12 @@
 #
 > “ The piece is known   , ” he      concluded lustily , “ as    ‘          Vladmir Tostoff’s Jazz  History
 # . D   NSg/V VL NSg/V/J . . NPr/ISg W?        R       . . NSg/R Unlintable ?       ?         NSg/V NSg
-> of  the World . ’ ”
-# V/P D   NSg/V . . .
+> of the World . ’ ”
+# P  D   NSg/V . . .
 >
 #
-> The nature of  Mr  . Tostoff’s composition eluded me        , because just as    it        began my
-# D   NSg/V  V/P NSg . ?         NSg         W?     NPrSg/ISg . C/P     V/J  NSg/R NPrSg/ISg V     D
+> The nature of Mr  . Tostoff’s composition eluded me        , because just as    it        began my
+# D   NSg/V  P  NSg . ?         NSg         W?     NPrSg/ISg . C/P     V/J  NSg/R NPrSg/ISg V     D
 > eyes fell    on  Gatsby , standing alone on  the marble  steps and looking from one
 # NPl  NSg/V/J J/P NPr    . NSg/V/J  J     J/P D   NSg/V/J NPl   V/C V       P    NSg/I/V/J
 > group to another with approving eyes . His   tanned skin  was drawn attractively
@@ -3054,8 +3054,8 @@
 # ISg NSg/VX NSg/V NSg/I/J J        J/P   I   . ISg W?       NSg/C D   NSg  N/I/C/D NPr/ISg V   NSg/C
 > drinking helped to set       him off       from his   guests , for it        seemed to me        that    he      grew
 # V        W?     P  NPrSg/V/J I   NSg/V/J/P P    ISg/D NPl    . C/P NPrSg/ISg W?     P  NPrSg/ISg N/I/C/D NPr/ISg V
-> more        correct as    the fraternal hilarity increased . When    the “ Jazz  History of  the
-# NPrSg/I/V/J NSg/V/J NSg/R D   NSg/J     NSg      W?        . NSg/I/C D   . NSg/V NSg     V/P D
+> more        correct as    the fraternal hilarity increased . When    the “ Jazz  History of the
+# NPrSg/I/V/J NSg/V/J NSg/R D   NSg/J     NSg      W?        . NSg/I/C D   . NSg/V NSg     P  D
 > World ” was over      , girls were  putting their heads on  men’s shoulders in          a
 # NSg/V . V   NSg/V/J/P . NPl   NSg/V NSg/V   D     NPl   J/P N$    NPl       NPrSg/V/J/P D/P
 > puppyish , convivial way   , girls were  swooning backward playfully into men’s arms ,
@@ -3110,12 +3110,12 @@
 # NSg NSg/V  NPl   . V/C NPrSg/I W?       NPrSg/ISg P  NSg/V I   . ISg NSg/V NSg/J/P .
 >
 #
-> The large room    was full    of  people . One       of  the girls in          yellow  was playing the
-# D   NSg/J NSg/V/J V   NSg/V/J V/P NSg/V  . NSg/I/V/J V/P D   NPl   NPrSg/V/J/P NSg/V/J V   V       D
+> The large room    was full    of people . One       of the girls in          yellow  was playing the
+# D   NSg/J NSg/V/J V   NSg/V/J P  NSg/V  . NSg/I/V/J P  D   NPl   NPrSg/V/J/P NSg/V/J V   V       D
 > piano   , and beside her   stood a   tall  , red   - haired young     lady    from a   famous chorus ,
 # NSg/V/J . V/C P      I/J/D V     D/P NSg/J . NSg/J . W?     NPrSg/V/J NPrSg/V P    D/P V/J    NSg/V  .
-> engaged in          song . She had drunk   a   quantity of  champagne , and during the course of
-# W?      NPrSg/V/J/P NSg  . ISg V   NSg/V/J D/P NSg      V/P NSg/V/J   . V/C V/P    D   NSg/V  V/P
+> engaged in          song . She had drunk   a   quantity of champagne , and during the course of
+# W?      NPrSg/V/J/P NSg  . ISg V   NSg/V/J D/P NSg      P  NSg/V/J   . V/C V/P    D   NSg/V  P
 > her   song she had decided , ineptly , that    everything was very , very sad     — she was
 # I/J/D NSg  ISg V   NSg/V/J . J/R     . N/I/C/D N/I/V      V   J    . J    NSg/V/J . ISg V
 > not   only singing , she was weeping too . Whenever there was a   pause in          the song
@@ -3126,8 +3126,8 @@
 # V         NSg/V   . D   NPl   W?      NSg/V/J/P I/J/D NPl    . NSg/C J/R    . C       . C/P
 > when    they came    into contact with her   heavily beaded eyelashes they assumed an
 # NSg/I/C IPl  NSg/V/P P    NSg/V   P    I/J/D R       W?     NPl       IPl  W?      D/P
-> inky color      , and pursued the rest  of  their way   in          slow    black   rivulets . A   humorous
-# J    NSg/V/J/Am . V/C W?      D   NSg/V V/P D     NSg/J NPrSg/V/J/P NSg/V/J NSg/V/J NPl      . D/P J
+> inky color      , and pursued the rest  of their way   in          slow    black   rivulets . A   humorous
+# J    NSg/V/J/Am . V/C W?      D   NSg/V P  D     NSg/J NPrSg/V/J/P NSg/V/J NSg/V/J NPl      . D/P J
 > suggestion was made  that    she sing  the notes on  her   face  , whereupon she threw up
 # NSg        V   NSg/V N/I/C/D ISg NSg/V D   NPl   J/P I/J/D NSg/V . C         ISg V     NSg/V/J/P
 > her   hands , sank into a   chair , and went  off       into a   deep  vinous sleep .
@@ -3140,12 +3140,12 @@
 # NSg/V .
 >
 #
-> I   looked around . Most    of  the remaining women were  now         having fights with men
-# ISg W?     J/P    . NSg/I/J V/P D   V         NPl   NSg/V NPrSg/V/J/C V      NPl    P    NSg
+> I   looked around . Most    of the remaining women were  now         having fights with men
+# ISg W?     J/P    . NSg/I/J P  D   V         NPl   NSg/V NPrSg/V/J/C V      NPl    P    NSg
 > said to be     their husbands . Even    Jordan’s party   , the quartet from East    Egg   , were
 # V/J  P  NSg/VX D     NPl      . NSg/V/J N$       NSg/V/J . D   NSg     P    NPrSg/J NSg/V . NSg/V
-> rent    asunder by      dissension . One       of  the men was talking with curious intensity to
-# NSg/V/J W?      NSg/J/P NSg        . NSg/I/V/J V/P D   NSg V   V       P    J       NSg       P
+> rent    asunder by      dissension . One       of the men was talking with curious intensity to
+# NSg/V/J W?      NSg/J/P NSg        . NSg/I/V/J P  D   NSg V   V       P    J       NSg       P
 > a   young     actress , and his   wife  , after attempting to laugh at        the situation in          a
 # D/P NPrSg/V/J NSg     . V/C ISg/D NSg/V . J/P   V          P  NSg/V NSg/I/V/P D   NSg       NPrSg/V/J/P D/P
 > dignified and indifferent way   , broke   down      entirely and resorted to flank
@@ -3180,22 +3180,22 @@
 # . NSg/I/J/C V   IPl . .
 >
 #
-> “ Well    , we’re almost the last    to - night , ” said one       of  the men sheepishly . “ The
-# . NSg/V/J . W?    NSg    D   NSg/V/J P  . NSg/V . . V/J  NSg/I/V/J V/P D   NSg J/R        . . D
+> “ Well    , we’re almost the last    to - night , ” said one       of the men sheepishly . “ The
+# . NSg/V/J . W?    NSg    D   NSg/V/J P  . NSg/V . . V/J  NSg/I/V/J P  D   NSg J/R        . . D
 > orchestra left      half      an  hour ago . ”
 # NSg       NPrSg/V/J NSg/V/J/P D/P NSg  J/P . .
 >
 #
-> In          spite   of  the wives ’ agreement that    such  malevolence was beyond credibility ,
-# NPrSg/V/J/P NSg/V/P V/P D   NPl   . NSg       N/I/C/D NSg/I NSg         V   NSg/P  NSg         .
+> In          spite   of the wives ’ agreement that    such  malevolence was beyond credibility ,
+# NPrSg/V/J/P NSg/V/P P  D   NPl   . NSg       N/I/C/D NSg/I NSg         V   NSg/P  NSg         .
 > the dispute ended in          a   short       struggle , and both wives were  lifted , kicking , into
 # D   NSg/V   W?    NPrSg/V/J/P D/P NPrSg/V/J/P NSg/V    . V/C I/C  NPl   NSg/V W?     . V       . P
 > the night .
 # D   NSg/V .
 >
 #
-> As    I   waited for my hat   in          the hall  the door  of  the library opened and Jordan
-# NSg/R ISg W?     C/P D  NSg/V NPrSg/V/J/P D   NPrSg D   NSg/V V/P D   NSg     V/J    V/C NPr
+> As    I   waited for my hat   in          the hall  the door  of the library opened and Jordan
+# NSg/R ISg W?     C/P D  NSg/V NPrSg/V/J/P D   NPrSg D   NSg/V P  D   NSg     V/J    V/C NPr
 > Baker   and Gatsby came    out         together . He      was saying some  last    word  to her   , but     the
 # NPrSg/J V/C NPr    NSg/V/P NSg/V/J/R/P J        . NPr/ISg V   NSg/V  I/J/R NSg/V/J NSg/V P  I/J/D . NSg/C/P D
 > eagerness in          his   manner tightened abruptly into formality as    several people
@@ -3224,8 +3224,8 @@
 # . NPrSg/ISg V   . . . R      V/J     . . ISg V/J      J/R          . . NSg/C/P ISg V     ISg
 > wouldn’t tell    it        and here    I   am        tantalizing you . ” She yawned gracefully in          my
 # VX       NPrSg/V NPrSg/ISg V/C NSg/J/R ISg NPrSg/V/J NSg/V/J     IPl . . ISg W?     J/R        NPrSg/V/J/P D
-> face  . “ Please come    and see   me        . . . . Phone book  . . . . Under   the name  of  Mrs .
-# NSg/V . . V      NSg/V/P V/C NSg/V NPrSg/ISg . . . . NSg/V NSg/V . . . . NSg/J/P D   NSg/V V/P NPl .
+> face  . “ Please come    and see   me        . . . . Phone book  . . . . Under   the name  of Mrs .
+# NSg/V . . V      NSg/V/P V/C NSg/V NPrSg/ISg . . . . NSg/V NSg/V . . . . NSg/J/P D   NSg/V P  NPl .
 > Sigourney Howard . . . . My aunt . . . . ” She was hurrying off       as    she talked — her
 # ?         NPr    . . . . D  NSg  . . . . . ISg V   V        NSg/V/J/P NSg/R ISg W?     . I/J/D
 > brown     hand  waved a   jaunty salute as    she melted into her   party   at        the door  .
@@ -3234,8 +3234,8 @@
 #
 > Rather    ashamed that    on  my first   appearance I   had stayed so        late  , I   joined the
 # NPrSg/V/J V/J     N/I/C/D J/P D  NSg/V/J NSg        ISg V   W?     NSg/I/J/C NSg/J . ISg W?     D
-> last    of  Gatsby’s guests , who     were  clustered around him . I   wanted to explain that
-# NSg/V/J V/P N$       NPl    . NPrSg/I NSg/V W?        J/P    I   . ISg V/J    P  V       N/I/C/D
+> last    of Gatsby’s guests , who     were  clustered around him . I   wanted to explain that
+# NSg/V/J P  N$       NPl    . NPrSg/I NSg/V W?        J/P    I   . ISg V/J    P  V       N/I/C/D
 > I’d hunted for him early   in          the evening and to apologize for not   having known
 # W?  W?     C/P I   NSg/J/R NPrSg/V/J/P D   NSg/V   V/C P  V         C/P NSg/C V      NSg/V/J
 > him in          the garden  .
@@ -3280,26 +3280,26 @@
 # NSg/C/P NSg/R ISg W?     NSg/V/J/P D   NPl   ISg NSg/V N/I/C/D D   NSg/V   V   NSg/C NSg   NSg/V/J/P . NSg
 > feet from the door  a   dozen headlights illuminated a   bizarre and tumultuous
 # NSg  P    D   NSg/V D/P NSg   NPl        W?          D/P J       V/C J
-> scene . In          the ditch beside the road  , right     side    up        , but     violently shorn of  one
-# NSg/V . NPrSg/V/J/P D   NSg/V P      D   NSg/J . NPrSg/V/J NSg/V/J NSg/V/J/P . NSg/C/P J/R       ?     V/P NSg/I/V/J
+> scene . In          the ditch beside the road  , right     side    up        , but     violently shorn of one
+# NSg/V . NPrSg/V/J/P D   NSg/V P      D   NSg/J . NPrSg/V/J NSg/V/J NSg/V/J/P . NSg/C/P J/R       ?     P  NSg/I/V/J
 > wheel , rested a   new     coupé which had left      Gatsby’s drive not   two minutes before .
 # NSg/V . W?     D/P NSg/V/J ?     I/C   V   NPrSg/V/J N$       NSg/V NSg/C NSg NPl     C/P    .
-> The sharp     jut   of  a   wall    accounted for the detachment of  the wheel , which was now
-# D   NPrSg/V/J NSg/V V/P D/P NPrSg/V V         C/P D   NSg        V/P D   NSg/V . I/C   V   NPrSg/V/J/C
+> The sharp     jut   of a   wall    accounted for the detachment of the wheel , which was now
+# D   NPrSg/V/J NSg/V P  D/P NPrSg/V V         C/P D   NSg        P  D   NSg/V . I/C   V   NPrSg/V/J/C
 > getting considerable attention from half      a   dozen curious chauffeurs . However , as
 # NSg/V   NSg/J        NSg       P    NSg/V/J/P D/P NSg   J       NPl        . C       . NSg/R
 > they had left      their cars blocking the road  , a   harsh , discordant din   from those
 # IPl  V   NPrSg/V/J D     NPl  V        D   NSg/J . D/P V/J   . J          NSg/V P    I/D
 > in          the rear    had been  audible for some  time  , and added to the already violent
 # NPrSg/V/J/P D   NSg/V/J V   NSg/V NSg/V/J C/P I/J/R NSg/V . V/C W?    P  D   W?      NSg/V/J
-> confusion of  the scene .
-# NSg/V     V/P D   NSg/V .
+> confusion of the scene .
+# NSg/V     P  D   NSg/V .
 >
 #
 > A   man         in          a   long      duster had dismounted from the wreck and now         stood in          the middle
 # D/P NPrSg/I/V/J NPrSg/V/J/P D/P NPrSg/V/J NSg/J  V   W?         P    D   NSg/V V/C NPrSg/V/J/C V     NPrSg/V/J/P D   NSg/V/J
-> of  the road  , looking from the car to the tire  and from the tire  to the observers
-# V/P D   NSg/J . V       P    D   NSg P  D   NSg/V V/C P    D   NSg/V P  D   W?
+> of the road  , looking from the car to the tire  and from the tire  to the observers
+# P  D   NSg/J . V       P    D   NSg P  D   NSg/V V/C P    D   NSg/V P  D   W?
 > in          a   pleasant , puzzled way   .
 # NPrSg/V/J/P D/P NSg/J    . W?      NSg/J .
 >
@@ -3310,8 +3310,8 @@
 #
 > The fact was infinitely astonishing to him , and I   recognized first   the unusual
 # D   NSg  V   J/R        V/J         P  I   . V/C ISg V/J        NSg/V/J D   NSg/J
-> quality of  wonder , and then    the man         — it        was the late  patron of  Gatsby’s library .
-# NSg/J   V/P NSg/V  . V/C NSg/J/C D   NPrSg/I/V/J . NPrSg/ISg V   D   NSg/J NSg/V  V/P N$       NSg     .
+> quality of wonder , and then    the man         — it        was the late  patron of Gatsby’s library .
+# NSg/J   P  NSg/V  . V/C NSg/J/C D   NPrSg/I/V/J . NPrSg/ISg V   D   NSg/J NSg/V  P  N$       NSg     .
 >
 #
 > “ How’d it        happen ? ”
@@ -3330,8 +3330,8 @@
 # . NSg/C/P NSg/C V   NPrSg/ISg V      . V   IPl NSg/V P    D   NPrSg/V . .
 >
 #
-> “ Don’t ask   me        , ” said Owl   Eyes , washing his   hands of  the whole matter  . “ I   know
-# . NSg/V NSg/V NPrSg/ISg . . V/J  NSg/V NPl  . NSg/V   ISg/D NPl   V/P D   NSg/J NSg/V/J . . ISg NSg/V
+> “ Don’t ask   me        , ” said Owl   Eyes , washing his   hands of the whole matter  . “ I   know
+# . NSg/V NSg/V NPrSg/ISg . . V/J  NSg/V NPl  . NSg/V   ISg/D NPl   P  D   NSg/J NSg/V/J . . ISg NSg/V
 > very little    about driving — next    to nothing . It        happened , and that’s all       I   know  . ”
 # J    NPrSg/I/J J/P   V       . NSg/J/P P  NSg/I/J . NPrSg/ISg W?       . V/C N$     NSg/I/J/C ISg NSg/V . .
 >
@@ -3364,18 +3364,18 @@
 #
 > The shock   that    followed this declaration found voice in          a   sustained “ Ah      - h       - h       ! ” as
 # D   NSg/V/J N/I/C/D W?       I/D  NSg         NSg/V NSg/V NPrSg/V/J/P D/P W?        . NSg/I/V . NSg/V/J . NSg/V/J . . NSg/R
-> the door  of  the coupé swung slowly open    . The crowd — it        was now         a   crowd — stepped
-# D   NSg/V V/P D   ?     V     J/R    NSg/V/J . D   NSg/V . NPrSg/ISg V   NPrSg/V/J/C D/P NSg/V . W?
+> the door  of the coupé swung slowly open    . The crowd — it        was now         a   crowd — stepped
+# D   NSg/V P  D   ?     V     J/R    NSg/V/J . D   NSg/V . NPrSg/ISg V   NPrSg/V/J/C D/P NSg/V . W?
 > back    involuntarily , and when    the door  had opened wide  there was a   ghostly pause .
 # NSg/V/J R             . V/C NSg/I/C D   NSg/V V   V/J    NSg/J W?    V   D/P J/R     NSg/V .
 > Then    , very gradually , part    by      part    , a   pale    , dangling individual stepped out         of
-# NSg/J/C . J    J/R       . NSg/V/J NSg/J/P NSg/V/J . D/P NSg/V/J . V        NSg/J      W?      NSg/V/J/R/P V/P
+# NSg/J/C . J    J/R       . NSg/V/J NSg/J/P NSg/V/J . D/P NSg/V/J . V        NSg/J      W?      NSg/V/J/R/P P
 > the wreck , pawing tentatively at        the ground  with a   large uncertain dancing shoe  .
 # D   NSg/V . V      J/R         NSg/I/V/P D   NSg/V/J P    D/P NSg/J I/J       NSg/V   NSg/V .
 >
 #
-> Blinded by      the glare   of  the headlights and confused by      the incessant groaning of
-# W?      NSg/J/P D   NSg/V/J V/P D   NPl        V/C V/J      NSg/J/P D   J         V        V/P
+> Blinded by      the glare   of the headlights and confused by      the incessant groaning of
+# W?      NSg/J/P D   NSg/V/J P  D   NPl        V/C V/J      NSg/J/P D   J         V        P
 > the horns , the apparition stood swaying for a   moment before he      perceived the man
 # D   NPl   . D   NSg        V     V       C/P D/P NSg    C/P    NPr/ISg V/J       D   NPrSg/I/V/J
 > in          the duster .
@@ -3420,8 +3420,8 @@
 # . ?         NPrSg/V NPrSg/ISg NSg/C W?      D/P ?        NSg/V   . .
 >
 #
-> At        least a   dozen men , some  of  them a   little    better   off       than he      was , explained to
-# NSg/I/V/P NSg/J D/P NSg   NSg . I/J/R V/P N/I  D/P NPrSg/I/J NSg/VX/J NSg/V/J/P C/P  NPr/ISg V   . V         P
+> At        least a   dozen men , some  of them a   little    better   off       than he      was , explained to
+# NSg/I/V/P NSg/J D/P NSg   NSg . I/J/R P  N/I  D/P NPrSg/I/J NSg/VX/J NSg/V/J/P C/P  NPr/ISg V   . V         P
 > him that    wheel and car were  no      longer joined by      any   physical bond      .
 # I   N/I/C/D NSg/V V/C NSg NSg/V NPrSg/P NSg/J  W?     NSg/J/P I/R/D NSg/J    NPrSg/V/J .
 >
@@ -3444,34 +3444,34 @@
 #
 > The caterwauling horns had reached a   crescendo and I   turned away and cut     across
 # D   V            NPl   V   W?      D/P NSg/V     V/C ISg W?     V/J  V/C NSg/V/J NSg/P
-> the lawn  toward home    . I   glanced back    once  . A   wafer of  a   moon    was shining over
-# D   NSg/V J/P    NSg/V/J . ISg W?      NSg/V/J NSg/C . D/P NSg/V V/P D/P NPrSg/V V   V       NSg/V/J/P
+> the lawn  toward home    . I   glanced back    once  . A   wafer of a   moon    was shining over
+# D   NSg/V J/P    NSg/V/J . ISg W?      NSg/V/J NSg/C . D/P NSg/V P  D/P NPrSg/V V   V       NSg/V/J/P
 > Gatsby’s house   , making the night fine    as    before , and surviving the laughter and
 # N$       NPrSg/V . NSg/V  D   NSg/V NSg/V/J NSg/R C/P    . V/C V         D   NSg      V/C
-> the sound   of  his   still   glowing garden  . A   sudden emptiness seemed to flow  now
-# D   NSg/V/J V/P ISg/D NSg/V/J NSg/V/J NSg/V/J . D/P NSg/J  NSg       W?     P  NSg/V NPrSg/V/J/C
+> the sound   of his   still   glowing garden  . A   sudden emptiness seemed to flow  now
+# D   NSg/V/J P  ISg/D NSg/V/J NSg/V/J NSg/V/J . D/P NSg/J  NSg       W?     P  NSg/V NPrSg/V/J/C
 > from the windows and the great doors , endowing with complete isolation the
 # P    D   NPrPl   V/C D   NSg/J NPl   . V        P    NSg/V/J  NSg       D
-> figure of  the host  , who     stood on  the porch , his   hand  up        in          a   formal gesture of
-# NSg/V  V/P D   NSg/V . NPrSg/I V     J/P D   NSg   . ISg/D NSg/V NSg/V/J/P NPrSg/V/J/P D/P NSg/J  NSg/V   V/P
+> figure of the host  , who     stood on  the porch , his   hand  up        in          a   formal gesture of
+# NSg/V  P  D   NSg/V . NPrSg/I V     J/P D   NSg   . ISg/D NSg/V NSg/V/J/P NPrSg/V/J/P D/P NSg/J  NSg/V   P
 > farewell .
 # NSg/V/J  .
 >
 #
 > Reading over      what  I   have   written so        far     , I   see   I   have   given     the impression that
 # NPrSg/V NSg/V/J/P NSg/I ISg NSg/VX V/J     NSg/I/J/C NSg/V/J . ISg NSg/V ISg NSg/VX NSg/V/J/P D   NSg/V      N/I/C/D
-> the events of  three nights several weeks apart were  all       that    absorbed me        . On  the
-# D   NPl    V/P NSg   NPl    J/D     NPrPl NSg/J NSg/V NSg/I/J/C N/I/C/D W?       NPrSg/ISg . J/P D
+> the events of three nights several weeks apart were  all       that    absorbed me        . On  the
+# D   NPl    P  NSg   NPl    J/D     NPrPl NSg/J NSg/V NSg/I/J/C N/I/C/D W?       NPrSg/ISg . J/P D
 > contrary , they were  merely casual events in          a   crowded summer  , and , until much
 # NSg/V/J  . IPl  NSg/V J/R    NSg/J  NPl    NPrSg/V/J/P D/P V/J     NPrSg/V . V/C . C/P   N/I/J
 > later , they absorbed me        infinitely less    than my personal affairs .
 # J     . IPl  W?       NPrSg/ISg J/R        V/J/C/P C/P  D  NSg/J    NPl     .
 >
 #
-> Most    of  the time  I   worked . In          the early   morning the sun     threw my shadow  westward
-# NSg/I/J V/P D   NSg/V ISg W?     . NPrSg/V/J/P D   NSg/J/R NSg/V   D   NPrSg/V V     D  NSg/V/J NSg/J
-> as    I   hurried down      the white     chasms of  lower New     York to the Probity Trust   . I
-# NSg/R ISg V/J     NSg/V/J/P D   NPrSg/V/J NPl    V/P V/J   NSg/V/J NPr  P  D   NSg     NSg/V/J . ISg
+> Most    of the time  I   worked . In          the early   morning the sun     threw my shadow  westward
+# NSg/I/J P  D   NSg/V ISg W?     . NPrSg/V/J/P D   NSg/J/R NSg/V   D   NPrSg/V V     D  NSg/V/J NSg/J
+> as    I   hurried down      the white     chasms of lower New     York to the Probity Trust   . I
+# NSg/R ISg V/J     NSg/V/J/P D   NPrSg/V/J NPl    P  V/J   NSg/V/J NPr  P  D   NSg     NSg/V/J . ISg
 > knew the other   clerks and young     bond      - salesmen by      their first   names , and lunched
 # V    D   NSg/V/J NPl    V/C NPrSg/V/J NPrSg/V/J . NPl      NSg/J/P D     NSg/V/J NPl   . V/C W?
 > with them in          dark    , crowded restaurants on  little    pig   sausages and mashed
@@ -3488,8 +3488,8 @@
 #
 > I   took dinner usually at        the Yale Club  — for some  reason it        was the gloomiest
 # ISg V    NSg/V  J/R     NSg/I/V/P D   NPr  NSg/V . C/P I/J/R NSg/V  NPrSg/ISg V   D   W?
-> event of  my day   — and then    I   went  up        - stairs to the library and studied investments
-# NSg/V V/P D  NPrSg . V/C NSg/J/C ISg NSg/V NSg/V/J/P . NPl    P  D   NSg     V/C V/J     NPl
+> event of my day   — and then    I   went  up        - stairs to the library and studied investments
+# NSg/V P  D  NPrSg . V/C NSg/J/C ISg NSg/V NSg/V/J/P . NPl    P  D   NSg     V/C V/J     NPl
 > and securities for a   conscientious hour . There were  generally a   few rioters
 # V/C NPl        C/P D/P J             NSg  . W?    NSg/V J/R       D/P N/I W?
 > around , but     they never came    into the library , so        it        was a   good      place to work  .
@@ -3500,32 +3500,32 @@
 # NPr    NPrSg/V NSg   . V/C NSg/V/J/P #  NPrSg/J NSg/V/J P  D   NPr          NSg/V   .
 >
 #
-> I   began to like        New     York , the racy , adventurous feel      of  it        at        night , and the
-# ISg V     P  NSg/V/J/C/P NSg/V/J NPr  . D   J    . J           NSg/I/V/J V/P NPrSg/ISg NSg/I/V/P NSg/V . V/C D
-> satisfaction that    the constant flicker of  men and women and machines gives to
-# NSg          N/I/C/D D   NSg/J    NSg/V/J V/P NSg V/C NPl   V/C NPl      NPl   P
+> I   began to like        New     York , the racy , adventurous feel      of it        at        night , and the
+# ISg V     P  NSg/V/J/C/P NSg/V/J NPr  . D   J    . J           NSg/I/V/J P  NPrSg/ISg NSg/I/V/P NSg/V . V/C D
+> satisfaction that    the constant flicker of men and women and machines gives to
+# NSg          N/I/C/D D   NSg/J    NSg/V/J P  NSg V/C NPl   V/C NPl      NPl   P
 > the restless eye   . I   liked to walk  up        Fifth   Avenue and pick  out         romantic women
 # D   J        NSg/V . ISg W?    P  NSg/V NSg/V/J/P NSg/V/J NSg    V/C NSg/V NSg/V/J/R/P NSg/J    NPl
 > from the crowd and imagine that    in          a   few minutes I   was going   to enter into their
 # P    D   NSg/V V/C NSg/V   N/I/C/D NPrSg/V/J/P D/P N/I NPl     ISg V   NSg/V/J P  NSg/V P    D
 > lives , and no      one       would  ever know  or      disapprove . Sometimes , in          my mind  , I
 # NPl   . V/C NPrSg/P NSg/I/V/J NSg/VX J    NSg/V NPrSg/C V          . R         . NPrSg/V/J/P D  NSg/V . ISg
-> followed them to their apartments on  the corners of  hidden streets , and they
-# W?       N/I  P  D     NPl        J/P D   W?      V/P V/J    NPl     . V/C IPl
+> followed them to their apartments on  the corners of hidden streets , and they
+# W?       N/I  P  D     NPl        J/P D   W?      P  V/J    NPl     . V/C IPl
 > turned and smiled back    at        me        before they faded through a   door  into warm
 # W?     V/C W?     NSg/V/J NSg/I/V/P NPrSg/ISg C/P    IPl  W?    NSg/J/P D/P NSg/V P    NSg/V/J
 > darkness . At        the enchanted metropolitan twilight I   felt    a   haunting loneliness
 # NSg      . NSg/I/V/P D   W?        NSg/J        NSg/V/J  ISg NSg/V/J D/P NSg/V/J  NSg
 > sometimes , and felt    it        in          others — poor    young     clerks who     loitered in          front   of
-# R         . V/C NSg/V/J NPrSg/ISg NPrSg/V/J/P NPl    . NSg/V/J NPrSg/V/J NPl    NPrSg/I W?       NPrSg/V/J/P NSg/V/J V/P
+# R         . V/C NSg/V/J NPrSg/ISg NPrSg/V/J/P NPl    . NSg/V/J NPrSg/V/J NPl    NPrSg/I W?       NPrSg/V/J/P NSg/V/J P
 > windows waiting until it        was time  for a   solitary restaurant dinner — young     clerks
 # NPrPl   NSg/V   C/P   NPrSg/ISg V   NSg/V C/P D/P NSg/J    NSg        NSg/V  . NPrSg/V/J NPl
-> in          the dusk    , wasting the most    poignant moments of  night and life  .
-# NPrSg/V/J/P D   NSg/V/J . V       D   NSg/I/J J        NPl     V/P NSg/V V/C NSg/V .
+> in          the dusk    , wasting the most    poignant moments of night and life  .
+# NPrSg/V/J/P D   NSg/V/J . V       D   NSg/I/J J        NPl     P  NSg/V V/C NSg/V .
 >
 #
-> Again at        eight o’clock , when    the dark    lanes of  the Forties were  lined five deep
-# P     NSg/I/V/P NSg/J W?      . NSg/I/C D   NSg/V/J NPl   V/P D   NPl     NSg/V V/J   NSg  NSg/J
+> Again at        eight o’clock , when    the dark    lanes of the Forties were  lined five deep
+# P     NSg/I/V/P NSg/J W?      . NSg/I/C D   NSg/V/J NPl   P  D   NPl     NSg/V V/J   NSg  NSg/J
 > with throbbing taxicabs , bound   for the theatre district , I   felt    a   sinking in          my
 # P    NSg/V/J   NPl      . NSg/V/J C/P D   NSg/Br  NSg/V/J  . ISg NSg/V/J D/P V       NPrSg/V/J/P D
 > heart . Forms leaned together in          the taxis as    they waited , and voices sang    , and
@@ -3538,14 +3538,14 @@
 # V/C V       D     NSg/V/J  NSg        . ISg W?     N/I  NSg/V/J .
 >
 #
-> For a   while     I   lost sight of  Jordan Baker   , and then    in          midsummer I   found her
-# C/P D/P NSg/V/C/P ISg V/J  NSg/V V/P NPr    NPrSg/J . V/C NSg/J/C NPrSg/V/J/P NSg/J     ISg NSg/V I/J/D
+> For a   while     I   lost sight of Jordan Baker   , and then    in          midsummer I   found her
+# C/P D/P NSg/V/C/P ISg V/J  NSg/V P  NPr    NPrSg/J . V/C NSg/J/C NPrSg/V/J/P NSg/J     ISg NSg/V I/J/D
 > again . At        first   I   was flattered to go      places with her   , because she was a   golf
 # P     . NSg/I/V/P NSg/V/J ISg V   W?        P  NSg/V/J NPl    P    I/J/D . C/P     ISg V   D/P NSg/V
 > champion , and every one       knew her   name  . Then    it        was something more        . I   wasn’t
 # NSg/V/J  . V/C D     NSg/I/V/J V    I/J/D NSg/V . NSg/J/C NPrSg/ISg V   NSg/I/V/J NPrSg/I/V/J . ISg V
-> actually in          love    , but     I   felt    a   sort  of  tender  curiosity . The bored haughty face
-# J/R      NPrSg/V/J/P NPrSg/V . NSg/C/P ISg NSg/V/J D/P NSg/V V/P NSg/V/J NSg       . D   W?    J       NSg/V
+> actually in          love    , but     I   felt    a   sort  of tender  curiosity . The bored haughty face
+# J/R      NPrSg/V/J/P NPrSg/V . NSg/C/P ISg NSg/V/J D/P NSg/V P  NSg/V/J NSg       . D   W?    J       NSg/V
 > that    she turned to the world concealed something — most    affectations conceal
 # N/I/C/D ISg W?     P  D   NSg/V V/J       NSg/I/V/J . NSg/I/J NPl          V
 > something eventually , even    though they don’t in          the beginning — and one       day   I
@@ -3560,8 +3560,8 @@
 # NSg/I/V/P N$      . NSg/I/V/P I/J/D NSg/V/J NSg/V/J NSg/V NSg        W?    V   D/P NSg/V N/I/C/D J/R    W?
 > the newspapers — a   suggestion that    she had moved her   ball    from a   bad     lie     in          the
 # D   NPl        . D/P NSg        N/I/C/D ISg V   V/J   I/J/D NPrSg/V P    D/P NSg/V/J NPrSg/V NPrSg/V/J/P D
-> semi - final   round     . The thing approached the proportions of  a   scandal — then    died
-# NSg  . NSg/V/J NSg/V/J/P . D   NSg/V W?         D   NPl         V/P D/P NSg/V   . NSg/J/C W?
+> semi - final   round     . The thing approached the proportions of a   scandal — then    died
+# NSg  . NSg/V/J NSg/V/J/P . D   NSg/V W?         D   NPl         P  D/P NSg/V   . NSg/J/C W?
 > away . A   caddy retracted his   statement , and the only other   witness admitted that
 # V/J  . D/P NSg   W?        ISg/D NSg/V/J   . V/C D   W?   NSg/V/J NSg/V   V        N/I/C/D
 > he      might    have   been  mistaken . The incident and the name  had remained together in
@@ -3580,8 +3580,8 @@
 # NSg/I/V/P D/P NSg/V        V/C . NSg/V/J/P I/D  NSg           . ISg V       ISg V   V     NSg/V
 > in          subterfuges when    she was very young     in          order to keep  that    cool    , insolent
 # NPrSg/V/J/P NPl         NSg/I/C ISg V   J    NPrSg/V/J NPrSg/V/J/P NSg/V P  NSg/V N/I/C/D NSg/V/J . NSg/J
-> smile turned to the world and yet     satisfy the demands of  her   hard    , jaunty body  .
-# NSg/V W?     P  D   NSg/V V/C NSg/V/C V       D   NPl     V/P I/J/D NSg/V/J . NSg/J  NSg/V .
+> smile turned to the world and yet     satisfy the demands of her   hard    , jaunty body  .
+# NSg/V W?     P  D   NSg/V V/C NSg/V/C V       D   NPl     P  I/J/D NSg/V/J . NSg/J  NSg/V .
 >
 #
 > It        made  no      difference to me        . Dishonesty in          a   woman is a   thing you never blame
@@ -3618,8 +3618,8 @@
 # . N$     N/I/C/D V   P  NSg/VX P    NPrSg/ISg . .
 >
 #
-> “ They’ll keep  out         of  my way   , ” she insisted . “ It        takes two to make  an  accident . ”
-# . W?      NSg/V NSg/V/J/R/P V/P D  NSg/J . . ISg W?       . . NPrSg/ISg NPl   NSg P  NSg/V D/P NSg/J    . .
+> “ They’ll keep  out         of my way   , ” she insisted . “ It        takes two to make  an  accident . ”
+# . W?      NSg/V NSg/V/J/R/P P  D  NSg/J . . ISg W?       . . NPrSg/ISg NPl   NSg P  NSg/V D/P NSg/J    . .
 >
 #
 > “ Suppose you met somebody just as    careless as    yourself . ”
@@ -3636,24 +3636,24 @@
 # I/J/D NPrSg/V/J/Am . NPrSg/V . W?       NPl  W?     NSg/V/J  W?    . NSg/C/P ISg V   J/R
 > shifted our relations , and for a   moment I   thought I   loved her   . But     I   am
 # W?      D   W?        . V/C C/P D/P NSg    ISg NSg/V   ISg V/J   I/J/D . NSg/C/P ISg NPrSg/V/J
-> slow    - thinking and full    of  interior rules that    act     as    brakes on  my desires , and I
-# NSg/V/J . V        V/C NSg/V/J V/P NSg/J    NPl   N/I/C/D NPrSg/V NSg/R NPl    J/P D  NPl     . V/C ISg
-> knew that    first   I   had to get   myself definitely out         of  that    tangle back    home    . I'd
-# V    N/I/C/D NSg/V/J ISg V   P  NSg/V I      J/R        NSg/V/J/R/P V/P N/I/C/D NSg/V  NSg/V/J NSg/V/J . W?
+> slow    - thinking and full    of interior rules that    act     as    brakes on  my desires , and I
+# NSg/V/J . V        V/C NSg/V/J P  NSg/J    NPl   N/I/C/D NPrSg/V NSg/R NPl    J/P D  NPl     . V/C ISg
+> knew that    first   I   had to get   myself definitely out         of that    tangle back    home    . I'd
+# V    N/I/C/D NSg/V/J ISg V   P  NSg/V I      J/R        NSg/V/J/R/P P  N/I/C/D NSg/V  NSg/V/J NSg/V/J . W?
 > been  writing letters once  a   week and signing them : “ Love    , Nick    , ” and all       I   could
 # NSg/V NSg/V   NPl     NSg/C D/P NSg  V/C V       N/I  . . NPrSg/V . NPrSg/V . . V/C NSg/I/J/C ISg NSg/VX
-> think of  was how   , when    that    certain girl  played tennis , a   faint   mustache of
-# NSg/V V/P V   NSg/C . NSg/I/C N/I/C/D I/J     NSg/V W?     NSg/V  . D/P NSg/V/J NSg      V/P
+> think of was how   , when    that    certain girl  played tennis , a   faint   mustache of
+# NSg/V P  V   NSg/C . NSg/I/C N/I/C/D I/J     NSg/V W?     NSg/V  . D/P NSg/V/J NSg      P
 > perspiration appeared on  her   upper lip   . Nevertheless there was a   vague
 # NSg          W?       J/P I/J/D NSg/J NSg/V . W?           W?    V   D/P NSg/V/J
 > understanding that    had to be     tactfully broken off       before I   was free    .
 # NSg/V/J       N/I/C/D V   P  NSg/VX J/R       V/J    NSg/V/J/P C/P    ISg V   NSg/V/J .
 >
 #
-> Every one       suspects himself of  at        least one       of  the cardinal virtues , and this is
-# D     NSg/I/V/J NPl      I       V/P NSg/I/V/P NSg/J NSg/I/V/J V/P D   NSg/J    NPl     . V/C I/D  VL
-> mine    : I   am        one       of  the few honest people that    I   have   ever known   .
-# NSg/I/V . ISg NPrSg/V/J NSg/I/V/J V/P D   N/I V/J    NSg/V  N/I/C/D ISg NSg/VX J    NSg/V/J .
+> Every one       suspects himself of at        least one       of the cardinal virtues , and this is
+# D     NSg/I/V/J NPl      I       P  NSg/I/V/P NSg/J NSg/I/V/J P  D   NSg/J    NPl     . V/C I/D  VL
+> mine    : I   am        one       of the few honest people that    I   have   ever known   .
+# NSg/I/V . ISg NPrSg/V/J NSg/I/V/J P  D   N/I V/J    NSg/V  N/I/C/D ISg NSg/VX J    NSg/V/J .
 >
 #
 > CHAPTER IV
@@ -3678,18 +3678,18 @@
 # NSg/V/J . V/C NSg/V NPrSg/ISg D/P NSg/V/J NSg/V P    N/I/C/D W?    NPrSg/J NPrSg/V . .
 >
 #
-> Once  I   wrote down      on  the empty   spaces of  a   timetable the names of  those who     came
-# NSg/C ISg V     NSg/V/J/P J/P D   NSg/V/J NPl    V/P D/P NSg/V     D   NPl   V/P I/D   NPrSg/I NSg/V/P
+> Once  I   wrote down      on  the empty   spaces of a   timetable the names of those who     came
+# NSg/C ISg V     NSg/V/J/P J/P D   NSg/V/J NPl    P  D/P NSg/V     D   NPl   P  I/D   NPrSg/I NSg/V/P
 > to Gatsby’s house   that    summer  . It        is an  old   time  - table now         , disintegrating at
 # P  N$       NPrSg/V N/I/C/D NPrSg/V . NPrSg/ISg VL D/P NSg/J NSg/V . NSg/V NPrSg/V/J/C . V              NSg/I/V/P
 > its   folds , and headed “ This schedule in          effect July 5th , 1922 . ” But     I   can      still
 # ISg/D NPl   . V/C W?     . I/D  NSg/V    NPrSg/V/J/P NSg/V  NPr  #   . #    . . NSg/C/P ISg NPrSg/VX NSg/V/J
 > read  the gray         names , and they will     give  you a   better   impression than my
 # NSg/V D   NPrSg/V/J/Am NPl   . V/C IPl  NPrSg/VX NSg/V IPl D/P NSg/VX/J NSg/V      C/P  D
-> generalities of  those who     accepted Gatsby’s hospitality and paid him the subtle
-# NPl          V/P I/D   NPrSg/I V/J      N$       NSg         V/C V/J  I   D   J
-> tribute of  knowing   nothing whatever about him .
-# NSg/V   V/P NSg/V/J/P NSg/I/J NSg/I/J  J/P   I   .
+> generalities of those who     accepted Gatsby’s hospitality and paid him the subtle
+# NPl          P  I/D   NPrSg/I V/J      N$       NSg         V/C V/J  I   D   J
+> tribute of knowing   nothing whatever about him .
+# NSg/V   P  NSg/V/J/P NSg/I/J NSg/I/J  J/P   I   .
 >
 #
 > From East    Egg   , then    , came    the Chester Beckers and the Leeches , and a   man         named
@@ -3714,8 +3714,8 @@
 # NSg            . V/C V   D/P NSg/V P    D/P NSg/V/J V/J   ?    NPrSg/V/J/P D   NSg/V/J . P
 > farther out         on  the Island came    the Cheadles and the O. R. P. Schraeders , and the
 # V/J     NSg/V/J/R/P J/P D   NSg/V  NSg/V/P D   ?        V/C D   ?  ?  ?  ?          . V/C D
-> Stonewall Jackson Abrams of  Georgia , and the Fishguards and the Ripley Snells .
-# NSg/V/J   NPr     NPrPl  V/P NPr     . V/C D   ?          V/C D   NPr    ?      .
+> Stonewall Jackson Abrams of Georgia , and the Fishguards and the Ripley Snells .
+# NSg/V/J   NPr     NPrPl  P  NPr     . V/C D   ?          V/C D   NPr    ?      .
 > Snell was there three days before he      went  to the penitentiary , so        drunk   out         on
 # NPr   V   W?    NSg   NPl  C/P    NPr/ISg NSg/V P  D   NSg/J        . NSg/I/J/C NSg/V/J NSg/V/J/R/P J/P
 > the gravel drive that    Mrs . Ulysses Swett’s automobile ran   over      his   right     hand  .
@@ -3750,8 +3750,8 @@
 #
 > A   man         named Klipspringer was there so        often and so        long      that    he      became known   as
 # D/P NPrSg/I/V/J V/J   ?            V   W?    NSg/I/J/C J     V/C NSg/I/J/C NPrSg/V/J N/I/C/D NPr/ISg V      NSg/V/J NSg/R
-> “ the boarder ” — I   doubt if    he      had any   other   home    . Of  theatrical people there were
-# . D   NSg/J   . . ISg NSg/V NSg/C NPr/ISg V   I/R/D NSg/V/J NSg/V/J . V/P NSg/J      NSg/V  W?    NSg/V
+> “ the boarder ” — I   doubt if    he      had any   other   home    . Of theatrical people there were
+# . D   NSg/J   . . ISg NSg/V NSg/C NPr/ISg V   I/R/D NSg/V/J NSg/V/J . P  NSg/J      NSg/V  W?    NSg/V
 > Gus Waize and Horace O’Donavan and Lester Myer and George Duckweed and Francis
 # NPr ?     V/C NPr    ?         V/C NPr    ?    V/C NPrSg  NSg      V/C NPr
 > Bull    . Also from New     York were  the Chromes and the Backhyssons and the Dennickers
@@ -3760,8 +3760,8 @@
 # V/C NPr    NPrSg V/C D   ?         V/C D   ?         V/C D   ?      V/C D
 > Scullys and S. W. Belcher and the Smirkes and the young     Quinns , divorced now         ,
 # ?       V/C ?  ?  ?       V/C D   ?       V/C D   NPrSg/V/J ?      . W?       NPrSg/V/J/C .
-> and Henry L. Palmetto , who     killed himself by      jumping in          front   of  a   subway train
-# V/C NPrSg ?  NSg      . NPrSg/I W?     I       NSg/J/P V       NPrSg/V/J/P NSg/V/J V/P D/P NSg/V  NSg/V
+> and Henry L. Palmetto , who     killed himself by      jumping in          front   of a   subway train
+# V/C NPrSg ?  NSg      . NPrSg/I W?     I       NSg/J/P V       NPrSg/V/J/P NSg/V/J P  D/P NSg/V  NSg/V
 > in          Times Square  .
 # NPrSg/V/J/P NPl   NSg/V/J .
 >
@@ -3774,10 +3774,10 @@
 # R          W?     IPl  V   NSg/V W?    C/P    . ISg NSg/VX NSg/V/J   D
 > names — Jaqueline , I   think , or      else  Consuela , or      Gloria or      Judy  or      June , and their
 # NPl   . ?         . ISg NSg/V . NPrSg/C N/J/C ?        . NPrSg/C NPr    NPrSg/C NPrSg NPrSg/C NPr  . V/C D
-> last    names were  either the melodious names of  flowers and months or      the sterner
-# NSg/V/J NPl   NSg/V I/C    D   J         NPl   V/P NPrPl   V/C NSg    NPrSg/C D   J
-> ones of  the great American capitalists whose cousins , if    pressed , they would
-# NPl  V/P D   NSg/J NPrSg/J  NPl         I     NPl     . NSg/C V/J     . IPl  NSg/VX
+> last    names were  either the melodious names of flowers and months or      the sterner
+# NSg/V/J NPl   NSg/V I/C    D   J         NPl   P  NPrPl   V/C NSg    NPrSg/C D   J
+> ones of the great American capitalists whose cousins , if    pressed , they would
+# NPl  P  D   NSg/J NPrSg/J  NPl         I     NPl     . NSg/C V/J     . IPl  NSg/VX
 > confess themselves to be     .
 # NSg/V/J I          P  NSg/VX .
 >
@@ -3788,10 +3788,10 @@
 # NSg/J NSg/C V/C D   NPrSg    NPl   V/C NPrSg/V/J NPrSg/J . NPrSg/I V   ISg/D NSg/V NSg/V/J NSg/V/J/P NPrSg/V/J/P
 > the war   , and Mr  . Albrucksburger and Miss  Haag , his   fiancée , and Ardita
 # D   NSg/V . V/C NSg . ?              V/C NSg/V ?    . ISg/D ?       . V/C ?
-> Fitz - Peters and Mr  . P. Jewett , once  head      of  the American Legion  , and Miss
-# ?    . NPr    V/C NSg . ?  ?      . NSg/C NPrSg/V/J V/P D   NPrSg/J  NSg/V/J . V/C NSg/V
-> Claudia Hip     , with a   man         reputed to be     her   chauffeur , and a   prince  of  something ,
-# NPr     NSg/V/J . P    D/P NPrSg/I/V/J V/J     P  NSg/VX I/J/D NSg/V     . V/C D/P NPrSg/V V/P NSg/I/V/J .
+> Fitz - Peters and Mr  . P. Jewett , once  head      of the American Legion  , and Miss
+# ?    . NPr    V/C NSg . ?  ?      . NSg/C NPrSg/V/J P  D   NPrSg/J  NSg/V/J . V/C NSg/V
+> Claudia Hip     , with a   man         reputed to be     her   chauffeur , and a   prince  of something ,
+# NPr     NSg/V/J . P    D/P NPrSg/I/V/J V/J     P  NSg/VX I/J/D NSg/V     . V/C D/P NPrSg/V P  NSg/I/V/J .
 > whom we  called Duke    , and whose name  , if    I   ever knew it        , I   have   forgotten .
 # I    IPl V/J    NPrSg/V . V/C I     NSg/V . NSg/C ISg J    V    NPrSg/ISg . ISg NSg/VX NSg/V/J   .
 >
@@ -3802,14 +3802,14 @@
 #
 > At        nine o’clock , one       morning late  in          July , Gatsby’s gorgeous car lurched up        the
 # NSg/I/V/P NSg  W?      . NSg/I/V/J NSg/V   NSg/J NPrSg/V/J/P NPr  . N$       J        NSg W?      NSg/V/J/P D
-> rocky drive to my door  and gave out         a   burst of  melody from its   three - noted horn    .
-# NPr/J NSg/V P  D  NSg/V V/C V    NSg/V/J/R/P D/P NSg/V V/P NPrSg  P    ISg/D NSg   . W?    NPrSg/V .
-> It        was the first   time  he      had called on  me        , though I   had gone  to two of  his
-# NPrSg/ISg V   D   NSg/V/J NSg/V NPr/ISg V   V/J    J/P NPrSg/ISg . V/C    ISg V   V/J/P P  NSg V/P ISg/D
+> rocky drive to my door  and gave out         a   burst of melody from its   three - noted horn    .
+# NPr/J NSg/V P  D  NSg/V V/C V    NSg/V/J/R/P D/P NSg/V P  NPrSg  P    ISg/D NSg   . W?    NPrSg/V .
+> It        was the first   time  he      had called on  me        , though I   had gone  to two of his
+# NPrSg/ISg V   D   NSg/V/J NSg/V NPr/ISg V   V/J    J/P NPrSg/ISg . V/C    ISg V   V/J/P P  NSg P  ISg/D
 > parties , mounted in          his   hydroplane , and , at        his   urgent invitation , made  frequent
 # NPl     . V/J     NPrSg/V/J/P ISg/D NSg/V      . V/C . NSg/I/V/P ISg/D J      NSg        . NSg/V V/J
-> use   of  his   beach   .
-# NSg/V V/P ISg/D NPrSg/V .
+> use   of his   beach   .
+# NSg/V P  ISg/D NPrSg/V .
 >
 #
 > “ Good      morning , old   sport . You’re having lunch with me        to - day   and I   thought we’d
@@ -3818,18 +3818,18 @@
 # NSg/V NSg/V/J/P J        . .
 >
 #
-> He      was balancing himself on  the dashboard of  his   car with that    resourcefulness
-# NPr/ISg V   V         I       J/P D   NSg/V     V/P ISg/D NSg P    N/I/C/D NSg
-> of  movement that    is so        peculiarly American — that    comes , I   suppose , with the
-# V/P NSg      N/I/C/D VL NSg/I/J/C J/R        NPrSg/J  . N/I/C/D NPl   . ISg V       . P    D
-> absence of  lifting work  in          youth and , even    more        , with the formless grace   of  our
-# NSg     V/P V       NSg/V NPrSg/V/J/P NSg   V/C . NSg/V/J NPrSg/I/V/J . P    D   J        NPrSg/V V/P D
+> He      was balancing himself on  the dashboard of his   car with that    resourcefulness
+# NPr/ISg V   V         I       J/P D   NSg/V     P  ISg/D NSg P    N/I/C/D NSg
+> of movement that    is so        peculiarly American — that    comes , I   suppose , with the
+# P  NSg      N/I/C/D VL NSg/I/J/C J/R        NPrSg/J  . N/I/C/D NPl   . ISg V       . P    D
+> absence of lifting work  in          youth and , even    more        , with the formless grace   of our
+# NSg     P  V       NSg/V NPrSg/V/J/P NSg   V/C . NSg/V/J NPrSg/I/V/J . P    D   J        NPrSg/V P  D
 > nervous , sporadic games . This quality was continually breaking through his
 # J       . J        NPl   . I/D  NSg/J   V   J/R         V        NSg/J/P ISg/D
-> punctilious manner in          the shape of  restlessness . He      was never quite still   ; there
-# J           NSg    NPrSg/V/J/P D   NSg/V V/P NSg          . NPr/ISg V   V     NSg   NSg/V/J . W?
-> was always a   tapping foot  somewhere or      the impatient opening and closing of  a
-# V   W?     D/P NSg/V   NSg/V NSg       NPrSg/C D   J         NSg/V/J V/C NSg/V/J V/P D/P
+> punctilious manner in          the shape of restlessness . He      was never quite still   ; there
+# J           NSg    NPrSg/V/J/P D   NSg/V P  NSg          . NPr/ISg V   V     NSg   NSg/V/J . W?
+> was always a   tapping foot  somewhere or      the impatient opening and closing of a
+# V   W?     D/P NSg/V   NSg/V NSg       NPrSg/C D   J         NSg/V/J V/C NSg/V/J P  D/P
 > hand  .
 # NSg/V .
 >
@@ -3848,34 +3848,34 @@
 # W?  NSg/V NPrSg/ISg . N/I       V   NSg/V NPrSg/ISg . NPrSg/ISg V   D/P NPrSg/V/J NSg/V/J NSg/V/J/Am . NPrSg/V/J P
 > nickel  , swollen here    and there in          its   monstrous length with triumphant hat   - boxes
 # NSg/V/J . V/J     NSg/J/R V/C W?    NPrSg/V/J/P ISg/D J         NSg/V  P    J          NSg/V . NPl
-> and supper  - boxes and tool  - boxes , and terraced with a   labyrinth of  wind  - shields
-# V/C NSg/V/J . NPl   V/C NSg/V . NPl   . V/C W?       P    D/P NSg/V     V/P NSg/V . NPrPl
-> that    mirrored a   dozen suns . Sitting down      behind  many    layers of  glass   in          a   sort
-# N/I/C/D W?       D/P NSg   NPl  . NSg/V/J NSg/V/J/P NSg/J/P N/I/J/D NPl    V/P NPrSg/V NPrSg/V/J/P D/P NSg/V
-> of  green     leather conservatory , we  started to town .
-# V/P NPrSg/V/J NSg/V/J NSg/J        . IPl W?      P  NSg  .
+> and supper  - boxes and tool  - boxes , and terraced with a   labyrinth of wind  - shields
+# V/C NSg/V/J . NPl   V/C NSg/V . NPl   . V/C W?       P    D/P NSg/V     P  NSg/V . NPrPl
+> that    mirrored a   dozen suns . Sitting down      behind  many    layers of glass   in          a   sort
+# N/I/C/D W?       D/P NSg   NPl  . NSg/V/J NSg/V/J/P NSg/J/P N/I/J/D NPl    P  NPrSg/V NPrSg/V/J/P D/P NSg/V
+> of green     leather conservatory , we  started to town .
+# P  NPrSg/V/J NSg/V/J NSg/J        . IPl W?      P  NSg  .
 >
 #
 > I   had talked with him perhaps half      a   dozen times in          the past      month and found , to
 # ISg V   W?     P    I   NSg     NSg/V/J/P D/P NSg   NPl   NPrSg/V/J/P D   NSg/V/J/P NSg   V/C NSg/V . P
 > my disappointment , that    he      had little    to say   . So        my first   impression , that    he
 # D  NSg            . N/I/C/D NPr/ISg V   NPrSg/I/J P  NSg/V . NSg/I/J/C D  NSg/V/J NSg/V      . N/I/C/D NPr/ISg
-> was a   person of  some  undefined consequence , had gradually faded and he      had
-# V   D/P NSg/V  V/P I/J/R V/J       NSg/V       . V   J/R       W?    V/C NPr/ISg V
-> become simply the proprietor of  an  elaborate road  - house   next    door  .
-# V      R      D   NSg        V/P D/P V/J       NSg/J . NPrSg/V NSg/J/P NSg/V .
+> was a   person of some  undefined consequence , had gradually faded and he      had
+# V   D/P NSg/V  P  I/J/R V/J       NSg/V       . V   J/R       W?    V/C NPr/ISg V
+> become simply the proprietor of an  elaborate road  - house   next    door  .
+# V      R      D   NSg        P  D/P V/J       NSg/J . NPrSg/V NSg/J/P NSg/V .
 >
 #
 > And then    came    that    disconcerting ride  . We  hadn’t reached West      Egg   Village before
 # V/C NSg/J/C NSg/V/P N/I/C/D V/J           NSg/V . IPl V      W?      NPrSg/V/J NSg/V NSg     C/P
 > Gatsby began leaving his   elegant sentences unfinished and slapping himself
 # NPr    V     V       ISg/D NSg/J   NPl       V/J        V/C NSg/V/J  I
-> indecisively on  the knee  of  his   caramel - colored    suit  .
-# J/R          J/P D   NSg/V V/P ISg/D NSg/V/J . NSg/V/J/Am NSg/V .
+> indecisively on  the knee  of his   caramel - colored    suit  .
+# J/R          J/P D   NSg/V P  ISg/D NSg/V/J . NSg/V/J/Am NSg/V .
 >
 #
-> “ Look  here    , old   sport , ” he      broke   out         surprisingly , “ what’s your opinion of  me        ,
-# . NSg/V NSg/J/R . NSg/J NSg/V . . NPr/ISg NSg/V/J NSg/V/J/R/P J/R          . . N$     D    NSg/V   V/P NPrSg/ISg .
+> “ Look  here    , old   sport , ” he      broke   out         surprisingly , “ what’s your opinion of me        ,
+# . NSg/V NSg/J/R . NSg/J NSg/V . . NPr/ISg NSg/V/J NSg/V/J/R/P J/R          . . N$     D    NSg/V   P  NPrSg/ISg .
 > anyhow ? ”
 # J      . .
 >
@@ -3888,20 +3888,20 @@
 #
 > “ Well    , I’m going   to tell    you something about my life  , ” he      interrupted . “ I   don’t
 # . NSg/V/J . W?  NSg/V/J P  NPrSg/V IPl NSg/I/V/J J/P   D  NSg/V . . NPr/ISg W?          . . ISg NSg/V
-> want  you to get   a   wrong   idea of  me        from all       these stories you hear . ”
-# NSg/V IPl P  NSg/V D/P NSg/V/J NSg  V/P NPrSg/ISg P    NSg/I/J/C I/D   NPl     IPl V    . .
+> want  you to get   a   wrong   idea of me        from all       these stories you hear . ”
+# NSg/V IPl P  NSg/V D/P NSg/V/J NSg  P  NPrSg/ISg P    NSg/I/J/C I/D   NPl     IPl V    . .
 >
 #
-> So        he      was aware of  the bizarre accusations that    flavored conversation in          his
-# NSg/I/J/C NPr/ISg V   V/J   V/P D   J       NPl         N/I/C/D V/J      NSg/V        NPrSg/V/J/P ISg/D
+> So        he      was aware of the bizarre accusations that    flavored conversation in          his
+# NSg/I/J/C NPr/ISg V   V/J   P  D   J       NPl         N/I/C/D V/J      NSg/V        NPrSg/V/J/P ISg/D
 > halls .
 # NPl   .
 >
 #
 > “ I’ll tell    you God’s truth . ” His   right     hand  suddenly ordered divine    retribution
 # . W?   NPrSg/V IPl N$    NSg/V . . ISg/D NPrSg/V/J NSg/V J/R      V/J     NPrSg/V/J NSg
-> to stand by      . “ I   am        the son     of  some  wealthy people in          the Middle  West      — all       dead
-# P  NSg/V NSg/J/P . . ISg NPrSg/V/J D   NPrSg/V V/P I/J/R NSg/J   NSg/V  NPrSg/V/J/P D   NSg/V/J NPrSg/V/J . NSg/I/J/C NSg/V/J
+> to stand by      . “ I   am        the son     of some  wealthy people in          the Middle  West      — all       dead
+# P  NSg/V NSg/J/P . . ISg NPrSg/V/J D   NPrSg/V P  I/J/R NSg/J   NSg/V  NPrSg/V/J/P D   NSg/V/J NPrSg/V/J . NSg/I/J/C NSg/V/J
 > now         . I   was brought up        in          America but     educated at        Oxford , because all       my
 # NPrSg/V/J/C . ISg V   V       NSg/V/J/P NPrSg/V/J/P NPr     NSg/C/P V/J      NSg/I/V/P NPrSg  . C/P     NSg/I/J/C D
 > ancestors have   been  educated there for many    years . It        is a   family tradition . ”
@@ -3920,8 +3920,8 @@
 # J/P   NSg/I/J/C .
 >
 #
-> “ What  part    of  the Middle  West      ? ” I   inquired casually .
-# . NSg/I NSg/V/J V/P D   NSg/V/J NPrSg/V/J . . ISg W?       J/R      .
+> “ What  part    of the Middle  West      ? ” I   inquired casually .
+# . NSg/I NSg/V/J P  D   NSg/V/J NPrSg/V/J . . ISg W?       J/R      .
 >
 #
 > “ San   Francisco . ”
@@ -3932,20 +3932,20 @@
 # . ISg NSg/V . .
 >
 #
-> “ My family all       died and I   came    into a   good      deal    of  money . ”
-# . D  NSg/J  NSg/I/J/C W?   V/C ISg NSg/V/P P    D/P NPrSg/V/J NSg/V/J V/P NSg/J . .
+> “ My family all       died and I   came    into a   good      deal    of money . ”
+# . D  NSg/J  NSg/I/J/C W?   V/C ISg NSg/V/P P    D/P NPrSg/V/J NSg/V/J P  NSg/J . .
 >
 #
-> His   voice was solemn , as    if    the memory of  that    sudden extinction of  a   clan still
-# ISg/D NSg/V V   J      . NSg/R NSg/C D   NSg    V/P N/I/C/D NSg/J  NSg        V/P D/P NSg  NSg/V/J
+> His   voice was solemn , as    if    the memory of that    sudden extinction of a   clan still
+# ISg/D NSg/V V   J      . NSg/R NSg/C D   NSg    P  N/I/C/D NSg/J  NSg        P  D/P NSg  NSg/V/J
 > haunted him . For a   moment I   suspected that    he      was pulling my leg     , but     a   glance
 # W?      I   . C/P D/P NSg    ISg V/J       N/I/C/D NPr/ISg V   V       D  NSg/V/J . NSg/C/P D/P NSg/V
 > at        him convinced me        otherwise .
 # NSg/I/V/P I   V/J       NPrSg/ISg J         .
 >
 #
-> “ After that    I   lived like        a   young     rajah in          all       the capitals of  Europe — Paris ,
-# . J/P   N/I/C/D ISg W?    NSg/V/J/C/P D/P NPrSg/V/J NSg   NPrSg/V/J/P NSg/I/J/C D   NPl      V/P NPr    . NPr   .
+> “ After that    I   lived like        a   young     rajah in          all       the capitals of Europe — Paris ,
+# . J/P   N/I/C/D ISg W?    NSg/V/J/C/P D/P NPrSg/V/J NSg   NPrSg/V/J/P NSg/I/J/C D   NPl      P  NPr    . NPr   .
 > Venice , Rome — collecting jewels , chiefly rubies , hunting big     game    , painting a
 # NPr    . NPr  . V          NPl    . J/R     NPl    . NSg/V   NSg/V/J NSg/V/J . NSg/V    D/P
 > little    , things for myself only , and trying  to forget something very sad     that    had
@@ -3956,8 +3956,8 @@
 #
 > With an  effort I   managed to restrain my incredulous laughter . The very phrases
 # P    D/P NSg/V  ISg W?      P  NSg/V    D  J           NSg      . D   J    NPl
-> were  worn so        threadbare that    they evoked no      image except that    of  a   turbaned
-# NSg/V V/J  NSg/I/J/C J          N/I/C/D IPl  W?     NPrSg/P NSg/V V/C/P  N/I/C/D V/P D/P W?
+> were  worn so        threadbare that    they evoked no      image except that    of a   turbaned
+# NSg/V V/J  NSg/I/J/C J          N/I/C/D IPl  W?     NPrSg/P NSg/V V/C/P  N/I/C/D P  D/P W?
 > “ character ” leaking sawdust at        every pore  as    he      pursued a   tiger through the Bois
 # . NSg/V     . V       NSg/V   NSg/I/V/P D     NSg/V NSg/R NPr/ISg W?      D/P NSg   NSg/J/P D   ?
 > de    Boulogne .
@@ -3968,18 +3968,18 @@
 # . NSg/J/C NSg/V/P D   NSg/V . NSg/J NSg/V . NPrSg/ISg V   D/P NSg/J NSg/J  . V/C ISg V/J   J    NSg/V/J P
 > die   , but     I   seemed to bear    an  enchanted life  . I   accepted a   commission as    first
 # NSg/V . NSg/C/P ISg W?     P  NSg/V/J D/P W?        NSg/V . ISg V/J      D/P NSg/V      NSg/R NSg/V/J
-> lieutenant when    it        began . In          the Argonne Forest  I   took the remains of  my
-# NSg/J      NSg/I/C NPrSg/ISg V     . NPrSg/V/J/P D   NPr     NPrSg/V ISg V    D   NPl     V/P D
+> lieutenant when    it        began . In          the Argonne Forest  I   took the remains of my
+# NSg/J      NSg/I/C NPrSg/ISg V     . NPrSg/V/J/P D   NPr     NPrSg/V ISg V    D   NPl     P  D
 > machine - gun   battalion so        far     forward that    there was a   half      mile gap     on  either
 # NSg/V   . NSg/V NSg/V     NSg/I/J/C NSg/V/J NSg/V/J N/I/C/D W?    V   D/P NSg/V/J/P NSg  NPrSg/V J/P I/C
-> side    of  us      where the infantry couldn’t advance . We  stayed there two days and two
-# NSg/V/J V/P NPr/ISg NSg/C D   NSg      V        NSg/V/J . IPl W?     W?    NSg NPl  V/C NSg
+> side    of us      where the infantry couldn’t advance . We  stayed there two days and two
+# NSg/V/J P  NPr/ISg NSg/C D   NSg      V        NSg/V/J . IPl W?     W?    NSg NPl  V/C NSg
 > nights , a   hundred and thirty men with sixteen Lewis guns , and when    the infantry
 # NPl    . D/P NSg     V/C NSg    NSg P    N       NPr   NPl  . V/C NSg/I/C D   NSg
-> came    up        at        last    they found the insignia of  three German  divisions among the
-# NSg/V/P NSg/V/J/P NSg/I/V/P NSg/V/J IPl  NSg/V D   NSg      V/P NSg   NPrSg/J NPl       P     D
-> piles of  dead    . I   was promoted to be     a   major     , and every Allied government gave me
-# NPl   V/P NSg/V/J . ISg V   W?       P  NSg/VX D/P NPrSg/V/J . V/C D     W?     NSg        V    NPrSg/ISg
+> came    up        at        last    they found the insignia of three German  divisions among the
+# NSg/V/P NSg/V/J/P NSg/I/V/P NSg/V/J IPl  NSg/V D   NSg      P  NSg   NPrSg/J NPl       P     D
+> piles of dead    . I   was promoted to be     a   major     , and every Allied government gave me
+# NPl   P  NSg/V/J . ISg V   W?       P  NSg/VX D/P NPrSg/V/J . V/C D     W?     NSg        V    NPrSg/ISg
 > a   decoration — even    Montenegro , little    Montenegro down      on  the Adriatic Sea ! ”
 # D/P NSg        . NSg/V/J NPr        . NPrSg/I/J NPr        NSg/V/J/P J/P D   NPr/J    NSg . .
 >
@@ -3988,8 +3988,8 @@
 # NPrSg/I/J NPr        . NPr/ISg W?     NSg/V/J/P D   NPl   V/C V      NSg/I/V/P N/I  . P    ISg/D NSg/V . D
 > smile comprehended Montenegro’s troubled history and sympathized with the brave
 # NSg/V W?           N$           V/J      NSg     V/C W?          P    D   NSg/V/J
-> struggles of  the Montenegrin people . It        appreciated fully the chain of  national
-# NPl       V/P D   NSg/J       NSg/V  . NPrSg/ISg V/J         V     D   NSg/V V/P NSg/J
+> struggles of the Montenegrin people . It        appreciated fully the chain of national
+# NPl       P  D   NSg/J       NSg/V  . NPrSg/ISg V/J         V     D   NSg/V P  NSg/J
 > circumstances which had elicited this tribute from Montenegro’s warm    little
 # NPl           I/C   V   W?       I/D  NSg/V   P    N$           NSg/V/J NPrSg/I/J
 > heart . My incredulity was submerged in          fascination now         ; it        was like        skimming
@@ -3998,8 +3998,8 @@
 # R       NSg/J/P D/P NSg   NPl       .
 >
 #
-> He      reached in          his   pocket  , and a   piece of  metal   , slung on  a   ribbon , fell    into my
-# NPr/ISg W?      NPrSg/V/J/P ISg/D NSg/V/J . V/C D/P NSg/V V/P NSg/V/J . V     J/P D/P NSg/V  . NSg/V/J P    D
+> He      reached in          his   pocket  , and a   piece of metal   , slung on  a   ribbon , fell    into my
+# NPr/ISg W?      NPrSg/V/J/P ISg/D NSg/V/J . V/C D/P NSg/V P  NSg/V/J . V     J/P D/P NSg/V  . NSg/V/J P    D
 > palm  .
 # NSg/V .
 >
@@ -4022,30 +4022,30 @@
 # . NPrSg/V/J NPrSg NPr    . . ISg NSg/V . . C/P NSg/Br NSg/J         . .
 >
 #
-> “ Here’s another thing I   always carry . A   souvenir of  Oxford days . It        was taken in
-# . W?     I/D     NSg/V ISg W?     NSg/V . D/P NSg/V    V/P NPrSg  NPl  . NPrSg/ISg V   V/J   NPrSg/V/J/P
-> Trinity Quad    — the man         on  my left      is now         the Earl  of  Doncaster . ”
-# NPrSg   NSg/V/J . D   NPrSg/I/V/J J/P D  NPrSg/V/J VL NPrSg/V/J/C D   NPrSg V/P ?         . .
+> “ Here’s another thing I   always carry . A   souvenir of Oxford days . It        was taken in
+# . W?     I/D     NSg/V ISg W?     NSg/V . D/P NSg/V    P  NPrSg  NPl  . NPrSg/ISg V   V/J   NPrSg/V/J/P
+> Trinity Quad    — the man         on  my left      is now         the Earl  of Doncaster . ”
+# NPrSg   NSg/V/J . D   NPrSg/I/V/J J/P D  NPrSg/V/J VL NPrSg/V/J/C D   NPrSg P  ?         . .
 >
 #
-> It        was a   photograph of  half      a   dozen young     men in          blazers loafing in          an  archway
-# NPrSg/ISg V   D/P NSg/V      V/P NSg/V/J/P D/P NSg   NPrSg/V/J NSg NPrSg/V/J/P W?      V       NPrSg/V/J/P D/P NSg
-> through which were  visible a   host  of  spires . There was Gatsby , looking a   little    ,
-# NSg/J/P I/C   NSg/V J       D/P NSg/V V/P NPl    . W?    V   NPr    . V       D/P NPrSg/I/J .
+> It        was a   photograph of half      a   dozen young     men in          blazers loafing in          an  archway
+# NPrSg/ISg V   D/P NSg/V      P  NSg/V/J/P D/P NSg   NPrSg/V/J NSg NPrSg/V/J/P W?      V       NPrSg/V/J/P D/P NSg
+> through which were  visible a   host  of spires . There was Gatsby , looking a   little    ,
+# NSg/J/P I/C   NSg/V J       D/P NSg/V P  NPl    . W?    V   NPr    . V       D/P NPrSg/I/J .
 > not   much  , younger — with a   cricket bat   in          his   hand  .
 # NSg/C N/I/J . J       . P    D/P NSg/V   NSg/V NPrSg/V/J/P ISg/D NSg/V .
 >
 #
-> Then    it        was all       true    . I   saw   the skins of  tigers flaming in          his   palace on  the
-# NSg/J/C NPrSg/ISg V   NSg/I/J/C NSg/V/J . ISg NSg/V D   NPl   V/P NPl    V       NPrSg/V/J/P ISg/D NSg/V  J/P D
-> Grand Canal ; I   saw   him opening a   chest of  rubies to ease  , with their
-# NSg/J NSg/V . ISg NSg/V I   NSg/V/J D/P NSg/V V/P NPl    P  NSg/V . P    D
-> crimson - lighted depths , the gnawings of  his   broken heart .
-# NSg/V/J . V/J     NSg    . D   ?        V/P ISg/D V/J    NSg/V .
+> Then    it        was all       true    . I   saw   the skins of tigers flaming in          his   palace on  the
+# NSg/J/C NPrSg/ISg V   NSg/I/J/C NSg/V/J . ISg NSg/V D   NPl   P  NPl    V       NPrSg/V/J/P ISg/D NSg/V  J/P D
+> Grand Canal ; I   saw   him opening a   chest of rubies to ease  , with their
+# NSg/J NSg/V . ISg NSg/V I   NSg/V/J D/P NSg/V P  NPl    P  NSg/V . P    D
+> crimson - lighted depths , the gnawings of his   broken heart .
+# NSg/V/J . V/J     NSg    . D   ?        P  ISg/D V/J    NSg/V .
 >
 #
-> “ I’m going   to make  a   big     request of  you to - day   , ” he      said , pocketing his
-# . W?  NSg/V/J P  NSg/V D/P NSg/V/J NSg/V   V/P IPl P  . NPrSg . . NPr/ISg V/J  . V         ISg/D
+> “ I’m going   to make  a   big     request of you to - day   , ” he      said , pocketing his
+# . W?  NSg/V/J P  NSg/V D/P NSg/V/J NSg/V   P  IPl P  . NPrSg . . NPr/ISg V/J  . V         ISg/D
 > souvenirs with satisfaction , “ so        I   thought you ought    to know  something about me        .
 # NPl       P    NSg          . . NSg/I/J/C ISg NSg/V   IPl NSg/I/VX P  NSg/V NSg/I/V/J J/P   NPrSg/ISg .
 > I   didn’t want  you to think I   was just some  nobody . You see   , I   usually find
@@ -4088,24 +4088,24 @@
 #
 > He      wouldn’t say   another word  . His   correctness grew on  him as    we  neared the city .
 # NPr/ISg VX       NSg/V I/D     NSg/V . ISg/D NSg         V    J/P I   NSg/R IPl W?     D   NSg  .
-> We  passed Port      Roosevelt , where there was a   glimpse of  red   - belted ocean - going
-# IPl W?     NPrSg/V/J NPr       . NSg/C W?    V   D/P NSg/V   V/P NSg/J . W?     NSg   . NSg/V/J
+> We  passed Port      Roosevelt , where there was a   glimpse of red   - belted ocean - going
+# IPl W?     NPrSg/V/J NPr       . NSg/C W?    V   D/P NSg/V   P  NSg/J . W?     NSg   . NSg/V/J
 > ships , and sped  along a   cobbled slum  lined with the dark    , undeserted saloons of
-# NPl   . V/C NSg/V P     D/P W?      NSg/V V/J   P    D   NSg/V/J . ?          NPl     V/P
-> the faded - gilt    nineteen - hundreds . Then    the valley of  ashes opened out         on  both
-# D   W?    . NSg/V/J N        . NPl      . NSg/J/C D   NSg/V  V/P NPl   V/J    NSg/V/J/R/P J/P I/C
-> sides of  us      , and I   had a   glimpse of  Mrs . Wilson straining at        the garage pump
-# NPl   V/P NPr/ISg . V/C ISg V   D/P NSg/V   V/P NPl . NPr    V         NSg/I/V/P D   NSg/V  NSg/V
+# NPl   . V/C NSg/V P     D/P W?      NSg/V V/J   P    D   NSg/V/J . ?          NPl     P
+> the faded - gilt    nineteen - hundreds . Then    the valley of ashes opened out         on  both
+# D   W?    . NSg/V/J N        . NPl      . NSg/J/C D   NSg/V  P  NPl   V/J    NSg/V/J/R/P J/P I/C
+> sides of us      , and I   had a   glimpse of Mrs . Wilson straining at        the garage pump
+# NPl   P  NPr/ISg . V/C ISg V   D/P NSg/V   P  NPl . NPr    V         NSg/I/V/P D   NSg/V  NSg/V
 > with panting vitality as    we  went  by      .
 # P    V       NSg      NSg/R IPl NSg/V NSg/J/P .
 >
 #
 > With fenders spread like        wings we  scattered light   through half      Astoria — only
 # P    W?      NSg/V  NSg/V/J/C/P NPl   IPl W?        NSg/V/J NSg/J/P NSg/V/J/P NPr     . W?
-> half      , for as    we  twisted among the pillars of  the elevated I   heard the familiar
-# NSg/V/J/P . C/P NSg/R IPl W?      P     D   NPl     V/P D   W?       ISg V/J   D   NSg/J
-> “ jug   - jug   - spat  ! ” of  a   motorcycle , and a   frantic policeman rode  alongside .
-# . NSg/V . NSg/V . NSg/V . . V/P D/P NSg/V      . V/C D/P NSg/J   NSg       NSg/V P         .
+> half      , for as    we  twisted among the pillars of the elevated I   heard the familiar
+# NSg/V/J/P . C/P NSg/R IPl W?      P     D   NPl     P  D   W?       ISg V/J   D   NSg/J
+> “ jug   - jug   - spat  ! ” of a   motorcycle , and a   frantic policeman rode  alongside .
+# . NSg/V . NSg/V . NSg/V . . P  D/P NSg/V      . V/C D/P NSg/J   NSg       NSg/V P         .
 >
 #
 > “ All       right     , old   sport , ” called Gatsby . We  slowed down      . Taking  a   white     card  from
@@ -4120,8 +4120,8 @@
 # NPr    . NSg/V  NPrSg/ISg . .
 >
 #
-> “ What  was that    ? ” I   inquired . “ The picture of  Oxford ? ”
-# . NSg/I V   N/I/C/D . . ISg W?       . . D   NSg/V   V/P NPrSg  . .
+> “ What  was that    ? ” I   inquired . “ The picture of Oxford ? ”
+# . NSg/I V   N/I/C/D . . ISg W?       . . D   NSg/V   P  NPrSg  . .
 >
 #
 > “ I   was able    to do     the commissioner a   favor once  , and he      sends me        a   Christmas
@@ -4134,28 +4134,28 @@
 # NSg/V/J/P D   NSg/J NSg/V  . P    D   NSg/V    NSg/J/P D   W?      NSg/V  D/P NSg/J
 > flicker upon the moving  cars , with the city rising    up        across the river   in          white
 # NSg/V/J P    D   NSg/V/J NPl  . P    D   NSg  NSg/V/J/P NSg/V/J/P NSg/P  D   NSg/V/J NPrSg/V/J/P NPrSg/V/J
-> heaps and sugar lumps all       built   with a   wish  out         of  non - olfactory money . The city
-# NPl   V/C NSg/V NPl   NSg/I/J/C NSg/V/J P    D/P NSg/V NSg/V/J/R/P V/P NSg . NSg/J     NSg/J . D   NSg
+> heaps and sugar lumps all       built   with a   wish  out         of non - olfactory money . The city
+# NPl   V/C NSg/V NPl   NSg/I/J/C NSg/V/J P    D/P NSg/V NSg/V/J/R/P P  NSg . NSg/J     NSg/J . D   NSg
 > seen  from the Queensboro Bridge is always the city seen  for the first   time  , in
 # NSg/V P    D   ?          NSg/V  VL W?     D   NSg  NSg/V C/P D   NSg/V/J NSg/V . NPrSg/V/J/P
-> its   first   wild    promise of  all       the mystery and the beauty  in          the world .
-# ISg/D NSg/V/J NSg/V/J NSg/V   V/P NSg/I/J/C D   NSg     V/C D   NSg/V/J NPrSg/V/J/P D   NSg/V .
+> its   first   wild    promise of all       the mystery and the beauty  in          the world .
+# ISg/D NSg/V/J NSg/V/J NSg/V   P  NSg/I/J/C D   NSg     V/C D   NSg/V/J NPrSg/V/J/P D   NSg/V .
 >
 #
 > A   dead    man         passed us      in          a   hearse heaped with blooms , followed by      two carriages
 # D/P NSg/V/J NPrSg/I/V/J W?     NPr/ISg NPrSg/V/J/P D/P NSg/V  W?     P    NPl    . W?       NSg/J/P NSg NPl
 > with drawn blinds , and by      more        cheerful carriages for friends . The friends
 # P    V/J   NPl    . V/C NSg/J/P NPrSg/I/V/J J        NPl       C/P NPl     . D   NPl
-> looked out         at        us      with the tragic eyes and short       upper lips of  southeastern
-# W?     NSg/V/J/R/P NSg/I/V/P NPr/ISg P    D   NSg/J  NPl  V/C NPrSg/V/J/P NSg/J NPl  V/P J
-> Europe , and I   was glad    that    the sight of  Gatsby’s splendid car was included in
-# NPr    . V/C ISg V   NSg/V/J N/I/C/D D   NSg/V V/P N$       J        NSg V   W?       NPrSg/V/J/P
+> looked out         at        us      with the tragic eyes and short       upper lips of southeastern
+# W?     NSg/V/J/R/P NSg/I/V/P NPr/ISg P    D   NSg/J  NPl  V/C NPrSg/V/J/P NSg/J NPl  P  J
+> Europe , and I   was glad    that    the sight of Gatsby’s splendid car was included in
+# NPr    . V/C ISg V   NSg/V/J N/I/C/D D   NSg/V P  N$       J        NSg V   W?       NPrSg/V/J/P
 > their sombre     holiday . As    we  crossed Blackwell’s Island a   limousine passed us      ,
 # D     NSg/V/J/Br NPrSg/V . NSg/R IPl W?      N$          NSg/V  D/P NSg       W?     NPr/ISg .
 > driven by      a   white     chauffeur , in          which sat     three modish negroes , two bucks and a
 # V/J    NSg/J/P D/P NPrSg/V/J NSg/V     . NPrSg/V/J/P I/C   NSg/V/J NSg   J      NSg     . NSg NPl   V/C D/P
-> girl  . I   laughed aloud as    the yolks of  their eyeballs rolled toward us      in          haughty
-# NSg/V . ISg W?      J     NSg/R D   NPl   V/P D     NPl      W?     J/P    NPr/ISg NPrSg/V/J/P J
+> girl  . I   laughed aloud as    the yolks of their eyeballs rolled toward us      in          haughty
+# NSg/V . ISg W?      J     NSg/R D   NPl   P  D     NPl      W?     J/P    NPr/ISg NPrSg/V/J/P J
 > rivalry .
 # NSg     .
 >
@@ -4172,8 +4172,8 @@
 #
 > Roaring noon  . In          a   well    - fanned Forty - second  Street  cellar I   met Gatsby for
 # NSg/V/J NSg/V . NPrSg/V/J/P D/P NSg/V/J . V      NSg/J . NSg/V/J NSg/V/J NSg/V  ISg V   NPr    C/P
-> lunch . Blinking away the brightness of  the street  outside   , my eyes picked him
-# NSg/V . V        V/J  D   NSg        V/P D   NSg/V/J NSg/V/J/P . D  NPl  W?     I
+> lunch . Blinking away the brightness of the street  outside   , my eyes picked him
+# NSg/V . V        V/J  D   NSg        P  D   NSg/V/J NSg/V/J/P . D  NPl  W?     I
 > out         obscurely in          the anteroom , talking to another man         .
 # NSg/V/J/R/P J/R       NPrSg/V/J/P D   NSg      . V       P  I/D     NPrSg/I/V/J .
 >
@@ -4184,8 +4184,8 @@
 #
 > A   small     , flat    - nosed Jew       raised his   large head      and regarded me        with two fine
 # D/P NPrSg/V/J . NSg/V/J . W?    NPrSg/V/J W?     ISg/D NSg/J NPrSg/V/J V/C W?       NPrSg/ISg P    NSg NSg/V/J
-> growths of  hair  which luxuriated in          either nostril . After a   moment I   discovered
-# NSg     V/P NSg/V I/C   W?         NPrSg/V/J/P I/C    NSg     . J/P   D/P NSg    ISg V
+> growths of hair  which luxuriated in          either nostril . After a   moment I   discovered
+# NSg     P  NSg/V I/C   W?         NPrSg/V/J/P I/C    NSg     . J/P   D/P NSg    ISg V
 > his   tiny  eyes in          the half      - darkness .
 # ISg/D NSg/J NPl  NPrSg/V/J/P D   NSg/V/J/P . NSg      .
 >
@@ -4212,8 +4212,8 @@
 # D/P NPrSg/V NSg/V/C/P NPr/ISg NPl   ISg/D NSg/V . . NPr/ISg NSg/V/J NPrSg/ISg NSg/J/C V/C W?    . .
 >
 #
-> Gatsby took an  arm     of  each of  us      and moved forward into the restaurant ,
-# NPr    V    D/P NSg/V/J V/P D    V/P NPr/ISg V/C V/J   NSg/V/J P    D   NSg        .
+> Gatsby took an  arm     of each of us      and moved forward into the restaurant ,
+# NPr    V    D/P NSg/V/J P  D    P  NPr/ISg V/C V/J   NSg/V/J P    D   NSg        .
 > whereupon Mr  . Wolfshiem swallowed a   new     sentence he      was starting and lapsed into
 # C         NSg . ?         W?        D/P NSg/V/J NSg/V    NPr/ISg V   V        V/C W?     P
 > a   somnambulatory abstraction .
@@ -4236,8 +4236,8 @@
 # W?    . .
 >
 #
-> “ Hot     and small     — yes   , ” said Mr  . Wolfshiem , “ but     full    of  memories . ”
-# . NSg/V/J V/C NPrSg/V/J . NSg/V . . V/J  NSg . ?         . . NSg/C/P NSg/V/J V/P NPl      . .
+> “ Hot     and small     — yes   , ” said Mr  . Wolfshiem , “ but     full    of memories . ”
+# . NSg/V/J V/C NPrSg/V/J . NSg/V . . V/J  NSg . ?         . . NSg/C/P NSg/V/J P  NPl      . .
 >
 #
 > “ What  place is that    ? ” I   asked .
@@ -4252,8 +4252,8 @@
 # . D   NSg/J ?         . . W?      NSg . ?         R        . . V/J    P    NPl   NSg/V/J V/C
 > gone  . Filled with friends gone  now         forever . I   can’t forget so        long      as    I   live the
 # V/J/P . V/J    P    NPl     V/J/P NPrSg/V/J/C NSg/J   . ISg VX    V      NSg/I/J/C NPrSg/V/J NSg/R ISg V/J  D
-> night they shot    Rosy    Rosenthal there . It        was six of  us      at        the table , and Rosy
-# NSg/V IPl  NSg/V/J NSg/V/J NPr       W?    . NPrSg/ISg V   NSg V/P NPr/ISg NSg/I/V/P D   NSg/V . V/C NSg/V/J
+> night they shot    Rosy    Rosenthal there . It        was six of us      at        the table , and Rosy
+# NSg/V IPl  NSg/V/J NSg/V/J NPr       W?    . NPrSg/ISg V   NSg P  NPr/ISg NSg/I/V/P D   NSg/V . V/C NSg/V/J
 > had eat   and drunk   a   lot     all       evening . When    it        was almost morning the waiter  came
 # V   NSg/V V/C NSg/V/J D/P NPrSg/V NSg/I/J/C NSg/V   . NSg/I/C NPrSg/ISg V   NSg    NSg/V   D   NSg/V/J NSg/V/P
 > up        to him with a   funny look  and says somebody wants to speak to him outside   .
@@ -4270,10 +4270,10 @@
 # NPrSg/ISg . NSg/V NSg/V/J/P I/D  NSg/V/J . .
 >
 #
-> “ It        was four o’clock in          the morning then    , and if    we’d of  raised the blinds we’d
-# . NPrSg/ISg V   NSg  W?      NPrSg/V/J/P D   NSg/V   NSg/J/C . V/C NSg/C W?   V/P W?     D   NPl    W?
-> of  seen  daylight . ”
-# V/P NSg/V NSg/V    . .
+> “ It        was four o’clock in          the morning then    , and if    we’d of raised the blinds we’d
+# . NPrSg/ISg V   NSg  W?      NPrSg/V/J/P D   NSg/V   NSg/J/C . V/C NSg/C W?   P  W?     D   NPl    W?
+> of seen  daylight . ”
+# P  NSg/V NSg/V    . .
 >
 #
 > “ Did he      go      ? ” I   asked innocently .
@@ -4290,8 +4290,8 @@
 # NSg/V V/J  . .
 >
 #
-> “ Four of  them were  electrocuted , ” I   said , remembering .
-# . NSg  V/P N/I  NSg/V W?           . . ISg V/J  . V           .
+> “ Four of them were  electrocuted , ” I   said , remembering .
+# . NSg  P  N/I  NSg/V W?           . . ISg V/J  . V           .
 >
 #
 > “ Five , with Becker . ” His   nostrils turned to me        in          an  interested way   . “ I
@@ -4300,8 +4300,8 @@
 # V          W?     V       C/P D/P NSg/J    ?          . .
 >
 #
-> The juxtaposition of  these two remarks was startling . Gatsby answered for me        :
-# D   NSg/V         V/P I/D   NSg NPl     V   NSg/V/J   . NPr    V/J      C/P NPrSg/ISg .
+> The juxtaposition of these two remarks was startling . Gatsby answered for me        :
+# D   NSg/V         P  I/D   NSg NPl     V   NSg/V/J   . NPr    V/J      C/P NPrSg/ISg .
 >
 #
 > “ Oh      , no      , ” he      exclaimed , ‘          ‘          this isn’t the man         . ”
@@ -4322,8 +4322,8 @@
 #
 > A   succulent hash  arrived , and Mr  . Wolfshiem , forgetting the more        sentimental
 # D/P NSg/J     NSg/V W?      . V/C NSg . ?         . NSg/V      D   NPrSg/I/V/J J
-> atmosphere of  the old   Metropole , began to eat   with ferocious delicacy . His   eyes ,
-# NSg        V/P D   NSg/J ?         . V     P  NSg/V P    J         NSg      . ISg/D NPl  .
+> atmosphere of the old   Metropole , began to eat   with ferocious delicacy . His   eyes ,
+# NSg        P  D   NSg/J ?         . V     P  NSg/V P    J         NSg      . ISg/D NPl  .
 > meanwhile , roved very slowly all       around the room    — he      completed the arc       by      turning
 # NSg       . W?    J    J/R    NSg/I/J/C J/P    D   NSg/V/J . NPr/ISg V/J       D   NPrSg/V/J NSg/J/P NSg/V
 > to inspect the people directly behind  . I   think that    , except for my presence , he
@@ -4384,12 +4384,12 @@
 # . NPr/ISg NSg/V P  ?        NSg     NPrSg/V/J/P NPr     . IPl NSg/V ?        NSg     . .
 >
 #
-> “ I’ve heard of  it        . ”
-# . W?   V/J   V/P NPrSg/ISg . .
+> “ I’ve heard of it        . ”
+# . W?   V/J   P  NPrSg/ISg . .
 >
 #
-> “ It’s one       of  the most    famous colleges in          the world . ”
-# . W?   NSg/I/V/J V/P D   NSg/I/J V/J    NPl      NPrSg/V/J/P D   NSg/V . .
+> “ It’s one       of the most    famous colleges in          the world . ”
+# . W?   NSg/I/V/J P  D   NSg/I/J V/J    NPl      NPrSg/V/J/P D   NSg/V . .
 >
 #
 > “ Have   you known   Gatsby for a   long      time  ? ” I   inquired .
@@ -4400,24 +4400,24 @@
 # . J/D     NPl   . . NPr/ISg V/J      NPrSg/V/J/P D/P W?        NSg/J .
 >
 #
-> “ I   made  the pleasure of  his   acquaintance just after the war   . But     I   knew I   had
-# . ISg NSg/V D   NSg/V    V/P ISg/D NSg          V/J  J/P   D   NSg/V . NSg/C/P ISg V    ISg V
-> discovered a   man         of  fine    breeding after I   talked with him an  hour . I   said to
-# V          D/P NPrSg/I/V/J V/P NSg/V/J NSg/V/J  J/P   ISg W?     P    I   D/P NSg  . ISg V/J  P
-> myself : ‘          There’s the kind  of  man         you’d like        to take  home    and introduce to your
-# I      . Unlintable W?      D   NSg/J V/P NPrSg/I/V/J W?    NSg/V/J/C/P P  NSg/V NSg/V/J V/C V         P  D
+> “ I   made  the pleasure of his   acquaintance just after the war   . But     I   knew I   had
+# . ISg NSg/V D   NSg/V    P  ISg/D NSg          V/J  J/P   D   NSg/V . NSg/C/P ISg V    ISg V
+> discovered a   man         of fine    breeding after I   talked with him an  hour . I   said to
+# V          D/P NPrSg/I/V/J P  NSg/V/J NSg/V/J  J/P   ISg W?     P    I   D/P NSg  . ISg V/J  P
+> myself : ‘          There’s the kind  of man         you’d like        to take  home    and introduce to your
+# I      . Unlintable W?      D   NSg/J P  NPrSg/I/V/J W?    NSg/V/J/C/P P  NSg/V NSg/V/J V/C V         P  D
 > mother and sister . ’ ” He      paused . “ I   see   you’re looking at        my cuff  buttons . ”
 # NSg/V  V/C NSg/V  . . . NPr/ISg W?     . . ISg NSg/V W?     V       NSg/I/V/P D  NSg/V NPl     . .
 >
 #
-> I   hadn’t been  looking at        them , but     I   did now         . They were  composed of  oddly
-# ISg V      NSg/V V       NSg/I/V/P N/I  . NSg/C/P ISg V   NPrSg/V/J/C . IPl  NSg/V W?       V/P J/R
-> familiar pieces of  ivory   .
-# NSg/J    NPl    V/P NPrSg/J .
+> I   hadn’t been  looking at        them , but     I   did now         . They were  composed of oddly
+# ISg V      NSg/V V       NSg/I/V/P N/I  . NSg/C/P ISg V   NPrSg/V/J/C . IPl  NSg/V W?       P  J/R
+> familiar pieces of ivory   .
+# NSg/J    NPl    P  NPrSg/J .
 >
 #
-> “ Finest specimens of  human   molars , ” he      informed me        .
-# . W?     NPl       V/P NSg/V/J NPl    . . NPr/ISg V/J      NPrSg/ISg .
+> “ Finest specimens of human   molars , ” he      informed me        .
+# . W?     NPl       P  NSg/V/J NPl    . . NPr/ISg V/J      NPrSg/ISg .
 >
 #
 > “ Well    ! ” I   inspected them . “ That’s a   very interesting idea . ”
@@ -4430,8 +4430,8 @@
 # J/P   NPl   . NPr/ISg NSg/VX V     NSg/I/J/C N/I/J NSg/R NSg/V NSg/I/V/P D/P N$       NSg/V . .
 >
 #
-> When    the subject of  this instinctive trust   returned to the table and sat     down
-# NSg/I/C D   NSg/V/J V/P I/D  J           NSg/V/J W?       P  D   NSg/V V/C NSg/V/J NSg/V/J/P
+> When    the subject of this instinctive trust   returned to the table and sat     down
+# NSg/I/C D   NSg/V/J P  I/D  J           NSg/V/J W?       P  D   NSg/V V/C NSg/V/J NSg/V/J/P
 > Mr  . Wolfshiem drank his   coffee  with a   jerk  and got to his   feet .
 # NSg . ?         NSg/V ISg/D NSg/V/J P    D/P NSg/V V/C V   P  ISg/D NSg  .
 >
@@ -4444,16 +4444,16 @@
 #
 > “ Don’t hurry , Meyer , ” said Gatsby , without enthusiasm . Mr  . Wolfshiem raised his
 # . NSg/V NSg/V . NPr   . . V/J  NPr    . C/P     NSg        . NSg . ?         W?     ISg/D
-> hand  in          a   sort  of  benediction .
-# NSg/V NPrSg/V/J/P D/P NSg/V V/P NSg         .
+> hand  in          a   sort  of benediction .
+# NSg/V NPrSg/V/J/P D/P NSg/V P  NSg         .
 >
 #
 > “ You’re very polite , but     I   belong to another generation , ” he      announced solemnly .
 # . W?     J    V/J    . NSg/C/P ISg V/P    P  I/D     NSg        . . NPr/ISg V/J       J/R      .
 > “ You sit   here    and discuss your sports and your young     ladies and your — ” He
 # . IPl NSg/V NSg/J/R V/C NSg/V   D    NPl    V/C D    NPrSg/V/J NPl    V/C D    . . NPr/ISg
-> supplied an  imaginary noun  with another wave  of  his   hand  . “ As    for me        , I   am        fifty
-# W?       D/P NSg/J     NSg/V P    I/D     NSg/V V/P ISg/D NSg/V . . NSg/R C/P NPrSg/ISg . ISg NPrSg/V/J NSg
+> supplied an  imaginary noun  with another wave  of his   hand  . “ As    for me        , I   am        fifty
+# W?       D/P NSg/J     NSg/V P    I/D     NSg/V P  ISg/D NSg/V . . NSg/R C/P NPrSg/ISg . ISg NPrSg/V/J NSg
 > years old   , and I   won’t impose myself on  you any   longer . ”
 # NPl   NSg/J . V/C ISg V     NSg/V  I      J/P IPl I/R/D NSg/J  . .
 >
@@ -4464,10 +4464,10 @@
 # V   V/J  NSg/I/V  P  V      I   .
 >
 #
-> “ He      becomes very sentimental sometimes , ” explained Gatsby . “ This is one       of  his
-# . NPr/ISg NPl     J    J           R         . . V         NPr    . . I/D  VL NSg/I/V/J V/P ISg/D
-> sentimental days . He’s quite a   character around New     York — a   denizen of  Broadway . ”
-# J           NPl  . N$   NSg   D/P NSg/V     J/P    NSg/V/J NPr  . D/P NSg/V   V/P NPrSg/J  . .
+> “ He      becomes very sentimental sometimes , ” explained Gatsby . “ This is one       of his
+# . NPr/ISg NPl     J    J           R         . . V         NPr    . . I/D  VL NSg/I/V/J P  ISg/D
+> sentimental days . He’s quite a   character around New     York — a   denizen of Broadway . ”
+# J           NPl  . N$   NSg   D/P NSg/V     J/P    NSg/V/J NPr  . D/P NSg/V   P  NPrSg/J  . .
 >
 #
 > “ Who     is he      , anyhow , an  actor ? ”
@@ -4492,16 +4492,16 @@
 # . V/J   D   N$      NSg    . . ISg V/J      .
 >
 #
-> The idea staggered me        . I   remembered , of  course , that    the World’s Series had been
-# D   NSg  W?        NPrSg/ISg . ISg V          . V/P NSg/V  . N/I/C/D D   N$      NSg    V   NSg/V
-> fixed in          1919 , but     if    I   had thought of  it        at        all       I   would  have   thought of  it        as    a
-# V/J   NPrSg/V/J/P #    . NSg/C/P NSg/C ISg V   NSg/V   V/P NPrSg/ISg NSg/I/V/P NSg/I/J/C ISg NSg/VX NSg/VX NSg/V   V/P NPrSg/ISg NSg/R D/P
-> thing that    merely happened , the end   of  some  inevitable chain . It        never occurred
-# NSg/V N/I/C/D J/R    W?       . D   NSg/V V/P I/J/R NSg/J      NSg/V . NPrSg/ISg V     V
-> to me        that    one       man         could  start to play  with the faith of  fifty million
-# P  NPrSg/ISg N/I/C/D NSg/I/V/J NPrSg/I/V/J NSg/VX NSg/V P  NSg/V P    D   NPrSg V/P NSg   N
-> people — with the single  - mindedness of  a   burglar blowing a   safe    .
-# NSg/V  . P    D   NSg/V/J . W?         V/P D/P NSg/V   V       D/P NSg/V/J .
+> The idea staggered me        . I   remembered , of course , that    the World’s Series had been
+# D   NSg  W?        NPrSg/ISg . ISg V          . P  NSg/V  . N/I/C/D D   N$      NSg    V   NSg/V
+> fixed in          1919 , but     if    I   had thought of it        at        all       I   would  have   thought of it        as    a
+# V/J   NPrSg/V/J/P #    . NSg/C/P NSg/C ISg V   NSg/V   P  NPrSg/ISg NSg/I/V/P NSg/I/J/C ISg NSg/VX NSg/VX NSg/V   P  NPrSg/ISg NSg/R D/P
+> thing that    merely happened , the end   of some  inevitable chain . It        never occurred
+# NSg/V N/I/C/D J/R    W?       . D   NSg/V P  I/J/R NSg/J      NSg/V . NPrSg/ISg V     V
+> to me        that    one       man         could  start to play  with the faith of fifty million
+# P  NPrSg/ISg N/I/C/D NSg/I/V/J NPrSg/I/V/J NSg/VX NSg/V P  NSg/V P    D   NPrSg P  NSg   N
+> people — with the single  - mindedness of a   burglar blowing a   safe    .
+# NSg/V  . P    D   NSg/V/J . W?         P  D/P NSg/V   V       D/P NSg/V/J .
 >
 #
 > “ How   did he      happen to do     that    ? ” I   asked after a   minute  .
@@ -4522,8 +4522,8 @@
 #
 > I   insisted on  paying the check   . As    the waiter  brought my change I   caught sight
 # ISg W?       J/P V      D   NSg/V/J . NSg/R D   NSg/V/J V       D  NSg/V  ISg V/J    NSg/V
-> of  Tom     Buchanan across the crowded room    .
-# V/P NPrSg/V NPr      NSg/P  D   V/J     NSg/V/J .
+> of Tom     Buchanan across the crowded room    .
+# P  NPrSg/V NPr      NSg/P  D   V/J     NSg/V/J .
 >
 #
 > “ Come    along with me        for a   minute  , ” I   said ; “ I’ve got to say   hello to some  one       . ”
@@ -4544,14 +4544,14 @@
 # . I/D  VL NSg . NPr    . NSg . NPr      . .
 >
 #
-> They shook   hands briefly , and a   strained , unfamiliar look  of  embarrassment came
-# IPl  NSg/V/J NPl   R       . V/C D/P W?       . NSg/J      NSg/V V/P NSg           NSg/V/P
+> They shook   hands briefly , and a   strained , unfamiliar look  of embarrassment came
+# IPl  NSg/V/J NPl   R       . V/C D/P W?       . NSg/J      NSg/V P  NSg           NSg/V/P
 > over      Gatsby’s face  .
 # NSg/V/J/P N$       NSg/V .
 >
 #
-> “ How’ve you been  , anyhow ? ” demanded Tom     of  me        . “ How’d you happen to come    up        this
-# . ?      IPl NSg/V . J      . . W?       NPrSg/V V/P NPrSg/ISg . . W?    IPl V      P  NSg/V/P NSg/V/J/P I/D
+> “ How’ve you been  , anyhow ? ” demanded Tom     of me        . “ How’d you happen to come    up        this
+# . ?      IPl NSg/V . J      . . W?       NPrSg/V P  NPrSg/ISg . . W?    IPl V      P  NSg/V/P NSg/V/J/P I/D
 > far     to eat   ? ”
 # NSg/V/J P  NSg/V . .
 >
@@ -4582,22 +4582,22 @@
 # P    NSg/V/J NPl  J/P D   NPl   N/I/C/D NSg/V P    D   NSg/J NSg/V/J . ISg V   J/P D/P NSg/V/J
 > plaid   skirt also that    blew    a   little    in          the wind  , and whenever this happened the
 # NSg/V/J NSg/V W?   N/I/C/D NSg/V/J D/P NPrSg/I/J NPrSg/V/J/P D   NSg/V . V/C C        I/D  W?       D
-> red   , white     , and blue    banners in          front   of  all       the houses stretched out         stiff   and
-# NSg/J . NPrSg/V/J . V/C NSg/V/J NPl     NPrSg/V/J/P NSg/V/J V/P NSg/I/J/C D   NPl    W?        NSg/V/J/R/P NSg/V/J V/C
+> red   , white     , and blue    banners in          front   of all       the houses stretched out         stiff   and
+# NSg/J . NPrSg/V/J . V/C NSg/V/J NPl     NPrSg/V/J/P NSg/V/J P  NSg/I/J/C D   NPl    W?        NSg/V/J/R/P NSg/V/J V/C
 > said tut     - tut     - tut     - tut     , in          a   disapproving way   .
 # V/J  NPrSg/V . NPrSg/V . NPrSg/V . NPrSg/V . NPrSg/V/J/P D/P V/J          NSg/J .
 >
 #
-> The largest of  the banners and the largest of  the lawns belonged to Daisy Fay’s
-# D   W?      V/P D   NPl     V/C D   W?      V/P D   NPl   W?       P  NPrSg N$
+> The largest of the banners and the largest of the lawns belonged to Daisy Fay’s
+# D   W?      P  D   NPl     V/C D   W?      P  D   NPl   W?       P  NPrSg N$
 > house   . She was just eighteen , two years older than me        , and by      far     the most
 # NPrSg/V . ISg V   V/J  N        . NSg NPl   J     C/P  NPrSg/ISg . V/C NSg/J/P NSg/V/J D   NSg/I/J
-> popular of  all       the young     girls in          Louisville . She dressed in          white     , and had a
-# NSg/J   V/P NSg/I/J/C D   NPrSg/V/J NPl   NPrSg/V/J/P NPr        . ISg W?      NPrSg/V/J/P NPrSg/V/J . V/C V   D/P
+> popular of all       the young     girls in          Louisville . She dressed in          white     , and had a
+# NSg/J   P  NSg/I/J/C D   NPrSg/V/J NPl   NPrSg/V/J/P NPr        . ISg W?      NPrSg/V/J/P NPrSg/V/J . V/C V   D/P
 > little    white     roadster , and all       day   long      the telephone rang in          her   house   and
 # NPrSg/I/J NPrSg/V/J NSg      . V/C NSg/I/J/C NPrSg NPrSg/V/J D   NSg/V     V    NPrSg/V/J/P I/J/D NPrSg/V V/C
-> excited young     officers from Camp    Taylor demanded the privilege of  monopolizing
-# V/J     NPrSg/V/J W?       P    NSg/V/J NPr    W?       D   NSg/V     V/P V
+> excited young     officers from Camp    Taylor demanded the privilege of monopolizing
+# V/J     NPrSg/V/J W?       P    NSg/V/J NPr    W?       D   NSg/V     P  V
 > her   that    night . “ Anyways , for an  hour ! ”
 # I/J/D N/I/C/D NSg/V . . NPl     . C/P D/P NSg  . .
 >
@@ -4616,8 +4616,8 @@
 # . NSg/V . NPr    . . ISg V/J    J/R          . . V      NSg/V/P NSg/J/R . .
 >
 #
-> I   was flattered that    she wanted to speak to me        , because of  all       the older girls I
-# ISg V   W?        N/I/C/D ISg V/J    P  NSg/V P  NPrSg/ISg . C/P     V/P NSg/I/J/C D   J     NPl   ISg
+> I   was flattered that    she wanted to speak to me        , because of all       the older girls I
+# ISg V   W?        N/I/C/D ISg V/J    P  NSg/V P  NPrSg/ISg . C/P     P  NSg/I/J/C D   J     NPl   ISg
 > admired her   most    . She asked me        if    I   was going   to the Red   Cross       and make
 # W?      I/J/D NSg/I/J . ISg V/J   NPrSg/ISg NSg/C ISg V   NSg/V/J P  D   NSg/J NPrSg/V/J/P V/C NSg/V
 > bandages . I   was . Well    , then    , would  I   tell    them that    she couldn’t come    that    day   ?
@@ -4658,14 +4658,14 @@
 # NSg/J/P D   NSg/J/P NPrSg/V ISg V   NPrSg/V/J P     . NPrSg/V/J NSg/R J    . ISg V   D/P ?     J/P   D
 > armistice , and in          February she was presumably engaged to a   man         from New     Orleans .
 # NPrSg     . V/C NPrSg/V/J/P NPr      ISg V   R          W?      P  D/P NPrSg/I/V/J P    NSg/V/J NPrSg   .
-> In          June she married Tom     Buchanan of  Chicago , with more        pomp  and circumstance
-# NPrSg/V/J/P NPr  ISg NSg/V/J NPrSg/V NPr      V/P NPr     . P    NPrSg/I/V/J NSg/V V/C NSg/V
+> In          June she married Tom     Buchanan of Chicago , with more        pomp  and circumstance
+# NPrSg/V/J/P NPr  ISg NSg/V/J NPrSg/V NPr      P  NPr     . P    NPrSg/I/V/J NSg/V V/C NSg/V
 > than Louisville ever knew before . He      came    down      with a   hundred people in          four
 # C/P  NPr        J    V    C/P    . NPr/ISg NSg/V/P NSg/V/J/P P    D/P NSg     NSg/V  NPrSg/V/J/P NSg
-> private cars , and hired a   whole floor of  the Muhlbach Hotel , and the day   before
-# NSg/V/J NPl  . V/C W?    D/P NSg/J NSg/V V/P D   ?        NSg   . V/C D   NPrSg C/P
-> the wedding he      gave her   a   string of  pearls valued at        three hundred and fifty
-# D   NSg/V   NPr/ISg V    I/J/D D/P NSg/V  V/P NPl    W?     NSg/I/V/P NSg   NSg     V/C NSg
+> private cars , and hired a   whole floor of the Muhlbach Hotel , and the day   before
+# NSg/V/J NPl  . V/C W?    D/P NSg/J NSg/V P  D   ?        NSg   . V/C D   NPrSg C/P
+> the wedding he      gave her   a   string of pearls valued at        three hundred and fifty
+# D   NSg/V   NPr/ISg V    I/J/D D/P NSg/V  P  NPl    W?     NSg/I/V/P NSg   NSg     V/C NSg
 > thousand dollars .
 # NSg      NPl     .
 >
@@ -4674,8 +4674,8 @@
 # ISg V   D/P NSg/V      . ISg NSg/V/P P    I/J/D NSg/V/J NSg/V/J/P D/P NSg  C/P    D   NSg/J  NSg/V  .
 > and found her   lying   on  her   bed   as    lovely  as    the June night in          her   flowered
 # V/C NSg/V I/J/D NSg/V/J J/P I/J/D NSg/V NSg/R NSg/J/R NSg/R D   NPr  NSg/V NPrSg/V/J/P I/J/D W?
-> dress — and as    drunk   as    a   monkey . She had a   bottle of  Sauterne in          one       hand  and a
-# NSg/V . V/C NSg/R NSg/V/J NSg/R D/P NSg/V  . ISg V   D/P NSg/V  V/P ?        NPrSg/V/J/P NSg/I/V/J NSg/V V/C D/P
+> dress — and as    drunk   as    a   monkey . She had a   bottle of Sauterne in          one       hand  and a
+# NSg/V . V/C NSg/R NSg/V/J NSg/R D/P NSg/V  . ISg V   D/P NSg/V  P  ?        NPrSg/V/J/P NSg/I/V/J NSg/V V/C D/P
 > letter in          the other   .
 # NSg/V  NPrSg/V/J/P D   NSg/V/J .
 >
@@ -4696,8 +4696,8 @@
 #
 > “ Here    , deares ’ . ” She groped around in          a   wastebasket she had with her   on  the bed
 # . NSg/J/R . ?      . . . ISg W?     J/P    NPrSg/V/J/P D/P NSg/V       ISg V   P    I/J/D J/P D   NSg/V
-> and pulled out         the string of  pearls . ‘          Take  ’ em      down      - stairs and give  ’ em      back    to
-# V/C W?     NSg/V/J/R/P D   NSg/V  V/P NPl    . Unlintable NSg/V . NSg/I/J NSg/V/J/P . NPl    V/C NSg/V . NSg/I/J NSg/V/J P
+> and pulled out         the string of pearls . ‘          Take  ’ em      down      - stairs and give  ’ em      back    to
+# V/C W?     NSg/V/J/R/P D   NSg/V  P  NPl    . Unlintable NSg/V . NSg/I/J NSg/V/J/P . NPl    V/C NSg/V . NSg/I/J NSg/V/J P
 > whoever they belong to . Tell    ’ em      all       Daisy’s change ’ her   mine    . Say   : ‘          Daisy’s
 # I       IPl  V/P    P  . NPrSg/V . NSg/I/J NSg/I/J/C N$      NSg/V  . I/J/D NSg/I/V . NSg/V . Unlintable N$
 > change ’ her   mine    ! ’ ”
@@ -4706,8 +4706,8 @@
 #
 > She began to cry   — she cried and cried . I   rushed out         and found her   mother’s maid ,
 # ISg V     P  NSg/V . ISg W?    V/C W?    . ISg W?     NSg/V/J/R/P V/C NSg/V I/J/D N$       NSg  .
-> and we  locked the door  and got her   into a   cold  bath  . She wouldn’t let   go      of  the
-# V/C IPl W?     D   NSg/V V/C V   I/J/D P    D/P NSg/J NSg/V . ISg VX       NSg/V NSg/V/J V/P D
+> and we  locked the door  and got her   into a   cold  bath  . She wouldn’t let   go      of the
+# V/C IPl W?     D   NSg/V V/C V   I/J/D P    D/P NSg/J NSg/V . ISg VX       NSg/V NSg/V/J P  D
 > letter . She took it        into the tub   with her   and squeezed it        up        into a   wet     ball    ,
 # NSg/V  . ISg V    NPrSg/ISg P    D   NSg/V P    I/J/D V/C W?       NPrSg/ISg NSg/V/J/P P    D/P NSg/V/J NPrSg/V .
 > and only let   me        leave it        in          the soap  - dish  when    she saw   that    it        was coming  to
@@ -4716,12 +4716,12 @@
 # NPl    NSg/V/J/C/P NPrSg/V .
 >
 #
-> But     she didn’t say   another word  . We  gave her   spirits of  ammonia and put   ice     on
-# NSg/C/P ISg V      NSg/V I/D     NSg/V . IPl V    I/J/D NPl     V/P NSg     V/C NSg/V NPrSg/V J/P
+> But     she didn’t say   another word  . We  gave her   spirits of ammonia and put   ice     on
+# NSg/C/P ISg V      NSg/V I/D     NSg/V . IPl V    I/J/D NPl     P  NSg     V/C NSg/V NPrSg/V J/P
 > her   forehead and hooked her   back    into her   dress , and half      an  hour later , when    we
 # I/J/D NSg      V/C W?     I/J/D NSg/V/J P    I/J/D NSg/V . V/C NSg/V/J/P D/P NSg  J     . NSg/I/C IPl
-> walked out         of  the room    , the pearls were  around her   neck  and the incident was
-# W?     NSg/V/J/R/P V/P D   NSg/V/J . D   NPl    NSg/V J/P    I/J/D NSg/V V/C D   NSg/J    V
+> walked out         of the room    , the pearls were  around her   neck  and the incident was
+# W?     NSg/V/J/R/P P  D   NSg/V/J . D   NPl    NSg/V J/P    I/J/D NSg/V V/C D   NSg/J    V
 > over      . Next    day   at        five o’clock she married Tom     Buchanan without so        much  as    a
 # NSg/V/J/P . NSg/J/P NPrSg NSg/I/V/P NSg  W?      ISg NSg/V/J NPrSg/V NPr      C/P     NSg/I/J/C N/I/J NSg/R D/P
 > shiver  , and started off       on  a   three months ’ trip    to the South     Seas .
@@ -4746,8 +4746,8 @@
 # NSg  J/P   ISg NPrSg/V/J NPrSg NPr     NPrSg/V NSg/V P    D/P NSg/V J/P D   ?       NSg/J NSg/I/V/J
 > night , and ripped a   front   wheel off       his   car . The girl  who     was with him got into
 # NSg/V . V/C V/J    D/P NSg/V/J NSg/V NSg/V/J/P ISg/D NSg . D   NSg/V NPrSg/I V   P    I   V   P
-> the papers , too , because her   arm     was broken — she was one       of  the chambermaids in
-# D   NPl    . W?  . C/P     I/J/D NSg/V/J V   V/J    . ISg V   NSg/I/V/J V/P D   NPl          NPrSg/V/J/P
+> the papers , too , because her   arm     was broken — she was one       of the chambermaids in
+# D   NPl    . W?  . C/P     I/J/D NSg/V/J V   V/J    . ISg V   NSg/I/V/J P  D   NPl          NPrSg/V/J/P
 > the Santa Barbara Hotel .
 # D   NPrSg NPr     NSg   .
 >
@@ -4758,18 +4758,18 @@
 # NSg/V N/I  NSg/I/V/J NSg/V  NPrSg/V/J/P NPr    . V/C J     NPrSg/V/J/P ?         . V/C NSg/J/C IPl  NSg/V/P NSg/V/J
 > to Chicago to settle down      . Daisy was popular in          Chicago , as    you know  . They moved
 # P  NPr     P  NSg/V  NSg/V/J/P . NPrSg V   NSg/J   NPrSg/V/J/P NPr     . NSg/R IPl NSg/V . IPl  V/J
-> with a   fast    crowd , all       of  them young     and rich      and wild    , but     she came    out         with an
-# P    D/P NSg/V/J NSg/V . NSg/I/J/C V/P N/I  NPrSg/V/J V/C NPrSg/V/J V/C NSg/V/J . NSg/C/P ISg NSg/V/P NSg/V/J/R/P P    D/P
+> with a   fast    crowd , all       of them young     and rich      and wild    , but     she came    out         with an
+# P    D/P NSg/V/J NSg/V . NSg/I/J/C P  N/I  NPrSg/V/J V/C NPrSg/V/J V/C NSg/V/J . NSg/C/P ISg NSg/V/P NSg/V/J/R/P P    D/P
 > absolutely perfect reputation . Perhaps because she doesn’t drink . It’s a   great
 # J/R        NSg/V/J NSg        . NSg     C/P     ISg V       NSg/V . W?   D/P NSg/J
 > advantage not   to drink among hard    - drinking people . You can      hold    your tongue ,
 # NSg/V     NSg/C P  NSg/V P     NSg/V/J . V        NSg/V  . IPl NPrSg/VX NSg/V/J D    NSg/V  .
-> and , moreover , you can      time  any   little    irregularity of  your own     so        that
-# V/C . W?       . IPl NPrSg/VX NSg/V I/R/D NPrSg/I/J NSg          V/P D    NSg/V/J NSg/I/J/C N/I/C/D
+> and , moreover , you can      time  any   little    irregularity of your own     so        that
+# V/C . W?       . IPl NPrSg/VX NSg/V I/R/D NPrSg/I/J NSg          P  D    NSg/V/J NSg/I/J/C N/I/C/D
 > everybody else  is so        blind   that    they don’t see   or      care  . Perhaps Daisy never went
 # N/I       N/J/C VL NSg/I/J/C NSg/V/J N/I/C/D IPl  NSg/V NSg/V NPrSg/C NSg/V . NSg     NPrSg V     NSg/V
-> in          for amour at        all       — and yet     there’s something in          that    voice of  hers . . . .
-# NPrSg/V/J/P C/P NSg   NSg/I/V/P NSg/I/J/C . V/C NSg/V/C W?      NSg/I/V/J NPrSg/V/J/P N/I/C/D NSg/V V/P ISg  . . . .
+> in          for amour at        all       — and yet     there’s something in          that    voice of hers . . . .
+# NPrSg/V/J/P C/P NSg   NSg/I/V/P NSg/I/J/C . V/C NSg/V/C W?      NSg/I/V/J NPrSg/V/J/P N/I/C/D NSg/V P  ISg  . . . .
 >
 #
 > Well    , about six weeks ago , she heard the name  Gatsby for the first   time  in
@@ -4790,16 +4790,16 @@
 # NSg/I/C NPr    NPrSg/J V   V/J      NSg/V/J NSg/I/J/C I/D  IPl V   NPrSg/V/J D   NSg   C/P NSg/V/J/P
 > an  hour and were  driving in          a   victoria through Central Park    . The sun     had gone
 # D/P NSg  V/C NSg/V V       NPrSg/V/J/P D/P NPrSg    NSg/J/P NPrSg/J NPrSg/V . D   NPrSg/V V   V/J/P
-> down      behind  the tall  apartments of  the movie stars in          the West      Fifties , and the
-# NSg/V/J/P NSg/J/P D   NSg/J NPl        V/P D   NSg   NPl   NPrSg/V/J/P D   NPrSg/V/J NPl     . V/C D
-> clear   voices of  children , already gathered like        crickets on  the grass   , rose
-# NSg/V/J NPl    V/P NPl      . W?      W?       NSg/V/J/C/P NPl      J/P D   NPrSg/V . NPrSg/V/J
+> down      behind  the tall  apartments of the movie stars in          the West      Fifties , and the
+# NSg/V/J/P NSg/J/P D   NSg/J NPl        P  D   NSg   NPl   NPrSg/V/J/P D   NPrSg/V/J NPl     . V/C D
+> clear   voices of children , already gathered like        crickets on  the grass   , rose
+# NSg/V/J NPl    P  NPl      . W?      W?       NSg/V/J/C/P NPl      J/P D   NPrSg/V . NPrSg/V/J
 > through the hot     twilight :
 # NSg/J/P D   NSg/V/J NSg/V/J  .
 >
 #
-> “ I’m the Sheik  of  Araby . Your love    belongs to me        . At        night when    you’re asleep
-# . W?  D   NSg/Ca V/P NPr   . D    NPrSg/V NPl     P  NPrSg/ISg . NSg/I/V/P NSg/V NSg/I/C W?     J
+> “ I’m the Sheik  of Araby . Your love    belongs to me        . At        night when    you’re asleep
+# . W?  D   NSg/Ca P  NPr   . D    NPrSg/V NPl     P  NPrSg/ISg . NSg/I/V/P NSg/V NSg/I/C W?     J
 > Into your tent  I’ll creep — ”
 # P    D    NSg/V W?   NSg/V . .
 >
@@ -4822,8 +4822,8 @@
 #
 > Then    it        had not   been  merely the stars to which he      had aspired on  that    June
 # NSg/J/C NPrSg/ISg V   NSg/C NSg/V J/R    D   NPl   P  I/C   NPr/ISg V   W?      J/P N/I/C/D NPr
-> night . He      came    alive to me        , delivered suddenly from the womb  of  his   purposeless
-# NSg/V . NPr/ISg NSg/V/P W?    P  NPrSg/ISg . V/J       J/R      P    D   NSg/V V/P ISg/D J
+> night . He      came    alive to me        , delivered suddenly from the womb  of his   purposeless
+# NSg/V . NPr/ISg NSg/V/P W?    P  NPrSg/ISg . V/J       J/R      P    D   NSg/V P  ISg/D J
 > splendor .
 # NSg      .
 >
@@ -4834,8 +4834,8 @@
 # NSg       V/C NSg/J/C NSg/V I   NSg/V/P NSg/V/J/P . .
 >
 #
-> The modesty of  the demand shook   me        . He      had waited five years and bought a
-# D   NSg     V/P D   NSg/V  NSg/V/J NPrSg/ISg . NPr/ISg V   W?     NSg  NPl   V/C NSg/V  D/P
+> The modesty of the demand shook   me        . He      had waited five years and bought a
+# D   NSg     P  D   NSg/V  NSg/V/J NPrSg/ISg . NPr/ISg V   W?     NSg  NPl   V/C NSg/V  D/P
 > mansion where he      dispensed starlight to casual moths — so        that    he      could  “ come
 # NSg     NSg/C NPr/ISg W?        NSg       P  NSg/J  NSg/V . NSg/I/J/C N/I/C/D NPr/ISg NSg/VX . NSg/V/P
 > over      ” some  afternoon to a   stranger’s garden  .
@@ -4870,32 +4870,32 @@
 # . NPrSg/V . .
 >
 #
-> “ I   think he      half      expected her   to wander into one       of  his   parties , some  night , ”
-# . ISg NSg/V NPr/ISg NSg/V/J/P NSg/J    I/J/D P  NSg/V  P    NSg/I/V/J V/P ISg/D NPl     . I/J/R NSg/V . .
+> “ I   think he      half      expected her   to wander into one       of his   parties , some  night , ”
+# . ISg NSg/V NPr/ISg NSg/V/J/P NSg/J    I/J/D P  NSg/V  P    NSg/I/V/J P  ISg/D NPl     . I/J/R NSg/V . .
 > went  on  Jordan , “ but     she never did . Then    he      began asking people casually if    they
 # NSg/V J/P NPr    . . NSg/C/P ISg V     V   . NSg/J/C NPr/ISg V     V      NSg/V  J/R      NSg/C IPl
 > knew her   , and I   was the first   one       he      found . It        was that    night he      sent  for me        at
 # V    I/J/D . V/C ISg V   D   NSg/V/J NSg/I/V/J NPr/ISg NSg/V . NPrSg/ISg V   N/I/C/D NSg/V NPr/ISg NSg/V C/P NPrSg/ISg NSg/I/V/P
 > his   dance , and you should have   heard the elaborate way   he      worked up        to it        . Of
-# ISg/D NSg/V . V/C IPl VX     NSg/VX V/J   D   V/J       NSg/J NPr/ISg W?     NSg/V/J/P P  NPrSg/ISg . V/P
+# ISg/D NSg/V . V/C IPl VX     NSg/VX V/J   D   V/J       NSg/J NPr/ISg W?     NSg/V/J/P P  NPrSg/ISg . P
 > course , I   immediately suggested a   luncheon in          New     York — and I   thought he’d go
 # NSg/V  . ISg J/R         W?        D/P NSg/V    NPrSg/V/J/P NSg/V/J NPr  . V/C ISg NSg/V   W?   NSg/V/J
 > mad   :
 # N/V/J .
 >
 #
-> “ ‘          I   don’t want  to do     anything out         of  the way   ! ’ he      kept saying . ‘          I   want  to see
-# . Unlintable ISg NSg/V NSg/V P  NSg/VX NSg/I/V  NSg/V/J/R/P V/P D   NSg/J . . NPr/ISg V    NSg/V  . Unlintable ISg NSg/V P  NSg/V
+> “ ‘          I   don’t want  to do     anything out         of the way   ! ’ he      kept saying . ‘          I   want  to see
+# . Unlintable ISg NSg/V NSg/V P  NSg/VX NSg/I/V  NSg/V/J/R/P P  D   NSg/J . . NPr/ISg V    NSg/V  . Unlintable ISg NSg/V P  NSg/V
 > her   right     next    door  . ’
 # I/J/D NPrSg/V/J NSg/J/P NSg/V . .
 >
 #
-> “ When    I   said you were  a   particular friend  of  Tom’s , he      started to abandon the
-# . NSg/I/C ISg V/J  IPl NSg/V D/P NSg/J      NPrSg/V V/P N$    . NPr/ISg W?      P  NSg/V   D
+> “ When    I   said you were  a   particular friend  of Tom’s , he      started to abandon the
+# . NSg/I/C ISg V/J  IPl NSg/V D/P NSg/J      NPrSg/V P  N$    . NPr/ISg W?      P  NSg/V   D
 > whole idea . He      doesn’t know  very much  about Tom     , though he      says he’s read  a
 # NSg/J NSg  . NPr/ISg V       NSg/V J    N/I/J J/P   NPrSg/V . V/C    NPr/ISg NPl  N$   NSg/V D/P
-> Chicago paper   for years just on  the chance    of  catching a   glimpse of  Daisy’s
-# NPr     NSg/V/J C/P NPl   V/J  J/P D   NPrSg/V/J V/P V        D/P NSg/V   V/P N$
+> Chicago paper   for years just on  the chance    of catching a   glimpse of Daisy’s
+# NPr     NSg/V/J C/P NPl   V/J  J/P D   NPrSg/V/J P  V        D/P NSg/V   P  N$
 > name  . ”
 # NSg/V . .
 >
@@ -4904,14 +4904,14 @@
 # NPrSg/ISg V   NSg/V/J NPrSg/V/J/C . V/C NSg/R IPl V/J    NSg/J/P D/P NPrSg/I/J NSg/V  ISg NSg/V D  NSg/V/J J/P
 > Jordan’s golden    shoulder and drew  her   toward me        and asked her   to dinner .
 # N$       NPrSg/V/J NSg/V    V/C NPr/V I/J/D J/P    NPrSg/ISg V/C V/J   I/J/D P  NSg/V  .
-> Suddenly I   wasn’t thinking of  Daisy and Gatsby any   more        , but     of  this clean   ,
-# J/R      ISg V      V        V/P NPrSg V/C NPr    I/R/D NPrSg/I/V/J . NSg/C/P V/P I/D  NSg/V/J .
+> Suddenly I   wasn’t thinking of Daisy and Gatsby any   more        , but     of this clean   ,
+# J/R      ISg V      V        P  NPrSg V/C NPr    I/R/D NPrSg/I/V/J . NSg/C/P P  I/D  NSg/V/J .
 > hard    , limited person , who     dealt in          universal scepticism , and who     leaned back
 # NSg/V/J . NSg/V/J NSg/V  . NPrSg/I V     NPrSg/V/J/P NSg/J     NSg/Br     . V/C NPrSg/I W?     NSg/V/J
-> jauntily just within the circle of  my arm     . A   phrase began to beat    in          my ears
-# R        V/J  N/J/P  D   NSg/V  V/P D  NSg/V/J . D/P NSg/V  V     P  NSg/V/J NPrSg/V/J/P D  NPl
-> with a   sort  of  heady excitement : ‘          ‘          There are only the pursued , the pursuing , the
-# P    D/P NSg/V V/P J     NSg        . Unlintable Unlintable W?    V   W?   D   W?      . D   V        . D
+> jauntily just within the circle of my arm     . A   phrase began to beat    in          my ears
+# R        V/J  N/J/P  D   NSg/V  P  D  NSg/V/J . D/P NSg/V  V     P  NSg/V/J NPrSg/V/J/P D  NPl
+> with a   sort  of heady excitement : ‘          ‘          There are only the pursued , the pursuing , the
+# P    D/P NSg/V P  J     NSg        . Unlintable Unlintable W?    V   W?   D   W?      . D   V        . D
 > busy    and the tired . ”
 # NSg/V/J V/C D   V/J   . .
 >
@@ -4930,10 +4930,10 @@
 # V/J      P  NSg/V  I/J/D P  NSg/V . .
 >
 #
-> We  passed a   barrier of  dark    trees , and then    the façade of  Fifty - ninth   Street  , a
-# IPl W?     D/P NSg/V   V/P NSg/V/J NPl   . V/C NSg/J/C D   ?      V/P NSg   . NSg/V/J NSg/V/J . D/P
-> block of  delicate pale    light   , beamed down      into the park    . Unlike    Gatsby and Tom
-# NSg/V V/P NSg/J    NSg/V/J NSg/V/J . W?     NSg/V/J/P P    D   NPrSg/V . NSg/V/J/P NPr    V/C NPrSg/V
+> We  passed a   barrier of dark    trees , and then    the façade of Fifty - ninth   Street  , a
+# IPl W?     D/P NSg/V   P  NSg/V/J NPl   . V/C NSg/J/C D   ?      P  NSg   . NSg/V/J NSg/V/J . D/P
+> block of delicate pale    light   , beamed down      into the park    . Unlike    Gatsby and Tom
+# NSg/V P  NSg/J    NSg/V/J NSg/V/J . W?     NSg/V/J/P P    D   NPrSg/V . NSg/V/J/P NPr    V/C NPrSg/V
 > Buchanan , I   had no      girl  whose disembodied face  floated along the dark    cornices
 # NPr      . ISg V   NPrSg/P NSg/V I     W?          NSg/V W?      P     D   NSg/V/J NPl
 > and blinding signs , and so        I   drew  up        the girl  beside me        , tightening my arms . Her
@@ -4950,8 +4950,8 @@
 #
 > When    I   came    home    to West      Egg   that    night I   was afraid for a   moment that    my house
 # NSg/I/C ISg NSg/V/P NSg/V/J P  NPrSg/V/J NSg/V N/I/C/D NSg/V ISg V   J      C/P D/P NSg    N/I/C/D D  NPrSg/V
-> was on  fire    . Two o’clock and the whole corner  of  the peninsula was blazing with
-# V   J/P NSg/V/J . NSg W?      V/C D   NSg/J NSg/V/J V/P D   NSg       V   V/J     P
+> was on  fire    . Two o’clock and the whole corner  of the peninsula was blazing with
+# V   J/P NSg/V/J . NSg W?      V/C D   NSg/J NSg/V/J P  D   NSg       V   V/J     P
 > light   , which fell    unreal on  the shrubbery and made  thin    elongating glints upon
 # NSg/V/J . I/C   NSg/V/J J      J/P D   NSg       V/C NSg/V NSg/V/J V          NPl    P
 > the roadside wires . Turning a   corner  , I   saw   that    it        was Gatsby’s house   , lit     from
@@ -4980,16 +4980,16 @@
 #
 > “ Does  it        ? ” He      turned his   eyes toward it        absently . “ I   have   been  glancing into
 # . NSg/V NPrSg/ISg . . NPr/ISg W?     ISg/D NPl  J/P    NPrSg/ISg J/R      . . ISg NSg/VX NSg/V V        P
-> some  of  the rooms . Let’s go      to Coney Island , old   sport . In          my car . ”
-# I/J/R V/P D   NPl   . N$    NSg/V/J P  ?     NSg/V  . NSg/J NSg/V . NPrSg/V/J/P D  NSg . .
+> some  of the rooms . Let’s go      to Coney Island , old   sport . In          my car . ”
+# I/J/R P  D   NPl   . N$    NSg/V/J P  ?     NSg/V  . NSg/J NSg/V . NPrSg/V/J/P D  NSg . .
 >
 #
 > “ It’s too late  . ”
 # . W?   W?  NSg/J . .
 >
 #
-> “ Well    , suppose we  take  a   plunge in          the swimming - pool  ? I   haven’t made  use   of  it
-# . NSg/V/J . V       IPl NSg/V D/P NSg/V  NPrSg/V/J/P D   NSg/V    . NSg/V . ISg V       NSg/V NSg/V V/P NPrSg/ISg
+> “ Well    , suppose we  take  a   plunge in          the swimming - pool  ? I   haven’t made  use   of it
+# . NSg/V/J . V       IPl NSg/V D/P NSg/V  NPrSg/V/J/P D   NSg/V    . NSg/V . ISg V       NSg/V NSg/V P  NPrSg/ISg
 > all       summer  . ”
 # NSg/I/J/C NPrSg/V . .
 >
@@ -5042,8 +5042,8 @@
 #
 > We  both looked down      at        the grass   — there was a   sharp     line  where my ragged lawn
 # IPl I/C  W?     NSg/V/J/P NSg/I/V/P D   NPrSg/V . W?    V   D/P NPrSg/V/J NSg/V NSg/C D  V/J    NSg/V
-> ended and the darker , well    - kept expanse of  his   began . I   suspected that    he      meant
-# W?    V/C D   J      . NSg/V/J . V    NSg     V/P ISg/D V     . ISg V/J       N/I/C/D NPr/ISg V
+> ended and the darker , well    - kept expanse of his   began . I   suspected that    he      meant
+# W?    V/C D   J      . NSg/V/J . V    NSg     P  ISg/D V     . ISg V/J       N/I/C/D NPr/ISg V
 > my grass   .
 # D  NPrSg/V .
 >
@@ -5056,8 +5056,8 @@
 # . NSg/VX IPl NPrSg/V/J NSg/V NPrSg/ISg NSg/V/J/P C/P D/P N/I NPl  . . ISg V/J   .
 >
 #
-> “ Oh      , it        isn’t about that    . At        least — ’ ’ He      fumbled with a   series of  beginnings .
-# . NPrSg/V . NPrSg/ISg NSg/V J/P   N/I/C/D . NSg/I/V/P NSg/J . . . NPr/ISg W?      P    D/P NSg    V/P NPl        .
+> “ Oh      , it        isn’t about that    . At        least — ’ ’ He      fumbled with a   series of beginnings .
+# . NPrSg/V . NPrSg/ISg NSg/V J/P   N/I/C/D . NSg/I/V/P NSg/J . . . NPr/ISg W?      P    D/P NSg    P  NPl        .
 > “ Why   , I   thought — why   , look  here    , old   sport , you don’t make  much  money , do     you ? ”
 # . NSg/V . ISg NSg/V   . NSg/V . NSg/V NSg/J/R . NSg/J NSg/V . IPl NSg/V NSg/V N/I/J NSg/J . NSg/VX IPl . .
 >
@@ -5072,8 +5072,8 @@
 #
 > “ I   thought you didn’t , if    you'll pardon my — you see   , I   carry on  a   little    business
 # . ISg NSg/V   IPl V      . NSg/C W?     NSg/V  D  . IPl NSg/V . ISg NSg/V J/P D/P NPrSg/I/J NSg/J
-> on  the side    , a   sort  of  side    line  , you understand . And I   thought that    if    you
-# J/P D   NSg/V/J . D/P NSg/V V/P NSg/V/J NSg/V . IPl V          . V/C ISg NSg/V   N/I/C/D NSg/C IPl
+> on  the side    , a   sort  of side    line  , you understand . And I   thought that    if    you
+# J/P D   NSg/V/J . D/P NSg/V P  NSg/V/J NSg/V . IPl V          . V/C ISg NSg/V   N/I/C/D NSg/C IPl
 > don’t make  very much  — You’re selling bonds , aren’t you , old   sport ? ”
 # NSg/V NSg/V J    N/I/J . W?     V       NPl   . V      IPl . NSg/J NSg/V . .
 >
@@ -5082,18 +5082,18 @@
 # . NSg/V/J P  . .
 >
 #
-> “ Well    , this would  interest you . It        wouldn’t take  up        much  of  your time  and you
-# . NSg/V/J . I/D  NSg/VX NSg/V    IPl . NPrSg/ISg VX       NSg/V NSg/V/J/P N/I/J V/P D    NSg/V V/C IPl
-> might    pick  up        a   nice      bit   of  money . It        happens to be     a   rather    confidential sort
-# NSg/VX/J NSg/V NSg/V/J/P D/P NPrSg/V/J NSg/V V/P NSg/J . NPrSg/ISg NPl     P  NSg/VX D/P NPrSg/V/J J            NSg/V
-> of  thing . ”
-# V/P NSg/V . .
+> “ Well    , this would  interest you . It        wouldn’t take  up        much  of your time  and you
+# . NSg/V/J . I/D  NSg/VX NSg/V    IPl . NPrSg/ISg VX       NSg/V NSg/V/J/P N/I/J P  D    NSg/V V/C IPl
+> might    pick  up        a   nice      bit   of money . It        happens to be     a   rather    confidential sort
+# NSg/VX/J NSg/V NSg/V/J/P D/P NPrSg/V/J NSg/V P  NSg/J . NPrSg/ISg NPl     P  NSg/VX D/P NPrSg/V/J J            NSg/V
+> of thing . ”
+# P  NSg/V . .
 >
 #
 > I   realize now         that    under   different circumstances that    conversation might    have
 # ISg V       NPrSg/V/J/C N/I/C/D NSg/J/P NSg/J     NPl           N/I/C/D NSg/V        NSg/VX/J NSg/VX
-> been  one       of  the crises of  my life  . But     , because the offer   was obviously and
-# NSg/V NSg/I/V/J V/P D   NSg    V/P D  NSg/V . NSg/C/P . C/P     D   NSg/V/J V   J/R       V/C
+> been  one       of the crises of my life  . But     , because the offer   was obviously and
+# NSg/V NSg/I/V/J P  D   NSg    P  D  NSg/V . NSg/C/P . C/P     D   NSg/V/J V   J/R       V/C
 > tactlessly for a   service to be     rendered , I   had no      choice except to cut     him off
 # J/R        C/P D/P NSg/V   P  NSg/VX W?       . ISg V   NPrSg/P NSg/J  V/C/P  P  NSg/V/J I   NSg/V/J/P
 > there .
@@ -5163,7 +5163,7 @@
 > door  opened nervously , and Gatsby , in          a   white     flannel suit  , silver  shirt , and
 # NSg/V V/J    J/R       . V/C NPr    . NPrSg/V/J/P D/P NPrSg/V/J NSg/V/J NSg/V . NSg/V/J NSg/V . V/C
 > gold    - colored    tie   , hurried in          . He      was pale    , and there were  dark    signs of
-# NSg/V/J . NSg/V/J/Am NSg/V . V/J     NPrSg/V/J/P . NPr/ISg V   NSg/V/J . V/C W?    NSg/V NSg/V/J NPl   V/P
+# NSg/V/J . NSg/V/J/Am NSg/V . V/J     NPrSg/V/J/P . NPr/ISg V   NSg/V/J . V/C W?    NSg/V NSg/V/J NPl   P
 > sleeplessness beneath his   eyes .
 # NSg           P       ISg/D NPl  .
 >
@@ -5184,12 +5184,12 @@
 # NSg/V .
 >
 #
-> “ Looks very good      , ” he      remarked vaguely . “ One       of  the papers said they thought the
-# . NPl   J    NPrSg/V/J . . NPr/ISg V/J      J/R     . . NSg/I/V/J V/P D   NPl    V/J  IPl  NSg/V   D
+> “ Looks very good      , ” he      remarked vaguely . “ One       of the papers said they thought the
+# . NPl   J    NPrSg/V/J . . NPr/ISg V/J      J/R     . . NSg/I/V/J P  D   NPl    V/J  IPl  NSg/V   D
 > rain  would  stop  about four . I   think it        was The Journal . Have   you got everything
 # NSg/V NSg/VX NSg/V J/P   NSg  . ISg NSg/V NPrSg/ISg V   D   NSg/V/J . NSg/VX IPl V   N/I/V
-> you need   in          the shape of  — of  tea   ? ”
-# IPl NSg/VX NPrSg/V/J/P D   NSg/V V/P . V/P NSg/V . .
+> you need   in          the shape of — of tea   ? ”
+# IPl NSg/VX NPrSg/V/J/P D   NSg/V P  . P  NSg/V . .
 >
 #
 > I   took him into the pantry , where he      looked a   little    reproachfully at        the Finn  .
@@ -5202,18 +5202,18 @@
 # . NPrSg/VX IPl  NSg/VX . . ISg V/J   .
 >
 #
-> “ Of  course , of  course ! They’re fine    ! ” and he      added hollowly , “ . . . old   sport . ”
-# . V/P NSg/V  . V/P NSg/V  . W?      NSg/V/J . . V/C NPr/ISg W?    J/R      . . . . . NSg/J NSg/V . .
+> “ Of course , of course ! They’re fine    ! ” and he      added hollowly , “ . . . old   sport . ”
+# . P  NSg/V  . P  NSg/V  . W?      NSg/V/J . . V/C NPr/ISg W?    J/R      . . . . . NSg/J NSg/V . .
 >
 #
 > The rain  cooled about half      - past      three to a   damp    mist  , through which occasional
 # D   NSg/V W?     J/P   NSg/V/J/P . NSg/V/J/P NSg   P  D/P NSg/V/J NSg/V . NSg/J/P I/C   NSg/J
 > thin    drops swam like        dew   . Gatsby looked with vacant eyes through a   copy  of
-# NSg/V/J NPl   V    NSg/V/J/C/P NSg/V . NPr    W?     P    J      NPl  NSg/J/P D/P NSg/V V/P
+# NSg/V/J NPl   V    NSg/V/J/C/P NSg/V . NPr    W?     P    J      NPl  NSg/J/P D/P NSg/V P
 > Clay’s “ Economics , ” starting at        the Finnish tread that    shook   the kitchen floor ,
 # N$     . NSg       . . V        NSg/I/V/P D   NSg/J   NSg/V N/I/C/D NSg/V/J D   NSg/V   NSg/V .
 > and peering toward the bleared windows from time  to time  as    if    a   series of
-# V/C V       J/P    D   ?       NPrPl   P    NSg/V P  NSg/V NSg/R NSg/C D/P NSg    V/P
+# V/C V       J/P    D   ?       NPrPl   P    NSg/V P  NSg/V NSg/R NSg/C D/P NSg    P
 > invisible but     alarming happenings were  taking  place outside   . Finally he      got up
 # J         NSg/C/P V/J      W?         NSg/V NSg/V/J NSg/V NSg/V/J/P . J/R     NPr/ISg V   NSg/V/J/P
 > and informed me        , in          an  uncertain voice , that    he      was going   home    .
@@ -5236,8 +5236,8 @@
 #
 > He      sat     down      miserably , as    if    I   had pushed him , and simultaneously there was the
 # NPr/ISg NSg/V/J NSg/V/J/P R         . NSg/R NSg/C ISg V   W?     I   . V/C J/R            W?    V   D
-> sound   of  a   motor   turning into my lane  . We  both jumped up        , and , a   little    harrowed
-# NSg/V/J V/P D/P NSg/V/J NSg/V   P    D  NPrSg . IPl I/C  W?     NSg/V/J/P . V/C . D/P NPrSg/I/J W?
+> sound   of a   motor   turning into my lane  . We  both jumped up        , and , a   little    harrowed
+# NSg/V/J P  D/P NSg/V/J NSg/V   P    D  NPrSg . IPl I/C  W?     NSg/V/J/P . V/C . D/P NPrSg/I/J W?
 > myself , I   went  out         into the yard  .
 # I      . ISg NSg/V NSg/V/J/R/P P    D   NSg/V .
 >
@@ -5254,12 +5254,12 @@
 # . VL I/D  J/R        NSg/C IPl V/J  . D  NSg/J   NSg/I/V/J . .
 >
 #
-> The exhilarating ripple of  her   voice was a   wild    tonic   in          the rain  . I   had to
-# D   V            NSg/V  V/P I/J/D NSg/V V   D/P NSg/V/J NSg/V/J NPrSg/V/J/P D   NSg/V . ISg V   P
-> follow the sound   of  it        for a   moment , up        and down      , with my ear   alone , before any
-# NSg/V  D   NSg/V/J V/P NPrSg/ISg C/P D/P NSg    . NSg/V/J/P V/C NSg/V/J/P . P    D  NSg/V J     . C/P    I/R/D
-> words came    through . A   damp    streak of  hair  lay     like        a   dash  of  blue    paint across
-# NPl   NSg/V/P NSg/J/P . D/P NSg/V/J NSg/V  V/P NSg/V NSg/V/J NSg/V/J/C/P D/P NSg/V V/P NSg/V/J NSg/V NSg/P
+> The exhilarating ripple of her   voice was a   wild    tonic   in          the rain  . I   had to
+# D   V            NSg/V  P  I/J/D NSg/V V   D/P NSg/V/J NSg/V/J NPrSg/V/J/P D   NSg/V . ISg V   P
+> follow the sound   of it        for a   moment , up        and down      , with my ear   alone , before any
+# NSg/V  D   NSg/V/J P  NPrSg/ISg C/P D/P NSg    . NSg/V/J/P V/C NSg/V/J/P . P    D  NSg/V J     . C/P    I/R/D
+> words came    through . A   damp    streak of hair  lay     like        a   dash  of blue    paint across
+# NPl   NSg/V/P NSg/J/P . D/P NSg/V/J NSg/V  P  NSg/V NSg/V/J NSg/V/J/C/P D/P NSg/V P  NSg/V/J NSg/V NSg/P
 > her   cheek , and her   hand  was wet     with glistening drops as    I   took it        to help  her
 # I/J/D NSg/V . V/C I/J/D NSg/V V   NSg/V/J P    V          NPl   NSg/R ISg V    NPrSg/ISg P  NSg/V I/J/D
 > from the car .
@@ -5272,8 +5272,8 @@
 # J     . .
 >
 #
-> “ That’s the secret  of  Castle Rackrent . Tell    your chauffeur to go      far     away and
-# . N$     D   NSg/V/J V/P NSg/V  ?        . NPrSg/V D    NSg/V     P  NSg/V/J NSg/V/J V/J  V/C
+> “ That’s the secret  of Castle Rackrent . Tell    your chauffeur to go      far     away and
+# . N$     D   NSg/V/J P  NSg/V  ?        . NPrSg/V D    NSg/V     P  NSg/V/J NSg/V/J V/J  V/C
 > spend an  hour . ”
 # NSg/V D/P NSg  . .
 >
@@ -5306,8 +5306,8 @@
 # ISg W?     I/J/D NPrSg/V/J NSg/R W?    V   D/P NSg/V/J V/J       V        NSg/I/V/P D   NSg/V/J NSg/V . ISg
 > went  out         and opened it        . Gatsby , pale    as    death , with his   hands plunged like
 # NSg/V NSg/V/J/R/P V/C V/J    NPrSg/ISg . NPr    . NSg/V/J NSg/R NPrSg . P    ISg/D NPl   W?      NSg/V/J/C/P
-> weights in          his   coat  pockets , was standing in          a   puddle of  water glaring
-# NPl     NPrSg/V/J/P ISg/D NSg/V NPl     . V   NSg/V/J  NPrSg/V/J/P D/P NSg/V  V/P NSg/V NSg/V/J
+> weights in          his   coat  pockets , was standing in          a   puddle of water glaring
+# NPl     NPrSg/V/J/P ISg/D NSg/V NPl     . V   NSg/V/J  NPrSg/V/J/P D/P NSg/V  P  NSg/V NSg/V/J
 > tragically into my eyes .
 # R          P    D  NPl  .
 >
@@ -5316,16 +5316,16 @@
 # P    ISg/D NPl   NSg/V/J NPrSg/V/J/P ISg/D NSg/V NPl     NPr/ISg W?      NSg/J/P NPrSg/ISg P    D   NPrSg . W?
 > sharply as    if    he      were  on  a   wire  , and disappeared into the living  - room    . It        wasn’t
 # J/R     NSg/R NSg/C NPr/ISg NSg/V J/P D/P NSg/V . V/C W?          P    D   NSg/V/J . NSg/V/J . NPrSg/ISg V
-> a   bit   funny . Aware of  the loud  beating of  my own     heart I   pulled the door  to
-# D/P NSg/V NSg/J . V/J   V/P D   NSg/J NSg/V   V/P D  NSg/V/J NSg/V ISg W?     D   NSg/V P
+> a   bit   funny . Aware of the loud  beating of my own     heart I   pulled the door  to
+# D/P NSg/V NSg/J . V/J   P  D   NSg/J NSg/V   P  D  NSg/V/J NSg/V ISg W?     D   NSg/V P
 > against the increasing rain  .
 # C/P     D   NSg/V/J    NSg/V .
 >
 #
 > For half      a   minute  there wasn’t a   sound   . Then    from the living  - room    I   heard a   sort
 # C/P NSg/V/J/P D/P NSg/V/J W?    V      D/P NSg/V/J . NSg/J/C P    D   NSg/V/J . NSg/V/J ISg V/J   D/P NSg/V
-> of  choking murmur and part    of  a   laugh , followed by      Daisy’s voice on  a   clear
-# V/P V       NSg/V  V/C NSg/V/J V/P D/P NSg/V . W?       NSg/J/P N$      NSg/V J/P D/P NSg/V/J
+> of choking murmur and part    of a   laugh , followed by      Daisy’s voice on  a   clear
+# P  V       NSg/V  V/C NSg/V/J P  D/P NSg/V . W?       NSg/J/P N$      NSg/V J/P D/P NSg/V/J
 > artificial note  :
 # J          NSg/V .
 >
@@ -5342,26 +5342,26 @@
 #
 > Gatsby , his   hands still   in          his   pockets , was reclining against the mantelpiece in
 # NPr    . ISg/D NPl   NSg/V/J NPrSg/V/J/P ISg/D NPl     . V   V         C/P     D   NSg         NPrSg/V/J/P
-> a   strained counterfeit of  perfect ease  , even    of  boredom . His   head      leaned back    so
-# D/P W?       NSg/V/J     V/P NSg/V/J NSg/V . NSg/V/J V/P NSg     . ISg/D NPrSg/V/J W?     NSg/V/J NSg/I/J/C
-> far     that    it        rested against the face  of  a   defunct mantelpiece clock , and from
-# NSg/V/J N/I/C/D NPrSg/ISg W?     C/P     D   NSg/V V/P D/P NSg/V/J NSg         NSg/V . V/C P
+> a   strained counterfeit of perfect ease  , even    of boredom . His   head      leaned back    so
+# D/P W?       NSg/V/J     P  NSg/V/J NSg/V . NSg/V/J P  NSg     . ISg/D NPrSg/V/J W?     NSg/V/J NSg/I/J/C
+> far     that    it        rested against the face  of a   defunct mantelpiece clock , and from
+# NSg/V/J N/I/C/D NPrSg/ISg W?     C/P     D   NSg/V P  D/P NSg/V/J NSg         NSg/V . V/C P
 > this position his   distraught eyes stared down      at        Daisy , who     was sitting ,
 # I/D  NSg/V    ISg/D J          NPl  W?     NSg/V/J/P NSg/I/V/P NPrSg . NPrSg/I V   NSg/V/J .
-> frightened but     graceful , on  the edge  of  a   stiff   chair .
-# W?         NSg/C/P J        . J/P D   NSg/V V/P D/P NSg/V/J NSg/V .
+> frightened but     graceful , on  the edge  of a   stiff   chair .
+# W?         NSg/C/P J        . J/P D   NSg/V P  D/P NSg/V/J NSg/V .
 >
 #
 > “ We've met before , ” muttered Gatsby . His   eyes glanced momentarily at        me        , and his
 # . W?    V   C/P    . . W?       NPr    . ISg/D NPl  W?      R           NSg/I/V/P NPrSg/ISg . V/C ISg/D
 > lips parted with an  abortive attempt at        a   laugh . Luckily the clock took this
 # NPl  W?     P    D/P NSg/V/J  NSg/V   NSg/I/V/P D/P NSg/V . R       D   NSg/V V    I/D
-> moment to tilt  dangerously at        the pressure of  his   head      , whereupon he      turned and
-# NSg    P  NSg/V J/R         NSg/I/V/P D   NSg/V    V/P ISg/D NPrSg/V/J . C         NPr/ISg W?     V/C
+> moment to tilt  dangerously at        the pressure of his   head      , whereupon he      turned and
+# NSg    P  NSg/V J/R         NSg/I/V/P D   NSg/V    P  ISg/D NPrSg/V/J . C         NPr/ISg W?     V/C
 > caught it        with trembling fingers , and set       it        back    in          place . Then    he      sat     down      ,
 # V/J    NPrSg/ISg P    V         NPl     . V/C NPrSg/V/J NPrSg/ISg NSg/V/J NPrSg/V/J/P NSg/V . NSg/J/C NPr/ISg NSg/V/J NSg/V/J/P .
-> rigidly , his   elbow on  the arm     of  the sofa  and his   chin    in          his   hand  .
-# J/R     . ISg/D NSg/V J/P D   NSg/V/J V/P D   NSg/V V/C ISg/D NPrSg/V NPrSg/V/J/P ISg/D NSg/V .
+> rigidly , his   elbow on  the arm     of the sofa  and his   chin    in          his   hand  .
+# J/R     . ISg/D NSg/V J/P D   NSg/V/J P  D   NSg/V V/C ISg/D NPrSg/V NPrSg/V/J/P ISg/D NSg/V .
 >
 #
 > “ I’m sorry   about the clock , ” he      said .
@@ -5370,8 +5370,8 @@
 #
 > My own     face  had now         assumed a   deep  tropical burn  . I   couldn’t muster  up        a   single
 # D  NSg/V/J NSg/V V   NPrSg/V/J/C W?      D/P NSg/J NSg/J    NSg/V . ISg V        NSg/V/J NSg/V/J/P D/P NSg/V/J
-> commonplace out         of  the thousand in          my head      .
-# NSg/V/J     NSg/V/J/R/P V/P D   NSg      NPrSg/V/J/P D  NPrSg/V/J .
+> commonplace out         of the thousand in          my head      .
+# NSg/V/J     NSg/V/J/R/P P  D   NSg      NPrSg/V/J/P D  NPrSg/V/J .
 >
 #
 > “ It’s an  old   clock , ” I   told them idiotically .
@@ -5382,8 +5382,8 @@
 # ISg NSg/V IPl NSg/I/J/C W?       C/P D/P NSg    N/I/C/D NPrSg/ISg V   W?      NPrSg/V/J/P NPl    J/P D   NSg/V .
 >
 #
-> “ We  haven’t met for many    years , ” said Daisy , her   voice as    matter  - of  - fact as    it
-# . IPl V       V   C/P N/I/J/D NPl   . . V/J  NPrSg . I/J/D NSg/V NSg/R NSg/V/J . V/P . NSg  NSg/R NPrSg/ISg
+> “ We  haven’t met for many    years , ” said Daisy , her   voice as    matter  - of - fact as    it
+# . IPl V       V   C/P N/I/J/D NPl   . . V/J  NPrSg . I/J/D NSg/V NSg/R NSg/V/J . P  . NSg  NSg/R NPrSg/ISg
 > could  ever be     .
 # NSg/VX J    NSg/VX .
 >
@@ -5392,20 +5392,20 @@
 # . NSg  NPl   NSg/J/P NPrSg    . .
 >
 #
-> The automatic quality of  Gatsby’s answer set       us      all       back    at        least another
-# D   NSg/J     NSg/J   V/P N$       NSg/V  NPrSg/V/J NPr/ISg NSg/I/J/C NSg/V/J NSg/I/V/P NSg/J I/D
+> The automatic quality of Gatsby’s answer set       us      all       back    at        least another
+# D   NSg/J     NSg/J   P  N$       NSg/V  NPrSg/V/J NPr/ISg NSg/I/J/C NSg/V/J NSg/I/V/P NSg/J I/D
 > minute  . I   had them both on  their feet with the desperate suggestion that    they
 # NSg/V/J . ISg V   N/I  I/C  J/P D     NSg  P    D   NSg/J     NSg        N/I/C/D IPl
 > help  me        make  tea   in          the kitchen when    the demoniac Finn  brought it        in          on  a   tray  .
 # NSg/V NPrSg/ISg NSg/V NSg/V NPrSg/V/J/P D   NSg/V   NSg/I/C D   NSg/J    NPrSg V       NPrSg/ISg NPrSg/V/J/P J/P D/P NSg/V .
 >
 #
-> Amid  the welcome confusion of  cups and cakes a   certain physical decency
-# NSg/P D   NSg/V/J NSg/V     V/P NPl  V/C NPl   D/P I/J     NSg/J    NSg
+> Amid  the welcome confusion of cups and cakes a   certain physical decency
+# NSg/P D   NSg/V/J NSg/V     P  NPl  V/C NPl   D/P I/J     NSg/J    NSg
 > established itself . Gatsby got himself into a   shadow  and , while     Daisy and I
 # W?          I      . NPr    V   I       P    D/P NSg/V/J V/C . NSg/V/C/P NPrSg V/C ISg
-> talked , looked conscientiously from one       to the other   of  us      with tense   , unhappy
-# W?     . W?     J/R             P    NSg/I/V/J P  D   NSg/V/J V/P NPr/ISg P    NSg/V/J . NSg/V/J
+> talked , looked conscientiously from one       to the other   of us      with tense   , unhappy
+# W?     . W?     J/R             P    NSg/I/V/J P  D   NSg/V/J P  NPr/ISg P    NSg/V/J . NSg/V/J
 > eyes . However , as    calmness wasn’t an  end   in          itself , I   made  an  excuse at        the
 # NPl  . C       . NSg/R NSg      V      D/P NSg/V NPrSg/V/J/P I      . ISg NSg/V D/P NSg/V  NSg/I/V/P D
 > first   possible moment , and got to my feet .
@@ -5472,8 +5472,8 @@
 #
 > I   walked out         the back    way   — just as    Gatsby had when    he      had made  his   nervous
 # ISg W?     NSg/V/J/R/P D   NSg/V/J NSg/J . V/J  NSg/R NPr    V   NSg/I/C NPr/ISg V   NSg/V ISg/D J
-> circuit of  the house   half      an  hour before — and ran   for a   huge black   knotted tree  ,
-# NSg/V   V/P D   NPrSg/V NSg/V/J/P D/P NSg  C/P    . V/C NSg/V C/P D/P J    NSg/V/J V/J     NSg/V .
+> circuit of the house   half      an  hour before — and ran   for a   huge black   knotted tree  ,
+# NSg/V   P  D   NPrSg/V NSg/V/J/P D/P NSg  C/P    . V/C NSg/V C/P D/P J    NSg/V/J V/J     NSg/V .
 > whose massed leaves made  a   fabric against the rain  . Once  more        it        was pouring ,
 # I     W?     NPl    NSg/V D/P NSg/V  C/P     D   NSg/V . NSg/C NPrSg/I/V/J NPrSg/ISg V   V       .
 > and my irregular lawn  , well    - shaved by      Gatsby’s gardener , abounded in          small     muddy
@@ -5488,8 +5488,8 @@
 # NSg    C/P    . V/C W?    V   D/P NSg/V N/I/C/D W?   W?     P  NSg/V/J NSg  NPl   . NPl
 > on  all       the neighboring cottages if    the owners would  have   their roofs thatched
 # J/P NSg/I/J/C D   V           NPl      NSg/C D   NPl    NSg/VX NSg/VX D     NPl   W?
-> with straw   . Perhaps their refusal took the heart out         of  his   plan  to Found a
-# P    NSg/V/J . NSg     D     NSg     V    D   NSg/V NSg/V/J/R/P V/P ISg/D NSg/V P  NSg/V D/P
+> with straw   . Perhaps their refusal took the heart out         of his   plan  to Found a
+# P    NSg/V/J . NSg     D     NSg     V    D   NSg/V NSg/V/J/R/P P  ISg/D NSg/V P  NSg/V D/P
 > Family — he      went  into an  immediate decline . His   children sold  his   house   with the
 # NSg/J  . NPr/ISg NSg/V P    D/P J         NSg/V   . ISg/D NPl      NSg/V ISg/D NPrSg/V P    D
 > black   wreath still   on  the door  . Americans , while     willing , even    eager   , to be
@@ -5502,34 +5502,34 @@
 # J/P   NSg/V/J/P D/P NSg  . D   NPrSg/V V     P     . V/C D   N$       NSg/V/J    W?
 > Gatsby’s drive with the raw     material for his   servants ’ dinner — I   felt    sure he
 # N$       NSg/V P    D   NSg/V/J NSg/V/J  C/P ISg/D NPl      . NSg/V  . ISg NSg/V/J J    NPr/ISg
-> wouldn’t eat   a   spoonful . A   maid began opening the upper windows of  his   house   ,
-# VX       NSg/V D/P NSg      . D/P NSg  V     NSg/V/J D   NSg/J NPrPl   V/P ISg/D NPrSg/V .
+> wouldn’t eat   a   spoonful . A   maid began opening the upper windows of his   house   ,
+# VX       NSg/V D/P NSg      . D/P NSg  V     NSg/V/J D   NSg/J NPrPl   P  ISg/D NPrSg/V .
 > appeared momentarily in          each , and , leaning from the large central bay     , spat
 # W?       R           NPrSg/V/J/P D    . V/C . NSg/V   P    D   NSg/J NPrSg/J NSg/V/J . NSg/V
 > meditatively into the garden  . It        was time  I   went  back    . While     the rain  continued
 # J/R          P    D   NSg/V/J . NPrSg/ISg V   NSg/V ISg NSg/V NSg/V/J . NSg/V/C/P D   NSg/V W?
-> it        had seemed like        the murmur of  their voices , rising    and swelling a   little    now
-# NPrSg/ISg V   W?     NSg/V/J/C/P D   NSg/V  V/P D     NPl    . NSg/V/J/P V/C NSg/V    D/P NPrSg/I/J NPrSg/V/J/C
-> and then    with gusts of  emotion . But     in          the new     silence I   felt    that    silence had
-# V/C NSg/J/C P    NPl   V/P NSg     . NSg/C/P NPrSg/V/J/P D   NSg/V/J NSg/V   ISg NSg/V/J N/I/C/D NSg/V   V
+> it        had seemed like        the murmur of their voices , rising    and swelling a   little    now
+# NPrSg/ISg V   W?     NSg/V/J/C/P D   NSg/V  P  D     NPl    . NSg/V/J/P V/C NSg/V    D/P NPrSg/I/J NPrSg/V/J/C
+> and then    with gusts of emotion . But     in          the new     silence I   felt    that    silence had
+# V/C NSg/J/C P    NPl   P  NSg     . NSg/C/P NPrSg/V/J/P D   NSg/V/J NSg/V   ISg NSg/V/J N/I/C/D NSg/V   V
 > fallen within the house   too .
 # W?     N/J/P  D   NPrSg/V W?  .
 >
 #
-> I   went  in          — after making every possible noise in          the kitchen , short       of  pushing
-# ISg NSg/V NPrSg/V/J/P . J/P   NSg/V  D     NSg/J    NSg/V NPrSg/V/J/P D   NSg/V   . NPrSg/V/J/P V/P V
+> I   went  in          — after making every possible noise in          the kitchen , short       of pushing
+# ISg NSg/V NPrSg/V/J/P . J/P   NSg/V  D     NSg/J    NSg/V NPrSg/V/J/P D   NSg/V   . NPrSg/V/J/P P  V
 > over      the stove — but     I   don’t believe they heard a   sound   . They were  sitting at
 # NSg/V/J/P D   NSg/V . NSg/C/P ISg NSg/V V       IPl  V/J   D/P NSg/V/J . IPl  NSg/V NSg/V/J NSg/I/V/P
-> either end   of  the couch , looking at        each other   as    if    some  question had been
-# I/C    NSg/V V/P D   NSg/V . V       NSg/I/V/P D    NSg/V/J NSg/R NSg/C I/J/R NSg/V    V   NSg/V
-> asked , or      was in          the air   , and every vestige of  embarrassment was gone  . Daisy’s
-# V/J   . NPrSg/C V   NPrSg/V/J/P D   NSg/V . V/C D     NSg     V/P NSg           V   V/J/P . N$
+> either end   of the couch , looking at        each other   as    if    some  question had been
+# I/C    NSg/V P  D   NSg/V . V       NSg/I/V/P D    NSg/V/J NSg/R NSg/C I/J/R NSg/V    V   NSg/V
+> asked , or      was in          the air   , and every vestige of embarrassment was gone  . Daisy’s
+# V/J   . NPrSg/C V   NPrSg/V/J/P D   NSg/V . V/C D     NSg     P  NSg           V   V/J/P . N$
 > face  was smeared with tears , and when    I   came    in          she jumped up        and began wiping
 # NSg/V V   W?      P    NPl   . V/C NSg/I/C ISg NSg/V/P NPrSg/V/J/P ISg W?     NSg/V/J/P V/C V     V
 > at        it        with her   handkerchief before a   mirror . But     there was a   change in          Gatsby
 # NSg/I/V/P NPrSg/ISg P    I/J/D NSg          C/P    D/P NSg/V  . NSg/C/P W?    V   D/P NSg/V  NPrSg/V/J/P NPr
 > that    was simply confounding . He      literally glowed ; without a   word  or      a   gesture of
-# N/I/C/D V   R      V           . NPr/ISg J/R       W?     . C/P     D/P NSg/V NPrSg/C D/P NSg/V   V/P
+# N/I/C/D V   R      V           . NPr/ISg J/R       W?     . C/P     D/P NSg/V NPrSg/C D/P NSg/V   P
 > exultation a   new     well    - being   radiated from him and filled the little    room    .
 # NSg        D/P NSg/V/J NSg/V/J . NSg/V/C W?       P    I   V/C V/J    D   NPrSg/I/J NSg/V/J .
 >
@@ -5546,16 +5546,16 @@
 #
 > “ Has it        ? ” When    he      realized what  I   was talking about , that    there were
 # . V   NPrSg/ISg . . NSg/I/C NPr/ISg V        NSg/I ISg V   V       J/P   . N/I/C/D W?    NSg/V
-> twinkle - bells of  sunshine in          the room    , he      smiled like        a   weather man         , like        an
-# NSg/V   . NPl   V/P NSg/J    NPrSg/V/J/P D   NSg/V/J . NPr/ISg W?     NSg/V/J/C/P D/P NSg/V/J NPrSg/I/V/J . NSg/V/J/C/P D/P
-> ecstatic patron of  recurrent light   , and repeated the news  to Daisy . “ What  do     you
-# NSg/J    NSg/V  V/P NSg/J     NSg/V/J . V/C V/J      D   NSg/V P  NPrSg . . NSg/I NSg/VX IPl
-> think of  that    ? It’s stopped raining . ”
-# NSg/V V/P N/I/C/D . W?   V/J     V       . .
+> twinkle - bells of sunshine in          the room    , he      smiled like        a   weather man         , like        an
+# NSg/V   . NPl   P  NSg/J    NPrSg/V/J/P D   NSg/V/J . NPr/ISg W?     NSg/V/J/C/P D/P NSg/V/J NPrSg/I/V/J . NSg/V/J/C/P D/P
+> ecstatic patron of recurrent light   , and repeated the news  to Daisy . “ What  do     you
+# NSg/J    NSg/V  P  NSg/J     NSg/V/J . V/C V/J      D   NSg/V P  NPrSg . . NSg/I NSg/VX IPl
+> think of that    ? It’s stopped raining . ”
+# NSg/V P  N/I/C/D . W?   V/J     V       . .
 >
 #
-> “ I’m glad    , Jay   . ” Her   throat , full    of  aching  , grieving beauty  , told only of  her
-# . W?  NSg/V/J . NPrSg . . I/J/D NSg/V  . NSg/V/J V/P NSg/V/J . V        NSg/V/J . V    W?   V/P I/J/D
+> “ I’m glad    , Jay   . ” Her   throat , full    of aching  , grieving beauty  , told only of her
+# . W?  NSg/V/J . NPrSg . . I/J/D NSg/V  . NSg/V/J P  NSg/V/J . V        NSg/V/J . V    W?   P  I/J/D
 > unexpected joy     .
 # NSg/J      NPrSg/V .
 >
@@ -5574,14 +5574,14 @@
 # . J/R        . NSg/J NSg/V . .
 >
 #
-> Daisy went  up        - stairs to wash    her   face  — too late  I   thought with humiliation of  my
-# NPrSg NSg/V NSg/V/J/P . NPl    P  NPrSg/V I/J/D NSg/V . W?  NSg/J ISg NSg/V   P    NSg         V/P D
+> Daisy went  up        - stairs to wash    her   face  — too late  I   thought with humiliation of my
+# NPrSg NSg/V NSg/V/J/P . NPl    P  NPrSg/V I/J/D NSg/V . W?  NSg/J ISg NSg/V   P    NSg         P  D
 > towels — while     Gatsby and I   waited on  the lawn  .
 # NPl    . NSg/V/C/P NPr    V/C ISg W?     J/P D   NSg/V .
 >
 #
-> “ My house   looks well    , doesn’t it        ? ” he      demanded . “ See   how   the whole front   of  it
-# . D  NPrSg/V NPl   NSg/V/J . V       NPrSg/ISg . . NPr/ISg W?       . . NSg/V NSg/C D   NSg/J NSg/V/J V/P NPrSg/ISg
+> “ My house   looks well    , doesn’t it        ? ” he      demanded . “ See   how   the whole front   of it
+# . D  NPrSg/V NPl   NSg/V/J . V       NPrSg/ISg . . NPr/ISg W?       . . NSg/V NSg/C D   NSg/J NSg/V/J P  NPrSg/ISg
 > catches the light   . ”
 # NPl     D   NSg/V/J . .
 >
@@ -5600,10 +5600,10 @@
 # . ISg NSg/V   IPl W?        D    NSg/J . .
 >
 #
-> “ I   did , old   sport , ” he      said automatically , “ but     I   lost most    of  it        in          the big
-# . ISg V   . NSg/J NSg/V . . NPr/ISg V/J  W?            . . NSg/C/P ISg V/J  NSg/I/J V/P NPrSg/ISg NPrSg/V/J/P D   NSg/V/J
-> panic   — the panic   of  the war   . ”
-# NSg/V/J . D   NSg/V/J V/P D   NSg/V . .
+> “ I   did , old   sport , ” he      said automatically , “ but     I   lost most    of it        in          the big
+# . ISg V   . NSg/J NSg/V . . NPr/ISg V/J  W?            . . NSg/C/P ISg V/J  NSg/I/J P  NPrSg/ISg NPrSg/V/J/P D   NSg/V/J
+> panic   — the panic   of the war   . ”
+# NSg/V/J . D   NSg/V/J P  D   NSg/V . .
 >
 #
 > I   think he      hardly knew what  he      was saying , for when    I   asked him what  business he
@@ -5624,8 +5624,8 @@
 # W?       D   NSg/V/J NSg/V . .
 >
 #
-> Before I   could  answer , Daisy came    out         of  the house   and two rows of  brass   buttons
-# C/P    ISg NSg/VX NSg/V  . NPrSg NSg/V/P NSg/V/J/R/P V/P D   NPrSg/V V/C NSg NPl  V/P NSg/V/J NPl
+> Before I   could  answer , Daisy came    out         of the house   and two rows of brass   buttons
+# C/P    ISg NSg/VX NSg/V  . NPrSg NSg/V/P NSg/V/J/R/P P  D   NPrSg/V V/C NSg NPl  P  NSg/V/J NPl
 > on  her   dress gleamed in          the sunlight .
 # J/P I/J/D NSg/V W?      NPrSg/V/J/P D   NSg/V    .
 >
@@ -5642,24 +5642,24 @@
 # . ISg NPrSg/V NPrSg/ISg . NSg/C/P ISg NSg/V NSg/V NSg/C IPl V/J  W?    NSg/I/J/C J     . .
 >
 #
-> “ I   keep  it        always full    of  interesting people , night and day   . People who     do
-# . ISg NSg/V NPrSg/ISg W?     NSg/V/J V/P V/J         NSg/V  . NSg/V V/C NPrSg . NSg/V  NPrSg/I NSg/VX
+> “ I   keep  it        always full    of interesting people , night and day   . People who     do
+# . ISg NSg/V NPrSg/ISg W?     NSg/V/J P  V/J         NSg/V  . NSg/V V/C NPrSg . NSg/V  NPrSg/I NSg/VX
 > interesting things . Celebrated people . ”
 # V/J         NPl    . W?         NSg/V  . .
 >
 #
-> Instead of  taking  the short       cut     along the Sound   we  went  down      to the road  and
-# W?      V/P NSg/V/J D   NPrSg/V/J/P NSg/V/J P     D   NSg/V/J IPl NSg/V NSg/V/J/P P  D   NSg/J V/C
+> Instead of taking  the short       cut     along the Sound   we  went  down      to the road  and
+# W?      P  NSg/V/J D   NPrSg/V/J/P NSg/V/J P     D   NSg/V/J IPl NSg/V NSg/V/J/P P  D   NSg/J V/C
 > entered by      the big     postern . With enchanting murmurs Daisy admired this aspect or
 # W?      NSg/J/P D   NSg/V/J ?       . P    NSg/V/J    NPl     NPrSg W?      I/D  NSg/V  NPrSg/C
-> that    of  the feudal silhouette against the sky   , admired the gardens , the
-# N/I/C/D V/P D   J      NSg/V      C/P     D   NSg/V . W?      D   NPl     . D
-> sparkling odor of  jonquils and the frothy odor of  hawthorn and plum    blossoms and
-# V         NSg  V/P NPl      V/C D   NSg/J  NSg  V/P NSg      V/C NSg/V/J NPl      V/C
-> the pale    gold    odor of  kiss  - me        - at        - the - gate  . It        was strange to reach the marble
-# D   NSg/V/J NSg/V/J NSg  V/P NSg/V . NPrSg/ISg . NSg/I/V/P . D   . NSg/V . NPrSg/ISg V   NSg/V/J P  NSg/V D   NSg/V/J
-> steps and find  no      stir  of  bright    dresses in          and out         the door  , and hear no      sound
-# NPl   V/C NSg/V NPrSg/P NSg/V V/P NPrSg/V/J NPl     NPrSg/V/J/P V/C NSg/V/J/R/P D   NSg/V . V/C V    NPrSg/P NSg/V/J
+> that    of the feudal silhouette against the sky   , admired the gardens , the
+# N/I/C/D P  D   J      NSg/V      C/P     D   NSg/V . W?      D   NPl     . D
+> sparkling odor of jonquils and the frothy odor of hawthorn and plum    blossoms and
+# V         NSg  P  NPl      V/C D   NSg/J  NSg  P  NSg      V/C NSg/V/J NPl      V/C
+> the pale    gold    odor of kiss  - me        - at        - the - gate  . It        was strange to reach the marble
+# D   NSg/V/J NSg/V/J NSg  P  NSg/V . NPrSg/ISg . NSg/I/V/P . D   . NSg/V . NPrSg/ISg V   NSg/V/J P  NSg/V D   NSg/V/J
+> steps and find  no      stir  of bright    dresses in          and out         the door  , and hear no      sound
+# NPl   V/C NSg/V NPrSg/P NSg/V P  NPrSg/V/J NPl     NPrSg/V/J/P V/C NSg/V/J/R/P D   NSg/V . V/C V    NPrSg/P NSg/V/J
 > but     bird      voices in          the trees .
 # NSg/C/P NPrSg/V/J NPl    NPrSg/V/J/P D   NPl   .
 >
@@ -5670,8 +5670,8 @@
 # NPl    . ISg NSg/V/J N/I/C/D W?    NSg/V NPl    V/J       NSg/J/P D     NSg/V V/C NSg/V .
 > under   orders to be     breathlessly silent until we  had passed through . As    Gatsby
 # NSg/J/P NPl    P  NSg/VX J/R          NSg/J  C/P   IPl V   W?     NSg/J/P . NSg/R NPr
-> closed the door  of  ‘          ‘          the Merton College Library ” I   could  have   sworn I   heard the
-# W?     D   NSg/V V/P Unlintable Unlintable D   NPr    NSg     NSg     . ISg NSg/VX NSg/VX V/J   ISg V/J   D
+> closed the door  of ‘          ‘          the Merton College Library ” I   could  have   sworn I   heard the
+# W?     D   NSg/V P  Unlintable Unlintable D   NPr    NSg     NSg     . ISg NSg/VX NSg/VX V/J   ISg V/J   D
 > owl   - eyed man         break into ghostly laughter .
 # NSg/V . W?   NPrSg/I/V/J NSg/V P    J/R     NSg      .
 >
@@ -5688,26 +5688,26 @@
 # V   NSg/V I   V         R        J/P   D   NPrSg/V N/I/C/D NSg/V   . J/R     IPl NSg/V/P P
 > Gatsby’s own     apartment , a   bedroom and a   bath  , and an  Adam’s study , where we  sat
 # N$       NSg/V/J NSg       . D/P NSg     V/C D/P NSg/V . V/C D/P N$     NSg/V . NSg/C IPl NSg/V/J
-> down      and drank a   glass   of  some  Chartreuse he      took from a   cupboard in          the wall    .
-# NSg/V/J/P V/C NSg/V D/P NPrSg/V V/P I/J/R NSg/J      NPr/ISg V    P    D/P NSg/V    NPrSg/V/J/P D   NPrSg/V .
+> down      and drank a   glass   of some  Chartreuse he      took from a   cupboard in          the wall    .
+# NSg/V/J/P V/C NSg/V D/P NPrSg/V P  I/J/R NSg/J      NPr/ISg V    P    D/P NSg/V    NPrSg/V/J/P D   NPrSg/V .
 >
 #
 > He      hadn’t once  ceased looking at        Daisy , and I   think he      revalued everything in
 # NPr/ISg V      NSg/C W?     V       NSg/I/V/P NPrSg . V/C ISg NSg/V NPr/ISg W?       N/I/V      NPrSg/V/J/P
-> his   house   according to the measure of  response it        drew  from her   well    - loved eyes .
-# ISg/D NPrSg/V V/J       P  D   NSg/V   V/P NSg      NPrSg/ISg NPr/V P    I/J/D NSg/V/J . V/J   NPl  .
+> his   house   according to the measure of response it        drew  from her   well    - loved eyes .
+# ISg/D NPrSg/V V/J       P  D   NSg/V   P  NSg      NPrSg/ISg NPr/V P    I/J/D NSg/V/J . V/J   NPl  .
 > Sometimes , too , he      stared around at        his   possessions in          a   dazed way   , as    though in
 # R         . W?  . NPr/ISg W?     J/P    NSg/I/V/P ISg/D NPl         NPrSg/V/J/P D/P V/J   NSg/J . NSg/R V/C    NPrSg/V/J/P
-> her   actual and astounding presence none  of  it        was any   longer real  . Once  he
-# I/J/D NSg/J  V/C V/J        NSg/V    NSg/I V/P NPrSg/ISg V   I/R/D NSg/J  NSg/J . NSg/C NPr/ISg
-> nearly toppled down      a   flight  of  stairs .
-# J/R    W?      NSg/V/J/P D/P NSg/V/J V/P NPl    .
+> her   actual and astounding presence none  of it        was any   longer real  . Once  he
+# I/J/D NSg/J  V/C V/J        NSg/V    NSg/I P  NPrSg/ISg V   I/R/D NSg/J  NSg/J . NSg/C NPr/ISg
+> nearly toppled down      a   flight  of stairs .
+# J/R    W?      NSg/V/J/P D/P NSg/V/J P  NPl    .
 >
 #
-> His   bedroom was the simplest room    of  all       — except where the dresser was garnished
-# ISg/D NSg     V   D   W?       NSg/V/J V/P NSg/I/J/C . V/C/P  NSg/C D   NSg     V   W?
-> with a   toilet set       of  pure    dull gold    . Daisy took the brush with delight , and
-# P    D/P NSg/V  NPrSg/V/J V/P NSg/V/J V/J  NSg/V/J . NPrSg V    D   NSg/V P    NSg/V/J . V/C
+> His   bedroom was the simplest room    of all       — except where the dresser was garnished
+# ISg/D NSg     V   D   W?       NSg/V/J P  NSg/I/J/C . V/C/P  NSg/C D   NSg     V   W?
+> with a   toilet set       of pure    dull gold    . Daisy took the brush with delight , and
+# P    D/P NSg/V  NPrSg/V/J P  NSg/V/J V/J  NSg/V/J . NPrSg V    D   NSg/V P    NSg/V/J . V/C
 > smoothed her   hair  , whereupon Gatsby sat     down      and shaded his   eyes and began to
 # W?       I/J/D NSg/V . C         NPr    NSg/V/J NSg/V/J/P V/C W?     ISg/D NPl  V/C V     P
 > laugh .
@@ -5724,10 +5724,10 @@
 # NPr/ISg V   W?     R       NSg/J/P NSg NPrSg  V/C V   V        P    D/P NSg/V/J . J/P
 > his   embarrassment and his   unreasoning joy     he      was consumed with wonder at        her
 # ISg/D NSg           V/C ISg/D J           NPrSg/V NPr/ISg V   V/J      P    NSg/V  NSg/I/V/P I/J/D
-> presence . He      had been  full    of  the idea so        long      , dreamed it        right     through to the
-# NSg/V    . NPr/ISg V   NSg/V NSg/V/J V/P D   NSg  NSg/I/J/C NPrSg/V/J . V       NPrSg/ISg NPrSg/V/J NSg/J/P P  D
+> presence . He      had been  full    of the idea so        long      , dreamed it        right     through to the
+# NSg/V    . NPr/ISg V   NSg/V NSg/V/J P  D   NSg  NSg/I/J/C NPrSg/V/J . V       NPrSg/ISg NPrSg/V/J NSg/J/P P  D
 > end   , waited with his   teeth set       , so        to speak , at        an  inconceivable pitch   of
-# NSg/V . W?     P    ISg/D W?    NPrSg/V/J . NSg/I/J/C P  NSg/V . NSg/I/V/P D/P J             NSg/V/J V/P
+# NSg/V . W?     P    ISg/D W?    NPrSg/V/J . NSg/I/J/C P  NSg/V . NSg/I/V/P D/P J             NSg/V/J P
 > intensity . Now         , in          the reaction , he      was running   down      like        an  overwound clock .
 # NSg       . NPrSg/V/J/C . NPrSg/V/J/P D   NSg/V/J  . NPr/ISg V   NSg/V/J/P NSg/V/J/P NSg/V/J/C/P D/P ?         NSg/V .
 >
@@ -5741,23 +5741,23 @@
 >
 #
 > “ I’ve got a   man         in          England who     buys me        clothes . He      sends over      a   selection of
-# . W?   V   D/P NPrSg/I/V/J NPrSg/V/J/P NPr     NPrSg/I NPl  NPrSg/ISg NPl     . NPr/ISg NPl   NSg/V/J/P D/P NSg       V/P
-> things at        the beginning of  each season , spring and fall  . ”
-# NPl    NSg/I/V/P D   NSg/V/J   V/P D    NSg/V  . NSg/V  V/C NSg/V . .
+# . W?   V   D/P NPrSg/I/V/J NPrSg/V/J/P NPr     NPrSg/I NPl  NPrSg/ISg NPl     . NPr/ISg NPl   NSg/V/J/P D/P NSg       P
+> things at        the beginning of each season , spring and fall  . ”
+# NPl    NSg/I/V/P D   NSg/V/J   P  D    NSg/V  . NSg/V  V/C NSg/V . .
 >
 #
-> He      took out         a   pile  of  shirts and began throwing them , one       by      one       , before us      ,
-# NPr/ISg V    NSg/V/J/R/P D/P NSg/V V/P NPl    V/C V     V        N/I  . NSg/I/V/J NSg/J/P NSg/I/V/J . C/P    NPr/ISg .
-> shirts of  sheer   linen and thick   silk  and fine    flannel , which lost their folds as
-# NPl    V/P NSg/V/J NSg/J V/C NSg/V/J NSg/V V/C NSg/V/J NSg/V/J . I/C   V/J  D     NPl   NSg/R
+> He      took out         a   pile  of shirts and began throwing them , one       by      one       , before us      ,
+# NPr/ISg V    NSg/V/J/R/P D/P NSg/V P  NPl    V/C V     V        N/I  . NSg/I/V/J NSg/J/P NSg/I/V/J . C/P    NPr/ISg .
+> shirts of sheer   linen and thick   silk  and fine    flannel , which lost their folds as
+# NPl    P  NSg/V/J NSg/J V/C NSg/V/J NSg/V V/C NSg/V/J NSg/V/J . I/C   V/J  D     NPl   NSg/R
 > they fell    and covered the table in          many    colored    disarray . While     we  admired he
 # IPl  NSg/V/J V/C W?      D   NSg/V NPrSg/V/J/P N/I/J/D NSg/V/J/Am NSg/V    . NSg/V/C/P IPl W?      NPr/ISg
 > brought more        and the soft  rich      heap  mounted higher — shirts with stripes and
 # V       NPrSg/I/V/J V/C D   NSg/J NPrSg/V/J NSg/V V/J     J      . NPl    P    NPl     V/C
 > scrolls and plaids in          coral and applegreen and lavender and faint   orange    , with
 # NPl     V/C NPl    NPrSg/V/J/P NSg/J V/C ?          V/C NSg/V/J  V/C NSg/V/J NPrSg/V/J . P
-> monograms of  Indian  blue    . Suddenly , with a   strained sound   , Daisy bent    her   head
-# NPl       V/P NPrSg/J NSg/V/J . J/R      . P    D/P W?       NSg/V/J . NPrSg NSg/V/J I/J/D NPrSg/V/J
+> monograms of Indian  blue    . Suddenly , with a   strained sound   , Daisy bent    her   head
+# NPl       P  NPrSg/J NSg/V/J . J/R      . P    D/P W?       NSg/V/J . NPrSg NSg/V/J I/J/D NPrSg/V/J
 > into the shirts and began to cry   stormily .
 # P    D   NPl    V/C V     P  NSg/V R        .
 >
@@ -5774,34 +5774,34 @@
 # J/P   D   NPrSg/V . IPl NSg/V P  NSg/V D   NPl     V/C D   NSg/V    . NSg/V . V/C D
 > hydroplane and the midsummer flowers — but     outside   Gatsby’s window it        began to
 # NSg/V      V/C D   NSg/J     NPrPl   . NSg/C/P NSg/V/J/P N$       NSg/V  NPrSg/ISg V     P
-> rain  again , so        we  stood in          a   row   looking at        the corrugated surface of  the Sound   .
-# NSg/V P     . NSg/I/J/C IPl V     NPrSg/V/J/P D/P NSg/V V       NSg/I/V/P D   W?         NSg/V   V/P D   NSg/V/J .
+> rain  again , so        we  stood in          a   row   looking at        the corrugated surface of the Sound   .
+# NSg/V P     . NSg/I/J/C IPl V     NPrSg/V/J/P D/P NSg/V V       NSg/I/V/P D   W?         NSg/V   P  D   NSg/V/J .
 >
 #
 > “ If    it        wasn’t for the mist  we  could  see   your home    across the bay     , ” said Gatsby .
 # . NSg/C NPrSg/ISg V      C/P D   NSg/V IPl NSg/VX NSg/V D    NSg/V/J NSg/P  D   NSg/V/J . . V/J  NPr    .
-> “ You always have   a   green     light   that    burns all       night at        the end   of  your dock  . ”
-# . IPl W?     NSg/VX D/P NPrSg/V/J NSg/V/J N/I/C/D NPrPl NSg/I/J/C NSg/V NSg/I/V/P D   NSg/V V/P D    NSg/V . .
+> “ You always have   a   green     light   that    burns all       night at        the end   of your dock  . ”
+# . IPl W?     NSg/VX D/P NPrSg/V/J NSg/V/J N/I/C/D NPrPl NSg/I/J/C NSg/V NSg/I/V/P D   NSg/V P  D    NSg/V . .
 >
 #
 > Daisy put   her   arm     through his   abruptly , but     he      seemed absorbed in          what  he      had
 # NPrSg NSg/V I/J/D NSg/V/J NSg/J/P ISg/D J/R      . NSg/C/P NPr/ISg W?     W?       NPrSg/V/J/P NSg/I NPr/ISg V
 > just said . Possibly it        had occurred to him that    the colossal significance of
-# V/J  V/J  . R        NPrSg/ISg V   V        P  I   N/I/C/D D   J        NSg          V/P
+# V/J  V/J  . R        NPrSg/ISg V   V        P  I   N/I/C/D D   J        NSg          P
 > that    light   had now         vanished forever . Compared to the great distance that    had
 # N/I/C/D NSg/V/J V   NPrSg/V/J/C W?       NSg/J   . W?       P  D   NSg/J NSg/V    N/I/C/D V
 > separated him from Daisy it        had seemed very near      to her   , almost touching  her   . It
 # W?        I   P    NPrSg NPrSg/ISg V   W?     J    NSg/V/J/P P  I/J/D . NSg    NSg/V/J/P I/J/D . NPrSg/ISg
 > had seemed as    close   as    a   star  to the moon    . Now         it        was again a   green     light   on  a
 # V   W?     NSg/R NSg/V/J NSg/R D/P NSg/V P  D   NPrSg/V . NPrSg/V/J/C NPrSg/ISg V   P     D/P NPrSg/V/J NSg/V/J J/P D/P
-> dock  . His   count of  enchanted objects had diminished by      one       .
-# NSg/V . ISg/D NSg/V V/P W?        NPl     V   V/J        NSg/J/P NSg/I/V/J .
+> dock  . His   count of enchanted objects had diminished by      one       .
+# NSg/V . ISg/D NSg/V P  W?        NPl     V   V/J        NSg/J/P NSg/I/V/J .
 >
 #
 > I   began to walk  about the room    , examining various indefinite objects in          the half
 # ISg V     P  NSg/V J/P   D   NSg/V/J . V         J       NSg/J      NPl     NPrSg/V/J/P D   NSg/V/J/P
-> darkness . A   large photograph of  an  elderly man         in          yachting costume attracted me        ,
-# NSg      . D/P NSg/J NSg/V      V/P D/P J/R     NPrSg/I/V/J NPrSg/V/J/P NSg/V    NSg/V   W?        NPrSg/ISg .
+> darkness . A   large photograph of an  elderly man         in          yachting costume attracted me        ,
+# NSg      . D/P NSg/J NSg/V      P  D/P J/R     NPrSg/I/V/J NPrSg/V/J/P NSg/V    NSg/V   W?        NPrSg/ISg .
 > hung    on  the wall    over      his   desk  .
 # NPr/V/J J/P D   NPrSg/V NSg/V/J/P ISg/D NSg/V .
 >
@@ -5822,8 +5822,8 @@
 # . N$   NSg/V/J NPrSg/V/J/C . NPr/ISg V/J  P  NSg/VX D  NPrSg/VX/J NPrSg/V NPl   J/P . .
 >
 #
-> There was a   small     picture of  Gatsby , also in          yachting costume , on  the
-# W?    V   D/P NPrSg/V/J NSg/V   V/P NPr    . W?   NPrSg/V/J/P NSg/V    NSg/V   . J/P D
+> There was a   small     picture of Gatsby , also in          yachting costume , on  the
+# W?    V   D/P NPrSg/V/J NSg/V   P  NPr    . W?   NPrSg/V/J/P NSg/V    NSg/V   . J/P D
 > bureau — Gatsby with his   head      thrown back    defiantly — taken apparently when    he      was
 # NSg    . NPr    P    ISg/D NPrSg/V/J V/J    NSg/V/J J/R       . V/J   J/R        NSg/I/C NPr/ISg V
 > about eighteen .
@@ -5836,8 +5836,8 @@
 # NSg/V     . NPrSg/C D/P NSg/V . .
 >
 #
-> “ Look  at        this , ” said Gatsby quickly . “ Here’s a   lot     of  clippings — about you . ”
-# . NSg/V NSg/I/V/P I/D  . . V/J  NPr    J/R     . . W?     D/P NPrSg/V V/P NPl       . J/P   IPl . .
+> “ Look  at        this , ” said Gatsby quickly . “ Here’s a   lot     of clippings — about you . ”
+# . NSg/V NSg/I/V/P I/D  . . V/J  NPr    J/R     . . W?     D/P NPrSg/V P  NPl       . J/P   IPl . .
 >
 #
 > They stood side    by      side    examining it        . I   was going   to ask   to see   the rubies when
@@ -5850,8 +5850,8 @@
 # . NSg/V . . . . NSg/V/J . ISg VX    NSg/V NPrSg/V/J/C . . . . ISg VX    NSg/V NPrSg/V/J/C . NSg/J NSg/V . . . . ISg
 > said a   small     town . . . . He      must  know  what  a   small     town is . . . . Well    , he’s no
 # V/J  D/P NPrSg/V/J NSg  . . . . NPr/ISg NSg/V NSg/V NSg/I D/P NPrSg/V/J NSg  VL . . . . NSg/V/J . N$   NPrSg/P
-> use   to us      if    Detroit is his   idea of  a   small     town . . . . ” He      rang off       .
-# NSg/V P  NPr/ISg NSg/C NPr     VL ISg/D NSg  V/P D/P NPrSg/V/J NSg  . . . . . NPr/ISg V    NSg/V/J/P .
+> use   to us      if    Detroit is his   idea of a   small     town . . . . ” He      rang off       .
+# NSg/V P  NPr/ISg NSg/C NPr     VL ISg/D NSg  P  D/P NPrSg/V/J NSg  . . . . . NPr/ISg V    NSg/V/J/P .
 >
 #
 > “ Come    here    quick   ! ” cried Daisy at        the window .
@@ -5860,18 +5860,18 @@
 #
 > The rain  was still   falling , but     the darkness had parted in          the west      , and there
 # D   NSg/V V   NSg/V/J V       . NSg/C/P D   NSg      V   W?     NPrSg/V/J/P D   NPrSg/V/J . V/C W?
-> was a   pink    and golden    billow of  foamy clouds above   the sea .
-# V   D/P NSg/V/J V/C NPrSg/V/J NSg/V  V/P NSg/J NPl    NSg/J/P D   NSg .
+> was a   pink    and golden    billow of foamy clouds above   the sea .
+# V   D/P NSg/V/J V/C NPrSg/V/J NSg/V  P  NSg/J NPl    NSg/J/P D   NSg .
 >
 #
 > “ Look  at        that    , ” she whispered , and then    after a   moment : “ I’d like        to just get
 # . NSg/V NSg/I/V/P N/I/C/D . . ISg W?        . V/C NSg/J/C J/P   D/P NSg    . . W?  NSg/V/J/C/P P  V/J  NSg/V
-> one       of  those pink    clouds and put   you in          it        and push  you around . ”
-# NSg/I/V/J V/P I/D   NSg/V/J NPl    V/C NSg/V IPl NPrSg/V/J/P NPrSg/ISg V/C NSg/V IPl J/P    . .
+> one       of those pink    clouds and put   you in          it        and push  you around . ”
+# NSg/I/V/J P  I/D   NSg/V/J NPl    V/C NSg/V IPl NPrSg/V/J/P NPrSg/ISg V/C NSg/V IPl J/P    . .
 >
 #
-> I   tried to go      then    , but     they wouldn’t hear of  it        ; perhaps my presence made  them
-# ISg V/J   P  NSg/V/J NSg/J/C . NSg/C/P IPl  VX       V    V/P NPrSg/ISg . NSg     D  NSg/V    NSg/V N/I
+> I   tried to go      then    , but     they wouldn’t hear of it        ; perhaps my presence made  them
+# ISg V/J   P  NSg/V/J NSg/J/C . NSg/C/P IPl  VX       V    P  NPrSg/ISg . NSg     D  NSg/V    NSg/V N/I
 > feel      more        satisfactorily alone .
 # NSg/I/V/J NPrSg/I/V/J R              J     .
 >
@@ -5880,22 +5880,22 @@
 # . ISg NSg/V NSg/I W?    NSg/VX . . V/J  NPr    . . W?    NSg/VX ?            NSg/V D   NSg/V/J . .
 >
 #
-> He      went  out         of  the room    calling “ Ewing ! ” and returned in          a   few minutes
-# NPr/ISg NSg/V NSg/V/J/R/P V/P D   NSg/V/J NSg/V   . NPr   . . V/C W?       NPrSg/V/J/P D/P N/I NPl
+> He      went  out         of the room    calling “ Ewing ! ” and returned in          a   few minutes
+# NPr/ISg NSg/V NSg/V/J/R/P P  D   NSg/V/J NSg/V   . NPr   . . V/C W?       NPrSg/V/J/P D/P N/I NPl
 > accompanied by      an  embarrassed , slightly worn young     man         , with shell   - rimmed
 # V/J         NSg/J/P D/P V/J         . J/R      V/J  NPrSg/V/J NPrSg/I/V/J . P    NPrSg/V . V/J
 > glasses and scanty blond   hair  . He      was now         decently clothed in          a   “ sport shirt , ”
 # NPl     V/C J      NSg/V/J NSg/V . NPr/ISg V   NPrSg/V/J/C J/R      W?      NPrSg/V/J/P D/P . NSg/V NSg/V . .
-> open    at        the neck  , sneakers , and duck  trousers of  a   nebulous hue .
-# NSg/V/J NSg/I/V/P D   NSg/V . W?       . V/C NSg/V NSg      V/P D/P J        NSg .
+> open    at        the neck  , sneakers , and duck  trousers of a   nebulous hue .
+# NSg/V/J NSg/I/V/P D   NSg/V . W?       . V/C NSg/V NSg      P  D/P J        NSg .
 >
 #
 > “ Did we  interrupt your exercises ? ” inquired Daisy politely .
 # . V   IPl NSg/V     D    NPl       . . W?       NPrSg J/R      .
 >
 #
-> “ I   was asleep , ” cried Mr  . Klipspringer , in          a   spasm of  embarrassment . “ That    is ,
-# . ISg V   J      . . W?    NSg . ?            . NPrSg/V/J/P D/P NSg/V V/P NSg           . . N/I/C/D VL .
+> “ I   was asleep , ” cried Mr  . Klipspringer , in          a   spasm of embarrassment . “ That    is ,
+# . ISg V   J      . . W?    NSg . ?            . NPrSg/V/J/P D/P NSg/V P  NSg           . . N/I/C/D VL .
 > I’d been  asleep . Then    I   got up        . . . ”
 # W?  NSg/V J      . NSg/J/C ISg V   NSg/V/J/P . . . .
 >
@@ -5906,14 +5906,14 @@
 # NSg/J NSg/V . .
 >
 #
-> “ I   don’t play  well    . I   don’t — I   hardly play  at        all       . I’m all       out         of  prac — — — ”
-# . ISg NSg/V NSg/V NSg/V/J . ISg NSg/V . ISg J/R    NSg/V NSg/I/V/P NSg/I/J/C . W?  NSg/I/J/C NSg/V/J/R/P V/P ?    . . . .
+> “ I   don’t play  well    . I   don’t — I   hardly play  at        all       . I’m all       out         of prac — — — ”
+# . ISg NSg/V NSg/V NSg/V/J . ISg NSg/V . ISg J/R    NSg/V NSg/I/V/P NSg/I/J/C . W?  NSg/I/J/C NSg/V/J/R/P P  ?    . . . .
 >
 #
 > “ We’ll go      down      - stairs , ” interrupted Gatsby . He      flipped a   switch  . The gray
 # . W?    NSg/V/J NSg/V/J/P . NPl    . . W?          NPr    . NPr/ISg V       D/P NSg/V/J . D   NPrSg/V/J/Am
-> windows disappeared as    the house   glowed full    of  light   .
-# NPrPl   W?          NSg/R D   NPrSg/V W?     NSg/V/J V/P NSg/V/J .
+> windows disappeared as    the house   glowed full    of light   .
+# NPrPl   W?          NSg/R D   NPrSg/V W?     NSg/V/J P  NSg/V/J .
 >
 #
 > In          the music   - room    Gatsby turned on  a   solitary lamp  beside the piano   . He      lit
@@ -5932,8 +5932,8 @@
 # W?       R         C/P NPr    NPrSg/V/J/P D   NSg/V .
 >
 #
-> “ I’m all       out         of  practice , you see   . I   told you I   couldn’t play  . I’m all       out         of
-# . W?  NSg/I/J/C NSg/V/J/R/P V/P NSg/V    . IPl NSg/V . ISg V    IPl ISg V        NSg/V . W?  NSg/I/J/C NSg/V/J/R/P V/P
+> “ I’m all       out         of practice , you see   . I   told you I   couldn’t play  . I’m all       out         of
+# . W?  NSg/I/J/C NSg/V/J/R/P P  NSg/V    . IPl NSg/V . ISg V    IPl ISg V        NSg/V . W?  NSg/I/J/C NSg/V/J/R/P P
 > prac — ”
 # ?    . .
 >
@@ -5946,12 +5946,12 @@
 # . NPrSg/V/J/P D   NSg/V   . NPrSg/V/J/P D   NSg/V   . V     IPl V   NSg/V/J . . . .
 >
 #
-> Outside   the wind  was loud  and there was a   faint   flow  of  thunder along the Sound   .
-# NSg/V/J/P D   NSg/V V   NSg/J V/C W?    V   D/P NSg/V/J NSg/V V/P NSg/V   P     D   NSg/V/J .
+> Outside   the wind  was loud  and there was a   faint   flow  of thunder along the Sound   .
+# NSg/V/J/P D   NSg/V V   NSg/J V/C W?    V   D/P NSg/V/J NSg/V P  NSg/V   P     D   NSg/V/J .
 > All       the lights were  going   on  in          West      Egg   now         ; the electric trains , men - carrying ,
 # NSg/I/J/C D   NPl    NSg/V NSg/V/J J/P NPrSg/V/J/P NPrSg/V/J NSg/V NPrSg/V/J/C . D   NSg/J    NPl    . NSg . V        .
-> were  plunging home    through the rain  from New     York . It        was the hour of  a   profound
-# NSg/V V        NSg/V/J NSg/J/P D   NSg/V P    NSg/V/J NPr  . NPrSg/ISg V   D   NSg  V/P D/P NSg/V/J
+> were  plunging home    through the rain  from New     York . It        was the hour of a   profound
+# NSg/V V        NSg/V/J NSg/J/P D   NSg/V P    NSg/V/J NPr  . NPrSg/ISg V   D   NSg  P  D/P NSg/V/J
 > human   change , and excitement was generating on  the air   .
 # NSg/V/J NSg/V  . V/C NSg        V   V          J/P D   NSg/V .
 >
@@ -5962,32 +5962,32 @@
 # NSg/V . NPl      . NPrSg/V/J/P D   NSg      . NPrSg/V/J/P NSg/P   NSg/V . . . .
 >
 #
-> As    I   went  over      to say   good      - by      I   saw   that    the expression of  bewilderment had come
-# NSg/R ISg NSg/V NSg/V/J/P P  NSg/V NPrSg/V/J . NSg/J/P ISg NSg/V N/I/C/D D   NSg        V/P NSg          V   NSg/V/P
+> As    I   went  over      to say   good      - by      I   saw   that    the expression of bewilderment had come
+# NSg/R ISg NSg/V NSg/V/J/P P  NSg/V NPrSg/V/J . NSg/J/P ISg NSg/V N/I/C/D D   NSg        P  NSg          V   NSg/V/P
 > back    into Gatsby’s face  , as    though a   faint   doubt had occurred to him as    to the
 # NSg/V/J P    N$       NSg/V . NSg/R V/C    D/P NSg/V/J NSg/V V   V        P  I   NSg/R P  D
-> quality of  his   present happiness . Almost five years ! There must  have   been
-# NSg/J   V/P ISg/D NSg/V/J NSg       . NSg    NSg  NPl   . W?    NSg/V NSg/VX NSg/V
-> moments even    that    afternoon when    Daisy tumbled short       of  his   dreams — not   through
-# NPl     NSg/V/J N/I/C/D NSg       NSg/I/C NPrSg W?      NPrSg/V/J/P V/P ISg/D NPl    . NSg/C NSg/J/P
-> her   own     fault , but     because of  the colossal vitality of  his   illusion . It        had gone
-# I/J/D NSg/V/J NSg/V . NSg/C/P C/P     V/P D   J        NSg      V/P ISg/D NSg      . NPrSg/ISg V   V/J/P
+> quality of his   present happiness . Almost five years ! There must  have   been
+# NSg/J   P  ISg/D NSg/V/J NSg       . NSg    NSg  NPl   . W?    NSg/V NSg/VX NSg/V
+> moments even    that    afternoon when    Daisy tumbled short       of his   dreams — not   through
+# NPl     NSg/V/J N/I/C/D NSg       NSg/I/C NPrSg W?      NPrSg/V/J/P P  ISg/D NPl    . NSg/C NSg/J/P
+> her   own     fault , but     because of the colossal vitality of his   illusion . It        had gone
+# I/J/D NSg/V/J NSg/V . NSg/C/P C/P     P  D   J        NSg      P  ISg/D NSg      . NPrSg/ISg V   V/J/P
 > beyond her   , beyond everything . He      had thrown himself into it        with a   creative
 # NSg/P  I/J/D . NSg/P  N/I/V      . NPr/ISg V   V/J    I       P    NPrSg/ISg P    D/P NSg/J
 > passion , adding to it        all       the time  , decking it        out         with every bright    feather
 # NPrSg/V . V      P  NPrSg/ISg NSg/I/J/C D   NSg/V . V       NPrSg/ISg NSg/V/J/R/P P    D     NPrSg/V/J NSg/V
-> that    drifted his   way   . No      amount of  fire    or      freshness can      challenge what  a   man
-# N/I/C/D W?      ISg/D NSg/J . NPrSg/P NSg/V  V/P NSg/V/J NPrSg/C NSg       NPrSg/VX NSg/V     NSg/I D/P NPrSg/I/V/J
+> that    drifted his   way   . No      amount of fire    or      freshness can      challenge what  a   man
+# N/I/C/D W?      ISg/D NSg/J . NPrSg/P NSg/V  P  NSg/V/J NPrSg/C NSg       NPrSg/VX NSg/V     NSg/I D/P NPrSg/I/V/J
 > can      store up        in          his   ghostly heart .
 # NPrSg/VX NSg/V NSg/V/J/P NPrSg/V/J/P ISg/D J/R     NSg/V .
 >
 #
 > As    I   watched him he      adjusted himself a   little    , visibly . His   hand  took hold    of
-# NSg/R ISg W?      I   NPr/ISg W?       I       D/P NPrSg/I/J . R       . ISg/D NSg/V V    NSg/V/J V/P
+# NSg/R ISg W?      I   NPr/ISg W?       I       D/P NPrSg/I/J . R       . ISg/D NSg/V V    NSg/V/J P
 > hers , and as    she said something low     in          his   ear   he      turned toward her   with a   rush
 # ISg  . V/C NSg/R ISg V/J  NSg/I/V/J NSg/V/J NPrSg/V/J/P ISg/D NSg/V NPr/ISg W?     J/P    I/J/D P    D/P NPrSg/V/J
-> of  emotion . I   think that    voice held him most    , with its   fluctuating , feverish
-# V/P NSg     . ISg NSg/V N/I/C/D NSg/V V    I   NSg/I/J . P    ISg/D V           . J
+> of emotion . I   think that    voice held him most    , with its   fluctuating , feverish
+# P  NSg     . ISg NSg/V N/I/C/D NSg/V V    I   NSg/I/J . P    ISg/D V           . J
 > warmth , because it        couldn’t be     over      - dreamed — that    voice was a   deathless song .
 # NSg    . C/P     NPrSg/ISg V        NSg/VX NSg/V/J/P . V       . N/I/C/D NSg/V V   D/P J         NSg  .
 >
@@ -5996,8 +5996,8 @@
 # IPl  V   NSg/V/J   NPrSg/ISg . NSg/C/P NPrSg W?      NSg/V/J/P V/C V    NSg/V/J/R/P I/J/D NSg/V . NPr    V
 > know  me        now         at        all       . I   looked once  more        at        them and they looked back    at        me        ,
 # NSg/V NPrSg/ISg NPrSg/V/J/C NSg/I/V/P NSg/I/J/C . ISg W?     NSg/C NPrSg/I/V/J NSg/I/V/P N/I  V/C IPl  W?     NSg/V/J NSg/I/V/P NPrSg/ISg .
-> remotely , possessed by      intense life  . Then    I   went  out         of  the room    and down      the
-# J/R      . W?        NSg/J/P J       NSg/V . NSg/J/C ISg NSg/V NSg/V/J/R/P V/P D   NSg/V/J V/C NSg/V/J/P D
+> remotely , possessed by      intense life  . Then    I   went  out         of the room    and down      the
+# J/R      . W?        NSg/J/P J       NSg/V . NSg/J/C ISg NSg/V NSg/V/J/R/P P  D   NSg/V/J V/C NSg/V/J/P D
 > marble  steps into the rain  , leaving them there together .
 # NSg/V/J NPl   P    D   NSg/V . V       N/I  W?    J        .
 >
@@ -6036,28 +6036,28 @@
 # NSg       . NSg/V  J/P   NSg/J/P D   NPl      NPrSg/I V   V/J      ISg/D NSg         V/C NSg/I/J/C
 > become authorities upon his   past      , had increased all       summer  until he      fell    just
 # V      NPl         P    ISg/D NSg/V/J/P . V   W?        NSg/I/J/C NPrSg/V C/P   NPr/ISg NSg/V/J V/J
-> short       of  being   news  . Contemporary legends such  as    the “ underground pipe  - line  to
-# NPrSg/V/J/P V/P NSg/V/C NSg/V . NSg/J        NPl     NSg/I NSg/R D   . NSg/V/J     NSg/V . NSg/V P
+> short       of being   news  . Contemporary legends such  as    the “ underground pipe  - line  to
+# NPrSg/V/J/P P  NSg/V/C NSg/V . NSg/J        NPl     NSg/I NSg/R D   . NSg/V/J     NSg/V . NSg/V P
 > Canada ” attached themselves to him , and there was one       persistent story that    he
 # NPrSg  . V/J      I          P  I   . V/C W?    V   NSg/I/V/J J          NSg/V N/I/C/D NPr/ISg
 > didn’t live in          a   house   at        all       , but     in          a   boat  that    looked like        a   house   and was
 # V      V/J  NPrSg/V/J/P D/P NPrSg/V NSg/I/V/P NSg/I/J/C . NSg/C/P NPrSg/V/J/P D/P NSg/V N/I/C/D W?     NSg/V/J/C/P D/P NPrSg/V V/C V
 > moved secretly up        and down      the Long      Island shore . Just why   these inventions were
 # V/J   J/R      NSg/V/J/P V/C NSg/V/J/P D   NPrSg/V/J NSg/V  NSg/V . V/J  NSg/V I/D   NPl        NSg/V
-> a   source of  satisfaction to James Gatz of  North     Dakota , isn’t easy    to say   .
-# D/P NSg/V  V/P NSg          P  NPrPl ?    V/P NPrSg/V/J NPrSg  . NSg/V NSg/V/J P  NSg/V .
+> a   source of satisfaction to James Gatz of North     Dakota , isn’t easy    to say   .
+# D/P NSg/V  P  NSg          P  NPrPl ?    P  NPrSg/V/J NPrSg  . NSg/V NSg/V/J P  NSg/V .
 >
 #
 > James Gatz — that    was really , or      at        least legally , his   name  . He      had changed it        at
 # NPrPl ?    . N/I/C/D V   J/R    . NPrSg/C NSg/I/V/P NSg/J J/R     . ISg/D NSg/V . NPr/ISg V   V/J     NPrSg/ISg NSg/I/V/P
-> the age   of  seventeen and at        the specific moment that    witnessed the beginning of
-# D   NSg/V V/P N         V/C NSg/I/V/P D   NSg/J    NSg    N/I/C/D W?        D   NSg/V/J   V/P
+> the age   of seventeen and at        the specific moment that    witnessed the beginning of
+# D   NSg/V P  N         V/C NSg/I/V/P D   NSg/J    NSg    N/I/C/D W?        D   NSg/V/J   P
 > his   career  — when    he      saw   Dan   Cody’s yacht drop  anchor over      the most    insidious flat
 # ISg/D NSg/V/J . NSg/I/C NPr/ISg NSg/V NPrSg N$     NSg/V NSg/V NSg/V  NSg/V/J/P D   NSg/I/J J         NSg/V/J
 > on  Lake  Superior . It        was James Gatz who     had been  loafing along the beach   that
 # J/P NSg/V NPrSg/J  . NPrSg/ISg V   NPrPl ?    NPrSg/I V   NSg/V V       P     D   NPrSg/V N/I/C/D
-> afternoon in          a   torn green     jersey and a   pair  of  canvas pants , but     it        was already
-# NSg       NPrSg/V/J/P D/P V/J  NPrSg/V/J NPrSg  V/C D/P NSg/V V/P NSg/V  NPl   . NSg/C/P NPrSg/ISg V   W?
+> afternoon in          a   torn green     jersey and a   pair  of canvas pants , but     it        was already
+# NSg       NPrSg/V/J/P D/P V/J  NPrSg/V/J NPrSg  V/C D/P NSg/V P  NSg/V  NPl   . NSg/C/P NPrSg/ISg V   W?
 > Jay   Gatsby who     borrowed a   rowboat , pulled out         to the Tuolomee , and informed Cody
 # NPrSg NPr    NPrSg/I W?       D/P NSg/V   . W?     NSg/V/J/R/P P  D   ?        . V/C V/J      NPr
 > that    a   wind  might    catch him and break him up        in          half      an  hour .
@@ -6068,62 +6068,62 @@
 # ISg V       W?   V   D   NSg/V NSg/V/J C/P D/P NPrSg/V/J NSg/V . NSg/V/J NSg/J/C . ISg/D NPl     NSg/V
 > shiftless and unsuccessful farm  people — his   imagination had never really accepted
 # J         V/C J            NSg/V NSg/V  . ISg/D NSg         V   V     J/R    V/J
-> them as    his   parents at        all       . The truth was that    Jay   Gatsby of  West      Egg   , Long
-# N/I  NSg/R ISg/D NPl     NSg/I/V/P NSg/I/J/C . D   NSg/V V   N/I/C/D NPrSg NPr    V/P NPrSg/V/J NSg/V . NPrSg/V/J
-> Island , sprang from his   Platonic conception of  himself . He      was a   son     of  God     — a
-# NSg/V  . V      P    ISg/D NSg/J    NSg        V/P I       . NPr/ISg V   D/P NPrSg/V V/P NPrSg/V . D/P
+> them as    his   parents at        all       . The truth was that    Jay   Gatsby of West      Egg   , Long
+# N/I  NSg/R ISg/D NPl     NSg/I/V/P NSg/I/J/C . D   NSg/V V   N/I/C/D NPrSg NPr    P  NPrSg/V/J NSg/V . NPrSg/V/J
+> Island , sprang from his   Platonic conception of himself . He      was a   son     of God     — a
+# NSg/V  . V      P    ISg/D NSg/J    NSg        P  I       . NPr/ISg V   D/P NPrSg/V P  NPrSg/V . D/P
 > phrase which , if    it        means anything , means just that    — and he      must  be     about His
 # NSg/V  I/C   . NSg/C NPrSg/ISg NPl   NSg/I/V  . NPl   V/J  N/I/C/D . V/C NPr/ISg NSg/V NSg/VX J/P   ISg/D
-> Father’s business , the service of  a   vast  , vulgar , and meretricious beauty  . So        he
-# N$       NSg/J    . D   NSg/V   V/P D/P NSg/J . NSg/J  . V/C J            NSg/V/J . NSg/I/J/C NPr/ISg
-> invented just the sort  of  Jay   Gatsby that    a   seventeen year - old   boy   would  be
-# W?       V/J  D   NSg/V V/P NPrSg NPr    N/I/C/D D/P N         NSg  . NSg/J NSg/V NSg/VX NSg/VX
+> Father’s business , the service of a   vast  , vulgar , and meretricious beauty  . So        he
+# N$       NSg/J    . D   NSg/V   P  D/P NSg/J . NSg/J  . V/C J            NSg/V/J . NSg/I/J/C NPr/ISg
+> invented just the sort  of Jay   Gatsby that    a   seventeen year - old   boy   would  be
+# W?       V/J  D   NSg/V P  NPrSg NPr    N/I/C/D D/P N         NSg  . NSg/J NSg/V NSg/VX NSg/VX
 > likely to invent , and to this conception he      was faithful to the end   .
 # NSg/J  P  V      . V/C P  I/D  NSg        NPr/ISg V   NSg/J    P  D   NSg/V .
 >
 #
-> For over      a   year he      had been  beating his   way   along the south     shore of  Lake
-# C/P NSg/V/J/P D/P NSg  NPr/ISg V   NSg/V NSg/V   ISg/D NSg/J P     D   NPrSg/V/J NSg/V V/P NSg/V
+> For over      a   year he      had been  beating his   way   along the south     shore of Lake
+# C/P NSg/V/J/P D/P NSg  NPr/ISg V   NSg/V NSg/V   ISg/D NSg/J P     D   NPrSg/V/J NSg/V P  NSg/V
 > Superior as    a   clam    - digger and a   salmon  - fisher  or      in          any   other   capacity that
 # NPrSg/J  NSg/R D/P NSg/V/J . NSg    V/C D/P NSg/V/J . NPrSg/J NPrSg/C NPrSg/V/J/P I/R/D NSg/V/J NSg/J    N/I/C/D
 > brought him food and bed   . His   brown     , hardening body  lived naturally through the
 # V       I   NSg  V/C NSg/V . ISg/D NPrSg/V/J . V         NSg/V W?    J/R       NSg/J/P D
-> half      - fierce , half      - lazy    work  of  the bracing days . He      knew women early   , and since
-# NSg/V/J/P . J      . NSg/V/J/P . NSg/V/J NSg/V V/P D   V       NPl  . NPr/ISg V    NPl   NSg/J/R . V/C C/P
-> they spoiled him he      became contemptuous of  them , of  young     virgins because they
-# IPl  V/J     I   NPr/ISg V      J            V/P N/I  . V/P NPrSg/V/J NPl     C/P     IPl
-> were  ignorant , of  the others because they were  hysterical about things which in
-# NSg/V NSg/J    . V/P D   NPl    C/P     IPl  NSg/V J          J/P   NPl    I/C   NPrSg/V/J/P
+> half      - fierce , half      - lazy    work  of the bracing days . He      knew women early   , and since
+# NSg/V/J/P . J      . NSg/V/J/P . NSg/V/J NSg/V P  D   V       NPl  . NPr/ISg V    NPl   NSg/J/R . V/C C/P
+> they spoiled him he      became contemptuous of them , of young     virgins because they
+# IPl  V/J     I   NPr/ISg V      J            P  N/I  . P  NPrSg/V/J NPl     C/P     IPl
+> were  ignorant , of the others because they were  hysterical about things which in
+# NSg/V NSg/J    . P  D   NPl    C/P     IPl  NSg/V J          J/P   NPl    I/C   NPrSg/V/J/P
 > his   overwhelming self      - absorbtion he      took for granted .
 # ISg/D NSg/V/J      NSg/I/V/J . ?          NPr/ISg V    C/P W?      .
 >
 #
 > But     his   heart was in          a   constant , turbulent riot  . The most    grotesque and
 # NSg/C/P ISg/D NSg/V V   NPrSg/V/J/P D/P NSg/J    . J         NSg/V . D   NSg/I/J NSg/J     V/C
-> fantastic conceits haunted him in          his   bed   at        night . A   universe of  ineffable
-# NSg/J     NPl      W?      I   NPrSg/V/J/P ISg/D NSg/V NSg/I/V/P NSg/V . D/P NPrSg    V/P J
+> fantastic conceits haunted him in          his   bed   at        night . A   universe of ineffable
+# NSg/J     NPl      W?      I   NPrSg/V/J/P ISg/D NSg/V NSg/I/V/P NSg/V . D/P NPrSg    P  J
 > gaudiness spun itself out         in          his   brain   while     the clock ticked on  the wash    - stand
 # NSg       V    I      NSg/V/J/R/P NPrSg/V/J/P ISg/D NPrSg/V NSg/V/C/P D   NSg/V W?     J/P D   NPrSg/V . NSg/V
 > and the moon    soaked with wet     light   his   tangled clothes upon the floor . Each
 # V/C D   NPrSg/V W?     P    NSg/V/J NSg/V/J ISg/D W?      NPl     P    D   NSg/V . D
-> night he      added to the pattern of  his   fancies until drowsiness closed down      upon
-# NSg/V NPr/ISg W?    P  D   NSg/V/J V/P ISg/D NPl     C/P   NSg        W?     NSg/V/J/P P
+> night he      added to the pattern of his   fancies until drowsiness closed down      upon
+# NSg/V NPr/ISg W?    P  D   NSg/V/J P  ISg/D NPl     C/P   NSg        W?     NSg/V/J/P P
 > some  vivid scene with an  oblivious embrace . For a   while     these reveries provided
 # I/J/R NSg/J NSg/V P    D/P J         NSg/V   . C/P D/P NSg/V/C/P I/D   NPl      V/C
-> an  outlet for his   imagination ; they were  a   satisfactory hint  of  the unreality of
-# D/P NSg    C/P ISg/D NSg         . IPl  NSg/V D/P NSg/J        NSg/V V/P D   NSg       V/P
-> reality , a   promise that    the rock    of  the world was founded securely on  a   fairy’s
-# NSg     . D/P NSg/V   N/I/C/D D   NPrSg/V V/P D   NSg/V V   V/J     J/R      J/P D/P N$
+> an  outlet for his   imagination ; they were  a   satisfactory hint  of the unreality of
+# D/P NSg    C/P ISg/D NSg         . IPl  NSg/V D/P NSg/J        NSg/V P  D   NSg       P
+> reality , a   promise that    the rock    of the world was founded securely on  a   fairy’s
+# NSg     . D/P NSg/V   N/I/C/D D   NPrSg/V P  D   NSg/V V   V/J     J/R      J/P D/P N$
 > wing  .
 # NSg/V .
 >
 #
 > An  instinct toward his   future glory had led him , some  months before , to the
 # D/P NSg/J    J/P    ISg/D NSg/J  NSg/V V   NSg I   . I/J/R NSg    C/P    . P  D
-> small     Lutheran College of  St      . Olaf’s in          northern Minnesota . He      stayed there two
-# NPrSg/V/J NSg/J    NSg     V/P NPrSg/V . N$     NPrSg/V/J/P NSg/J    NPr       . NPr/ISg W?     W?    NSg
-> weeks , dismayed at        its   ferocious indifference to the drums of  his   destiny , to
-# NPrPl . V/J      NSg/I/V/P ISg/D J         NSg/V        P  D   NPl   V/P ISg/D NSg     . P
+> small     Lutheran College of St      . Olaf’s in          northern Minnesota . He      stayed there two
+# NPrSg/V/J NSg/J    NSg     P  NPrSg/V . N$     NPrSg/V/J/P NSg/J    NPr       . NPr/ISg W?     W?    NSg
+> weeks , dismayed at        its   ferocious indifference to the drums of his   destiny , to
+# NPrPl . V/J      NSg/I/V/P ISg/D J         NSg/V        P  D   NPl   P  ISg/D NSg     . P
 > destiny itself , and despising the janitor’s work  with which he      was to pay     his
 # NSg     I      . V/C V         D   N$        NSg/V P    I/C   NPr/ISg V   P  NSg/V/J ISg/D
 > way   through . Then    he      drifted back    to Lake  Superior , and he      was still   searching
@@ -6134,22 +6134,22 @@
 # NPl      J          .
 >
 #
-> Cody was fifty years old   then    , a   product of  the Nevada silver  fields , of  the
-# NPr  V   NSg   NPl   NSg/J NSg/J/C . D/P NSg/V   V/P D   NPr    NSg/V/J NPrPl  . V/P D
-> Yukon , of  every rush      for metal   since seventy - five . The transactions in          Montana
-# NPrSg . V/P D     NPrSg/V/J C/P NSg/V/J C/P   N       . NSg  . D   NPl          NPrSg/V/J/P NPr
+> Cody was fifty years old   then    , a   product of the Nevada silver  fields , of the
+# NPr  V   NSg   NPl   NSg/J NSg/J/C . D/P NSg/V   P  D   NPr    NSg/V/J NPrPl  . P  D
+> Yukon , of every rush      for metal   since seventy - five . The transactions in          Montana
+# NPrSg . P  D     NPrSg/V/J C/P NSg/V/J C/P   N       . NSg  . D   NPl          NPrSg/V/J/P NPr
 > copper  that    made  him many    times a   millionaire found him physically robust but     on
 # NSg/V/J N/I/C/D NSg/V I   N/I/J/D NPl   D/P NSg         NSg/V I   J/R        J      NSg/C/P J/P
-> the verge of  soft  - mindedness , and , suspecting this , an  infinite number  of  women
-# D   NSg/V V/P NSg/J . W?         . V/C . V          I/D  . D/P NSg/J    NSg/V/J V/P NPl
+> the verge of soft  - mindedness , and , suspecting this , an  infinite number  of women
+# D   NSg/V P  NSg/J . W?         . V/C . V          I/D  . D/P NSg/J    NSg/V/J P  NPl
 > tried to separate him from his   money . The none  too savory ramifications by      which
 # V/J   P  NSg/V/J  I   P    ISg/D NSg/J . D   NSg/I W?  NSg/J  W?            NSg/J/P I/C
 > Ella Kaye , the newspaper woman , played Madame de    Maintenon to his   weakness and
 # NPr  NPr  . D   NSg/V     NSg/V . W?     NSg    NPrSg ?         P  ISg/D NSg      V/C
-> sent  him to sea in          a   yacht , were  common  property of  the turgid journalism
-# NSg/V I   P  NSg NPrSg/V/J/P D/P NSg/V . NSg/V NSg/V/J NSg/V    V/P D   J      NSg
-> of  1902 . He      had been  coasting along all       too hospitable shores for five years
-# V/P #    . NPr/ISg V   NSg/V V        P     NSg/I/J/C W?  J          NPl    C/P NSg  NPl
+> sent  him to sea in          a   yacht , were  common  property of the turgid journalism
+# NSg/V I   P  NSg NPrSg/V/J/P D/P NSg/V . NSg/V NSg/V/J NSg/V    P  D   J      NSg
+> of 1902 . He      had been  coasting along all       too hospitable shores for five years
+# P  #    . NPr/ISg V   NSg/V V        P     NSg/I/J/C W?  J          NPl    C/P NSg  NPl
 > when    he      turned up        as    James Gatz’s destiny in          Little    Girl  Bay     .
 # NSg/I/C NPr/ISg W?     NSg/V/J/P NSg/R NPrPl ?      NSg     NPrSg/V/J/P NPrSg/I/J NSg/V NSg/V/J .
 >
@@ -6160,12 +6160,12 @@
 # V           NSg/I/J/C D   NSg/V/J V/C NSg/V   NPrSg/V/J/P D   NSg/V . ISg V       NPr/ISg W?     NSg/I/V/P
 > Cody — he      had probably discovered that    people liked him when    he      smiled . At        any
 # NPr  . NPr/ISg V   R        V          N/I/C/D NSg/V  W?    I   NSg/I/C NPr/ISg W?     . NSg/I/V/P I/R/D
-> rate  Cody asked him a   few questions ( one       of  them elicited the brand new     name  )
-# NSg/V NPr  V/J   I   D/P N/I NPl       . NSg/I/V/J V/P N/I  W?       D   NSg/V NSg/V/J NSg/V .
+> rate  Cody asked him a   few questions ( one       of them elicited the brand new     name  )
+# NSg/V NPr  V/J   I   D/P N/I NPl       . NSg/I/V/J P  N/I  W?       D   NSg/V NSg/V/J NSg/V .
 > and found that    he      was quick   and extravagantly ambitious . A   few days later he
 # V/C NSg/V N/I/C/D NPr/ISg V   NSg/V/J V/C J/R           J         . D/P N/I NPl  J     NPr/ISg
-> took him to Duluth and bought him a   blue    coat  , six pair  of  white     duck  trousers ,
-# V    I   P  NPr    V/C NSg/V  I   D/P NSg/V/J NSg/V . NSg NSg/V V/P NPrSg/V/J NSg/V NSg      .
+> took him to Duluth and bought him a   blue    coat  , six pair  of white     duck  trousers ,
+# V    I   P  NPr    V/C NSg/V  I   D/P NSg/V/J NSg/V . NSg NSg/V P  NPrSg/V/J NSg/V NSg      .
 > and a   yachting cap     . And when    the Tuolomee left      for the West      Indies and the
 # V/C D/P NSg/V    NPrSg/V . V/C NSg/I/C D   ?        NPrSg/V/J C/P D   NPrSg/V/J NPrPl  V/C D
 > Barbary Coast Gatsby left      too .
@@ -6188,44 +6188,44 @@
 # NSg/V NSg/I/V/J NSg/V NPrSg/V/J/P NPrSg  V/C D/P NSg  J     NPrSg NPr  R            W?   .
 >
 #
-> I   remember the portrait of  him up        in          Gatsby’s bedroom , a   gray         , florid man         with a
-# ISg NSg/V    D   NSg/V/J  V/P I   NSg/V/J/P NPrSg/V/J/P N$       NSg     . D/P NPrSg/V/J/Am . J      NPrSg/I/V/J P    D/P
-> hard    , empty   face  — the pioneer debauchee , who     during one       phase   of  American life
-# NSg/V/J . NSg/V/J NSg/V . D   NSg/V   NSg       . NPrSg/I V/P    NSg/I/V/J NPrSg/V V/P NPrSg/J  NSg/V
-> brought back    to the Eastern seaboard the savage    violence of  the frontier brothel
-# V       NSg/V/J P  D   J       NSg      D   NPrSg/V/J NSg/V    V/P D   NSg/V    NSg
+> I   remember the portrait of him up        in          Gatsby’s bedroom , a   gray         , florid man         with a
+# ISg NSg/V    D   NSg/V/J  P  I   NSg/V/J/P NPrSg/V/J/P N$       NSg     . D/P NPrSg/V/J/Am . J      NPrSg/I/V/J P    D/P
+> hard    , empty   face  — the pioneer debauchee , who     during one       phase   of American life
+# NSg/V/J . NSg/V/J NSg/V . D   NSg/V   NSg       . NPrSg/I V/P    NSg/I/V/J NPrSg/V P  NPrSg/J  NSg/V
+> brought back    to the Eastern seaboard the savage    violence of the frontier brothel
+# V       NSg/V/J P  D   J       NSg      D   NPrSg/V/J NSg/V    P  D   NSg/V    NSg
 > and saloon . It        was indirectly due   to Cody that    Gatsby drank so        little    . Sometimes
 # V/C NSg    . NPrSg/ISg V   J/R        NSg/J P  NPr  N/I/C/D NPr    NSg/V NSg/I/J/C NPrSg/I/J . R
-> in          the course of  gay       parties women used to rub   champagne into his   hair  ; for
-# NPrSg/V/J/P D   NSg/V  V/P NPrSg/V/J NPl     NPl   V/J  P  NSg/V NSg/V/J   P    ISg/D NSg/V . C/P
-> himself he      formed the habit of  letting liquor alone .
-# I       NPr/ISg V      D   NSg/V V/P NSg/V   NSg/V  J     .
+> in          the course of gay       parties women used to rub   champagne into his   hair  ; for
+# NPrSg/V/J/P D   NSg/V  P  NPrSg/V/J NPl     NPl   V/J  P  NSg/V NSg/V/J   P    ISg/D NSg/V . C/P
+> himself he      formed the habit of letting liquor alone .
+# I       NPr/ISg V      D   NSg/V P  NSg/V   NSg/V  J     .
 >
 #
-> And it        was from Cody that    he      inherited money — a   legacy of  twenty - five thousand
-# V/C NPrSg/ISg V   P    NPr  N/I/C/D NPr/ISg W?        NSg/J . D/P NSg/J  V/P NSg    . NSg  NSg
+> And it        was from Cody that    he      inherited money — a   legacy of twenty - five thousand
+# V/C NPrSg/ISg V   P    NPr  N/I/C/D NPr/ISg W?        NSg/J . D/P NSg/J  P  NSg    . NSg  NSg
 > dollars . He      didn’t get   it        . He      never understood the legal device    that    was used
 # NPl     . NPr/ISg V      NSg/V NPrSg/ISg . NPr/ISg V     V/J        D   NSg/J NSg/V/J/P N/I/C/D V   V/J
-> against him , but     what  remained of  the millions went  intact to Ella Kaye . He      was
-# C/P     I   . NSg/C/P NSg/I W?       V/P D   NPl      NSg/V J      P  NPr  NPr  . NPr/ISg V
-> left      with his   singularly appropriate education ; the vague   contour of  Jay   Gatsby
-# NPrSg/V/J P    ISg/D J/R        V/J         NSg       . D   NSg/V/J NSg/V   V/P NPrSg NPr
-> had filled out         to the substantiality of  a   man         .
-# V   V/J    NSg/V/J/R/P P  D   ?              V/P D/P NPrSg/I/V/J .
+> against him , but     what  remained of the millions went  intact to Ella Kaye . He      was
+# C/P     I   . NSg/C/P NSg/I W?       P  D   NPl      NSg/V J      P  NPr  NPr  . NPr/ISg V
+> left      with his   singularly appropriate education ; the vague   contour of Jay   Gatsby
+# NPrSg/V/J P    ISg/D J/R        V/J         NSg       . D   NSg/V/J NSg/V   P  NPrSg NPr
+> had filled out         to the substantiality of a   man         .
+# V   V/J    NSg/V/J/R/P P  D   ?              P  D/P NPrSg/I/V/J .
 >
 #
 > He      told me        all       this very much  later , but     I’ve put   it        down      here    with the idea of
-# NPr/ISg V    NPrSg/ISg NSg/I/J/C I/D  J    N/I/J J     . NSg/C/P W?   NSg/V NPrSg/ISg NSg/V/J/P NSg/J/R P    D   NSg  V/P
+# NPr/ISg V    NPrSg/ISg NSg/I/J/C I/D  J    N/I/J J     . NSg/C/P W?   NSg/V NPrSg/ISg NSg/V/J/P NSg/J/R P    D   NSg  P
 > exploding those first   wild    rumors about his   antecedents , which weren’t even
 # V         I/D   NSg/V/J NSg/V/J NPl    J/P   ISg/D NPl         . I/C   V       NSg/V/J
-> faintly true    . Moreover he      told it        to me        at        a   time  of  confusion , when    I   had
-# J/R     NSg/V/J . W?       NPr/ISg V    NPrSg/ISg P  NPrSg/ISg NSg/I/V/P D/P NSg/V V/P NSg/V     . NSg/I/C ISg V
-> reached the point of  believing everything and nothing about him . So        I   take
-# W?      D   NSg/V V/P NSg/V     N/I/V      V/C NSg/I/J J/P   I   . NSg/I/J/C ISg NSg/V
-> advantage of  this short       halt    , while     Gatsby , so        to speak , caught his   breath  , to
-# NSg/V     V/P I/D  NPrSg/V/J/P NSg/V/J . NSg/V/C/P NPr    . NSg/I/J/C P  NSg/V . V/J    ISg/D NSg/V/J . P
-> clear   this set       of  misconceptions away .
-# NSg/V/J I/D  NPrSg/V/J V/P NPl            V/J  .
+> faintly true    . Moreover he      told it        to me        at        a   time  of confusion , when    I   had
+# J/R     NSg/V/J . W?       NPr/ISg V    NPrSg/ISg P  NPrSg/ISg NSg/I/V/P D/P NSg/V P  NSg/V     . NSg/I/C ISg V
+> reached the point of believing everything and nothing about him . So        I   take
+# W?      D   NSg/V P  NSg/V     N/I/V      V/C NSg/I/J J/P   I   . NSg/I/J/C ISg NSg/V
+> advantage of this short       halt    , while     Gatsby , so        to speak , caught his   breath  , to
+# NSg/V     P  I/D  NPrSg/V/J/P NSg/V/J . NSg/V/C/P NPr    . NSg/I/J/C P  NSg/V . V/J    ISg/D NSg/V/J . P
+> clear   this set       of misconceptions away .
+# NSg/V/J I/D  NPrSg/V/J P  NPl            V/J  .
 >
 #
 > It        was a   halt    , too , in          my association with his   affairs . For several weeks I
@@ -6242,8 +6242,8 @@
 # J/R       . NSg/C/P D   J/R    NSg/V/J    NSg/V V   N/I/C/D NPrSg/ISg V      W?       C/P    .
 >
 #
-> They were  a   party   of  three on  horseback — Tom     and a   man         named Sloane and a   pretty
-# IPl  NSg/V D/P NSg/V/J V/P NSg   J/P NSg       . NPrSg/V V/C D/P NPrSg/I/V/J V/J   NPrSg  V/C D/P NSg/V/J
+> They were  a   party   of three on  horseback — Tom     and a   man         named Sloane and a   pretty
+# IPl  NSg/V D/P NSg/V/J P  NSg   J/P NSg       . NPrSg/V V/C D/P NPrSg/I/V/J V/J   NPrSg  V/C D/P NSg/V/J
 > woman in          a   brown     riding - habit , who     had been  there previously .
 # NSg/V NPrSg/V/J/P D/P NPrSg/V/J NSg/V  . NSg/V . NPrSg/I V   NSg/V W?    J/R        .
 >
@@ -6362,16 +6362,16 @@
 # V        NSg/V/J . .
 >
 #
-> “ Please don’t hurry , ” Gatsby urged them . He      had control of  himself now         , and he
-# . V      NSg/V NSg/V . . NPr    W?    N/I  . NPr/ISg V   NSg/V   V/P I       NPrSg/V/J/C . V/C NPr/ISg
-> wanted to see   more        of  Tom     . “ Why   don’t you — why   don’t you stay    for supper  ? I
-# V/J    P  NSg/V NPrSg/I/V/J V/P NPrSg/V . . NSg/V NSg/V IPl . NSg/V NSg/V IPl NSg/V/J C/P NSg/V/J . ISg
+> “ Please don’t hurry , ” Gatsby urged them . He      had control of himself now         , and he
+# . V      NSg/V NSg/V . . NPr    W?    N/I  . NPr/ISg V   NSg/V   P  I       NPrSg/V/J/C . V/C NPr/ISg
+> wanted to see   more        of Tom     . “ Why   don’t you — why   don’t you stay    for supper  ? I
+# V/J    P  NSg/V NPrSg/I/V/J P  NPrSg/V . . NSg/V NSg/V IPl . NSg/V NSg/V IPl NSg/V/J C/P NSg/V/J . ISg
 > wouldn’t be     surprised if    some  other   people dropped in          from New     York . ”
 # VX       NSg/VX W?        NSg/C I/J/R NSg/V/J NSg/V  V/J     NPrSg/V/J/P P    NSg/V/J NPr  . .
 >
 #
-> “ You come    to supper  with me        , ” said the lady    enthusiastically . “ Both of  you . ”
-# . IPl NSg/V/P P  NSg/V/J P    NPrSg/ISg . . V/J  D   NPrSg/V W?               . . I/C  V/P IPl . .
+> “ You come    to supper  with me        , ” said the lady    enthusiastically . “ Both of you . ”
+# . IPl NSg/V/P P  NSg/V/J P    NPrSg/ISg . . V/J  D   NPrSg/V W?               . . I/C  P  IPl . .
 >
 #
 > This included me        . Mr  . Sloane got to his   feet .
@@ -6382,8 +6382,8 @@
 # . NSg/V/P P     . . NPr/ISg V/J  . NSg/C/P P  I/J/D W?   .
 >
 #
-> “ I   mean    it        , ” she insisted . “ I’d love    to have   you . Lots of  room    . ”
-# . ISg NSg/V/J NPrSg/ISg . . ISg W?       . . W?  NPrSg/V P  NSg/VX IPl . NPl  V/P NSg/V/J . .
+> “ I   mean    it        , ” she insisted . “ I’d love    to have   you . Lots of room    . ”
+# . ISg NSg/V/J NPrSg/ISg . . ISg W?       . . W?  NPrSg/V P  NSg/VX IPl . NPl  P  NSg/V/J . .
 >
 #
 > Gatsby looked at        me        questioningly . He      wanted to go      , and he      didn’t see   that    Mr  .
@@ -6416,8 +6416,8 @@
 # NSg/V/J . .
 >
 #
-> The rest  of  us      walked out         on  the porch , where Sloane and the lady    began an
-# D   NSg/V V/P NPr/ISg W?     NSg/V/J/R/P J/P D   NSg   . NSg/C NPrSg  V/C D   NPrSg/V V     D/P
+> The rest  of us      walked out         on  the porch , where Sloane and the lady    began an
+# D   NSg/V P  NPr/ISg W?     NSg/V/J/R/P J/P D   NSg   . NSg/C NPrSg  V/C D   NPrSg/V V     D/P
 > impassioned conversation aside .
 # J           NSg/V        NSg/J .
 >
@@ -6438,8 +6438,8 @@
 # NSg/V  NSg/C NPrSg/V/J/P D   NPrSg/V NPr/ISg V   NPrSg . NSg/J/P NPrSg/V . ISg NPrSg/VX NSg/VX NSg/J . W?        NPrSg/V/J/P D
 > ideas , but     women run   around too much  these days to suit  me        . They meet    all       kinds
 # NPl   . NSg/C/P NPl   NSg/V J/P    W?  N/I/J I/D   NPl  P  NSg/V NPrSg/ISg . IPl  NSg/V/J NSg/I/J/C NSg
-> of  crazy fish  . ”
-# V/P NSg/J NSg/V . .
+> of crazy fish  . ”
+# P  NSg/J NSg/V . .
 >
 #
 > Suddenly Mr  . Sloane and the lady    walked down      the steps and mounted their horses .
@@ -6452,8 +6452,8 @@
 # NPrSg/ISg . . NPrSg/V I   IPl V        NSg/V . NPrSg/VX IPl . .
 >
 #
-> Tom     and I   shook   hands , the rest  of  us      exchanged a   cool    nod   , and they trotted
-# NPrSg/V V/C ISg NSg/V/J NPl   . D   NSg/V V/P NPr/ISg W?        D/P NSg/V/J NSg/V . V/C IPl  V
+> Tom     and I   shook   hands , the rest  of us      exchanged a   cool    nod   , and they trotted
+# NPrSg/V V/C ISg NSg/V/J NPl   . D   NSg/V P  NPr/ISg W?        D/P NSg/V/J NSg/V . V/C IPl  V
 > quickly down      the drive , disappearing under   the August    foliage just as    Gatsby ,
 # J/R     NSg/V/J/P D   NSg/V . V            NSg/J/P D   NPrSg/V/J NSg     V/J  NSg/R NPr    .
 > with hat   and light   overcoat in          hand  , came    out         the front   door  .
@@ -6464,12 +6464,12 @@
 # NPrSg/V V   J/R       V/J       NSg/I/V/P N$      NSg/V/J/P J/P    J     . C/P J/P D
 > following Saturday night he      came    with her   to Gatsby’s party   . Perhaps his
 # NSg/V/J/P NSg/V    NSg/V NPr/ISg NSg/V/P P    I/J/D P  N$       NSg/V/J . NSg     ISg/D
-> presence gave the evening its   peculiar quality of  oppressiveness — it        stands out
-# NSg/V    V    D   NSg/V   ISg/D NSg/J    NSg/J   V/P NSg            . NPrSg/ISg NPl    NSg/V/J/R/P
+> presence gave the evening its   peculiar quality of oppressiveness — it        stands out
+# NSg/V    V    D   NSg/V   ISg/D NSg/J    NSg/J   P  NSg            . NPrSg/ISg NPl    NSg/V/J/R/P
 > in          my memory from Gatsby’s other   parties that    summer  . There were  the same
 # NPrSg/V/J/P D  NSg    P    N$       NSg/V/J NPl     N/I/C/D NPrSg/V . W?    NSg/V D   I/J
-> people , or      at        least the same sort  of  people , the same profusion of  champagne ,
-# NSg/V  . NPrSg/C NSg/I/V/P NSg/J D   I/J  NSg/V V/P NSg/V  . D   I/J  NSg/V     V/P NSg/V/J   .
+> people , or      at        least the same sort  of people , the same profusion of champagne ,
+# NSg/V  . NPrSg/C NSg/I/V/P NSg/J D   I/J  NSg/V P  NSg/V  . D   I/J  NSg/V     P  NSg/V/J   .
 > the same many    - colored    , many    - keyed commotion , but     I   felt    an  unpleasantness in          the
 # D   I/J  N/I/J/D . NSg/V/J/Am . N/I/J/D . W?    NSg       . NSg/C/P ISg NSg/V/J D/P NSg            NPrSg/V/J/P D
 > air   , a   pervading harshness that    hadn’t been  there before . Or      perhaps I   had
@@ -6478,12 +6478,12 @@
 # J/R    V/J   V/J  P  NPrSg/ISg . V/J   P  NSg/V/J NPrSg/V/J NSg/V NSg/R D/P NSg/V NSg/V/J  NPrSg/V/J/P I      .
 > with its   own     standards and its   own     great figures , second  to nothing because it
 # P    ISg/D NSg/V/J NPl       V/C ISg/D NSg/V/J NSg/J NPl     . NSg/V/J P  NSg/I/J C/P     NPrSg/ISg
-> had no      consciousness of  being   so        , and now         I   was looking at        it        again , through
-# V   NPrSg/P NSg           V/P NSg/V/C NSg/I/J/C . V/C NPrSg/V/J/C ISg V   V       NSg/I/V/P NPrSg/ISg P     . NSg/J/P
+> had no      consciousness of being   so        , and now         I   was looking at        it        again , through
+# V   NPrSg/P NSg           P  NSg/V/C NSg/I/J/C . V/C NPrSg/V/J/C ISg V   V       NSg/I/V/P NPrSg/ISg P     . NSg/J/P
 > Daisy’s eyes . It        is invariably saddening to look  through new     eyes at        things upon
 # N$      NPl  . NPrSg/ISg VL R          V         P  NSg/V NSg/J/P NSg/V/J NPl  NSg/I/V/P NPl    P
-> which you have   expended your own     powers of  adjustment .
-# I/C   IPl NSg/VX W?       D    NSg/V/J NPrSg  V/P NSg        .
+> which you have   expended your own     powers of adjustment .
+# I/C   IPl NSg/VX W?       D    NSg/V/J NPrSg  P  NSg        .
 >
 #
 > They arrived at        twilight , and , as    we  strolled out         among the sparkling hundreds ,
@@ -6508,8 +6508,8 @@
 # . W?  V       J/P    . W?  V      D/P J/Br       . .
 >
 #
-> “ You must  see   the faces of  many    people you’ve heard about . ”
-# . IPl NSg/V NSg/V D   NPl   V/P N/I/J/D NSg/V  W?     V/J   J/P   . .
+> “ You must  see   the faces of many    people you’ve heard about . ”
+# . IPl NSg/V NSg/V D   NPl   P  N/I/J/D NSg/V  W?     V/J   J/P   . .
 >
 #
 > Tom’s arrogant eyes roamed the crowd .
@@ -6524,12 +6524,12 @@
 #
 > “ Perhaps you know  that    lady    , ” Gatsby indicated a   gorgeous , scarcely human   orchid
 # . NSg     IPl NSg/V N/I/C/D NPrSg/V . . NPr    W?        D/P J        . J/R      NSg/V/J NSg/J
-> of  a   woman who     sat     in          state under   a   white     - plum    tree  . Tom     and Daisy stared , with
-# V/P D/P NSg/V NPrSg/I NSg/V/J NPrSg/V/J/P NSg/V NSg/J/P D/P NPrSg/V/J . NSg/V/J NSg/V . NPrSg/V V/C NPrSg W?     . P
-> that    peculiarly unreal feeling that    accompanies the recognition of  a   hitherto
-# N/I/C/D J/R        J      NSg/V/J N/I/C/D NPl         D   NSg         V/P D/P W?
-> ghostly celebrity of  the movies .
-# J/R     NSg       V/P D   NPl    .
+> of a   woman who     sat     in          state under   a   white     - plum    tree  . Tom     and Daisy stared , with
+# P  D/P NSg/V NPrSg/I NSg/V/J NPrSg/V/J/P NSg/V NSg/J/P D/P NPrSg/V/J . NSg/V/J NSg/V . NPrSg/V V/C NPrSg W?     . P
+> that    peculiarly unreal feeling that    accompanies the recognition of a   hitherto
+# N/I/C/D J/R        J      NSg/V/J N/I/C/D NPl         D   NSg         P  D/P W?
+> ghostly celebrity of the movies .
+# J/R     NSg       P  D   NPl    .
 >
 #
 > “ She’s lovely  , ” said Daisy .
@@ -6554,16 +6554,16 @@
 # . NPrSg/V NPrSg/P . . W?       NPrSg/V J/R     . . NSg/C NPrSg/ISg . .
 >
 #
-> But     evidently the sound   of  it        pleased Gatsby for Tom     remained “ the polo  player ”
-# NSg/C/P J/R       D   NSg/V/J V/P NPrSg/ISg W?      NPr    C/P NPrSg/V W?       . D   NPrSg NSg    .
-> for the rest  of  the evening .
-# C/P D   NSg/V V/P D   NSg/V   .
+> But     evidently the sound   of it        pleased Gatsby for Tom     remained “ the polo  player ”
+# NSg/C/P J/R       D   NSg/V/J P  NPrSg/ISg W?      NPr    C/P NPrSg/V W?       . D   NPrSg NSg    .
+> for the rest  of the evening .
+# C/P D   NSg/V P  D   NSg/V   .
 >
 #
 > “ I’ve never met so        many    celebrities , ” Daisy exclaimed , “ I   liked that    man         — what
 # . W?   V     V   NSg/I/J/C N/I/J/D NPl         . . NPrSg W?        . . ISg W?    N/I/C/D NPrSg/I/V/J . NSg/I
-> was his   name  ? — with the sort  of  blue    nose  . ”
-# V   ISg/D NSg/V . . P    D   NSg/V V/P NSg/V/J NSg/V . .
+> was his   name  ? — with the sort  of blue    nose  . ”
+# V   ISg/D NSg/V . . P    D   NSg/V P  NSg/V/J NSg/V . .
 >
 #
 > Gatsby identified him , adding that    he      was a   small     producer .
@@ -6588,8 +6588,8 @@
 # NSg/V/J/P P  D  NPrSg/V V/C NSg/V/J J/P D   NPl   C/P NSg/V/J/P D/P NSg  . NSg/V/C/P NSg/I/V/P I/J/D NSg/V   ISg
 > remained watchfully in          the garden  . “ In          case    there’s a   fire    or      a   flood , ” she
 # W?       J/R        NPrSg/V/J/P D   NSg/V/J . . NPrSg/V/J/P NPrSg/V W?      D/P NSg/V/J NPrSg/C D/P NSg/V . . ISg
-> explained , ‘          ‘          or      any   act     of  God     . ”
-# V         . Unlintable Unlintable NPrSg/C I/R/D NPrSg/V V/P NPrSg/V . .
+> explained , ‘          ‘          or      any   act     of God     . ”
+# V         . Unlintable Unlintable NPrSg/C I/R/D NPrSg/V P  NPrSg/V . .
 >
 #
 > Tom     appeared from his   oblivion as    we  were  sitting down      to supper  together . “ Do
@@ -6681,7 +6681,7 @@
 > watching the moving  - picture director and his   Star  . They were  still   under   the
 # V        D   NSg/V/J . NSg/V   NSg      V/C ISg/D NSg/V . IPl  NSg/V NSg/V/J NSg/J/P D
 > white     - plum    tree  and their faces were  touching  except for a   pale    , thin    ray     of
-# NPrSg/V/J . NSg/V/J NSg/V V/C D     NPl   NSg/V NSg/V/J/P V/C/P  C/P D/P NSg/V/J . NSg/V/J NPrSg/V V/P
+# NPrSg/V/J . NSg/V/J NSg/V V/C D     NPl   NSg/V NSg/V/J/P V/C/P  C/P D/P NSg/V/J . NSg/V/J NPrSg/V P
 > moonlight between . It        occurred to me        that    he      had been  very slowly bending toward
 # NSg/V     NSg/P   . NPrSg/ISg V        P  NPrSg/ISg N/I/C/D NPr/ISg V   NSg/V J    J/R    V       J/P
 > her   all       evening to attain this proximity , and even    while     I   watched I   saw   him
@@ -6710,12 +6710,12 @@
 #
 > I   sat     on  the front   steps with them while     they waited for their car . It        was dark
 # ISg NSg/V/J J/P D   NSg/V/J NPl   P    N/I  NSg/V/C/P IPl  W?     C/P D     NSg . NPrSg/ISg V   NSg/V/J
-> here    in          front   ; only the bright    door  sent  ten square  feet of  light   volleying out
-# NSg/J/R NPrSg/V/J/P NSg/V/J . W?   D   NPrSg/V/J NSg/V NSg/V NSg NSg/V/J NSg  V/P NSg/V/J V         NSg/V/J/R/P
+> here    in          front   ; only the bright    door  sent  ten square  feet of light   volleying out
+# NSg/J/R NPrSg/V/J/P NSg/V/J . W?   D   NPrSg/V/J NSg/V NSg/V NSg NSg/V/J NSg  P  NSg/V/J V         NSg/V/J/R/P
 > into the soft  black   morning . Sometimes a   shadow  moved against a   dressing - room
 # P    D   NSg/J NSg/V/J NSg/V   . R         D/P NSg/V/J V/J   C/P     D/P NSg/V    . NSg/V/J
-> blind   above   , gave way   to another shadow  , an  indefinite procession of  shadows ,
-# NSg/V/J NSg/J/P . V    NSg/J P  I/D     NSg/V/J . D/P NSg/J      NSg/V      V/P NPl     .
+> blind   above   , gave way   to another shadow  , an  indefinite procession of shadows ,
+# NSg/V/J NSg/J/P . V    NSg/J P  I/D     NSg/V/J . D/P NSg/J      NSg/V      P  NPl     .
 > who     rouged and powdered in          an  invisible glass   .
 # NPrSg/I W?     V/C W?       NPrSg/V/J/P D/P J         NPrSg/V .
 >
@@ -6728,8 +6728,8 @@
 # . W?      IPl V    N/I/C/D . . ISg W?       .
 >
 #
-> “ I   didn’t hear it        . I   imagined it        . A   lot     of  these newly rich      people are just big
-# . ISg V      V    NPrSg/ISg . ISg W?       NPrSg/ISg . D/P NPrSg/V V/P I/D   J/R   NPrSg/V/J NSg/V  V   V/J  NSg/V/J
+> “ I   didn’t hear it        . I   imagined it        . A   lot     of these newly rich      people are just big
+# . ISg V      V    NPrSg/ISg . ISg W?       NPrSg/ISg . D/P NPrSg/V P  I/D   J/R   NPrSg/V/J NSg/V  V   V/J  NSg/V/J
 > bootleggers , you know  . ”
 # NPl         . IPl NSg/V . .
 >
@@ -6738,16 +6738,16 @@
 # . NSg/C NPr    . . ISg V/J  J/R     .
 >
 #
-> He      was silent for a   moment . The pebbles of  the drive crunched under   his   feet .
-# NPr/ISg V   NSg/J  C/P D/P NSg    . D   NPl     V/P D   NSg/V W?       NSg/J/P ISg/D NSg  .
+> He      was silent for a   moment . The pebbles of the drive crunched under   his   feet .
+# NPr/ISg V   NSg/J  C/P D/P NSg    . D   NPl     P  D   NSg/V W?       NSg/J/P ISg/D NSg  .
 >
 #
 > “ Well    , he      certainly must  have   strained himself to get   this menagerie together . ”
 # . NSg/V/J . NPr/ISg J/R       NSg/V NSg/VX W?       I       P  NSg/V I/D  NSg       J        . .
 >
 #
-> A   breeze stirred the gray         haze  of  Daisy’s fur       collar .
-# D/P NSg/V  V       D   NPrSg/V/J/Am NSg/V V/P N$      NSg/V/C/P NSg/V  .
+> A   breeze stirred the gray         haze  of Daisy’s fur       collar .
+# D/P NSg/V  V       D   NPrSg/V/J/Am NSg/V P  N$      NSg/V/C/P NSg/V  .
 >
 #
 > “ At        least they are more        interesting than the people we  know  , ” she said with an
@@ -6780,14 +6780,14 @@
 # NSg/V/J NPrSg/V/J/P D    NSg/V N/I/C/D NPrSg/ISg V   V     V   C/P    V/C NSg/VX V     NSg/VX P     .
 > When    the melody rose      her   voice broke   up        sweetly , following it        , in          a   way
 # NSg/I/C D   NPrSg  NPrSg/V/J I/J/D NSg/V NSg/V/J NSg/V/J/P J/R     . NSg/V/J/P NPrSg/ISg . NPrSg/V/J/P D/P NSg/J
-> contralto voices have   , and each change tipped out         a   little    of  her   warm    human
-# NSg       NPl    NSg/VX . V/C D    NSg/V  V      NSg/V/J/R/P D/P NPrSg/I/J V/P I/J/D NSg/V/J NSg/V/J
+> contralto voices have   , and each change tipped out         a   little    of her   warm    human
+# NSg       NPl    NSg/VX . V/C D    NSg/V  V      NSg/V/J/R/P D/P NPrSg/I/J P  I/J/D NSg/V/J NSg/V/J
 > magic   upon the air   .
 # NSg/V/J P    D   NSg/V .
 >
 #
-> “ Lots of  people come    who     haven’t been  invited , ” she said suddenly . “ That    girl
-# . NPl  V/P NSg/V  NSg/V/P NPrSg/I V       NSg/V NSg/V/J . . ISg V/J  J/R      . . N/I/C/D NSg/V
+> “ Lots of people come    who     haven’t been  invited , ” she said suddenly . “ That    girl
+# . NPl  P  NSg/V  NSg/V/P NPrSg/I V       NSg/V NSg/V/J . . ISg V/J  J/R      . . N/I/C/D NSg/V
 > hadn’t been  invited . They simply force their way   in          and he’s too polite to
 # V      NSg/V NSg/V/J . IPl  R      NSg/V D     NSg/J NPrSg/V/J/P V/C N$   W?  V/J    P
 > object . ”
@@ -6796,12 +6796,12 @@
 #
 > “ I’d like        to know  who     he      is and what  he      does  , ” insisted Tom     . “ And I   think I’ll
 # . W?  NSg/V/J/C/P P  NSg/V NPrSg/I NPr/ISg VL V/C NSg/I NPr/ISg NSg/V . . W?       NPrSg/V . . V/C ISg NSg/V W?
-> make  a   point of  finding out         . ”
-# NSg/V D/P NSg/V V/P NSg/V   NSg/V/J/R/P . .
+> make  a   point of finding out         . ”
+# NSg/V D/P NSg/V P  NSg/V   NSg/V/J/R/P . .
 >
 #
 > “ I   can      tell    you right     now         , ” she answered . “ He      owned some  drug  - stores , a   lot     of
-# . ISg NPrSg/VX NPrSg/V IPl NPrSg/V/J NPrSg/V/J/C . . ISg V/J      . . NPr/ISg W?    I/J/R NSg/V . NPl    . D/P NPrSg/V V/P
+# . ISg NPrSg/VX NPrSg/V IPl NPrSg/V/J NPrSg/V/J/C . . ISg V/J      . . NPr/ISg W?    I/J/R NSg/V . NPl    . D/P NPrSg/V P
 > drug  - stores . He      built   them up        himself . ”
 # NSg/V . NPl    . NPr/ISg NSg/V/J N/I  NSg/V/J/P I       . .
 >
@@ -6814,12 +6814,12 @@
 # . NPrSg/V/J NSg/V . NPrSg/V . . V/J  NPrSg .
 >
 #
-> Her   glance left      me        and sought the lighted top     of  the steps , where “ Three o’Clock
-# I/J/D NSg/V  NPrSg/V/J NPrSg/ISg V/C V      D   V/J     NSg/V/J V/P D   NPl   . NSg/C . NSg   W?
-> in          the Morning , ” a   neat  , sad     little    waltz of  that    year , was drifting out         the
-# NPrSg/V/J/P D   NSg/V   . . D/P NSg/J . NSg/V/J NPrSg/I/J NSg/V V/P N/I/C/D NSg  . V   V        NSg/V/J/R/P D
-> open    door  . After all       , in          the very casualness of  Gatsby’s party   there were
-# NSg/V/J NSg/V . J/P   NSg/I/J/C . NPrSg/V/J/P D   J    NSg        V/P N$       NSg/V/J W?    NSg/V
+> Her   glance left      me        and sought the lighted top     of the steps , where “ Three o’Clock
+# I/J/D NSg/V  NPrSg/V/J NPrSg/ISg V/C V      D   V/J     NSg/V/J P  D   NPl   . NSg/C . NSg   W?
+> in          the Morning , ” a   neat  , sad     little    waltz of that    year , was drifting out         the
+# NPrSg/V/J/P D   NSg/V   . . D/P NSg/J . NSg/V/J NPrSg/I/J NSg/V P  N/I/C/D NSg  . V   V        NSg/V/J/R/P D
+> open    door  . After all       , in          the very casualness of Gatsby’s party   there were
+# NSg/V/J NSg/V . J/P   NSg/I/J/C . NPrSg/V/J/P D   J    NSg        P  N$       NSg/V/J W?    NSg/V
 > romantic possibilities totally absent    from her   world . What  was it        up        there in
 # NSg/J    NPl           J/R     NSg/V/J/P P    I/J/D NSg/V . NSg/I V   NPrSg/ISg NSg/V/J/P W?    NPrSg/V/J/P
 > the song that    seemed to be     calling her   back    inside  ? What  would  happen now         in          the
@@ -6828,10 +6828,10 @@
 # NSg/V/J . J            NPl   . NSg     I/J/R J            NSg/V NSg/VX V      . D/P NSg/V
 > infinitely rare    and to be     marvelled at        , some  authentically radiant young     girl
 # J/R        NSg/V/J V/C P  NSg/VX V/Br      NSg/I/V/P . I/J/R R             NSg/J   NPrSg/V/J NSg/V
-> who     with one       fresh   glance at        Gatsby , one       moment of  magical encounter , would  blot
-# NPrSg/I P    NSg/I/V/J NSg/V/J NSg/V  NSg/I/V/P NPr    . NSg/I/V/J NSg    V/P J       NSg/V     . NSg/VX NSg/V
-> out         those five years of  unwavering devotion .
-# NSg/V/J/R/P I/D   NSg  NPl   V/P J          NSg      .
+> who     with one       fresh   glance at        Gatsby , one       moment of magical encounter , would  blot
+# NPrSg/I P    NSg/I/V/J NSg/V/J NSg/V  NSg/I/V/P NPr    . NSg/I/V/J NSg    P  J       NSg/V     . NSg/VX NSg/V
+> out         those five years of unwavering devotion .
+# NSg/V/J/R/P I/D   NSg  NPl   P  J          NSg      .
 >
 #
 > I   stayed late  that    night , Gatsby asked me        to wait  until he      was free    , and I
@@ -6850,8 +6850,8 @@
 # . ISg V      NSg/V/J/C/P NPrSg/ISg . . NPr/ISg V/J  J/R         .
 >
 #
-> “ Of  course she did . ”
-# . V/P NSg/V  ISg V   . .
+> “ Of course she did . ”
+# . P  NSg/V  ISg V   . .
 >
 #
 > “ She didn’t like        it        , ” he      insisted . “ She didn’t have   a   good      time  . ”
@@ -6870,18 +6870,18 @@
 # . IPl NSg/V/J J/P   D   NSg/V . .
 >
 #
-> “ The dance ? ” He      dismissed all       the dances he      had given     with a   snap    of  his
-# . D   NSg/V . . NPr/ISg W?        NSg/I/J/C D   NPl    NPr/ISg V   NSg/V/J/P P    D/P NSg/V/J V/P ISg/D
+> “ The dance ? ” He      dismissed all       the dances he      had given     with a   snap    of his
+# . D   NSg/V . . NPr/ISg W?        NSg/I/J/C D   NPl    NPr/ISg V   NSg/V/J/P P    D/P NSg/V/J P  ISg/D
 > fingers . “ Old   sport , the dance is unimportant . ”
 # NPl     . . NSg/J NSg/V . D   NSg/V VL J           . .
 >
 #
-> He      wanted nothing less    of  Daisy than that    she should go      to Tom     and say   : “ I   never
-# NPr/ISg V/J    NSg/I/J V/J/C/P V/P NPrSg C/P  N/I/C/D ISg VX     NSg/V/J P  NPrSg/V V/C NSg/V . . ISg V
+> He      wanted nothing less    of Daisy than that    she should go      to Tom     and say   : “ I   never
+# NPr/ISg V/J    NSg/I/J V/J/C/P P  NPrSg C/P  N/I/C/D ISg VX     NSg/V/J P  NPrSg/V V/C NSg/V . . ISg V
 > loved you . ” After she had obliterated four years with that    sentence they could
 # V/J   IPl . . J/P   ISg V   W?          NSg  NPl   P    N/I/C/D NSg/V    IPl  NSg/VX
-> decide upon the more        practical measures to be     taken . One       of  them was that    , after
-# V      P    D   NPrSg/I/V/J NSg/J     NPl      P  NSg/VX V/J   . NSg/I/V/J V/P N/I  V   N/I/C/D . J/P
+> decide upon the more        practical measures to be     taken . One       of them was that    , after
+# V      P    D   NPrSg/I/V/J NSg/J     NPl      P  NSg/VX V/J   . NSg/I/V/J P  N/I  V   N/I/C/D . J/P
 > she was free    , they were  to go      back    to Louisville and be     married from her
 # ISg V   NSg/V/J . IPl  NSg/V P  NSg/V/J NSg/V/J P  NPr        V/C NSg/VX NSg/V/J P    I/J/D
 > house   — just as    if    it        were  five years ago .
@@ -6894,24 +6894,24 @@
 # NSg/V C/P NPl   . .
 >
 #
-> He      broke   off       and began to walk  up        and down      a   desolate path  of  fruit rinds and
-# NPr/ISg NSg/V/J NSg/V/J/P V/C V     P  NSg/V NSg/V/J/P V/C NSg/V/J/P D/P V/J      NSg/V V/P NSg/V NPl   V/C
+> He      broke   off       and began to walk  up        and down      a   desolate path  of fruit rinds and
+# NPr/ISg NSg/V/J NSg/V/J/P V/C V     P  NSg/V NSg/V/J/P V/C NSg/V/J/P D/P V/J      NSg/V P  NSg/V NPl   V/C
 > discarded favors and crushed flowers .
 # W?        NPl    V/C W?      NPrPl   .
 >
 #
-> “ I   wouldn’t ask   too much  of  her   , ” I   ventured . “ You can’t repeat the past      . ”
-# . ISg VX       NSg/V W?  N/I/J V/P I/J/D . . ISg W?       . . IPl VX    NSg/V  D   NSg/V/J/P . .
+> “ I   wouldn’t ask   too much  of her   , ” I   ventured . “ You can’t repeat the past      . ”
+# . ISg VX       NSg/V W?  N/I/J P  I/J/D . . ISg W?       . . IPl VX    NSg/V  D   NSg/V/J/P . .
 >
 #
-> “ Can’t repeat the past      ? ” he      cried incredulously . “ Why   of  course you can      ! ”
-# . VX    NSg/V  D   NSg/V/J/P . . NPr/ISg W?    J/R           . . NSg/V V/P NSg/V  IPl NPrSg/VX . .
+> “ Can’t repeat the past      ? ” he      cried incredulously . “ Why   of course you can      ! ”
+# . VX    NSg/V  D   NSg/V/J/P . . NPr/ISg W?    J/R           . . NSg/V P  NSg/V  IPl NPrSg/VX . .
 >
 #
 > He      looked around him wildly , as    if    the past      were  lurking here    in          the shadow  of
-# NPr/ISg W?     J/P    I   J/R    . NSg/R NSg/C D   NSg/V/J/P NSg/V V       NSg/J/R NPrSg/V/J/P D   NSg/V/J V/P
-> his   house   , just out         of  reach of  his   hand  .
-# ISg/D NPrSg/V . V/J  NSg/V/J/R/P V/P NSg/V V/P ISg/D NSg/V .
+# NPr/ISg W?     J/P    I   J/R    . NSg/R NSg/C D   NSg/V/J/P NSg/V V       NSg/J/R NPrSg/V/J/P D   NSg/V/J P
+> his   house   , just out         of reach of his   hand  .
+# ISg/D NPrSg/V . V/J  NSg/V/J/R/P P  NSg/V P  ISg/D NSg/V .
 >
 #
 > “ I’m going   to fix   everything just the way   it        was before , ” he      said , nodding
@@ -6922,8 +6922,8 @@
 #
 > He      talked a   lot     about the past      , and I   gathered that    he      wanted to recover
 # NPr/ISg W?     D/P NPrSg/V J/P   D   NSg/V/J/P . V/C ISg W?       N/I/C/D NPr/ISg V/J    P  NSg/V/J
-> something , some  idea of  himself perhaps , that    had gone  into loving  Daisy . His
-# NSg/I/V/J . I/J/R NSg  V/P I       NSg     . N/I/C/D V   V/J/P P    NSg/V/J NPrSg . ISg/D
+> something , some  idea of himself perhaps , that    had gone  into loving  Daisy . His
+# NSg/I/V/J . I/J/R NSg  P  I       NSg     . N/I/C/D V   V/J/P P    NSg/V/J NPrSg . ISg/D
 > life  had been  confused and disordered since then    , but     if    he      could  once  return to
 # NSg/V V   NSg/V V/J      V/C W?         C/P   NSg/J/C . NSg/C/P NSg/C NPr/ISg NSg/VX NSg/C NSg/V  P
 > a   certain starting place and go      over      it        all       slowly , he      could  find  out         what  that
@@ -6940,26 +6940,26 @@
 # V/C D   NSg      V   NPrSg/V/J P    NSg/V     . IPl  V/J     NSg/J/R V/C W?     J/P
 > each other   . Now         it        was a   cool    night with that    mysterious excitement in          it        which
 # D    NSg/V/J . NPrSg/V/J/C NPrSg/ISg V   D/P NSg/V/J NSg/V P    N/I/C/D J          NSg        NPrSg/V/J/P NPrSg/ISg I/C
-> comes at        the two changes of  the year . The quiet   lights in          the houses were
-# NPl   NSg/I/V/P D   NSg NPl     V/P D   NSg  . D   NSg/V/J NPl    NPrSg/V/J/P D   NPl    NSg/V
+> comes at        the two changes of the year . The quiet   lights in          the houses were
+# NPl   NSg/I/V/P D   NSg NPl     P  D   NSg  . D   NSg/V/J NPl    NPrSg/V/J/P D   NPl    NSg/V
 > humming out         into the darkness and there was a   stir  and bustle among the stars .
 # NSg/V/J NSg/V/J/R/P P    D   NSg      V/C W?    V   D/P NSg/V V/C NSg/V  P     D   NPl   .
-> Out         of  the corner  of  his   eye   Gatsby saw   that    the blocks of  the sidewalks really
-# NSg/V/J/R/P V/P D   NSg/V/J V/P ISg/D NSg/V NPr    NSg/V N/I/C/D D   NPl    V/P D   NPl       J/R
+> Out         of the corner  of his   eye   Gatsby saw   that    the blocks of the sidewalks really
+# NSg/V/J/R/P P  D   NSg/V/J P  ISg/D NSg/V NPr    NSg/V N/I/C/D D   NPl    P  D   NPl       J/R
 > formed a   ladder and mounted to a   secret  place above   the trees — he      could  climb to
 # V      D/P NSg/V  V/C V/J     P  D/P NSg/V/J NSg/V NSg/J/P D   NPl   . NPr/ISg NSg/VX NSg/V P
-> it        , if    he      climbed alone , and once  there he      could  suck  on  the pap     of  life  , gulp
-# NPrSg/ISg . NSg/C NPr/ISg W?      J     . V/C NSg/C W?    NPr/ISg NSg/VX NSg/V J/P D   NSg/V/J V/P NSg/V . NSg/V
-> down      the incomparable milk  of  wonder .
-# NSg/V/J/P D   NSg/J        NSg/V V/P NSg/V  .
+> it        , if    he      climbed alone , and once  there he      could  suck  on  the pap     of life  , gulp
+# NPrSg/ISg . NSg/C NPr/ISg W?      J     . V/C NSg/C W?    NPr/ISg NSg/VX NSg/V J/P D   NSg/V/J P  NSg/V . NSg/V
+> down      the incomparable milk  of wonder .
+# NSg/V/J/P D   NSg/J        NSg/V P  NSg/V  .
 >
 #
 > His   heart beat    faster and faster as    Daisy’s white     face  came    up        to his   own     . He
 # ISg/D NSg/V NSg/V/J J      V/C J      NSg/R N$      NPrSg/V/J NSg/V NSg/V/P NSg/V/J/P P  ISg/D NSg/V/J . NPr/ISg
 > knew that    when    he      kissed this girl  , and forever wed   his   unutterable visions to
 # V    N/I/C/D NSg/I/C NPr/ISg W?     I/D  NSg/V . V/C NSg/J   NSg/V ISg/D NSg/J       NPl     P
-> her   perishable breath  , his   mind  would  never romp  again like        the mind  of  God     . So
-# I/J/D NSg/J      NSg/V/J . ISg/D NSg/V NSg/VX V     NSg/V P     NSg/V/J/C/P D   NSg/V V/P NPrSg/V . NSg/I/J/C
+> her   perishable breath  , his   mind  would  never romp  again like        the mind  of God     . So
+# I/J/D NSg/J      NSg/V/J . ISg/D NSg/V NSg/VX V     NSg/V P     NSg/V/J/C/P D   NSg/V P  NPrSg/V . NSg/I/J/C
 > he      waited , listening for a   moment longer to the tuning - fork  that    had been  struck
 # NPr/ISg W?     . V         C/P D/P NSg    NSg/J  P  D   V      . NSg/V N/I/C/D V   NSg/V V
 > upon a   star  . Then    he      kissed her   . At        his   lips ’ touch she blossomed for him like        a
@@ -6970,14 +6970,14 @@
 #
 > Through all       he      said , even    through his   appalling sentimentality , I   was reminded
 # NSg/J/P NSg/I/J/C NPr/ISg V/J  . NSg/V/J NSg/J/P ISg/D V         NSg            . ISg V   W?
-> of  something — an  elusive rhythm , a   fragment of  lost words , that    I   had heard
-# V/P NSg/I/V/J . D/P J       NSg/V  . D/P NSg/V    V/P V/J  NPl   . N/I/C/D ISg V   V/J
+> of something — an  elusive rhythm , a   fragment of lost words , that    I   had heard
+# P  NSg/I/V/J . D/P J       NSg/V  . D/P NSg/V    P  V/J  NPl   . N/I/C/D ISg V   V/J
 > somewhere a   long      time  ago . For a   moment a   phrase tried to take  shape in          my mouth
 # NSg       D/P NPrSg/V/J NSg/V J/P . C/P D/P NSg    D/P NSg/V  V/J   P  NSg/V NSg/V NPrSg/V/J/P D  NSg/V
 > and my lips parted like        a   dumb man’s        , as    though there was more        struggling upon
 # V/C D  NPl  W?     NSg/V/J/C/P D/P V/J  NPrSg$/I/V/J . NSg/R V/C    W?    V   NPrSg/I/V/J V          P
-> them than a   wisp  of  startled air   . But     they made  no      sound   , and what  I   had almost
-# N/I  C/P  D/P NSg/V V/P W?       NSg/V . NSg/C/P IPl  NSg/V NPrSg/P NSg/V/J . V/C NSg/I ISg V   NSg
+> them than a   wisp  of startled air   . But     they made  no      sound   , and what  I   had almost
+# N/I  C/P  D/P NSg/V P  W?       NSg/V . NSg/C/P IPl  NSg/V NPrSg/P NSg/V/J . V/C NSg/I ISg V   NSg
 > remembered was uncommunicable forever .
 # V          V   ?              NSg/J   .
 >
@@ -7098,14 +7098,14 @@
 # NSg/V/J .
 >
 #
-> The next    day   was broiling , almost the last    , certainly the warmest , of  the
-# D   NSg/J/P NPrSg V   V        . NSg    D   NSg/V/J . J/R       D   W?      . V/P D
+> The next    day   was broiling , almost the last    , certainly the warmest , of the
+# D   NSg/J/P NPrSg V   V        . NSg    D   NSg/V/J . J/R       D   W?      . P  D
 > summer  . As    my train emerged from the tunnel into sunlight , only the hot     whistles
 # NPrSg/V . NSg/R D  NSg/V W?      P    D   NSg/V  P    NSg/V    . W?   D   NSg/V/J NPl
-> of  the National Biscuit Company broke   the simmering hush  at        noon  . The straw
-# V/P D   NSg/J    NSg     NSg/V   NSg/V/J D   V         NSg/V NSg/I/V/P NSg/V . D   NSg/V/J
-> seats of  the car hovered on  the edge  of  combustion ; the woman next    to me
-# NPl   V/P D   NSg W?      J/P D   NSg/V V/P NSg        . D   NSg/V NSg/J/P P  NPrSg/ISg
+> of the National Biscuit Company broke   the simmering hush  at        noon  . The straw
+# P  D   NSg/J    NSg     NSg/V   NSg/V/J D   V         NSg/V NSg/I/V/P NSg/V . D   NSg/V/J
+> seats of the car hovered on  the edge  of combustion ; the woman next    to me
+# NPl   P  D   NSg W?      J/P D   NSg/V P  NSg        . D   NSg/V NSg/J/P P  NPrSg/ISg
 > perspired delicately for a   while     into her   white     shirtwaist , and then    , as    her
 # W?        J/R        C/P D/P NSg/V/C/P P    I/J/D NPrSg/V/J NSg        . V/C NSg/J/C . NSg/R I/J/D
 > newspaper dampened under   her   fingers , lapsed despairingly into deep  heat  with a
@@ -7120,8 +7120,8 @@
 #
 > I   picked it        up        with a   weary bend    and handed it        back    to her   , holding it        at        arm’s
 # ISg W?     NPrSg/ISg NSg/V/J/P P    D/P V/J   NPrSg/V V/C V/J    NPrSg/ISg NSg/V/J P  I/J/D . NSg/V   NPrSg/ISg NSg/I/V/P W?
-> length and by      the extreme tip   of  the corners to indicate that    I   had no      designs
-# NSg/V  V/C NSg/J/P D   NSg/J   NSg/V V/P D   W?      P  V        N/I/C/D ISg V   NPrSg/P NPl
+> length and by      the extreme tip   of the corners to indicate that    I   had no      designs
+# NSg/V  V/C NSg/J/P D   NSg/J   NSg/V P  D   W?      P  V        N/I/C/D ISg V   NPrSg/P NPl
 > upon it        — but     every one       near      by      , including the woman , suspected me        just the same .
 # P    NPrSg/ISg . NSg/C/P D     NSg/I/V/J NSg/V/J/P NSg/J/P . V         D   NSg/V . V/J       NPrSg/ISg V/J  D   I/J  .
 >
@@ -7140,10 +7140,10 @@
 # D   NSg    NSg/V/J NSg/V/J/P ISg/D NSg/V .
 >
 #
-> . . . Through the hall  of  the Buchanans ’ house   blew    a   faint   wind  , carrying the
-# . . . NSg/J/P D   NPrSg V/P D   ?         . NPrSg/V NSg/V/J D/P NSg/V/J NSg/V . V        D
-> sound   of  the telephone bell    out         to Gatsby and me        as    we  waited at        the door  .
-# NSg/V/J V/P D   NSg/V     NPrSg/V NSg/V/J/R/P P  NPr    V/C NPrSg/ISg NSg/R IPl W?     NSg/I/V/P D   NSg/V .
+> . . . Through the hall  of the Buchanans ’ house   blew    a   faint   wind  , carrying the
+# . . . NSg/J/P D   NPrSg P  D   ?         . NPrSg/V NSg/V/J D/P NSg/V/J NSg/V . V        D
+> sound   of the telephone bell    out         to Gatsby and me        as    we  waited at        the door  .
+# NSg/V/J P  D   NSg/V     NPrSg/V NSg/V/J/R/P P  NPr    V/C NPrSg/ISg NSg/R IPl W?     NSg/I/V/P D   NSg/V .
 >
 #
 > “ The master’s body  ! ” roared the butler  into the mouthpiece . “ I’m sorry   , madame ,
@@ -7166,16 +7166,16 @@
 # . NSg    NPl     IPl NPrSg/V/J/P D   NSg   . . NPr/ISg W?    . J/R        V          D
 > direction . In          this heat  every extra gesture was an  affront to the common  store
 # NSg       . NPrSg/V/J/P I/D  NSg/V D     NSg/J NSg/V   V   D/P NSg/V   P  D   NSg/V/J NSg/V
-> of  life  .
-# V/P NSg/V .
+> of life  .
+# P  NSg/V .
 >
 #
 > The room    , shadowed well    with awnings , was dark    and cool    . Daisy and Jordan lay
 # D   NSg/V/J . W?       NSg/V/J P    W?      . V   NSg/V/J V/C NSg/V/J . NPrSg V/C NPr    NSg/V/J
 > upon an  enormous couch , like        silver  idols weighing down      their own     white     dresses
 # P    D/P J        NSg/V . NSg/V/J/C/P NSg/V/J NPl   V        NSg/V/J/P D     NSg/V/J NPrSg/V/J NPl
-> against the singing breeze of  the fans .
-# C/P     D   NSg/V/J NSg/V  V/P D   NPl  .
+> against the singing breeze of the fans .
+# C/P     D   NSg/V/J NSg/V  P  D   NPl  .
 >
 #
 > “ We  can’t move  , ” they said together .
@@ -7194,12 +7194,12 @@
 # J/R            ISg V/J   ISg/D NSg/V . NSg/V/J . W?      . NSg/J . NSg/I/V/P D   NPrSg NSg/V     .
 >
 #
-> Gatsby stood in          the centre   of  the crimson carpet and gazed around with
-# NPr    V     NPrSg/V/J/P D   NSg/V/Br V/P D   NSg/V/J NSg/V  V/C W?    J/P    P
+> Gatsby stood in          the centre   of the crimson carpet and gazed around with
+# NPr    V     NPrSg/V/J/P D   NSg/V/Br P  D   NSg/V/J NSg/V  V/C W?    J/P    P
 > fascinated eyes . Daisy watched him and laughed , her   sweet     , exciting laugh ; a
 # W?         NPl  . NPrSg W?      I   V/C W?      . I/J/D NPrSg/V/J . NSg/V/J  NSg/V . D/P
-> tiny  gust  of  powder rose      from her   bosom   into the air   .
-# NSg/J NSg/V V/P NSg/V  NPrSg/V/J P    I/J/D NSg/V/J P    D   NSg/V .
+> tiny  gust  of powder rose      from her   bosom   into the air   .
+# NSg/J NSg/V P  NSg/V  NPrSg/V/J P    I/J/D NSg/V/J P    D   NSg/V .
 >
 #
 > “ The rumor is , ” whispered Jordan , “ that    that’s Tom’s girl  on  the telephone . ”
@@ -7308,8 +7308,8 @@
 #
 > “ That’s because your mother wanted to show  you off       . ” Her   face  bent    into the
 # . N$     C/P     D    NSg/V  V/J    P  NSg/V IPl NSg/V/J/P . . I/J/D NSg/V NSg/V/J P    D
-> single  wrinkle of  the small     white     neck  . “ You dream   , you . You absolute little
-# NSg/V/J NSg/V   V/P D   NPrSg/V/J NPrSg/V/J NSg/V . . IPl NSg/V/J . IPl . IPl NSg/J    NPrSg/I/J
+> single  wrinkle of the small     white     neck  . “ You dream   , you . You absolute little
+# NSg/V/J NSg/V   P  D   NPrSg/V/J NPrSg/V/J NSg/V . . IPl NSg/V/J . IPl . IPl NSg/J    NPrSg/I/J
 > dream   . ”
 # NSg/V/J . .
 >
@@ -7330,8 +7330,8 @@
 #
 > “ She doesn’t look  like        her   father  , ” explained Daisy . “ She looks like        me        . She’s
 # . ISg V       NSg/V NSg/V/J/C/P I/J/D NPrSg/V . . V         NPrSg . . ISg NPl   NSg/V/J/C/P NPrSg/ISg . W?
-> got my hair  and shape of  the face  . ”
-# V   D  NSg/V V/C NSg/V V/P D   NSg/V . .
+> got my hair  and shape of the face  . ”
+# V   D  NSg/V V/C NSg/V P  D   NSg/V . .
 >
 #
 > Daisy sat     back    upon the couch . The nurse took a   step  forward and held out         her
@@ -7352,8 +7352,8 @@
 # P    D/P J         NSg/J    NSg/V  D   NSg/V/J . V/J         NSg/V V    P  I/J/D N$
 > hand  and was pulled out         the door  , just as    Tom     came    back    , preceding four gin
 # NSg/V V/C V   W?     NSg/V/J/R/P D   NSg/V . V/J  NSg/R NPrSg/V NSg/V/P NSg/V/J . V         NSg  NSg/V/C
-> rickeys that    clicked full    of  ice     .
-# ?       N/I/C/D W?      NSg/V/J V/P NPrSg/V .
+> rickeys that    clicked full    of ice     .
+# ?       N/I/C/D W?      NSg/V/J P  NPrSg/V .
 >
 #
 > Gatsby took up        his   drink .
@@ -7398,12 +7398,12 @@
 # . NSg/I/J/C IPl V   . .
 >
 #
-> Our eyes lifted over      the rose      - beds and the hot     lawn  and the weedy refuse of  the
-# D   NPl  W?     NSg/V/J/P D   NPrSg/V/J . NPl  V/C D   NSg/V/J NSg/V V/C D   J     NSg/V  V/P D
-> dog     - days alongshore . Slowly the white     wings of  the boat  moved against the blue
-# NSg/V/J . NPl  J          . J/R    D   NPrSg/V/J NPl   V/P D   NSg/V V/J   C/P     D   NSg/V/J
-> cool    limit   of  the sky   . Ahead lay     the scalloped ocean and the abounding blessed
-# NSg/V/J NSg/V/J V/P D   NSg/V . W?    NSg/V/J D   W?        NSg   V/C D   V         V/J
+> Our eyes lifted over      the rose      - beds and the hot     lawn  and the weedy refuse of the
+# D   NPl  W?     NSg/V/J/P D   NPrSg/V/J . NPl  V/C D   NSg/V/J NSg/V V/C D   J     NSg/V  P  D
+> dog     - days alongshore . Slowly the white     wings of the boat  moved against the blue
+# NSg/V/J . NPl  J          . J/R    D   NPrSg/V/J NPl   P  D   NSg/V V/J   C/P     D   NSg/V/J
+> cool    limit   of the sky   . Ahead lay     the scalloped ocean and the abounding blessed
+# NSg/V/J NSg/V/J P  D   NSg/V . W?    NSg/V/J D   W?        NSg   V/C D   V         V/J
 > isles .
 # NPl   .
 >
@@ -7432,8 +7432,8 @@
 # NPrSg/V/J/P D   NSg/V . .
 >
 #
-> “ But     it’s so        hot     , ” insisted Daisy , on  the verge of  tears , “ and everything’s so
-# . NSg/C/P W?   NSg/I/J/C NSg/V/J . . W?       NPrSg . J/P D   NSg/V V/P NPl   . . V/C N$           NSg/I/J/C
+> “ But     it’s so        hot     , ” insisted Daisy , on  the verge of tears , “ and everything’s so
+# . NSg/C/P W?   NSg/I/J/C NSg/V/J . . W?       NPrSg . J/P D   NSg/V P  NPl   . . V/C N$           NSg/I/J/C
 > confused . Let’s all       go      to town ! ”
 # V/J      . N$    NSg/I/J/C NSg/V/J P  NSg  . .
 >
@@ -7444,10 +7444,10 @@
 # NSg           P    NPl   .
 >
 #
-> “ I’ve heard of  making a   garage out         of  a   stable  , ” Tom     was saying to Gatsby , “ but
-# . W?   V/J   V/P NSg/V  D/P NSg/V  NSg/V/J/R/P V/P D/P NSg/V/J . . NPrSg/V V   NSg/V  P  NPr    . . NSg/C/P
-> I’m the first   man         who     ever made  a   stable  out         of  a   garage . ”
-# W?  D   NSg/V/J NPrSg/I/V/J NPrSg/I J    NSg/V D/P NSg/V/J NSg/V/J/R/P V/P D/P NSg/V  . .
+> “ I’ve heard of making a   garage out         of a   stable  , ” Tom     was saying to Gatsby , “ but
+# . W?   V/J   P  NSg/V  D/P NSg/V  NSg/V/J/R/P P  D/P NSg/V/J . . NPrSg/V V   NSg/V  P  NPr    . . NSg/C/P
+> I’m the first   man         who     ever made  a   stable  out         of a   garage . ”
+# W?  D   NSg/V/J NPrSg/I/V/J NPrSg/I J    NSg/V D/P NSg/V/J NSg/V/J/R/P P  D/P NSg/V  . .
 >
 #
 > “ Who     wants to go      to town ? ” demanded Daisy insistently . Gatsby’s eyes floated
@@ -7474,10 +7474,10 @@
 # V   V/J  V/J        I/J/D NSg/R I/J/R NSg/I/V/J NPr/ISg V    D/P NPrSg/V/J NSg/V J/P .
 >
 #
-> “ You resemble the advertisement of  the man         , ” she went  on  innocently . ‘          You know
-# . IPl V        D   NSg           V/P D   NPrSg/I/V/J . . ISg NSg/V J/P J/R        . Unlintable IPl NSg/V
-> the advertisement of  the man         — ”
-# D   NSg           V/P D   NPrSg/I/V/J . .
+> “ You resemble the advertisement of the man         , ” she went  on  innocently . ‘          You know
+# . IPl V        D   NSg           P  D   NPrSg/I/V/J . . ISg NSg/V J/P J/R        . Unlintable IPl NSg/V
+> the advertisement of the man         — ”
+# D   NSg           P  D   NPrSg/I/V/J . .
 >
 #
 > “ All       right     , ” broke   in          Tom     quickly , “ I’m perfectly willing to go      to town . Come
@@ -7498,8 +7498,8 @@
 #
 > His   hand  , trembling with his   effort at        self      - control , bore  to his   lips the last
 # ISg/D NSg/V . V         P    ISg/D NSg/V  NSg/I/V/P NSg/I/V/J . NSg/V   . NSg/V P  ISg/D NPl  D   NSg/V/J
-> of  his   glass   of  ale . Daisy’s voice got us      to our feet and out         on  to the blazing
-# V/P ISg/D NPrSg/V V/P NSg . N$      NSg/V V   NPr/ISg P  D   NSg  V/C NSg/V/J/R/P J/P P  D   V/J
+> of his   glass   of ale . Daisy’s voice got us      to our feet and out         on  to the blazing
+# P  ISg/D NPrSg/V P  NSg . N$      NSg/V V   NPr/ISg P  D   NSg  V/C NSg/V/J/R/P J/P P  D   V/J
 > gravel drive .
 # NSg/V  NSg/V .
 >
@@ -7528,8 +7528,8 @@
 #
 > They went  up        - stairs to get   ready   while     we  three men stood there shuffling the
 # IPl  NSg/V NSg/V/J/P . NPl    P  NSg/V NSg/V/J NSg/V/C/P IPl NSg   NSg V     W?    V         D
-> hot     pebbles with our feet . A   silver  curve   of  the moon    hovered already in          the
-# NSg/V/J NPl     P    D   NSg  . D/P NSg/V/J NSg/V/J V/P D   NPrSg/V W?      W?      NPrSg/V/J/P D
+> hot     pebbles with our feet . A   silver  curve   of the moon    hovered already in          the
+# NSg/V/J NPl     P    D   NSg  . D/P NSg/V/J NSg/V/J P  D   NPrSg/V W?      W?      NPrSg/V/J/P D
 > western sky   . Gatsby started to speak , changed his   mind  , but     not   before Tom
 # NPrSg/J NSg/V . NPr    W?      P  NSg/V . V/J     ISg/D NSg/V . NSg/C/P NSg/C C/P    NPrSg/V
 > wheeled and faced him expectantly .
@@ -7540,8 +7540,8 @@
 # . NSg/VX IPl V   D    NPl     NSg/J/R . . V/J   NPr    P    D/P NSg/V  .
 >
 #
-> “ About a   quarter of  a   mile down      the road  . ”
-# . J/P   D/P NSg/V/J V/P D/P NSg  NSg/V/J/P D   NSg/J . .
+> “ About a   quarter of a   mile down      the road  . ”
+# . J/P   D/P NSg/V/J P  D/P NSg  NSg/V/J/P D   NSg/J . .
 >
 #
 > “ Oh      . ”
@@ -7552,8 +7552,8 @@
 # D/P NSg/V .
 >
 #
-> “ I   don’t see   the idea of  going   to town , ” broke   out         Tom     savagely . “ Women get
-# . ISg NSg/V NSg/V D   NSg  V/P NSg/V/J P  NSg  . . NSg/V/J NSg/V/J/R/P NPrSg/V J/R      . . NPl   NSg/V
+> “ I   don’t see   the idea of going   to town , ” broke   out         Tom     savagely . “ Women get
+# . ISg NSg/V NSg/V D   NSg  P  NSg/V/J P  NSg  . . NSg/V/J NSg/V/J/R/P NPrSg/V J/R      . . NPl   NSg/V
 > these notions in          their heads — — — ”
 # I/D   NPl     NPrSg/V/J/P D     NPl   . . . .
 >
@@ -7574,34 +7574,34 @@
 # . ISg VX    NSg/V NSg/I/V  NPrSg/V/J/P ISg/D NPrSg/V . NSg/J NSg/V . .
 >
 #
-> “ She’s got an  indiscreet voice , ” I   remarked . “ It’s full    of  — ” I   hesitated .
-# . W?    V   D/P J          NSg/V . . ISg V/J      . . W?   NSg/V/J V/P . . ISg W?        .
+> “ She’s got an  indiscreet voice , ” I   remarked . “ It’s full    of — ” I   hesitated .
+# . W?    V   D/P J          NSg/V . . ISg V/J      . . W?   NSg/V/J P  . . ISg W?        .
 >
 #
-> “ Her   voice is full    of  money , ” he      said suddenly .
-# . I/J/D NSg/V VL NSg/V/J V/P NSg/J . . NPr/ISg V/J  J/R      .
+> “ Her   voice is full    of money , ” he      said suddenly .
+# . I/J/D NSg/V VL NSg/V/J P  NSg/J . . NPr/ISg V/J  J/R      .
 >
 #
-> That    was it        . I’d never understood before . It        was full    of  money — that    was the
-# N/I/C/D V   NPrSg/ISg . W?  V     V/J        C/P    . NPrSg/ISg V   NSg/V/J V/P NSg/J . N/I/C/D V   D
-> inexhaustible charm that    rose      and fell    in          it        , the jingle of  it        , the cymbals ’
-# J             NSg/V N/I/C/D NPrSg/V/J V/C NSg/V/J NPrSg/V/J/P NPrSg/ISg . D   NSg/V  V/P NPrSg/ISg . D   NPl     .
-> song of  it        . . . . High    in          a   white     palace the king’s daughter , the golden    girl  . .
-# NSg  V/P NPrSg/ISg . . . . NSg/V/J NPrSg/V/J/P D/P NPrSg/V/J NSg/V  D   N$     NSg      . D   NPrSg/V/J NSg/V . .
+> That    was it        . I’d never understood before . It        was full    of money — that    was the
+# N/I/C/D V   NPrSg/ISg . W?  V     V/J        C/P    . NPrSg/ISg V   NSg/V/J P  NSg/J . N/I/C/D V   D
+> inexhaustible charm that    rose      and fell    in          it        , the jingle of it        , the cymbals ’
+# J             NSg/V N/I/C/D NPrSg/V/J V/C NSg/V/J NPrSg/V/J/P NPrSg/ISg . D   NSg/V  P  NPrSg/ISg . D   NPl     .
+> song of it        . . . . High    in          a   white     palace the king’s daughter , the golden    girl  . .
+# NSg  P  NPrSg/ISg . . . . NSg/V/J NPrSg/V/J/P D/P NPrSg/V/J NSg/V  D   N$     NSg      . D   NPrSg/V/J NSg/V . .
 > . .
 # . .
 >
 #
-> Tom     came    out         of  the house   wrapping a   quart   bottle in          a   towel , followed by      Daisy
-# NPrSg/V NSg/V/P NSg/V/J/R/P V/P D   NPrSg/V NSg/V    D/P NSg/V/J NSg/V  NPrSg/V/J/P D/P NSg/V . W?       NSg/J/P NPrSg
-> and Jordan wearing small     tight hats of  metallic cloth and carrying light   capes
-# V/C NPr    V       NPrSg/V/J V/J   NPl  V/P NSg/J    NSg   V/C V        NSg/V/J NPl
+> Tom     came    out         of the house   wrapping a   quart   bottle in          a   towel , followed by      Daisy
+# NPrSg/V NSg/V/P NSg/V/J/R/P P  D   NPrSg/V NSg/V    D/P NSg/V/J NSg/V  NPrSg/V/J/P D/P NSg/V . W?       NSg/J/P NPrSg
+> and Jordan wearing small     tight hats of metallic cloth and carrying light   capes
+# V/C NPr    V       NPrSg/V/J V/J   NPl  P  NSg/J    NSg   V/C V        NSg/V/J NPl
 > over      their arms .
 # NSg/V/J/P D     NPl  .
 >
 #
 > “ Shall we  all       go      in          my car ? ” suggested Gatsby . He      felt    the hot     , green     leather of
-# . VX    IPl NSg/I/J/C NSg/V/J NPrSg/V/J/P D  NSg . . W?        NPr    . NPr/ISg NSg/V/J D   NSg/V/J . NPrSg/V/J NSg/V/J V/P
+# . VX    IPl NSg/I/J/C NSg/V/J NPrSg/V/J/P D  NSg . . W?        NPr    . NPr/ISg NSg/V/J D   NSg/V/J . NPrSg/V/J NSg/V/J P
 > the seat  . “ I   ought    to have   left      it        in          the shade . ”
 # D   NSg/V . . ISg NSg/I/VX P  NSg/VX NPrSg/V/J NPrSg/ISg NPrSg/V/J/P D   NSg/V . .
 >
@@ -7626,8 +7626,8 @@
 # . ISg NSg/V NSg/V W?      N/I/J NSg/V/J . . NPr/ISg W?       .
 >
 #
-> “ Plenty  of  gas     , ” said Tom     boisterously . He      looked at        the gauge . “ And if    it        runs
-# . NSg/I/J V/P NSg/V/J . . V/J  NPrSg/V J/R          . NPr/ISg W?     NSg/I/V/P D   NSg/V . . V/C NSg/C NPrSg/ISg NPl
+> “ Plenty  of gas     , ” said Tom     boisterously . He      looked at        the gauge . “ And if    it        runs
+# . NSg/I/J P  NSg/V/J . . V/J  NPrSg/V J/R          . NPr/ISg W?     NSg/I/V/P D   NSg/V . . V/C NSg/C NPrSg/ISg NPl
 > out         I   can      stop  at        a   drug  - store . You can      buy   anything at        a   drug  - store nowadays . ”
 # NSg/V/J/R/P ISg NPrSg/VX NSg/V NSg/I/V/P D/P NSg/V . NSg/V . IPl NPrSg/VX NSg/V NSg/I/V  NSg/I/V/P D/P NSg/V . NSg/V N        . .
 >
@@ -7648,8 +7648,8 @@
 # . W?   NSg/V IPl NPrSg/V/J/P I/D  NSg/V  NSg/V . .
 >
 #
-> He      opened the door  , but     she moved out         from the circle of  his   arm     .
-# NPr/ISg V/J    D   NSg/V . NSg/C/P ISg V/J   NSg/V/J/R/P P    D   NSg/V  V/P ISg/D NSg/V/J .
+> He      opened the door  , but     she moved out         from the circle of his   arm     .
+# NPr/ISg V/J    D   NSg/V . NSg/C/P ISg V/J   NSg/V/J/R/P P    D   NSg/V  P  ISg/D NSg/V/J .
 >
 #
 > “ You take  Nick    and Jordan . We’ll follow you in          the coupé . ”
@@ -7658,10 +7658,10 @@
 #
 > She walked close   to Gatsby , touching  his   coat  with her   hand  . Jordan and Tom     and
 # ISg W?     NSg/V/J P  NPr    . NSg/V/J/P ISg/D NSg/V P    I/J/D NSg/V . NPr    V/C NPrSg/V V/C
-> I   got into the front   seat  of  Gatsby’s car , Tom     pushed the unfamiliar gears
-# ISg V   P    D   NSg/V/J NSg/V V/P N$       NSg . NPrSg/V W?     D   NSg/J      NPl
-> tentatively , and we  shot    off       into the oppressive heat  , leaving them out         of  sight
-# J/R         . V/C IPl NSg/V/J NSg/V/J/P P    D   J          NSg/V . V       N/I  NSg/V/J/R/P V/P NSg/V
+> I   got into the front   seat  of Gatsby’s car , Tom     pushed the unfamiliar gears
+# ISg V   P    D   NSg/V/J NSg/V P  N$       NSg . NPrSg/V W?     D   NSg/J      NPl
+> tentatively , and we  shot    off       into the oppressive heat  , leaving them out         of sight
+# J/R         . V/C IPl NSg/V/J NSg/V/J/P P    D   J          NSg/V . V       N/I  NSg/V/J/R/P P  NSg/V
 > behind  .
 # NSg/J/P .
 >
@@ -7688,12 +7688,12 @@
 #
 > He      paused . The immediate contingency overtook him , pulled him back    from the edge
 # NPr/ISg W?     . D   J         NSg         V        I   . W?     I   NSg/V/J P    D   NSg/V
-> of  the theoretical abyss .
-# V/P D   J           NSg   .
+> of the theoretical abyss .
+# P  D   J           NSg   .
 >
 #
-> “ I’ve made  a   small     investigation of  this fellow , ” he      continued . “ I   could  have
-# . W?   NSg/V D/P NPrSg/V/J NSg           V/P I/D  NSg/V  . . NPr/ISg W?        . . ISg NSg/VX NSg/VX
+> “ I’ve made  a   small     investigation of this fellow , ” he      continued . “ I   could  have
+# . W?   NSg/V D/P NPrSg/V/J NSg           P  I/D  NSg/V  . . NPr/ISg W?        . . ISg NSg/VX NSg/VX
 > gone  deeper if    I’d known   — — — ”
 # V/J/P J      NSg/C W?  NSg/V/J . . . .
 >
@@ -7711,7 +7711,7 @@
 >
 #
 > “ About Gatsby ! No      , I   haven’t . I   said I’d been  making a   small     investigation of
-# . J/P   NPr    . NPrSg/P . ISg V       . ISg V/J  W?  NSg/V NSg/V  D/P NPrSg/V/J NSg           V/P
+# . J/P   NPr    . NPrSg/P . ISg V       . ISg V/J  W?  NSg/V NSg/V  D/P NPrSg/V/J NSg           P
 > his   past      . ”
 # ISg/D NSg/V/J/P . .
 >
@@ -7742,8 +7742,8 @@
 # . NPrSg NSg/V/J I   . ISg V    I   C/P    IPl NSg/V NSg/V/J . NPrSg/V NPl   NSg/C . .
 >
 #
-> We  were  all       irritable now         with the fading ale , and aware of  it        we  drove for a
-# IPl NSg/V NSg/I/J/C J         NPrSg/V/J/C P    D   NSg/V  NSg . V/C V/J   V/P NPrSg/ISg IPl NSg/V C/P D/P
+> We  were  all       irritable now         with the fading ale , and aware of it        we  drove for a
+# IPl NSg/V NSg/I/J/C J         NPrSg/V/J/C P    D   NSg/V  NSg . V/C V/J   P  NPrSg/ISg IPl NSg/V C/P D/P
 > while     in          silence . Then    as    Doctor T. J. Eckleburg’s faded eyes came    into sight
 # NSg/V/C/P NPrSg/V/J/P NSg/V   . NSg/J/C NSg/R NSg/V  ?  ?  ?           W?    NPl  NSg/V/P P    NSg/V
 > down      the road  , I   remembered Gatsby’s caution about gasoline .
@@ -7762,8 +7762,8 @@
 #
 > Tom     threw on  both brakes impatiently , and we  slid to an  abrupt  dusty   spot    under
 # NPrSg/V V     J/P I/C  NPl    J/R         . V/C IPl V    P  D/P NSg/V/J NPrSg/J NSg/V/J NSg/J/P
-> Wilson’s sign  . After a   moment the proprietor emerged from the interior of  his
-# N$       NSg/V . J/P   D/P NSg    D   NSg        W?      P    D   NSg/J    V/P ISg/D
+> Wilson’s sign  . After a   moment the proprietor emerged from the interior of his
+# N$       NSg/V . J/P   D/P NSg    D   NSg        W?      P    D   NSg/J    P  ISg/D
 > establishment and gazed hollow  - eyed at        the car .
 # NSg           V/C W?    NSg/V/J . W?   NSg/I/V/P D   NSg .
 >
@@ -7792,10 +7792,10 @@
 # NSg/V . .
 >
 #
-> With an  effort Wilson left      the shade and support of  the doorway and , breathing
-# P    D/P NSg/V  NPr    NPrSg/V/J D   NSg/V V/C NSg/V   V/P D   NSg     V/C . NSg/V
-> hard    , unscrewed the cap     of  the tank  . In          the sunlight his   face  was green     .
-# NSg/V/J . W?        D   NPrSg/V V/P D   NSg/V . NPrSg/V/J/P D   NSg/V    ISg/D NSg/V V   NPrSg/V/J .
+> With an  effort Wilson left      the shade and support of the doorway and , breathing
+# P    D/P NSg/V  NPr    NPrSg/V/J D   NSg/V V/C NSg/V   P  D   NSg     V/C . NSg/V
+> hard    , unscrewed the cap     of the tank  . In          the sunlight his   face  was green     .
+# NSg/V/J . W?        D   NPrSg/V P  D   NSg/V . NPrSg/V/J/P D   NSg/V    ISg/D NSg/V V   NPrSg/V/J .
 >
 #
 > “ I   didn’t mean    to interrupt your lunch , ” he      said . “ But     I   need   money pretty  bad     ,
@@ -7822,8 +7822,8 @@
 # NSg/V/J . .
 >
 #
-> “ What  do     you want  money for , all       of  a   sudden ? ”
-# . NSg/I NSg/VX IPl NSg/V NSg/J C/P . NSg/I/J/C V/P D/P NSg/J  . .
+> “ What  do     you want  money for , all       of a   sudden ? ”
+# . NSg/I NSg/VX IPl NSg/V NSg/J C/P . NSg/I/J/C P  D/P NSg/J  . .
 >
 #
 > “ I’ve been  here    too long      . I   want  to get   away . My wife  and I   want  to go      West      . ”
@@ -7842,8 +7842,8 @@
 # NSg/V/J P  NSg/V I/J/D V/J  . .
 >
 #
-> The coupé flashed by      us      with a   flurry of  dust  and the flash   of  a   waving hand  .
-# D   ?     W?      NSg/J/P NPr/ISg P    D/P NSg/V  V/P NSg/V V/C D   NSg/V/J V/P D/P V      NSg/V .
+> The coupé flashed by      us      with a   flurry of dust  and the flash   of a   waving hand  .
+# D   ?     W?      NSg/J/P NPr/ISg P    D/P NSg/V  P  NSg/V V/C D   NSg/V/J P  D/P V      NSg/V .
 >
 #
 > “ What  do     I   owe you ? ” demanded Tom     harshly .
@@ -7868,8 +7868,8 @@
 # D   J          NSg/V   NSg/V V   NSg/V/J   P  NSg/V   NPrSg/ISg V/C ISg V   D/P NSg/V/J NSg
 > there before I   realized that    so        far     his   suspicions hadn’t alighted on  Tom     . He
 # W?    C/P    ISg V        N/I/C/D NSg/I/J/C NSg/V/J ISg/D NPl        V      W?       J/P NPrSg/V . NPr/ISg
-> had discovered that    Myrtle had some  sort  of  life  apart from him in          another
-# V   V          N/I/C/D NPrSg  V   I/J/R NSg/V V/P NSg/V NSg/J P    I   NPrSg/V/J/P I/D
+> had discovered that    Myrtle had some  sort  of life  apart from him in          another
+# V   V          N/I/C/D NPrSg  V   I/J/R NSg/V P  NSg/V NSg/J P    I   NPrSg/V/J/P I/D
 > world , and the shock   had made  him physically sick    . I   stared at        him and then    at
 # NSg/V . V/C D   NSg/V/J V   NSg/V I   J/R        NSg/V/J . ISg W?     NSg/I/V/P I   V/C NSg/J/C NSg/I/V/P
 > Tom     , who     had made  a   parallel discovery less    than an  hour before — and it        occurred
@@ -7889,23 +7889,23 @@
 >
 #
 > That    locality was always vaguely disquieting , even    in          the broad glare   of
-# N/I/C/D NSg      V   W?     J/R     V           . NSg/V/J NPrSg/V/J/P D   NSg/J NSg/V/J V/P
-> afternoon , and now         I   turned my head      as    though I   had been  warned of  something
-# NSg       . V/C NPrSg/V/J/C ISg W?     D  NPrSg/V/J NSg/R V/C    ISg V   NSg/V W?     V/P NSg/I/V/J
-> behind  . Over      the ashheaps the giant eyes of  Doctor T. J. Eckleburg kept their
-# NSg/J/P . NSg/V/J/P D   ?        D   NSg/J NPl  V/P NSg/V  ?  ?  ?         V    D
+# N/I/C/D NSg      V   W?     J/R     V           . NSg/V/J NPrSg/V/J/P D   NSg/J NSg/V/J P
+> afternoon , and now         I   turned my head      as    though I   had been  warned of something
+# NSg       . V/C NPrSg/V/J/C ISg W?     D  NPrSg/V/J NSg/R V/C    ISg V   NSg/V W?     P  NSg/I/V/J
+> behind  . Over      the ashheaps the giant eyes of Doctor T. J. Eckleburg kept their
+# NSg/J/P . NSg/V/J/P D   ?        D   NSg/J NPl  P  NSg/V  ?  ?  ?         V    D
 > vigil , but     I   perceived , after a   moment , that    other   eyes were  regarding us      with
 # NSg/V . NSg/C/P ISg V/J       . J/P   D/P NSg    . N/I/C/D NSg/V/J NPl  NSg/V V         NPr/ISg P
 > peculiar intensity from less    than twenty feet away .
 # NSg/J    NSg       P    V/J/C/P C/P  NSg    NSg  V/J  .
 >
 #
-> In          one       of  the windows over      the garage the curtains had been  moved aside a
-# NPrSg/V/J/P NSg/I/V/J V/P D   NPrPl   NSg/V/J/P D   NSg/V  D   NPl      V   NSg/V V/J   NSg/J D/P
+> In          one       of the windows over      the garage the curtains had been  moved aside a
+# NPrSg/V/J/P NSg/I/V/J P  D   NPrPl   NSg/V/J/P D   NSg/V  D   NPl      V   NSg/V V/J   NSg/J D/P
 > little    , and Myrtle Wilson was peering down      at        the car . So        engrossed was she that
 # NPrSg/I/J . V/C NPrSg  NPr    V   V       NSg/V/J/P NSg/I/V/P D   NSg . NSg/I/J/C W?        V   ISg N/I/C/D
-> she had no      consciousness of  being   observed , and one       emotion after another crept
-# ISg V   NPrSg/P NSg           V/P NSg/V/C V        . V/C NSg/I/V/J NSg     J/P   I/D     V
+> she had no      consciousness of being   observed , and one       emotion after another crept
+# ISg V   NPrSg/P NSg           P  NSg/V/C V        . V/C NSg/I/V/J NSg     J/P   I/D     V
 > into her   face  like        objects into a   slowly developing picture . Her   expression was
 # P    I/J/D NSg/V NSg/V/J/C/P NPl     P    D/P J/R    V          NSg/V   . I/J/D NSg        V
 > curiously familiar — it        was an  expression I   had often seen  on  women’s faces , but
@@ -7918,18 +7918,18 @@
 # NPrSg/J . I    ISg V    P  NSg/VX ISg/D NSg/V .
 >
 #
-> There is no      confusion like        the confusion of  a   simple  mind  , and as    we  drove away
-# W?    VL NPrSg/P NSg/V     NSg/V/J/C/P D   NSg/V     V/P D/P NSg/V/J NSg/V . V/C NSg/R IPl NSg/V V/J
-> Tom     was feeling the hot     whips of  panic   . His   wife  and his   mistress , until an  hour
-# NPrSg/V V   NSg/V/J D   NSg/V/J NPl   V/P NSg/V/J . ISg/D NSg/V V/C ISg/D NSg/V    . C/P   D/P NSg
+> There is no      confusion like        the confusion of a   simple  mind  , and as    we  drove away
+# W?    VL NPrSg/P NSg/V     NSg/V/J/C/P D   NSg/V     P  D/P NSg/V/J NSg/V . V/C NSg/R IPl NSg/V V/J
+> Tom     was feeling the hot     whips of panic   . His   wife  and his   mistress , until an  hour
+# NPrSg/V V   NSg/V/J D   NSg/V/J NPl   P  NSg/V/J . ISg/D NSg/V V/C ISg/D NSg/V    . C/P   D/P NSg
 > ago secure and inviolate , were  slipping precipitately from his   control . Instinct
 # J/P V/J    V/C J         . NSg/V NSg/V    J/R           P    ISg/D NSg/V   . NSg/J
-> made  him step  on  the accelerator with the double  purpose of  overtaking Daisy and
-# NSg/V I   NSg/V J/P D   NSg         P    D   NSg/V/J NSg/V   V/P V          NPrSg V/C
+> made  him step  on  the accelerator with the double  purpose of overtaking Daisy and
+# NSg/V I   NSg/V J/P D   NSg         P    D   NSg/V/J NSg/V   P  V          NPrSg V/C
 > leaving Wilson behind  , and we  sped  along toward Astoria at        fifty miles an  hour ,
 # V       NPr    NSg/J/P . V/C IPl NSg/V P     J/P    NPr     NSg/I/V/P NSg   NPrPl D/P NSg  .
-> until , among the spidery girders of  the elevated , we  came    in          sight of  the
-# C/P   . P     D   J       W?      V/P D   W?       . IPl NSg/V/P NPrSg/V/J/P NSg/V V/P D
+> until , among the spidery girders of the elevated , we  came    in          sight of the
+# C/P   . P     D   J       W?      P  D   W?       . IPl NSg/V/P NPrSg/V/J/P NSg/V P  D
 > easy    - going   blue    coupé .
 # NSg/V/J . NSg/V/J NSg/V/J ?     .
 >
@@ -7938,14 +7938,14 @@
 # . I/D   NSg/V/J NPl    J/P    NSg/J    NSg/V/J V   NSg/V/J . . W?        NPr    . . ISg NPrSg/V
 > New     York on  summer  afternoons when    every one’s away . There’s something very
 # NSg/V/J NPr  J/P NPrSg/V NPl        NSg/I/C D     N$    V/J  . W?      NSg/I/V/J J
-> sensuous about it        — overripe , as    if    all       sorts of  funny fruits were  going   to fall
-# J        J/P   NPrSg/ISg . N/J      . NSg/R NSg/C NSg/I/J/C NPl   V/P NSg/J NPl    NSg/V NSg/V/J P  NSg/V
+> sensuous about it        — overripe , as    if    all       sorts of funny fruits were  going   to fall
+# J        J/P   NPrSg/ISg . N/J      . NSg/R NSg/C NSg/I/J/C NPl   P  NSg/J NPl    NSg/V NSg/V/J P  NSg/V
 > into your hands . ”
 # P    D    NPl   . .
 >
 #
-> The word  “ sensuous ” had the effect of  further disquieting Tom     , but     before he
-# D   NSg/V . J        . V   D   NSg/V  V/P V/J     V           NPrSg/V . NSg/C/P C/P    NPr/ISg
+> The word  “ sensuous ” had the effect of further disquieting Tom     , but     before he
+# D   NSg/V . J        . V   D   NSg/V  P  V/J     V           NPrSg/V . NSg/C/P C/P    NPr/ISg
 > could  invent a   protest the coupé came    to a   stop  , and Daisy signalled us      to draw
 # NSg/VX V      D/P NSg/V   D   ?     NSg/V/P P  D/P NSg/V . V/C NPrSg V/Br      NPr/ISg P  NSg/V
 > up        alongside .
@@ -7970,38 +7970,38 @@
 #
 > “ We  can’t argue about it        here    , ” Tom     said impatiently , as    a   truck gave out         a
 # . IPl VX    V     J/P   NPrSg/ISg NSg/J/R . . NPrSg/V V/J  J/R         . NSg/R D/P NSg/V V    NSg/V/J/R/P D/P
-> cursing whistle behind  us      . “ You follow me        to the south     side    of  Central Park    , in
-# V       NSg/V   NSg/J/P NPr/ISg . . IPl NSg/V  NPrSg/ISg P  D   NPrSg/V/J NSg/V/J V/P NPrSg/J NPrSg/V . NPrSg/V/J/P
-> front   of  the Plaza . ”
-# NSg/V/J V/P D   NSg   . .
+> cursing whistle behind  us      . “ You follow me        to the south     side    of Central Park    , in
+# V       NSg/V   NSg/J/P NPr/ISg . . IPl NSg/V  NPrSg/ISg P  D   NPrSg/V/J NSg/V/J P  NPrSg/J NPrSg/V . NPrSg/V/J/P
+> front   of the Plaza . ”
+# NSg/V/J P  D   NSg   . .
 >
 #
 > Several times he      turned his   head      and looked back    for their car , and if    the
 # J/D     NPl   NPr/ISg W?     ISg/D NPrSg/V/J V/C W?     NSg/V/J C/P D     NSg . V/C NSg/C D
 > traffic delayed them he      slowed up        until they came    into sight . I   think he      was
 # NSg/V/J W?      N/I  NPr/ISg W?     NSg/V/J/P C/P   IPl  NSg/V/P P    NSg/V . ISg NSg/V NPr/ISg V
-> afraid they would  dart  down      a   side    street  and out         of  his   life  forever .
-# J      IPl  NSg/VX NSg/V NSg/V/J/P D/P NSg/V/J NSg/V/J V/C NSg/V/J/R/P V/P ISg/D NSg/V NSg/J   .
+> afraid they would  dart  down      a   side    street  and out         of his   life  forever .
+# J      IPl  NSg/VX NSg/V NSg/V/J/P D/P NSg/V/J NSg/V/J V/C NSg/V/J/R/P P  ISg/D NSg/V NSg/J   .
 >
 #
-> But     they didn’t . And we  all       took the less    explicable step  of  engaging the parlor
-# NSg/C/P IPl  V      . V/C IPl NSg/I/J/C V    D   V/J/C/P J          NSg/V V/P V        D   NSg
-> of  a   suite in          the Plaza Hotel .
-# V/P D/P NSg   NPrSg/V/J/P D   NSg   NSg   .
+> But     they didn’t . And we  all       took the less    explicable step  of engaging the parlor
+# NSg/C/P IPl  V      . V/C IPl NSg/I/J/C V    D   V/J/C/P J          NSg/V P  V        D   NSg
+> of a   suite in          the Plaza Hotel .
+# P  D/P NSg   NPrSg/V/J/P D   NSg   NSg   .
 >
 #
 > The prolonged and tumultuous argument that    ended by      herding us      into that    room
 # D   W?        V/C J          NSg/V    N/I/C/D W?    NSg/J/P V       NPr/ISg P    N/I/C/D NSg/V/J
-> eludes me        , though I   have   a   sharp     physical memory that    , in          the course of  it        , my
-# NPl    NPrSg/ISg . V/C    ISg NSg/VX D/P NPrSg/V/J NSg/J    NSg    N/I/C/D . NPrSg/V/J/P D   NSg/V  V/P NPrSg/ISg . D
+> eludes me        , though I   have   a   sharp     physical memory that    , in          the course of it        , my
+# NPl    NPrSg/ISg . V/C    ISg NSg/VX D/P NPrSg/V/J NSg/J    NSg    N/I/C/D . NPrSg/V/J/P D   NSg/V  P  NPrSg/ISg . D
 > underwear kept climbing like        a   damp    snake   around my legs and intermittent beads
 # NSg       V    NSg/V/J  NSg/V/J/C/P D/P NSg/V/J NPrSg/V J/P    D  NPl  V/C NSg/J        NPl
-> of  sweat raced cool    across my back    . The notion originated with Daisy’s
-# V/P NSg/V W?    NSg/V/J NSg/P  D  NSg/V/J . D   NSg    W?         P    N$
+> of sweat raced cool    across my back    . The notion originated with Daisy’s
+# P  NSg/V W?    NSg/V/J NSg/P  D  NSg/V/J . D   NSg    W?         P    N$
 > suggestion that    we  hire  five bathrooms and take  cold  baths , and then    assumed
 # NSg        N/I/C/D IPl NSg/V NSg  NPl       V/C NSg/V NSg/J NSg/V . V/C NSg/J/C W?
-> more        tangible form  as    “ a   place to have   a   mint    julep . ” Each of  us      said over      and
-# NPrSg/I/V/J NSg/J    NSg/V NSg/R . D/P NSg/V P  NSg/VX D/P NSg/V/J NSg   . . D    V/P NPr/ISg V/J  NSg/V/J/P V/C
+> more        tangible form  as    “ a   place to have   a   mint    julep . ” Each of us      said over      and
+# NPrSg/I/V/J NSg/J    NSg/V NSg/R . D/P NSg/V P  NSg/VX D/P NSg/V/J NSg   . . D    P  NPr/ISg V/J  NSg/V/J/P V/C
 > over      that    it        was a   “ crazy idea ” — we  all       talked at        once  to a   baffled clerk and
 # NSg/V/J/P N/I/C/D NPrSg/ISg V   D/P . NSg/J NSg  . . IPl NSg/I/J/C W?     NSg/I/V/P NSg/C P  D/P W?      NSg/V V/C
 > thought , or      pretended to think , that    we  were  being   very funny . . .
@@ -8010,8 +8010,8 @@
 #
 > The room    was large and stifling , and , though it        was already four o’clock ,
 # D   NSg/V/J V   NSg/J V/C NSg/V/J  . V/C . V/C    NPrSg/ISg V   W?      NSg  W?      .
-> opening the windows admitted only a   gust  of  hot     shrubbery from the Park    . Daisy
-# NSg/V/J D   NPrPl   V        W?   D/P NSg/V V/P NSg/V/J NSg       P    D   NPrSg/V . NPrSg
+> opening the windows admitted only a   gust  of hot     shrubbery from the Park    . Daisy
+# NSg/V/J D   NPrPl   V        W?   D/P NSg/V P  NSg/V/J NSg       P    D   NPrSg/V . NPrSg
 > went  to the mirror and stood with her   back    to us      , fixing her   hair  .
 # NSg/V P  D   NSg/V  V/C V     P    I/J/D NSg/V/J P  NPr/ISg . V      I/J/D NSg/V .
 >
@@ -8038,8 +8038,8 @@
 # NPrSg/ISg NSg NPl   NSg/V/J NSg/J/P NSg/V    J/P   NPrSg/ISg . .
 >
 #
-> He      unrolled the bottle of  whiskey from the towel and put   it        on  the table .
-# NPr/ISg W?       D   NSg/V  V/P NSg     P    D   NSg/V V/C NSg/V NPrSg/ISg J/P D   NSg/V .
+> He      unrolled the bottle of whiskey from the towel and put   it        on  the table .
+# NPr/ISg W?       D   NSg/V  P  NSg     P    D   NSg/V V/C NSg/V NPrSg/ISg J/P D   NSg/V .
 >
 #
 > “ Why   not   let   her   alone , old   sport ? ” remarked Gatsby . “ You’re the one       that    wanted
@@ -8048,8 +8048,8 @@
 # P  NSg/V/P P  NSg  . .
 >
 #
-> There was a   moment of  silence . The telephone book  slipped from its   nail  and
-# W?    V   D/P NSg    V/P NSg/V   . D   NSg/V     NSg/V V/J     P    ISg/D NSg/V V/C
+> There was a   moment of silence . The telephone book  slipped from its   nail  and
+# W?    V   D/P NSg    P  NSg/V   . D   NSg/V     NSg/V V/J     P    ISg/D NSg/V V/C
 > splashed to the floor , whereupon Jordan whispered , “ Excuse me        ” — but     this time  no
 # W?       P  D   NSg/V . C         NPr    W?        . . NSg/V  NPrSg/ISg . . NSg/C/P I/D  NSg/V NPrSg/P
 > one       laughed .
@@ -8066,8 +8066,8 @@
 # V/J        NSg/J . V/C W?     D   NSg/V J/P D/P NSg/V .
 >
 #
-> “ That’s a   great expression of  yours , isn’t it        ? ” said Tom     sharply .
-# . N$     D/P NSg/J NSg        V/P I     . NSg/V NPrSg/ISg . . V/J  NPrSg/V J/R     .
+> “ That’s a   great expression of yours , isn’t it        ? ” said Tom     sharply .
+# . N$     D/P NSg/J NSg        P  I     . NSg/V NPrSg/ISg . . V/J  NPrSg/V J/R     .
 >
 #
 > “ What  is ? ”
@@ -8088,8 +8088,8 @@
 #
 > As    Tom     took up        the receiver the compressed heat  exploded into sound   and we  were
 # NSg/R NPrSg/V V    NSg/V/J/P D   NSg/J    D   V/J        NSg/V W?       P    NSg/V/J V/C IPl NSg/V
-> listening to the portentous chords of  Mendelssohn’s Wedding March   from the
-# V         P  D   J          NPl    V/P N$            NSg/V   NPrSg/V P    D
+> listening to the portentous chords of Mendelssohn’s Wedding March   from the
+# V         P  D   J          NPl    P  N$            NSg/V   NPrSg/V P    D
 > ballroom below .
 # NSg/V    P     .
 >
@@ -8098,8 +8098,8 @@
 # . NSg/V   V        N/I     NPrSg/V/J/P I/D  NSg/V . . W?    NPr    J/R      .
 >
 #
-> “ Still   — I   was married in          the middle  of  June , ” Daisy remembered , “ Louisville in
-# . NSg/V/J . ISg V   NSg/V/J NPrSg/V/J/P D   NSg/V/J V/P NPr  . . NPrSg V          . . NPr        NPrSg/V/J/P
+> “ Still   — I   was married in          the middle  of June , ” Daisy remembered , “ Louisville in
+# . NSg/V/J . ISg V   NSg/V/J NPrSg/V/J/P D   NSg/V/J P  NPr  . . NPrSg V          . . NPr        NPrSg/V/J/P
 > June ! Somebody fainted . Who     was it        fainted , Tom     ? ”
 # NPr  . NSg/I    W?      . NPrSg/I V   NPrSg/ISg W?      . NPrSg/V . .
 >
@@ -8136,10 +8136,10 @@
 #
 > The music   had died down      as    the ceremony began and now         a   long      cheer floated in          at
 # D   NSg/V/J V   W?   NSg/V/J/P NSg/R D   NSg      V     V/C NPrSg/V/J/C D/P NPrSg/V/J NSg/V W?      NPrSg/V/J/P NSg/I/V/P
-> the window , followed by      intermittent cries of  “ Yea   — ea  — ea  ! ” and finally by      a
-# D   NSg/V  . W?       NSg/J/P NSg/J        NPl   V/P . NSg/C . NSg . NSg . . V/C J/R     NSg/J/P D/P
-> burst of  jazz  as    the dancing began .
-# NSg/V V/P NSg/V NSg/R D   NSg/V   V     .
+> the window , followed by      intermittent cries of “ Yea   — ea  — ea  ! ” and finally by      a
+# D   NSg/V  . W?       NSg/J/P NSg/J        NPl   P  . NSg/C . NSg . NSg . . V/C J/R     NSg/J/P D/P
+> burst of jazz  as    the dancing began .
+# NSg/V P  NSg/V NSg/R D   NSg/V   V     .
 >
 #
 > “ We're getting old   , ” said Daisy . “ lf we  were  young     we’d rise  and dance . ”
@@ -8151,7 +8151,7 @@
 >
 #
 > “ Biloxi ? ” He      concentrated with an  effort . “ I   didn’t know  him . He      was a   friend  of
-# . ?      . . NPr/ISg W?           P    D/P NSg/V  . . ISg V      NSg/V I   . NPr/ISg V   D/P NPrSg/V V/P
+# . ?      . . NPr/ISg W?           P    D/P NSg/V  . . ISg V      NSg/V I   . NPr/ISg V   D/P NPrSg/V P
 > Daisy’s . ”
 # N$      . .
 >
@@ -8172,8 +8172,8 @@
 # NPr    W?     .
 >
 #
-> “ He      was probably bumming his   way   home    . He      told me        he      was president of  your class
-# . NPr/ISg V   R        V       ISg/D NSg/J NSg/V/J . NPr/ISg V    NPrSg/ISg NPr/ISg V   NSg/V     V/P D    NSg/V/J
+> “ He      was probably bumming his   way   home    . He      told me        he      was president of your class
+# . NPr/ISg V   R        V       ISg/D NSg/J NSg/V/J . NPr/ISg V    NPrSg/ISg NPr/ISg V   NSg/V     P  D    NSg/V/J
 > at        Yale . ”
 # NSg/I/V/P NPr  . .
 >
@@ -8220,8 +8220,8 @@
 #
 > Another pause . A   waiter  knocked and came    in          with crushed mint    and ice     but     the
 # I/D     NSg/V . D/P NSg/V/J W?      V/C NSg/V/P NPrSg/V/J/P P    W?      NSg/V/J V/C NPrSg/V NSg/C/P D
-> silence was unbroken by      his   “ thank you ” and the soft  closing of  the door  . This
-# NSg/V   V   V/J      NSg/J/P ISg/D . NSg/V IPl . V/C D   NSg/J NSg/V/J V/P D   NSg/V . I/D
+> silence was unbroken by      his   “ thank you ” and the soft  closing of the door  . This
+# NSg/V   V   V/J      NSg/J/P ISg/D . NSg/V IPl . V/C D   NSg/J NSg/V/J P  D   NSg/V . I/D
 > tremendous detail  was to be     cleared up        at        last    .
 # J          NSg/V/J V   P  NSg/VX W?      NSg/V/J/P NSg/I/V/P NSg/V/J .
 >
@@ -8246,14 +8246,14 @@
 # NSg/I/V/P NPr    .
 >
 #
-> “ It        was an  opportunity they gave to some  of  the officers after the armistice , ”
-# . NPrSg/ISg V   D/P NSg         IPl  V    P  I/J/R V/P D   W?       J/P   D   NPrSg     . .
-> he      continued . “ We  could  go      to any   of  the universities in          England or      France . ”
-# NPr/ISg W?        . . IPl NSg/VX NSg/V/J P  I/R/D V/P D   NPl          NPrSg/V/J/P NPr     NPrSg/C NPr    . .
+> “ It        was an  opportunity they gave to some  of the officers after the armistice , ”
+# . NPrSg/ISg V   D/P NSg         IPl  V    P  I/J/R P  D   W?       J/P   D   NPrSg     . .
+> he      continued . “ We  could  go      to any   of the universities in          England or      France . ”
+# NPr/ISg W?        . . IPl NSg/VX NSg/V/J P  I/R/D P  D   NPl          NPrSg/V/J/P NPr     NPrSg/C NPr    . .
 >
 #
-> I   wanted to get   up        and slap    him on  the back    . I   had one       of  those renewals of
-# ISg V/J    P  NSg/V NSg/V/J/P V/C NSg/V/J I   J/P D   NSg/V/J . ISg V   NSg/I/V/J V/P I/D   NPl      V/P
+> I   wanted to get   up        and slap    him on  the back    . I   had one       of those renewals of
+# ISg V/J    P  NSg/V NSg/V/J/P V/C NSg/V/J I   J/P D   NSg/V/J . ISg V   NSg/I/V/J P  I/D   NPl      P
 > complete faith in          him that    I’d experienced before .
 # NSg/V/J  NPrSg NPrSg/V/J/P I   N/I/C/D W?  W?          C/P    .
 >
@@ -8276,8 +8276,8 @@
 # . NSg/V/J J/P . . NPr    V/J  J/R      .
 >
 #
-> “ What  kind  of  a   row   are you trying  to cause   in          my house   anyhow ? ”
-# . NSg/I NSg/J V/P D/P NSg/V V   IPl NSg/V/J P  NSg/V/C NPrSg/V/J/P D  NPrSg/V J      . .
+> “ What  kind  of a   row   are you trying  to cause   in          my house   anyhow ? ”
+# . NSg/I NSg/J P  D/P NSg/V V   IPl NSg/V/J P  NSg/V/C NPrSg/V/J/P D  NPrSg/V J      . .
 >
 #
 > They were  out         in          the open    at        last    and Gatsby was content .
@@ -8304,8 +8304,8 @@
 #
 > Flushed with his   impassioned gibberish , he      saw   himself standing alone on  the
 # W?      P    ISg/D J           NSg/J     . NPr/ISg NSg/V I       NSg/V/J  J     J/P D
-> last    barrier of  civilization .
-# NSg/V/J NSg/V   V/P NPrSg        .
+> last    barrier of civilization .
+# NSg/V/J NSg/V   P  NPrSg        .
 >
 #
 > “ We’re all       white     here    , ” murmured Jordan .
@@ -8360,18 +8360,18 @@
 #
 > “ She never loved you , do     you hear ? ” he      cried . “ She only married you because I
 # . ISg V     V/J   IPl . NSg/VX IPl V    . . NPr/ISg W?    . . ISg W?   NSg/V/J IPl C/P     ISg
-> was poor    and she was tired of  waiting for me        . It        was a   terrible mistake , but     in
-# V   NSg/V/J V/C ISg V   V/J   V/P NSg/V   C/P NPrSg/ISg . NPrSg/ISg V   D/P J        NSg/V   . NSg/C/P NPrSg/V/J/P
+> was poor    and she was tired of waiting for me        . It        was a   terrible mistake , but     in
+# V   NSg/V/J V/C ISg V   V/J   P  NSg/V   C/P NPrSg/ISg . NPrSg/ISg V   D/P J        NSg/V   . NSg/C/P NPrSg/V/J/P
 > her   heart she never loved any   one       except me        ! ”
 # I/J/D NSg/V ISg V     V/J   I/R/D NSg/I/V/J V/C/P  NPrSg/ISg . .
 >
 #
 > At        this point Jordan and I   tried to go      , but     Tom     and Gatsby insisted with
 # NSg/I/V/P I/D  NSg/V NPr    V/C ISg V/J   P  NSg/V/J . NSg/C/P NPrSg/V V/C NPr    W?       P
-> competitive firmness that    we  remain — as    though neither of  them had anything to
-# J           NSg      N/I/C/D IPl NSg/V  . NSg/R V/C    I/C     V/P N/I  V   NSg/I/V  P
-> conceal and it        would  be     a   privilege to partake vicariously of  their emotions .
-# V       V/C NPrSg/ISg NSg/VX NSg/VX D/P NSg/V     P  V       J/R         V/P D     W?       .
+> competitive firmness that    we  remain — as    though neither of them had anything to
+# J           NSg      N/I/C/D IPl NSg/V  . NSg/R V/C    I/C     P  N/I  V   NSg/I/V  P
+> conceal and it        would  be     a   privilege to partake vicariously of their emotions .
+# V       V/C NPrSg/ISg NSg/VX NSg/VX D/P NSg/V     P  V       J/R         P  D     W?       .
 >
 #
 > “ Sit   down      , Daisy , ” Tom’s voice groped unsuccessfully for the paternal note  .
@@ -8394,8 +8394,8 @@
 # . W?     NSg/V NSg/V/J/C I/D  NSg/V  C/P NSg  NPl   . .
 >
 #
-> “ Not   seeing    , ” said Gatsby . “ No      , we  couldn’t meet    . But     both of  us      loved each
-# . NSg/C NSg/V/J/C . . V/J  NPr    . . NPrSg/P . IPl V        NSg/V/J . NSg/C/P I/C  V/P NPr/ISg V/J   D
+> “ Not   seeing    , ” said Gatsby . “ No      , we  couldn’t meet    . But     both of us      loved each
+# . NSg/C NSg/V/J/C . . V/J  NPr    . . NPrSg/P . IPl V        NSg/V/J . NSg/C/P I/C  P  NPr/ISg V/J   D
 > other   all       that    time  , old   sport , and you didn’t know  . I   used to laugh
 # NSg/V/J NSg/I/J/C N/I/C/D NSg/V . NSg/J NSg/V . V/C IPl V      NSg/V . ISg V/J  P  NSg/V
 > sometimes ” — but     there was no      laughter in          his   eyes — “ to think that    you didn’t
@@ -8414,10 +8414,10 @@
 # . W?     NSg/J . . NPr/ISg W?       . . ISg VX    NSg/V J/P   NSg/I W?       NSg  NPl   J/P .
 > because I   didn’t know  Daisy then    — and I’ll be     damned if    I   see   how   you got within
 # C/P     ISg V      NSg/V NPrSg NSg/J/C . V/C W?   NSg/VX V/J    NSg/C ISg NSg/V NSg/C IPl V   N/J/P
-> a   mile of  her   unless you brought the groceries to the back    door  . But     all       the
-# D/P NSg  V/P I/J/D C      IPl V       D   NPl       P  D   NSg/V/J NSg/V . NSg/C/P NSg/I/J/C D
-> rest  of  that’s a   God     damned lie     . Daisy loved me        when    she married me        and she
-# NSg/V V/P N$     D/P NPrSg/V V/J    NPrSg/V . NPrSg V/J   NPrSg/ISg NSg/I/C ISg NSg/V/J NPrSg/ISg V/C ISg
+> a   mile of her   unless you brought the groceries to the back    door  . But     all       the
+# D/P NSg  P  I/J/D C      IPl V       D   NPl       P  D   NSg/V/J NSg/V . NSg/C/P NSg/I/J/C D
+> rest  of that’s a   God     damned lie     . Daisy loved me        when    she married me        and she
+# NSg/V P  N$     D/P NPrSg/V V/J    NPrSg/V . NPrSg V/J   NPrSg/ISg NSg/I/C ISg NSg/V/J NPrSg/ISg V/C ISg
 > loves me        now         . ”
 # NPl   NPrSg/ISg NPrSg/V/J/C . .
 >
@@ -8430,8 +8430,8 @@
 # . ISg NSg/V . V/C    . D   NSg/V   VL N/I/C/D R         ISg NPl  J       NPl   NPrSg/V/J/P I/J/D
 > head      and doesn’t know  what  she’s doing . ” He      nodded sagely . “ And what’s more        , I
 # NPrSg/V/J V/C V       NSg/V NSg/I W?    NSg/V . . NPr/ISg V      J/R    . . V/C N$     NPrSg/I/V/J . ISg
-> love    Daisy too . Once  in          a   while     I   go      off       on  a   spree and make  a   fool    of  myself ,
-# NPrSg/V NPrSg W?  . NSg/C NPrSg/V/J/P D/P NSg/V/C/P ISg NSg/V/J NSg/V/J/P J/P D/P NSg/V V/C NSg/V D/P NSg/V/J V/P I      .
+> love    Daisy too . Once  in          a   while     I   go      off       on  a   spree and make  a   fool    of myself ,
+# NPrSg/V NPrSg W?  . NSg/C NPrSg/V/J/P D/P NSg/V/C/P ISg NSg/V/J NSg/V/J/P J/P D/P NSg/V V/C NSg/V D/P NSg/V/J P  I      .
 > but     I   always come    back    , and in          my heart I   love    her   all       the time  . ”
 # NSg/C/P ISg W?     NSg/V/P NSg/V/J . V/C NPrSg/V/J/P D  NSg/V ISg NPrSg/V I/J/D NSg/I/J/C D   NSg/V . .
 >
@@ -8440,8 +8440,8 @@
 # . W?     NSg/V/J   . . V/J  NPrSg . ISg W?     P  NPrSg/ISg . V/C I/J/D NSg/V . NSg/V    D/P
 > octave  lower , filled the room    with thrilling scorn : “ Do     you know  why   we  left
 # NSg/V/J V/J   . V/J    D   NSg/V/J P    NSg/V/J   NSg/V . . NSg/VX IPl NSg/V NSg/V IPl NPrSg/V/J
-> Chicago ? I’m surprised that    they didn’t treat you to the story of  that    little
-# NPr     . W?  W?        N/I/C/D IPl  V      NSg/V IPl P  D   NSg/V V/P N/I/C/D NPrSg/I/J
+> Chicago ? I’m surprised that    they didn’t treat you to the story of that    little
+# NPr     . W?  W?        N/I/C/D IPl  V      NSg/V IPl P  D   NSg/V P  N/I/C/D NPrSg/I/J
 > spree . ”
 # NSg/V . .
 >
@@ -8466,8 +8466,8 @@
 # . IPl V     V/J   I   . .
 >
 #
-> She hesitated . Her   eyes fell    on  Jordan and me        with a   sort  of  appeal , as    though
-# ISg W?        . I/J/D NPl  NSg/V/J J/P NPr    V/C NPrSg/ISg P    D/P NSg/V V/P NSg/V  . NSg/R V/C
+> She hesitated . Her   eyes fell    on  Jordan and me        with a   sort  of appeal , as    though
+# ISg W?        . I/J/D NPl  NSg/V/J J/P NPr    V/C NPrSg/ISg P    D/P NSg/V P  NSg/V  . NSg/R V/C
 > she realized at        last    what  she was doing — and as    though she had never , all       along ,
 # ISg V        NSg/I/V/P NSg/V/J NSg/I ISg V   NSg/V . V/C NSg/R V/C    ISg V   V     . NSg/I/J/C P     .
 > intended doing anything at        all       . But     it        was done    now         . It        was too late  .
@@ -8488,8 +8488,8 @@
 #
 > From the ballroom beneath , muffled and suffocating chords were  drifting up        on
 # P    D   NSg/V    P       . W?      V/C V           NPl    NSg/V V        NSg/V/J/P J/P
-> hot     waves of  air   .
-# NSg/V/J NPl   V/P NSg/V .
+> hot     waves of air   .
+# NSg/V/J NPl   P  NSg/V .
 >
 #
 > “ Not   that    day   I   carried you down      from the Punch   Bowl  to keep  your shoes dry     ? ”
@@ -8528,8 +8528,8 @@
 # . NSg/V/J N$     D/P NPrSg/V . . V/J  NPrSg/V J/R      . . ISg V      NSg/V IPl NSg/V W?    .
 > Why   — there’re things between Daisy and me        that    you’ll never know  , things that
 # NSg/V . ?        NPl    NSg/P   NPrSg V/C NPrSg/ISg N/I/C/D W?     V     NSg/V . NPl    N/I/C/D
-> neither of  us      can      ever forget . ”
-# I/C     V/P NPr/ISg NPrSg/VX J    V      . .
+> neither of us      can      ever forget . ”
+# I/C     P  NPr/ISg NPrSg/VX J    V      . .
 >
 #
 > The words seemed to bite  physically into Gatsby .
@@ -8546,8 +8546,8 @@
 # VX       NSg/VX NSg/V/J . .
 >
 #
-> “ Of  course it        wouldn’t , ” agreed Tom     .
-# . V/P NSg/V  NPrSg/ISg VX       . . W?     NPrSg/V .
+> “ Of course it        wouldn’t , ” agreed Tom     .
+# . P  NSg/V  NPrSg/ISg VX       . . W?     NPrSg/V .
 >
 #
 > She turned to her   husband .
@@ -8558,14 +8558,14 @@
 # . NSg/R NSg/C NPrSg/ISg W?       P  IPl . . ISg V/J  .
 >
 #
-> “ Of  course it        matters . I’m going   to take  better   care  of  you from now         on  . ”
-# . V/P NSg/V  NPrSg/ISg W?      . W?  NSg/V/J P  NSg/V NSg/VX/J NSg/V V/P IPl P    NPrSg/V/J/C J/P . .
+> “ Of course it        matters . I’m going   to take  better   care  of you from now         on  . ”
+# . P  NSg/V  NPrSg/ISg W?      . W?  NSg/V/J P  NSg/V NSg/VX/J NSg/V P  IPl P    NPrSg/V/J/C J/P . .
 >
 #
-> “ You don’t understand , ” said Gatsby , with a   touch of  panic   . “ You’re not   going   to
-# . IPl NSg/V V          . . V/J  NPr    . P    D/P NSg/V V/P NSg/V/J . . W?     NSg/C NSg/V/J P
-> take  care  of  her   any   more        . ”
-# NSg/V NSg/V V/P I/J/D I/R/D NPrSg/I/V/J . .
+> “ You don’t understand , ” said Gatsby , with a   touch of panic   . “ You’re not   going   to
+# . IPl NSg/V V          . . V/J  NPr    . P    D/P NSg/V P  NSg/V/J . . W?     NSg/C NSg/V/J P
+> take  care  of her   any   more        . ”
+# NSg/V NSg/V P  I/J/D I/R/D NPrSg/I/V/J . .
 >
 #
 > “ I’m not   ? ” Tom     opened his   eyes wide  and laughed . He      could  afford to control
@@ -8596,8 +8596,8 @@
 # . ISg V     NSg/V I/D  . . W?    NPrSg . . NPrSg/V . V      N$    NSg/V NSg/V/J/R/P . .
 >
 #
-> “ Who     are you , anyhow ? ” broke   out         Tom     . “ You’re one       of  that    bunch that    hangs
-# . NPrSg/I V   IPl . J      . . NSg/V/J NSg/V/J/R/P NPrSg/V . . W?     NSg/I/V/J V/P N/I/C/D NSg/V N/I/C/D NPl
+> “ Who     are you , anyhow ? ” broke   out         Tom     . “ You’re one       of that    bunch that    hangs
+# . NPrSg/I V   IPl . J      . . NSg/V/J NSg/V/J/R/P NPrSg/V . . W?     NSg/I/V/J P  N/I/C/D NSg/V N/I/C/D NPl
 > around with Meyer Wolfshiem — that    much  I   happen to know  . I’ve made  a   little
 # J/P    P    NPr   ?         . N/I/C/D N/I/J ISg V      P  NSg/V . W?   NSg/V D/P NPrSg/I/J
 > investigation into your affairs — and I’ll carry it        further to - morrow  . ”
@@ -8610,10 +8610,10 @@
 #
 > “ I   found out         what  your ‘          drug  - stores ’ were  . ” He      turned to us      and spoke rapidly .
 # . ISg NSg/V NSg/V/J/R/P NSg/I D    Unlintable NSg/V . NPl    . NSg/V . . NPr/ISg W?     P  NPr/ISg V/C NSg/V J/R     .
-> “ He      and this Wolfshiem bought up        a   lot     of  side    - street  drug  - stores here    and in
-# . NPr/ISg V/C I/D  ?         NSg/V  NSg/V/J/P D/P NPrSg/V V/P NSg/V/J . NSg/V/J NSg/V . NPl    NSg/J/R V/C NPrSg/V/J/P
-> Chicago and sold  grain alcohol over      the counter . That’s one       of  his   little
-# NPr     V/C NSg/V NSg/V NSg     NSg/V/J/P D   NSg/V/J . N$     NSg/I/V/J V/P ISg/D NPrSg/I/J
+> “ He      and this Wolfshiem bought up        a   lot     of side    - street  drug  - stores here    and in
+# . NPr/ISg V/C I/D  ?         NSg/V  NSg/V/J/P D/P NPrSg/V P  NSg/V/J . NSg/V/J NSg/V . NPl    NSg/J/R V/C NPrSg/V/J/P
+> Chicago and sold  grain alcohol over      the counter . That’s one       of his   little
+# NPr     V/C NSg/V NSg/V NSg     NSg/V/J/P D   NSg/V/J . N$     NSg/I/V/J P  ISg/D NPrSg/I/J
 > stunts . I   picked him for a   bootlegger the first   time  I   saw   him , and I   wasn’t far
 # NPl    . ISg W?     I   C/P D/P NSg        D   NSg/V/J NSg/V ISg NSg/V I   . V/C ISg V      NSg/V/J
 > wrong   . ”
@@ -8628,8 +8628,8 @@
 #
 > “ And you left      him in          the lurch , didn’t you ? You let   him go      to jail  for a   month
 # . V/C IPl NPrSg/V/J I   NPrSg/V/J/P D   NSg/V . V      IPl . IPl NSg/V I   NSg/V/J P  NSg/V C/P D/P NSg
-> over      in          New     Jersey . God     ! You ought    to hear Walter on  the subject of  you . ”
-# NSg/V/J/P NPrSg/V/J/P NSg/V/J NPrSg  . NPrSg/V . IPl NSg/I/VX P  V    NPr/J  J/P D   NSg/V/J V/P IPl . .
+> over      in          New     Jersey . God     ! You ought    to hear Walter on  the subject of you . ”
+# NSg/V/J/P NPrSg/V/J/P NSg/V/J NPrSg  . NPrSg/V . IPl NSg/I/VX P  V    NPr/J  J/P D   NSg/V/J P  IPl . .
 >
 #
 > “ He      came    to us      dead    broke   . He      was very glad    to pick  up        some  money , old   sport . ”
@@ -8658,12 +8658,12 @@
 # ISg W?      NSg/I/V/P NPrSg . NPrSg/I V   V       W?        NSg/P   NPr    V/C I/J/D NSg/V   .
 > and at        Jordan , who     had begun to balance an  invisible but     absorbing object on  the
 # V/C NSg/I/V/P NPr    . NPrSg/I V   V     P  NSg/V   D/P J         NSg/C/P V/J       NSg/V  J/P D
-> tip   of  her   chin    . Then    I   turned back    to Gatsby — and was startled at        his
-# NSg/V V/P I/J/D NPrSg/V . NSg/J/C ISg W?     NSg/V/J P  NPr    . V/C V   W?       NSg/I/V/P ISg/D
+> tip   of her   chin    . Then    I   turned back    to Gatsby — and was startled at        his
+# NSg/V P  I/J/D NPrSg/V . NSg/J/C ISg W?     NSg/V/J P  NPr    . V/C V   W?       NSg/I/V/P ISg/D
 > expression . He      looked — and this is said in          all       contempt for the babbled slander
 # NSg        . NPr/ISg W?     . V/C I/D  VL V/J  NPrSg/V/J/P NSg/I/J/C NSg      C/P D   W?      NSg/V
-> of  his   garden  — as    if    he      had “ killed a   man         . ” For a   moment the set       of  his   face
-# V/P ISg/D NSg/V/J . NSg/R NSg/C NPr/ISg V   . W?     D/P NPrSg/I/V/J . . C/P D/P NSg    D   NPrSg/V/J V/P ISg/D NSg/V
+> of his   garden  — as    if    he      had “ killed a   man         . ” For a   moment the set       of his   face
+# P  ISg/D NSg/V/J . NSg/R NSg/C NPr/ISg V   . W?     D/P NPrSg/I/V/J . . C/P D/P NSg    D   NPrSg/V/J P  ISg/D NSg/V
 > could  be     described in          just that    fantastic way   .
 # NSg/VX NSg/VX W?        NPrSg/V/J/P V/J  N/I/C/D NSg/J     NSg/J .
 >
@@ -8716,14 +8716,14 @@
 # NPl    . NSg/V/J P    D   NSg/V .
 >
 #
-> After a   moment Tom     got up        and began wrapping the unopened bottle of  whiskey in
-# J/P   D/P NSg    NPrSg/V V   NSg/V/J/P V/C V     NSg/V    D   V/J      NSg/V  V/P NSg     NPrSg/V/J/P
+> After a   moment Tom     got up        and began wrapping the unopened bottle of whiskey in
+# J/P   D/P NSg    NPrSg/V V   NSg/V/J/P V/C V     NSg/V    D   V/J      NSg/V  P  NSg     NPrSg/V/J/P
 > the towel .
 # D   NSg/V .
 >
 #
-> “ Want  any   of  this stuff ? Jordan ? . . . Nick    ? ”
-# . NSg/V I/R/D V/P I/D  NSg/V . NPr    . . . . NPrSg/V . .
+> “ Want  any   of this stuff ? Jordan ? . . . Nick    ? ”
+# . NSg/V I/R/D P  I/D  NSg/V . NPr    . . . . NPrSg/V . .
 >
 #
 > I   didn’t answer .
@@ -8746,8 +8746,8 @@
 # . NPrSg/P . . . ISg V/J  V          N/I/C/D P  . N$    D  NSg/V    . .
 >
 #
-> I   was thirty . Before me        stretched the portentous , menacing road  of  a   new     decade .
-# ISg V   NSg    . C/P    NPrSg/ISg W?        D   J          . NSg/V/J  NSg/J V/P D/P NSg/V/J NSg    .
+> I   was thirty . Before me        stretched the portentous , menacing road  of a   new     decade .
+# ISg V   NSg    . C/P    NPrSg/ISg W?        D   J          . NSg/V/J  NSg/J P  D/P NSg/V/J NSg    .
 >
 #
 > It        was seven o’clock when    we  got into the coupé with him and started for Long
@@ -8755,23 +8755,23 @@
 > Island . Tom     talked incessantly , exulting and laughing , but     his   voice was as
 # NSg/V  . NPrSg/V W?     J/R         . V        V/C NSg/V    . NSg/C/P ISg/D NSg/V V   NSg/R
 > remote  from Jordan and me        as    the foreign clamor on  the sidewalk or      the tumult of
-# NSg/V/J P    NPr    V/C NPrSg/ISg NSg/R D   NSg/J   NSg/V  J/P D   NSg      NPrSg/C D   NSg/V  V/P
+# NSg/V/J P    NPr    V/C NPrSg/ISg NSg/R D   NSg/J   NSg/V  J/P D   NSg      NPrSg/C D   NSg/V  P
 > the elevated overhead . Human   sympathy has its   limits , and we  were  content to let
 # D   W?       NSg/J/P  . NSg/V/J NSg      V   ISg/D NPl    . V/C IPl NSg/V NSg/V/J P  NSg/V
 > all       their tragic arguments fade    with the city lights behind  . Thirty — the promise
 # NSg/I/J/C D     NSg/J  NPl       NSg/V/J P    D   NSg  NPl    NSg/J/P . NSg    . D   NSg/V
-> of  a   decade of  loneliness , a   thinning list  of  single  men to know  , a   thinning
-# V/P D/P NSg    V/P NSg        . D/P NSg/V/J  NSg/V V/P NSg/V/J NSg P  NSg/V . D/P NSg/V/J
-> brief   - case    of  enthusiasm , thinning hair  . But     there was Jordan beside me        , who     ,
-# NSg/V/J . NPrSg/V V/P NSg        . NSg/V/J  NSg/V . NSg/C/P W?    V   NPr    P      NPrSg/ISg . NPrSg/I .
+> of a   decade of loneliness , a   thinning list  of single  men to know  , a   thinning
+# P  D/P NSg    P  NSg        . D/P NSg/V/J  NSg/V P  NSg/V/J NSg P  NSg/V . D/P NSg/V/J
+> brief   - case    of enthusiasm , thinning hair  . But     there was Jordan beside me        , who     ,
+# NSg/V/J . NPrSg/V P  NSg        . NSg/V/J  NSg/V . NSg/C/P W?    V   NPr    P      NPrSg/ISg . NPrSg/I .
 > unlike    Daisy , was too wise      ever to carry well    - forgotten dreams from age   to age   .
 # NSg/V/J/P NPrSg . V   W?  NPrSg/V/J J    P  NSg/V NSg/V/J . NSg/V/J   NPl    P    NSg/V P  NSg/V .
 > As    we  passed over      the dark    bridge her   wan     face  fell    lazily against my coat’s
 # NSg/R IPl W?     NSg/V/J/P D   NSg/V/J NSg/V  I/J/D NSg/V/J NSg/V NSg/V/J R      C/P     D  N$
-> shoulder and the formidable stroke of  thirty died away with the reassuring
-# NSg/V    V/C D   J          NSg/V  V/P NSg    W?   V/J  P    D   NSg/V/J
-> pressure of  her   hand  .
-# NSg/V    V/P I/J/D NSg/V .
+> shoulder and the formidable stroke of thirty died away with the reassuring
+# NSg/V    V/C D   J          NSg/V  P  NSg    W?   V/J  P    D   NSg/V/J
+> pressure of her   hand  .
+# NSg/V    P  I/J/D NSg/V .
 >
 #
 > So        we  drove on  toward death through the cooling twilight .
@@ -8787,7 +8787,7 @@
 > office — really sick    , pale    as    his   own     pale    hair  and shaking all       over      . Michaelis
 # NSg/V  . J/R    NSg/V/J . NSg/V/J NSg/R ISg/D NSg/V/J NSg/V/J NSg/V V/C V       NSg/I/J/C NSg/V/J/P . ?
 > advised him to go      to bed   , but     Wilson refused , saying that    he’d miss  a   lot     of
-# V/J     I   P  NSg/V/J P  NSg/V . NSg/C/P NPr    W?      . NSg/V  N/I/C/D W?   NSg/V D/P NPrSg/V V/P
+# V/J     I   P  NSg/V/J P  NSg/V . NSg/C/P NPr    W?      . NSg/V  N/I/C/D W?   NSg/V D/P NPrSg/V P
 > business if    he      did . While     his   neighbor was trying  to persuade him a   violent
 # NSg/J    NSg/C NPr/ISg V   . NSg/V/C/P ISg/D NSg/V    V   NSg/V/J P  V        I   D/P NSg/V/J
 > racket broke   out         overhead .
@@ -8802,8 +8802,8 @@
 #
 > Michaelis was astonished ; they had been  neighbors for four years , and Wilson had
 # ?         V   W?         . IPl  V   NSg/V NPl       C/P NSg  NPl   . V/C NPr    V
-> never seemed faintly capable of  such  a   statement . Generally he      was one       of  these
-# V     W?     J/R     J       V/P NSg/I D/P NSg/V/J   . J/R       NPr/ISg V   NSg/I/V/J V/P I/D
+> never seemed faintly capable of such  a   statement . Generally he      was one       of these
+# V     W?     J/R     J       P  NSg/I D/P NSg/V/J   . J/R       NPr/ISg V   NSg/I/V/J P  I/D
 > worn - out         men : when    he      wasn’t working , he      sat     on  a   chair in          the doorway and
 # V/J  . NSg/V/J/R/P NSg . NSg/I/C NPr/ISg V      V       . NPr/ISg NSg/V/J J/P D/P NSg/V NPrSg/V/J/P D   NSg     V/C
 > stared at        the people and the cars that    passed along the road  . When    any   one       spoke
@@ -8826,8 +8826,8 @@
 # NSg        . V/C ?         V    D   NSg         P  NSg/V V/J  . V         P  NSg/V/P
 > back    later . But     he      didn’t . He      supposed he      forgot to , that’s all       . When    he      came
 # NSg/V/J J     . NSg/C/P NPr/ISg V      . NPr/ISg V/J      NPr/ISg V      P  . N$     NSg/I/J/C . NSg/I/C NPr/ISg NSg/V/P
-> outside   again , a   little    after seven , he      was reminded of  the conversation because
-# NSg/V/J/P P     . D/P NPrSg/I/J J/P   NSg   . NPr/ISg V   W?       V/P D   NSg/V        C/P
+> outside   again , a   little    after seven , he      was reminded of the conversation because
+# NSg/V/J/P P     . D/P NPrSg/I/J J/P   NSg   . NPr/ISg V   W?       P  D   NSg/V        C/P
 > he      heard Mrs . Wilson’s voice , loud  and scolding , down      - stairs in          the garage .
 # NPr/ISg V/J   NPl . N$       NSg/V . NSg/J V/C NSg/V    . NSg/V/J/P . NPl    NPrSg/V/J/P D   NSg/V  .
 >
@@ -8844,12 +8844,12 @@
 # V        . C/P    NPr/ISg NSg/VX NSg/V P    ISg/D NSg/V D   NSg/J    V   NSg/V/J/P .
 >
 #
-> The “ death car ” as    the newspapers called it        , didn’t stop  ; it        came    out         of  the
-# D   . NPrSg NSg . NSg/R D   NPl        V/J    NPrSg/ISg . V      NSg/V . NPrSg/ISg NSg/V/P NSg/V/J/R/P V/P D
+> The “ death car ” as    the newspapers called it        , didn’t stop  ; it        came    out         of the
+# D   . NPrSg NSg . NSg/R D   NPl        V/J    NPrSg/ISg . V      NSg/V . NPrSg/ISg NSg/V/P NSg/V/J/R/P P  D
 > gathering darkness , wavered tragically for a   moment , and then    disappeared around
 # NSg/V/J   NSg      . W?      R          C/P D/P NSg    . V/C NSg/J/C W?          J/P
-> the next    bend    . Mavromichaelis wasn’t even    sure of  its   color      — he      told the first
-# D   NSg/J/P NPrSg/V . ?              V      NSg/V/J J    V/P ISg/D NSg/V/J/Am . NPr/ISg V    D   NSg/V/J
+> the next    bend    . Mavromichaelis wasn’t even    sure of its   color      — he      told the first
+# D   NSg/J/P NPrSg/V . ?              V      NSg/V/J J    P  ISg/D NSg/V/J/Am . NPr/ISg V    D   NSg/V/J
 > policeman that    it        was light   green     . The other   car , the one       going   toward New     York ,
 # NSg       N/I/C/D NPrSg/ISg V   NSg/V/J NPrSg/V/J . D   NSg/V/J NSg . D   NSg/I/V/J NSg/V/J J/P    NSg/V/J NPr  .
 > came    to rest  a   hundred yards beyond , and it’s driver hurried back    to where
@@ -8884,10 +8884,10 @@
 # . NSg/V . . V/J  NPrSg/V . . N$     NPrSg/V/J . ?         NSg/VX D/P NPrSg/I/J NSg/J    NSg/I/V/P NSg/V/J . .
 >
 #
-> He      slowed down      , but     still   without any   intention of  stopping , until , as    we  came
-# NPr/ISg W?     NSg/V/J/P . NSg/C/P NSg/V/J C/P     I/R/D NSg/V     V/P NSg/V    . C/P   . NSg/R IPl NSg/V/P
-> nearer , the hushed , intent faces of  the people at        the garage door  made  him
-# J      . D   W?     . NSg/J  NPl   V/P D   NSg/V  NSg/I/V/P D   NSg/V  NSg/V NSg/V I
+> He      slowed down      , but     still   without any   intention of stopping , until , as    we  came
+# NPr/ISg W?     NSg/V/J/P . NSg/C/P NSg/V/J C/P     I/R/D NSg/V     P  NSg/V    . C/P   . NSg/R IPl NSg/V/P
+> nearer , the hushed , intent faces of the people at        the garage door  made  him
+# J      . D   W?     . NSg/J  NPl   P  D   NSg/V  NSg/I/V/P D   NSg/V  NSg/V NSg/V I
 > automatically put   on  the brakes .
 # W?            NSg/V J/P D   NPl    .
 >
@@ -8896,10 +8896,10 @@
 # . W?    NSg/V D/P NSg/V . . NPr/ISg V/J  J/R        . . V/J  D/P NSg/V . .
 >
 #
-> I   became aware now         of  a   hollow  , wailing sound   which issued incessantly from the
-# ISg V      V/J   NPrSg/V/J/C V/P D/P NSg/V/J . NSg/V   NSg/V/J I/C   W?     J/R         P    D
-> garage , a   sound   which as    we  got out         of  the coupé and walked toward the door
-# NSg/V  . D/P NSg/V/J I/C   NSg/R IPl V   NSg/V/J/R/P V/P D   ?     V/C W?     J/P    D   NSg/V
+> I   became aware now         of a   hollow  , wailing sound   which issued incessantly from the
+# ISg V      V/J   NPrSg/V/J/C P  D/P NSg/V/J . NSg/V   NSg/V/J I/C   W?     J/R         P    D
+> garage , a   sound   which as    we  got out         of the coupé and walked toward the door
+# NSg/V  . D/P NSg/V/J I/C   NSg/R IPl V   NSg/V/J/R/P P  D   ?     V/C W?     J/P    D   NSg/V
 > resolved itself into the words “ Oh      , my God     ! ” uttered over      and over      in          a   gasping
 # V/J      I      P    D   NPl   . NPrSg/V . D  NPrSg/V . . W?      NSg/V/J/P V/C NSg/V/J/P NPrSg/V/J/P D/P V
 > moan  .
@@ -8910,18 +8910,18 @@
 # . W?      I/J/R NSg/V/J NSg/V   NSg/J/R . . V/J  NPrSg/V J/R       .
 >
 #
-> He      reached up        on  tiptoes and peered over      a   circle of  heads into the garage ,
-# NPr/ISg W?      NSg/V/J/P J/P NPl     V/C W?     NSg/V/J/P D/P NSg/V  V/P NPl   P    D   NSg/V  .
+> He      reached up        on  tiptoes and peered over      a   circle of heads into the garage ,
+# NPr/ISg W?      NSg/V/J/P J/P NPl     V/C W?     NSg/V/J/P D/P NSg/V  P  NPl   P    D   NSg/V  .
 > which was lit     only by      a   yellow  light   in          a   swinging metal   basket overhead . Then
 # I/C   V   NSg/V/J W?   NSg/J/P D/P NSg/V/J NSg/V/J NPrSg/V/J/P D/P V        NSg/V/J NSg/V  NSg/J/P  . NSg/J/C
 > he      made  a   harsh sound   in          his   throat , and with a   violent thrusting movement of
-# NPr/ISg NSg/V D/P V/J   NSg/V/J NPrSg/V/J/P ISg/D NSg/V  . V/C P    D/P NSg/V/J V         NSg      V/P
+# NPr/ISg NSg/V D/P V/J   NSg/V/J NPrSg/V/J/P ISg/D NSg/V  . V/C P    D/P NSg/V/J V         NSg      P
 > his   powerful arms pushed his   way   through .
 # ISg/D J        NPl  W?     ISg/D NSg/J NSg/J/P .
 >
 #
-> The circle closed up        again with a   running   murmur of  expostulation ; it        was a
-# D   NSg/V  W?     NSg/V/J/P P     P    D/P NSg/V/J/P NSg/V  V/P NSg           . NPrSg/ISg V   D/P
+> The circle closed up        again with a   running   murmur of expostulation ; it        was a
+# D   NSg/V  W?     NSg/V/J/P P     P    D/P NSg/V/J/P NSg/V  P  NSg           . NPrSg/ISg V   D/P
 > minute  before I   could  see   anything at        all       . Then    new     arrivals deranged the line  ,
 # NSg/V/J C/P    ISg NSg/VX NSg/V NSg/I/V  NSg/I/V/P NSg/I/J/C . NSg/J/C NSg/V/J NPl      W?       D   NSg/V .
 > and Jordan and I   were  pushed suddenly inside  .
@@ -8936,12 +8936,12 @@
 # NPrSg/V . V/C NPrSg/V . P    ISg/D NSg/V/J P  NPr/ISg . V   V       NSg/V/J/P NPrSg/ISg . J          . NSg/J/P P  I
 > stood a   motorcycle policeman taking  down      names with much  sweat and correction in
 # V     D/P NSg/V      NSg       NSg/V/J NSg/V/J/P NPl   P    N/I/J NSg/V V/C NSg        NPrSg/V/J/P
-> a   little    book  . At        first   I   couldn’t find  the source of  the high    , groaning words
-# D/P NPrSg/I/J NSg/V . NSg/I/V/P NSg/V/J ISg V        NSg/V D   NSg/V  V/P D   NSg/V/J . V        NPl
+> a   little    book  . At        first   I   couldn’t find  the source of the high    , groaning words
+# D/P NPrSg/I/J NSg/V . NSg/I/V/P NSg/V/J ISg V        NSg/V D   NSg/V  P  D   NSg/V/J . V        NPl
 > that    echoed clamorously through the bare    garage — then    I   saw   Wilson standing on
 # N/I/C/D W?     ?           NSg/J/P D   NSg/V/J NSg/V  . NSg/J/C ISg NSg/V NPr    NSg/V/J  J/P
-> the raised threshold of  his   office , swaying back    and forth and holding to the
-# D   W?     NSg       V/P ISg/D NSg/V  . V       NSg/V/J V/C W?    V/C NSg/V   P  D
+> the raised threshold of his   office , swaying back    and forth and holding to the
+# D   W?     NSg       P  ISg/D NSg/V  . V       NSg/V/J V/C W?    V/C NSg/V   P  D
 > doorposts with both hands . Some  man         was talking to him in          a   low     voice and
 # NPl       P    I/C  NPl   . I/J/R NPrSg/I/V/J V   V       P  I   NPrSg/V/J/P D/P NSg/V/J NSg/V V/C
 > attempting , from time  to time  , to lay     a   hand  on  his   shoulder , but     Wilson neither
@@ -9002,8 +9002,8 @@
 # . J/R       W?     . . V/J      NPrSg/V . V       .
 >
 #
-> “ She ran   out         ina road  . Son     - of  - a   - bitch didn’t even    stopus car . ”
-# . ISg NSg/V NSg/V/J/R/P NPr NSg/J . NPrSg/V . V/P . D/P . NSg/V V      NSg/V/J ?      NSg . .
+> “ She ran   out         ina road  . Son     - of - a   - bitch didn’t even    stopus car . ”
+# . ISg NSg/V NSg/V/J/R/P NPr NSg/J . NPrSg/V . P  . D/P . NSg/V V      NSg/V/J ?      NSg . .
 >
 #
 > “ There was two cars , ” said Michaelis , “ one       comin ’ , one       goin ’ , see   ? ”
@@ -9022,8 +9022,8 @@
 # NSg/V NPrSg/V/J P    I/J/D . ?    . NSg    NPrSg/C NSg/J NPrPl D/P NSg  . .
 >
 #
-> “ What’s the name  of  this place here    ? ” demanded the officer .
-# . N$     D   NSg/V V/P I/D  NSg/V NSg/J/R . . W?       D   NSg/V/J .
+> “ What’s the name  of this place here    ? ” demanded the officer .
+# . N$     D   NSg/V P  I/D  NSg/V NSg/J/R . . W?       D   NSg/V/J .
 >
 #
 > “ Hasn’t got any   name  . ”
@@ -9052,22 +9052,22 @@
 # . NSg/V/P NSg/J/R V/C N$    NSg/VX D    NSg/V . NSg/V NSg/V/J/R/P NPrSg/V/J/C . ISg NSg/V P  NSg/V ISg/D NSg/V . .
 >
 #
-> Some  words of  this conversation must  have   reached Wilson , swaying in          the office
-# I/J/R NPl   V/P I/D  NSg/V        NSg/V NSg/VX W?      NPr    . V       NPrSg/V/J/P D   NSg/V
+> Some  words of this conversation must  have   reached Wilson , swaying in          the office
+# I/J/R NPl   P  I/D  NSg/V        NSg/V NSg/VX W?      NPr    . V       NPrSg/V/J/P D   NSg/V
 > door  , for suddenly a   new     theme found voice among his   gasping cries :
 # NSg/V . C/P J/R      D/P NSg/V/J NSg/V NSg/V NSg/V P     ISg/D V       NPl   .
 >
 #
-> “ You don’t have   to tell    me        what  kind  of  car it        was ! I   know  what  kind  of  car it
-# . IPl NSg/V NSg/VX P  NPrSg/V NPrSg/ISg NSg/I NSg/J V/P NSg NPrSg/ISg V   . ISg NSg/V NSg/I NSg/J V/P NSg NPrSg/ISg
+> “ You don’t have   to tell    me        what  kind  of car it        was ! I   know  what  kind  of car it
+# . IPl NSg/V NSg/VX P  NPrSg/V NPrSg/ISg NSg/I NSg/J P  NSg NPrSg/ISg V   . ISg NSg/V NSg/I NSg/J P  NSg NPrSg/ISg
 > was ! ”
 # V   . .
 >
 #
-> Watching Tom     , I   saw   the wad   of  muscle back    of  his   shoulder tighten under   his
-# V        NPrSg/V . ISg NSg/V D   NSg/V V/P NSg/V  NSg/V/J V/P ISg/D NSg/V    V       NSg/J/P ISg/D
-> coat  . He      walked quickly over      to Wilson and , standing in          front   of  him seized him ,
-# NSg/V . NPr/ISg W?     J/R     NSg/V/J/P P  NPr    V/C . NSg/V/J  NPrSg/V/J/P NSg/V/J V/P I   W?     I   .
+> Watching Tom     , I   saw   the wad   of muscle back    of his   shoulder tighten under   his
+# V        NPrSg/V . ISg NSg/V D   NSg/V P  NSg/V  NSg/V/J P  ISg/D NSg/V    V       NSg/J/P ISg/D
+> coat  . He      walked quickly over      to Wilson and , standing in          front   of him seized him ,
+# NSg/V . NPr/ISg W?     J/R     NSg/V/J/P P  NPr    V/C . NSg/V/J  NPrSg/V/J/P NSg/V/J P  I   W?     I   .
 > firmly by      the upper arms .
 # J/R    NSg/J/P D   NSg/J NPl  .
 >
@@ -9102,8 +9102,8 @@
 # . N$     NSg/I/J/C N/I/C/D . . NPr/ISg W?       .
 >
 #
-> “ I’m a   friend  of  his   . ” Tom     turned his   head      but     kept his   hands firm    on  Wilson’s
-# . W?  D/P NPrSg/V V/P ISg/D . . NPrSg/V W?     ISg/D NPrSg/V/J NSg/C/P V    ISg/D NPl   NSg/V/J J/P N$
+> “ I’m a   friend  of his   . ” Tom     turned his   head      but     kept his   hands firm    on  Wilson’s
+# . W?  D/P NPrSg/V P  ISg/D . . NPrSg/V W?     ISg/D NPrSg/V/J NSg/C/P V    ISg/D NPl   NSg/V/J J/P N$
 > body  . “ He      says he      knows the car that    did it        . . . . It        was a   yellow  car . ”
 # NSg/V . . NPr/ISg NPl  NPr/ISg NPl   D   NSg N/I/C/D V   NPrSg/ISg . . . . NPrSg/ISg V   D/P NSg/V/J NSg . .
 >
@@ -9180,8 +9180,8 @@
 # NPrPl   W?      P    NSg/V/J P     D   NPl   .
 >
 #
-> “ Daisy’s home    , ” he      said . As    we  got out         of  the car he      glanced at        me        and frowned
-# . N$      NSg/V/J . . NPr/ISg V/J  . NSg/R IPl V   NSg/V/J/R/P V/P D   NSg NPr/ISg W?      NSg/I/V/P NPrSg/ISg V/C W?
+> “ Daisy’s home    , ” he      said . As    we  got out         of the car he      glanced at        me        and frowned
+# . N$      NSg/V/J . . NPr/ISg V/J  . NSg/R IPl V   NSg/V/J/R/P P  D   NSg NPr/ISg W?      NSg/I/V/P NPrSg/ISg V/C W?
 > slightly .
 # J/R      .
 >
@@ -9194,8 +9194,8 @@
 #
 > A   change had come    over      him , and he      spoke gravely , and with decision . As    we
 # D/P NSg/V  V   NSg/V/P NSg/V/J/P I   . V/C NPr/ISg NSg/V J/R     . V/C P    NSg/V    . NSg/R IPl
-> walked across the moonlight gravel to the porch he      disposed of  the situation in
-# W?     NSg/P  D   NSg/V     NSg/V  P  D   NSg   NPr/ISg V/J      V/P D   NSg       NPrSg/V/J/P
+> walked across the moonlight gravel to the porch he      disposed of the situation in
+# W?     NSg/P  D   NSg/V     NSg/V  P  D   NSg   NPr/ISg V/J      P  D   NSg       NPrSg/V/J/P
 > a   few brisk phrases .
 # D/P N/I V/J   NPl     .
 >
@@ -9234,10 +9234,10 @@
 # . W?   W?   NSg/V/J/P . NSg/V/J/P NSg  . . ISg V/J  .
 >
 #
-> I’d be     damned if    I’d go      in          ; I’d had enough of  all       of  them for one       day   , and
-# W?  NSg/VX V/J    NSg/C W?  NSg/V/J NPrSg/V/J/P . W?  V   NSg/I  V/P NSg/I/J/C V/P N/I  C/P NSg/I/V/J NPrSg . V/C
-> suddenly that    included Jordan too . She must  have   seen  something of  this in          my
-# J/R      N/I/C/D W?       NPr    W?  . ISg NSg/V NSg/VX NSg/V NSg/I/V/J V/P I/D  NPrSg/V/J/P D
+> I’d be     damned if    I’d go      in          ; I’d had enough of all       of them for one       day   , and
+# W?  NSg/VX V/J    NSg/C W?  NSg/V/J NPrSg/V/J/P . W?  V   NSg/I  P  NSg/I/J/C P  N/I  C/P NSg/I/V/J NPrSg . V/C
+> suddenly that    included Jordan too . She must  have   seen  something of this in          my
+# J/R      N/I/C/D W?       NPr    W?  . ISg NSg/V NSg/VX NSg/V NSg/I/V/J P  I/D  NPrSg/V/J/P D
 > expression , for she turned abruptly away and ran   up        the porch steps into the
 # NSg        . C/P ISg W?     J/R      V/J  V/C NSg/V NSg/V/J/P D   NSg   NPl   P    D
 > house   . I   sat     down      for a   few minutes with my head      in          my hands , until I   heard the
@@ -9252,8 +9252,8 @@
 # ISg V      V/J/P NSg    NPl   NSg/I/C ISg V/J   D  NSg/V V/C NPr    W?      P    NSg/P
 > two bushes into the path  . I   must  have   felt    pretty  weird   by      that    time  , because I
 # NSg NPl    P    D   NSg/V . ISg NSg/V NSg/VX NSg/V/J NSg/V/J NSg/V/J NSg/J/P N/I/C/D NSg/V . C/P     ISg
-> could  think of  nothing except the luminosity of  his   pink    suit  under   the moon    .
-# NSg/VX NSg/V V/P NSg/I/J V/C/P  D   NSg        V/P ISg/D NSg/V/J NSg/V NSg/J/P D   NPrSg/V .
+> could  think of nothing except the luminosity of his   pink    suit  under   the moon    .
+# NSg/VX NSg/V P  NSg/I/J V/C/P  D   NSg        P  ISg/D NSg/V/J NSg/V NSg/J/P D   NPrSg/V .
 >
 #
 > “ What  are you doing ? ” I   inquired .
@@ -9268,8 +9268,8 @@
 # W?      . N/I/C/D W?     D/P NSg/J      NSg        . C/P NSg/I/J/C ISg V    NPr/ISg V   NSg/V/J P  NPrSg/V
 > the house   in          a   moment ; I   wouldn’t have   been  surprised to see   sinister faces , the
 # D   NPrSg/V NPrSg/V/J/P D/P NSg    . ISg VX       NSg/VX NSg/V W?        P  NSg/V J        NPl   . D
-> faces of  “ Wolfshiem’s people , ” behind  him in          the dark    shrubbery .
-# NPl   V/P . ?           NSg/V  . . NSg/J/P I   NPrSg/V/J/P D   NSg/V/J NSg       .
+> faces of “ Wolfshiem’s people , ” behind  him in          the dark    shrubbery .
+# NPl   P  . ?           NSg/V  . . NSg/J/P I   NPrSg/V/J/P D   NSg/V/J NSg       .
 >
 #
 > “ Did you see   any   trouble on  the road  ? ” he      asked after a   minute  .
@@ -9304,8 +9304,8 @@
 #
 > “ I   got to West      Egg   by      a   side    road  , ” he      went  on  , “ and left      the car in          my garage .
 # . ISg V   P  NPrSg/V/J NSg/V NSg/J/P D/P NSg/V/J NSg/J . . NPr/ISg NSg/V J/P . . V/C NPrSg/V/J D   NSg NPrSg/V/J/P D  NSg/V  .
-> I   don’t think anybody saw   us      , but     of  course I   can’t be     sure . ”
-# ISg NSg/V NSg/V N/I     NSg/V NPr/ISg . NSg/C/P V/P NSg/V  ISg VX    NSg/VX J    . .
+> I   don’t think anybody saw   us      , but     of course I   can’t be     sure . ”
+# ISg NSg/V NSg/V N/I     NSg/V NPr/ISg . NSg/C/P P  NSg/V  ISg VX    NSg/VX J    . .
 >
 #
 > I   disliked him so        much  by      this time  that    I   didn’t find  it        necessary to tell    him
@@ -9332,8 +9332,8 @@
 # . V   NPrSg V       . .
 >
 #
-> “ Yes   , ” he      said after a   moment , “ but     of  course I'll say   I   was . You see   , when    we
-# . NSg/V . . NPr/ISg V/J  J/P   D/P NSg    . . NSg/C/P V/P NSg/V  W?   NSg/V ISg V   . IPl NSg/V . NSg/I/C IPl
+> “ Yes   , ” he      said after a   moment , “ but     of course I'll say   I   was . You see   , when    we
+# . NSg/V . . NPr/ISg V/J  J/P   D/P NSg    . . NSg/C/P P  NSg/V  W?   NSg/V ISg V   . IPl NSg/V . NSg/I/C IPl
 > left      New     York she was very nervous and she thought it        would  steady  her   to
 # NPrSg/V/J NSg/V/J NPr  ISg V   J    J       V/C ISg NSg/V   NPrSg/ISg NSg/VX NSg/V/J I/J/D P
 > drive — and this woman rushed out         at        us      just as    we  were  passing a   car coming  the
@@ -9388,8 +9388,8 @@
 # . NSg/I/J/C NSg/V . NSg/C NSg/J     . J      . NSg/V/C/P IPl  NSg/I/J/C NSg/V/J P  NSg/V . .
 >
 #
-> A   new     point of  view  occurred to me        . Suppose Tom     found out         that    Daisy had been
-# D/P NSg/V/J NSg/V V/P NSg/V V        P  NPrSg/ISg . V       NPrSg/V NSg/V NSg/V/J/R/P N/I/C/D NPrSg V   NSg/V
+> A   new     point of view  occurred to me        . Suppose Tom     found out         that    Daisy had been
+# D/P NSg/V/J NSg/V P  NSg/V V        P  NPrSg/ISg . V       NPrSg/V NSg/V NSg/V/J/R/P N/I/C/D NPrSg V   NSg/V
 > driving . He      might    think he      saw   a   connection in          it        — he      might    think anything . I
 # V       . NPr/ISg NSg/VX/J NSg/V NPr/ISg NSg/V D/P NSg        NPrSg/V/J/P NPrSg/ISg . NPr/ISg NSg/VX/J NSg/V NSg/I/V  . ISg
 > looked at        the house   ; there were  two or      three bright    windows down      - stairs and the
@@ -9398,26 +9398,26 @@
 # NSg/V/J NSg/V P    N$      NSg/V/J J/P D   NSg/V/J NSg/V .
 >
 #
-> “ You wait  here    , ” I   said . “ I’ll see   if    there’s any   sign  of  a   commotion . ”
-# . IPl NSg/V NSg/J/R . . ISg V/J  . . W?   NSg/V NSg/C W?      I/R/D NSg/V V/P D/P NSg       . .
+> “ You wait  here    , ” I   said . “ I’ll see   if    there’s any   sign  of a   commotion . ”
+# . IPl NSg/V NSg/J/R . . ISg V/J  . . W?   NSg/V NSg/C W?      I/R/D NSg/V P  D/P NSg       . .
 >
 #
-> I   walked back    along the border of  the lawn  , traversed the gravel softly , and
-# ISg W?     NSg/V/J P     D   NSg/V  V/P D   NSg/V . W?        D   NSg/V  J/R    . V/C
+> I   walked back    along the border of the lawn  , traversed the gravel softly , and
+# ISg W?     NSg/V/J P     D   NSg/V  P  D   NSg/V . W?        D   NSg/V  J/R    . V/C
 > tiptoed up        the veranda steps . The drawing - room    curtains were  open    , and I   saw
 # W?      NSg/V/J/P D   NSg/Br  NPl   . D   NSg/V   . NSg/V/J NPl      NSg/V NSg/V/J . V/C ISg NSg/V
 > that    the room    was empty   . Crossing the porch where we  had dined that    June night
 # N/I/C/D D   NSg/V/J V   NSg/V/J . NSg/V/J  D   NSg   NSg/C IPl V   W?    N/I/C/D NPr  NSg/V
-> three months before , I   came    to a   small     rectangle of  light   which I   guessed was
-# NSg   NSg    C/P    . ISg NSg/V/P P  D/P NPrSg/V/J NSg/J     V/P NSg/V/J I/C   ISg W?      V
+> three months before , I   came    to a   small     rectangle of light   which I   guessed was
+# NSg   NSg    C/P    . ISg NSg/V/P P  D/P NPrSg/V/J NSg/J     P  NSg/V/J I/C   ISg W?      V
 > the pantry window . The blind   was drawn , but     I   found a   rift  at        the sill  .
 # D   NSg    NSg/V  . D   NSg/V/J V   V/J   . NSg/C/P ISg NSg/V D/P NSg/V NSg/I/V/P D   NSg/J .
 >
 #
 > Daisy and Tom     were  sitting opposite each other   at        the kitchen table , with a
 # NPrSg V/C NPrSg/V NSg/V NSg/V/J NSg/J/P  D    NSg/V/J NSg/I/V/P D   NSg/V   NSg/V . P    D/P
-> plate of  cold  fried chicken between them , and two bottles of  ale . He      was talking
-# NSg/V V/P NSg/J W?    NSg/V/J NSg/P   N/I  . V/C NSg NPl     V/P NSg . NPr/ISg V   V
+> plate of cold  fried chicken between them , and two bottles of ale . He      was talking
+# NSg/V P  NSg/J W?    NSg/V/J NSg/P   N/I  . V/C NSg NPl     P  NSg . NPr/ISg V   V
 > intently across the table at        her   , and in          his   earnestness his   hand  had fallen
 # J/R      NSg/P  D   NSg/V NSg/I/V/P I/J/D . V/C NPrSg/V/J/P ISg/D NSg         ISg/D NSg/V V   W?
 > upon and covered her   own     . Once  in          a   while     she looked up        at        him and nodded in
@@ -9426,10 +9426,10 @@
 # NSg       .
 >
 #
-> They weren’t happy   , and neither of  them had touched the chicken or      the ale — and
-# IPl  V       NSg/V/J . V/C I/C     V/P N/I  V   V/J     D   NSg/V/J NPrSg/C D   NSg . V/C
-> yet     they weren’t unhappy either . There was an  unmistakable air   of  natural
-# NSg/V/C IPl  V       NSg/V/J I/C    . W?    V   D/P J            NSg/V V/P NSg/J
+> They weren’t happy   , and neither of them had touched the chicken or      the ale — and
+# IPl  V       NSg/V/J . V/C I/C     P  N/I  V   V/J     D   NSg/V/J NPrSg/C D   NSg . V/C
+> yet     they weren’t unhappy either . There was an  unmistakable air   of natural
+# NSg/V/C IPl  V       NSg/V/J I/C    . W?    V   D/P J            NSg/V P  NSg/J
 > intimacy about the picture , and anybody would  have   said that    they were
 # NSg      J/P   D   NSg/V   . V/C N/I     NSg/VX NSg/VX V/J  N/I/C/D IPl  NSg/V
 > conspiring together .
@@ -9459,9 +9459,9 @@
 >
 #
 > He      put   his   hands in          his   coat  pockets and turned back    eagerly to his   scrutiny of
-# NPr/ISg NSg/V ISg/D NPl   NPrSg/V/J/P ISg/D NSg/V NPl     V/C W?     NSg/V/J J/R     P  ISg/D NSg/V    V/P
-> the house   , as    though my presence marred the sacredness of  the vigil . So        I   walked
-# D   NPrSg/V . NSg/R V/C    D  NSg/V    V/J    D   NSg        V/P D   NSg/V . NSg/I/J/C ISg W?
+# NPr/ISg NSg/V ISg/D NPl   NPrSg/V/J/P ISg/D NSg/V NPl     V/C W?     NSg/V/J J/R     P  ISg/D NSg/V    P
+> the house   , as    though my presence marred the sacredness of the vigil . So        I   walked
+# D   NPrSg/V . NSg/R V/C    D  NSg/V    V/J    D   NSg        P  D   NSg/V . NSg/I/J/C ISg W?
 > away and left      him standing there in          the moonlight — watching over      nothing .
 # V/J  V/C NPrSg/V/J I   NSg/V/J  W?    NPrSg/V/J/P D   NSg/V     . V        NSg/V/J/P NSg/I/J .
 >
@@ -9475,7 +9475,7 @@
 > and I   tossed half      - sick    between grotesque reality and savage    , frightening dreams .
 # V/C ISg W?     NSg/V/J/P . NSg/V/J NSg/P   NSg/J     NSg     V/C NPrSg/V/J . V/J         NPl    .
 > Toward dawn    I   heard a   taxi  go      up        Gatsby’s drive , and immediately I   jumped out         of
-# J/P    NPrSg/V ISg V/J   D/P NSg/V NSg/V/J NSg/V/J/P N$       NSg/V . V/C J/R         ISg W?     NSg/V/J/R/P V/P
+# J/P    NPrSg/V ISg V/J   D/P NSg/V NSg/V/J NSg/V/J/P N$       NSg/V . V/C J/R         ISg W?     NSg/V/J/R/P P
 > bed   and began to dress — I   felt    that    I   had something to tell    him , something to
 # NSg/V V/C V     P  NSg/V . ISg NSg/V/J N/I/C/D ISg V   NSg/I/V/J P  NPrSg/V I   . NSg/I/V/J P
 > warn him about , and morning would  be     too late  .
@@ -9498,18 +9498,18 @@
 # ISg/D NPrSg/V V   V     W?     NSg/I/J/C J        P  NPrSg/ISg NSg/R NPrSg/ISg V   N/I/C/D NSg/V NSg/I/C IPl W?
 > through the great rooms for cigarettes . We  pushed aside curtains that    were  like
 # NSg/J/P D   NSg/J NPl   C/P NPl        . IPl W?     NSg/J NPl      N/I/C/D NSg/V NSg/V/J/C/P
-> pavilions , and felt    over      innumerable feet of  dark    wall    for electric light
-# NPl       . V/C NSg/V/J NSg/V/J/P J           NSg  V/P NSg/V/J NPrSg/V C/P NSg/J    NSg/V/J
-> switches — once  I   tumbled with a   sort  of  splash upon the keys of  a   ghostly piano   .
-# NPl      . NSg/C ISg W?      P    D/P NSg/V V/P NSg/V  P    D   NPl  V/P D/P J/R     NSg/V/J .
-> There was an  inexplicable amount of  dust  everywhere , and the rooms were  musty   ,
-# W?    V   D/P J            NSg/V  V/P NSg/V W?         . V/C D   NPl   NSg/V NSg/V/J .
+> pavilions , and felt    over      innumerable feet of dark    wall    for electric light
+# NPl       . V/C NSg/V/J NSg/V/J/P J           NSg  P  NSg/V/J NPrSg/V C/P NSg/J    NSg/V/J
+> switches — once  I   tumbled with a   sort  of splash upon the keys of a   ghostly piano   .
+# NPl      . NSg/C ISg W?      P    D/P NSg/V P  NSg/V  P    D   NPl  P  D/P J/R     NSg/V/J .
+> There was an  inexplicable amount of dust  everywhere , and the rooms were  musty   ,
+# W?    V   D/P J            NSg/V  P  NSg/V W?         . V/C D   NPl   NSg/V NSg/V/J .
 > as    though they hadn’t been  aired for many    days . I   found the humidor on  an
 # NSg/R V/C    IPl  V      NSg/V W?    C/P N/I/J/D NPl  . ISg NSg/V D   NSg     J/P D/P
 > unfamiliar table , with two stale   , dry     cigarettes inside  . Throwing open    the
 # NSg/J      NSg/V . P    NSg NSg/V/J . NSg/V/J NPl        NSg/J/P . V        NSg/V/J D
-> French    windows of  the drawing - room    , we  sat     smoking out         into the darkness .
-# NPrSg/V/J NPrPl   V/P D   NSg/V   . NSg/V/J . IPl NSg/V/J NSg/V/J NSg/V/J/R/P P    D   NSg      .
+> French    windows of the drawing - room    , we  sat     smoking out         into the darkness .
+# NPrSg/V/J NPrPl   P  D   NSg/V   . NSg/V/J . IPl NSg/V/J NSg/V/J NSg/V/J/R/P P    D   NSg      .
 >
 #
 > “ You ought    to go      away , ” I   said . “ It’s pretty  certain they'll trace your car . ”
@@ -9532,8 +9532,8 @@
 # I   NSg/V/J .
 >
 #
-> It        was this night that    he      told me        the strange story of  his   youth with Dan
-# NPrSg/ISg V   I/D  NSg/V N/I/C/D NPr/ISg V    NPrSg/ISg D   NSg/V/J NSg/V V/P ISg/D NSg   P    NPrSg
+> It        was this night that    he      told me        the strange story of his   youth with Dan
+# NPrSg/ISg V   I/D  NSg/V N/I/C/D NPr/ISg V    NPrSg/ISg D   NSg/V/J NSg/V P  ISg/D NSg   P    NPrSg
 > Cody — told it        to me        because “ Jay   Gatsby ” had broken up        like        glass   against Tom’s
 # NPr  . V    NPrSg/ISg P  NPrSg/ISg C/P     . NPrSg NPr    . V   V/J    NSg/V/J/P NSg/V/J/C/P NPrSg/V C/P     N$
 > hard    malice , and the long      secret  extravaganza was played out         . I   think that    he
@@ -9554,34 +9554,34 @@
 # I/J/D NPrSg/V . NSg/I/V/P NSg/V/J P    NSg/V/J W?       P    NSg/V/J NPr    . NSg/J/C J     . NPrSg/ISg W?
 > him — he      had never been  in          such  a   beautiful house   before . But     what  gave it        an  air
 # I   . NPr/ISg V   V     NSg/V NPrSg/V/J/P NSg/I D/P NSg/J     NPrSg/V C/P    . NSg/C/P NSg/I V    NPrSg/ISg D/P NSg/V
-> of  breathless intensity , was that    Daisy lived there — it        was as    casual a   thing to
-# V/P J          NSg       . V   N/I/C/D NPrSg W?    W?    . NPrSg/ISg V   NSg/R NSg/J  D/P NSg/V P
+> of breathless intensity , was that    Daisy lived there — it        was as    casual a   thing to
+# P  J          NSg       . V   N/I/C/D NPrSg W?    W?    . NPrSg/ISg V   NSg/R NSg/J  D/P NSg/V P
 > her   as    his   tent  out         at        camp    was to him . There was a   ripe    mystery about it        , a
 # I/J/D NSg/R ISg/D NSg/V NSg/V/J/R/P NSg/I/V/P NSg/V/J V   P  I   . W?    V   D/P NSg/V/J NSg     J/P   NPrSg/ISg . D/P
-> hint  of  bedrooms up        - stairs more        beautiful and cool    than other   bedrooms , of  gay
-# NSg/V V/P NPl      NSg/V/J/P . NPl    NPrSg/I/V/J NSg/J     V/C NSg/V/J C/P  NSg/V/J NPl      . V/P NPrSg/V/J
-> and radiant activities taking  place through its   corridors , and of  romances that
-# V/C NSg/J   NSg        NSg/V/J NSg/V NSg/J/P ISg/D NPl       . V/C V/P NPl      N/I/C/D
+> hint  of bedrooms up        - stairs more        beautiful and cool    than other   bedrooms , of gay
+# NSg/V P  NPl      NSg/V/J/P . NPl    NPrSg/I/V/J NSg/J     V/C NSg/V/J C/P  NSg/V/J NPl      . P  NPrSg/V/J
+> and radiant activities taking  place through its   corridors , and of romances that
+# V/C NSg/J   NSg        NSg/V/J NSg/V NSg/J/P ISg/D NPl       . V/C P  NPl      N/I/C/D
 > were  not   musty   and laid away already in          lavender but     fresh   and breathing and
 # NSg/V NSg/C NSg/V/J V/C V/J  V/J  W?      NPrSg/V/J/P NSg/V/J  NSg/C/P NSg/V/J V/C NSg/V     V/C
-> redolent of  this year’s shining motor   - cars and of  dances whose flowers were
-# J        V/P I/D  N$     V       NSg/V/J . NPl  V/C V/P NPl    I     NPrPl   NSg/V
+> redolent of this year’s shining motor   - cars and of dances whose flowers were
+# J        P  I/D  N$     V       NSg/V/J . NPl  V/C P  NPl    I     NPrPl   NSg/V
 > scarcely withered . It        excited him , too , that    many    men had already loved Daisy — it
 # J/R      W?       . NPrSg/ISg V/J     I   . W?  . N/I/C/D N/I/J/D NSg V   W?      V/J   NPrSg . NPrSg/ISg
 > increased her   value in          his   eyes . He      felt    their presence all       about the house   ,
 # W?        I/J/D NSg/V NPrSg/V/J/P ISg/D NPl  . NPr/ISg NSg/V/J D     NSg/V    NSg/I/J/C J/P   D   NPrSg/V .
-> pervading the air   with the shades and echoes of  still   vibrant emotions .
-# V         D   NSg/V P    D   NPl    V/C NSg/V  V/P NSg/V/J NSg/J   W?       .
+> pervading the air   with the shades and echoes of still   vibrant emotions .
+# V         D   NSg/V P    D   NPl    V/C NSg/V  P  NSg/V/J NSg/J   W?       .
 >
 #
 > But     he      knew that    he      was in          Daisy’s house   by      a   colossal accident . However
 # NSg/C/P NPr/ISg V    N/I/C/D NPr/ISg V   NPrSg/V/J/P N$      NPrSg/V NSg/J/P D/P J        NSg/J    . C
 > glorious might    be     his   future as    Jay   Gatsby , he      was at        present a   penniless young
 # J        NSg/VX/J NSg/VX ISg/D NSg/J  NSg/R NPrSg NPr    . NPr/ISg V   NSg/I/V/P NSg/V/J D/P J         NPrSg/V/J
-> man         without a   past      , and at        any   moment the invisible cloak of  his   uniform might
-# NPrSg/I/V/J C/P     D/P NSg/V/J/P . V/C NSg/I/V/P I/R/D NSg    D   J         NSg/V V/P ISg/D NSg/V/J NSg/VX/J
-> slip  from his   shoulders . So        he      made  the most    of  his   time  . He      took what  he      could
-# NSg/V P    ISg/D NPl       . NSg/I/J/C NPr/ISg NSg/V D   NSg/I/J V/P ISg/D NSg/V . NPr/ISg V    NSg/I NPr/ISg NSg/VX
+> man         without a   past      , and at        any   moment the invisible cloak of his   uniform might
+# NPrSg/I/V/J C/P     D/P NSg/V/J/P . V/C NSg/I/V/P I/R/D NSg    D   J         NSg/V P  ISg/D NSg/V/J NSg/VX/J
+> slip  from his   shoulders . So        he      made  the most    of his   time  . He      took what  he      could
+# NSg/V P    ISg/D NPl       . NSg/I/J/C NPr/ISg NSg/V D   NSg/I/J P  ISg/D NSg/V . NPr/ISg V    NSg/I NPr/ISg NSg/VX
 > get   , ravenously and unscrupulously — eventually he      took Daisy one       still   October
 # NSg/V . J/R        V/C J/R            . J/R        NPr/ISg V    NPrSg NSg/I/V/J NSg/V/J NPrSg/V
 > night , took her   because he      had no      real  right     to touch her   hand  .
@@ -9592,14 +9592,14 @@
 # NPr/ISg NSg/VX/J NSg/VX W?       I       . C/P NPr/ISg V   J/R       V/J   I/J/D NSg/J/P NSg/V/J
 > pretenses . I   don’t mean    that    he      had traded on  his   phantom millions , but     he      had
 # NPl       . ISg NSg/V NSg/V/J N/I/C/D NPr/ISg V   W?     J/P ISg/D NSg/J   NPl      . NSg/C/P NPr/ISg V
-> deliberately given     Daisy a   sense of  security ; he      let   her   believe that    he      was a
-# J/R          NSg/V/J/P NPrSg D/P NSg/V V/P NSg      . NPr/ISg NSg/V I/J/D V       N/I/C/D NPr/ISg V   D/P
+> deliberately given     Daisy a   sense of security ; he      let   her   believe that    he      was a
+# J/R          NSg/V/J/P NPrSg D/P NSg/V P  NSg      . NPr/ISg NSg/V I/J/D V       N/I/C/D NPr/ISg V   D/P
 > person from much  the same strata as    herself — that    he      was fully able    to take  care
 # NSg/V  P    N/I/J D   I/J  NSg    NSg/R I       . N/I/C/D NPr/ISg V   V     NSg/V/J P  NSg/V NSg/V
-> of  her   . As    a   matter  of  fact , he      had no      such  facilities — he      had no      comfortable
-# V/P I/J/D . NSg/R D/P NSg/V/J V/P NSg  . NPr/ISg V   NPrSg/P NSg/I NPl        . NPr/ISg V   NPrSg/P NSg/J
-> family standing behind  him , and he      was liable at        the whim  of  an  impersonal
-# NSg/J  NSg/V/J  NSg/J/P I   . V/C NPr/ISg V   J      NSg/I/V/P D   NSg/V V/P D/P NSg/J
+> of her   . As    a   matter  of fact , he      had no      such  facilities — he      had no      comfortable
+# P  I/J/D . NSg/R D/P NSg/V/J P  NSg  . NPr/ISg V   NPrSg/P NSg/I NPl        . NPr/ISg V   NPrSg/P NSg/J
+> family standing behind  him , and he      was liable at        the whim  of an  impersonal
+# NSg/J  NSg/V/J  NSg/J/P I   . V/C NPr/ISg V   J      NSg/I/V/P D   NSg/V P  D/P NSg/J
 > government to be     blown anywhere about the world .
 # NSg        P  NSg/VX V/J   NSg/I    J/P   D   NSg/V .
 >
@@ -9608,8 +9608,8 @@
 # NSg/C/P NPr/ISg V      V       I       V/C NPrSg/ISg V      NSg/V NSg/V/J/R/P NSg/R NPr/ISg V   W?       . NPr/ISg V
 > intended , probably , to take  what  he      could  and go      — but     now         he      found that    he      had
 # NSg/V/J  . R        . P  NSg/V NSg/I NPr/ISg NSg/VX V/C NSg/V/J . NSg/C/P NPrSg/V/J/C NPr/ISg NSg/V N/I/C/D NPr/ISg V
-> committed himself to the following of  a   grail . He      knew that    Daisy was
-# V/J       I       P  D   NSg/V/J/P V/P D/P NSg   . NPr/ISg V    N/I/C/D NPrSg V
+> committed himself to the following of a   grail . He      knew that    Daisy was
+# V/J       I       P  D   NSg/V/J/P P  D/P NSg   . NPr/ISg V    N/I/C/D NPrSg V
 > extraordinary , but     he      didn’t realize just how   extraordinary a   “ nice      ” girl  could
 # NSg/J         . NSg/C/P NPr/ISg V      V       V/J  NSg/C NSg/J         D/P . NPrSg/V/J . NSg/V NSg/VX
 > be     . She vanished into her   rich      house   , into her   rich      , full    life  , leaving
@@ -9620,20 +9620,20 @@
 #
 > When    they met again , two days later , it        was Gatsby who     was breathless , who     was ,
 # NSg/I/C IPl  V   P     . NSg NPl  J     . NPrSg/ISg V   NPr    NPrSg/I V   J          . NPrSg/I V   .
-> somehow , betrayed . Her   porch was bright    with the bought luxury of  star  - shine ;
-# W?      . W?       . I/J/D NSg   V   NPrSg/V/J P    D   NSg/V  NSg/J  V/P NSg/V . NSg/V .
-> the wicker of  the settee squeaked fashionably as    she turned toward him and he
-# D   NSg/J  V/P D   NSg    W?       R           NSg/R ISg W?     J/P    I   V/C NPr/ISg
+> somehow , betrayed . Her   porch was bright    with the bought luxury of star  - shine ;
+# W?      . W?       . I/J/D NSg   V   NPrSg/V/J P    D   NSg/V  NSg/J  P  NSg/V . NSg/V .
+> the wicker of the settee squeaked fashionably as    she turned toward him and he
+# D   NSg/J  P  D   NSg    W?       R           NSg/R ISg W?     J/P    I   V/C NPr/ISg
 > kissed her   curious and lovely  mouth . She had caught a   cold  , and it        made  her
 # W?     I/J/D J       V/C NSg/J/R NSg/V . ISg V   V/J    D/P NSg/J . V/C NPrSg/ISg NSg/V I/J/D
 > voice huskier and more        charming than ever , and Gatsby was overwhelmingly aware
 # NSg/V J       V/C NPrSg/I/V/J NSg/V/J  C/P  J    . V/C NPr    V   J/R            V/J
-> of  the youth and mystery that    wealth imprisons and preserves , of  the freshness
-# V/P D   NSg   V/C NSg     N/I/C/D NSg    NPl       V/C NPl       . V/P D   NSg
-> of  many    clothes , and of  Daisy , gleaming like        silver  , safe    and proud above   the
-# V/P N/I/J/D NPl     . V/C V/P NPrSg . V        NSg/V/J/C/P NSg/V/J . NSg/V/J V/C J     NSg/J/P D
-> hot     struggles of  the poor    .
-# NSg/V/J NPl       V/P D   NSg/V/J .
+> of the youth and mystery that    wealth imprisons and preserves , of the freshness
+# P  D   NSg   V/C NSg     N/I/C/D NSg    NPl       V/C NPl       . P  D   NSg
+> of many    clothes , and of Daisy , gleaming like        silver  , safe    and proud above   the
+# P  N/I/J/D NPl     . V/C P  NPrSg . V        NSg/V/J/C/P NSg/V/J . NSg/V/J V/C J     NSg/J/P D
+> hot     struggles of the poor    .
+# NSg/V/J NPl       P  D   NSg/V/J .
 >
 #
 > “ I   can’t describe to you how   surprised I   was to find  out         I   loved her   , old   sport .
@@ -9644,8 +9644,8 @@
 # V   NPrSg/V/J/P NPrSg/V P    NPrSg/ISg W?  . ISg NSg/V   ISg V    D/P NPrSg/V C/P     ISg V    NSg/J
 > things from her   . . . Well    , there I   was , ’ way   off       my ambitions , getting deeper
 # NPl    P    I/J/D . . . NSg/V/J . W?    ISg V   . . NSg/J NSg/V/J/P D  NPl       . NSg/V   J
-> in          love    every minute  , and all       of  a   sudden I   didn’t care  . What  was the use   of
-# NPrSg/V/J/P NPrSg/V D     NSg/V/J . V/C NSg/I/J/C V/P D/P NSg/J  ISg V      NSg/V . NSg/I V   D   NSg/V V/P
+> in          love    every minute  , and all       of a   sudden I   didn’t care  . What  was the use   of
+# NPrSg/V/J/P NPrSg/V D     NSg/V/J . V/C NSg/I/J/C P  D/P NSg/J  ISg V      NSg/V . NSg/I V   D   NSg/V P
 > doing great things if    I   could  have   a   better   time  telling her   what  I   was going   to
 # NSg/V NSg/J NPl    NSg/C ISg NSg/VX NSg/VX D/P NSg/VX/J NSg/V NSg/V/J I/J/D NSg/I ISg V   NSg/V/J P
 > do     ? ”
@@ -9662,12 +9662,12 @@
 # W?     I/J/D NSg/V/J V       NSg/V . D   NSg       V   NSg/V N/I  J        C/P D/P NSg/V/C/P .
 > as    if    to give  them a   deep  memory for the long      parting the next    day   promised .
 # NSg/R NSg/C P  NSg/V N/I  D/P NSg/J NSg    C/P D   NPrSg/V/J NSg/V   D   NSg/J/P NPrSg W?       .
-> They had never been  closer in          their month of  love    , nor   communicated more
-# IPl  V   V     NSg/V NSg/J  NPrSg/V/J/P D     NSg   V/P NPrSg/V . NSg/C W?           NPrSg/I/V/J
+> They had never been  closer in          their month of love    , nor   communicated more
+# IPl  V   V     NSg/V NSg/J  NPrSg/V/J/P D     NSg   P  NPrSg/V . NSg/C W?           NPrSg/I/V/J
 > profoundly one       with another , than when    she brushed silent lips against his
 # J/R        NSg/I/V/J P    I/D     . C/P  NSg/I/C ISg W?      NSg/J  NPl  C/P     ISg/D
-> coat’s shoulder or      when    he      touched the end   of  her   fingers , gently , as    though she
-# N$     NSg/V    NPrSg/C NSg/I/C NPr/ISg V/J     D   NSg/V V/P I/J/D NPl     . R      . NSg/R V/C    ISg
+> coat’s shoulder or      when    he      touched the end   of her   fingers , gently , as    though she
+# N$     NSg/V    NPrSg/C NSg/I/C NPr/ISg V/J     D   NSg/V P  I/J/D NPl     . R      . NSg/R V/C    ISg
 > were  asleep .
 # NSg/V J      .
 >
@@ -9675,31 +9675,31 @@
 > He      did extraordinarily well    in          the war   . He      was a   captain before he      went  to the
 # NPr/ISg V   R               NSg/V/J NPrSg/V/J/P D   NSg/V . NPr/ISg V   D/P NSg/V   C/P    NPr/ISg NSg/V P  D
 > front   , and following the Argonne battles he      got his   majority and the command of
-# NSg/V/J . V/C NSg/V/J/P D   NPr     NPl     NPr/ISg V   ISg/D NSg      V/C D   NSg/V   V/P
+# NSg/V/J . V/C NSg/V/J/P D   NPr     NPl     NPr/ISg V   ISg/D NSg      V/C D   NSg/V   P
 > the divisional machine - guns . After the armistice he      tried frantically to get
 # D   NSg/J      NSg/V   . NPl  . J/P   D   NPrSg     NPr/ISg V/J   W?          P  NSg/V
 > home    , but     some  complication or      misunderstanding sent  him to Oxford instead . He
 # NSg/V/J . NSg/C/P I/J/R NSg          NPrSg/C NSg/V            NSg/V I   P  NPrSg  W?      . NPr/ISg
-> was worried now         — there was a   quality of  nervous despair in          Daisy’s letters . She
-# V   V/J     NPrSg/V/J/C . W?    V   D/P NSg/J   V/P J       NSg/V   NPrSg/V/J/P N$      NPl     . ISg
-> didn’t see   why   he      couldn’t come    . She was feeling the pressure of  the world
-# V      NSg/V NSg/V NPr/ISg V        NSg/V/P . ISg V   NSg/V/J D   NSg/V    V/P D   NSg/V
+> was worried now         — there was a   quality of nervous despair in          Daisy’s letters . She
+# V   V/J     NPrSg/V/J/C . W?    V   D/P NSg/J   P  J       NSg/V   NPrSg/V/J/P N$      NPl     . ISg
+> didn’t see   why   he      couldn’t come    . She was feeling the pressure of the world
+# V      NSg/V NSg/V NPr/ISg V        NSg/V/P . ISg V   NSg/V/J D   NSg/V    P  D   NSg/V
 > outside   , and she wanted to see   him and feel      his   presence beside her   and be
 # NSg/V/J/P . V/C ISg V/J    P  NSg/V I   V/C NSg/I/V/J ISg/D NSg/V    P      I/J/D V/C NSg/VX
 > reassured that    she was doing the right     thing after all       .
 # W?        N/I/C/D ISg V   NSg/V D   NPrSg/V/J NSg/V J/P   NSg/I/J/C .
 >
 #
-> For Daisy was young     and her   artificial world was redolent of  orchids and
-# C/P NPrSg V   NPrSg/V/J V/C I/J/D J          NSg/V V   J        V/P NPl     V/C
-> pleasant , cheerful snobbery and orchestras which set       the rhythm of  the year ,
-# NSg/J    . J        NSg      V/C NPl        I/C   NPrSg/V/J D   NSg/V  V/P D   NSg  .
-> summing up        the sadness and suggestiveness of  life  in          new     tunes . All       night the
-# NSg/V   NSg/V/J/P D   NSg     V/C NSg            V/P NSg/V NPrSg/V/J/P NSg/V/J NPl   . NSg/I/J/C NSg/V D
-> saxophones wailed the hopeless comment of  the “ Beale Street  Blues ” while     a
-# NPl        W?     D   J        NSg/V   V/P D   . ?     NSg/V/J NPl   . NSg/V/C/P D/P
-> hundred pairs of  golden    and silver  slippers shuffled the shining dust  . At        the
-# NSg     NPl   V/P NPrSg/V/J V/C NSg/V/J NPl      W?       D   V       NSg/V . NSg/I/V/P D
+> For Daisy was young     and her   artificial world was redolent of orchids and
+# C/P NPrSg V   NPrSg/V/J V/C I/J/D J          NSg/V V   J        P  NPl     V/C
+> pleasant , cheerful snobbery and orchestras which set       the rhythm of the year ,
+# NSg/J    . J        NSg      V/C NPl        I/C   NPrSg/V/J D   NSg/V  P  D   NSg  .
+> summing up        the sadness and suggestiveness of life  in          new     tunes . All       night the
+# NSg/V   NSg/V/J/P D   NSg     V/C NSg            P  NSg/V NPrSg/V/J/P NSg/V/J NPl   . NSg/I/J/C NSg/V D
+> saxophones wailed the hopeless comment of the “ Beale Street  Blues ” while     a
+# NPl        W?     D   J        NSg/V   P  D   . ?     NSg/V/J NPl   . NSg/V/C/P D/P
+> hundred pairs of golden    and silver  slippers shuffled the shining dust  . At        the
+# NSg     NPl   P  NPrSg/V/J V/C NSg/V/J NPl      W?       D   V       NSg/V . NSg/I/V/P D
 > gray         tea   hour there were  always rooms that    throbbed incessantly with this low     ,
 # NPrSg/V/J/Am NSg/V NSg  W?    NSg/V W?     NPl   N/I/C/D V        J/R         P    I/D  NSg/V/J .
 > sweet     fever , while     fresh   faces drifted here    and there like        rose      petals blown by
@@ -9712,20 +9712,20 @@
 # NSg/J/P I/D  NSg/V/J  NPrSg    NPrSg V     P  NSg/V P     P    D   NSg/V  .
 > suddenly she was again keeping half      a   dozen dates a   day   with half      a   dozen men ,
 # J/R      ISg V   P     NSg/V   NSg/V/J/P D/P NSg   NPl   D/P NPrSg P    NSg/V/J/P D/P NSg   NSg .
-> and drowsing asleep at        dawn    with the beads and chiffon of  an  evening dress
-# V/C V        J      NSg/I/V/P NPrSg/V P    D   NPl   V/C NSg     V/P D/P NSg/V   NSg/V
+> and drowsing asleep at        dawn    with the beads and chiffon of an  evening dress
+# V/C V        J      NSg/I/V/P NPrSg/V P    D   NPl   V/C NSg     P  D/P NSg/V   NSg/V
 > tangled among dying   orchids on  the floor beside her   bed   . And all       the time
 # W?      P     NSg/V/J NPl     J/P D   NSg/V P      I/J/D NSg/V . V/C NSg/I/J/C D   NSg/V
 > something within her   was crying for a   decision . She wanted her   life  shaped now         ,
 # NSg/I/V/J N/J/P  I/J/D V   V      C/P D/P NSg/V    . ISg V/J    I/J/D NSg/V V/J    NPrSg/V/J/C .
-> immediately — and the decision must  be     made  by      some  force — of  love    , of  money , of
-# J/R         . V/C D   NSg/V    NSg/V NSg/VX NSg/V NSg/J/P I/J/R NSg/V . V/P NPrSg/V . V/P NSg/J . V/P
+> immediately — and the decision must  be     made  by      some  force — of love    , of money , of
+# J/R         . V/C D   NSg/V    NSg/V NSg/VX NSg/V NSg/J/P I/J/R NSg/V . P  NPrSg/V . P  NSg/J . P
 > unquestionable practicality — that    was close   at        hand  .
 # J              NSg          . N/I/C/D V   NSg/V/J NSg/I/V/P NSg/V .
 >
 #
-> That    force took shape in          the middle  of  spring with the arrival of  Tom     Buchanan .
-# N/I/C/D NSg/V V    NSg/V NPrSg/V/J/P D   NSg/V/J V/P NSg/V  P    D   NSg     V/P NPrSg/V NPr      .
+> That    force took shape in          the middle  of spring with the arrival of Tom     Buchanan .
+# N/I/C/D NSg/V V    NSg/V NPrSg/V/J/P D   NSg/V/J P  NSg/V  P    D   NSg     P  NPrSg/V NPr      .
 > There was a   wholesome bulkiness about his   person and his   position , and Daisy was
 # W?    V   D/P J         NSg       J/P   ISg/D NSg/V  V/C ISg/D NSg/V    . V/C NPrSg V
 > flattered . Doubtless there was a   certain struggle and a   certain relief . The
@@ -9734,12 +9734,12 @@
 # NSg/V  W?      NPr    NSg/V/C/P NPr/ISg V   NSg/V/J NSg/I/V/P NPrSg  .
 >
 #
-> It        was dawn    now         on  Long      Island and we  went  about opening the rest  of  the windows
-# NPrSg/ISg V   NPrSg/V NPrSg/V/J/C J/P NPrSg/V/J NSg/V  V/C IPl NSg/V J/P   NSg/V/J D   NSg/V V/P D   NPrPl
+> It        was dawn    now         on  Long      Island and we  went  about opening the rest  of the windows
+# NPrSg/ISg V   NPrSg/V NPrSg/V/J/C J/P NPrSg/V/J NSg/V  V/C IPl NSg/V J/P   NSg/V/J D   NSg/V P  D   NPrPl
 > down      - stairs , filling the house   with gray         - turning , gold    - turning light   . The shadow
 # NSg/V/J/P . NPl    . NSg/V/J D   NPrSg/V P    NPrSg/V/J/Am . NSg/V   . NSg/V/J . NSg/V   NSg/V/J . D   NSg/V/J
-> of  a   tree  fell    abruptly across the dew   and ghostly birds began to sing  among the
-# V/P D/P NSg/V NSg/V/J J/R      NSg/P  D   NSg/V V/C J/R     NPl   V     P  NSg/V P     D
+> of a   tree  fell    abruptly across the dew   and ghostly birds began to sing  among the
+# P  D/P NSg/V NSg/V/J J/R      NSg/P  D   NSg/V V/C J/R     NPl   V     P  NSg/V P     D
 > blue    leaves . There was a   slow    , pleasant movement in          the air   , scarcely a   wind  ,
 # NSg/V/J NPl    . W?    V   D/P NSg/V/J . NSg/J    NSg      NPrSg/V/J/P D   NSg/V . J/R      D/P NSg/V .
 > promising a   cool    , lovely  day   .
@@ -9752,8 +9752,8 @@
 # W?     NSg/I/V/P NPrSg/ISg ?             . . IPl NSg/V NSg/V    . NSg/J NSg/V . ISg V   J    V/J
 > this afternoon . He      told her   those things in          a   way   that    frightened her   — that    made
 # I/D  NSg       . NPr/ISg V    I/J/D I/D   NPl    NPrSg/V/J/P D/P NSg/J N/I/C/D W?         I/J/D . N/I/C/D NSg/V
-> it        look  as    if    I   was some  kind  of  cheap   sharper . And the result was she hardly
-# NPrSg/ISg NSg/V NSg/R NSg/C ISg V   I/J/R NSg/J V/P NSg/V/J NSg/J   . V/C D   NSg/V  V   ISg J/R
+> it        look  as    if    I   was some  kind  of cheap   sharper . And the result was she hardly
+# NPrSg/ISg NSg/V NSg/R NSg/C ISg V   I/J/R NSg/J P  NSg/V/J NSg/J   . V/C D   NSg/V  V   ISg J/R
 > knew what  she was saying . ”
 # V    NSg/I ISg V   NSg/V  . .
 >
@@ -9762,8 +9762,8 @@
 # NPr/ISg NSg/V/J NSg/V/J/P R        .
 >
 #
-> “ Of  course she might    have   loved him just for a   minute  , when    they were  first
-# . V/P NSg/V  ISg NSg/VX/J NSg/VX V/J   I   V/J  C/P D/P NSg/V/J . NSg/I/C IPl  NSg/V NSg/V/J
+> “ Of course she might    have   loved him just for a   minute  , when    they were  first
+# . P  NSg/V  ISg NSg/VX/J NSg/VX V/J   I   V/J  C/P D/P NSg/V/J . NSg/I/C IPl  NSg/V NSg/V/J
 > married — and loved me        more        even    then    , do     you see   ? ”
 # NSg/V/J . V/C V/J   NPrSg/ISg NPrSg/I/V/J NSg/V/J NSg/J/C . NSg/VX IPl NSg/V . .
 >
@@ -9776,24 +9776,24 @@
 # . NPrSg/V/J/P I/R/D NPrSg/V . . NPr/ISg V/J  . . NPrSg/ISg V   V/J  NSg/J    . .
 >
 #
-> What  could  you make  of  that    , except to suspect some  intensity in          his   conception
-# NSg/I NSg/VX IPl NSg/V V/P N/I/C/D . V/C/P  P  NSg/V/J I/J/R NSg       NPrSg/V/J/P ISg/D NSg
-> of  the affair that    couldn’t be     measured ?
-# V/P D   NSg    N/I/C/D V        NSg/VX V/J      .
+> What  could  you make  of that    , except to suspect some  intensity in          his   conception
+# NSg/I NSg/VX IPl NSg/V P  N/I/C/D . V/C/P  P  NSg/V/J I/J/R NSg       NPrSg/V/J/P ISg/D NSg
+> of the affair that    couldn’t be     measured ?
+# P  D   NSg    N/I/C/D V        NSg/VX V/J      .
 >
 #
 > He      came    back    from France when    Tom     and Daisy were  still   on  their wedding trip    ,
 # NPr/ISg NSg/V/P NSg/V/J P    NPr    NSg/I/C NPrSg/V V/C NPrSg NSg/V NSg/V/J J/P D     NSg/V   NSg/V/J .
-> and made  a   miserable but     irresistible journey to Louisville on  the last    of  his
-# V/C NSg/V D/P W?        NSg/C/P J            NSg/V   P  NPr        J/P D   NSg/V/J V/P ISg/D
+> and made  a   miserable but     irresistible journey to Louisville on  the last    of his
+# V/C NSg/V D/P W?        NSg/C/P J            NSg/V   P  NPr        J/P D   NSg/V/J P  ISg/D
 > army pay     . He      stayed there a   week , walking the streets where their footsteps had
 # NSg  NSg/V/J . NPr/ISg W?     W?    D/P NSg  . NSg/V/J D   NPl     NSg/C D     NPl       V
-> clicked together through the November night and revisiting the out         - of  - the - way
-# W?      J        NSg/J/P D   NPrSg    NSg/V V/C V          D   NSg/V/J/R/P . V/P . D   . NSg/J
+> clicked together through the November night and revisiting the out         - of - the - way
+# W?      J        NSg/J/P D   NPrSg    NSg/V V/C V          D   NSg/V/J/R/P . P  . D   . NSg/J
 > places to which they had driven in          her   white     car . Just as    Daisy’s house   had
 # NPl    P  I/C   IPl  V   V/J    NPrSg/V/J/P I/J/D NPrSg/V/J NSg . V/J  NSg/R N$      NPrSg/V V
 > always seemed to him more        mysterious and gay       than other   houses , so        his   idea of
-# W?     W?     P  I   NPrSg/I/V/J J          V/C NPrSg/V/J C/P  NSg/V/J NPl    . NSg/I/J/C ISg/D NSg  V/P
+# W?     W?     P  I   NPrSg/I/V/J J          V/C NPrSg/V/J C/P  NSg/V/J NPl    . NSg/I/J/C ISg/D NSg  P
 > the city itself , even    though she was gone  from it        , was pervaded with a
 # D   NSg  I      . NSg/V/J V/C    ISg V   V/J/P P    NPrSg/ISg . V   W?       P    D/P
 > melancholy beauty  .
@@ -9806,12 +9806,12 @@
 # V   V       I/J/D NSg/J/P . D   NPrSg . NSg/V . NPr/ISg V   J         NPrSg/V/J/C . V   NSg/V/J . NPr/ISg NSg/V NSg/V/J/R/P
 > to the open    vestibule and sat     down      on  a   folding - chair , and the station slid away
 # P  D   NSg/V/J NSg/V     V/C NSg/V/J NSg/V/J/P J/P D/P V       . NSg/V . V/C D   NSg/V   V    V/J
-> and the backs of  unfamiliar buildings moved by      . Then    out         into the spring fields ,
-# V/C D   NPl   V/P NSg/J      W?        V/J   NSg/J/P . NSg/J/C NSg/V/J/R/P P    D   NSg/V  NPrPl  .
+> and the backs of unfamiliar buildings moved by      . Then    out         into the spring fields ,
+# V/C D   NPl   P  NSg/J      W?        V/J   NSg/J/P . NSg/J/C NSg/V/J/R/P P    D   NSg/V  NPrPl  .
 > where a   yellow  trolley raced them for a   minute  with people in          it        who     might    once
 # NSg/C D/P NSg/V/J NSg/V   W?    N/I  C/P D/P NSg/V/J P    NSg/V  NPrSg/V/J/P NPrSg/ISg NPrSg/I NSg/VX/J NSg/C
-> have   seen  the pale    magic   of  her   face  along the casual street  .
-# NSg/VX NSg/V D   NSg/V/J NSg/V/J V/P I/J/D NSg/V P     D   NSg/J  NSg/V/J .
+> have   seen  the pale    magic   of her   face  along the casual street  .
+# NSg/VX NSg/V D   NSg/V/J NSg/V/J P  I/J/D NSg/V P     D   NSg/J  NSg/V/J .
 >
 #
 > The track curved and now         it        was going   away from the sun     , which , as    it        sank
@@ -9820,22 +9820,22 @@
 # V/J   . W?     P  NSg/V  I      NPrSg/V/J/P NSg         NSg/V/J/P D   V         NSg  NSg/C ISg
 > had drawn her   breath  . He      stretched out         his   hand  desperately as    if    to snatch only
 # V   V/J   I/J/D NSg/V/J . NPr/ISg W?        NSg/V/J/R/P ISg/D NSg/V J/R         NSg/R NSg/C P  NSg/V  W?
-> a   wisp  of  air   , to save      a   fragment of  the spot    that    she had made  lovely  for him .
-# D/P NSg/V V/P NSg/V . P  NSg/V/C/P D/P NSg/V    V/P D   NSg/V/J N/I/C/D ISg V   NSg/V NSg/J/R C/P I   .
+> a   wisp  of air   , to save      a   fragment of the spot    that    she had made  lovely  for him .
+# D/P NSg/V P  NSg/V . P  NSg/V/C/P D/P NSg/V    P  D   NSg/V/J N/I/C/D ISg V   NSg/V NSg/J/R C/P I   .
 > But     it        was all       going   by      too fast    now         for his   blurred eyes and he      knew that    he
 # NSg/C/P NPrSg/ISg V   NSg/I/J/C NSg/V/J NSg/J/P W?  NSg/V/J NPrSg/V/J/C C/P ISg/D V/J     NPl  V/C NPr/ISg V    N/I/C/D NPr/ISg
-> had lost that    part    of  it        , the freshest and the best       , forever .
-# V   V/J  N/I/C/D NSg/V/J V/P NPrSg/ISg . D   W?       V/C D   NPrSg/VX/J . NSg/J   .
+> had lost that    part    of it        , the freshest and the best       , forever .
+# V   V/J  N/I/C/D NSg/V/J P  NPrSg/ISg . D   W?       V/C D   NPrSg/VX/J . NSg/J   .
 >
 #
 > It        was nine o’clock when    we  finished breakfast and went  out         on  the porch . The
 # NPrSg/ISg V   NSg  W?      NSg/I/C IPl V/J      NSg/V     V/C NSg/V NSg/V/J/R/P J/P D   NSg   . D
 > night had made  a   sharp     difference in          the weather and there was an  autumn  flavor
 # NSg/V V   NSg/V D/P NPrSg/V/J NSg/V      NPrSg/V/J/P D   NSg/V/J V/C W?    V   D/P NPrSg/V NSg/V
-> in          the air   . The gardener , the last    one       of  Gatsby’s former servants , came    to the
-# NPrSg/V/J/P D   NSg/V . D   NSg/J    . D   NSg/V/J NSg/I/V/J V/P N$       NSg/J  NPl      . NSg/V/P P  D
-> foot  of  the steps .
-# NSg/V V/P D   NPl   .
+> in          the air   . The gardener , the last    one       of Gatsby’s former servants , came    to the
+# NPrSg/V/J/P D   NSg/V . D   NSg/J    . D   NSg/V/J NSg/I/V/J P  N$       NSg/J  NPl      . NSg/V/P P  D
+> foot  of the steps .
+# NSg/V P  D   NPl   .
 >
 #
 > “ I’m going   to drain the pool  to - day   , Mr  . Gatsby . Leaves’ll start falling pretty
@@ -9858,8 +9858,8 @@
 # . NSg    NPl     P  D  NSg/V . .
 >
 #
-> I   didn’t want  to go      to the city . I   wasn’t worth   a   decent stroke of  work  , but     it
-# ISg V      NSg/V P  NSg/V/J P  D   NSg  . ISg V      NSg/V/J D/P J      NSg/V  V/P NSg/V . NSg/C/P NPrSg/ISg
+> I   didn’t want  to go      to the city . I   wasn’t worth   a   decent stroke of work  , but     it
+# ISg V      NSg/V P  NSg/V/J P  D   NSg  . ISg V      NSg/V/J D/P J      NSg/V  P  NSg/V . NSg/C/P NPrSg/ISg
 > was more        than that    — I   didn’t want  to leave Gatsby . I   missed that    train , and then
 # V   NPrSg/I/V/J C/P  N/I/C/D . ISg V      NSg/V P  NSg/V NPr    . ISg V      N/I/C/D NSg/V . V/C NSg/J/C
 > another , before I   could  get   myself away .
@@ -9910,18 +9910,18 @@
 #
 > I’ve always been  glad    I   said that    . It        was the only compliment I   ever gave him ,
 # W?   W?     NSg/V NSg/V/J ISg V/J  N/I/C/D . NPrSg/ISg V   D   W?   NSg/V      ISg J    V    I   .
-> because I   disapproved of  him from beginning to end   . First   he      nodded politely ,
-# C/P     ISg W?          V/P I   P    NSg/V/J   P  NSg/V . NSg/V/J NPr/ISg V      J/R      .
+> because I   disapproved of him from beginning to end   . First   he      nodded politely ,
+# C/P     ISg W?          P  I   P    NSg/V/J   P  NSg/V . NSg/V/J NPr/ISg V      J/R      .
 > and then    his   face  broke   into that    radiant and understanding smile , as    if    we’d
 # V/C NSg/J/C ISg/D NSg/V NSg/V/J P    N/I/C/D NSg/J   V/C NSg/V/J       NSg/V . NSg/R NSg/C W?
-> been  in          ecstatic cahoots on  that    fact all       the time  . His   gorgeous pink    rag   of  a
-# NSg/V NPrSg/V/J/P NSg/J    NPl     J/P N/I/C/D NSg  NSg/I/J/C D   NSg/V . ISg/D J        NSg/V/J NSg/V V/P D/P
-> suit  made  a   bright    spot    of  color      against the white     steps , and I   thought of  the
-# NSg/V NSg/V D/P NPrSg/V/J NSg/V/J V/P NSg/V/J/Am C/P     D   NPrSg/V/J NPl   . V/C ISg NSg/V   V/P D
+> been  in          ecstatic cahoots on  that    fact all       the time  . His   gorgeous pink    rag   of a
+# NSg/V NPrSg/V/J/P NSg/J    NPl     J/P N/I/C/D NSg  NSg/I/J/C D   NSg/V . ISg/D J        NSg/V/J NSg/V P  D/P
+> suit  made  a   bright    spot    of color      against the white     steps , and I   thought of the
+# NSg/V NSg/V D/P NPrSg/V/J NSg/V/J P  NSg/V/J/Am C/P     D   NPrSg/V/J NPl   . V/C ISg NSg/V   P  D
 > night when    I   first   came    to his   ancestral home    , three months before . The lawn  and
 # NSg/V NSg/I/C ISg NSg/V/J NSg/V/P P  ISg/D NSg/J     NSg/V/J . NSg   NSg    C/P    . D   NSg/V V/C
-> drive had been  crowded with the faces of  those who     guessed at        his   corruption — and
-# NSg/V V   NSg/V V/J     P    D   NPl   V/P I/D   NPrSg/I W?      NSg/I/V/P ISg/D NSg        . V/C
+> drive had been  crowded with the faces of those who     guessed at        his   corruption — and
+# NSg/V V   NSg/V V/J     P    D   NPl   P  I/D   NPrSg/I W?      NSg/I/V/P ISg/D NSg        . V/C
 > he      had stood on  those steps , concealing his   incorruptible dream   , as    he      waved
 # NPr/ISg V   V     J/P I/D   NPl   . V          ISg/D NSg/J         NSg/V/J . NSg/R NPr/ISg W?
 > them good      - by      .
@@ -9940,12 +9940,12 @@
 #
 > Up        in          the city , I   tried for a   while     to list  the quotations on  an  interminable
 # NSg/V/J/P NPrSg/V/J/P D   NSg  . ISg V/J   C/P D/P NSg/V/C/P P  NSg/V D   NPl        J/P D/P J
-> amount of  stock   , then    I   fell    asleep in          my swivel - chair . Just before noon  the
-# NSg/V  V/P NSg/V/J . NSg/J/C ISg NSg/V/J J      NPrSg/V/J/P D  NSg/V  . NSg/V . V/J  C/P    NSg/V D
+> amount of stock   , then    I   fell    asleep in          my swivel - chair . Just before noon  the
+# NSg/V  P  NSg/V/J . NSg/J/C ISg NSg/V/J J      NPrSg/V/J/P D  NSg/V  . NSg/V . V/J  C/P    NSg/V D
 > phone woke    me        , and I   started up        with sweat breaking out         on  my forehead . It        was
 # NSg/V NSg/V/J NPrSg/ISg . V/C ISg W?      NSg/V/J/P P    NSg/V V        NSg/V/J/R/P J/P D  NSg      . NPrSg/ISg V
-> Jordan Baker   ; she often called me        up        at        this hour because the uncertainty of  her
-# NPr    NPrSg/J . ISg J     V/J    NPrSg/ISg NSg/V/J/P NSg/I/V/P I/D  NSg  C/P     D   NSg         V/P I/J/D
+> Jordan Baker   ; she often called me        up        at        this hour because the uncertainty of her
+# NPr    NPrSg/J . ISg J     V/J    NPrSg/ISg NSg/V/J/P NSg/I/V/P I/D  NSg  C/P     D   NSg         P  I/J/D
 > own     movements between hotels and clubs and private houses made  her   hard    to find
 # NSg/V/J NPl       NSg/P   NPl    V/C NPl   V/C NSg/V/J NPl    NSg/V I/J/D NSg/V/J P  NSg/V
 > in          any   other   way   . Usually her   voice came    over      the wire  as    something fresh   and
@@ -10006,8 +10006,8 @@
 #
 > We  talked like        that    for a   while     , and then    abruptly we  weren’t talking any
 # IPl W?     NSg/V/J/C/P N/I/C/D C/P D/P NSg/V/C/P . V/C NSg/J/C J/R      IPl V       V       I/R/D
-> longer . I   don’t know  which of  us      hung    up        with a   sharp     click , but     I   know  I   didn’t
-# NSg/J  . ISg NSg/V NSg/V I/C   V/P NPr/ISg NPr/V/J NSg/V/J/P P    D/P NPrSg/V/J NSg/V . NSg/C/P ISg NSg/V ISg V
+> longer . I   don’t know  which of us      hung    up        with a   sharp     click , but     I   know  I   didn’t
+# NSg/J  . ISg NSg/V NSg/V I/C   P  NPr/ISg NPr/V/J NSg/V/J/P P    D/P NPrSg/V/J NSg/V . NSg/C/P ISg NSg/V ISg V
 > care  . I   couldn’t have   talked to her   across a   tea   - table that    day   if    I   never
 # NSg/V . ISg V        NSg/VX W?     P  I/J/D NSg/P  D/P NSg/V . NSg/V N/I/C/D NPrSg NSg/C ISg V
 > talked to her   again in          this world .
@@ -10028,8 +10028,8 @@
 #
 > When    I   passed the ashheaps on  the train that    morning I   had crossed deliberately
 # NSg/I/C ISg W?     D   ?        J/P D   NSg/V N/I/C/D NSg/V   ISg V   W?      J/R
-> to the other   side    of  the car . I   supposed there’d be     a   curious crowd around there
-# P  D   NSg/V/J NSg/V/J V/P D   NSg . ISg V/J      W?      NSg/VX D/P J       NSg/V J/P    W?
+> to the other   side    of the car . I   supposed there’d be     a   curious crowd around there
+# P  D   NSg/V/J NSg/V/J P  D   NSg . ISg V/J      W?      NSg/VX D/P J       NSg/V J/P    W?
 > all       day   with little    boys searching for dark    spots in          the dust  , and some
 # NSg/I/J/C NPrSg P    NPrSg/I/J NPl  NSg/V/J   C/P NSg/V/J NPl   NPrSg/V/J/P D   NSg/V . V/C I/J/R
 > garrulous man         telling over      and over      what  had happened , until it        became less    and
@@ -10048,20 +10048,20 @@
 # NSg/V C/P     V        N/I/C/D NSg/V . C/P NSg/I/C ISg W?      ISg V   NSg/J  P
 > liquor and unable  to understand that    the ambulance had already gone  to Flushing .
 # NSg/V  V/C NSg/V/J P  V          N/I/C/D D   NSg/V     V   W?      V/J/P P  V        .
-> When    they convinced her   of  this , she immediately fainted , as    if    that    was the
-# NSg/I/C IPl  V/J       I/J/D V/P I/D  . ISg J/R         W?      . NSg/R NSg/C N/I/C/D V   D
-> intolerable part    of  the affair . Some  one       , kind  or      curious , took her   in          his   car
-# J           NSg/V/J V/P D   NSg    . I/J/R NSg/I/V/J . NSg/J NPrSg/C J       . V    I/J/D NPrSg/V/J/P ISg/D NSg
-> and drove her   in          the wake    of  her   sister’s body  .
-# V/C NSg/V I/J/D NPrSg/V/J/P D   NPrSg/V V/P I/J/D N$       NSg/V .
+> When    they convinced her   of this , she immediately fainted , as    if    that    was the
+# NSg/I/C IPl  V/J       I/J/D P  I/D  . ISg J/R         W?      . NSg/R NSg/C N/I/C/D V   D
+> intolerable part    of the affair . Some  one       , kind  or      curious , took her   in          his   car
+# J           NSg/V/J P  D   NSg    . I/J/R NSg/I/V/J . NSg/J NPrSg/C J       . V    I/J/D NPrSg/V/J/P ISg/D NSg
+> and drove her   in          the wake    of her   sister’s body  .
+# V/C NSg/V I/J/D NPrSg/V/J/P D   NPrSg/V P  I/J/D N$       NSg/V .
 >
 #
-> Until long      after midnight a   changing crowd lapped up        against the front   of  the
-# C/P   NPrSg/V/J J/P   NSg/J    D/P NSg/V    NSg/V V/J    NSg/V/J/P C/P     D   NSg/V/J V/P D
+> Until long      after midnight a   changing crowd lapped up        against the front   of the
+# C/P   NPrSg/V/J J/P   NSg/J    D/P NSg/V    NSg/V V/J    NSg/V/J/P C/P     D   NSg/V/J P  D
 > garage , while     George Wilson rocked himself back    and forth on  the couch inside  .
 # NSg/V  . NSg/V/C/P NPrSg  NPr    W?     I       NSg/V/J V/C W?    J/P D   NSg/V NSg/J/P .
-> For a   while     the door  of  the office was open    , and every one       who     came    into the
-# C/P D/P NSg/V/C/P D   NSg/V V/P D   NSg/V  V   NSg/V/J . V/C D     NSg/I/V/J NPrSg/I NSg/V/P P    D
+> For a   while     the door  of the office was open    , and every one       who     came    into the
+# C/P D/P NSg/V/C/P D   NSg/V P  D   NSg/V  V   NSg/V/J . V/C D     NSg/I/V/J NPrSg/I NSg/V/P P    D
 > garage glanced irresistibly through it        . Finally some  one       said it        was a   shame   ,
 # NSg/V  W?      R            NSg/J/P NPrSg/ISg . J/R     I/J/R NSg/I/V/J V/J  NPrSg/ISg V   D/P NSg/V/J .
 > and closed the door  . Michaelis and several other   men were  with him ; first   , four
@@ -10070,20 +10070,20 @@
 # NPrSg/C NSg  NSg . J     NSg NPrSg/C NSg   NSg . NSg/V/J J     ?         V   P  NSg/V D   NSg/V/J
 > stranger to wait  there fifteen minutes longer , while     he      went  back    to his   own
 # NSg/V/J  P  NSg/V W?    NSg     NPl     NSg/J  . NSg/V/C/P NPr/ISg NSg/V NSg/V/J P  ISg/D NSg/V/J
-> place and made  a   pot   of  coffee  . After that    , he      stayed there alone with Wilson
-# NSg/V V/C NSg/V D/P NSg/V V/P NSg/V/J . J/P   N/I/C/D . NPr/ISg W?     W?    J     P    NPr
+> place and made  a   pot   of coffee  . After that    , he      stayed there alone with Wilson
+# NSg/V V/C NSg/V D/P NSg/V P  NSg/V/J . J/P   N/I/C/D . NPr/ISg W?     W?    J     P    NPr
 > until dawn    .
 # C/P   NPrSg/V .
 >
 #
-> About three o’clock the quality of  Wilson’s incoherent muttering changed — he      grew
-# J/P   NSg   W?      D   NSg/J   V/P N$       J          NSg/V     V/J     . NPr/ISg V
+> About three o’clock the quality of Wilson’s incoherent muttering changed — he      grew
+# J/P   NSg   W?      D   NSg/J   P  N$       J          NSg/V     V/J     . NPr/ISg V
 > quieter and began to talk  about the yellow  car . He      announced that    he      had a   way
 # J       V/C V     P  NSg/V J/P   D   NSg/V/J NSg . NPr/ISg V/J       N/I/C/D NPr/ISg V   D/P NSg/J
-> of  finding out         whom the yellow  car belonged to , and then    he      blurted out         that    a
-# V/P NSg/V   NSg/V/J/R/P I    D   NSg/V/J NSg W?       P  . V/C NSg/J/C NPr/ISg W?      NSg/V/J/R/P N/I/C/D D/P
-> couple  of  months ago his   wife  had come    from the city with her   face  bruised and
-# NSg/V/J V/P NSg    J/P ISg/D NSg/V V   NSg/V/P P    D   NSg  P    I/J/D NSg/V W?      V/C
+> of finding out         whom the yellow  car belonged to , and then    he      blurted out         that    a
+# P  NSg/V   NSg/V/J/R/P I    D   NSg/V/J NSg W?       P  . V/C NSg/J/C NPr/ISg W?      NSg/V/J/R/P N/I/C/D D/P
+> couple  of months ago his   wife  had come    from the city with her   face  bruised and
+# NSg/V/J P  NSg    J/P ISg/D NSg/V V   NSg/V/P P    D   NSg  P    I/J/D NSg/V W?      V/C
 > her   nose  swollen .
 # I/J/D NSg/V V/J     .
 >
@@ -10150,8 +10150,8 @@
 # . N/I/C/D V   D/P NPrSg/V/J NSg/V J/P . .
 >
 #
-> The effort of  answering broke   the rhythm of  his   rocking — for a   moment he      was
-# D   NSg/V  V/P V         NSg/V/J D   NSg/V  V/P ISg/D V       . C/P D/P NSg    NPr/ISg V
+> The effort of answering broke   the rhythm of his   rocking — for a   moment he      was
+# D   NSg/V  P  V         NSg/V/J D   NSg/V  P  ISg/D V       . C/P D/P NSg    NPr/ISg V
 > silent . Then    the same half      - knowing   , half      - bewildered look  came    back    into his
 # NSg/J  . NSg/J/C D   I/J  NSg/V/J/P . NSg/V/J/P . NSg/V/J/P . W?         NSg/V NSg/V/P NSg/V/J P    ISg/D
 > faded eyes .
@@ -10172,8 +10172,8 @@
 #
 > Michaelis opened the drawer nearest his   hand  . There was nothing in          it        but     a
 # ?         V/J    D   NSg/J  W?      ISg/D NSg/V . W?    V   NSg/I/J NPrSg/V/J/P NPrSg/ISg NSg/C/P D/P
-> small     , expensive dog     - leash , made  of  leather and braided silver  . It        was
-# NPrSg/V/J . J         NSg/V/J . NSg/V . NSg/V V/P NSg/V/J V/C W?      NSg/V/J . NPrSg/ISg V
+> small     , expensive dog     - leash , made  of leather and braided silver  . It        was
+# NPrSg/V/J . J         NSg/V/J . NSg/V . NSg/V P  NSg/V/J V/C W?      NSg/V/J . NPrSg/ISg V
 > apparently new     .
 # J/R        NSg/V/J .
 >
@@ -10204,8 +10204,8 @@
 # ?         V      NSg/V NSg/I/V  NSg/J NPrSg/V/J/P N/I/C/D . V/C NPr/ISg V    NPr    D/P NSg   NPl
 > why   his   wife  might    have   bought the dog     - leash . But     conceivably Wilson had heard
 # NSg/V ISg/D NSg/V NSg/VX/J NSg/VX NSg/V  D   NSg/V/J . NSg/V . NSg/C/P R           NPr    V   V/J
-> some  of  these same explanations before , from Myrtle , because he      began saying
-# I/J/R V/P I/D   I/J  NPl          C/P    . P    NPrSg  . C/P     NPr/ISg V     NSg/V
+> some  of these same explanations before , from Myrtle , because he      began saying
+# I/J/R P  I/D   I/J  NPl          C/P    . P    NPrSg  . C/P     NPr/ISg V     NSg/V
 > “ Oh      , my God     ! ” again in          a   whisper — his   comforter left      several explanations in          the
 # . NPrSg/V . D  NPrSg/V . . P     NPrSg/V/J/P D/P NSg/V   . ISg/D NSg       NPrSg/V/J J/D     NPl          NPrSg/V/J/P D
 > air   .
@@ -10220,8 +10220,8 @@
 # . NPrSg/I V   . .
 >
 #
-> “ I   have   a   way   of  finding out         . ”
-# . ISg NSg/VX D/P NSg/J V/P NSg/V   NSg/V/J/R/P . .
+> “ I   have   a   way   of finding out         . ”
+# . ISg NSg/VX D/P NSg/J P  NSg/V   NSg/V/J/R/P . .
 >
 #
 > “ You’re morbid , George , ” said his   friend  . “ This has been  a   strain to you and you
@@ -10240,12 +10240,12 @@
 #
 > Wilson shook   his   head      . His   eyes narrowed and his   mouth widened slightly with the
 # NPr    NSg/V/J ISg/D NPrSg/V/J . ISg/D NPl  W?       V/C ISg/D NSg/V W?      J/R      P    D
-> ghost of  a   superior “ Hm    ! ”
-# NSg/V V/P D/P NPrSg/J  . NPrSg . .
+> ghost of a   superior “ Hm    ! ”
+# NSg/V P  D/P NPrSg/J  . NPrSg . .
 >
 #
-> “ I   know  , ” he      said definitely , “ I’m one       of  these trusting fellas and I   don’t
-# . ISg NSg/V . . NPr/ISg V/J  J/R        . . W?  NSg/I/V/J V/P I/D   V/J      NPl    V/C ISg NSg/V
+> “ I   know  , ” he      said definitely , “ I’m one       of these trusting fellas and I   don’t
+# . ISg NSg/V . . NPr/ISg V/J  J/R        . . W?  NSg/I/V/J P  I/D   V/J      NPl    V/C ISg NSg/V
 > think any   harm  to nobody , but     when    I   get   to know  a   thing I   know  it        . It        was the
 # NSg/V I/R/D NSg/V P  NSg/I  . NSg/C/P NSg/I/C ISg NSg/V P  NSg/V D/P NSg/V ISg NSg/V NPrSg/ISg . NPrSg/ISg V   D
 > man         in          that    car . She ran   out         to speak to him and he      wouldn’t stop  . ”
@@ -10260,8 +10260,8 @@
 # P    I/J/D NSg/V   . NPrSg/V/J C/P  NSg/V/J P  NSg/V I/R/D NSg/J      NSg .
 >
 #
-> “ How   could  she of  been  like        that    ? ”
-# . NSg/C NSg/VX ISg V/P NSg/V NSg/V/J/C/P N/I/C/D . .
+> “ How   could  she of been  like        that    ? ”
+# . NSg/C NSg/VX ISg P  NSg/V NSg/V/J/C/P N/I/C/D . .
 >
 #
 > “ She’s a   deep  one       , ” said Wilson , as    if    that    answered the question . “ Ah      - h       - h       — — — ”
@@ -10278,8 +10278,8 @@
 #
 > This was a   forlorn hope    — he      was almost sure that    Wilson had no      friend  : there was
 # I/D  V   D/P NSg/V/J NPrSg/V . NPr/ISg V   NSg    J    N/I/C/D NPr    V   NPrSg/P NPrSg/V . W?    V
-> not   enough of  him for his   wife  . He      was glad    a   little    later when    he      noticed a
-# NSg/C NSg/I  V/P I   C/P ISg/D NSg/V . NPr/ISg V   NSg/V/J D/P NPrSg/I/J J     NSg/I/C NPr/ISg V       D/P
+> not   enough of him for his   wife  . He      was glad    a   little    later when    he      noticed a
+# NSg/C NSg/I  P  I   C/P ISg/D NSg/V . NPr/ISg V   NSg/V/J D/P NPrSg/I/J J     NSg/I/C NPr/ISg V       D/P
 > change in          the room    , a   blue    quickening by      the window , and realized that    dawn
 # NSg/V  NPrSg/V/J/P D   NSg/V/J . D/P NSg/V/J V          NSg/J/P D   NSg/V  . V/C V        N/I/C/D NPrSg/V
 > wasn’t far     off       . About five o’clock it        was blue    enough outside   to snap    off       the
@@ -10308,8 +10308,8 @@
 #
 > Standing behind  him , Michaelis saw   with a   shock   that    he      was looking at        the eyes
 # NSg/V/J  NSg/J/P I   . ?         NSg/V P    D/P NSg/V/J N/I/C/D NPr/ISg V   V       NSg/I/V/P D   NPl
-> of  Doctor T. J. Eckleburg , which had just emerged , pale    and enormous , from the
-# V/P NSg/V  ?  ?  ?         . I/C   V   V/J  W?      . NSg/V/J V/C J        . P    D
+> of Doctor T. J. Eckleburg , which had just emerged , pale    and enormous , from the
+# P  NSg/V  ?  ?  ?         . I/C   V   V/J  W?      . NSg/V/J V/C J        . P    D
 > dissolving night .
 # V          NSg/V .
 >
@@ -10326,10 +10326,10 @@
 # ISg/D NSg/V NSg/V/J P  D   NSg/V  NSg/V . NSg/V/J P    D   NSg/V/J  .
 >
 #
-> By      six o’clock Michaelis was worn out         , and grateful for the sound   of  a   car
-# NSg/J/P NSg W?      ?         V   V/J  NSg/V/J/R/P . V/C J        C/P D   NSg/V/J V/P D/P NSg
-> stopping outside   . It        was one       of  the watchers of  the night before who     had
-# NSg/V    NSg/V/J/P . NPrSg/ISg V   NSg/I/V/J V/P D   W?       V/P D   NSg/V C/P    NPrSg/I V
+> By      six o’clock Michaelis was worn out         , and grateful for the sound   of a   car
+# NSg/J/P NSg W?      ?         V   V/J  NSg/V/J/R/P . V/C J        C/P D   NSg/V/J P  D/P NSg
+> stopping outside   . It        was one       of the watchers of the night before who     had
+# NSg/V    NSg/V/J/P . NPrSg/ISg V   NSg/I/V/J P  D   W?       P  D   NSg/V C/P    NPrSg/I V
 > promised to come    back    , so        he      cooked breakfast for three , which he      and the other
 # W?       P  NSg/V/P NSg/V/J . NSg/I/J/C NPr/ISg V/J    NSg/V     C/P NSg   . I/C   NPr/ISg V/C D   NSg/V/J
 > man         ate   together . Wilson was quieter now         , and Michaelis went  home    to sleep ; when
@@ -10342,24 +10342,24 @@
 # ISg/D NPl       . NPr/ISg V   J/P NSg/V NSg/I/J/C D   NSg/V . NSg/V R/Am      W?     P  NPrSg/V/J
 > Roosevelt and then    to Gad’s Hill    , where he      bought a   sandwich that    he      didn’t eat   ,
 # NPr       V/C NSg/J/C P  ?     NPrSg/V . NSg/C NPr/ISg NSg/V  D/P NSg/V/J  N/I/C/D NPr/ISg V      NSg/V .
-> and a   cup   of  coffee  . He      must  have   been  tired and walking slowly , for he      didn’t
-# V/C D/P NSg/V V/P NSg/V/J . NPr/ISg NSg/V NSg/VX NSg/V V/J   V/C NSg/V/J J/R    . C/P NPr/ISg V
+> and a   cup   of coffee  . He      must  have   been  tired and walking slowly , for he      didn’t
+# V/C D/P NSg/V P  NSg/V/J . NPr/ISg NSg/V NSg/VX NSg/V V/J   V/C NSg/V/J J/R    . C/P NPr/ISg V
 > reach Gad’s Hill    until noon  . Thus far     there was no      difficulty in          accounting for
 # NSg/V ?     NPrSg/V C/P   NSg/V . NSg  NSg/V/J W?    V   NPrSg/P NSg        NPrSg/V/J/P NSg/V      C/P
-> his   time  — there were  boys who     had seen  a   man         “ acting  sort  of  crazy , ” and
-# ISg/D NSg/V . W?    NSg/V NPl  NPrSg/I V   NSg/V D/P NPrSg/I/V/J . NSg/V/J NSg/V V/P NSg/J . . V/C
-> motorists at        whom he      stared oddly from the side    of  the road  . Then    for three
-# NPl       NSg/I/V/P I    NPr/ISg W?     J/R   P    D   NSg/V/J V/P D   NSg/J . NSg/J/C C/P NSg
-> hours he      disappeared from view  . The police , on  the strength of  what  he      said to
-# NPl   NPr/ISg W?          P    NSg/V . D   NSg/V  . J/P D   NSg/V    V/P NSg/I NPr/ISg V/J  P
-> Michaelis , that    he      “ had a   way   of  finding out         , ” supposed that    he      spent that    time
-# ?         . N/I/C/D NPr/ISg . V   D/P NSg/J V/P NSg/V   NSg/V/J/R/P . . V/J      N/I/C/D NPr/ISg V/J   N/I/C/D NSg/V
+> his   time  — there were  boys who     had seen  a   man         “ acting  sort  of crazy , ” and
+# ISg/D NSg/V . W?    NSg/V NPl  NPrSg/I V   NSg/V D/P NPrSg/I/V/J . NSg/V/J NSg/V P  NSg/J . . V/C
+> motorists at        whom he      stared oddly from the side    of the road  . Then    for three
+# NPl       NSg/I/V/P I    NPr/ISg W?     J/R   P    D   NSg/V/J P  D   NSg/J . NSg/J/C C/P NSg
+> hours he      disappeared from view  . The police , on  the strength of what  he      said to
+# NPl   NPr/ISg W?          P    NSg/V . D   NSg/V  . J/P D   NSg/V    P  NSg/I NPr/ISg V/J  P
+> Michaelis , that    he      “ had a   way   of finding out         , ” supposed that    he      spent that    time
+# ?         . N/I/C/D NPr/ISg . V   D/P NSg/J P  NSg/V   NSg/V/J/R/P . . V/J      N/I/C/D NPr/ISg V/J   N/I/C/D NSg/V
 > going   from garage to garage thereabout , inquiring for a   yellow  car . On  the other
 # NSg/V/J P    NSg/V  P  NSg/V  W?         . NSg/V/J   C/P D/P NSg/V/J NSg . J/P D   NSg/V/J
 > hand  , no      garage man         who     had seen  him ever came    forward , and perhaps he      had an
 # NSg/V . NPrSg/P NSg/V  NPrSg/I/V/J NPrSg/I V   NSg/V I   J    NSg/V/P NSg/V/J . V/C NSg     NPr/ISg V   D/P
-> easier , surer way   of  finding out         what  he      wanted to know  . By      half      - past      two he      was
-# J      . J     NSg/J V/P NSg/V   NSg/V/J/R/P NSg/I NPr/ISg V/J    P  NSg/V . NSg/J/P NSg/V/J/P . NSg/V/J/P NSg NPr/ISg V
+> easier , surer way   of finding out         what  he      wanted to know  . By      half      - past      two he      was
+# J      . J     NSg/J P  NSg/V   NSg/V/J/R/P NSg/I NPr/ISg V/J    P  NSg/V . NSg/J/P NSg/V/J/P . NSg/V/J/P NSg NPr/ISg V
 > in          West      Egg   , where he      asked some  one       the way   to Gatsby’s house   . So        by      that    time
 # NPrSg/V/J/P NPrSg/V/J NSg/V . NSg/C NPr/ISg V/J   I/J/R NSg/I/V/J D   NSg/J P  N$       NPrSg/V . NSg/I/J/C NSg/J/P N/I/C/D NSg/V
 > he      knew Gatsby’s name  .
@@ -10412,32 +10412,32 @@
 # NPl   .
 >
 #
-> The chauffeur — he      was one       of  Wolfshiem’s protégés — heard the shots — afterward he
-# D   NSg/V     . NPr/ISg V   NSg/I/V/J V/P ?           ?        . V/J   D   NPl   . R/Am      NPr/ISg
+> The chauffeur — he      was one       of Wolfshiem’s protégés — heard the shots — afterward he
+# D   NSg/V     . NPr/ISg V   NSg/I/V/J P  ?           ?        . V/J   D   NPl   . R/Am      NPr/ISg
 > could  only say   that    he      hadn’t thought anything much  about them . I   drove from the
 # NSg/VX W?   NSg/V N/I/C/D NPr/ISg V      NSg/V   NSg/I/V  N/I/J J/P   N/I  . ISg NSg/V P    D
 > station directly to Gatsby’s house   and my rushing anxiously up        the front   steps
 # NSg/V   R/C      P  N$       NPrSg/V V/C D  V       J/R       NSg/V/J/P D   NSg/V/J NPl
 > was the first   thing that    alarmed any   one       . But     they knew then    , I   firmly believe .
 # V   D   NSg/V/J NSg/V N/I/C/D W?      I/R/D NSg/I/V/J . NSg/C/P IPl  V    NSg/J/C . ISg J/R    V       .
-> With scarcely a   word  said , four of  us      , the chauffeur , butler  , gardener , and I   ,
-# P    J/R      D/P NSg/V V/J  . NSg  V/P NPr/ISg . D   NSg/V     . NPrSg/V . NSg/J    . V/C ISg .
+> With scarcely a   word  said , four of us      , the chauffeur , butler  , gardener , and I   ,
+# P    J/R      D/P NSg/V V/J  . NSg  P  NPr/ISg . D   NSg/V     . NPrSg/V . NSg/J    . V/C ISg .
 > hurried down      to the pool  .
 # V/J     NSg/V/J/P P  D   NSg/V .
 >
 #
-> There was a   faint   , barely perceptible movement of  the water as    the fresh   flow
-# W?    V   D/P NSg/V/J . J/R    NSg/J       NSg      V/P D   NSg/V NSg/R D   NSg/V/J NSg/V
+> There was a   faint   , barely perceptible movement of the water as    the fresh   flow
+# W?    V   D/P NSg/V/J . J/R    NSg/J       NSg      P  D   NSg/V NSg/R D   NSg/V/J NSg/V
 > from one       end   urged its   way   toward the drain at        the other   . With little    ripples
 # P    NSg/I/V/J NSg/V W?    ISg/D NSg/J J/P    D   NSg/V NSg/I/V/P D   NSg/V/J . P    NPrSg/I/J NPl
-> that    were  hardly the shadows of  waves , the laden mattress moved irregularly down
-# N/I/C/D NSg/V J/R    D   NPl     V/P NPl   . D   V/J   NSg/V    V/J   J/R         NSg/V/J/P
-> the pool  . A   small     gust  of  wind  that    scarcely corrugated the surface was enough
-# D   NSg/V . D/P NPrSg/V/J NSg/V V/P NSg/V N/I/C/D J/R      W?         D   NSg/V   V   NSg/I
-> to disturb its   accidental course with its   accidental burden . The touch of  a
-# P  NSg/V   ISg/D NSg/J      NSg/V  P    ISg/D NSg/J      NSg/V  . D   NSg/V V/P D/P
-> cluster of  leaves revolved it        slowly , tracing , like        the leg     of  transit , a   thin
-# NSg/V   V/P NPl    W?       NPrSg/ISg J/R    . NSg/V   . NSg/V/J/C/P D   NSg/V/J V/P NSg/V   . D/P NSg/V/J
+> that    were  hardly the shadows of waves , the laden mattress moved irregularly down
+# N/I/C/D NSg/V J/R    D   NPl     P  NPl   . D   V/J   NSg/V    V/J   J/R         NSg/V/J/P
+> the pool  . A   small     gust  of wind  that    scarcely corrugated the surface was enough
+# D   NSg/V . D/P NPrSg/V/J NSg/V P  NSg/V N/I/C/D J/R      W?         D   NSg/V   V   NSg/I
+> to disturb its   accidental course with its   accidental burden . The touch of a
+# P  NSg/V   ISg/D NSg/J      NSg/V  P    ISg/D NSg/J      NSg/V  . D   NSg/V P  D/P
+> cluster of leaves revolved it        slowly , tracing , like        the leg     of transit , a   thin
+# NSg/V   P  NPl    W?       NPrSg/ISg J/R    . NSg/V   . NSg/V/J/C/P D   NSg/V/J P  NSg/V   . D/P NSg/V/J
 > red   circle in          the water .
 # NSg/J NSg/V  NPrSg/V/J/P D   NSg/V .
 >
@@ -10452,54 +10452,54 @@
 # NSg/V   W?
 >
 #
-> After two years I   remember the rest  of  that    day   , and that    night and the next
-# J/P   NSg NPl   ISg NSg/V    D   NSg/V V/P N/I/C/D NPrSg . V/C N/I/C/D NSg/V V/C D   NSg/J/P
-> day   , only as    an  endless drill of  police and photographers and newspaper men in
-# NPrSg . W?   NSg/R D/P J       NSg/V V/P NSg/V  V/C W?            V/C NSg/V     NSg NPrSg/V/J/P
-> and out         of  Gatsby’s front   door  . A   rope  stretched across the main    gate  and a
-# V/C NSg/V/J/R/P V/P N$       NSg/V/J NSg/V . D/P NSg/V W?        NSg/P  D   NSg/V/J NSg/V V/C D/P
+> After two years I   remember the rest  of that    day   , and that    night and the next
+# J/P   NSg NPl   ISg NSg/V    D   NSg/V P  N/I/C/D NPrSg . V/C N/I/C/D NSg/V V/C D   NSg/J/P
+> day   , only as    an  endless drill of police and photographers and newspaper men in
+# NPrSg . W?   NSg/R D/P J       NSg/V P  NSg/V  V/C W?            V/C NSg/V     NSg NPrSg/V/J/P
+> and out         of Gatsby’s front   door  . A   rope  stretched across the main    gate  and a
+# V/C NSg/V/J/R/P P  N$       NSg/V/J NSg/V . D/P NSg/V W?        NSg/P  D   NSg/V/J NSg/V V/C D/P
 > policeman by      it        kept out         the curious , but     little    boys soon discovered that    they
 # NSg       NSg/J/P NPrSg/ISg V    NSg/V/J/R/P D   J       . NSg/C/P NPrSg/I/J NPl  J/R  V          N/I/C/D IPl
-> could  enter through my yard  , and there were  always a   few of  them clustered
-# NSg/VX NSg/V NSg/J/P D  NSg/V . V/C W?    NSg/V W?     D/P N/I V/P N/I  W?
+> could  enter through my yard  , and there were  always a   few of them clustered
+# NSg/VX NSg/V NSg/J/P D  NSg/V . V/C W?    NSg/V W?     D/P N/I P  N/I  W?
 > open    - mouthed about the pool  . Some  one       with a   positive manner , perhaps a
 # NSg/V/J . W?      J/P   D   NSg/V . I/J/R NSg/I/V/J P    D/P NSg/J    NSg    . NSg     D/P
 > detective , used the expression “ madman ” as    he      bent    over      Wilson’s body  that
 # NSg/J     . V/J  D   NSg        . NSg    . NSg/R NPr/ISg NSg/V/J NSg/V/J/P N$       NSg/V N/I/C/D
-> afternoon , and the adventitious authority of  his   voice set       the key       for the
-# NSg       . V/C D   J            NSg       V/P ISg/D NSg/V NPrSg/V/J D   NPrSg/V/J C/P D
+> afternoon , and the adventitious authority of his   voice set       the key       for the
+# NSg       . V/C D   J            NSg       P  ISg/D NSg/V NPrSg/V/J D   NPrSg/V/J C/P D
 > newspaper reports next    morning .
 # NSg/V     NPl     NSg/J/P NSg/V   .
 >
 #
-> Most    of  those reports were  a   nightmare — grotesque , circumstantial , eager   , and
-# NSg/I/J V/P I/D   NPl     NSg/V D/P NSg/V     . NSg/J     . NSg/J          . NSg/V/J . V/C
+> Most    of those reports were  a   nightmare — grotesque , circumstantial , eager   , and
+# NSg/I/J P  I/D   NPl     NSg/V D/P NSg/V     . NSg/J     . NSg/J          . NSg/V/J . V/C
 > untrue . When    Michaelis’s testimony at        the inquest brought to light   Wilson’s
 # J      . NSg/I/C ?           NSg       NSg/I/V/P D   NSg/V   V       P  NSg/V/J N$
-> suspicions of  his   wife  I   thought the whole tale  would  shortly be     served up        in
-# NPl        V/P ISg/D NSg/V ISg NSg/V   D   NSg/J NSg/V NSg/VX J/R     NSg/VX W?     NSg/V/J/P NPrSg/V/J/P
+> suspicions of his   wife  I   thought the whole tale  would  shortly be     served up        in
+# NPl        P  ISg/D NSg/V ISg NSg/V   D   NSg/J NSg/V NSg/VX J/R     NSg/VX W?     NSg/V/J/P NPrSg/V/J/P
 > racy pasquinade — but     Catherine , who     might    have   said anything , didn’t say   a   word  .
 # J    ?          . NSg/C/P NPr       . NPrSg/I NSg/VX/J NSg/VX V/J  NSg/I/V  . V      NSg/V D/P NSg/V .
-> She showed a   surprising amount of  character about it        too — looked at        the coroner
-# ISg W?     D/P NSg/V/J    NSg/V  V/P NSg/V     J/P   NPrSg/ISg W?  . W?     NSg/I/V/P D   NSg
-> with determined eyes under   that    corrected brow  of  hers , and swore that    her
-# P    V/J        NPl  NSg/J/P N/I/C/D V         NSg/V V/P ISg  . V/C V     N/I/C/D I/J/D
+> She showed a   surprising amount of character about it        too — looked at        the coroner
+# ISg W?     D/P NSg/V/J    NSg/V  P  NSg/V     J/P   NPrSg/ISg W?  . W?     NSg/I/V/P D   NSg
+> with determined eyes under   that    corrected brow  of hers , and swore that    her
+# P    V/J        NPl  NSg/J/P N/I/C/D V         NSg/V P  ISg  . V/C V     N/I/C/D I/J/D
 > sister had never seen  Gatsby , that    her   sister was completely happy   with her
 # NSg/V  V   V     NSg/V NPr    . N/I/C/D I/J/D NSg/V  V   J/R        NSg/V/J P    I/J/D
 > husband , that    her   sister had been  into no      mischief whatever . She convinced
 # NSg/V   . N/I/C/D I/J/D NSg/V  V   NSg/V P    NPrSg/P NSg/V    NSg/I/J  . ISg V/J
-> herself of  it        , and cried into her   handkerchief , as    if    the very suggestion was
-# I       V/P NPrSg/ISg . V/C W?    P    I/J/D NSg          . NSg/R NSg/C D   J    NSg        V
+> herself of it        , and cried into her   handkerchief , as    if    the very suggestion was
+# I       P  NPrSg/ISg . V/C W?    P    I/J/D NSg          . NSg/R NSg/C D   J    NSg        V
 > more        than she could  endure . So        Wilson was reduced to a   man         “ deranged by      grief ”
 # NPrSg/I/V/J C/P  ISg NSg/VX V      . NSg/I/J/C NPr    V   W?      P  D/P NPrSg/I/V/J . W?       NSg/J/P NSg/V .
 > in          order that    the case    might    remain in          its   simplest form  . And it        rested there .
 # NPrSg/V/J/P NSg/V N/I/C/D D   NPrSg/V NSg/VX/J NSg/V  NPrSg/V/J/P ISg/D W?       NSg/V . V/C NPrSg/ISg W?     W?    .
 >
 #
-> But     all       this part    of  it        seemed remote  and unessential . I   found myself on
-# NSg/C/P NSg/I/J/C I/D  NSg/V/J V/P NPrSg/ISg W?     NSg/V/J V/C J           . ISg NSg/V I      J/P
-> Gatsby’s side    , and alone . From the moment I   telephoned news  of  the catastrophe
-# N$       NSg/V/J . V/C J     . P    D   NSg    ISg W?         NSg/V V/P D   NSg
+> But     all       this part    of it        seemed remote  and unessential . I   found myself on
+# NSg/C/P NSg/I/J/C I/D  NSg/V/J P  NPrSg/ISg W?     NSg/V/J V/C J           . ISg NSg/V I      J/P
+> Gatsby’s side    , and alone . From the moment I   telephoned news  of the catastrophe
+# N$       NSg/V/J . V/C J     . P    D   NSg    ISg W?         NSg/V P  D   NSg
 > to West      Egg   village , every surmise about him , and every practical question , was
 # P  NPrSg/V/J NSg/V NSg     . D     NSg/V   J/P   I   . V/C D     NSg/J     NSg/V    . V
 > referred to me        . At        first   I   was surprised and confused ; then    , as    he      lay     in          his
@@ -10596,12 +10596,12 @@
 #
 > Some  one       started to ask   me        questions , but     I   broke   away and going   up        - stairs
 # I/J/R NSg/I/V/J W?      P  NSg/V NPrSg/ISg NPl       . NSg/C/P ISg NSg/V/J V/J  V/C NSg/V/J NSg/V/J/P . NPl
-> looked hastily through the unlocked parts of  his   desk  — he’d never told me
-# W?     R       NSg/J/P D   W?       NPl   V/P ISg/D NSg/V . W?   V     V    NPrSg/ISg
+> looked hastily through the unlocked parts of his   desk  — he’d never told me
+# W?     R       NSg/J/P D   W?       NPl   P  ISg/D NSg/V . W?   V     V    NPrSg/ISg
 > definitely that    his   parents were  dead    . But     there was nothing — only the picture of
-# J/R        N/I/C/D ISg/D NPl     NSg/V NSg/V/J . NSg/C/P W?    V   NSg/I/J . W?   D   NSg/V   V/P
-> Dan   Cody , a   token   of  forgotten violence , staring down      from the wall    .
-# NPrSg NPr  . D/P NSg/V/J V/P NSg/V/J   NSg/V    . V       NSg/V/J/P P    D   NPrSg/V .
+# J/R        N/I/C/D ISg/D NPl     NSg/V NSg/V/J . NSg/C/P W?    V   NSg/I/J . W?   D   NSg/V   P
+> Dan   Cody , a   token   of forgotten violence , staring down      from the wall    .
+# NPrSg NPr  . D/P NSg/V/J P  NSg/V/J   NSg/V    . V       NSg/V/J/P P    D   NPrSg/V .
 >
 #
 > Next    morning I   sent  the butler  to New     York with a   letter to Wolfshiem , which
@@ -10616,14 +10616,14 @@
 # I/C     D/P NSg/V NSg/C NSg . ?         W?      . NPrSg/P NSg/I/V/J W?      V/C/P  NPrSg/I/V/J NSg/V  V/C
 > photographers and newspaper men . When    the butler  brought back    Wolfshiem’s answer
 # W?            V/C NSg/V     NSg . NSg/I/C D   NPrSg/V V       NSg/V/J ?           NSg/V
-> I   began to have   a   feeling of  defiance , of  scornful solidarity between Gatsby and
-# ISg V     P  NSg/VX D/P NSg/V/J V/P NSg/V    . V/P J        NSg        NSg/P   NPr    V/C
+> I   began to have   a   feeling of defiance , of scornful solidarity between Gatsby and
+# ISg V     P  NSg/VX D/P NSg/V/J P  NSg/V    . P  J        NSg        NSg/P   NPr    V/C
 > me        against them all       .
 # NPrSg/ISg C/P     N/I  NSg/I/J/C .
 >
 #
-> Dear    Mr  . Carraway . This has been  one       of  the most    terrible shocks of  my life  to
-# NSg/V/J NSg . ?        . I/D  V   NSg/V NSg/I/V/J V/P D   NSg/I/J J        NPl    V/P D  NSg/V P
+> Dear    Mr  . Carraway . This has been  one       of the most    terrible shocks of my life  to
+# NSg/V/J NSg . ?        . I/D  V   NSg/V NSg/I/V/J P  D   NSg/I/J J        NPl    P  D  NSg/V P
 > me        I   hardly can      believe it        that    it        is true    at        all       . Such  a   mad   act     as    that    man
 # NPrSg/ISg ISg J/R    NPrSg/VX V       NPrSg/ISg N/I/C/D NPrSg/ISg VL NSg/V/J NSg/I/V/P NSg/I/J/C . NSg/I D/P N/V/J NPrSg/V NSg/R N/I/C/D NPrSg/I/V/J
 > did should make  us      all       think . I   cannot come    down      now         as    I   am        tied up        in          some
@@ -10670,8 +10670,8 @@
 # . NSg/V . . D   NSg/V V   NSg/J      .
 >
 #
-> “ Hell    of  a   note  , isn’t it        ? Get   my wire  ? ”
-# . NPrSg/V V/P D/P NSg/V . NSg/V NPrSg/ISg . NSg/V D  NSg/V . .
+> “ Hell    of a   note  , isn’t it        ? Get   my wire  ? ”
+# . NPrSg/V P  D/P NSg/V . NSg/V NPrSg/ISg . NSg/V D  NSg/V . .
 >
 #
 > “ There haven’t been  any   wires . ”
@@ -10694,8 +10694,8 @@
 # N$       NSg/V/J . .
 >
 #
-> There was a   long      silence on  the other   end   of  the wire  , followed by      an
-# W?    V   D/P NPrSg/V/J NSg/V   J/P D   NSg/V/J NSg/V V/P D   NSg/V . W?       NSg/J/P D/P
+> There was a   long      silence on  the other   end   of the wire  , followed by      an
+# W?    V   D/P NPrSg/V/J NSg/V   J/P D   NSg/V/J NSg/V P  D   NSg/V . W?       NSg/J/P D/P
 > exclamation . . . then    a   quick   squawk as    the connection was broken .
 # NSg         . . . NSg/J/C D/P NSg/V/J NSg/V  NSg/R D   NSg        V   V/J    .
 >
@@ -10716,12 +10716,12 @@
 # J/R          P    NSg        . V/C NSg/I/C ISg V    D   NSg/V V/C NSg/V    P    ISg/D
 > hands he      began to pull  so        incessantly at        his   sparse gray         beard   that    I   had
 # NPl   NPr/ISg V     P  NSg/V NSg/I/J/C J/R         NSg/I/V/P ISg/D V/J    NPrSg/V/J/Am NPrSg/V N/I/C/D ISg V
-> difficulty in          getting off       his   coat  . He      was on  the point of  collapse , so        I   took
-# NSg        NPrSg/V/J/P NSg/V   NSg/V/J/P ISg/D NSg/V . NPr/ISg V   J/P D   NSg/V V/P NSg/V    . NSg/I/J/C ISg V
+> difficulty in          getting off       his   coat  . He      was on  the point of collapse , so        I   took
+# NSg        NPrSg/V/J/P NSg/V   NSg/V/J/P ISg/D NSg/V . NPr/ISg V   J/P D   NSg/V P  NSg/V    . NSg/I/J/C ISg V
 > him into the music   room    and made  him sit   down      while     I   sent  for something to eat   .
 # I   P    D   NSg/V/J NSg/V/J V/C NSg/V I   NSg/V NSg/V/J/P NSg/V/C/P ISg NSg/V C/P NSg/I/V/J P  NSg/V .
-> But     he      wouldn’t eat   , and the glass   of  milk  spilled from his   trembling hand  .
-# NSg/C/P NPr/ISg VX       NSg/V . V/C D   NPrSg/V V/P NSg/V W?      P    ISg/D V         NSg/V .
+> But     he      wouldn’t eat   , and the glass   of milk  spilled from his   trembling hand  .
+# NSg/C/P NPr/ISg VX       NSg/V . V/C D   NPrSg/V P  NSg/V W?      P    ISg/D V         NSg/V .
 >
 #
 > “ I   saw   it        in          the Chicago newspaper , ” he      said . “ It        was all       in          the Chicago
@@ -10770,12 +10770,12 @@
 # J/P   D/P NPrSg/I/J NSg/V/C/P NSg . ?    V/J    D   NSg/V V/C NSg/V/P NSg/V/J/R/P . ISg/D NSg/V V/J  . ISg/D
 > face  flushed slightly , his   eyes leaking isolated and unpunctual tears . He      had
 # NSg/V W?      J/R      . ISg/D NPl  V       W?       V/C ?          NPl   . NPr/ISg V
-> reached an  age   where death no      longer has the quality of  ghastly surprise , and
-# W?      D/P NSg/V NSg/C NPrSg NPrSg/P NSg/J  V   D   NSg/J   V/P J       NSg/V    . V/C
+> reached an  age   where death no      longer has the quality of ghastly surprise , and
+# W?      D/P NSg/V NSg/C NPrSg NPrSg/P NSg/J  V   D   NSg/J   P  J       NSg/V    . V/C
 > when    he      looked around him now         for the first   time  and saw   the height and splendor
 # NSg/I/C NPr/ISg W?     J/P    I   NPrSg/V/J/C C/P D   NSg/V/J NSg/V V/C NSg/V D   NSg    V/C NSg
-> of  the hall  and the great rooms opening out         from it        into other   rooms , his   grief
-# V/P D   NPrSg V/C D   NSg/J NPl   NSg/V/J NSg/V/J/R/P P    NPrSg/ISg P    NSg/V/J NPl   . ISg/D NSg/V
+> of the hall  and the great rooms opening out         from it        into other   rooms , his   grief
+# P  D   NPrSg V/C D   NSg/J NPl   NSg/V/J NSg/V/J/R/P P    NPrSg/ISg P    NSg/V/J NPl   . ISg/D NSg/V
 > began to be     mixed with an  awed pride . I   helped him to a   bedroom up        - stairs ; while
 # V     P  NSg/VX V/J   P    D/P W?   NSg/V . ISg W?     I   P  D/P NSg     NSg/V/J/P . NPl    . NSg/V/C/P
 > he      took off       his   coat  and vest  I   told him that    all       arrangements had been  deferred
@@ -10802,8 +10802,8 @@
 #
 > “ Jimmy   always liked it        better   down      East    . He      rose      up        to his   position in          the East    .
 # . NPrSg/V W?     W?    NPrSg/ISg NSg/VX/J NSg/V/J/P NPrSg/J . NPr/ISg NPrSg/V/J NSg/V/J/P P  ISg/D NSg/V    NPrSg/V/J/P D   NPrSg/J .
-> Were  you a   friend  of  my boy’s , Mr  . — — — ? ”
-# NSg/V IPl D/P NPrSg/V V/P D  N$    . NSg . . . . . .
+> Were  you a   friend  of my boy’s , Mr  . — — — ? ”
+# NSg/V IPl D/P NPrSg/V P  D  N$    . NSg . . . . . .
 >
 #
 > “ We  were  close   friends . ”
@@ -10812,16 +10812,16 @@
 #
 > “ He      had a   big     future before him , you know  . He      was only a   young     man         , but     he      had a
 # . NPr/ISg V   D/P NSg/V/J NSg/J  C/P    I   . IPl NSg/V . NPr/ISg V   W?   D/P NPrSg/V/J NPrSg/I/V/J . NSg/C/P NPr/ISg V   D/P
-> lot     of  brain   power   here    . ”
-# NPrSg/V V/P NPrSg/V NSg/V/J NSg/J/R . .
+> lot     of brain   power   here    . ”
+# NPrSg/V P  NPrSg/V NSg/V/J NSg/J/R . .
 >
 #
 > He      touched his   head      impressively , and I   nodded .
 # NPr/ISg V/J     ISg/D NPrSg/V/J J/R          . V/C ISg V      .
 >
 #
-> “ If    he’d of  lived , he’d of  been  a   great man         . A   man         like        James J. Hill    . He’d of
-# . NSg/C W?   V/P W?    . W?   V/P NSg/V D/P NSg/J NPrSg/I/V/J . D/P NPrSg/I/V/J NSg/V/J/C/P NPrPl ?  NPrSg/V . W?   V/P
+> “ If    he’d of lived , he’d of been  a   great man         . A   man         like        James J. Hill    . He’d of
+# . NSg/C W?   P  W?    . W?   P  NSg/V D/P NSg/J NPrSg/I/V/J . D/P NPrSg/I/V/J NSg/V/J/C/P NPrPl ?  NPrSg/V . W?   P
 > helped build up        the country . ”
 # W?     NSg/V NSg/V/J/P D   NSg/J   . .
 >
@@ -10864,8 +10864,8 @@
 # W?    NPrSg/V N/I     W?    NSg/VX V/J        . .
 >
 #
-> “ Oh      , I   will     , ” he      broke   out         hastily . “ Of  course I’m not   likely to see   anybody ,
-# . NPrSg/V . ISg NPrSg/VX . . NPr/ISg NSg/V/J NSg/V/J/R/P R       . . V/P NSg/V  W?  NSg/C NSg/J  P  NSg/V N/I     .
+> “ Oh      , I   will     , ” he      broke   out         hastily . “ Of course I’m not   likely to see   anybody ,
+# . NPrSg/V . ISg NPrSg/VX . . NPr/ISg NSg/V/J NSg/V/J/R/P R       . . P  NSg/V  W?  NSg/C NSg/J  P  NSg/V N/I     .
 > but     if    I   do     . ”
 # NSg/C/P NSg/C ISg NSg/VX . .
 >
@@ -10874,8 +10874,8 @@
 # ISg/D NSg/I/V NSg/V NPrSg/ISg J          .
 >
 #
-> “ Of  course you’ll be     there yourself . ”
-# . V/P NSg/V  W?     NSg/VX W?    I        . .
+> “ Of course you’ll be     there yourself . ”
+# . P  NSg/V  W?     NSg/VX W?    I        . .
 >
 #
 > “ Well    , I’ll certainly try     . What  I   called up        about is — — — ”
@@ -10886,12 +10886,12 @@
 # . NSg/V D/P NSg/V/J . . ISg W?          . . NSg/C J/P   NSg/V  W?     NSg/V/P . .
 >
 #
-> “ Well    , the fact is — the truth of  the matter  is that    I’m staying with some  people
-# . NSg/V/J . D   NSg  VL . D   NSg/V V/P D   NSg/V/J VL N/I/C/D W?  V       P    I/J/R NSg/V
+> “ Well    , the fact is — the truth of the matter  is that    I’m staying with some  people
+# . NSg/V/J . D   NSg  VL . D   NSg/V P  D   NSg/V/J VL N/I/C/D W?  V       P    I/J/R NSg/V
 > up        here    in          Greenwich , and they rather    expect me        to be     with them tomorrow . In
 # NSg/V/J/P NSg/J/R NPrSg/V/J/P NPr       . V/C IPl  NPrSg/V/J V      NPrSg/ISg P  NSg/VX P    N/I  NSg      . NPrSg/V/J/P
-> fact , there’s a   sort  of  picnic or      something . Of  course I’ll do     my very best       to
-# NSg  . W?      D/P NSg/V V/P NSg/V  NPrSg/C NSg/I/V/J . V/P NSg/V  W?   NSg/VX D  J    NPrSg/VX/J P
+> fact , there’s a   sort  of picnic or      something . Of course I’ll do     my very best       to
+# NSg  . W?      D/P NSg/V P  NSg/V  NPrSg/C NSg/I/V/J . P  NSg/V  W?   NSg/VX D  J    NPrSg/VX/J P
 > get   away . ”
 # NSg/V V/J  . .
 >
@@ -10902,34 +10902,34 @@
 # J/R       .
 >
 #
-> “ What  I   called up        about was a   pair  of  shoes I   left      there . I   wonder if    it’d be
-# . NSg/I ISg V/J    NSg/V/J/P J/P   V   D/P NSg/V V/P NPl   ISg NPrSg/V/J W?    . ISg NSg/V  NSg/C W?   NSg/VX
+> “ What  I   called up        about was a   pair  of shoes I   left      there . I   wonder if    it’d be
+# . NSg/I ISg V/J    NSg/V/J/P J/P   V   D/P NSg/V P  NPl   ISg NPrSg/V/J W?    . ISg NSg/V  NSg/C W?   NSg/VX
 > too much  trouble to have   the butler  send  them on  . You see   , they’re tennis shoes ,
 # W?  N/I/J NSg/V   P  NSg/VX D   NPrSg/V NSg/V N/I  J/P . IPl NSg/V . W?      NSg/V  NPl   .
-> and I’m sort  of  helpless without them . My address is care  of  B. F. — — — ”
-# V/C W?  NSg/V V/P J        C/P     N/I  . D  NSg/V   VL NSg/V V/P ?  ?  . . . .
+> and I’m sort  of helpless without them . My address is care  of B. F. — — — ”
+# V/C W?  NSg/V P  J        C/P     N/I  . D  NSg/V   VL NSg/V P  ?  ?  . . . .
 >
 #
-> I   didn’t hear the rest  of  the name  , because I   hung    up        the receiver .
-# ISg V      V    D   NSg/V V/P D   NSg/V . C/P     ISg NPr/V/J NSg/V/J/P D   NSg/J    .
+> I   didn’t hear the rest  of the name  , because I   hung    up        the receiver .
+# ISg V      V    D   NSg/V P  D   NSg/V . C/P     ISg NPr/V/J NSg/V/J/P D   NSg/J    .
 >
 #
 > After that    I   felt    a   certain shame   for Gatsby — one       gentleman to whom I   telephoned
 # J/P   N/I/C/D ISg NSg/V/J D/P I/J     NSg/V/J C/P NPr    . NSg/I/V/J NSg       P  I    ISg W?
 > implied that    he      had got what  he      deserved . However , that    was my fault , for he      was
 # W?      N/I/C/D NPr/ISg V   V   NSg/I NPr/ISg V/J      . C       . N/I/C/D V   D  NSg/V . C/P NPr/ISg V
-> one       of  those who     used to sneer most    bitterly at        Gatsby on  the courage of
-# NSg/I/V/J V/P I/D   NPrSg/I V/J  P  NSg/V NSg/I/J J/R      NSg/I/V/P NPr    J/P D   NSg/V   V/P
+> one       of those who     used to sneer most    bitterly at        Gatsby on  the courage of
+# NSg/I/V/J P  I/D   NPrSg/I V/J  P  NSg/V NSg/I/J J/R      NSg/I/V/P NPr    J/P D   NSg/V   P
 > Gatsby’s liquor , and I   should have   known   better   than to call  him .
 # N$       NSg/V  . V/C ISg VX     NSg/VX NSg/V/J NSg/VX/J C/P  P  NSg/V I   .
 >
 #
-> The morning of  the funeral I   went  up        to New     York to see   Meyer Wolfshiem ; I
-# D   NSg/V   V/P D   NSg/J   ISg NSg/V NSg/V/J/P P  NSg/V/J NPr  P  NSg/V NPr   ?         . ISg
+> The morning of the funeral I   went  up        to New     York to see   Meyer Wolfshiem ; I
+# D   NSg/V   P  D   NSg/J   ISg NSg/V NSg/V/J/P P  NSg/V/J NPr  P  NSg/V NPr   ?         . ISg
 > couldn’t seem to reach him any   other   way   . The door  that    I   pushed open    , on  the
 # V        V    P  NSg/V I   I/R/D NSg/V/J NSg/J . D   NSg/V N/I/C/D ISg W?     NSg/V/J . J/P D
-> advice of  an  elevator boy   , was marked “ The Swastika Holding Company , ” and at
-# NSg/V  V/P D/P NSg/V    NSg/V . V   V/J    . D   NSg      NSg/V   NSg/V   . . V/C NSg/I/V/P
+> advice of an  elevator boy   , was marked “ The Swastika Holding Company , ” and at
+# NSg/V  P  D/P NSg/V    NSg/V . V   V/J    . D   NSg      NSg/V   NSg/V   . . V/C NSg/I/V/P
 > first   there didn’t seem to be     any   one       inside  . But     when    I’d shouted “ hello ”
 # NSg/V/J W?    V      V    P  NSg/VX I/R/D NSg/I/V/J NSg/J/P . NSg/C/P NSg/I/C W?  W?      . NSg/V .
 > several times in          vain , an  argument broke   out         behind  a   partition , and presently a
@@ -10944,8 +10944,8 @@
 # . N$       NPrSg/V/J/P . . ISg V/J  . . NSg . ?           V/J/P P  NPr     . .
 >
 #
-> The first   part    of  this was obviously untrue , for some  one       had begun to whistle
-# D   NSg/V/J NSg/V/J V/P I/D  V   J/R       J      . C/P I/J/R NSg/I/V/J V   V     P  NSg/V
+> The first   part    of this was obviously untrue , for some  one       had begun to whistle
+# D   NSg/V/J NSg/V/J P  I/D  V   J/R       J      . C/P I/J/R NSg/I/V/J V   V     P  NSg/V
 > “ The Rosary , ” tunelessly , inside  .
 # . D   NSg    . . J/R        . NSg/J/P .
 >
@@ -10960,8 +10960,8 @@
 #
 > At        this moment a   voice , unmistakably Wolfshiem’s , called “ Stella ! ” from the
 # NSg/I/V/P I/D  NSg    D/P NSg/V . R            ?           . V/J    . NPrSg  . . P    D
-> other   side    of  the door  .
-# NSg/V/J NSg/V/J V/P D   NSg/V .
+> other   side    of the door  .
+# NSg/V/J NSg/V/J P  D   NSg/V .
 >
 #
 > “ Leave your name  on  the desk  , ” she said quickly . “ I’ll give  it        to him when    he
@@ -10982,8 +10982,8 @@
 #
 > “ You young     men think you can      force your way   in          here    any   time  , ” she scolded .
 # . IPl NPrSg/V/J NSg NSg/V IPl NPrSg/VX NSg/V D    NSg/J NPrSg/V/J/P NSg/J/R I/R/D NSg/V . . ISg W?      .
-> “ We’re getting sick    in          tired of  it        . When    I   say   he’s in          Chicago , he’s in
-# . W?    NSg/V   NSg/V/J NPrSg/V/J/P V/J   V/P NPrSg/ISg . NSg/I/C ISg NSg/V N$   NPrSg/V/J/P NPr     . N$   NPrSg/V/J/P
+> “ We’re getting sick    in          tired of it        . When    I   say   he’s in          Chicago , he’s in
+# . W?    NSg/V   NSg/V/J NPrSg/V/J/P V/J   P  NPrSg/ISg . NSg/I/C ISg NSg/V N$   NPrSg/V/J/P NPr     . N$   NPrSg/V/J/P
 > Chicago . ”
 # NPr     . .
 >
@@ -11000,22 +11000,22 @@
 # ISg W?       . NPrSg/V/J/P D/P NSg    NPr   ?         V     J/R      NPrSg/V/J/P D   NSg     . NSg/V
 > out         both hands . He      drew  me        into his   office , remarking in          a   reverent voice that
 # NSg/V/J/R/P I/C  NPl   . NPr/ISg NPr/V NPrSg/ISg P    ISg/D NSg/V  . V         NPrSg/V/J/P D/P J        NSg/V N/I/C/D
-> it        was a   sad     time  for all       of  us      , and offered me        a   cigar .
-# NPrSg/ISg V   D/P NSg/V/J NSg/V C/P NSg/I/J/C V/P NPr/ISg . V/C W?      NPrSg/ISg D/P NSg   .
+> it        was a   sad     time  for all       of us      , and offered me        a   cigar .
+# NPrSg/ISg V   D/P NSg/V/J NSg/V C/P NSg/I/J/C P  NPr/ISg . V/C W?      NPrSg/ISg D/P NSg   .
 >
 #
 > “ My memory goes  back    to when    first   I   met him , ” he      said . “ A   young     major     just out
 # . D  NSg    NSg/V NSg/V/J P  NSg/I/C NSg/V/J ISg V   I   . . NPr/ISg V/J  . . D/P NPrSg/V/J NPrSg/V/J V/J  NSg/V/J/R/P
-> of  the army and covered over      with medals he      got in          the war   . He      was so        hard    up        he
-# V/P D   NSg  V/C W?      NSg/V/J/P P    NPl    NPr/ISg V   NPrSg/V/J/P D   NSg/V . NPr/ISg V   NSg/I/J/C NSg/V/J NSg/V/J/P NPr/ISg
+> of the army and covered over      with medals he      got in          the war   . He      was so        hard    up        he
+# P  D   NSg  V/C W?      NSg/V/J/P P    NPl    NPr/ISg V   NPrSg/V/J/P D   NSg/V . NPr/ISg V   NSg/I/J/C NSg/V/J NSg/V/J/P NPr/ISg
 > had to keep  on  wearing his   uniform because he      couldn’t buy   some  regular clothes .
 # V   P  NSg/V J/P V       ISg/D NSg/V/J C/P     NPr/ISg V        NSg/V I/J/R NSg/J   NPl     .
 > First   time  I   saw   him was when    he      come    into Winebrenner’s poolroom at        Forty - third
 # NSg/V/J NSg/V ISg NSg/V I   V   NSg/I/C NPr/ISg NSg/V/P P    ?             NSg      NSg/I/V/P NSg/J . NSg/V/J
-> Street  and asked for a   job     . He      hadn’t eat   anything for a   couple  of  days . ‘          Come
-# NSg/V/J V/C V/J   C/P D/P NPrSg/V . NPr/ISg V      NSg/V NSg/I/V  C/P D/P NSg/V/J V/P NPl  . Unlintable NSg/V/P
-> on  have   some  lunch with me        , ’ I   sid . He      ate   more        than four dollars ’ worth   of  food
-# J/P NSg/VX I/J/R NSg/V P    NPrSg/ISg . . ISg NPr . NPr/ISg NSg/V NPrSg/I/V/J C/P  NSg  NPl     . NSg/V/J V/P NSg
+> Street  and asked for a   job     . He      hadn’t eat   anything for a   couple  of days . ‘          Come
+# NSg/V/J V/C V/J   C/P D/P NPrSg/V . NPr/ISg V      NSg/V NSg/I/V  C/P D/P NSg/V/J P  NPl  . Unlintable NSg/V/P
+> on  have   some  lunch with me        , ’ I   sid . He      ate   more        than four dollars ’ worth   of food
+# J/P NSg/VX I/J/R NSg/V P    NPrSg/ISg . . ISg NPr . NPr/ISg NSg/V NPrSg/I/V/J C/P  NSg  NPl     . NSg/V/J P  NSg
 > in          half      an  hour . ”
 # NPrSg/V/J/P NSg/V/J/P D/P NSg  . .
 >
@@ -11032,16 +11032,16 @@
 # . NPrSg/V . .
 >
 #
-> “ I   raised him up        out         of  nothing , right     out         of  the gutter . I   saw   right     away he
-# . ISg W?     I   NSg/V/J/P NSg/V/J/R/P V/P NSg/I/J . NPrSg/V/J NSg/V/J/R/P V/P D   NSg/V  . ISg NSg/V NPrSg/V/J V/J  NPr/ISg
+> “ I   raised him up        out         of nothing , right     out         of the gutter . I   saw   right     away he
+# . ISg W?     I   NSg/V/J/P NSg/V/J/R/P P  NSg/I/J . NPrSg/V/J NSg/V/J/R/P P  D   NSg/V  . ISg NSg/V NPrSg/V/J V/J  NPr/ISg
 > was a   fine    - appearing , gentlemanly young     man         , and when    he      told me        he      was an
 # V   D/P NSg/V/J . V         . J/R         NPrSg/V/J NPrSg/I/V/J . V/C NSg/I/C NPr/ISg V    NPrSg/ISg NPr/ISg V   D/P
 > Oggsford I   knew I   could  use   him good      . I   got him to join  up        in          the American
 # ?        ISg V    ISg NSg/VX NSg/V I   NPrSg/V/J . ISg V   I   P  NSg/V NSg/V/J/P NPrSg/V/J/P D   NPrSg/J
 > Legion  and he      used to stand high    there . Right     off       he      did some  work  for a   client
 # NSg/V/J V/C NPr/ISg V/J  P  NSg/V NSg/V/J W?    . NPrSg/V/J NSg/V/J/P NPr/ISg V   I/J/R NSg/V C/P D/P NSg
-> of  mine    up        to Albany . We  were  so        thick   like        that    in          everything ” — he      held up        two
-# V/P NSg/I/V NSg/V/J/P P  NPr    . IPl NSg/V NSg/I/J/C NSg/V/J NSg/V/J/C/P N/I/C/D NPrSg/V/J/P N/I/V      . . NPr/ISg V    NSg/V/J/P NSg
+> of mine    up        to Albany . We  were  so        thick   like        that    in          everything ” — he      held up        two
+# P  NSg/I/V NSg/V/J/P P  NPr    . IPl NSg/V NSg/I/J/C NSg/V/J NSg/V/J/C/P N/I/C/D NPrSg/V/J/P N/I/V      . . NPr/ISg V    NSg/V/J/P NSg
 > bulbous fingers — “ always together . ”
 # J       NPl     . . W?     J        . .
 >
@@ -11082,16 +11082,16 @@
 #
 > “ When    a   man         gets killed I   never like        to get   mixed up        in          it        in          any   way   . I   keep
 # . NSg/I/C D/P NPrSg/I/V/J NPl  W?     ISg V     NSg/V/J/C/P P  NSg/V V/J   NSg/V/J/P NPrSg/V/J/P NPrSg/ISg NPrSg/V/J/P I/R/D NSg/J . ISg NSg/V
-> out         . When    I   was a   young     man         it        was different — if    a   friend  of  mine    died , no      matter
-# NSg/V/J/R/P . NSg/I/C ISg V   D/P NPrSg/V/J NPrSg/I/V/J NPrSg/ISg V   NSg/J     . NSg/C D/P NPrSg/V V/P NSg/I/V W?   . NPrSg/P NSg/V/J
+> out         . When    I   was a   young     man         it        was different — if    a   friend  of mine    died , no      matter
+# NSg/V/J/R/P . NSg/I/C ISg V   D/P NPrSg/V/J NPrSg/I/V/J NPrSg/ISg V   NSg/J     . NSg/C D/P NPrSg/V P  NSg/I/V W?   . NPrSg/P NSg/V/J
 > how   , I   stuck   with them to the end   . You may      think that’s sentimental , but     I   mean
 # NSg/C . ISg NSg/V/J P    N/I  P  D   NSg/V . IPl NPrSg/VX NSg/V N$     J           . NSg/C/P ISg NSg/V/J
 > it        — to the bitter  end   . ”
 # NPrSg/ISg . P  D   NSg/V/J NSg/V . .
 >
 #
-> I   saw   that    for some  reason of  his   own     he      was determined not   to come    , so        I   stood
-# ISg NSg/V N/I/C/D C/P I/J/R NSg/V  V/P ISg/D NSg/V/J NPr/ISg V   V/J        NSg/C P  NSg/V/P . NSg/I/J/C ISg V
+> I   saw   that    for some  reason of his   own     he      was determined not   to come    , so        I   stood
+# ISg NSg/V N/I/C/D C/P I/J/R NSg/V  P  ISg/D NSg/V/J NPr/ISg V   V/J        NSg/C P  NSg/V/P . NSg/I/J/C ISg V
 > up        .
 # NSg/V/J/P .
 >
@@ -11128,8 +11128,8 @@
 # . NSg/V W?    . .
 >
 #
-> It        was a   photograph of  the house   , cracked in          the corners and dirty with many
-# NPrSg/ISg V   D/P NSg/V      V/P D   NPrSg/V . W?      NPrSg/V/J/P D   W?      V/C V/J   P    N/I/J/D
+> It        was a   photograph of the house   , cracked in          the corners and dirty with many
+# NPrSg/ISg V   D/P NSg/V      P  D   NPrSg/V . W?      NPrSg/V/J/P D   W?      V/C V/J   P    N/I/J/D
 > hands . He      pointed out         every detail  to me        eagerly . “ Look  there ! ” and then    sought
 # NPl   . NPr/ISg V/J     NSg/V/J/R/P D     NSg/V/J P  NPrSg/ISg J/R     . . NSg/V W?    . . V/C NSg/J/C V
 > admiration from my eyes . He      had shown it        so        often that    I   think it        was more        real
@@ -11147,11 +11147,11 @@
 >
 #
 > “ He      come    out         to see   me        two years ago and bought me        the house   I   live in          now         . Of
-# . NPr/ISg NSg/V/P NSg/V/J/R/P P  NSg/V NPrSg/ISg NSg NPl   J/P V/C NSg/V  NPrSg/ISg D   NPrSg/V ISg V/J  NPrSg/V/J/P NPrSg/V/J/C . V/P
+# . NPr/ISg NSg/V/P NSg/V/J/R/P P  NSg/V NPrSg/ISg NSg NPl   J/P V/C NSg/V  NPrSg/ISg D   NPrSg/V ISg V/J  NPrSg/V/J/P NPrSg/V/J/C . P
 > course we  was broke   up        when    he      run   off       from home    , but     I   see   now         there was a
 # NSg/V  IPl V   NSg/V/J NSg/V/J/P NSg/I/C NPr/ISg NSg/V NSg/V/J/P P    NSg/V/J . NSg/C/P ISg NSg/V NPrSg/V/J/C W?    V   D/P
-> reason for it        . He      knew he      had a   big     future in          front   of  him . And ever since he
-# NSg/V  C/P NPrSg/ISg . NPr/ISg V    NPr/ISg V   D/P NSg/V/J NSg/J  NPrSg/V/J/P NSg/V/J V/P I   . V/C J    C/P   NPr/ISg
+> reason for it        . He      knew he      had a   big     future in          front   of him . And ever since he
+# NSg/V  C/P NPrSg/ISg . NPr/ISg V    NPr/ISg V   D/P NSg/V/J NSg/J  NPrSg/V/J/P NSg/V/J P  I   . V/C J    C/P   NPr/ISg
 > made  a   success he      was very generous with me        . ”
 # NSg/V D/P NSg     NPr/ISg V   J    J        P    NPrSg/ISg . .
 >
@@ -11160,8 +11160,8 @@
 # NPr/ISg W?     J         P  NSg/V V/J  D   NSg/V   . V    NPrSg/ISg C/P I/D     NSg/V/J .
 > lingeringly , before my eyes . Then    he      returned the wallet and pulled from his
 # J/R         . C/P    D  NPl  . NSg/J/C NPr/ISg W?       D   NSg    V/C W?     P    ISg/D
-> pocket  a   ragged old   copy  of  a   book  called “ Hopalong Cassidy . ”
-# NSg/V/J D/P V/J    NSg/J NSg/V V/P D/P NSg/V V/J    . ?        NPr     . .
+> pocket  a   ragged old   copy  of a   book  called “ Hopalong Cassidy . ”
+# NSg/V/J D/P V/J    NSg/J NSg/V P  D/P NSg/V V/J    . ?        NPr     . .
 >
 #
 > “ Look  here    , this is a   book  he      had when    he      was a   boy   . It        just shows you . ”
@@ -11238,8 +11238,8 @@
 # P  NSg/V R             NSg/V/J/R/P D   NPrPl   C/P NSg/V/J NPl  . NSg/I/J/C V   N$       NPrSg/V .
 > And as    the time  passed and the servants came    in          and stood waiting in          the hall  ,
 # V/C NSg/R D   NSg/V W?     V/C D   NPl      NSg/V/P NPrSg/V/J/P V/C V     NSg/V   NPrSg/V/J/P D   NPrSg .
-> his   eyes began to blink anxiously , and he      spoke of  the rain  in          a   worried ,
-# ISg/D NPl  V     P  NSg/V J/R       . V/C NPr/ISg NSg/V V/P D   NSg/V NPrSg/V/J/P D/P V/J     .
+> his   eyes began to blink anxiously , and he      spoke of the rain  in          a   worried ,
+# ISg/D NPl  V     P  NSg/V J/R       . V/C NPr/ISg NSg/V P  D   NSg/V NPrSg/V/J/P D/P V/J     .
 > uncertain way   . The minister glanced several times at        his   watch , so        I   took him
 # I/J       NSg/J . D   NSg/V    W?      J/D     NPl   NSg/I/V/P ISg/D NSg/V . NSg/I/J/C ISg V    I
 > aside and asked him to wait  for half      an  hour . But     it        wasn’t any   use   . Nobody
@@ -11248,8 +11248,8 @@
 # NSg/V/P .
 >
 #
-> About five o’clock our procession of  three cars reached the cemetery and stopped
-# J/P   NSg  W?      D   NSg/V      V/P NSg   NPl  W?      D   NSg      V/C V/J
+> About five o’clock our procession of three cars reached the cemetery and stopped
+# J/P   NSg  W?      D   NSg/V      P  NSg   NPl  W?      D   NSg      V/C V/J
 > in          a   thick   drizzle beside the gate  — first   a   motor   hearse , horribly black   and wet     ,
 # NPrSg/V/J/P D/P NSg/V/J NSg/V   P      D   NSg/V . NSg/V/J D/P NSg/V/J NSg/V  . R        NSg/V/J V/C NSg/V/J .
 > then    Mr  . Gatz and the minister and I   in          the limousine , and a   little    later four
@@ -11258,8 +11258,8 @@
 # NPrSg/C NSg  NPl      V/C D   NSg     P    NPrSg/V/J NSg/V . NPrSg/V/J/P N$       NSg/V   NSg/V . NSg/I/J/C
 > wet     to the skin  . As    we  started through the gate  into the cemetery I   heard a   car
 # NSg/V/J P  D   NSg/V . NSg/R IPl W?      NSg/J/P D   NSg/V P    D   NSg      ISg V/J   D/P NSg
-> stop  and then    the sound   of  some  one       splashing after us      over      the soggy ground  . I
-# NSg/V V/C NSg/J/C D   NSg/V/J V/P I/J/R NSg/I/V/J V         J/P   NPr/ISg NSg/V/J/P D   J     NSg/V/J . ISg
+> stop  and then    the sound   of some  one       splashing after us      over      the soggy ground  . I
+# NSg/V V/C NSg/J/C D   NSg/V/J P  I/J/R NSg/I/V/J V         J/P   NPr/ISg NSg/V/J/P D   J     NSg/V/J . ISg
 > looked around . It        was the man         with owl   - eyed glasses whom I   had found marvelling
 # W?     J/P    . NPrSg/ISg V   D   NPrSg/I/V/J P    NSg/V . W?   NPl     I    ISg V   NSg/V NSg/V/Br
 > over      Gatsby’s books in          the library one       night three months before .
@@ -11308,28 +11308,28 @@
 # NPr/ISg V    NSg/V/J/P ISg/D NPl     V/C W?    N/I  P     . NSg/V/J/P V/C NPrSg/V/J/P .
 >
 #
-> “ The poor    son     - of  - a   - bitch , ” he      said .
-# . D   NSg/V/J NPrSg/V . V/P . D/P . NSg/V . . NPr/ISg V/J  .
+> “ The poor    son     - of - a   - bitch , ” he      said .
+# . D   NSg/V/J NPrSg/V . P  . D/P . NSg/V . . NPr/ISg V/J  .
 >
 #
-> One       of  my most    vivid memories is of  coming  back    West      from prep  school and later
-# NSg/I/V/J V/P D  NSg/I/J NSg/J NPl      VL V/P NSg/V/J NSg/V/J NPrSg/V/J P    NSg/V NSg/V  V/C J
+> One       of my most    vivid memories is of coming  back    West      from prep  school and later
+# NSg/I/V/J P  D  NSg/I/J NSg/J NPl      VL P  NSg/V/J NSg/V/J NPrSg/V/J P    NSg/V NSg/V  V/C J
 > from college at        Christmas time  . Those who     went  farther than Chicago would  gather
 # P    NSg     NSg/I/V/P NPrSg/V/J NSg/V . I/D   NPrSg/I NSg/V V/J     C/P  NPr     NSg/VX NSg/V
-> in          the old   dim     Union     Street  station at        six o’clock of  a   December evening , with a
-# NPrSg/V/J/P D   NSg/J NSg/V/J NPrSg/V/J NSg/V/J NSg/V   NSg/I/V/P NSg W?      V/P D/P NPr      NSg/V   . P    D/P
+> in          the old   dim     Union     Street  station at        six o’clock of a   December evening , with a
+# NPrSg/V/J/P D   NSg/J NSg/V/J NPrSg/V/J NSg/V/J NSg/V   NSg/I/V/P NSg W?      P  D/P NPr      NSg/V   . P    D/P
 > few Chicago friends , already caught up        into their own     holiday gayeties , to bid
 # N/I NPr     NPl     . W?      V/J    NSg/V/J/P P    D     NSg/V/J NPrSg/V ?        . P  NSg/V
-> them a   hasty good      - by      . I   remember the fur       coats of  the girls returning from Miss
-# N/I  D/P J     NPrSg/V/J . NSg/J/P . ISg NSg/V    D   NSg/V/C/P NPl   V/P D   NPl   V         P    NSg/V
-> This - or      - That’s and the chatter of  frozen breath  and the hands waving overhead as
-# I/D  . NPrSg/C . N$     V/C D   NSg/V   V/P V/J    NSg/V/J V/C D   NPl   V      NSg/J/P  NSg/R
-> we  caught sight of  old   acquaintances , and the matchings of  invitations : “ Are you
-# IPl V/J    NSg/V V/P NSg/J NPl           . V/C D   ?         V/P NPl         . . V   IPl
+> them a   hasty good      - by      . I   remember the fur       coats of the girls returning from Miss
+# N/I  D/P J     NPrSg/V/J . NSg/J/P . ISg NSg/V    D   NSg/V/C/P NPl   P  D   NPl   V         P    NSg/V
+> This - or      - That’s and the chatter of frozen breath  and the hands waving overhead as
+# I/D  . NPrSg/C . N$     V/C D   NSg/V   P  V/J    NSg/V/J V/C D   NPl   V      NSg/J/P  NSg/R
+> we  caught sight of old   acquaintances , and the matchings of invitations : “ Are you
+# IPl V/J    NSg/V P  NSg/J NPl           . V/C D   ?         P  NPl         . . V   IPl
 > going   to the Ordways ’ ? the Herseys ’ ? the Schultzes ’ ? ” and the long      green     tickets
 # NSg/V/J P  D   ?       . . D   ?       . . D   ?         . . . V/C D   NPrSg/V/J NPrSg/V/J NPl
-> clasped tight in          our gloved hands . And last    the murky yellow  cars of  the
-# W?      V/J   NPrSg/V/J/P D   W?     NPl   . V/C NSg/V/J D   J     NSg/V/J NPl  V/P D
+> clasped tight in          our gloved hands . And last    the murky yellow  cars of the
+# W?      V/J   NPrSg/V/J/P D   W?     NPl   . V/C NSg/V/J D   J     NSg/V/J NPl  P  D
 > Chicago , Milwaukee & St      . Paul railroad looking cheerful as    Christmas itself on
 # NPr     . NPr       . NPrSg/V . NPr  NSg/V    V       J        NSg/R NPrSg/V/J I      J/P
 > the tracks beside the gate  .
@@ -11339,45 +11339,45 @@
 > When    we  pulled out         into the winter night and the real  snow    , our snow    , began to
 # NSg/I/C IPl W?     NSg/V/J/R/P P    D   NSg/V  NSg/V V/C D   NSg/J NPrSg/V . D   NPrSg/V . V     P
 > stretch out         beside us      and twinkle against the windows , and the dim     lights of
-# NSg/V   NSg/V/J/R/P P      NPr/ISg V/C NSg/V   C/P     D   NPrPl   . V/C D   NSg/V/J NPl    V/P
+# NSg/V   NSg/V/J/R/P P      NPr/ISg V/C NSg/V   C/P     D   NPrPl   . V/C D   NSg/V/J NPl    P
 > small     Wisconsin stations moved by      , a   sharp     wild    brace came    suddenly into the
 # NPrSg/V/J NPr       W?       V/J   NSg/J/P . D/P NPrSg/V/J NSg/V/J NSg/V NSg/V/P J/R      P    D
-> air   . We  drew  in          deep  breaths of  it        as    we  walked back    from dinner through the
-# NSg/V . IPl NPr/V NPrSg/V/J/P NSg/J NSg     V/P NPrSg/ISg NSg/R IPl W?     NSg/V/J P    NSg/V  NSg/J/P D
-> cold  vestibules , unutterably aware of  our identity with this country for one
-# NSg/J NPl        . R           V/J   V/P D   NSg      P    I/D  NSg/J   C/P NSg/I/V/J
+> air   . We  drew  in          deep  breaths of it        as    we  walked back    from dinner through the
+# NSg/V . IPl NPr/V NPrSg/V/J/P NSg/J NSg     P  NPrSg/ISg NSg/R IPl W?     NSg/V/J P    NSg/V  NSg/J/P D
+> cold  vestibules , unutterably aware of our identity with this country for one
+# NSg/J NPl        . R           V/J   P  D   NSg      P    I/D  NSg/J   C/P NSg/I/V/J
 > strange hour , before we  melted indistinguishably into it        again .
 # NSg/V/J NSg  . C/P    IPl W?     R                 P    NPrSg/ISg P     .
 >
 #
 > That’s my Middle  West      — not   the wheat or      the prairies or      the lost Swede towns , but
 # N$     D  NSg/V/J NPrSg/V/J . NSg/C D   NSg/J NPrSg/C D   NPl      NPrSg/C D   V/J  NSg/V NPl   . NSg/C/P
-> the thrilling returning trains of  my youth , and the street  lamps and sleigh
-# D   NSg/V/J   V         NPl    V/P D  NSg   . V/C D   NSg/V/J NPl   V/C NSg/V/J
-> bells in          the frosty dark    and the shadows of  holly wreaths thrown by      lighted
-# NPl   NPrSg/V/J/P D   J      NSg/V/J V/C D   NPl     V/P NPrSg NSg/V   V/J    NSg/J/P V/J
-> windows on  the snow    . I   am        part    of  that    , a   little    solemn with the feel      of  those
-# NPrPl   J/P D   NPrSg/V . ISg NPrSg/V/J NSg/V/J V/P N/I/C/D . D/P NPrSg/I/J J      P    D   NSg/I/V/J V/P I/D
+> the thrilling returning trains of my youth , and the street  lamps and sleigh
+# D   NSg/V/J   V         NPl    P  D  NSg   . V/C D   NSg/V/J NPl   V/C NSg/V/J
+> bells in          the frosty dark    and the shadows of holly wreaths thrown by      lighted
+# NPl   NPrSg/V/J/P D   J      NSg/V/J V/C D   NPl     P  NPrSg NSg/V   V/J    NSg/J/P V/J
+> windows on  the snow    . I   am        part    of that    , a   little    solemn with the feel      of those
+# NPrPl   J/P D   NPrSg/V . ISg NPrSg/V/J NSg/V/J P  N/I/C/D . D/P NPrSg/I/J J      P    D   NSg/I/V/J P  I/D
 > long      winters , a   little    complacent from growing up        in          the Carraway house   in          a
 # NPrSg/V/J NPrPl   . D/P NPrSg/I/J J          P    NSg/V   NSg/V/J/P NPrSg/V/J/P D   ?        NPrSg/V NPrSg/V/J/P D/P
 > city where dwellings are still   called through decades by      a   family’s name  . I   see
 # NSg  NSg/C W?        V   NSg/V/J V/J    NSg/J/P NPl     NSg/J/P D/P N$       NSg/V . ISg NSg/V
-> now         that    this has been  a   story of  the West      , after all       — Tom     and Gatsby , Daisy and
-# NPrSg/V/J/C N/I/C/D I/D  V   NSg/V D/P NSg/V V/P D   NPrSg/V/J . J/P   NSg/I/J/C . NPrSg/V V/C NPr    . NPrSg V/C
+> now         that    this has been  a   story of the West      , after all       — Tom     and Gatsby , Daisy and
+# NPrSg/V/J/C N/I/C/D I/D  V   NSg/V D/P NSg/V P  D   NPrSg/V/J . J/P   NSg/I/J/C . NPrSg/V V/C NPr    . NPrSg V/C
 > Jordan and I   , were  all       Westerners , and perhaps we  possessed some  deficiency in
 # NPr    V/C ISg . NSg/V NSg/I/J/C W?         . V/C NSg     IPl W?        I/J/R NSg        NPrSg/V/J/P
 > common  which made  us      subtly unadaptable to Eastern life  .
 # NSg/V/J I/C   NSg/V NPr/ISg R      ?           P  J       NSg/V .
 >
 #
-> Even    when    the East    excited me        most    , even    when    I   was most    keenly aware of  its
-# NSg/V/J NSg/I/C D   NPrSg/J V/J     NPrSg/ISg NSg/I/J . NSg/V/J NSg/I/C ISg V   NSg/I/J J/R    V/J   V/P ISg/D
+> Even    when    the East    excited me        most    , even    when    I   was most    keenly aware of its
+# NSg/V/J NSg/I/C D   NPrSg/J V/J     NPrSg/ISg NSg/I/J . NSg/V/J NSg/I/C ISg V   NSg/I/J J/R    V/J   P  ISg/D
 > superiority to the bored , sprawling , swollen towns beyond the Ohio  , with their
 # NSg         P  D   W?    . V         . V/J     NPl   NSg/P  D   NPr/J . P    D
 > interminable inquisitions which spared only the children and the very old   — even
 # J            NPl          I/C   W?     W?   D   NPl      V/C D   J    NSg/J . NSg/V/J
-> then    it        had always for me        a   quality of  distortion . West      Egg   , especially , still
-# NSg/J/C NPrSg/ISg V   W?     C/P NPrSg/ISg D/P NSg/J   V/P NSg        . NPrSg/V/J NSg/V . J/R        . NSg/V/J
+> then    it        had always for me        a   quality of distortion . West      Egg   , especially , still
+# NSg/J/C NPrSg/ISg V   W?     C/P NPrSg/ISg D/P NSg/J   P  NSg        . NPrSg/V/J NSg/V . J/R        . NSg/V/J
 > figures in          my more        fantastic dreams . I   see   it        as    a   night scene by      El Greco : a
 # NPl     NPrSg/V/J/P D  NPrSg/I/V/J NSg/J     NPl    . ISg NSg/V NPrSg/ISg NSg/R D/P NSg/V NSg/V NSg/J/P ?  ?     . D/P
 > hundred houses , at        once  conventional and grotesque , crouching under   a   sullen  ,
@@ -11396,8 +11396,8 @@
 #
 > After Gatsby’s death the East    was haunted for me        like        that    , distorted beyond my
 # J/P   N$       NPrSg D   NPrSg/J V   W?      C/P NPrSg/ISg NSg/V/J/C/P N/I/C/D . W?        NSg/P  D
-> eyes ’ power   of  correction . So        when    the blue    smoke of  brittle leaves was in          the
-# NPl  . NSg/V/J V/P NSg        . NSg/I/J/C NSg/I/C D   NSg/V/J NSg/V V/P NSg/V/J NPl    V   NPrSg/V/J/P D
+> eyes ’ power   of correction . So        when    the blue    smoke of brittle leaves was in          the
+# NPl  . NSg/V/J P  NSg        . NSg/I/J/C NSg/I/C D   NSg/V/J NSg/V P  NSg/V/J NPl    V   NPrSg/V/J/P D
 > air   and the wind  blew    the wet     laundry stiff   on  the line  I   decided to come    back
 # NSg/V V/C D   NSg/V NSg/V/J D   NSg/V/J NSg     NSg/V/J J/P D   NSg/V ISg NSg/V/J P  NSg/V/P NSg/V/J
 > home    .
@@ -11420,14 +11420,14 @@
 #
 > She was dressed to play  golf  , and I   remember thinking she looked like        a   good
 # ISg V   W?      P  NSg/V NSg/V . V/C ISg NSg/V    V        ISg W?     NSg/V/J/C/P D/P NPrSg/V/J
-> illustration , her   chin    raised a   little    jauntily , her   hair  the color      of  an  autumn
-# NSg          . I/J/D NPrSg/V W?     D/P NPrSg/I/J R        . I/J/D NSg/V D   NSg/V/J/Am V/P D/P NPrSg/V
+> illustration , her   chin    raised a   little    jauntily , her   hair  the color      of an  autumn
+# NSg          . I/J/D NPrSg/V W?     D/P NPrSg/I/J R        . I/J/D NSg/V D   NSg/V/J/Am P  D/P NPrSg/V
 > leaf  , her   face  the same brown     tint  as    the fingerless glove on  her   knee  . When    I
 # NSg/V . I/J/D NSg/V D   I/J  NPrSg/V/J NSg/V NSg/R D   ?          NSg/V J/P I/J/D NSg/V . NSg/I/C ISg
 > had finished she told me        without comment that    she was engaged to another man         . I
 # V   V/J      ISg V    NPrSg/ISg C/P     NSg/V   N/I/C/D ISg V   W?      P  I/D     NPrSg/I/V/J . ISg
-> doubted that    , though there were  several she could  have   married at        a   nod   of  her
-# W?      N/I/C/D . V/C    W?    NSg/V J/D     ISg NSg/VX NSg/VX NSg/V/J NSg/I/V/P D/P NSg/V V/P I/J/D
+> doubted that    , though there were  several she could  have   married at        a   nod   of her
+# W?      N/I/C/D . V/C    W?    NSg/V J/D     ISg NSg/VX NSg/VX NSg/V/J NSg/I/V/P D/P NSg/V P  I/J/D
 > head      , but     I   pretended to be     surprised . For just a   minute  I   wondered if    I   wasn’t
 # NPrSg/V/J . NSg/C/P ISg W?        P  NSg/VX W?        . C/P V/J  D/P NSg/V/J ISg W?       NSg/C ISg V
 > making a   mistake , then    I   thought it        all       over      again quickly and got up        to say
@@ -11460,8 +11460,8 @@
 #
 > “ You said a   bad     driver was only safe    until she met another bad     driver ? Well    , I
 # . IPl V/J  D/P NSg/V/J NSg/J  V   W?   NSg/V/J C/P   ISg V   I/D     NSg/V/J NSg/J  . NSg/V/J . ISg
-> met another bad     driver , didn’t I   ? I   mean    it        was careless of  me        to make  such  a
-# V   I/D     NSg/V/J NSg/J  . V      ISg . ISg NSg/V/J NPrSg/ISg V   J        V/P NPrSg/ISg P  NSg/V NSg/I D/P
+> met another bad     driver , didn’t I   ? I   mean    it        was careless of me        to make  such  a
+# V   I/D     NSg/V/J NSg/J  . V      ISg . ISg NSg/V/J NPrSg/ISg V   J        P  NPrSg/ISg P  NSg/V NSg/I D/P
 > wrong   guess . I   thought you were  rather    an  honest , straightforward person . I
 # NSg/V/J NSg/V . ISg NSg/V   IPl NSg/V NPrSg/V/J D/P V/J    . J               NSg/V  . ISg
 > thought it        was your secret  pride . ”
@@ -11480,16 +11480,16 @@
 # W?     V/J  .
 >
 #
-> One       afternoon late  in          October I   saw   Tom     Buchanan . He      was walking ahead of  me
-# NSg/I/V/J NSg       NSg/J NPrSg/V/J/P NPrSg/V ISg NSg/V NPrSg/V NPr      . NPr/ISg V   NSg/V/J W?    V/P NPrSg/ISg
+> One       afternoon late  in          October I   saw   Tom     Buchanan . He      was walking ahead of me
+# NSg/I/V/J NSg       NSg/J NPrSg/V/J/P NPrSg/V ISg NSg/V NPrSg/V NPr      . NPr/ISg V   NSg/V/J W?    P  NPrSg/ISg
 > along Fifth   Avenue in          his   alert   , aggressive way   , his   hands out         a   little    from his
 # P     NSg/V/J NSg    NPrSg/V/J/P ISg/D NSg/V/J . NSg/J      NSg/J . ISg/D NPl   NSg/V/J/R/P D/P NPrSg/I/J P    ISg/D
 > body  as    if    to fight off       interference , his   head      moving  sharply here    and there ,
 # NSg/V NSg/R NSg/C P  NSg/V NSg/V/J/P NSg/V        . ISg/D NPrSg/V/J NSg/V/J J/R     NSg/J/R V/C W?    .
 > adapting itself to his   restless eyes . Just as    I   slowed up        to avoid overtaking
 # V        I      P  ISg/D J        NPl  . V/J  NSg/R ISg W?     NSg/V/J/P P  V     V
-> him he      stopped and began frowning into the windows of  a   jewelry store . Suddenly
-# I   NPr/ISg V/J     V/C V     V        P    D   NPrPl   V/P D/P NSg/V   NSg/V . J/R
+> him he      stopped and began frowning into the windows of a   jewelry store . Suddenly
+# I   NPr/ISg V/J     V/C V     V        P    D   NPrPl   P  D/P NSg/V   NSg/V . J/R
 > he      saw   me        and walked back    , holding out         his   hand  .
 # NPr/ISg NSg/V NPrSg/ISg V/C W?     NSg/V/J . NSg/V   NSg/V/J/R/P ISg/D NSg/V .
 >
@@ -11498,8 +11498,8 @@
 # . N$     D   NSg/V/J . NPrSg/V . NSg/VX IPl NSg/V  P  V       NPl   P    NPrSg/ISg . .
 >
 #
-> “ Yes   . You know  what  I   think of  you . ”
-# . NSg/V . IPl NSg/V NSg/I ISg NSg/V V/P IPl . .
+> “ Yes   . You know  what  I   think of you . ”
+# . NSg/V . IPl NSg/V NSg/I ISg NSg/V P  IPl . .
 >
 #
 > “ You're crazy , Nick    , ” he      said quickly . “ Crazy as    hell    . I   don’t know  what’s the
@@ -11544,10 +11544,10 @@
 # NSg/V/J .
 >
 #
-> “ And if    you think I   didn’t have   my share of  suffering — look  here    , when    I   went  to
-# . V/C NSg/C IPl NSg/V ISg V      NSg/VX D  NSg/V V/P NSg/V/J   . NSg/V NSg/J/R . NSg/I/C ISg NSg/V P
-> give  up        that    flat    and saw   that    damn    box   of  dog     biscuits sitting there on  the
-# NSg/V NSg/V/J/P N/I/C/D NSg/V/J V/C NSg/V N/I/C/D NSg/V/J NSg/V V/P NSg/V/J NPl      NSg/V/J W?    J/P D
+> “ And if    you think I   didn’t have   my share of suffering — look  here    , when    I   went  to
+# . V/C NSg/C IPl NSg/V ISg V      NSg/VX D  NSg/V P  NSg/V/J   . NSg/V NSg/J/R . NSg/I/C ISg NSg/V P
+> give  up        that    flat    and saw   that    damn    box   of dog     biscuits sitting there on  the
+# NSg/V NSg/V/J/P N/I/C/D NSg/V/J V/C NSg/V N/I/C/D NSg/V/J NSg/V P  NSg/V/J NPl      NSg/V/J W?    J/P D
 > sideboard , I   sat     down      and cried like        a   baby    . By      God     it        was awful — ”
 # NSg/V     . ISg NSg/V/J NSg/V/J/P V/C W?    NSg/V/J/C/P D/P NSg/V/J . NSg/J/P NPrSg/V NPrSg/ISg V   J     . .
 >
@@ -11568,20 +11568,20 @@
 # ISg NSg/V/J NPl   P    I   . NPrSg/ISg W?     NSg/J NSg/C P  . C/P ISg NSg/V/J J/R      NSg/R V/C    ISg
 > were  talking to a   child . Then    he      went  into the jewelry store to buy   a   pearl
 # NSg/V V       P  D/P NSg/V . NSg/J/C NPr/ISg NSg/V P    D   NSg/V   NSg/V P  NSg/V D/P NPrSg/V
-> necklace — or      perhaps only a   pair  of  cuff  buttons — rid of  my provincial
-# NSg/V    . NPrSg/C NSg     W?   D/P NSg/V V/P NSg/V NPl     . V   V/P D  NSg/J
+> necklace — or      perhaps only a   pair  of cuff  buttons — rid of my provincial
+# NSg/V    . NPrSg/C NSg     W?   D/P NSg/V P  NSg/V NPl     . V   P  D  NSg/J
 > squeamishness forever .
 # NSg           NSg/J   .
 >
 #
 > Gatsby’s house   was still   empty   when    I   left      — the grass   on  his   lawn  had grown as
 # N$       NPrSg/V V   NSg/V/J NSg/V/J NSg/I/C ISg NPrSg/V/J . D   NPrSg/V J/P ISg/D NSg/V V   V/J   NSg/R
-> long      as    mine    . One       of  the taxi  drivers in          the village never took a   fare  past      the
-# NPrSg/V/J NSg/R NSg/I/V . NSg/I/V/J V/P D   NSg/V W?      NPrSg/V/J/P D   NSg     V     V    D/P NSg/V NSg/V/J/P D
+> long      as    mine    . One       of the taxi  drivers in          the village never took a   fare  past      the
+# NPrSg/V/J NSg/R NSg/I/V . NSg/I/V/J P  D   NSg/V W?      NPrSg/V/J/P D   NSg     V     V    D/P NSg/V NSg/V/J/P D
 > entrance gate  without stopping for a   minute  and pointing inside  ; perhaps it        was
 # NSg/V    NSg/V C/P     NSg/V    C/P D/P NSg/V/J V/C V        NSg/J/P . NSg     NPrSg/ISg V
-> he      who     drove Daisy and Gatsby over      to East    Egg   the night of  the accident , and
-# NPr/ISg NPrSg/I NSg/V NPrSg V/C NPr    NSg/V/J/P P  NPrSg/J NSg/V D   NSg/V V/P D   NSg/J    . V/C
+> he      who     drove Daisy and Gatsby over      to East    Egg   the night of the accident , and
+# NPr/ISg NPrSg/I NSg/V NPrSg V/C NPr    NSg/V/J/P P  NPrSg/J NSg/V D   NSg/V P  D   NSg/J    . V/C
 > perhaps he      had made  a   story about it        all       his   own     . I   didn’t want  to hear it        and I
 # NSg     NPr/ISg V   NSg/V D/P NSg/V J/P   NPrSg/ISg NSg/I/J/C ISg/D NSg/V/J . ISg V      NSg/V P  V    NPrSg/ISg V/C ISg
 > avoided him when    I   got off       the train .
@@ -11590,64 +11590,64 @@
 #
 > I   spent my Saturday nights in          New     York because those gleaming , dazzling parties
 # ISg V/J   D  NSg/V    NPl    NPrSg/V/J/P NSg/V/J NPr  C/P     I/D   V        . NSg/V/J  NPl
-> of  his   were  with me        so        vividly that    I   could  still   hear the music   and the
-# V/P ISg/D NSg/V P    NPrSg/ISg NSg/I/J/C J/R     N/I/C/D ISg NSg/VX NSg/V/J V    D   NSg/V/J V/C D
+> of his   were  with me        so        vividly that    I   could  still   hear the music   and the
+# P  ISg/D NSg/V P    NPrSg/ISg NSg/I/J/C J/R     N/I/C/D ISg NSg/VX NSg/V/J V    D   NSg/V/J V/C D
 > laughter , faint   and incessant , from his   garden  , and the cars going   up        and down
 # NSg      . NSg/V/J V/C J         . P    ISg/D NSg/V/J . V/C D   NPl  NSg/V/J NSg/V/J/P V/C NSg/V/J/P
 > his   drive . One       night I   did hear a   material car there , and saw   its   lights stop  at
 # ISg/D NSg/V . NSg/I/V/J NSg/V ISg V   V    D/P NSg/V/J  NSg W?    . V/C NSg/V ISg/D NPl    NSg/V NSg/I/V/P
 > his   front   steps . But     I   didn’t investigate . Probably it        was some  final   guest who
 # ISg/D NSg/V/J NPl   . NSg/C/P ISg V      V           . R        NPrSg/ISg V   I/J/R NSg/V/J NSg/V NPrSg/I
-> had been  away at        the ends of  the earth   and didn’t know  that    the party   was over      .
-# V   NSg/V V/J  NSg/I/V/P D   NPl  V/P D   NPrSg/V V/C V      NSg/V N/I/C/D D   NSg/V/J V   NSg/V/J/P .
+> had been  away at        the ends of the earth   and didn’t know  that    the party   was over      .
+# V   NSg/V V/J  NSg/I/V/P D   NPl  P  D   NPrSg/V V/C V      NSg/V N/I/C/D D   NSg/V/J V   NSg/V/J/P .
 >
 #
 > On  the last    night , with my trunk packed and my car sold  to the grocer , I   went
 # J/P D   NSg/V/J NSg/V . P    D  NSg/V W?     V/C D  NSg NSg/V P  D   NSg/V  . ISg NSg/V
-> over      and looked at        that    huge incoherent failure of  a   house   once  more        . On  the
-# NSg/V/J/P V/C W?     NSg/I/V/P N/I/C/D J    J          NSg     V/P D/P NPrSg/V NSg/C NPrSg/I/V/J . J/P D
-> white     steps an  obscene word  , scrawled by      some  boy   with a   piece of  brick   , stood
-# NPrSg/V/J NPl   D/P V/J     NSg/V . W?       NSg/J/P I/J/R NSg/V P    D/P NSg/V V/P NSg/V/J . V
+> over      and looked at        that    huge incoherent failure of a   house   once  more        . On  the
+# NSg/V/J/P V/C W?     NSg/I/V/P N/I/C/D J    J          NSg     P  D/P NPrSg/V NSg/C NPrSg/I/V/J . J/P D
+> white     steps an  obscene word  , scrawled by      some  boy   with a   piece of brick   , stood
+# NPrSg/V/J NPl   D/P V/J     NSg/V . W?       NSg/J/P I/J/R NSg/V P    D/P NSg/V P  NSg/V/J . V
 > out         clearly in          the moonlight , and I   erased it        , drawing my shoe  raspingly along
 # NSg/V/J/R/P J/R     NPrSg/V/J/P D   NSg/V     . V/C ISg W?     NPrSg/ISg . NSg/V   D  NSg/V ?         P
 > the stone     . Then    I   wandered down      to the beach   and sprawled out         on  the sand    .
 # D   NPrSg/V/J . NSg/J/C ISg W?       NSg/V/J/P P  D   NPrSg/V V/C W?       NSg/V/J/R/P J/P D   NSg/V/J .
 >
 #
-> Most    of  the big     shore places were  closed now         and there were  hardly any   lights
-# NSg/I/J V/P D   NSg/V/J NSg/V NPl    NSg/V W?     NPrSg/V/J/C V/C W?    NSg/V J/R    I/R/D NPl
-> except the shadowy , moving  glow  of  a   ferryboat across the Sound   . And as    the moon
-# V/C/P  D   J       . NSg/V/J NSg/V V/P D/P NSg       NSg/P  D   NSg/V/J . V/C NSg/R D   NPrSg/V
+> Most    of the big     shore places were  closed now         and there were  hardly any   lights
+# NSg/I/J P  D   NSg/V/J NSg/V NPl    NSg/V W?     NPrSg/V/J/C V/C W?    NSg/V J/R    I/R/D NPl
+> except the shadowy , moving  glow  of a   ferryboat across the Sound   . And as    the moon
+# V/C/P  D   J       . NSg/V/J NSg/V P  D/P NSg       NSg/P  D   NSg/V/J . V/C NSg/R D   NPrSg/V
 > rose      higher the inessential houses began to melt  away until gradually I   became
 # NPrSg/V/J J      D   NSg/J       NPl    V     P  NSg/V V/J  C/P   J/R       ISg V
-> aware of  the old   island here    that    flowered once  for Dutch     sailors ’ eyes — a   fresh   ,
-# V/J   V/P D   NSg/J NSg/V  NSg/J/R N/I/C/D W?       NSg/C C/P NPrSg/V/J NPl     . NPl  . D/P NSg/V/J .
-> green     breast of  the new     world . Its   vanished trees , the trees that    had made  way
-# NPrSg/V/J NSg/V  V/P D   NSg/V/J NSg/V . ISg/D W?       NPl   . D   NPl   N/I/C/D V   NSg/V NSg/J
+> aware of the old   island here    that    flowered once  for Dutch     sailors ’ eyes — a   fresh   ,
+# V/J   P  D   NSg/J NSg/V  NSg/J/R N/I/C/D W?       NSg/C C/P NPrSg/V/J NPl     . NPl  . D/P NSg/V/J .
+> green     breast of the new     world . Its   vanished trees , the trees that    had made  way
+# NPrSg/V/J NSg/V  P  D   NSg/V/J NSg/V . ISg/D W?       NPl   . D   NPl   N/I/C/D V   NSg/V NSg/J
 > for Gatsby’s house   , had once  pandered in          whispers to the last    and greatest of
-# C/P N$       NPrSg/V . V   NSg/C W?       NPrSg/V/J/P NPl      P  D   NSg/V/J V/C W?       V/P
+# C/P N$       NPrSg/V . V   NSg/C W?       NPrSg/V/J/P NPl      P  D   NSg/V/J V/C W?       P
 > all       human   dreams ; for a   transitory enchanted moment man         must  have   held his
 # NSg/I/J/C NSg/V/J NPl    . C/P D/P J          W?        NSg    NPrSg/I/V/J NSg/V NSg/VX V    ISg/D
-> breath  in          the presence of  this continent , compelled into an  esthetic
-# NSg/V/J NPrSg/V/J/P D   NSg/V    V/P I/D  NPrSg/J   . V/J       P    D/P ?
+> breath  in          the presence of this continent , compelled into an  esthetic
+# NSg/V/J NPrSg/V/J/P D   NSg/V    P  I/D  NPrSg/J   . V/J       P    D/P ?
 > contemplation he      neither understood nor   desired , face  to face  for the last    time
 # NSg           NPr/ISg I/C     V/J        NSg/C V/J     . NSg/V P  NSg/V C/P D   NSg/V/J NSg/V
 > in          history with something commensurate to his   capacity for wonder .
 # NPrSg/V/J/P NSg     P    NSg/I/V/J V/J          P  ISg/D NSg/J    C/P NSg/V  .
 >
 #
-> And as    I   sat     there brooding on  the old   , unknown world , I   thought of  Gatsby’s
-# V/C NSg/R ISg NSg/V/J W?    NSg/V/J  J/P D   NSg/J . NSg/V/J NSg/V . ISg NSg/V   V/P N$
-> wonder when    he      first   picked out         the green     light   at        the end   of  Daisy’s dock  . He
-# NSg/V  NSg/I/C NPr/ISg NSg/V/J W?     NSg/V/J/R/P D   NPrSg/V/J NSg/V/J NSg/I/V/P D   NSg/V V/P N$      NSg/V . NPr/ISg
+> And as    I   sat     there brooding on  the old   , unknown world , I   thought of Gatsby’s
+# V/C NSg/R ISg NSg/V/J W?    NSg/V/J  J/P D   NSg/J . NSg/V/J NSg/V . ISg NSg/V   P  N$
+> wonder when    he      first   picked out         the green     light   at        the end   of Daisy’s dock  . He
+# NSg/V  NSg/I/C NPr/ISg NSg/V/J W?     NSg/V/J/R/P D   NPrSg/V/J NSg/V/J NSg/I/V/P D   NSg/V P  N$      NSg/V . NPr/ISg
 > had come    a   long      way   to this blue    lawn  , and his   dream   must  have   seemed so        close
 # V   NSg/V/P D/P NPrSg/V/J NSg/J P  I/D  NSg/V/J NSg/V . V/C ISg/D NSg/V/J NSg/V NSg/VX W?     NSg/I/J/C NSg/V/J
 > that    he      could  hardly fail    to grasp it        . He      did not   know  that    it        was already
 # N/I/C/D NPr/ISg NSg/VX J/R    NSg/V/J P  NSg/V NPrSg/ISg . NPr/ISg V   NSg/C NSg/V N/I/C/D NPrSg/ISg V   W?
 > behind  him , somewhere back    in          that    vast  obscurity beyond the city , where the
 # NSg/J/P I   . NSg       NSg/V/J NPrSg/V/J/P N/I/C/D NSg/J NSg       NSg/P  D   NSg  . NSg/C D
-> dark    fields of  the republic rolled on  under   the night .
-# NSg/V/J NPrPl  V/P D   NSg/V/J  W?     J/P NSg/J/P D   NSg/V .
+> dark    fields of the republic rolled on  under   the night .
+# NSg/V/J NPrPl  P  D   NSg/V/J  W?     J/P NSg/J/P D   NSg/V .
 >
 #
 > Gatsby believed in          the green     light   , the orgastic future that    year by      year


### PR DESCRIPTION
# Description
According to wikionary, "of" can have the meaning of "have" in [Eye dialect](https://en.wiktionary.org/wiki/Appendix:Glossary#eye_dialect), a dialect of deliberate misspelling. Given how common the word "of" is in English, I believe it is more important to unambiguously tag "of" as a preposition than to support a deliberate misspelling. This will help prevent false positives in rules dealing with verbs.

# How Has This Been Tested?
See snapshots.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
