### PR TITLE
fix: prevent crash in PhrasalVerbAsCompoundNoun

### DIFF
--- a/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
+++ b/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
@@ -47,27 +47,25 @@ impl Linter for PhrasalVerbAsCompoundNoun {
                 continue;
             }
             let nountok_charsl = document.get_span_content(&token.span);
-            // * Can't contain a hyphen or space.
-            if nountok_charsl.contains(&'-') || nountok_charsl.contains(&' ') {
-                // This means Harper's tokenizer's concept of a word is different to what we expect
-                // or has changed since this code was written.
-                unreachable!();
-            }
-            // * Can't contain an apostrophe
-            if nountok_charsl.contains(&'\'') || nountok_charsl.contains(&'’') {
+            // * Can't contain space, hyphen or apostrophe
+            if nountok_charsl.contains(&' ')
+                || nountok_charsl.contains(&'-')
+                || nountok_charsl.contains(&'\'')
+                || nountok_charsl.contains(&'’')
+            {
                 continue;
             }
             // * Must end with the same letters as one of the particles used in phrasal verbs.
             let particle_endings: &[&[char]] = &[
-                &['a', 'r', 'o', 'u', 'n', 'd'][..],
-                &['b', 'a', 'c', 'k'][..],
-                &['d', 'o', 'w', 'n'][..],
-                &['i', 'n'][..],
-                &['o', 'n'][..],
-                &['o', 'f', 'f'][..],
-                &['o', 'u', 't'][..],
-                &['o', 'v', 'e', 'r'][..],
-                &['u', 'p'][..],
+                &['a', 'r', 'o', 'u', 'n', 'd'],
+                &['b', 'a', 'c', 'k'],
+                &['d', 'o', 'w', 'n'],
+                &['i', 'n'],
+                &['o', 'n'],
+                &['o', 'f', 'f'],
+                &['o', 'u', 't'],
+                &['o', 'v', 'e', 'r'],
+                &['u', 'p'],
             ];
 
             // * Must not be in the set of known false positives.

--- a/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
+++ b/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
@@ -369,4 +369,13 @@ mod tests {
             0,
         );
     }
+
+    #[test]
+    fn ignore_multi_word() {
+        assert_lint_count(
+            "I like this add-on!",
+            PhrasalVerbAsCompoundNoun::default(),
+            0,
+        );
+    }
 }


### PR DESCRIPTION
# Issues 
I noticed that Harper crashed with the following error:

```
thread 'main' panicked at harper-core\src\linting\phrasal_verb_as_compound_noun.rs:54:17:
internal error: entered unreachable code
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The VSC language server then repeatedly restarts and crashes until the following message pops up:

![image](https://github.com/user-attachments/assets/8913bbd1-b50a-4b97-887e-968e58999271)


# Description
The crash was caused by an `unreachable!` statement being very reachable. The dictionary contains some multi-word entries, which contain hyphens and spaces. The tokenizer seems to use this information to parse words like "add-on" as one token. This triggered the following code path:

```rs
            // * Can't contain a hyphen or space.
            if nountok_charsl.contains(&'-') || nountok_charsl.contains(&' ') {
                // This means Harper's tokenizer's concept of a word is different to what we expect
                // or has changed since this code was written.
                unreachable!();
            }
```

The fix is to *skip* tokens that contain these characters instead of crashing.

# How Has This Been Tested?
With a new test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
