### PR TITLE
fix: "towards" is a preposition

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -48466,7 +48466,8 @@ tourniquet/14MS
 tousle/41GDS
 tout/~14MDGS
 tow/~41SZGMDR
-toward/~+5S
+toward/~+5
+towards/~+
 towboat/1MS
 towel/~14JGSMD
 towelette/1SM

--- a/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
+++ b/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
@@ -2701,7 +2701,7 @@
 > mushroom , and raised herself to about two feet high    : even    then    she walked up
 # NSg/V/J  . V/C W?     I       P  J/P   NSg NSg  NSg/V/J . NSg/V/J NSg/J/C ISg W?     NSg/V/J/P
 > towards it        rather    timidly , saying to herself “ Suppose it        should be     raving  mad
-# NPl     NPrSg/ISg NPrSg/V/J J/R     . NSg/V  P  I       . V       NPrSg/ISg VX     NSg/VX NSg/V/J N/V/J
+# P       NPrSg/ISg NPrSg/V/J J/R     . NSg/V  P  I       . V       NPrSg/ISg VX     NSg/VX NSg/V/J N/V/J
 > after all       ! I   almost wish  I’d gone  to see   the Hatter instead ! ”
 # J/P   NSg/I/J/C . ISg NSg    NSg/V W?  V/J/P P  NSg/V D   NSg/V  W?      . .
 >


### PR DESCRIPTION
# Description
"towards" [is a preposition](https://en.wiktionary.org/wiki/towards#Preposition), but it was incorrectly tagged as noun plural.

# How Has This Been Tested?
See snapshots.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
