### PR TITLE
perf(core): `PlainEnglish` parser in `ExactPhrase`

### DIFF
--- a/harper-core/src/patterns/exact_phrase.rs
+++ b/harper-core/src/patterns/exact_phrase.rs
@@ -8,7 +8,7 @@ pub struct ExactPhrase {
 
 impl ExactPhrase {
     pub fn from_phrase(text: &str) -> Self {
-        let document = Document::new_markdown_default_curated(text);
+        let document = Document::new_plain_english_curated(text);
         Self::from_document(&document)
     }
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
Use the `PlainEnglish` rather than the `Markdown` parser in `ExactPhrase::from_phrase`.
<!-- Any details that you think are important to review this PR? -->
`SimilarToPhrase::from_phrase` already uses the `PlainEnglish` parser. I could well be wrong since I'm not too familiar with this part of the code, but I don't think we want to be parsing our phrases as markdown. A quick look through the callers of this function did not seem to indicate any need for markdown parsing.

(I noticed this when tinkering with `harper-cli` and seeing that the `Markdown::parse` function was being called multiple times even when parsing a file with the `PlainEnglish` parser.)

# How Has This Been Tested?
Quite possibly not well enough.
`cargo test` shows all tests still pass successfully.
I briefly tested `harper-ls` and `harper-cli` with the changes. I wasn't able to notice any new issues.
<!-- Please describe how you tested your changes. -->

# Checklist
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
