### PR TITLE
refactor: use `LSend` trait to simplify trait definitions

### DIFF
--- a/harper-core/src/parsers/mod.rs
+++ b/harper-core/src/parsers/mod.rs
@@ -11,17 +11,11 @@ pub use markdown::{Markdown, MarkdownOptions};
 pub use mask::Mask;
 pub use plain_english::PlainEnglish;
 
-use crate::{Token, TokenStringExt};
+use crate::{LSend, Token, TokenStringExt};
 
-#[cfg(not(feature = "concurrent"))]
-#[blanket(derive(Box, Rc))]
-pub trait Parser {
-    fn parse(&self, source: &[char]) -> Vec<Token>;
-}
-
-#[cfg(feature = "concurrent")]
-#[blanket(derive(Box, Arc))]
-pub trait Parser: Send + Sync {
+#[cfg_attr(feature = "concurrent", blanket(derive(Box, Arc)))]
+#[cfg_attr(not(feature = "concurrent"), blanket(derive(Box, Rc)))]
+pub trait Parser: LSend {
     fn parse(&self, source: &[char]) -> Vec<Token>;
 }
 

--- a/harper-core/src/patterns/mod.rs
+++ b/harper-core/src/patterns/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! See the page about [`SequencePattern`] for a concrete example of their use.
 
-use crate::{Document, Span, Token};
+use crate::{Document, LSend, Span, Token};
 
 mod all;
 mod any_pattern;
@@ -49,17 +49,9 @@ pub use word::Word;
 pub use word_pattern_group::WordPatternGroup;
 pub use word_set::WordSet;
 
-#[cfg(not(feature = "concurrent"))]
-#[blanket(derive(Rc, Arc))]
-pub trait Pattern {
-    /// Check if the pattern matches at the start of the given token slice.
-    ///
-    /// Returns the length of the match if successful, or `None` if not.
-    fn matches(&self, tokens: &[Token], source: &[char]) -> Option<usize>;
-}
-#[cfg(feature = "concurrent")]
-#[blanket(derive(Arc))]
-pub trait Pattern: Send + Sync {
+#[cfg_attr(feature = "concurrent", blanket(derive(Arc)))]
+#[cfg_attr(not(feature = "concurrent"), blanket(derive(Rc, Arc)))]
+pub trait Pattern: LSend {
     /// Check if the pattern matches at the start of the given token slice.
     ///
     /// Returns the length of the match if successful, or `None` if not.
@@ -79,9 +71,6 @@ impl<P> PatternExt for P
 where
     P: Pattern + ?Sized,
 {
-    fn find_all_matches(&self, tokens: &[Token], source: &[char]) -> Vec<Span> {
-        self.iter_matches(tokens, source).collect()
-    }
     fn iter_matches(&self, tokens: &[Token], source: &[char]) -> impl Iterator<Item = Span> {
         MatchIter::new(self, tokens, source)
     }
@@ -143,25 +132,9 @@ where
     }
 }
 
-#[cfg(feature = "concurrent")]
 impl<F> Pattern for F
 where
-    F: Fn(&Token, &[char]) -> bool,
-    F: Send + Sync,
-{
-    fn matches(&self, tokens: &[Token], source: &[char]) -> Option<usize> {
-        if self(tokens.first()?, source) {
-            Some(1)
-        } else {
-            None
-        }
-    }
-}
-
-#[cfg(not(feature = "concurrent"))]
-impl<F> Pattern for F
-where
-    F: Fn(&Token, &[char]) -> bool,
+    F: LSend + Fn(&Token, &[char]) -> bool,
 {
     fn matches(&self, tokens: &[Token], source: &[char]) -> Option<usize> {
         if self(tokens.first()?, source) {

--- a/harper-core/src/sync.rs
+++ b/harper-core/src/sync.rs
@@ -7,10 +7,10 @@ pub use std::sync::Arc as Lrc;
 pub trait LSend {}
 
 #[cfg(not(feature = "concurrent"))]
-impl<T> LSend for T {}
+impl<T: ?Sized> LSend for T {}
 
 #[cfg(feature = "concurrent")]
 pub trait LSend: Send + Sync {}
 
 #[cfg(feature = "concurrent")]
-impl<T: Send + Sync> LSend for T {}
+impl<T: Send + Sync + ?Sized> LSend for T {}


### PR DESCRIPTION
# Description
I found the `LSend` trait today and used it to simplify the trait definitions of `Pattern` and `Parser`

# How Has This Been Tested?
I just made sure that everything compiles. I also checked that tests runs.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
