### PR TITLE
Nominal phrase test helper

### DIFF
--- a/harper-core/src/patterns/nominal_phrase.rs
+++ b/harper-core/src/patterns/nominal_phrase.rs
@@ -38,6 +38,21 @@ mod tests {
     use super::NominalPhrase;
     use crate::{Document, Span, patterns::Pattern};
 
+    trait SpanVecExt {
+        fn to_strings(&self, doc: &Document) -> Vec<String>;
+    }
+    
+    impl SpanVecExt for Vec<Span> {
+        fn to_strings(&self, doc: &Document) -> Vec<String> {
+            self.iter()
+                .map(|sp| doc.get_tokens()[sp.start..sp.end]
+                    .iter()
+                    .map(|tok| doc.get_span_content_str(&tok.span))
+                    .collect::<String>())
+                .collect()
+        }
+    }
+
     #[test]
     fn simple_apple() {
         let doc = Document::new_markdown_default_curated("A red apple");
@@ -51,7 +66,7 @@ mod tests {
         let doc = Document::new_markdown_default_curated("A red apple with a long stem");
         let matches = NominalPhrase.find_all_matches_in_doc(&doc);
 
-        assert_eq!(matches, vec![Span::new(0, 5), Span::new(8, 13)])
+        assert_eq!(matches.to_strings(&doc), vec!["A red apple", "a long stem"])
     }
 
     #[test]
@@ -59,10 +74,7 @@ mod tests {
         let doc = Document::new_markdown_default_curated("An apple, a banana and a pear");
         let matches = NominalPhrase.find_all_matches_in_doc(&doc);
 
-        assert_eq!(
-            matches,
-            vec![Span::new(0, 3), Span::new(5, 8), Span::new(11, 14)]
-        )
+        assert_eq!(matches.to_strings(&doc), vec!["An apple", "a banana", "a pear"])
     }
 
     #[test]
@@ -84,15 +96,6 @@ mod tests {
 
         dbg!(&matches);
 
-        assert_eq!(
-            matches,
-            vec![
-                Span::new(0, 5),
-                Span::new(8, 9),
-                Span::new(11, 12),
-                Span::new(14, 15),
-                Span::new(18, 19)
-            ]
-        )
+        assert_eq!(matches.to_strings(&doc), vec!["My favorite foods", "pizza", "sushi", "tacos", "burgers"])
     }
 }

--- a/harper-core/src/patterns/nominal_phrase.rs
+++ b/harper-core/src/patterns/nominal_phrase.rs
@@ -41,14 +41,16 @@ mod tests {
     trait SpanVecExt {
         fn to_strings(&self, doc: &Document) -> Vec<String>;
     }
-    
+
     impl SpanVecExt for Vec<Span> {
         fn to_strings(&self, doc: &Document) -> Vec<String> {
             self.iter()
-                .map(|sp| doc.get_tokens()[sp.start..sp.end]
-                    .iter()
-                    .map(|tok| doc.get_span_content_str(&tok.span))
-                    .collect::<String>())
+                .map(|sp| {
+                    doc.get_tokens()[sp.start..sp.end]
+                        .iter()
+                        .map(|tok| doc.get_span_content_str(&tok.span))
+                        .collect::<String>()
+                })
                 .collect()
         }
     }
@@ -58,7 +60,7 @@ mod tests {
         let doc = Document::new_markdown_default_curated("A red apple");
         let matches = NominalPhrase.find_all_matches_in_doc(&doc);
 
-        assert_eq!(matches, vec![Span::new(0, 5)])
+        assert_eq!(matches.to_strings(&doc), vec!["A red apple"])
     }
 
     #[test]
@@ -74,7 +76,10 @@ mod tests {
         let doc = Document::new_markdown_default_curated("An apple, a banana and a pear");
         let matches = NominalPhrase.find_all_matches_in_doc(&doc);
 
-        assert_eq!(matches.to_strings(&doc), vec!["An apple", "a banana", "a pear"])
+        assert_eq!(
+            matches.to_strings(&doc),
+            vec!["An apple", "a banana", "a pear"]
+        )
     }
 
     #[test]
@@ -95,7 +100,16 @@ mod tests {
         let matches = NominalPhrase.find_all_matches_in_doc(&doc);
 
         dbg!(&matches);
+        dbg!(matches.to_strings(&doc));
 
-        assert_eq!(matches.to_strings(&doc), vec!["My favorite foods", "pizza", "sushi", "tacos", "burgers"])
+        for span in &matches {
+            let gc = span.get_content(doc.get_source());
+            dbg!(gc);
+        }
+
+        assert_eq!(
+            matches.to_strings(&doc),
+            vec!["My favorite foods", "pizza", "sushi", "tacos", "burgers"]
+        )
     }
 }


### PR DESCRIPTION
# Issues
Related to #1226 

# Description

This PR introduces a helper function in the test section of `nominal_phrase.rs` that allows assertions on matching a sequence of strings.

Currently tests are opaque as you have to compare the results against a collection of numbers which represent offsets into a slice of `Token`s but use `Span`, which is documented as representing a slice of `char`s.

See related issue #1226

One function used `dbg!` to output the resulting set of spans. I left it in but added a debug to also output the set of strings. If either or both of these should go, let me know.

# How to Has This Been Tested?

All tests still pass. I didn't introduce any new tests but converted the ones using numbers to use strings.
For instance:
```rs
    #[test]
    fn complex_apple() {
        let doc = Document::new_markdown_default_curated("A red apple with a long stem");
        let matches = NominalPhrase.find_all_matches_in_doc(&doc);

        assert_eq!(matches.to_strings(&doc), vec!["A red apple", "a long stem"])
    }
```
Previously required this:
```rs
        assert_eq!(matches, vec![Span::new(0, 5), Span::new(8, 13)])
```

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
