### PR TITLE
test: add snapshots for linters

### DIFF
--- a/harper-core/tests/linters.rs
+++ b/harper-core/tests/linters.rs
@@ -1,0 +1,237 @@
+//! This test creats snapshots of the reports of all linters.
+//!
+//! # Usage
+//!
+//! To add a new snapshot, simply add the document to `tests/text` and run this
+//! test. It will automatically create a new snapshot in `tests/text/linters`.
+//! To update an existing snapshot, also just run this test.
+//!
+//! Note: This test will fail if the snapshot files are not up to date. This
+//! ensures that CI will fail if linters change their behavior.
+
+use harper_core::{
+    Dialect, Document, FstDictionary,
+    linting::{LintGroup, Linter},
+};
+
+mod snapshot;
+
+struct LinePos {
+    /// 0-based index of the line
+    pub line: usize,
+    /// 0-based index of the column
+    pub col: usize,
+}
+
+struct Lines<'a> {
+    lines: Vec<&'a str>,
+    offsets: Vec<usize>,
+}
+impl Lines<'_> {
+    fn new(source: &str) -> Lines {
+        let lines: Vec<&str> = source.split('\n').collect();
+        let offsets: Vec<usize> = lines
+            .iter()
+            .scan(0, |offset, line| {
+                let old_offset = *offset;
+                *offset += line.chars().count() + 1;
+                Some(old_offset)
+            })
+            .collect();
+
+        Lines { lines, offsets }
+    }
+
+    fn len(&self) -> usize {
+        self.lines.len()
+    }
+
+    fn get_pos(&self, offset: usize) -> LinePos {
+        let line_index = self
+            .offsets
+            .binary_search(&offset)
+            .unwrap_or_else(|x| x - 1);
+
+        LinePos {
+            line: line_index,
+            col: offset - self.offsets[line_index],
+        }
+    }
+}
+impl<'a> std::ops::Index<usize> for Lines<'a> {
+    type Output = &'a str;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.lines[index]
+    }
+}
+
+fn print_error(lines: &Lines, start: usize, end: usize, message: &str) -> String {
+    let mut out = String::new();
+
+    fn print_line(out: &mut String, line: &str, number: usize) {
+        out.push_str(&format!("{number:>6} | {line}\n"));
+    }
+
+    fn is_sentence_boundary(c: char) -> bool {
+        matches!(c, '.' | '?' | '!' | ':' | ';')
+    }
+    fn print_pre_line_context(
+        out: &mut String,
+        context_line: &str,
+        number: usize,
+        line: &str,
+        start_col: usize,
+    ) {
+        if context_line.is_empty() {
+            return;
+        }
+        if start_col > 40 {
+            // that's enough context
+            return;
+        }
+
+        let last_char = context_line.chars().last().unwrap();
+        let mut chars_before = line.chars().take(start_col);
+        if !is_sentence_boundary(last_char) && !chars_before.any(is_sentence_boundary) {
+            print_line(out, context_line, number);
+        }
+    }
+    fn print_post_line_context(
+        out: &mut String,
+        context_line: &str,
+        number: usize,
+        line: &str,
+        end_col: usize,
+    ) {
+        if context_line.is_empty() {
+            return;
+        }
+        if end_col < 40 {
+            // that's enough context
+            return;
+        }
+
+        let mut chars_after = line.chars().skip(end_col);
+        if !chars_after.any(is_sentence_boundary) {
+            print_line(out, context_line, number);
+        }
+    }
+
+    fn print_underline(
+        out: &mut String,
+        start_col: usize,
+        end_col: usize,
+        continuation: bool,
+        message: &str,
+    ) {
+        out.push_str("       | ");
+        for _ in 0..start_col {
+            out.push(' ');
+        }
+        out.push(if continuation { '~' } else { '^' });
+        for _ in 0..end_col.saturating_sub(start_col) {
+            out.push('~');
+        }
+
+        if !message.is_empty() {
+            out.push(' ');
+            out.push_str(message);
+        }
+        out.push('\n');
+    }
+
+    let start = lines.get_pos(start);
+    let end = lines.get_pos(end - 1);
+
+    if start.line > 0 {
+        print_pre_line_context(
+            &mut out,
+            lines[start.line - 1],
+            start.line,
+            lines[start.line],
+            start.col,
+        );
+    }
+
+    if start.line == end.line {
+        print_line(&mut out, lines[start.line], start.line + 1);
+        print_underline(&mut out, start.col, end.col, false, message);
+    } else {
+        for i in start.line..end.line {
+            let line = lines[i];
+            print_line(&mut out, line, i + 1);
+            print_underline(
+                &mut out,
+                if i == start.line { start.col } else { 0 },
+                line.chars().count(),
+                i != start.line,
+                "",
+            );
+        }
+
+        print_line(&mut out, lines[end.line], end.line + 1);
+        print_underline(&mut out, 0, end.col, true, message);
+    }
+
+    if end.line + 1 < lines.len() {
+        print_post_line_context(
+            &mut out,
+            lines[end.line + 1],
+            end.line + 2,
+            lines[end.line],
+            end.col,
+        );
+    }
+
+    out
+}
+
+#[test]
+fn test_most_lints() {
+    snapshot::snapshot_all_text_files("linters", ".snap.yml", |source| {
+        let dict = FstDictionary::curated();
+        let document = Document::new_markdown_default(source, &dict);
+
+        let mut linter = LintGroup::new_curated(dict, Dialect::American);
+
+        let mut lints = linter.lint(&document);
+        lints.sort_by(|a, b| {
+            a.span
+                .start
+                .cmp(&b.span.start)
+                .then(a.span.end.cmp(&b.span.end))
+        });
+
+        // split the input document into lines
+        let lines = Lines::new(source);
+
+        let mut out = String::new();
+
+        for lint in lints {
+            out.push_str(&format!(
+                "Lint:    {:?} ({} priority)\n",
+                lint.lint_kind, lint.priority
+            ));
+
+            let message = print_error(&lines, lint.span.start, lint.span.end, &lint.message);
+            out.push_str("Message: |\n");
+            for l in message.lines() {
+                out.push_str("  ");
+                out.push_str(l);
+                out.push('\n');
+            }
+
+            if !lint.suggestions.is_empty() {
+                out.push_str("Suggest:\n");
+                for suggestion in &lint.suggestions {
+                    out.push_str(&format!("  - {}\n", suggestion));
+                }
+            }
+
+            out.push_str("\n\n\n");
+        }
+
+        out
+    });
+}

--- a/harper-core/tests/snapshot.rs
+++ b/harper-core/tests/snapshot.rs
@@ -1,0 +1,81 @@
+use std::path::{Path, PathBuf};
+
+fn get_tests_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests")
+}
+fn get_text_dir() -> PathBuf {
+    get_tests_dir().join("text")
+}
+
+pub fn get_text_files() -> Vec<PathBuf> {
+    let mut files = vec![];
+    for entry in std::fs::read_dir(get_text_dir())
+        .unwrap()
+        .filter_map(|f| f.ok())
+        .filter(|f| f.metadata().unwrap().is_file())
+    {
+        let path = entry.path();
+        let ext = path
+            .extension()
+            .map(|e| e.to_string_lossy().to_string())
+            .unwrap_or_default();
+        if matches!(ext.as_str(), "txt" | "md") {
+            files.push(entry.path());
+        }
+    }
+    files
+}
+
+fn tag_file(
+    text_file: &Path,
+    snapshot_file: &Path,
+    create_snapshot: impl Fn(&str) -> String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let source = std::fs::read_to_string(text_file)?.replace("\r\n", "\n");
+    let tagged = create_snapshot(source.trim_end());
+
+    // compare with snapshot
+    let has_snapshot = snapshot_file.exists();
+    if has_snapshot {
+        let snapshot = std::fs::read_to_string(snapshot_file)?;
+        if tagged == snapshot {
+            return Ok(());
+        }
+    }
+
+    // write snapshot
+    std::fs::write(snapshot_file, tagged)?;
+
+    Err(if has_snapshot {
+        "Snapshot mismatches!".into()
+    } else {
+        "No snapshot!".into()
+    })
+}
+fn get_snapshot_file(text_file: &Path, snapshot_dir: &Path, ext: &str) -> PathBuf {
+    let snapshot_name = text_file.file_stem().unwrap().to_string_lossy().to_string() + ext;
+    snapshot_dir.join(snapshot_name)
+}
+#[allow(dead_code)]
+pub fn snapshot_all_text_files(
+    out_dir: &str,
+    snapshot_ext: &str,
+    create_snapshot: impl Copy + Fn(&str) -> String,
+) {
+    let snapshot_dir = get_text_dir().join(out_dir);
+    std::fs::create_dir_all(&snapshot_dir).expect("Failed to create snapshot directory");
+
+    let mut errors = 0;
+    for text_file in get_text_files() {
+        println!("Processing {}", text_file.display());
+        let snapshot_file = get_snapshot_file(&text_file, &snapshot_dir, snapshot_ext);
+        if let Err(e) = tag_file(&text_file, &snapshot_file, create_snapshot) {
+            eprintln!("Error processing {}: {}", text_file.display(), e);
+            errors += 1;
+        }
+    }
+
+    if errors > 0 {
+        panic!("{} errors occurred while processing files", errors);
+    }
+}

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -1,0 +1,3675 @@
+Lint:    Readability (127 priority)
+Message: |
+       9 | Alice was beginning to get very tired of sitting by her sister on the bank, and
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      10 | of having nothing to do: once or twice she had peeped into the book her sister
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      11 | was reading, but it had no pictures or conversations in it, “and what is the use
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      12 | of a book,” thought Alice “without pictures or conversations?”
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 57 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      14 | So she was considering in her own mind (as well as she could, for the hot day
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      15 | made her feel very sleepy and stupid), whether the pleasure of making a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      16 | daisy-chain would be worth the trouble of getting up and picking the daisies,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      17 | when suddenly a White Rabbit with pink eyes ran close by her.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 56 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      21 | be late!” (when she thought it over afterwards, it occurred to her that she
+         |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      22 | ought to have wondered at this, but at the time it all seemed quite natural);
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      23 | but when the Rabbit actually took a watch out of its waistcoat-pocket, and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      24 | looked at it, and then hurried on, Alice started to her feet, for it flashed
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      25 | across her mind that she had never before seen a rabbit with either a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      26 | waistcoat-pocket, or a watch to take out of it, and burning with curiosity, she
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      27 | ran across the field after it, and fortunately was just in time to see it pop
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      28 | down a large rabbit-hole under the hedge.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 109 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      21 | be late!” (when she thought it over afterwards, it occurred to her that she
+         |                                     ^~~~~~~~~~ Did you mean to spell “afterwards” this way?
+      22 | ought to have wondered at this, but at the time it all seemed quite natural);
+Suggest:
+  - Replace with: “afterward”
+  - Replace with: “afterwords”
+  - Replace with: “afterword's”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      39 | next. First, she tried to look down and make out what she was coming to, but it
+         |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      40 | was too dark to see anything; then she looked at the sides of the well, and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      41 | noticed that they were filled with cupboards and book-shelves; here and there
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      42 | she saw maps and pictures hung upon pegs. She took down a jar from one of the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 53 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      42 | she saw maps and pictures hung upon pegs. She took down a jar from one of the
+         |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      43 | shelves as she passed; it was labelled “ORANGE MARMALADE”, but to her great
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      44 | disappointment it was empty: she did not like to drop the jar for fear of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      45 | killing somebody underneath, so managed to put it into one of the cupboards as
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      46 | she fell past it.
+         | ~~~~~~~~~~~~~~~~~ This sentence is 55 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      43 | shelves as she passed; it was labelled “ORANGE MARMALADE”, but to her great
+         |                               ^~~~~~~~ Did you mean to spell “labelled” this way?
+Suggest:
+  - Replace with: “labeled”
+  - Replace with: “labeler”
+  - Replace with: “labelless”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      54 | I’ve fallen by this time?” she said aloud. “I must be getting somewhere near the
+      55 | centre of the earth. Let me see: that would be four thousand miles down, I
+         | ^~~~~~ Did you mean to spell “centre” this way?
+Suggest:
+  - Replace with: “centred”
+  - Replace with: “centres”
+  - Replace with: “censure”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      55 | centre of the earth. Let me see: that would be four thousand miles down, I
+         |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      56 | think—” (for, you see, Alice had learnt several things of this sort in her
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      57 | lessons in the schoolroom, and though this was not a very good opportunity for
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      58 | showing off her knowledge, as there was no one to listen to her, still it was
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      59 | good practice to say it over) “—yes, that’s about the right distance—but then I
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      60 | wonder what Latitude or Longitude I’ve got to?” (Alice had no idea what Latitude
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 78 words long.
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+      57 | lessons in the schoolroom, and though this was not a very good opportunity for
+         |                                                      ^~~~~~~~~ Vocabulary enhancement: use `excellent` instead of `very good`
+      58 | showing off her knowledge, as there was no one to listen to her, still it was
+Suggest:
+  - Replace with: “excellent”
+
+
+
+Lint:    WordChoice (31 priority)
+Message: |
+      67 | have to ask them what the name of the country is, you know. Please, Ma’am, is
+      68 | this New Zealand or Australia?” (and she tried to curtsey as she spoke—fancy
+         |      ^~~ Did you mean “knew” (the past tense of “know”)?
+Suggest:
+  - Replace with: “Knew”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      68 | this New Zealand or Australia?” (and she tried to curtsey as she spoke—fancy
+         |                                                   ^~~~~~~ Did you mean to spell “curtsey” this way?
+      69 | curtseying as you’re falling through the air! Do you think you could manage it?)
+Suggest:
+  - Replace with: “curtsy”
+  - Replace with: “curse”
+  - Replace with: “cursed”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      68 | this New Zealand or Australia?” (and she tried to curtsey as she spoke—fancy
+      69 | curtseying as you’re falling through the air! Do you think you could manage it?)
+         | ^~~~~~~~~~ Did you mean “curtsying”?
+Suggest:
+  - Replace with: “curtsying”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      74 | again. “Dinah’ll miss me very much to-night, I should think!” (Dinah was the
+         |         ^~~~~~~~ Did you mean to spell “Dinah’ll” this way?
+Suggest:
+  - Replace with: “Dinah's”
+  - Replace with: “Dina's”
+  - Replace with: “Dinah”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+      84 | ever eat a bat?” when suddenly, thump! thump! down she came upon a heap of
+         |                                        ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “T”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+      84 | ever eat a bat?” when suddenly, thump! thump! down she came upon a heap of
+         |                                               ^ This sentence does not start with a capital letter
+      85 | sticks and dry leaves, and the fall was over.
+Suggest:
+  - Replace with: “D”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      87 | Alice was not a bit hurt, and she jumped up on to her feet in a moment: she
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      88 | looked up, but it was all dark overhead; before her was another long passage,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      89 | and the White Rabbit was still in sight, hurrying down it. There was not a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      96 | There were doors all round the hall, but they were all locked; and when Alice
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      97 | had been all the way down one side and up the other, trying every door, she
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      98 | walked sadly down the middle, wondering how she was ever to get out again.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 45 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     100 | Suddenly she came upon a little three-legged table, all made of solid glass;
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     101 | there was nothing on it except a tiny golden key, and Alice’s first thought was
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     102 | that it might belong to one of the doors of the hall; but, alas! either the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     102 | that it might belong to one of the doors of the hall; but, alas! either the
+         |                                                                  ^ This sentence does not start with a capital letter
+     103 | locks were too large, or the key was too small, but at any rate it would not
+Suggest:
+  - Replace with: “E”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     104 | open any of them. However, on the second time round, she came upon a low curtain
+         |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     105 | she had not noticed before, and behind it was a little door about fifteen inches
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     106 | high: she tried the little golden key in the lock, and to her great delight it
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     107 | fitted!
+         | ~~~~~~~ This sentence is 44 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     111 | loveliest garden you ever saw. How she longed to get out of that dark hall, and
+         |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     112 | wander about among those beds of bright flowers and those cool fountains, but
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     113 | she could not even get her head through the doorway; “and even if my head would
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     114 | go through,” thought poor Alice, “it would be of very little use without my
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     115 | shoulders. Oh, how I wish I could shut up like a telescope! I think I could, if
+         | ~~~~~~~~~~ This sentence is 55 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     120 | There seemed to be no use in waiting by the little door, so she went back to the
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     121 | table, half hoping she might find another key on it, or at any rate a book of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     122 | rules for shutting people up like telescopes: this time she found a little
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     123 | bottle on it, (“which certainly was not here before,” said Alice,) and round the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     124 | neck of the bottle was a paper label, with the words “DRINK ME,” beautifully
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     125 | printed on it in large letters.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 82 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     128 | to do that in a hurry. “No, I’ll look first,” she said, “and see whether it’s
+         |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     129 | marked ‘poison’ or not”; for she had read several nice little histories about
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     130 | children who had got burnt, and eaten up by wild beasts and other unpleasant
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     131 | things, all because they would not remember the simple rules their friends had
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     132 | taught them: such as, that a red-hot poker will burn you if you hold it too
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     133 | long; and that if you cut your finger very deeply with a knife, it usually
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     134 | bleeds; and she had never forgotten that, if you drink much from a bottle marked
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     135 | “poison,” it is almost certain to disagree with you, sooner or later.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 109 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     137 | However, this bottle was not marked “poison,” so Alice ventured to taste it, and
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     138 | finding it very nice, (it had, in fact, a sort of mixed flavour of cherry-tart,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     139 | custard, pine-apple, roast turkey, toffee, and hot buttered toast,) she very
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     140 | soon finished it off.
+         | ~~~~~~~~~~~~~~~~~~~~~ This sentence is 46 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     138 | finding it very nice, (it had, in fact, a sort of mixed flavour of cherry-tart,
+         |                                                         ^~~~~~~ Did you mean to spell “flavour” this way?
+     139 | custard, pine-apple, roast turkey, toffee, and hot buttered toast,) she very
+Suggest:
+  - Replace with: “flavor”
+  - Replace with: “flavours”
+  - Replace with: “favor”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     146 | door into that lovely garden. First, however, she waited for a few minutes to
+         |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     147 | see if she was going to shrink any further: she felt a little nervous about
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     148 | this; “for it might end, you know,” said Alice to herself, “in my going out
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     149 | altogether, like a candle. I wonder what I should be like then?” And she tried
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Style (63 priority)
+Message: |
+     149 | altogether, like a candle. I wonder what I should be like then?” And she tried
+     150 | to fancy what the flame of a candle is like after the candle is blown out, for
+         |                   ^~~~~~~~~~ The word `of` is not needed here.
+Suggest:
+  - Replace with: “flame a”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     154 | garden at once; but, alas for poor Alice! when she got to the door, she found
+         |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     155 | she had forgotten the little golden key, and when she went back to the table for
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     156 | it, she found she could not possibly reach it: she could see it quite plainly
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     157 | through the glass, and she tried her best to climb up one of the legs of the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     158 | table, but it was too slippery; and when she had tired herself out with trying,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     159 | the poor little thing sat down and cried.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 79 words long.
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     154 | garden at once; but, alas for poor Alice! when she got to the door, she found
+         |                                           ^ This sentence does not start with a capital letter
+     155 | she had forgotten the little golden key, and when she went back to the table for
+Suggest:
+  - Replace with: “W”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     162 | sharply; “I advise you to leave off this minute!” She generally gave herself
+         |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     163 | very good advice, (though she very seldom followed it), and sometimes she
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     164 | scolded herself so severely as to bring tears into her eyes; and once she
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     165 | remembered trying to box her own ears for having cheated herself in a game of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     166 | croquet she was playing against herself, for this curious child was very fond of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     167 | pretending to be two people. “But it’s no use now,” thought poor Alice, “to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 64 words long.
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+     162 | sharply; “I advise you to leave off this minute!” She generally gave herself
+     163 | very good advice, (though she very seldom followed it), and sometimes she
+         | ^~~~~~~~~ Vocabulary enhancement: use `excellent` instead of `very good`
+Suggest:
+  - Replace with: “excellent”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     173 | beautifully marked in currants. “Well, I’ll eat it,” said Alice, “and if it
+         |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     174 | makes me grow larger, I can reach the key; and if it makes me grow smaller, I
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     175 | can creep under the door; so either way I’ll get into the garden, and I don’t
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     176 | care which happens!”
+         | ~~~~~~~~~~~~~~~~~~~ This sentence is 45 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     178 | She ate a little bit, and said anxiously to herself, “Which way? Which way?”,
+         |                                                                            ^~~
+     179 | holding her hand on the top of her head to feel which way it was growing, and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     180 | she was quite surprised to find that she remained the same size: to be sure,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     181 | this generally happens when one eats cake, but Alice had got so much into the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     182 | way of expecting nothing but out-of-the-way things to happen, that it seemed
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     183 | quite dull and stupid for life to go on in the common way.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 75 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     189 | “Curiouser and curiouser!” cried Alice (she was so much surprised, that for the
+         |  ^~~~~~~~~ Did you mean to spell “Curiouser” this way?
+Suggest:
+  - Replace with: “Curious”
+  - Replace with: “Carouser”
+  - Replace with: “Curiously”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     189 | “Curiouser and curiouser!” cried Alice (she was so much surprised, that for the
+         |                ^~~~~~~~~ Did you mean to spell “curiouser” this way?
+Suggest:
+  - Replace with: “curious”
+  - Replace with: “carouser”
+  - Replace with: “curiously”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     194 | stockings for you now, dears? I’m sure I shan’t be able! I shall be a great deal
+         |                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~
+     195 | too far off to trouble myself about you: you must manage the best way you
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     196 | can;—but I must be kind to them,” thought Alice, “or perhaps they won’t walk the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     197 | way I want to go! Let me see: I’ll give them a new pair of boots every
+         | ~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     226 | himself as he came, “Oh! the Duchess, the Duchess! Oh! won’t she be savage if
+         |                          ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “T”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     226 | himself as he came, “Oh! the Duchess, the Duchess! Oh! won’t she be savage if
+         |                                                        ^ This sentence does not start with a capital letter
+     227 | I’ve kept her waiting!” Alice felt so desperate that she was ready to ask help
+Suggest:
+  - Replace with: “W”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     227 | I’ve kept her waiting!” Alice felt so desperate that she was ready to ask help
+         |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     228 | of any one; so, when the Rabbit came near her, she began, in a low, timid voice,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     229 | “If you please, sir—” The Rabbit started violently, dropped the white kid gloves
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     230 | and the fan, and skurried away into the darkness as hard as he could go.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 56 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     229 | “If you please, sir—” The Rabbit started violently, dropped the white kid gloves
+     230 | and the fan, and skurried away into the darkness as hard as he could go.
+         |                  ^~~~~~~~ Did you mean to spell “skurried” this way?
+Suggest:
+  - Replace with: “scurried”
+  - Replace with: “spurred”
+  - Replace with: “scurries”
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+     238 | puzzle!” And she began thinking over all the children she knew that were of the
+         |                                 ^~~~~~~~ Did you mean the closed compound `overall`?
+Suggest:
+  - Replace with: “overall”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     249 | Rome—no, that’s all wrong, I’m certain! I must have been changed for Mabel! I’ll
+         |                                                                            ^~~~~~
+     250 | try and say ‘How doth the little—’” and she crossed her hands on her lap as if
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     251 | she were saying lessons, and began to repeat it, but her voice sounded hoarse
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 47 words long.
+     252 | and strange, and the words did not come the same as they used to do:—
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     260 | “I’m sure those are not the right words,” said poor Alice, and her eyes filled
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     261 | with tears again as she went on, “I must be Mabel after all, and I shall have to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     262 | go and live in that poky little house, and have next to no toys to play with,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     263 | and oh! ever so many lessons to learn! No, I’ve made up my mind about it; if I’m
+         | ~~~~~~~ This sentence is 52 words long.
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     263 | and oh! ever so many lessons to learn! No, I’ve made up my mind about it; if I’m
+         |         ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “E”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     273 | “How can I have done that?” she thought. “I must be growing small again.” She
+         |                                                                         ^~~~~~
+     274 | got up and went to the table to measure herself by it, and found that, as nearly
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     275 | as she could guess, she was now about two feet high, and was going on shrinking
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     276 | rapidly: she soon found out that the cause of this was the fan she was holding,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     277 | and she dropped it hastily, just in time to avoid shrinking away altogether.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 63 words long.
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     281 | garden!” and she ran with all speed back to the little door: but, alas! the
+         |                                                                         ^ This sentence does not start with a capital letter
+     282 | little door was shut again, and the little golden key was lying on the glass
+Suggest:
+  - Replace with: “T”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     287 | As she said these words her foot slipped, and in another moment, splash! she was
+         |                                                                          ^ This sentence does not start with a capital letter
+     288 | up to her chin in salt water. Her first idea was that she had somehow fallen
+Suggest:
+  - Replace with: “S”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     289 | into the sea, “and in that case I can go back by railway,” she said to herself.
+         |                                                                                ^
+     290 | (Alice had been to the seaside once in her life, and had come to the general
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     291 | conclusion, that wherever you go to on the English coast you find a number of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     292 | bathing machines in the sea, some children digging in the sand with wooden
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     293 | spades, then a row of lodging houses, and behind them a railway station.)
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 57 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     302 | Just then she heard something splashing about in the pool a little way off, and
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     303 | she swam nearer to make out what it was: at first she thought it must be a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     304 | walrus or hippopotamus, but then she remembered how small she was now, and she
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     305 | soon made out that it was only a mouse that had slipped in like herself.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 61 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     311 | Mouse!” (Alice thought this must be the right way of speaking to a mouse: she
+         |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     312 | had never done such a thing before, but she remembered having seen in her
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     313 | brother’s Latin Grammar, “A mouse—of a mouse—to a mouse—a mouse—O mouse!”) The
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     320 | she began again: “Où est ma chatte?” which was the first sentence in her French
+         |                   ^~ Did you mean to spell “Où” this way?
+Suggest:
+  - Replace with: “Os”
+  - Replace with: “O”
+  - Replace with: “OD”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     320 | she began again: “Où est ma chatte?” which was the first sentence in her French
+         |                      ^~~ Did you mean to spell “est” this way?
+Suggest:
+  - Replace with: “east”
+  - Replace with: “eat”
+  - Replace with: “esp”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     320 | she began again: “Où est ma chatte?” which was the first sentence in her French
+         |                             ^~~~~~ Did you mean to spell “chatte” this way?
+Suggest:
+  - Replace with: “chatty”
+  - Replace with: “chaste”
+  - Replace with: “chatted”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     330 | cats if you could only see her. She is such a dear quiet thing,” Alice went on,
+         |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     331 | half to herself, as she swam lazily about in the pool, “and she sits purring so
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     332 | nicely by the fire, licking her paws and washing her face—and she is such a nice
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     333 | soft thing to nurse—and she’s such a capital one for catching mice—oh, I beg
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     334 | your pardon!” cried Alice again, for this time the Mouse was bristling all over,
+         | ~~~~~~~~~~~~ This sentence is 61 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     346 | curly brown hair! And it’ll fetch things when you throw them, and it’ll sit up
+         |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     347 | and beg for its dinner, and all sorts of things—I can’t remember half of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     348 | them—and it belongs to a farmer, you know, and he says it’s so useful, it’s
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     349 | worth a hundred pounds! He says it kills all the rats and—oh dear!” cried Alice
+         | ~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 47 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     355 | talk about cats or dogs either, if you don’t like them!” When the Mouse heard
+         |                                                        ^~~~~~~~~~~~~~~~~~~~~~~
+     356 | this, it turned round and swam slowly back to her: its face was quite pale (with
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     357 | passion, Alice thought), and it said in a low trembling voice, “Let us get to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     358 | the shore, and then I’ll tell you my history, and you’ll understand why it is I
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     359 | hate cats and dogs.”
+         | ~~~~~~~~~~~~~~~~~~~ This sentence is 55 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     362 | and animals that had fallen into it: there were a Duck and a Dodo, a Lory and an
+         |                                                                      ^~~~ Did you mean to spell “Lory” this way?
+     363 | Eaglet, and several other curious creatures. Alice led the way, and the whole
+Suggest:
+  - Replace with: “Lora”
+  - Replace with: “Lori”
+  - Replace with: “Gory”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     368 | They were indeed a queer-looking party that assembled on the bank—the birds with
+     369 | draggled feathers, the animals with their fur clinging close to them, and all
+         | ^~~~~~~~ Did you mean to spell “draggled” this way?
+Suggest:
+  - Replace with: “dragged”
+  - Replace with: “drugged”
+  - Replace with: “dangled”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     372 | The first question of course was, how to get dry again: they had a consultation
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     373 | about this, and after a few minutes it seemed quite natural to Alice to find
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     374 | herself talking familiarly with them, as if she had known them all her life.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 44 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     374 | herself talking familiarly with them, as if she had known them all her life.
+         |                                                                             ^
+     375 | Indeed, she had quite a long argument with the Lory, who at last turned sulky,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     376 | and would only say, “I am older than you, and must know better;” and this Alice
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     377 | would not allow without knowing how old it was, and, as the Lory positively
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     378 | refused to tell its age, there was no more to be said.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 57 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     375 | Indeed, she had quite a long argument with the Lory, who at last turned sulky,
+         |                                                ^~~~ Did you mean to spell “Lory” this way?
+     376 | and would only say, “I am older than you, and must know better;” and this Alice
+Suggest:
+  - Replace with: “Lora”
+  - Replace with: “Lori”
+  - Replace with: “Gory”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     377 | would not allow without knowing how old it was, and, as the Lory positively
+         |                                                             ^~~~ Did you mean to spell “Lory” this way?
+     378 | refused to tell its age, there was no more to be said.
+Suggest:
+  - Replace with: “Lora”
+  - Replace with: “Lori”
+  - Replace with: “Gory”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     390 | Edwin and Morcar, the earls of Mercia and Northumbria—’”
+         |           ^~~~~~ Did you mean to spell “Morcar” this way?
+Suggest:
+  - Replace with: “Mortar”
+  - Replace with: “Molnar”
+  - Replace with: “Mopar”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     390 | Edwin and Morcar, the earls of Mercia and Northumbria—’”
+         |                                           ^~~~~~~~~~~ Did you mean to spell “Northumbria” this way?
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     392 | “Ugh!” said the Lory, with a shiver.
+         |                 ^~~~ Did you mean to spell “Lory” this way?
+Suggest:
+  - Replace with: “Lora”
+  - Replace with: “Lori”
+  - Replace with: “Gory”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     397 | “Not I!” said the Lory hastily.
+         |                   ^~~~ Did you mean to spell “Lory” this way?
+Suggest:
+  - Replace with: “Lora”
+  - Replace with: “Lori”
+  - Replace with: “Gory”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     399 | “I thought you did,” said the Mouse. “—I proceed. ‘Edwin and Morcar, the earls
+         |                                                              ^~~~~~ Did you mean to spell “Morcar” this way?
+     400 | of Mercia and Northumbria, declared for him: and even Stigand, the patriotic
+Suggest:
+  - Replace with: “Mortar”
+  - Replace with: “Molnar”
+  - Replace with: “Mopar”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     399 | “I thought you did,” said the Mouse. “—I proceed. ‘Edwin and Morcar, the earls
+     400 | of Mercia and Northumbria, declared for him: and even Stigand, the patriotic
+         |               ^~~~~~~~~~~ Did you mean to spell “Northumbria” this way?
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     400 | of Mercia and Northumbria, declared for him: and even Stigand, the patriotic
+         |                                                       ^~~~~~~ Did you mean “Brigand”?
+     401 | archbishop of Canterbury, found it advisable—’”
+Suggest:
+  - Replace with: “Brigand”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     411 | The Mouse did not notice this question, but hurriedly went on, “‘—found it
+     412 | advisable to go with Edgar Atheling to meet William and offer him the crown.
+         |                            ^~~~~~~~ Did you mean to spell “Atheling” this way?
+Suggest:
+  - Replace with: “Steeling”
+  - Replace with: “Theming”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     445 | This question the Dodo could not answer without a great deal of thought, and it
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     446 | sat for a long time with one finger pressed upon its forehead (the position in
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     447 | which you usually see Shakespeare, in the pictures of him), while the rest
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     448 | waited in silence. At last the Dodo said, “Everybody has won, and all must have
+         | ~~~~~~~~~~~~~~~~~~ This sentence is 46 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     474 | Alice thought the whole thing very absurd, but they all looked so grave that she
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     475 | did not dare to laugh; and, as she could not think of anything to say, she
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     476 | simply bowed, and took the thimble, looking as solemn as she could.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     527 | “What a pity it wouldn’t stay!” sighed the Lory, as soon as it was quite out of
+         |                                            ^~~~ Did you mean to spell “Lory” this way?
+     528 | sight; and an old Crab took the opportunity of saying to her daughter “Ah, my
+Suggest:
+  - Replace with: “Lora”
+  - Replace with: “Lori”
+  - Replace with: “Gory”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     536 | “And who is Dinah, if I might venture to ask the question?” said the Lory.
+         |                                                                      ^~~~ Did you mean to spell “Lory” this way?
+Suggest:
+  - Replace with: “Lora”
+  - Replace with: “Lori”
+  - Replace with: “Gory”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     564 | wonder?” Alice guessed in a moment that it was looking for the fan and the pair
+         |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     565 | of white kid gloves, and she very good-naturedly began hunting about for them,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     566 | but they were nowhere to be seen—everything seemed to have changed since her
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     567 | swim in the pool, and the great hall, with the glass table and the little door,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     568 | had vanished completely.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 62 words long.
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+     564 | wonder?” Alice guessed in a moment that it was looking for the fan and the pair
+     565 | of white kid gloves, and she very good-naturedly began hunting about for them,
+         |                              ^~~~~~~~~ Vocabulary enhancement: use `excellent` instead of `very good`
+Suggest:
+  - Replace with: “excellent”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     564 | wonder?” Alice guessed in a moment that it was looking for the fan and the pair
+     565 | of white kid gloves, and she very good-naturedly began hunting about for them,
+         |                                        ^~~~~~~~~ Did you mean to spell “naturedly” this way?
+     566 | but they were nowhere to be seen—everything seemed to have changed since her
+Suggest:
+  - Replace with: “naturally”
+  - Replace with: “maturely”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     579 | little house, on the door of which was a bright brass plate with the name “W.
+         |                                                                            ^~ Did you mean to spell “W.” this way?
+Suggest:
+  - Replace with: “We”
+  - Replace with: “WA”
+  - Replace with: “WC”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+     581 | in great fear lest she should meet the real Mary Ann, and be turned out of the
+         |                                             ^~~~~~~~ Did you mean the closed compound noun “Maryann”?
+     582 | house before she had found the fan and gloves.
+Suggest:
+  - Replace with: “MaryAnn”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     585 | I suppose Dinah’ll be sending me on messages next!” And she began fancying the
+         |           ^~~~~~~~ Did you mean to spell “Dinah’ll” this way?
+Suggest:
+  - Replace with: “Dinah's”
+  - Replace with: “Dina's”
+  - Replace with: “Dinah”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     591 | By this time she had found her way into a tidy little room with a table in the
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     592 | window, and on it (as she had hoped) a fan and two or three pairs of tiny white
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     593 | kid gloves: she took up the fan and a pair of the gloves, and was just going to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     594 | leave the room, when her eye fell upon a little bottle that stood near the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     595 | looking-glass. There was no label this time with the words “DRINK ME,” but
+         | ~~~~~~~~~~~~~~ This sentence is 71 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     607 | Alas! it was too late to wish that! She went on growing, and growing, and very
+         |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     608 | soon had to kneel down on the floor: in another minute there was not even room
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     609 | for this, and she tried the effect of lying down with one elbow against the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     610 | door, and the other arm curled round her head. Still she went on growing, and,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 48 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     615 | Luckily for Alice, the little magic bottle had now had its full effect, and she
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     616 | grew no larger: still it was very uncomfortable, and, as there seemed to be no
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     617 | sort of chance of her ever getting out of the room again, no wonder she felt
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     618 | unhappy.
+         | ~~~~~~~~ This sentence is 47 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     643 | came a little pattering of feet on the stairs. Alice knew it was the Rabbit
+         |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     644 | coming to look for her, and she trembled till she shook the house, quite
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     645 | forgetting that she was now about a thousand times as large as the Rabbit, and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     646 | had no reason to be afraid of it.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     655 | snatch in the air. She did not get hold of anything, but she heard a little
+         |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     656 | shriek and a fall, and a crash of broken glass, from which she concluded that it
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     657 | was just possible it had fallen into a cucumber-frame, or something of the sort.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     660 | voice she had never heard before, “Sure then I’m here! Digging for apples, yer
+     661 | honour!”
+         | ^~~~~~ Did you mean to spell “honour” this way?
+Suggest:
+  - Replace with: “honor”
+  - Replace with: “honours”
+  - Replace with: “honour's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     668 | “Sure, it’s an arm, yer honour!” (He pronounced it “arrum.”)
+         |                         ^~~~~~ Did you mean to spell “honour” this way?
+Suggest:
+  - Replace with: “honor”
+  - Replace with: “honours”
+  - Replace with: “honour's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     668 | “Sure, it’s an arm, yer honour!” (He pronounced it “arrum.”)
+         |                                                     ^~~~~ Did you mean to spell “arrum” this way?
+Suggest:
+  - Replace with: “arum”
+  - Replace with: “album”
+  - Replace with: “alum”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     672 | “Sure, it does, yer honour: but it’s an arm for all that.”
+         |                     ^~~~~~ Did you mean to spell “honour” this way?
+Suggest:
+  - Replace with: “honor”
+  - Replace with: “honours”
+  - Replace with: “honour's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     677 | then; such as, “Sure, I don’t like it, yer honour, at all, at all!” “Do as I
+         |                                            ^~~~~~ Did you mean to spell “honour” this way?
+Suggest:
+  - Replace with: “honor”
+  - Replace with: “honours”
+  - Replace with: “honour's”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     688 | one; Bill’s got the other—Bill! fetch it here, lad!—Here, put ’em up at this
+         |                                 ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “F”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     690 | they’ll do well enough; don’t be particular—Here, Bill! catch hold of this
+         | ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “T”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     690 | they’ll do well enough; don’t be particular—Here, Bill! catch hold of this
+         |                                                         ^ This sentence does not start with a capital letter
+     691 | rope—Will the roof bear?—Mind that loose slate—Oh, it’s coming down! Heads
+Suggest:
+  - Replace with: “C”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+     692 | below!” (a loud crash)—“Now, who did that?—It was Bill, I fancy—Who’s to go down
+         |                                                                       ^~~~~ The possessive noun implies ownership of the closed compound noun “Togo”.
+     693 | the chimney?—Nay, I shan’t! You do it!—That I won’t, then!—Bill’s to go
+Suggest:
+  - Replace with: “Togo”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+     693 | the chimney?—Nay, I shan’t! You do it!—That I won’t, then!—Bill’s to go
+         |                                                                   ^~~~~ The possessive noun implies ownership of the closed compound noun “Togo”.
+     694 | down—Here, Bill! the master says you’re to go down the chimney!”
+Suggest:
+  - Replace with: “Togo”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     694 | down—Here, Bill! the master says you’re to go down the chimney!”
+         |                  ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “T”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     701 | She drew her foot as far down the chimney as she could, and waited till she
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     702 | heard a little animal (she couldn’t guess of what sort it was) scratching and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     703 | scrambling about in the chimney close above her: then, saying to herself “This
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     704 | is Bill,” she gave one sharp kick, and waited to see what would happen next.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 58 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     711 | Last came a little feeble, squeaking voice, (“That’s Bill,” thought Alice,)
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     712 | “Well, I hardly know—No more, thank ye; I’m better now—but I’m a deal too
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     713 | flustered to tell you—all I know is, something comes at me like a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     714 | Jack-in-the-box, and up I goes like a sky-rocket!”
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 53 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     723 | minute or two, they began moving about again, and Alice heard the Rabbit say, “A
+     724 | barrowful will do, to begin with.”
+         | ^~~~~~~~~ Did you mean “sorrowful”?
+Suggest:
+  - Replace with: “sorrowful”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     726 | “A barrowful of what?” thought Alice; but she had not long to doubt, for the
+         |    ^~~~~~~~~ Did you mean “sorrowful”?
+Suggest:
+  - Replace with: “sorrowful”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     749 | It sounded an excellent plan, no doubt, and very neatly and simply arranged; the
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     750 | only difficulty was, that she had not the smallest idea how to set about it; and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     751 | while she was peering about anxiously among the trees, a little sharp bark just
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     752 | over her head made her look up in a great hurry.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 55 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     755 | stretching out one paw, trying to touch her. “Poor little thing!” said Alice, in
+         |                                                                 ^~~~~~~~~~~~~~~~~
+     756 | a coaxing tone, and she tried hard to whistle to it; but she was terribly
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     757 | frightened all the time at the thought that it might be hungry, in which case it
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     758 | would be very likely to eat her up in spite of all her coaxing.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 48 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     760 | Hardly knowing what she did, she picked up a little bit of stick, and held it
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     761 | out to the puppy; whereupon the puppy jumped into the air off all its feet at
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     762 | once, with a yelp of delight, and rushed at the stick, and made believe to worry
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     763 | it; then Alice dodged behind a great thistle, to keep herself from being run
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     764 | over; and the moment she appeared on the other side, the puppy made another rush
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     765 | at the stick, and tumbled head over heels in its hurry to get hold of it; then
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     766 | Alice, thinking it was very like having a game of play with a cart-horse, and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     767 | expecting every moment to be trampled under its feet, ran round the thistle
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     768 | again; then the puppy began a series of short charges at the stick, running a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     769 | very little way forwards each time and a long way back, and barking hoarsely all
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     770 | the while, till at last it sat down a good way off, panting, with its tongue
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     771 | hanging out of its mouth, and its great eyes half shut.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 180 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     777 | “And yet what a dear little puppy it was!” said Alice, as she leant against a
+         |                                                               ^~~~~ Did you mean to spell “leant” this way?
+     778 | buttercup to rest herself, and fanned herself with one of the leaves: “I should
+Suggest:
+  - Replace with: “lean”
+  - Replace with: “learnt”
+  - Replace with: “least”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     786 | the right thing to eat or drink under the circumstances. There was a large
+         |                                                         ^~~~~~~~~~~~~~~~~~~
+     787 | mushroom growing near her, about the same height as herself; and when she had
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     788 | looked under it, and on both sides of it, and behind it, it occurred to her that
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     789 | she might as well look and see what was on the top of it.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 49 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     791 | She stretched herself up on tiptoe, and peeped over the edge of the mushroom,
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     792 | and her eyes immediately met those of a large blue caterpillar, that was sitting
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     793 | on the top with its arms folded, quietly smoking a long hookah, and taking not
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     794 | the smallest notice of her or of anything else.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 52 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     822 | “Well, perhaps you haven’t found it so yet,” said Alice; “but when you have to
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     823 | turn into a chrysalis—you will some day, you know—and then after that into a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     824 | butterfly, I should think you’ll feel it a little queer, won’t you?”
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     884 | > “In my youth,” said the sage, as he shook his grey locks, “I kept all my limbs
+         |                                                 ^~~~ Did you mean to spell “grey” this way?
+     885 | > very supple By the use of this ointment—one shilling the box— Allow me to sell
+Suggest:
+  - Replace with: “gray”
+  - Replace with: “grew”
+  - Replace with: “grep”
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+     929 | “It is a very good height indeed!” said the Caterpillar angrily, rearing itself
+         |          ^~~~~~~~~ Vocabulary enhancement: use `excellent` instead of `very good`
+Suggest:
+  - Replace with: “excellent”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     958 | She was a good deal frightened by this very sudden change, but she felt that
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     959 | there was no time to be lost, as she was shrinking rapidly; so she set to work
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     960 | at once to eat some of the other bit. Her chin was pressed so closely against
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     961 | her foot, that there was hardly room to open her mouth; but she did it at last,
+     962 | and managed to swallow a morsel of the lefthand bit.
+         |                                        ^~~~~~~~ Did you mean “leftward”?
+Suggest:
+  - Replace with: “leftward”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     964 | “Come, my head’s free at last!” said Alice in a tone of delight, which changed
+         |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     965 | into alarm in another moment, when she found that her shoulders were nowhere to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     966 | be found: all she could see, when she looked down, was an immense length of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     967 | neck, which seemed to rise like a stalk out of a sea of green leaves that lay
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     968 | far below her.
+         | ~~~~~~~~~~~~~~ This sentence is 58 words long.
+
+
+
+Lint:    Repetition (63 priority)
+Message: |
+     971 | to? And oh, my poor hands, how is it I can’t see you?” She was moving them about
+         |                                   ^~~~ There are too many personal pronouns in sequence here.
+Suggest:
+  - Replace with: “it”
+  - Replace with: “I”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     975 | As there seemed to be no chance of getting her hands up to her head, she tried
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     976 | to get her head down to them, and was delighted to find that her neck would bend
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     977 | about easily in any direction, like a serpent. She had just succeeded in curving
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     977 | about easily in any direction, like a serpent. She had just succeeded in curving
+         |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     978 | it down into a graceful zigzag, and was going to dive in among the leaves, which
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     979 | she found to be nothing but the tops of the trees under which she had been
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     980 | wandering, when a sharp hiss made her draw back in a hurry: a large pigeon had
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     981 | flown into her face, and was beating her violently with its wings.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 66 words long.
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+     979 | she found to be nothing but the tops of the trees under which she had been
+     980 | wandering, when a sharp hiss made her draw back in a hurry: a large pigeon had
+         |                                       ^~~~~~~~~ Did you mean the closed compound noun “drawback”?
+Suggest:
+  - Replace with: “drawback”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1007 | “And just as I’d taken the highest tree in the wood,” continued the Pigeon,
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1008 | raising its voice to a shriek, “and just as I was thinking I should be free of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1009 | them at last, they must needs come wriggling down from the sky! Ugh, Serpent!”
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+    1011 | “But I’m not a serpent, I tell you!” said Alice. “I’m a—I’m a—”
+         |                                                       ^ Incorrect indefinite article.
+Suggest:
+  - Replace with: “an”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1030 | This was such a new idea to Alice, that she was quite silent for a minute or
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1031 | two, which gave the Pigeon the opportunity of adding, “You’re looking for eggs,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1032 | I know that well enough; and what does it matter to me whether you’re a little
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1033 | girl or a serpent?”
+         | ~~~~~~~~~~~~~~~~~~ This sentence is 50 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1042 | to stop and untwist it. After a while she remembered that she still held the
+         |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1043 | pieces of mushroom in her hands, and she set to work very carefully, nibbling
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1044 | first at one and then at the other, and growing sometimes taller and sometimes
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1045 | shorter, until she had succeeded in bringing herself down to her usual height.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 51 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1055 | this size: why, I should frighten them out of their wits!” So she began nibbling
+    1056 | at the righthand bit again, and did not venture to go near the house till she
+         |        ^~~~~~~~~ Did you mean to spell “righthand” this way?
+Suggest:
+  - Replace with: “right-hand”
+  - Replace with: “rightward”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1061 | For a minute or two she stood looking at the house, and wondering what to do
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1062 | next, when suddenly a footman in livery came running out of the wood—(she
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1063 | considered him to be a footman because he was in livery: otherwise, judging by
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1064 | his face only, she would have called him a fish)—and rapped loudly at the door
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1065 | with his knuckles. It was opened by another footman in livery, with a round
+         | ~~~~~~~~~~~~~~~~~~ This sentence is 63 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1078 | Alice laughed so much at this, that she had to run back into the wood for fear
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1079 | of their hearing her; and when she next peeped out the Fish-Footman was gone,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1080 | and the other was sitting on the ground near the door, staring stupidly up into
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1081 | the sky.
+         | ~~~~~~~~ This sentence is 49 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1130 | The door led right into a large kitchen, which was full of smoke from one end to
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1131 | the other: the Duchess was sitting on a three-legged stool in the middle,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1132 | nursing a baby; the cook was leaning over the fire, stirring a large cauldron
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1133 | which seemed to be full of soup.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 52 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1165 | well to introduce some other subject of conversation. While she was trying to
+         |                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~
+    1166 | fix on one, the cook took the cauldron of soup off the fire, and at once set to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1167 | work throwing everything within her reach at the Duchess and the baby—the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1168 | fire-irons came first; then followed a shower of saucepans, plates, and dishes.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 49 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1187 | Alice glanced rather anxiously at the cook, to see if she meant to take the
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1188 | hint; but the cook was busily stirring the soup, and seemed not to be listening,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1189 | so she went on again: “Twenty-four hours, I think; or is it twelve? I—”
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 44 words long.
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+    1200 | > “Wow! wow! wow!”
+         |         ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “W”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+    1200 | > “Wow! wow! wow!”
+         |              ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “W”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+    1211 | > “Wow! wow! wow!”
+         |         ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “W”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+    1211 | > “Wow! wow! wow!”
+         |              ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “W”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+    1213 | “Here! you may nurse it a bit, if you like!” the Duchess said to Alice, flinging
+         |        ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “Y”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1220 | star-fish,” thought Alice. The poor little thing was snorting like a
+         |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1221 | steam-engine when she caught it, and kept doubling itself up and straightening
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1222 | itself out again, so that altogether, for the first minute or two, it was as
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1223 | much as she could do to hold it.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 44 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1225 | As soon as she had made out the proper way of nursing it, (which was to twist it
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1226 | up into a sort of knot, and then keep tight hold of its right ear and left foot,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1227 | so as to prevent its undoing itself,) she carried it out into the open air. “If
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 51 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1235 | what was the matter with it. There could be no doubt that it had a very turn-up
+         |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1236 | nose, much more like a snout than a real nose; also its eyes were getting
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1237 | extremely small for a baby: altogether Alice did not like the look of the thing
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1238 | at all. “But perhaps it was only sobbing,” she thought, and looked into its eyes
+         | ~~~~~~~ This sentence is 44 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1254 | made a dreadfully ugly child: but it makes rather a handsome pig, I think.” And
+         |                                                                           ^~~~~~
+    1255 | she began thinking over other children she knew, who might do very well as pigs,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1256 | and was just saying to herself, “if one only knew the right way to change them—”
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1257 | when she was a little startled by seeing the Cheshire Cat sitting on a bough of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1258 | a tree a few yards off.
+         | ~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 54 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1260 | The Cat only grinned when it saw Alice. It looked good-natured, she thought:
+         |                                                        ^~~~~~~ Did you mean to spell “natured” this way?
+Suggest:
+  - Replace with: “nature”
+  - Replace with: “natures”
+  - Replace with: “natural”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1348 | like ears and the roof was thatched with fur. It was so large a house, that she
+         |                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1349 | did not like to go nearer till she had nibbled some more of the lefthand bit of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1350 | mushroom, and raised herself to about two feet high: even then she walked up
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1351 | towards it rather timidly, saying to herself “Suppose it should be raving mad
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1352 | after all! I almost wish I’d gone to see the Hatter instead!”
+         | ~~~~~~~~~~ This sentence is 54 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1349 | did not like to go nearer till she had nibbled some more of the lefthand bit of
+         |                                                                 ^~~~~~~~ Did you mean “leftward”?
+    1350 | mushroom, and raised herself to about two feet high: even then she walked up
+Suggest:
+  - Replace with: “leftward”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1356 | There was a table set out under a tree in front of the house, and the March Hare
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1357 | and the Hatter were having tea at it: a Dormouse was sitting between them, fast
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1358 | asleep, and the other two were using it as a cushion, resting their elbows on
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1359 | it, and talking over its head. “Very uncomfortable for the Dormouse,” thought
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 54 words long.
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+    1415 | dropped, and the party sat silent for a minute, while Alice thought over all she
+         |                                                                     ^~~~~~~~ Did you mean the closed compound `overall`?
+    1416 | could remember about ravens and writing-desks, which wasn’t much.
+Suggest:
+  - Replace with: “overall”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1433 | The March Hare took the watch and looked at it gloomily: then he dipped it into
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1434 | his cup of tea, and looked at it again: but he could think of nothing better to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1435 | say than his first remark, “It was the best butter, you know.”
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 45 words long.
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+    1481 | “Ah! that accounts for it,” said the Hatter. “He won’t stand beating. Now, if
+         |      ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “T”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1497 | The Hatter shook his head mournfully. “Not I!” he replied. “We quarrelled last
+         |                                                                ^~~~~~~~~~ Did you mean to spell “quarrelled” this way?
+    1498 | March—just before he went mad, you know—” (pointing with his tea spoon at the
+Suggest:
+  - Replace with: “quarreled”
+  - Replace with: “quarreler”
+  - Replace with: “quarrellers”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    1498 | March—just before he went mad, you know—” (pointing with his tea spoon at the
+         |                                                              ^~~~~~~~~ Did you mean the closed compound noun “teaspoon”?
+    1499 | March Hare,) “—it was at the great concert given by the Queen of Hearts, and I
+Suggest:
+  - Replace with: “teaspoon”
+
+
+
+Lint:    WordChoice (127 priority)
+Message: |
+    1545 | feeble voice: “I heard every word you fellows were saying.”
+         |                                   ^~~ The possessive version of this word is more common in this context.
+Suggest:
+  - Replace with: “your”
+  - Replace with: “you're a”
+  - Replace with: “you're an”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1555 | great hurry; “and their names were Elsie, Lacie, and Tillie; and they lived at
+         |                                           ^~~~~ Did you mean to spell “Lacie” this way?
+Suggest:
+  - Replace with: “Lace”
+  - Replace with: “Lacier”
+  - Replace with: “Lacey”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1555 | great hurry; “and their names were Elsie, Lacie, and Tillie; and they lived at
+         |                                                      ^~~~~~ Did you mean to spell “Tillie” this way?
+Suggest:
+  - Replace with: “Billie”
+  - Replace with: “Lillie”
+  - Replace with: “Millie”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1637 | The Dormouse had closed its eyes by this time, and was going off into a doze;
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1638 | but, on being pinched by the Hatter, it woke up again with a little shriek, and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1639 | went on: “—that begins with an M, such as mouse-traps, and the moon, and memory,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1640 | and muchness—you know you say things are “much of a muchness”—did you ever see
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1641 | such a thing as a drawing of a muchness?”
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 73 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1647 | This piece of rudeness was more than Alice could bear: she got up in great
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1648 | disgust, and walked off; the Dormouse fell asleep instantly, and neither of the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1649 | others took the least notice of her going, though she looked back once or twice,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1650 | half hoping that they would call after her: the last time she saw them, they
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1651 | were trying to put the Dormouse into the teapot.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 67 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1662 | taking the little golden key, and unlocking the door that led into the garden.
+         |                                                                               ^
+    1663 | Then she went to work nibbling at the mushroom (she had kept a piece of it in
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1664 | her pocket) till she was about a foot high: then she walked down the little
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1665 | passage: and then—she found herself at last in the beautiful garden, among the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1666 | bright flower-beds and the cool fountains.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 53 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1691 | Seven flung down his brush, and had just begun “Well, of all the unjust things—”
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1692 | when his eye chanced to fall upon Alice, as she stood watching them, and he
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1693 | checked himself suddenly: the others looked round also, and all of them bowed
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1694 | low.
+         | ~~~~ This sentence is 44 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1699 | Five and Seven said nothing, but looked at Two. Two began in a low voice, “Why
+         |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1700 | the fact is, you see, Miss, this here ought to have been a red rose-tree, and we
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1701 | put a white one in by mistake; and if the Queen was to find it out, we should
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1702 | all have our heads cut off, you know. So you see, Miss, we’re doing our best,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 51 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1702 | all have our heads cut off, you know. So you see, Miss, we’re doing our best,
+    1703 | afore she comes, to—” At this moment Five, who had been anxiously looking across
+         | ^~~~~ Did you mean to spell “afore” this way?
+Suggest:
+  - Replace with: “adore”
+  - Replace with: “afire”
+  - Replace with: “fore”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1708 | First came ten soldiers carrying clubs; these were all shaped like the three
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1709 | gardeners, oblong and flat, with their hands and feet at the corners: next the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1710 | ten courtiers; these were ornamented all over with diamonds, and walked two and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1711 | two, as the soldiers did. After these came the royal children; there were ten of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 45 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1713 | they were all ornamented with hearts. Next came the guests, mostly Kings and
+    1714 | Queens, and among them Alice recognised the White Rabbit: it was talking in a
+         |                              ^~~~~~~~~~ Did you mean to spell “recognised” this way?
+Suggest:
+  - Replace with: “recognized”
+  - Replace with: “recogniser”
+  - Replace with: “recognises”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1720 | Alice was rather doubtful whether she ought not to lie down on her face like the
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1721 | three gardeners, but she could not remember ever having heard of such a rule at
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1722 | processions; “and besides, what would be the use of a procession,” thought she,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1723 | “if people had all to lie down upon their faces, so that they couldn’t see it?”
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 60 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1737 | “And who are these?” said the Queen, pointing to the three gardeners who were
+         |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1738 | lying round the rose-tree; for, you see, as they were lying on their faces, and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1739 | the pattern on their backs was the same as the rest of the pack, she could not
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1740 | tell whether they were gardeners, or soldiers, or courtiers, or three of her own
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1741 | children.
+         | ~~~~~~~~~ This sentence is 58 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1813 | got settled down in a minute or two, and the game began. Alice thought she had
+         |                                                         ^~~~~~~~~~~~~~~~~~~~~~~
+    1814 | never seen such a curious croquet-ground in her life; it was all ridges and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1815 | furrows; the balls were live hedgehogs, the mallets live flamingoes, and the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1816 | soldiers had to double themselves up and to stand on their hands and feet, to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1817 | make the arches.
+         | ~~~~~~~~~~~~~~~~ This sentence is 49 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1815 | furrows; the balls were live hedgehogs, the mallets live flamingoes, and the
+         |                                                          ^~~~~~~~~~ Did you mean to spell “flamingoes” this way?
+    1816 | soldiers had to double themselves up and to stand on their hands and feet, to
+Suggest:
+  - Replace with: “flamingo's”
+  - Replace with: “flamingos”
+  - Replace with: “flamingo”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1819 | The chief difficulty Alice found at first was in managing her flamingo: she
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1820 | succeeded in getting its body tucked away, comfortably enough, under her arm,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1821 | with its legs hanging down, but generally, just as she had got its neck nicely
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1822 | straightened out, and was going to give the hedgehog a blow with its head, it
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1823 | would twist itself round and look up in her face, with such a puzzled expression
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1824 | that she could not help bursting out laughing: and when she had got its head
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1825 | down, and was going to begin again, it was very provoking to find that the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1826 | hedgehog had unrolled itself, and was in the act of crawling away: besides all
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1827 | this, there was generally a ridge or furrow in the way wherever she wanted to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1828 | send the hedgehog to, and, as the doubled-up soldiers were always getting up and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1829 | walking off to other parts of the ground, Alice soon came to the conclusion that
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1830 | it was a very difficult game indeed.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 166 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1832 | The players all played at once without waiting for turns, quarrelling all the
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1833 | while, and fighting for the hedgehogs; and in a very short time the Queen was in
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1834 | a furious passion, and went stamping about, and shouting “Off with his head!” or
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1832 | The players all played at once without waiting for turns, quarrelling all the
+         |                                                           ^~~~~~~~~~~ Did you mean “quarreling”?
+    1833 | while, and fighting for the hedgehogs; and in a very short time the Queen was in
+Suggest:
+  - Replace with: “quarreling”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1842 | She was looking about for some way of escape, and wondering whether she could
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1843 | get away without being seen, when she noticed a curious appearance in the air:
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1844 | it puzzled her very much at first, but, after watching it a minute or two, she
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1845 | made it out to be a grin, and she said to herself “It’s the Cheshire Cat: now I
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1846 | shall have somebody to talk to.”
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 68 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1858 | “I don’t think they play at all fairly,” Alice began, in rather a complaining
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1859 | tone, “and they all quarrel so dreadfully one can’t hear oneself speak—and they
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1860 | don’t seem to have any rules in particular; at least, if there are, nobody
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1861 | attends to them—and you’ve no idea how confusing it is all the things being
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1862 | alive; for instance, there’s the arch I’ve got to go through next walking about
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1863 | at the other end of the ground—and I should have croqueted the Queen’s hedgehog
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1864 | just now, only it ran away when it saw mine coming!”
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 97 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1863 | at the other end of the ground—and I should have croqueted the Queen’s hedgehog
+         |                                                  ^~~~~~~~~ Did you mean to spell “croqueted” this way?
+    1864 | just now, only it ran away when it saw mine coming!”
+Suggest:
+  - Replace with: “croquet's”
+  - Replace with: “coquetted”
+  - Replace with: “crocheted”
+
+
+
+Lint:    Style (31 priority)
+Message: |
+    1894 | The Queen had only one way of settling all difficulties, great or small. “Off
+         |                                                          ^~~~~ An Oxford comma is necessary here.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1900 | she heard the Queen’s voice in the distance, screaming with passion. She had
+         |                                                                     ^~~~~~~~~
+    1901 | already heard her sentence three of the players to be executed for having missed
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1902 | their turns, and she did not like the look of things at all, as the game was in
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1903 | such confusion that she never knew whether it was her turn or not. So she went
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 47 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1906 | The hedgehog was engaged in a fight with another hedgehog, which seemed to Alice
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1907 | an excellent opportunity for croqueting one of them with the other: the only
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1908 | difficulty was, that her flamingo was gone across to the other side of the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1909 | garden, where Alice could see it trying in a helpless sort of way to fly up into
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1910 | a tree.
+         | ~~~~~~~ This sentence is 60 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1906 | The hedgehog was engaged in a fight with another hedgehog, which seemed to Alice
+    1907 | an excellent opportunity for croqueting one of them with the other: the only
+         |                              ^~~~~~~~~~ Did you mean to spell “croqueting” this way?
+Suggest:
+  - Replace with: “coquetting”
+  - Replace with: “crocheting”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1912 | By the time she had caught the flamingo and brought it back, the fight was over,
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1913 | and both the hedgehogs were out of sight: “but it doesn’t matter much,” thought
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1914 | Alice, “as all the arches are gone from this side of the ground.” So she tucked
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1918 | When she got back to the Cheshire Cat, she was surprised to find quite a large
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1919 | crowd collected round it: there was a dispute going on between the executioner,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1920 | the King, and the Queen, who were all talking at once, while all the rest were
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1921 | quite silent, and looked very uncomfortable.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 51 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1923 | The moment Alice appeared, she was appealed to by all three to settle the
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1924 | question, and they repeated their arguments to her, though, as they all spoke at
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1925 | once, she found it very hard indeed to make out exactly what they said.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1927 | The executioner’s argument was, that you couldn’t cut off a head unless there
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1928 | was a body to cut it off from: that he had never had to do such a thing before,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1929 | and he wasn’t going to begin at his time of life.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1944 | The Cat’s head began fading away the moment he was gone, and, by the time he had
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1945 | come back with the Duchess, it had entirely disappeared; so the King and the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1946 | executioner ran wildly up and down looking for it, while the rest of the party
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1947 | went back to the game.
+         | ~~~~~~~~~~~~~~~~~~~~~~ This sentence is 51 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1960 | “I won’t have any pepper in my kitchen at all. Soup does very well without—Maybe
+         |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1961 | it’s always pepper that makes people hot-tempered,” she went on, very much
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1962 | pleased at having found out a new kind of rule, “and vinegar that makes them
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1963 | sour—and camomile that makes them bitter—and—and barley-sugar and such things
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1964 | that make children sweet-tempered. I only wish people knew that: then they
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 53 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1962 | pleased at having found out a new kind of rule, “and vinegar that makes them
+    1963 | sour—and camomile that makes them bitter—and—and barley-sugar and such things
+         |          ^~~~~~~~ Did you mean to spell “camomile” this way?
+Suggest:
+  - Replace with: “chamomile”
+  - Replace with: “chamomiles”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1985 | “’Tis so,” said the Duchess: “and the moral of that is—‘Oh, ’tis love, ’tis
+         |   ^~~ Did you mean to spell “Tis” this way?
+Suggest:
+  - Replace with: “T's”
+  - Replace with: “This”
+  - Replace with: “Ti's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1985 | “’Tis so,” said the Duchess: “and the moral of that is—‘Oh, ’tis love, ’tis
+         |                                                              ^~~ Did you mean to spell “tis” this way?
+    1986 | love, that makes the world go round!’”
+Suggest:
+  - Replace with: “this”
+  - Replace with: “ti's”
+  - Replace with: “tbs”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1985 | “’Tis so,” said the Duchess: “and the moral of that is—‘Oh, ’tis love, ’tis
+         |                                                                         ^~~ Did you mean to spell “tis” this way?
+    1986 | love, that makes the world go round!’”
+Suggest:
+  - Replace with: “this”
+  - Replace with: “ti's”
+  - Replace with: “tbs”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2004 | “Very true,” said the Duchess: “flamingoes and mustard both bite. And the moral
+         |                                 ^~~~~~~~~~ Did you mean to spell “flamingoes” this way?
+Suggest:
+  - Replace with: “flamingo's”
+  - Replace with: “flamingos”
+  - Replace with: “flamingo”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    2009 | “Right, as usual,” said the Duchess: “what a clear way you have of putting
+         |                                              ^~~~~~~~~ Did you mean the closed compound noun “clearway”?
+    2010 | things!”
+Suggest:
+  - Replace with: “clearway”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2021 | “I quite agree with you,” said the Duchess; “and the moral of that is—‘Be what
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2022 | you would seem to be’—or if you’d like it put more simply—‘Never imagine
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2023 | yourself not to be otherwise than what it might appear to others that what you
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2024 | were or might have been was not otherwise than what you had been would have
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2025 | appeared to them to be otherwise.’”
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 67 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2048 | But here, to Alice’s great surprise, the Duchess’s voice died away, even in the
+    2049 | middle of her favourite word ‘moral,’ and the arm that was linked into hers
+         |               ^~~~~~~~~ Did you mean to spell “favourite” this way?
+Suggest:
+  - Replace with: “favorite”
+  - Replace with: “favourites”
+  - Replace with: “favourite's”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    2061 | “Let’s go on with the game,” the Queen said to Alice; and Alice was too much
+         |        ^~~~~ The possessive noun implies ownership of the closed compound noun “goon”.
+Suggest:
+  - Replace with: “goon”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2064 | The other guests had taken advantage of the Queen’s absence, and were resting in
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2065 | the shade: however, the moment they saw her, they hurried back to the game, the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2066 | Queen merely remarking that a moment’s delay would cost them their lives.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2068 | All the time they were playing the Queen never left off quarrelling with the
+         |                                                         ^~~~~~~~~~~ Did you mean “quarreling”?
+    2069 | other players, and shouting “Off with his head!” or “Off with her head!” Those
+Suggest:
+  - Replace with: “quarreling”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2069 | other players, and shouting “Off with his head!” or “Off with her head!” Those
+         |                                                                        ^~~~~~~~
+    2070 | whom she sentenced were taken into custody by the soldiers, who of course had to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2071 | leave off being arches to do this, so that by the end of half an hour or so
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2072 | there were no arches left, and all the players, except the King, the Queen, and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2073 | Alice, were in custody and under sentence of execution.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 58 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2091 | They very soon came upon a Gryphon, lying fast asleep in the sun. (If you don’t
+         |                            ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2091 | They very soon came upon a Gryphon, lying fast asleep in the sun. (If you don’t
+    2092 | know what a Gryphon is, look at the picture.) “Up, lazy thing!” said the Queen,
+         |             ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2094 | must go back and see after some executions I have ordered;” and she walked off,
+    2095 | leaving Alice alone with the Gryphon. Alice did not quite like the look of the
+         |                              ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2099 | The Gryphon sat up and rubbed its eyes: then it watched the Queen till she was
+         |     ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2100 | out of sight: then it chuckled. “What fun!” said the Gryphon, half to itself,
+         |                                                      ^~~~~~~ Did you mean “Krypton”?
+    2101 | half to Alice.
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2105 | “Why, she,” said the Gryphon. “It’s all her fancy, that: they never executes
+         |                      ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2114 | his sorrow?” she asked the Gryphon, and the Gryphon answered, very nearly in the
+         |                            ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2114 | his sorrow?” she asked the Gryphon, and the Gryphon answered, very nearly in the
+         |                                             ^~~~~~~ Did you mean “Krypton”?
+    2115 | same words as before, “It’s all his fancy, that: he hasn’t got no sorrow, you
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2121 | “This here young lady,” said the Gryphon, “she wants for to know your history,
+         |                                  ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2133 | These words were followed by a very long silence, broken only by an occasional
+    2134 | exclamation of “Hjckrrh!” from the Gryphon, and the constant heavy sobbing of
+         |                 ^~~~~~~ Did you mean to spell “Hjckrrh” this way?
+Suggest:
+  - Replace with: “Hacker”
+  - Replace with: “Hackish”
+  - Replace with: “Hackers”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2134 | exclamation of “Hjckrrh!” from the Gryphon, and the constant heavy sobbing of
+         |                                    ^~~~~~~ Did you mean “Krypton”?
+    2135 | the Mock Turtle. Alice was very nearly getting up and saying, “Thank you, sir,
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2148 | “You ought to be ashamed of yourself for asking such a simple question,” added
+    2149 | the Gryphon; and then they both sat silent and looked at poor Alice, who felt
+         |     ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2150 | ready to sink into the earth. At last the Gryphon said to the Mock Turtle,
+         |                                           ^~~~~~~ Did you mean “Krypton”?
+    2151 | “Drive on, old fellow! Don’t be all day about it!” and he went on in these
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2160 | “Hold your tongue!” added the Gryphon, before Alice could speak again. The Mock
+         |                               ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+    2176 | “Ah! then yours wasn’t a really good school,” said the Mock Turtle in a tone of
+         |      ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “T”
+
+
+
+Lint:    Repetition (63 priority)
+Message: |
+    2177 | great relief. “Now at ours they had at the end of the bill, ‘French, music, and
+         |                       ^~~~~~~~~ There are too many personal pronouns in sequence here.
+Suggest:
+  - Replace with: “ours”
+  - Replace with: “they”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2189 | then the different branches of Arithmetic—Ambition, Distraction, Uglification,
+         |                                                                  ^~~~~~~~~~~~ Did you mean “Vilification”?
+    2190 | and Derision.”
+Suggest:
+  - Replace with: “Vilification”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2192 | “I never heard of ‘Uglification,’” Alice ventured to say. “What is it?”
+         |                    ^~~~~~~~~~~~ Did you mean “Vilification”?
+Suggest:
+  - Replace with: “Vilification”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2194 | The Gryphon lifted up both its paws in surprise. “What! Never heard of
+         |     ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2194 | The Gryphon lifted up both its paws in surprise. “What! Never heard of
+    2195 | uglifying!” it exclaimed. “You know what to beautify is, I suppose?”
+         | ^~~~~~~~~ Did you mean to spell “uglifying” this way?
+Suggest:
+  - Replace with: “unifying”
+  - Replace with: “uplifting”
+  - Replace with: “nullifying”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2199 | “Well, then,” the Gryphon went on, “if you don’t know what to uglify is, you are
+         |                   ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2199 | “Well, then,” the Gryphon went on, “if you don’t know what to uglify is, you are
+         |                                                               ^~~~~~ Did you mean to spell “uglify” this way?
+    2200 | a simpleton.”
+Suggest:
+  - Replace with: “ugly”
+  - Replace with: “unify”
+  - Replace with: “uplift”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2205 | “Well, there was Mystery,” the Mock Turtle replied, counting off the subjects on
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2206 | his flappers, “—Mystery, ancient and modern, with Seaography: then Drawling—the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2207 | Drawling-master was an old conger-eel, that used to come once a week: he taught
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2208 | us Drawling, Stretching, and Fainting in Coils.”
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 47 words long.
+
+
+
+Lint:    Style (31 priority)
+Message: |
+    2205 | “Well, there was Mystery,” the Mock Turtle replied, counting off the subjects on
+    2206 | his flappers, “—Mystery, ancient and modern, with Seaography: then Drawling—the
+         |                          ^~~~~~~ An Oxford comma is necessary here.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2206 | his flappers, “—Mystery, ancient and modern, with Seaography: then Drawling—the
+         |                                                   ^~~~~~~~~~ Did you mean to spell “Seaography” this way?
+Suggest:
+  - Replace with: “Demography”
+  - Replace with: “Geography”
+  - Replace with: “Xerography”
+
+
+
+Lint:    WordChoice (127 priority)
+Message: |
+    2212 | “Well, I can’t show it you myself,” the Mock Turtle said: “I’m too stiff. And
+         |                        ^~~ The possessive version of this word is more common in this context.
+Suggest:
+  - Replace with: “your”
+  - Replace with: “you're a”
+  - Replace with: “you're an”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2212 | “Well, I can’t show it you myself,” the Mock Turtle said: “I’m too stiff. And
+    2213 | the Gryphon never learnt it.”
+         |     ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2215 | “Hadn’t time,” said the Gryphon: “I went to the Classics master, though. He was
+         |                         ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2221 | “So he did, so he did,” said the Gryphon, sighing in his turn; and both
+         |                                  ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2231 | “That’s the reason they’re called lessons,” the Gryphon remarked: “because they
+         |                                                 ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2241 | “That’s enough about lessons,” the Gryphon interrupted in a very decided tone:
+         |                                    ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2248 | voice. “Same as if he had a bone in his throat,” said the Gryphon: and it set to
+         |                                                           ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2252 | “You may not have lived much under the sea—” (“I haven’t,” said Alice)—“and
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2253 | perhaps you were never even introduced to a lobster—” (Alice began to say “I
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2254 | once tasted—” but checked herself hastily, and said “No, never”) “—so you can
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2255 | have no idea what a delightful thing a Lobster Quadrille is!”
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 52 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2259 | “Why,” said the Gryphon, “you first form into a line along the sea-shore—”
+         |                 ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2264 | “That generally takes some time,” interrupted the Gryphon.
+         |                                                   ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2268 | “Each with a lobster as a partner!” cried the Gryphon.
+         |                                               ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2272 | “—change lobsters, and retire in same order,” continued the Gryphon.
+         |                                                             ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2276 | “The lobsters!” shouted the Gryphon, with a bound into the air.
+         |                             ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2280 | “Swim after them!” screamed the Gryphon.
+         |                                 ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2284 | “Change lobsters again!” yelled the Gryphon at the top of its voice.
+         |                                     ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2286 | “Back to land again, and that’s all the first figure,” said the Mock Turtle,
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2287 | suddenly dropping his voice; and the two creatures, who had been jumping about
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2288 | like mad things all this time, sat down again very sadly and quietly, and looked
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2289 | at Alice.
+         | ~~~~~~~~~ This sentence is 44 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2297 | “Come, let’s try the first figure!” said the Mock Turtle to the Gryphon. “We can
+         |                                                                 ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2300 | “Oh, you sing,” said the Gryphon. “I’ve forgotten the words.”
+         |                          ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Style (31 priority)
+Message: |
+    2302 | So they began solemnly dancing round and round Alice, every now and then
+         |                                                                 ^~~ An Oxford comma is necessary here.
+    2303 | treading on her toes when they passed too close, and waving their forepaws to
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2303 | treading on her toes when they passed too close, and waving their forepaws to
+         |                                                                   ^~~~~~~~ Did you mean to spell “forepaws” this way?
+    2304 | mark the time, while the Mock Turtle sang this, very slowly and sadly:—
+Suggest:
+  - Replace with: “foreparts”
+  - Replace with: “forepart”
+  - Replace with: “foresaw”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2333 | “Yes,” said Alice, “I’ve often seen them at dinn—” she checked herself hastily.
+         |                                             ^~~~ Did you mean to spell “dinn” this way?
+Suggest:
+  - Replace with: “din”
+  - Replace with: “dine”
+  - Replace with: “ding”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2335 | “I don’t know where Dinn may be,” said the Mock Turtle, “but if you’ve seen them
+         |                     ^~~~ Did you mean to spell “Dinn” this way?
+Suggest:
+  - Replace with: “Dine”
+  - Replace with: “Diann”
+  - Replace with: “Dina”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2343 | here the Mock Turtle yawned and shut his eyes.—“Tell her about the reason and
+    2344 | all that,” he said to the Gryphon.
+         |                           ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2346 | “The reason is,” said the Gryphon, “that they would go with the lobsters to the
+         |                           ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2354 | “I can tell you more than that, if you like,” said the Gryphon. “Do you know why
+         |                                                        ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2359 | “It does the boots and shoes,” the Gryphon replied very solemnly.
+         |                                    ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2364 | “Why, what are your shoes done with?” said the Gryphon. “I mean, what makes them
+         |                                                ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2370 | “Boots and shoes under the sea,” the Gryphon went on in a deep voice, “are done
+         |                                      ^~~~~~~ Did you mean “Krypton”?
+    2371 | with a whiting. Now you know.”
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2375 | “Soles and eels, of course,” the Gryphon replied rather impatiently: “any shrimp
+         |                                  ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2392 | “I mean what I say,” the Mock Turtle replied in an offended tone. And the
+    2393 | Gryphon added “Come, let’s hear some of your adventures.”
+         | ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2401 | “No, no! The adventures first,” said the Gryphon in an impatient tone:
+         |                                          ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2407 | wide, but she gained courage as she went on. Her listeners were perfectly quiet
+         |                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2408 | till she got to the part about her repeating “You are old, Father William,” to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2409 | the Caterpillar, and the words all coming different, and then the Mock Turtle
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2410 | drew a long breath, and said “That’s very curious.”
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2412 | “It’s all about as curious as it can be,” said the Gryphon.
+         |                                                    ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2415 | to hear her try and repeat something now. Tell her to begin.” He looked at the
+    2416 | Gryphon as if he thought it had some kind of authority over Alice.
+         | ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2418 | “Stand up and repeat ‘’Tis the voice of the sluggard,’” said the Gryphon.
+         |                        ^~~ Did you mean to spell “Tis” this way?
+Suggest:
+  - Replace with: “T's”
+  - Replace with: “This”
+  - Replace with: “Ti's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2418 | “Stand up and repeat ‘’Tis the voice of the sluggard,’” said the Gryphon.
+         |                                                                  ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2425 | > “’Tis the voice of the Lobster; I heard him declare, “You have baked me too
+         |     ^~~ Did you mean to spell “Tis” this way?
+Suggest:
+  - Replace with: “T's”
+  - Replace with: “This”
+  - Replace with: “Ti's”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2428 | >
+    2429 | > (later editions continued as follows When the sands are all dry, he is gay as
+         |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2430 | > a lark, And will talk in contemptuous tones of the Shark, But, when the tide
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2431 | > rises and sharks are around, His voice has a timid and tremulous sound.)
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2433 | “That’s different from what I used to say when I was a child,” said the Gryphon.
+         |                                                                         ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2443 | “She can’t explain it,” said the Gryphon hastily. “Go on with the next verse.”
+         |                                  ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2451 | “Go on with the next verse,” the Gryphon repeated impatiently: “it begins ‘I
+         |                                  ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2470 | “Yes, I think you’d better leave off,” said the Gryphon: and Alice was only too
+         |                                                 ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2473 | “Shall we try another figure of the Lobster Quadrille?” the Gryphon went on. “Or
+         |                                                             ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2476 | “Oh, a song, please, if the Mock Turtle would be so kind,” Alice replied, so
+    2477 | eagerly that the Gryphon said, in a rather offended tone, “Hm! No accounting for
+         |                  ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2477 | eagerly that the Gryphon said, in a rather offended tone, “Hm! No accounting for
+         |                                                            ^~ Did you mean to spell “Hm” this way?
+Suggest:
+  - Replace with: “H”
+  - Replace with: “Ham”
+  - Replace with: “He”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2485 | > evening, beautiful Soup! Beau—ootiful Soo—oop! Beau—ootiful Soo—oop! Soo—oop
+         |                                 ^~~~~~~ Did you mean to spell “ootiful” this way?
+Suggest:
+  - Replace with: “dutiful”
+  - Replace with: “pitiful”
+  - Replace with: “potful”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2485 | > evening, beautiful Soup! Beau—ootiful Soo—oop! Beau—ootiful Soo—oop! Soo—oop
+         |                                         ^~~ Did you mean to spell “Soo” this way?
+Suggest:
+  - Replace with: “Son”
+  - Replace with: “Soho”
+  - Replace with: “Soto”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2485 | > evening, beautiful Soup! Beau—ootiful Soo—oop! Beau—ootiful Soo—oop! Soo—oop
+         |                                             ^~~ Did you mean to spell “oop” this way?
+Suggest:
+  - Replace with: “oops”
+  - Replace with: “op”
+  - Replace with: “opp”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2485 | > evening, beautiful Soup! Beau—ootiful Soo—oop! Beau—ootiful Soo—oop! Soo—oop
+         |                                                       ^~~~~~~ Did you mean to spell “ootiful” this way?
+Suggest:
+  - Replace with: “dutiful”
+  - Replace with: “pitiful”
+  - Replace with: “potful”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2485 | > evening, beautiful Soup! Beau—ootiful Soo—oop! Beau—ootiful Soo—oop! Soo—oop
+         |                                                               ^~~ Did you mean to spell “Soo” this way?
+Suggest:
+  - Replace with: “Son”
+  - Replace with: “Soho”
+  - Replace with: “Soto”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2485 | > evening, beautiful Soup! Beau—ootiful Soo—oop! Beau—ootiful Soo—oop! Soo—oop
+         |                                                                   ^~~ Did you mean to spell “oop” this way?
+Suggest:
+  - Replace with: “oops”
+  - Replace with: “op”
+  - Replace with: “opp”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2485 | > evening, beautiful Soup! Beau—ootiful Soo—oop! Beau—ootiful Soo—oop! Soo—oop
+         |                                                                        ^~~ Did you mean to spell “Soo” this way?
+    2486 | > of the e—e—evening, Beautiful, beautiful Soup!
+Suggest:
+  - Replace with: “Son”
+  - Replace with: “Soho”
+  - Replace with: “Soto”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2485 | > evening, beautiful Soup! Beau—ootiful Soo—oop! Beau—ootiful Soo—oop! Soo—oop
+         |                                                                            ^~~ Did you mean to spell “oop” this way?
+    2486 | > of the e—e—evening, Beautiful, beautiful Soup!
+Suggest:
+  - Replace with: “oops”
+  - Replace with: “op”
+  - Replace with: “opp”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    2488 | > “Beautiful Soup! Who cares for fish, Game, or any other dish? Who would not
+    2489 | > give all else for two p ennyworth only of beautiful Soup? Pennyworth only of
+         |                         ^~~~~~~~~~~ It seems these words would go better together.
+Suggest:
+  - Replace with: “pennyworth”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2488 | > “Beautiful Soup! Who cares for fish, Game, or any other dish? Who would not
+    2489 | > give all else for two p ennyworth only of beautiful Soup? Pennyworth only of
+         |                           ^~~~~~~~~ Did you mean “pennyworth”?
+Suggest:
+  - Replace with: “pennyworth”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2490 | > beautiful Soup? Beau—ootiful Soo—oop! Beau—ootiful Soo—oop! Soo—oop of the
+         |                        ^~~~~~~ Did you mean to spell “ootiful” this way?
+Suggest:
+  - Replace with: “dutiful”
+  - Replace with: “pitiful”
+  - Replace with: “potful”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2490 | > beautiful Soup? Beau—ootiful Soo—oop! Beau—ootiful Soo—oop! Soo—oop of the
+         |                                ^~~ Did you mean to spell “Soo” this way?
+Suggest:
+  - Replace with: “Son”
+  - Replace with: “Soho”
+  - Replace with: “Soto”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2490 | > beautiful Soup? Beau—ootiful Soo—oop! Beau—ootiful Soo—oop! Soo—oop of the
+         |                                    ^~~ Did you mean to spell “oop” this way?
+Suggest:
+  - Replace with: “oops”
+  - Replace with: “op”
+  - Replace with: “opp”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2490 | > beautiful Soup? Beau—ootiful Soo—oop! Beau—ootiful Soo—oop! Soo—oop of the
+         |                                              ^~~~~~~ Did you mean to spell “ootiful” this way?
+Suggest:
+  - Replace with: “dutiful”
+  - Replace with: “pitiful”
+  - Replace with: “potful”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2490 | > beautiful Soup? Beau—ootiful Soo—oop! Beau—ootiful Soo—oop! Soo—oop of the
+         |                                                      ^~~ Did you mean to spell “Soo” this way?
+Suggest:
+  - Replace with: “Son”
+  - Replace with: “Soho”
+  - Replace with: “Soto”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2490 | > beautiful Soup? Beau—ootiful Soo—oop! Beau—ootiful Soo—oop! Soo—oop of the
+         |                                                          ^~~ Did you mean to spell “oop” this way?
+Suggest:
+  - Replace with: “oops”
+  - Replace with: “op”
+  - Replace with: “opp”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2490 | > beautiful Soup? Beau—ootiful Soo—oop! Beau—ootiful Soo—oop! Soo—oop of the
+         |                                                               ^~~ Did you mean to spell “Soo” this way?
+    2491 | > e—e—evening, Beautiful, beauti—FUL SOUP!”
+Suggest:
+  - Replace with: “Son”
+  - Replace with: “Soho”
+  - Replace with: “Soto”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2490 | > beautiful Soup? Beau—ootiful Soo—oop! Beau—ootiful Soo—oop! Soo—oop of the
+         |                                                                   ^~~ Did you mean to spell “oop” this way?
+    2491 | > e—e—evening, Beautiful, beauti—FUL SOUP!”
+Suggest:
+  - Replace with: “oops”
+  - Replace with: “op”
+  - Replace with: “opp”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2490 | > beautiful Soup? Beau—ootiful Soo—oop! Beau—ootiful Soo—oop! Soo—oop of the
+    2491 | > e—e—evening, Beautiful, beauti—FUL SOUP!”
+         |                           ^~~~~~ Did you mean to spell “beauti” this way?
+Suggest:
+  - Replace with: “beauty”
+  - Replace with: “beaut”
+  - Replace with: “beauts”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2490 | > beautiful Soup? Beau—ootiful Soo—oop! Beau—ootiful Soo—oop! Soo—oop of the
+    2491 | > e—e—evening, Beautiful, beauti—FUL SOUP!”
+         |                                  ^~~ Did you mean to spell “FUL” this way?
+Suggest:
+  - Replace with: “FUD”
+  - Replace with: “F's”
+  - Replace with: “UL”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2493 | “Chorus again!” cried the Gryphon, and the Mock Turtle had just begun to repeat
+         |                           ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2496 | “Come on!” cried the Gryphon, and, taking Alice by the hand, it hurried off,
+         |                      ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2499 | “What trial is it?” Alice panted as she ran; but the Gryphon only answered “Come
+         |                                                      ^~~~~~~ Did you mean “Krypton”?
+    2500 | on!” and ran the faster, while more and more faintly came, carried on the breeze
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2503 | > “Soo—oop of the e—e—evening, Beautiful, beautiful Soup!”
+         |    ^~~ Did you mean to spell “Soo” this way?
+Suggest:
+  - Replace with: “Son”
+  - Replace with: “Soho”
+  - Replace with: “Soto”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2503 | > “Soo—oop of the e—e—evening, Beautiful, beautiful Soup!”
+         |        ^~~ Did you mean to spell “oop” this way?
+Suggest:
+  - Replace with: “oops”
+  - Replace with: “op”
+  - Replace with: “opp”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2507 | The King and Queen of Hearts were seated on their throne when they arrived, with
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2508 | a great crowd assembled about them—all sorts of little birds and beasts, as well
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2509 | as the whole pack of cards: the Knave was standing before them, in chains, with
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2510 | a soldier on each side to guard him; and near the King was the White Rabbit,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2511 | with a trumpet in one hand, and a scroll of parchment in the other. In the very
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 75 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2511 | with a trumpet in one hand, and a scroll of parchment in the other. In the very
+         |                                                                    ^~~~~~~~~~~~~
+    2512 | middle of the court was a table, with a large dish of tarts upon it: they looked
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2513 | so good, that it made Alice quite hungry to look at them—“I wish they’d get the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2514 | trial done,” she thought, “and hand round the refreshments!” But there seemed to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 46 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2523 | The judge, by the way, was the King; and as he wore his crown over the wig,
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2524 | (look at the frontispiece if you want to see how he did it,) he did not look at
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2525 | all comfortable, and it was certainly not becoming.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2534 | The twelve jurors were all writing very busily on slates. “What are they doing?”
+    2535 | Alice whispered to the Gryphon. “They can’t have anything to put down yet,
+         |                        ^~~~~~~ Did you mean “Krypton”?
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2538 | “They’re putting down their names,” the Gryphon whispered in reply, “for fear
+         |                                         ^~~~~~~ Did you mean “Krypton”?
+    2539 | they should forget them before the end of the trial.”
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2547 | even make out that one of them didn’t know how to spell “stupid,” and that he
+    2548 | had to ask his neighbour to tell him. “A nice muddle their slates’ll be in
+         |                ^~~~~~~~~ Did you mean to spell “neighbour” this way?
+Suggest:
+  - Replace with: “neighbor”
+  - Replace with: “neighbours”
+  - Replace with: “neighbour's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2548 | had to ask his neighbour to tell him. “A nice muddle their slates’ll be in
+         |                                                            ^~~~~~~~~ Did you mean to spell “slates’ll” this way?
+    2549 | before the trial’s over!” thought Alice.
+Suggest:
+  - Replace with: “slate's”
+  - Replace with: “slates”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2553 | opportunity of taking it away. She did it so quickly that the poor little juror
+         |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2554 | (it was Bill, the Lizard) could not make out at all what had become of it; so,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2555 | after hunting all about for it, he was obliged to write with one finger for the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2556 | rest of the day; and this was of very little use, as it left no mark on the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2557 | slate.
+         | ~~~~~~ This sentence is 62 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2608 | This did not seem to encourage the witness at all: he kept shifting from one
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2609 | foot to the other, looking uneasily at the Queen, and in his confusion he bit a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2610 | large piece out of his teacup instead of the bread-and-butter.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2612 | Just at this moment Alice felt a very curious sensation, which puzzled her a
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2613 | good deal until she made out what it was: she was beginning to grow larger
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2614 | again, and she thought at first she would get up and leave the court; but on
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2615 | second thoughts she decided to remain where she was as long as there was room
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2616 | for her.
+         | ~~~~~~~~ This sentence is 62 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2631 | All this time the Queen had never left off staring at the Hatter, and, just as
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2632 | the Dormouse crossed the court, she said to one of the officers of the court,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2633 | “Bring me the list of the singers in the last concert!” on which the wretched
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2639 | “I’m a poor man, your Majesty,” the Hatter began, in a trembling voice, “—and I
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2640 | hadn’t begun my tea—not above a week or so—and what with the bread-and-butter
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+    2641 | getting so thin—and the twinkling of the tea—”
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+    2643 | “The twinkling of the what?” said the King.
+         |                   ^~~~ Remove `the` before `what`. In most contexts, `what` alone is clearer.
+Suggest:
+  - Remove error
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2722 | “Well, if I must, I must,” the King said, with a melancholy air, and, after
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2723 | folding his arms and frowning at the cook till his eyes were nearly out of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2724 | sight, he said in a deep voice, “What are tarts made of?”
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2747 | “Here!” cried Alice, quite forgetting in the flurry of the moment how large she
+         |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2748 | had grown in the last few minutes, and she jumped up in such a hurry that she
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2749 | tipped over the jury-box with the edge of her skirt, upsetting all the jurymen
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2750 | on to the heads of the crowd below, and there they lay sprawling about,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2751 | reminding her very much of a globe of goldfish she had accidentally upset the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2752 | week before.
+         | ~~~~~~~~~~~~ This sentence is 75 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2754 | “Oh, I beg your pardon!” she exclaimed in a tone of great dismay, and began
+         |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2755 | picking them up again as quickly as she could, for the accident of the goldfish
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2756 | kept running in her head, and she had a vague sort of idea that they must be
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2757 | collected at once and put back into the jury-box, or they would die.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 56 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2769 | As soon as the jury had a little recovered from the shock of being upset, and
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2770 | their slates and pencils had been found and handed back to them, they set to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2771 | work very diligently to write out a history of the accident, all except the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2772 | Lizard, who seemed too much overcome to do anything but sit with its mouth open,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2773 | gazing up into the roof of the court.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 68 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2907 | “All right, so far,” said the King, and he went on muttering over the verses to
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2908 | himself: “‘We know it to be true—’ that’s the jury, of course—‘I gave her one,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 48 words long.
+    2909 | they gave him two—’ why, that must be what he did with the tarts, you know—”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2918 | spoke. (The unfortunate little Bill had left off writing on his slate with one
+         |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2919 | finger, as he found it made no mark; but he now hastily began again, using the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2920 | ink, that was trickling down his face, as long as it lasted.)
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2929 | “No, no!” said the Queen. “Sentence first—verdict afterwards.”
+         |                                                   ^~~~~~~~~~ Did you mean to spell “afterwards” this way?
+Suggest:
+  - Replace with: “afterward”
+  - Replace with: “afterwords”
+  - Replace with: “afterword's”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2943 | At this the whole pack rose up into the air, and came flying down upon her: she
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2944 | gave a little scream, half of fright and half of anger, and tried to beat them
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2945 | off, and found herself lying on the bank, with her head in the lap of her
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2946 | sister, who was gently brushing away some dead leaves that had fluttered down
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2947 | from the trees upon her face.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 68 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2951 | “Oh, I’ve had such a curious dream!” said Alice, and she told her sister, as
+         |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2952 | well as she could remember them, all these strange Adventures of hers that you
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2953 | have just been reading about; and when she had finished, her sister kissed her,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2954 | and said, “It was a curious dream, dear, certainly: but now run in to your tea;
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2955 | it’s getting late.” So Alice got up and ran off, thinking while she ran, as well
+         | ~~~~~~~~~~~~~~~~~~ This sentence is 55 words long.
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+    2954 | and said, “It was a curious dream, dear, certainly: but now run in to your tea;
+         |                                                                 ^~~~~ Did you mean the closed compound `into`?
+Suggest:
+  - Replace with: “into”
+
+
+
+Lint:    Formatting (255 priority)
+Message: |
+    2955 | it’s getting late.” So Alice got up and ran off, thinking while she ran, as well
+         |                   ^ This quote has no termination.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2960 | But her sister sat still just as she left her, leaning her head on her hand,
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2961 | watching the setting sun, and thinking of little Alice and all her wonderful
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2962 | Adventures, till she too began dreaming after a fashion, and this was her
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+    2963 | dream:—
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2965 | First, she dreamed of little Alice herself, and once again the tiny hands were
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2966 | clasped upon her knee, and the bright eager eyes were looking up into hers—she
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2967 | could hear the very tones of her voice, and see that queer little toss of her
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2968 | head to keep back the wandering hair that would always get into her eyes—and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2969 | still as she listened, or seemed to listen, the whole place around her became
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2970 | alive with the strange creatures of her little sister’s dream.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 84 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2972 | The long grass rustled at her feet as the White Rabbit hurried by—the frightened
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2973 | Mouse splashed his way through the neighbouring pool—she could hear the rattle
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2974 | of the teacups as the March Hare and his friends shared their never-ending meal,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2975 | and the shrill voice of the Queen ordering off her unfortunate guests to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2976 | execution—once more the pig-baby was sneezing on the Duchess’s knee, while
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2977 | plates and dishes crashed around it—once more the shriek of the Gryphon, the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2978 | squeaking of the Lizard’s slate-pencil, and the choking of the suppressed
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2979 | guinea-pigs, filled the air, mixed up with the distant sobs of the miserable
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2980 | Mock Turtle.
+         | ~~~~~~~~~~~~ This sentence is 111 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2977 | plates and dishes crashed around it—once more the shriek of the Gryphon, the
+         |                                                                 ^~~~~~~ Did you mean “Krypton”?
+    2978 | squeaking of the Lizard’s slate-pencil, and the choking of the suppressed
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2982 | So she sat on, with closed eyes, and half believed herself in Wonderland, though
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2983 | she knew she had but to open them again, and all would change to dull
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2984 | reality—the grass would be only rustling in the wind, and the pool rippling to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2985 | the waving of the reeds—the rattling teacups would change to tinkling
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2986 | sheep-bells, and the Queen’s shrill cries to the voice of the shepherd boy—and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2987 | the sneeze of the baby, the shriek of the Gryphon, and all the other queer
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2988 | noises, would change (she knew) to the confused clamour of the busy
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2989 | farm-yard—while the lowing of the cattle in the distance would take the place of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2990 | the Mock Turtle’s heavy sobs.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 119 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2987 | the sneeze of the baby, the shriek of the Gryphon, and all the other queer
+         |                                           ^~~~~~~ Did you mean “Krypton”?
+    2988 | noises, would change (she knew) to the confused clamour of the busy
+Suggest:
+  - Replace with: “Krypton”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2988 | noises, would change (she knew) to the confused clamour of the busy
+         |                                                 ^~~~~~~ Did you mean to spell “clamour” this way?
+    2989 | farm-yard—while the lowing of the cattle in the distance would take the place of
+Suggest:
+  - Replace with: “clamor”
+  - Replace with: “clamours”
+  - Replace with: “glamour”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2992 | Lastly, she pictured to herself how this same little sister of hers would, in
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2993 | the after-time, be herself a grown woman; and how she would keep, through all
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2994 | her riper years, the simple and loving heart of her childhood: and how she would
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2995 | gather about her other little children, and make their eyes bright and eager
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2996 | with many a strange tale, perhaps even with the dream of Wonderland of long ago:
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2997 | and how she would feel with all their simple sorrows, and find a pleasure in all
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2998 | their simple joys, remembering her own child-life, and the happy summer days.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 101 words long.
+
+
+
+Lint:    Style (31 priority)
+Message: |
+    2993 | the after-time, be herself a grown woman; and how she would keep, through all
+    2994 | her riper years, the simple and loving heart of her childhood: and how she would
+         |                      ^~~~~~ An Oxford comma is necessary here.
+Suggest:
+  - Insert “,”
+
+
+

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -476,15 +476,6 @@ Message: |
 Lint:    Capitalization (31 priority)
 Message: |
      226 | himself as he came, “Oh! the Duchess, the Duchess! Oh! won’t she be savage if
-         |                          ^ This sentence does not start with a capital letter
-Suggest:
-  - Replace with: “T”
-
-
-
-Lint:    Capitalization (31 priority)
-Message: |
-     226 | himself as he came, “Oh! the Duchess, the Duchess! Oh! won’t she be savage if
          |                                                        ^ This sentence does not start with a capital letter
      227 | I’ve kept her waiting!” Alice felt so desperate that she was ready to ask help
 Suggest:

--- a/harper-core/tests/text/linters/Computer science.snap.yml
+++ b/harper-core/tests/text/linters/Computer science.snap.yml
@@ -1,0 +1,1213 @@
+Lint:    Spelling (63 priority)
+Message: |
+      45 | Wilhelm Schickard designed and constructed the first working mechanical
+         |         ^~~~~~~~~ Did you mean “Schick”?
+Suggest:
+  - Replace with: “Schick”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      46 | calculator in 1623. In 1673, Gottfried Leibniz demonstrated a digital mechanical
+         |                              ^~~~~~~~~ Did you mean to spell “Gottfried” this way?
+Suggest:
+  - Replace with: “Lotteries”
+  - Replace with: “Notified”
+  - Replace with: “Pottered”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      46 | calculator in 1623. In 1673, Gottfried Leibniz demonstrated a digital mechanical
+      47 | calculator, called the Stepped Reckoner. Leibniz may be considered the first
+         |                                ^~~~~~~~ Did you mean to spell “Reckoner” this way?
+Suggest:
+  - Replace with: “Rickover”
+  - Replace with: “Reckoned”
+  - Replace with: “Beckoned”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      49 | including the fact that he documented the binary number system. In 1820, Thomas
+      50 | de Colmar launched the mechanical calculator industry[note 1] when he invented
+         | ^~ Did you mean to spell “de” this way?
+Suggest:
+  - Replace with: “d”
+  - Replace with: “db”
+  - Replace with: “dc”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      49 | including the fact that he documented the binary number system. In 1820, Thomas
+      50 | de Colmar launched the mechanical calculator industry[note 1] when he invented
+         |    ^~~~~~ Did you mean to spell “Colmar” this way?
+Suggest:
+  - Replace with: “Collar”
+  - Replace with: “Colemak”
+  - Replace with: “Coleman”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      50 | de Colmar launched the mechanical calculator industry[note 1] when he invented
+      51 | his simplified arithmometer, the first calculating machine strong enough and
+         |                ^~~~~~~~~~~~ Did you mean to spell “arithmometer” this way?
+Suggest:
+  - Replace with: “arithmetic”
+  - Replace with: “anemometer”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      59 | programmable.[note 2] In 1843, during the translation of a French article on the
+         |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      60 | Analytical Engine, Ada Lovelace wrote, in one of the many notes she included, an
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      61 | algorithm to compute the Bernoulli numbers, which is considered to be the first
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      62 | published algorithm ever specifically tailored for implementation on a computer.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 48 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      65 | Following Babbage, although unaware of his earlier work, Percy Ludgate in 1909
+         |                                                                ^~~~~~~ Did you mean to spell “Ludgate” this way?
+      66 | published the 2nd of the only two designs for mechanical analytical engines in
+Suggest:
+  - Replace with: “Luddite”
+  - Replace with: “Vulgate”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      67 | history. In 1914, the Spanish engineer Leonardo Torres Quevedo published his
+         |                                                        ^~~~~~~ Did you mean “Acevedo”?
+      68 | Essays on Automatics, and designed, inspired by Babbage, a theoretical
+Suggest:
+  - Replace with: “Acevedo”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      68 | Essays on Automatics, and designed, inspired by Babbage, a theoretical
+      69 | electromechanical calculating machine which was to be controlled by a read-only
+         | ^~~~~~~~~~~~~~~~~ Did you mean to spell “electromechanical” this way?
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      71 | 1920, to celebrate the 100th anniversary of the invention of the arithmometer,
+         |                                                                  ^~~~~~~~~~~~ Did you mean to spell “arithmometer” this way?
+      72 | Torres presented in Paris the Electromechanical Arithmometer, a prototype that
+Suggest:
+  - Replace with: “arithmetic”
+  - Replace with: “anemometer”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      71 | 1920, to celebrate the 100th anniversary of the invention of the arithmometer,
+      72 | Torres presented in Paris the Electromechanical Arithmometer, a prototype that
+         |                               ^~~~~~~~~~~~~~~~~ Did you mean to spell “Electromechanical” this way?
+      73 | demonstrated the feasibility of an electromechanical analytical engine, on which
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      72 | Torres presented in Paris the Electromechanical Arithmometer, a prototype that
+         |                                                 ^~~~~~~~~~~~ Did you mean to spell “Arithmometer” this way?
+      73 | demonstrated the feasibility of an electromechanical analytical engine, on which
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      72 | Torres presented in Paris the Electromechanical Arithmometer, a prototype that
+      73 | demonstrated the feasibility of an electromechanical analytical engine, on which
+         |                                    ^~~~~~~~~~~~~~~~~ Did you mean to spell “electromechanical” this way?
+      74 | commands could be typed and the results printed automatically. In 1937, one
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      74 | commands could be typed and the results printed automatically. In 1937, one
+         |                                                               ^~~~~~~~~~~~~~
+      75 | hundred years after Babbage's impossible dream, Howard Aiken convinced IBM,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      76 | which was making all kinds of punched card equipment and was also in the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      77 | calculator business to develop his giant programmable calculator, the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      78 | ASCC/Harvard Mark I, based on Babbage's Analytical Engine, which itself used
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      79 | cards and a central computing unit. When the machine was finished, some hailed
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 53 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      77 | calculator business to develop his giant programmable calculator, the
+      78 | ASCC/Harvard Mark I, based on Babbage's Analytical Engine, which itself used
+         | ^~~~ Did you mean to spell “ASCC” this way?
+Suggest:
+  - Replace with: “ABC”
+  - Replace with: “ABCs”
+  - Replace with: “ACL”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      82 | During the 1940s, with the development of new and more powerful computing
+      83 | machines such as the Atanasoff–Berry computer and ENIAC, the term computer came
+         |                      ^~~~~~~~~ Did you mean “Standoff”?
+Suggest:
+  - Replace with: “Standoff”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      83 | machines such as the Atanasoff–Berry computer and ENIAC, the term computer came
+         |                                                   ^~~~~ Did you mean to spell “ENIAC” this way?
+      84 | to refer to the machines rather than their human predecessors. As it became
+Suggest:
+  - Replace with: “ENE's”
+  - Replace with: “Anzac”
+  - Replace with: “Fenian”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+      87 | 1945, IBM founded the Watson Scientific Computing Laboratory at Columbia
+         |                                                                 ^~~~~~~~~
+      88 | University in New York City. The renovated fraternity house on Manhattan's West
+         | ~~~~~~~~~~ Ensure proper capitalization of major universities in the United States.
+Suggest:
+  - Replace with: “Columbia University”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+      91 | around the world. Ultimately, the close relationship between IBM and Columbia
+         |                                                                      ^~~~~~~~~
+      92 | University was instrumental in the emergence of a new scientific discipline,
+         | ~~~~~~~~~~ Ensure proper capitalization of major universities in the United States.
+Suggest:
+  - Replace with: “Columbia University”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     104 | Although first proposed in 1956, the term "computer science" appears in a 1959
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     105 | article in Communications of the ACM, in which Louis Fein argues for the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     106 | creation of a Graduate School in Computer Sciences analogous to the creation of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     107 | Harvard Business School in 1921. Louis justifies the name by arguing that, like
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     105 | article in Communications of the ACM, in which Louis Fein argues for the
+         |                                                      ^~~~ Did you mean to spell “Fein” this way?
+     106 | creation of a Graduate School in Computer Sciences analogous to the creation of
+Suggest:
+  - Replace with: “Fern”
+  - Replace with: “Fain”
+  - Replace with: “Vein”
+
+
+
+Lint:    Style (63 priority)
+Message: |
+     108 | management science, the subject is applied and interdisciplinary in nature,
+     109 | while having the characteristics typical of an academic discipline. His efforts,
+         |                                  ^~~~~~~~~~~~~ The word `of` is not needed here.
+Suggest:
+  - Replace with: “typical an”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     110 | and those of others such as numerical analyst George Forsythe, were rewarded:
+         |                                                      ^~~~~~~~ Did you mean to spell “Forsythe” this way?
+Suggest:
+  - Replace with: “Forster”
+  - Replace with: “Forsythia”
+  - Replace with: “Porsche”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     115 | computing science, to emphasize precisely that difference. Danish scientist
+     116 | Peter Naur suggested the term datalogy, to reflect the fact that the scientific
+         |       ^~~~ Did you mean to spell “Naur” this way?
+Suggest:
+  - Replace with: “Nauru”
+  - Replace with: “Nair”
+  - Replace with: “Na's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     115 | computing science, to emphasize precisely that difference. Danish scientist
+     116 | Peter Naur suggested the term datalogy, to reflect the fact that the scientific
+         |                               ^~~~~~~~ Did you mean to spell “datalogy” this way?
+Suggest:
+  - Replace with: “analogy”
+  - Replace with: “catalog”
+  - Replace with: “catalogs”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     118 | involving computers. The first scientific institution to use the term was the
+     119 | Department of Datalogy at the University of Copenhagen, founded in 1969, with
+         |               ^~~~~~~~ Did you mean to spell “Datalogy” this way?
+Suggest:
+  - Replace with: “Analogy”
+  - Replace with: “Catalog”
+  - Replace with: “Catalogs”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     119 | Department of Datalogy at the University of Copenhagen, founded in 1969, with
+     120 | Peter Naur being the first professor in datalogy. The term is used mainly in the
+         |       ^~~~ Did you mean to spell “Naur” this way?
+Suggest:
+  - Replace with: “Nauru”
+  - Replace with: “Nair”
+  - Replace with: “Na's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     119 | Department of Datalogy at the University of Copenhagen, founded in 1969, with
+     120 | Peter Naur being the first professor in datalogy. The term is used mainly in the
+         |                                         ^~~~~~~~ Did you mean to spell “datalogy” this way?
+Suggest:
+  - Replace with: “analogy”
+  - Replace with: “catalog”
+  - Replace with: “catalogs”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     121 | Scandinavian countries. An alternative term, also proposed by Naur, is data
+         |                                                               ^~~~ Did you mean to spell “Naur” this way?
+     122 | science; this is now used for a multi-disciplinary field of data analysis,
+Suggest:
+  - Replace with: “Nauru”
+  - Replace with: “Nair”
+  - Replace with: “Na's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     126 | field of computing were suggested (albeit facetiously) in the Communications of
+     127 | the ACM—turingineer, turologist, flow-charts-man, applied meta-mathematician,
+         |         ^~~~~~~~~~~ Did you mean to spell “turingineer” this way?
+Suggest:
+  - Replace with: “engineer”
+  - Replace with: “springier”
+  - Replace with: “springiness”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     126 | field of computing were suggested (albeit facetiously) in the Communications of
+     127 | the ACM—turingineer, turologist, flow-charts-man, applied meta-mathematician,
+         |                      ^~~~~~~~~~ Did you mean to spell “turologist” this way?
+Suggest:
+  - Replace with: “urologist”
+  - Replace with: “theologist”
+  - Replace with: “neurologist”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     127 | the ACM—turingineer, turologist, flow-charts-man, applied meta-mathematician,
+     128 | and applied epistemologist. Three months later in the same journal, comptologist
+         |             ^~~~~~~~~~~~~~ Did you mean to spell “epistemologist” this way?
+Suggest:
+  - Replace with: “epistemological”
+  - Replace with: “epistemology”
+  - Replace with: “epidemiologist”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     128 | and applied epistemologist. Three months later in the same journal, comptologist
+         |                                                                     ^~~~~~~~~~~~ Did you mean “cosmetologist”?
+     129 | was suggested, followed next year by hypologist. The term computics has also
+Suggest:
+  - Replace with: “cosmetologist”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     128 | and applied epistemologist. Three months later in the same journal, comptologist
+     129 | was suggested, followed next year by hypologist. The term computics has also
+         |                                      ^~~~~~~~~~ Did you mean to spell “hypologist” this way?
+Suggest:
+  - Replace with: “horologist”
+  - Replace with: “hydrologist”
+  - Replace with: “apologist”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     129 | was suggested, followed next year by hypologist. The term computics has also
+         |                                                           ^~~~~~~~~ Did you mean to spell “computics” this way?
+     130 | been suggested. In Europe, terms derived from contracted translations of the
+Suggest:
+  - Replace with: “computers”
+  - Replace with: “computes”
+  - Replace with: “computing”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     130 | been suggested. In Europe, terms derived from contracted translations of the
+         |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     131 | expression "automatic information" (e.g. "informazione automatica" in Italian)
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     132 | or "information and mathematics" are often used, e.g. informatique (French),
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     133 | Informatik (German), informatica (Italian, Dutch), informática (Spanish,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     134 | Portuguese), informatika (Slavic languages and Hungarian) or pliroforiki
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     135 | (πληροφορική, which means informatics) in Greek. Similar words have also been
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 47 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     131 | expression "automatic information" (e.g. "informazione automatica" in Italian)
+         |                                           ^~~~~~~~~~~~ Did you mean “information”?
+     132 | or "information and mathematics" are often used, e.g. informatique (French),
+Suggest:
+  - Replace with: “information”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     131 | expression "automatic information" (e.g. "informazione automatica" in Italian)
+         |                                                        ^~~~~~~~~~ Did you mean to spell “automatica” this way?
+     132 | or "information and mathematics" are often used, e.g. informatique (French),
+Suggest:
+  - Replace with: “automatic”
+  - Replace with: “automatics”
+  - Replace with: “automata”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     132 | or "information and mathematics" are often used, e.g. informatique (French),
+         |                                                       ^~~~~~~~~~~~ Did you mean “informative”?
+     133 | Informatik (German), informatica (Italian, Dutch), informática (Spanish,
+Suggest:
+  - Replace with: “informative”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     132 | or "information and mathematics" are often used, e.g. informatique (French),
+     133 | Informatik (German), informatica (Italian, Dutch), informática (Spanish,
+         | ^~~~~~~~~~ Did you mean to spell “Informatik” this way?
+Suggest:
+  - Replace with: “Informatics”
+  - Replace with: “Information”
+  - Replace with: “Informative”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     132 | or "information and mathematics" are often used, e.g. informatique (French),
+     133 | Informatik (German), informatica (Italian, Dutch), informática (Spanish,
+         |                      ^~~~~~~~~~~ Did you mean to spell “informatica” this way?
+Suggest:
+  - Replace with: “informatics”
+  - Replace with: “information”
+  - Replace with: “informative”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     133 | Informatik (German), informatica (Italian, Dutch), informática (Spanish,
+         |                                                    ^~~~~~~~~~~ Did you mean “informatics”?
+     134 | Portuguese), informatika (Slavic languages and Hungarian) or pliroforiki
+Suggest:
+  - Replace with: “informatics”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     133 | Informatik (German), informatica (Italian, Dutch), informática (Spanish,
+     134 | Portuguese), informatika (Slavic languages and Hungarian) or pliroforiki
+         |              ^~~~~~~~~~~ Did you mean to spell “informatika” this way?
+Suggest:
+  - Replace with: “informatics”
+  - Replace with: “information”
+  - Replace with: “informative”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     134 | Portuguese), informatika (Slavic languages and Hungarian) or pliroforiki
+         |                                                              ^~~~~~~~~~~ Did you mean to spell “pliroforiki” this way?
+     135 | (πληροφορική, which means informatics) in Greek. Similar words have also been
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     137 | "In the U.S., however, informatics is linked with applied computing, or
+         |         ^~~~ Did you mean to spell “U.S.” this way?
+Suggest:
+  - Replace with: “UBS”
+  - Replace with: “USA”
+  - Replace with: “USB”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     140 | A folkloric quotation, often attributed to—but almost certainly not first
+     141 | formulated by—Edsger Dijkstra, states that "computer science is no more about
+         |               ^~~~~~ Did you mean to spell “Edsger” this way?
+Suggest:
+  - Replace with: “Edger”
+  - Replace with: “Easter”
+  - Replace with: “Edgar”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     154 | computing is a mathematical science. Early computer science was strongly
+         |                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     155 | influenced by the work of mathematicians such as Kurt Gödel, Alan Turing, John
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     156 | von Neumann, Rózsa Péter and Alonzo Church and there continues to be a useful
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     157 | interchange of ideas between the two fields in areas such as mathematical logic,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     158 | category theory, domain theory, and algebra.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 51 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     155 | influenced by the work of mathematicians such as Kurt Gödel, Alan Turing, John
+         |                                                       ^~~~~ Did you mean to spell “Gödel” this way?
+     156 | von Neumann, Rózsa Péter and Alonzo Church and there continues to be a useful
+Suggest:
+  - Replace with: “Godel”
+  - Replace with: “Gael”
+  - Replace with: “Gide”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     155 | influenced by the work of mathematicians such as Kurt Gödel, Alan Turing, John
+     156 | von Neumann, Rózsa Péter and Alonzo Church and there continues to be a useful
+         | ^~~ Did you mean to spell “von” this way?
+Suggest:
+  - Replace with: “van”
+  - Replace with: “vol”
+  - Replace with: “vow”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     155 | influenced by the work of mathematicians such as Kurt Gödel, Alan Turing, John
+     156 | von Neumann, Rózsa Péter and Alonzo Church and there continues to be a useful
+         |     ^~~~~~~ Did you mean to spell “Neumann” this way?
+Suggest:
+  - Replace with: “Newman”
+  - Replace with: “Newman's”
+  - Replace with: “Norman”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     155 | influenced by the work of mathematicians such as Kurt Gödel, Alan Turing, John
+     156 | von Neumann, Rózsa Péter and Alonzo Church and there continues to be a useful
+         |              ^~~~~ Did you mean to spell “Rózsa” this way?
+Suggest:
+  - Replace with: “Rosa”
+  - Replace with: “R's”
+  - Replace with: “RV's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     155 | influenced by the work of mathematicians such as Kurt Gödel, Alan Turing, John
+     156 | von Neumann, Rózsa Péter and Alonzo Church and there continues to be a useful
+         |                    ^~~~~ Did you mean to spell “Péter” this way?
+Suggest:
+  - Replace with: “Peter”
+  - Replace with: “Patel”
+  - Replace with: “Pete”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+     161 | contentious issue, which is further muddied by disputes over what the term
+     162 | "software engineering" means, and how computer science is defined. David Parnas,
+         |                                   ^~~~ Insert `to` after `how` (e.g., `how to clone`).
+Suggest:
+  - Insert “to ”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     162 | "software engineering" means, and how computer science is defined. David Parnas,
+         |                                                                   ^~~~~~~~~~~~~~~
+     163 | taking a cue from the relationship between other engineering and science
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     164 | disciplines, has claimed that the principal focus of computer science is
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     165 | studying the properties of computation in general, while the principal focus of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     166 | software engineering is the design of specific computations to achieve practical
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     167 | goals, making the two separate but complementary disciplines.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 55 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     162 | "software engineering" means, and how computer science is defined. David Parnas,
+         |                                                                          ^~~~~~ Did you mean to spell “Parnas” this way?
+     163 | taking a cue from the relationship between other engineering and science
+Suggest:
+  - Replace with: “Parana's”
+  - Replace with: “Parr's”
+  - Replace with: “Patna's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     181 | computer science is a discipline of science, mathematics, or engineering. Allen
+     182 | Newell and Herbert A. Simon argued in 1975,
+         | ^~~~~~ Did you mean to spell “Newell” this way?
+Suggest:
+  - Replace with: “Newels”
+  - Replace with: “Jewell”
+  - Replace with: “Nell”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     181 | computer science is a discipline of science, mathematics, or engineering. Allen
+     182 | Newell and Herbert A. Simon argued in 1975,
+         |                    ^~ Did you mean to spell “A.” this way?
+Suggest:
+  - Replace with: “Ax”
+  - Replace with: “A”
+  - Replace with: “Ab”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     192 | It has since been argued that computer science can be classified as an empirical
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     193 | science since it makes use of empirical testing to evaluate the correctness of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     194 | programs, but a problem remains in defining the laws and theorems of computer
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     195 | science (if any exist) and defining the nature of experiments in computer
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     196 | science. Proponents of classifying computer science as an engineering discipline
+         | ~~~~~~~~ This sentence is 53 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     198 | way as bridges in civil engineering and airplanes in aerospace engineering. They
+         |                                                                            ^~~~~~
+     199 | also argue that while empirical sciences observe what presently exists, computer
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     200 | science observes what is possible to exist and while scientists discover laws
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     201 | from observation, no proper laws have been found in computer science and it is
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     202 | instead concerned with creating phenomena.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     207 | Computer scientists Edsger W. Dijkstra and Tony Hoare regard instructions for
+         |                     ^~~~~~ Did you mean to spell “Edsger” this way?
+Suggest:
+  - Replace with: “Edger”
+  - Replace with: “Easter”
+  - Replace with: “Edgar”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     207 | Computer scientists Edsger W. Dijkstra and Tony Hoare regard instructions for
+         |                            ^~ Did you mean to spell “W.” this way?
+Suggest:
+  - Replace with: “We”
+  - Replace with: “WA”
+  - Replace with: “WC”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     207 | Computer scientists Edsger W. Dijkstra and Tony Hoare regard instructions for
+         |                                                 ^~~~~ Did you mean to spell “Hoare” this way?
+     208 | computer programs as mathematical sentences and interpret formal semantics for
+Suggest:
+  - Replace with: “Hare”
+  - Replace with: “Hoard”
+  - Replace with: “Hoary”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     214 | separate paradigms in computer science. Peter Wegner argued that those paradigms
+         |                                               ^~~~~~ Did you mean to spell “Wegner” this way?
+     215 | are science, technology, and mathematics. Peter Denning's working group argued
+Suggest:
+  - Replace with: “Wagner”
+  - Replace with: “Wigner”
+  - Replace with: “Warner”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     215 | are science, technology, and mathematics. Peter Denning's working group argued
+         |                                                 ^~~~~~~~~ Did you mean to spell “Denning's” this way?
+     216 | that they are theory, abstraction (modeling), and design. Amnon H. Eden
+Suggest:
+  - Replace with: “Deming's”
+  - Replace with: “Dennis's”
+  - Replace with: “Jennings's”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     216 | that they are theory, abstraction (modeling), and design. Amnon H. Eden
+         |                                                          ^~~~~~~~~~~~~~~
+     217 | described them as the "rationalist paradigm" (which treats computer science as a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     218 | branch of mathematics, which is prevalent in theoretical computer science, and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     219 | mainly employs deductive reasoning), the "technocratic paradigm" (which might be
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     220 | found in engineering approaches, most prominently in software engineering), and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     221 | the "scientific paradigm" (which approaches computer-related artifacts from the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     222 | empirical perspective of natural sciences, identifiable in some branches of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     223 | artificial intelligence). Computer science focuses on methods involved in
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 68 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     216 | that they are theory, abstraction (modeling), and design. Amnon H. Eden
+         |                                                           ^~~~~ Did you mean to spell “Amnon” this way?
+Suggest:
+  - Replace with: “Amnion”
+  - Replace with: “Anon”
+  - Replace with: “Aaron”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     216 | that they are theory, abstraction (modeling), and design. Amnon H. Eden
+         |                                                                 ^~ Did you mean to spell “H.” this way?
+Suggest:
+  - Replace with: “Hi”
+  - Replace with: “H”
+  - Replace with: “He”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     231 | implementing computing systems in hardware and software. CSAB, formerly called
+         |                                                         ^~~~~~~~~~~~~~~~~~~~~~~
+     232 | Computing Sciences Accreditation Board—which is made up of representatives of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     233 | the Association for Computing Machinery (ACM), and the IEEE Computer Society
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     234 | (IEEE CS)—identifies four areas that it considers crucial to the discipline of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     235 | computer science: theory of computation, algorithms and data structures,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     236 | programming methodology and languages, and computer elements and architecture.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 56 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     231 | implementing computing systems in hardware and software. CSAB, formerly called
+         |                                                          ^~~~ Did you mean to spell “CSAB” this way?
+     232 | Computing Sciences Accreditation Board—which is made up of representatives of
+Suggest:
+  - Replace with: “Cab”
+  - Replace with: “CAI”
+  - Replace with: “CIA”
+
+
+
+Lint:    Style (31 priority)
+Message: |
+     235 | computer science: theory of computation, algorithms and data structures,
+         |                                          ^~~~~~~~~~ An Oxford comma is necessary here.
+     236 | programming methodology and languages, and computer elements and architecture.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     236 | programming methodology and languages, and computer elements and architecture.
+         |                                                                               ^
+     237 | In addition to these four areas, CSAB also identifies fields such as software
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     238 | engineering, artificial intelligence, computer networking and communication,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     239 | database systems, parallel computation, distributed computation, human–computer
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     240 | interaction, computer graphics, operating systems, and numerical and symbolic
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     241 | computation as being important areas of computer science.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 45 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     237 | In addition to these four areas, CSAB also identifies fields such as software
+         |                                  ^~~~ Did you mean to spell “CSAB” this way?
+Suggest:
+  - Replace with: “Cab”
+  - Replace with: “CAI”
+  - Replace with: “CIA”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     252 | According to Peter Denning, the fundamental question underlying computer science
+         |                    ^~~~~~~ Did you mean to spell “Denning” this way?
+Suggest:
+  - Replace with: “Denying”
+  - Replace with: “Donning”
+  - Replace with: “Penning”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     255 | are required to perform those computations. In an effort to answer the first
+     256 | question, computability theory examines which computational problems are
+         |           ^~~~~~~~~~~~~ Did you mean to spell “computability” this way?
+Suggest:
+  - Replace with: “compatibility”
+  - Replace with: “comparability”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     262 | The famous P = NP? problem, one of the Millennium Prize Problems, is an open
+         |                ^~ Did you mean to spell “NP” this way?
+Suggest:
+  - Replace with: “N”
+  - Replace with: “Nap”
+  - Replace with: “Nip”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     262 | The famous P = NP? problem, one of the Millennium Prize Problems, is an open
+         |                    ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “P”
+
+
+
+Lint:    Style (31 priority)
+Message: |
+     291 | Formal methods are a particular kind of mathematically based technique for the
+     292 | specification, development and verification of software and hardware systems.
+         |                ^~~~~~~~~~~ An Oxford comma is necessary here.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     302 | safety or security is of utmost importance. Formal methods are best described as
+         |                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     303 | the application of a fairly broad variety of theoretical computer science
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     304 | fundamentals, in particular logic calculi, formal languages, automata theory,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     305 | and program semantics, but also type systems and algebraic data types to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     306 | problems in software and hardware specification and verification.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 46 words long.
+
+
+
+Lint:    Style (31 priority)
+Message: |
+     320 | Information can take the form of images, sound, video or other multimedia. Bits
+         |                                                 ^~~~~ An Oxford comma is necessary here.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Style (31 priority)
+Message: |
+     323 | processing algorithms independently of the type of information carrier – whether
+     324 | it is electrical, mechanical or biological. This field plays important role in
+         |                   ^~~~~~~~~~ An Oxford comma is necessary here.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     327 | is the lower bound on the complexity of fast Fourier transform algorithms? is
+         |                                                                            ^ This sentence does not start with a capital letter
+     328 | one of the unsolved problems in theoretical computer science.
+Suggest:
+  - Replace with: “I”
+
+
+
+Lint:    Style (31 priority)
+Message: |
+     330 | #### Computational science, finance and engineering
+         |                             ^~~~~~~ An Oxford comma is necessary here.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     346 | Human–computer interaction (HCI) is the field of study and research concerned
+         |                             ^~~ Did you mean to spell “HCI” this way?
+Suggest:
+  - Replace with: “Hi”
+  - Replace with: “CI”
+  - Replace with: “MCI”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     348 | interaction between humans and computer interfaces. HCI has several subfields
+         |                                                     ^~~ Did you mean to spell “HCI” this way?
+     349 | that focus on the relationship between emotions, social behavior and brain
+Suggest:
+  - Replace with: “Hi”
+  - Replace with: “CI”
+  - Replace with: “MCI”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     371 | semiotics, electrical engineering, philosophy of mind, neurophysiology, and
+         |                                                        ^~~~~~~~~~~~~~~ Did you mean “neurobiology”?
+     372 | social intelligence. AI is associated in the popular mind with robotic
+Suggest:
+  - Replace with: “neurobiology”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     393 | term "architecture" in computer literature can be traced to the work of Lyle R.
+         |                                                                              ^~ Did you mean to spell “R.” this way?
+Suggest:
+  - Replace with: “Rm”
+  - Replace with: “R”
+  - Replace with: “Re”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     394 | Johnson and Frederick P. Brooks Jr., members of the Machine Organization
+         |                       ^~ Did you mean to spell “P.” this way?
+Suggest:
+  - Replace with: “Pt”
+  - Replace with: “Pa”
+  - Replace with: “Pf”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     401 | mathematical models have been developed for general concurrent computation
+     402 | including Petri nets, process calculi and the parallel random access machine
+         |           ^~~~~ Did you mean to spell “Petri” this way?
+Suggest:
+  - Replace with: “Petra”
+  - Replace with: “Patti”
+  - Replace with: “Peary”
+
+
+
+Lint:    WordChoice (127 priority)
+Message: |
+     421 | Modern cryptography is the scientific study of problems relating to distributed
+         |                                                                  ^~~~~~~~~~~~~~ The base form of the verb is needed here.
+     422 | computations that can be attacked. Technologies studied in modern cryptography
+Suggest:
+  - Replace with: “to distribute”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+     432 | languages. Data mining is a process of discovering patterns in large data sets.
+         |                                                                      ^~~~~~~~~ Did you mean the closed compound noun “datasets”?
+Suggest:
+  - Replace with: “datasets”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     436 | The philosopher of computing Bill Rapaport noted three Great Insights of
+         |                                   ^~~~~~~~ Did you mean to spell “Rapaport” this way?
+     437 | Computer Science:
+Suggest:
+  - Replace with: “Rapport”
+  - Replace with: “Rappaport”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     439 | - Gottfried Wilhelm Leibniz's, George Boole's, Alan Turing's, Claude Shannon's,
+         |   ^~~~~~~~~ Did you mean to spell “Gottfried” this way?
+Suggest:
+  - Replace with: “Lotteries”
+  - Replace with: “Notified”
+  - Replace with: “Pottered”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     441 |   deal with in order to represent "anything".[note 4]
+     442 |   > All the information about any computable problem can be represented using
+         |                                   ^~~~~~~~~~ Did you mean to spell “computable” this way?
+     443 |   > only 0 and 1 (or any other bistable pair that can flip-flop between two
+Suggest:
+  - Replace with: “commutable”
+  - Replace with: “comparable”
+  - Replace with: “compatible”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     442 |   > All the information about any computable problem can be represented using
+     443 |   > only 0 and 1 (or any other bistable pair that can flip-flop between two
+         |                                ^~~~~~~~ Did you mean to spell “bistable” this way?
+Suggest:
+  - Replace with: “beatable”
+  - Replace with: “biddable”
+  - Replace with: “billable”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     444 |   > easily distinguishable states, such as "on/off", "magnetized/de-magnetized",
+         |                                                                  ^~ Did you mean to spell “de” this way?
+     445 |   > "high-voltage/low-voltage", etc.).
+Suggest:
+  - Replace with: “d”
+  - Replace with: “db”
+  - Replace with: “dc”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     456 |   - print 1 at current location.
+         |     ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “P”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     458 | - Corrado Böhm and Giuseppe Jacopini's insight: there are only three ways of
+         |   ^~~~~~~ Did you mean to spell “Corrado” this way?
+Suggest:
+  - Replace with: “Colorado”
+  - Replace with: “Conrad”
+  - Replace with: “Coronado”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     458 | - Corrado Böhm and Giuseppe Jacopini's insight: there are only three ways of
+         |           ^~~~ Did you mean to spell “Böhm” this way?
+Suggest:
+  - Replace with: “Baum”
+  - Replace with: “Bohr”
+  - Replace with: “Chm”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     458 | - Corrado Böhm and Giuseppe Jacopini's insight: there are only three ways of
+         |                             ^~~~~~~~~~ Did you mean to spell “Jacopini's” this way?
+Suggest:
+  - Replace with: “Jacobin's”
+  - Replace with: “Jacobi's”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     466 |   - selection: IF such-and-such is the case, THEN do this, ELSE do that;
+         |     ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “S”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     467 |   - repetition: WHILE such-and-such is the case, DO this. The three rules of
+         |     ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “R”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     467 |   - repetition: WHILE such-and-such is the case, DO this. The three rules of
+     468 |     Boehm's and Jacopini's insight can be further simplified with the use of
+         |     ^~~~~~~ Did you mean to spell “Boehm's” this way?
+Suggest:
+  - Replace with: “Boer's”
+  - Replace with: “Bohr's”
+  - Replace with: “Ohm's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     467 |   - repetition: WHILE such-and-such is the case, DO this. The three rules of
+     468 |     Boehm's and Jacopini's insight can be further simplified with the use of
+         |                 ^~~~~~~~~~ Did you mean to spell “Jacopini's” this way?
+Suggest:
+  - Replace with: “Jacobin's”
+  - Replace with: “Jacobi's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     468 |     Boehm's and Jacopini's insight can be further simplified with the use of
+     469 |     goto (which means it is more elementary than structured programming).
+         |     ^~~~ Did you mean to spell “goto” this way?
+Suggest:
+  - Replace with: “got”
+  - Replace with: “goo”
+  - Replace with: “gore”
+
+
+

--- a/harper-core/tests/text/linters/Part-of-speech tagging.snap.yml
+++ b/harper-core/tests/text/linters/Part-of-speech tagging.snap.yml
@@ -1,0 +1,635 @@
+Lint:    Readability (127 priority)
+Message: |
+       8 | In corpus linguistics, part-of-speech tagging (POS tagging or PoS tagging or
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+       9 | POST), also called grammatical tagging is the process of marking up a word in a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      10 | text (corpus) as corresponding to a particular part of speech, based on both its
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      11 | definition and its context. A simplified form of this is commonly taught to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 46 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+       8 | In corpus linguistics, part-of-speech tagging (POS tagging or PoS tagging or
+         |                                                ^~~ Did you mean to spell “POS” this way?
+       9 | POST), also called grammatical tagging is the process of marking up a word in a
+Suggest:
+  - Replace with: “PBS”
+  - Replace with: “PMS”
+  - Replace with: “POV”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+       8 | In corpus linguistics, part-of-speech tagging (POS tagging or PoS tagging or
+         |                                                               ^~~ Did you mean to spell “PoS” this way?
+       9 | POST), also called grammatical tagging is the process of marking up a word in a
+Suggest:
+  - Replace with: “Poe”
+  - Replace with: “PBS”
+  - Replace with: “PMS”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      15 | Once performed by hand, POS tagging is now done in the context of computational
+         |                         ^~~ Did you mean to spell “POS” this way?
+Suggest:
+  - Replace with: “PBS”
+  - Replace with: “PMS”
+  - Replace with: “POV”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      17 | parts of speech, by a set of descriptive tags. POS-tagging algorithms fall into
+         |                                                ^~~ Did you mean to spell “POS” this way?
+      18 | two distinctive groups: rule-based and stochastic. E. Brill's tagger, one of the
+Suggest:
+  - Replace with: “PBS”
+  - Replace with: “PMS”
+  - Replace with: “POV”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      18 | two distinctive groups: rule-based and stochastic. E. Brill's tagger, one of the
+         |                                                    ^~ Did you mean to spell “E.” this way?
+Suggest:
+  - Replace with: “E”
+  - Replace with: “Ea”
+  - Replace with: “Ed”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      18 | two distinctive groups: rule-based and stochastic. E. Brill's tagger, one of the
+         |                                                       ^~~~~~~ Did you mean to spell “Brill's” this way?
+      19 | first and most widely used English POS-taggers, employs rule-based algorithms.
+Suggest:
+  - Replace with: “Brillo's”
+  - Replace with: “Bill's”
+  - Replace with: “Trill's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      18 | two distinctive groups: rule-based and stochastic. E. Brill's tagger, one of the
+      19 | first and most widely used English POS-taggers, employs rule-based algorithms.
+         |                                    ^~~ Did you mean to spell “POS” this way?
+Suggest:
+  - Replace with: “PBS”
+  - Replace with: “PMS”
+  - Replace with: “POV”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      33 | as the more common plural noun. Grammatical context is one way to determine
+         |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      34 | this; semantic analysis can also be used to infer that "sailor" and "hatch"
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      35 | implicate "dogs" as 1) in the nautical context and 2) an action applied to the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      36 | object "hatch" (in this context, "dogs" is a nautical term meaning "fastens (a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      37 | watertight door) securely").
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 49 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      49 | tags. For example, NN for singular common nouns, NNS for plural common nouns, NP
+         |                    ^~ Did you mean to spell “NN” this way?
+Suggest:
+  - Replace with: “Nun”
+  - Replace with: “Non”
+  - Replace with: “N1”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      49 | tags. For example, NN for singular common nouns, NNS for plural common nouns, NP
+         |                                                  ^~~ Did you mean to spell “NNS” this way?
+      50 | for singular proper nouns (see the POS tags used in the Brown Corpus). Other
+Suggest:
+  - Replace with: “NBS”
+  - Replace with: “NES”
+  - Replace with: “NS”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      49 | tags. For example, NN for singular common nouns, NNS for plural common nouns, NP
+         |                                                                               ^~ Did you mean to spell “NP” this way?
+      50 | for singular proper nouns (see the POS tags used in the Brown Corpus). Other
+Suggest:
+  - Replace with: “N”
+  - Replace with: “Nap”
+  - Replace with: “Nip”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      49 | tags. For example, NN for singular common nouns, NNS for plural common nouns, NP
+      50 | for singular proper nouns (see the POS tags used in the Brown Corpus). Other
+         |                                    ^~~ Did you mean to spell “POS” this way?
+Suggest:
+  - Replace with: “PBS”
+  - Replace with: “PMS”
+  - Replace with: “POV”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      55 | 150 separate parts of speech for English. Work on stochastic methods for tagging
+      56 | Koine Greek (DeRose 1990) has used over 1,000 parts of speech and found that
+         | ^~~~~ Did you mean to spell “Koine” this way?
+Suggest:
+  - Replace with: “Kine”
+  - Replace with: “Kline”
+  - Replace with: “Kane”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      55 | 150 separate parts of speech for English. Work on stochastic methods for tagging
+      56 | Koine Greek (DeRose 1990) has used over 1,000 parts of speech and found that
+         |              ^~~~~~ Did you mean to spell “DeRose” this way?
+Suggest:
+  - Replace with: “Depose”
+  - Replace with: “Defoe”
+  - Replace with: “Denise”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      57 | about as many words were ambiguous in that language as in English. A
+      58 | morphosyntactic descriptor in the case of morphologically rich languages is
+         | ^~~~~~~~~~~~~~~ Did you mean to spell “morphosyntactic” this way?
+Suggest:
+  - Replace with: “morphosyntax's”
+  - Replace with: “morphosyntax”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      58 | morphosyntactic descriptor in the case of morphologically rich languages is
+         |                                           ^~~~~~~~~~~~~~~ Did you mean “morphological”?
+      59 | commonly expressed using very short mnemonics, such as Ncmsan for Category=Noun,
+Suggest:
+  - Replace with: “morphological”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      59 | commonly expressed using very short mnemonics, such as Ncmsan for Category=Noun,
+         |                                                        ^~~~~~ Did you mean to spell “Ncmsan” this way?
+      60 | Type = common, Gender = masculine, Number = singular, Case = accusative, Animate
+Suggest:
+  - Replace with: “Nissan”
+  - Replace with: “Nisan”
+  - Replace with: “Nolan”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      63 | The most popular "tag set" for POS tagging for American English is probably the
+         |                                ^~~ Did you mean to spell “POS” this way?
+Suggest:
+  - Replace with: “PBS”
+  - Replace with: “PMS”
+  - Replace with: “POV”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      63 | The most popular "tag set" for POS tagging for American English is probably the
+      64 | Penn tag set, developed in the Penn Treebank project. It is largely similar to
+         |                                     ^~~~~~~~ Did you mean to spell “Treebank” this way?
+Suggest:
+  - Replace with: “Freeman”
+  - Replace with: “Reembark”
+  - Replace with: “Debank”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      69 | POS tagging work has been done in a variety of languages, and the set of POS
+         | ^~~ Did you mean to spell “POS” this way?
+Suggest:
+  - Replace with: “PBS”
+  - Replace with: “PMS”
+  - Replace with: “POV”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      69 | POS tagging work has been done in a variety of languages, and the set of POS
+         |                                                                          ^~~ Did you mean to spell “POS” this way?
+      70 | tags used varies greatly with language. Tags usually are designed to include
+Suggest:
+  - Replace with: “PBS”
+  - Replace with: “PMS”
+  - Replace with: “POV”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      74 | Greek and Latin can be very large; tagging words in agglutinative languages such
+         |                                                     ^~~~~~~~~~~~~ Did you mean to spell “agglutinative” this way?
+      75 | as Inuit languages may be virtually impossible. At the other extreme, Petrov et
+Suggest:
+  - Replace with: “agglutinate”
+  - Replace with: “agglutinating”
+  - Replace with: “agglutination”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      75 | as Inuit languages may be virtually impossible. At the other extreme, Petrov et
+         |                                                                       ^~~~~~ Did you mean to spell “Petrov” this way?
+      76 | al. have proposed a "universal" tag set, with 12 categories (for example, no
+Suggest:
+  - Replace with: “Petrol”
+  - Replace with: “Pedro”
+  - Replace with: “Peron”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      75 | as Inuit languages may be virtually impossible. At the other extreme, Petrov et
+         |                                                                              ^~~
+      76 | al. have proposed a "universal" tag set, with 12 categories (for example, no
+         | ~~~ Did you mean “et al.”?
+Suggest:
+  - Replace with: “et al.”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      86 | The first major corpus of English for computer analysis was the Brown Corpus
+      87 | developed at Brown University by Henry Kučera and W. Nelson Francis, in the
+         |                                        ^~~~~~ Did you mean to spell “Kučera” this way?
+Suggest:
+  - Replace with: “Kara”
+  - Replace with: “Kendra”
+  - Replace with: “Keri”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      87 | developed at Brown University by Henry Kučera and W. Nelson Francis, in the
+         |                                                   ^~ Did you mean to spell “W.” this way?
+Suggest:
+  - Replace with: “We”
+  - Replace with: “WA”
+  - Replace with: “WC”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      98 | and corrected by hand, and later users sent in errata so that by the late 70s
+         |                                                                             ^ Did you mean to spell “s” this way?
+      99 | the tagging was nearly perfect (allowing for some cases on which even human
+Suggest:
+  - Replace with: “sf”
+  - Replace with: “sh”
+  - Replace with: “so”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     105 | later part-of-speech tagging systems, such as CLAWS and VOLSUNGA. However, by
+         |                                                         ^~~~~~~~ Did you mean to spell “VOLSUNGA” this way?
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     110 | For some time, part-of-speech tagging was considered an inseparable part of
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     111 | natural language processing, because there are certain cases where the correct
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     112 | part of speech cannot be decided without understanding the semantics or even the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     113 | pragmatics of the context. This is extremely expensive, especially because
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     119 | In the mid-1980s, researchers in Europe began to use hidden Markov models (HMMs)
+         |                                                                            ^~~~ Did you mean to spell “HMMs” this way?
+     120 | to disambiguate parts of speech, when working to tag the Lancaster-Oslo-Bergen
+Suggest:
+  - Replace with: “Hams”
+  - Replace with: “Ha's”
+  - Replace with: “HMO's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     121 | Corpus of British English. HMMs involve counting cases (such as from the Brown
+         |                            ^~~~ Did you mean to spell “HMMs” this way?
+Suggest:
+  - Replace with: “Hams”
+  - Replace with: “Ha's”
+  - Replace with: “HMO's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     129 | More advanced ("higher-order") HMMs learn the probabilities not only of pairs
+         |                                ^~~~ Did you mean to spell “HMMs” this way?
+Suggest:
+  - Replace with: “Hams”
+  - Replace with: “Ha's”
+  - Replace with: “HMO's”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     141 | Eugene Charniak points out in Statistical techniques for natural language
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     142 | parsing (1997) that merely assigning the most common tag to each known word and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     143 | the tag "proper noun" to all unknowns will approach 90% accuracy because many
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     144 | words are unambiguous, and many others only rarely represent their less-common
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     145 | parts of speech.
+         | ~~~~~~~~~~~~~~~~ This sentence is 50 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     141 | Eugene Charniak points out in Statistical techniques for natural language
+         |        ^~~~~~~~ Did you mean to spell “Charniak” this way?
+Suggest:
+  - Replace with: “Carnap”
+  - Replace with: “Chadian”
+  - Replace with: “Chadwick”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     148 | expensive since it enumerated all possibilities. It sometimes had to resort to
+         |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     149 | backup methods when there were simply too many options (the Brown Corpus
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     150 | contains a case with 17 ambiguous words in a row, and there are words such as
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     151 | "still" that can represent as many as 7 distinct parts of speech.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 44 words long.
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+     148 | expensive since it enumerated all possibilities. It sometimes had to resort to
+     149 | backup methods when there were simply too many options (the Brown Corpus
+         | ^~~~~~ This word should be a phrasal verb, not a compound noun.
+Suggest:
+  - Replace with: “back up”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     153 | HMMs underlie the functioning of stochastic taggers and are used in various
+         | ^~~~ Did you mean to spell “HMMs” this way?
+Suggest:
+  - Replace with: “Hams”
+  - Replace with: “Ha's”
+  - Replace with: “HMO's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     159 | In 1987, Steven DeRose and Kenneth W. Church independently developed dynamic
+         |                 ^~~~~~ Did you mean to spell “DeRose” this way?
+Suggest:
+  - Replace with: “Depose”
+  - Replace with: “Defoe”
+  - Replace with: “Denise”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     159 | In 1987, Steven DeRose and Kenneth W. Church independently developed dynamic
+         |                                    ^~ Did you mean to spell “W.” this way?
+Suggest:
+  - Replace with: “We”
+  - Replace with: “WA”
+  - Replace with: “WC”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     160 | programming algorithms to solve the same problem in vastly less time. Their
+     161 | methods were similar to the Viterbi algorithm known for some time in other
+         |                             ^~~~~~~ Did you mean to spell “Viterbi” this way?
+Suggest:
+  - Replace with: “Vite's”
+  - Replace with: “Verdi”
+  - Replace with: “Vite”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     162 | fields. DeRose used a table of pairs, while Church used a table of triples and a
+         |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     163 | method of estimating the values for triples that were rare or nonexistent in the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     164 | Brown Corpus (an actual measurement of triple probabilities would require a much
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     165 | larger corpus). Both methods achieved an accuracy of over 95%. DeRose's 1990
+         | ~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     162 | fields. DeRose used a table of pairs, while Church used a table of triples and a
+         |         ^~~~~~ Did you mean to spell “DeRose” this way?
+Suggest:
+  - Replace with: “Depose”
+  - Replace with: “Defoe”
+  - Replace with: “Denise”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     165 | larger corpus). Both methods achieved an accuracy of over 95%. DeRose's 1990
+         |                                                                ^~~~~~~~ Did you mean to spell “DeRose's” this way?
+     166 | dissertation at Brown University included analyses of the specific error types,
+Suggest:
+  - Replace with: “Defoe's”
+  - Replace with: “Denise's”
+  - Replace with: “Repose's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     173 | levels of linguistic analysis: syntax, morphology, semantics, and so on. CLAWS,
+     174 | DeRose's and Church's methods did fail for some of the known cases where
+         | ^~~~~~~~ Did you mean to spell “DeRose's” this way?
+Suggest:
+  - Replace with: “Defoe's”
+  - Replace with: “Denise's”
+  - Replace with: “Repose's”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     175 | semantics is required, but those proved negligibly rare. This convinced many in
+         |                                                         ^~~~~~~~~~~~~~~~~~~~~~~~
+     176 | the field that part-of-speech tagging could usefully be separated from the other
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     177 | levels of processing; this, in turn, simplified the theory and practice of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     178 | computerized language analysis and encouraged researchers to find ways to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     179 | separate other pieces as well. Markov Models became the standard method for the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 45 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     186 | "unsupervised" tagging. Unsupervised tagging techniques use an untagged corpus
+         |                                                                ^~~~~~~~ Did you mean to spell “untagged” this way?
+     187 | for their training data and produce the tagset by induction. That is, they
+Suggest:
+  - Replace with: “untapped”
+  - Replace with: “untasted”
+  - Replace with: “unwaged”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     186 | "unsupervised" tagging. Unsupervised tagging techniques use an untagged corpus
+     187 | for their training data and produce the tagset by induction. That is, they
+         |                                         ^~~~~~ Did you mean to spell “tagset” this way?
+Suggest:
+  - Replace with: “tablet”
+  - Replace with: “tagged”
+  - Replace with: “target”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     200 | Some current major algorithms for part-of-speech tagging include the Viterbi
+         |                                                                      ^~~~~~~ Did you mean to spell “Viterbi” this way?
+     201 | algorithm, Brill tagger, Constraint Grammar, and the Baum-Welch algorithm (also
+Suggest:
+  - Replace with: “Vite's”
+  - Replace with: “Verdi”
+  - Replace with: “Vite”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     201 | algorithm, Brill tagger, Constraint Grammar, and the Baum-Welch algorithm (also
+         |                                                           ^~~~~ Did you mean to spell “Welch” this way?
+     202 | known as the forward-backward algorithm). Hidden Markov model and visible Markov
+Suggest:
+  - Replace with: “Welsh”
+  - Replace with: “Belch”
+  - Replace with: “Walsh”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     203 | model taggers can both be implemented using the Viterbi algorithm. The
+         |                                                 ^~~~~~~ Did you mean to spell “Viterbi” this way?
+Suggest:
+  - Replace with: “Vite's”
+  - Replace with: “Verdi”
+  - Replace with: “Vite”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     207 | Many machine learning methods have also been applied to the problem of POS
+         |                                                                        ^~~ Did you mean to spell “POS” this way?
+     208 | tagging. Methods such as SVM, maximum entropy classifier, perceptron, and
+Suggest:
+  - Replace with: “PBS”
+  - Replace with: “PMS”
+  - Replace with: “POV”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     208 | tagging. Methods such as SVM, maximum entropy classifier, perceptron, and
+         |                          ^~~ Did you mean to spell “SVM” this way?
+Suggest:
+  - Replace with: “Sim”
+  - Replace with: “Sam”
+  - Replace with: “SCM”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     213 | Wiki. This comparison uses the Penn tag set on some of the Penn Treebank data,
+         |                                                                 ^~~~~~~~ Did you mean to spell “Treebank” this way?
+     214 | so the results are directly comparable. However, many significant taggers are
+Suggest:
+  - Replace with: “Freeman”
+  - Replace with: “Reembark”
+  - Replace with: “Debank”
+
+
+

--- a/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
+++ b/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
@@ -1,0 +1,1683 @@
+Lint:    Readability (127 priority)
+Message: |
+       5 | **We the People** of the United States, in Order to form a more perfect Union,
+         |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+       6 | establish Justice, insure domestic Tranquility, provide for the common defence,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+       7 | promote the general Welfare, and secure the Blessings of Liberty to ourselves
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+       8 | and our Posterity, do ordain and establish this Constitution for the United
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+       9 | States of America.
+         | ~~~~~~~~~~~~~~~~~~ This sentence is 52 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+       6 | establish Justice, insure domestic Tranquility, provide for the common defence,
+         |                                                                        ^~~~~~~ Did you mean to spell “defence” this way?
+       7 | promote the general Welfare, and secure the Blessings of Liberty to ourselves
+Suggest:
+  - Replace with: “defense”
+  - Replace with: “decency”
+  - Replace with: “deface”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+       8 | and our Posterity, do ordain and establish this Constitution for the United
+         |                                                                      ^~~~~~~
+       9 | States of America.
+         | ~~~~~~ When referring to national or international organizations, make sure to treat them as a proper noun.
+Suggest:
+  - Replace with: “United States”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      11 | ## Article. I.
+         |             ^~ Did you mean to spell “I.” this way?
+Suggest:
+  - Replace with: “Ir”
+  - Replace with: “IC”
+  - Replace with: “IE”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      17 | Representatives. Congress shall make no law respecting an establishment of
+         |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      18 | religion, or prohibiting the free exercise thereof; or abridging the freedom of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      19 | speech, or of the press; or the right of the people peaceably to assemble, and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      20 | to petition the government for a redress of grievances.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 45 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      22 | No person shall be a Senator or Representative in Congress, or elector of
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      23 | President and Vice President, or hold any office, civil or military, under the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      24 | United States, or under any State, who, having previously taken an oath, as a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      25 | member of Congress, or as an officer of the United States, or as a member of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      26 | any State legislature, or as an executive or judicial officer of any State, to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      27 | support the Constitution of the United States, shall have engaged in
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      28 | insurrection or rebellion against the same, or given aid or comfort to the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      29 | enemies thereof. But Congress may, by a vote of two-thirds of each House,
+         | ~~~~~~~~~~~~~~~~ This sentence is 96 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      38 | The House of Representatives shall be composed of Members
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      39 | chosen every second Year by the People of the several States, and the Electors
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      40 | in each State shall have the Qualifications requisite for Electors of the most
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      41 | numerous Branch of the State Legislature.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      43 | No Person shall be a Representative who shall not have attained to the Age of
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      44 | twenty five Years, and been seven Years a Citizen of the United States, and who
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      45 | shall not, when elected, be an Inhabitant of that State in which he shall be
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      46 | chosen.
+         | ~~~~~~~ This sentence is 46 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      50 | excluding Indians not taxed. But when the right to vote at any election for the
+         |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      51 | choice of electors for President and Vice President of the United States,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      52 | Representatives in Congress, the Executive and Judicial officers of a State, or
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      53 | the members of the Legislature thereof, is denied to any of the male
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      54 | inhabitants of such State, being twenty-one years of age, and citizens of the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      55 | United States, or in any way abridged, except for participation in rebellion,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      56 | or other crime, the basis of representation therein shall be reduced in the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      57 | proportion which the number of such male citizens shall bear to the whole
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      58 | number of male citizens twenty-one years of age in such State. The actual
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 112 words long.
+
+
+
+Lint:    Style (31 priority)
+Message: |
+      51 | choice of electors for President and Vice President of the United States,
+      52 | Representatives in Congress, the Executive and Judicial officers of a State, or
+         |                                  ^~~~~~~~~ An Oxford comma is necessary here.
+      53 | the members of the Legislature thereof, is denied to any of the male
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      61 | in such Manner as they shall by Law direct. The Number of Representatives shall
+         |                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      62 | not exceed one for every thirty Thousand, but each State shall have at Least
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      63 | one Representative; and until such enumeration shall be made, the State of New
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      64 | Hampshire shall be entitled to chuse three, Massachusetts eight, Rhode-Island
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      65 | and Providence Plantations one, Connecticut five, New-York six, New Jersey
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      66 | four, Pennsylvania eight, Delaware one, Maryland six, Virginia ten, North
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      67 | Carolina five, South Carolina five, and Georgia three.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 72 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      63 | one Representative; and until such enumeration shall be made, the State of New
+      64 | Hampshire shall be entitled to chuse three, Massachusetts eight, Rhode-Island
+         |                                ^~~~~ Did you mean to spell “chuse” this way?
+Suggest:
+  - Replace with: “cause”
+  - Replace with: “chase”
+  - Replace with: “chose”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      72 | The House of Representatives shall chuse their Speaker and other Officers; and
+         |                                    ^~~~~ Did you mean to spell “chuse” this way?
+Suggest:
+  - Replace with: “cause”
+  - Replace with: “chase”
+  - Replace with: “chose”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      86 | they shall be divided as equally as may be into three Classes. The Seats of the
+         |                                                               ^~~~~~~~~~~~~~~~~~
+      87 | Senators of the first Class shall be vacated at the Expiration of the second
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      88 | Year, of the second Class at the Expiration of the fourth Year, and of the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      89 | third Class at the Expiration of the sixth Year, so that one third may be
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      90 | chosen every second Year; and when vacancies happen in the representation of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      91 | any State in the Senate, the executive authority of such State shall issue
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      92 | writs of election to fill such vacancies: Provided, That the legislature of any
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      93 | State may empower the executive thereof to make temporary appointments until
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      94 | the people fill the vacancies by election as the legislature may direct.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 109 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      96 | No Person shall be a Senator who shall not have attained to the Age of thirty
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      97 | Years, and been nine Years a Citizen of the United States, and who shall not,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      98 | when elected, be an Inhabitant of that State for which he shall be chosen.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 45 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     103 | The Senate shall chuse their other Officers, and also a President pro tempore,
+         |                  ^~~~~ Did you mean to spell “chuse” this way?
+Suggest:
+  - Replace with: “cause”
+  - Replace with: “chase”
+  - Replace with: “chose”
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+     103 | The Senate shall chuse their other Officers, and also a President pro tempore,
+         |                                              ^~~~~~~~ Consider using just `and`.
+     104 | in the Absence of the Vice President, or when he shall exercise the Office of
+Suggest:
+  - Replace with: “and”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     103 | The Senate shall chuse their other Officers, and also a President pro tempore,
+         |                                                                       ^~~~~~~ Did you mean to spell “tempore” this way?
+     104 | in the Absence of the Vice President, or when he shall exercise the Office of
+Suggest:
+  - Replace with: “temper”
+  - Replace with: “temple”
+  - Replace with: “tempo”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     112 | Judgment in Cases of impeachment shall not extend further than to removal from
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     113 | Office, and disqualification to hold and enjoy any Office of honor, Trust or
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     114 | Profit under the United States: but the Party convicted shall nevertheless be
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     115 | liable and subject to Indictment, Trial, Judgment and Punishment, according to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     116 | Law.
+         | ~~~~ This sentence is 50 words long.
+
+
+
+Lint:    Style (31 priority)
+Message: |
+     113 | Office, and disqualification to hold and enjoy any Office of honor, Trust or
+         |                                                                     ^~~~~ An Oxford comma is necessary here.
+     114 | Profit under the United States: but the Party convicted shall nevertheless be
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Style (31 priority)
+Message: |
+     115 | liable and subject to Indictment, Trial, Judgment and Punishment, according to
+         |                                          ^~~~~~~~ An Oxford comma is necessary here.
+     116 | Law.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     122 | The Times, Places and Manner of holding Elections for Senators
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     123 | and Representatives, shall be prescribed in each State by the Legislature
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     124 | thereof; but the Congress may at any time by Law make or alter such
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     125 | Regulations, except as to the Places of chusing Senators.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 44 words long.
+
+
+
+Lint:    Style (31 priority)
+Message: |
+     122 | The Times, Places and Manner of holding Elections for Senators
+         |            ^~~~~~ An Oxford comma is necessary here.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     124 | thereof; but the Congress may at any time by Law make or alter such
+     125 | Regulations, except as to the Places of chusing Senators.
+         |                                         ^~~~~~~ Did you mean to spell “chusing” this way?
+Suggest:
+  - Replace with: “chasing”
+  - Replace with: “causing”
+  - Replace with: “casing”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     133 | Each House shall be the Judge of the Elections, Returns and
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     134 | Qualifications of its own Members, and a Majority of each shall constitute a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     135 | Quorum to do Business; but a smaller Number may adjourn from day to day, and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     136 | may be authorized to compel the Attendance of absent Members, in such Manner,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     137 | and under such Penalties as each House may provide.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 61 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     139 | Each House may determine the Rules of its Proceedings, punish its Members for
+     140 | disorderly Behaviour, and, with the Concurrence of two thirds, expel a Member.
+         |            ^~~~~~~~~ Did you mean “Behavior”?
+Suggest:
+  - Replace with: “Behavior”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     142 | Each House shall keep a Journal of its Proceedings, and from time to time
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     143 | publish the same, excepting such Parts as may in their Judgment require
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     144 | Secrecy; and the Yeas and Nays of the Members of either House on any question
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     145 | shall, at the Desire of one fifth of those Present, be entered on the Journal.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 56 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     155 | the United States. They shall in all Cases, except Treason, Felony and Breach
+         |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     156 | of the Peace, be privileged from Arrest during their Attendance at the Session
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     157 | of their respective Houses, and in going to and returning from the same; and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     158 | for any Speech or Debate in either House, they shall not be questioned in any
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     159 | other Place.
+         | ~~~~~~~~~~~~ This sentence is 54 words long.
+
+
+
+Lint:    Style (31 priority)
+Message: |
+     155 | the United States. They shall in all Cases, except Treason, Felony and Breach
+         |                                                             ^~~~~~ An Oxford comma is necessary here.
+     156 | of the Peace, be privileged from Arrest during their Attendance at the Session
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     161 | No Senator or Representative shall, during the Time for which he was elected,
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     162 | be appointed to any civil Office under the Authority of the United States,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     163 | which shall have been created, or the Emoluments whereof shall have been
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     164 | encreased during such time; and no Person holding any Office under the United
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     165 | States, shall be a Member of either House during his Continuance in Office. No
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 64 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     163 | which shall have been created, or the Emoluments whereof shall have been
+     164 | encreased during such time; and no Person holding any Office under the United
+         | ^~~~~~~~~ Did you mean to spell “encreased” this way?
+Suggest:
+  - Replace with: “increased”
+  - Replace with: “encased”
+  - Replace with: “entreated”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     164 | encreased during such time; and no Person holding any Office under the United
+         |                                                                        ^~~~~~~
+     165 | States, shall be a Member of either House during his Continuance in Office. No
+         | ~~~~~~ When referring to national or international organizations, make sure to treat them as a proper noun.
+Suggest:
+  - Replace with: “United States”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     177 | Every Bill which shall have passed the House of Representatives and the Senate,
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     178 | shall, before it become a Law, be presented to the President of the United
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     179 | States; If he approve he shall sign it, but if not he shall return it, with his
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     180 | Objections to that House in which it shall have originated, who shall enter the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     181 | Objections at large on their Journal, and proceed to reconsider it. If after
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 69 words long.
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     178 | shall, before it become a Law, be presented to the President of the United
+         |                                                                     ^~~~~~~
+     179 | States; If he approve he shall sign it, but if not he shall return it, with his
+         | ~~~~~~ When referring to national or international organizations, make sure to treat them as a proper noun.
+Suggest:
+  - Replace with: “United States”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     181 | Objections at large on their Journal, and proceed to reconsider it. If after
+         |                                                                    ^~~~~~~~~~
+     182 | such Reconsideration two thirds of that House shall agree to pass the Bill, it
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     183 | shall be sent, together with the Objections, to the other House, by which it
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     184 | shall likewise be reconsidered, and if approved by two thirds of that House, it
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     185 | shall become a Law. But in all such Cases the Votes of both Houses shall be
+         | ~~~~~~~~~~~~~~~~~~~ This sentence is 48 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     187 | against the Bill shall be entered on the Journal of each House respectively. If
+         |                                                                             ^~~~
+     188 | any Bill shall not be returned by the President within ten Days (Sundays
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     189 | excepted) after it shall have been presented to him, the Same shall be a Law,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     190 | in like Manner as if he had signed it, unless the Congress by their Adjournment
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     191 | prevent its Return, in which Case it shall not be a Law.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 56 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     193 | Every Order, Resolution, or Vote to which the Concurrence of the Senate and
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     194 | House of Representatives may be necessary (except on a question of Adjournment)
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     195 | shall be presented to the President of the United States; and before the Same
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     196 | shall take Effect, shall be approved by him, or being disapproved by him, shall
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     197 | be repassed by two thirds of the Senate and House of Representatives, according
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     198 | to the Rules and Limitations prescribed in the Case of a Bill.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 78 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     196 | shall take Effect, shall be approved by him, or being disapproved by him, shall
+     197 | be repassed by two thirds of the Senate and House of Representatives, according
+         |    ^~~~~~~~ Did you mean to spell “repassed” this way?
+Suggest:
+  - Replace with: “recessed”
+  - Replace with: “rehashed”
+  - Replace with: “relapsed”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     202 | The Congress shall have Power To lay and collect Taxes, Duties,
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     203 | Imposts and Excises, to pay the Debts and provide for the common Defence and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     204 | general Welfare of the United States; but all Duties, Imposts and Excises shall
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 44 words long.
+     205 | be uniform throughout the United States;
+
+
+
+Lint:    Style (31 priority)
+Message: |
+     202 | The Congress shall have Power To lay and collect Taxes, Duties,
+     203 | Imposts and Excises, to pay the Debts and provide for the common Defence and
+         | ^~~~~~~ An Oxford comma is necessary here.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     203 | Imposts and Excises, to pay the Debts and provide for the common Defence and
+         |                                                                  ^~~~~~~ Did you mean to spell “Defence” this way?
+     204 | general Welfare of the United States; but all Duties, Imposts and Excises shall
+Suggest:
+  - Replace with: “Defense”
+  - Replace with: “Fence”
+  - Replace with: “Terence”
+
+
+
+Lint:    Style (31 priority)
+Message: |
+     204 | general Welfare of the United States; but all Duties, Imposts and Excises shall
+         |                                                       ^~~~~~~ An Oxford comma is necessary here.
+     205 | be uniform throughout the United States;
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+     212 | 3. To establish an uniform Rule of Naturalization, and uniform Laws on the subject
+         |                 ^~ Incorrect indefinite article.
+Suggest:
+  - Replace with: “a”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     229 | 9. To define and punish Piracies and Felonies committed on the high Seas, and
+         |                         ^~~~~~~~ Did you mean to spell “Piracies” this way?
+Suggest:
+  - Replace with: “Curacies”
+  - Replace with: “Miracles”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     245 | 15. To provide for organizing, arming, and disciplining, the Militia, and for
+         |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     246 | governing such Part of them as may be employed in the Service of the United
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     247 | States, reserving to the States respectively, the Appointment of the Officers,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     248 | and the Authority of training the Militia according to the discipline
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 51 words long.
+     249 | prescribed by Congress;
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     246 | governing such Part of them as may be employed in the Service of the United
+         |                                                                      ^~~~~~~
+     247 | States, reserving to the States respectively, the Appointment of the Officers,
+         | ~~~~~~ When referring to national or international organizations, make sure to treat them as a proper noun.
+Suggest:
+  - Replace with: “United States”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     251 | 16. To exercise exclusive Legislation in all Cases whatsoever, over such District
+         |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     252 | (not exceeding ten Miles square) as may, by Cession of particular States, and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     253 | the Acceptance of Congress, become the Seat of the Government of the United
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     254 | States, and to exercise like Authority over all Places purchased by the Consent
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     255 | of the Legislature of the State in which the Same shall be, for the Erection of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 76 words long.
+     256 | Forts, Magazines, Arsenals, dock-Yards, and other needful Buildings;—And
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     253 | the Acceptance of Congress, become the Seat of the Government of the United
+         |                                                                      ^~~~~~~
+     254 | States, and to exercise like Authority over all Places purchased by the Consent
+         | ~~~~~~ When referring to national or international organizations, make sure to treat them as a proper noun.
+Suggest:
+  - Replace with: “United States”
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+     253 | the Acceptance of Congress, become the Seat of the Government of the United
+     254 | States, and to exercise like Authority over all Places purchased by the Consent
+         |                                        ^~~~~~~~ Did you mean the closed compound `overall`?
+     255 | of the Legislature of the State in which the Same shall be, for the Erection of
+Suggest:
+  - Replace with: “overall”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     265 | The Migration or Importation of such Persons as any of the
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     266 | States now existing shall think proper to admit, shall not be prohibited by the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     267 | Congress prior to the Year one thousand eight hundred and eight, but a Tax or
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     268 | duty may be imposed on such Importation, not exceeding ten dollars for each
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     269 | Person.
+         | ~~~~~~~ This sentence is 54 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     271 | The Privilege of the Writ of Habeas Corpus shall not be suspended, unless when
+         |                              ^~~~~~ Did you mean to spell “Habeas” this way?
+Suggest:
+  - Replace with: “Haber's”
+  - Replace with: “Hale's”
+  - Replace with: “Hebe's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     274 | No Bill of Attainder or ex post facto Law shall be passed.
+         |                                 ^~~~~ Did you mean to spell “facto” this way?
+Suggest:
+  - Replace with: “fact”
+  - Replace with: “factor”
+  - Replace with: “facts”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     284 | No Preference shall be given by any Regulation of Commerce or Revenue to the
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     285 | Ports of one State over those of another: nor shall Vessels bound to, or from,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     286 | one State, be obliged to enter, clear, or pay Duties in another.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     292 | No Title of Nobility shall be granted by the United States: And no Person
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     293 | holding any Office of Profit or Trust under them, shall, without the Consent of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     294 | the Congress, accept of any present, Emolument, Office, or Title, of any kind
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     295 | whatever, from any King, Prince, or foreign State.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 49 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     297 | The right of citizens of the United States to vote in any primary or other
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     298 | election for President or Vice President, for electors for President or Vice
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     299 | President, or for Senator or Representative in Congress, shall not be denied or
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     300 | abridged by the United States or any State by reason of failure to pay any poll
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     301 | tax or other tax.
+         | ~~~~~~~~~~~~~~~~~ This sentence is 60 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     305 | No State shall enter into any Treaty, Alliance, or
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     306 | Confederation; grant Letters of Marque and Reprisal; coin Money; emit Bills of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     307 | Credit; make any Thing but gold and silver Coin a Tender in Payment of Debts;
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     308 | pass any Bill of Attainder, ex post facto Law, or Law impairing the Obligation
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     309 | of Contracts, or grant any Title of Nobility.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 58 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     308 | pass any Bill of Attainder, ex post facto Law, or Law impairing the Obligation
+         |                                     ^~~~~ Did you mean to spell “facto” this way?
+     309 | of Contracts, or grant any Title of Nobility.
+Suggest:
+  - Replace with: “fact”
+  - Replace with: “factor”
+  - Replace with: “facts”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     311 | No State shall, without the Consent of the Congress, lay any Imposts or Duties
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     312 | on Imports or Exports, except what may be absolutely necessary for executing
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     313 | it's inspection Laws: and the net Produce of all Duties and Imposts, laid by
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     314 | any State on Imports or Exports, shall be for the Use of the Treasury of the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     315 | United States; and all such Laws shall be subject to the Revision and Controul
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     316 | of the Congress.
+         | ~~~~~~~~~~~~~~~~ This sentence is 73 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     315 | United States; and all such Laws shall be subject to the Revision and Controul
+         |                                                                       ^~~~~~~~ Did you mean “Control”?
+     316 | of the Congress.
+Suggest:
+  - Replace with: “Control”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     318 | No State shall, without the Consent of Congress, lay any Duty of Tonnage, keep
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     319 | Troops, or Ships of War in time of Peace, enter into any Agreement or Compact
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     320 | with another State, or with a foreign Power, or engage in War, unless actually
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     321 | invaded, or in such imminent Danger as will not admit of delay.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 55 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     332 | Each State shall appoint, in such Manner as the Legislature thereof may direct,
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     333 | a Number of Electors, equal to the whole Number of Senators and Representatives
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     334 | to which the State may be entitled in the Congress: but no Senator or
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     335 | Representative, or Person holding an Office of Trust or Profit under the United
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     336 | States, shall be appointed an Elector.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 59 words long.
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     335 | Representative, or Person holding an Office of Trust or Profit under the United
+         |                                                                          ^~~~~~~
+     336 | States, shall be appointed an Elector.
+         | ~~~~~~ When referring to national or international organizations, make sure to treat them as a proper noun.
+Suggest:
+  - Replace with: “United States”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     340 | The Electors shall meet in their respective states, and vote
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     341 | by ballot for President and Vice-President, one of whom, at least, shall not be
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     342 | an inhabitant of the same state with themselves; they shall name in their
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     343 | ballots the person voted for as President, and in distinct ballots the person
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     344 | voted for as Vice-President, and they shall make distinct lists of all persons
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     345 | voted for as President, and all persons voted for as Vice-President and of the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     346 | number of votes for each, which lists they shall sign and certify, and transmit
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     347 | sealed to the seat of the government of the United States, directed to the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     348 | President of the Senate;—The President of the Senate shall, in the presence of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     349 | the Senate and House of Representatives, open all the certificates and the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     350 | votes shall then be counted;—The person having the greatest Number of votes for
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     351 | President, shall be the President, if such number be a majority of the whole
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     352 | number of Electors appointed; and if no person have such majority, then from
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     353 | the persons having the highest numbers not exceeding three on the list of those
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     354 | voted for as President, the House of Representatives shall choose immediately,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     355 | by ballot, the President. But in choosing the President, the votes shall be
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 204 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     355 | by ballot, the President. But in choosing the President, the votes shall be
+         |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     356 | taken by states, the representation from each state having one vote; a quorum
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     357 | for this purpose shall consist of a member or members from two-thirds of the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     358 | states, and a majority of all the states shall be necessary to a choice. [If,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 51 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     360 | elect shall have died, the Vice President elect shall become President. If a
+         |                                                                        ^~~~~~
+     361 | President shall not have been chosen before the time fixed for the beginning of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     362 | his term, or if the President elect shall have failed to qualify, then the Vice
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     363 | President elect shall act as President until a President shall have qualified;
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     364 | and the Congress may by law provide for the case wherein neither a President
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     365 | elect nor a Vice President elect shall have qualified, declaring who shall then
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     366 | act as President, or the manner in which one who is to act shall be selected,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     367 | and such person shall act accordingly until a President or Vice President shall
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     368 | have qualified.The Congress may by law provide for the case of the death of any
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     369 | of the persons from whom the House of Representatives may choose a President
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     370 | whenever the right of choice shall have devolved upon them, and for the case of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     371 | the death of any of the persons from whom the Senate may choose a Vice
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     372 | President whenever the right of choice shall have devolved upon them.]The
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 167 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     372 | President whenever the right of choice shall have devolved upon them.]The
+         |                                                                      ^~~~~
+     373 | person having the greatest number of votes as Vice-President, shall be the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     374 | Vice-President, if such number be a majority of the whole number of Electors
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     375 | appointed, and if no person have a majority, then from the two highest numbers
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     376 | on the list, the Senate shall choose the Vice-President; a quorum for the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     377 | purpose shall consist of two-thirds of the whole number of Senators, and a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     378 | majority of the whole number shall be necessary to a choice. But no person
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 81 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     383 | The Congress may determine the Time of chusing the Electors, and the Day on
+         |                                        ^~~~~~~ Did you mean to spell “chusing” this way?
+     384 | which they shall give their Votes; which Day shall be the same throughout the
+Suggest:
+  - Replace with: “chasing”
+  - Replace with: “causing”
+  - Replace with: “casing”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     390 | No Person except a natural born Citizen, or a Citizen of the
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     391 | United States, at the time of the Adoption of this Constitution, shall be
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     392 | eligible to the Office of President; neither shall any Person be eligible to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     393 | that Office who shall not have attained to the Age of thirty five Years, and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     394 | been fourteen Years a Resident within the United States.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 62 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     396 | No person shall be elected to the office of the President more than twice, and
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     397 | no person who has held the office of President, or acted as President, for more
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     398 | than two years of a term to which some other person was elected President shall
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     399 | be elected to the office of the President more than once. But this article
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 56 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     399 | be elected to the office of the President more than once. But this article
+         |                                                          ^~~~~~~~~~~~~~~~~~
+     400 | shall not apply to any person holding the office of President when this article
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     401 | was proposed by the Congress, and shall not prevent any person who may be
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     402 | holding the office of President, or acting as President, during the term within
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     403 | which this article becomes operative from holding the office of President or
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     404 | acting as President during the remainder of such term.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 65 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     415 | Whenever the President transmits to the President pro tempore of the Senate and
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     416 | the Speaker of the House of Representatives his written declaration that he is
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     417 | unable to discharge the powers and duties of his office, and until he transmits
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     418 | to them a written declaration to the contrary, such powers and duties shall be
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     419 | discharged by the Vice President as Acting President.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 62 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     415 | Whenever the President transmits to the President pro tempore of the Senate and
+         |                                                       ^~~~~~~ Did you mean to spell “tempore” this way?
+     416 | the Speaker of the House of Representatives his written declaration that he is
+Suggest:
+  - Replace with: “temper”
+  - Replace with: “temple”
+  - Replace with: “tempo”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     421 | Whenever the Vice President and a majority of either the principal officers of
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     422 | the executive departments or of such other body as Congress may by law provide,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     423 | transmit to the President pro tempore of the Senate and the Speaker of the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     424 | House of Representatives their written declaration that the President is unable
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     425 | to discharge the powers and duties of his office, the Vice President shall
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     426 | immediately assume the powers and duties of the office as Acting President.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 77 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     422 | the executive departments or of such other body as Congress may by law provide,
+     423 | transmit to the President pro tempore of the Senate and the Speaker of the
+         |                               ^~~~~~~ Did you mean to spell “tempore” this way?
+Suggest:
+  - Replace with: “temper”
+  - Replace with: “temple”
+  - Replace with: “tempo”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     428 | Thereafter, when the President transmits to the President pro tempore of the
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     429 | Senate and the Speaker of the House of Representatives his written declaration
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     430 | that no inability exists, he shall resume the powers and duties of his office
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     431 | unless the Vice President and a majority of either the principal officers of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     432 | the executive department or of such other body as Congress may by law provide,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     433 | transmit within four days to the President pro tempore of the Senate and the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     434 | Speaker of the House of Representatives their written declaration that the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     435 | President is unable to discharge the powers and duties of his office. Thereupon
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 102 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     428 | Thereafter, when the President transmits to the President pro tempore of the
+         |                                                               ^~~~~~~ Did you mean to spell “tempore” this way?
+     429 | Senate and the Speaker of the House of Representatives his written declaration
+Suggest:
+  - Replace with: “temper”
+  - Replace with: “temple”
+  - Replace with: “tempo”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     433 | transmit within four days to the President pro tempore of the Senate and the
+         |                                                ^~~~~~~ Did you mean to spell “tempore” this way?
+     434 | Speaker of the House of Representatives their written declaration that the
+Suggest:
+  - Replace with: “temper”
+  - Replace with: “temple”
+  - Replace with: “tempo”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     437 | purpose if not in session. If the Congress, within twenty-one days after
+         |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     438 | receipt of the latter written declaration, or, if Congress is not in session,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     439 | within twenty-one days after Congress is required to assemble, determines by
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     440 | two-thirds vote of both Houses that the President is unable to discharge the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     441 | powers and duties of his office, the Vice President shall continue to discharge
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     442 | the same as Acting President; otherwise, the President shall resume the powers
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     443 | and duties of his office.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 77 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     448 | The President shall, at stated Times, receive for his
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     449 | Services, a Compensation, which shall neither be encreased nor diminished
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     450 | during the Period for which he shall have been elected, and he shall not
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     451 | receive within that Period any other Emolument from the United States, or any
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     452 | of them.
+         | ~~~~~~~~ This sentence is 48 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     449 | Services, a Compensation, which shall neither be encreased nor diminished
+         |                                                  ^~~~~~~~~ Did you mean to spell “encreased” this way?
+     450 | during the Period for which he shall have been elected, and he shall not
+Suggest:
+  - Replace with: “increased”
+  - Replace with: “encased”
+  - Replace with: “entreated”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     454 | Before he enter on the Execution of his Office, he shall take the following
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     455 | Oath or Affirmation:-- "I do solemnly swear (or affirm) that I will faithfully
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     456 | execute the Office of President of the United States, and will to the best of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     457 | my Ability, preserve, protect and defend the Constitution of the United
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     458 | States."
+         | ~~~~~~~ This sentence is 54 words long.
+
+
+
+Lint:    Formatting (63 priority)
+Message: |
+     455 | Oath or Affirmation:-- "I do solemnly swear (or affirm) that I will faithfully
+         |                     ^~ A sequence of hyphens is not an en dash.
+Suggest:
+  - Replace with: “–”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     457 | my Ability, preserve, protect and defend the Constitution of the United
+         |                                                                  ^~~~~~~
+     458 | States."
+         | ~~~~~~ When referring to national or international organizations, make sure to treat them as a proper noun.
+Suggest:
+  - Replace with: “United States”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     465 | A number of electors of President and Vice President equal to the whole number
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     466 | of Senators and Representatives in Congress to which the District would be
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     467 | entitled if it were a State, but in no event more than the least populous
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     468 | State; they shall be in addition to those appointed by the States, but they
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     469 | shall be considered, for the purposes of the election of President and Vice
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     470 | President, to be electors appointed by a State; and they shall meet in the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     471 | District and perform such duties as provided by this article of the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     472 | Constitution.
+         | ~~~~~~~~~~~~~ This sentence is 95 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     476 | The President shall be Commander in Chief of the Army and Navy
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     477 | of the United States, and of the Militia of the several States, when called
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     478 | into the actual Service of the United States; he may require the Opinion, in
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     479 | writing, of the principal Officer in each of the executive Departments, upon
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     480 | any Subject relating to the Duties of their respective Offices, and he shall
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     481 | have Power to grant Reprieves and Pardons for Offences against the United
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     482 | States, except in Cases of Impeachment.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 83 words long.
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     481 | have Power to grant Reprieves and Pardons for Offences against the United
+         |                                                                    ^~~~~~~
+     482 | States, except in Cases of Impeachment.
+         | ~~~~~~ When referring to national or international organizations, make sure to treat them as a proper noun.
+Suggest:
+  - Replace with: “United States”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     484 | He shall have Power, by and with the Advice and Consent of the Senate, to make
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     485 | Treaties, provided two thirds of the Senators present concur; and he shall
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     486 | nominate, and by and with the Advice and Consent of the Senate, shall appoint
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     487 | Ambassadors, other public Ministers and Consuls, Judges of the supreme Court,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     488 | and all other Officers of the United States, whose Appointments are not herein
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     489 | otherwise provided for, and which shall be established by Law: but the Congress
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     490 | may by Law vest the Appointment of such inferior Officers, as they think
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     491 | proper, in the President alone, in the Courts of Law, or in the Heads of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     492 | Departments.
+         | ~~~~~~~~~~~~ This sentence is 108 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     504 | He shall from time to time give to the Congress Information of
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     505 | the State of the Union, and recommend to their Consideration such Measures as
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     506 | he shall judge necessary and expedient; he may, on extraordinary Occasions,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     507 | convene both Houses, or either of them, and in Case of Disagreement between
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     508 | them, with Respect to the Time of Adjournment, he may adjourn them to such Time
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     509 | as he shall think proper; he shall receive Ambassadors and other public
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     510 | Ministers; he shall take Care that the Laws be faithfully executed, and shall
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     511 | Commission all the Officers of the United States.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 97 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     525 | time ordain and establish. The Judges, both of the supreme and inferior Courts,
+     526 | shall hold their Offices during good Behaviour, and shall, at stated Times,
+         |                                      ^~~~~~~~~ Did you mean “Behavior”?
+     527 | receive for their Services, a Compensation, which shall not be diminished
+Suggest:
+  - Replace with: “Behavior”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     532 | The judicial Power shall extend to all Cases, in Law and
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     533 | Equity, arising under this Constitution, the Laws of the United States, and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     534 | Treaties made, or which shall be made, under their Authority;—to all Cases
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     535 | affecting Ambassadors, other public Ministers and Consuls;—to all Cases of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     536 | admiralty and maritime Jurisdiction;—to Controversies to which the United
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     537 | States shall be a Party;—to Controversies between two or more States;—between
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     538 | Citizens of different States, —between Citizens of the same State claiming
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     539 | Lands under Grants of different States.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 87 words long.
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     536 | admiralty and maritime Jurisdiction;—to Controversies to which the United
+         |                                                                    ^~~~~~~
+     537 | States shall be a Party;—to Controversies between two or more States;—between
+         | ~~~~~~ When referring to national or international organizations, make sure to treat them as a proper noun.
+Suggest:
+  - Replace with: “United States”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     548 | The Trial of all Crimes, except in Cases of Impeachment, shall be by Jury; and
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     549 | such Trial shall be held in the State where the said Crimes shall have been
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     550 | committed; but when not committed within any State, the Trial shall be at such
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     551 | Place or Places as the Congress may by Law have directed.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 55 words long.
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+     550 | committed; but when not committed within any State, the Trial shall be at such
+     551 | Place or Places as the Congress may by Law have directed.
+         |                                     ^~~~~~ The auxiliary verb “have” implies the existence of the closed compound noun “bylaw”.
+Suggest:
+  - Replace with: “byLaw”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     561 | Attainder of Treason shall work Corruption of Blood, or Forfeiture except
+     562 | during the Life of the Person attainted.
+         |                               ^~~~~~~~~ Did you mean to spell “attainted” this way?
+Suggest:
+  - Replace with: “attained”
+  - Replace with: “attainder”
+  - Replace with: “tainted”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     566 | The right of the people to be secure in their persons, houses,
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     567 | papers, and effects, against unreasonable searches and seizures, shall not be
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     568 | violated, and no warrants shall issue, but upon probable cause, supported by
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     569 | oath or affirmation, and particularly describing the place to be searched, and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     570 | the persons or things to be seized.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 54 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     572 | No person shall be held to answer for a capital, or otherwise infamous crime,
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     573 | unless on a presentment or indictment of a grand jury, except in cases arising
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     574 | in the land or naval forces, or in the militia, when in actual service in time
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     575 | of war or public danger; nor shall any person be subject for the same offense
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     576 | to be twice put in jeopardy of life or limb; nor shall be compelled in any
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     577 | criminal case to be a witness against himself, nor be deprived of life,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     578 | liberty, or property, without due process of law; nor shall private property be
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     579 | taken for public use, without just compensation.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 108 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     581 | In all criminal prosecutions, the accused shall enjoy the right to a speedy and
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     582 | public trial, by an impartial jury of the state and district wherein the crime
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     583 | shall have been committed, which district shall have been previously
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     584 | ascertained by law, and to be informed of the nature and cause of the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     585 | accusation; to be confronted with the witnesses against him; to have compulsory
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     586 | process for obtaining witnesses in his favor, and to have the assistance of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     587 | counsel for his defense.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 81 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     589 | In suits at common law, where the value in controversy shall exceed twenty
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     590 | dollars, the right of trial by jury shall be preserved, and no fact tried by a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     591 | jury, shall be otherwise reexamined in any court of the United States, than
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     592 | according to the rules of the common law.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 50 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     610 | the State wherein they reside. No State shall make or enforce any law which
+         |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     611 | shall abridge the privileges or immunities of citizens of the United States;
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     612 | nor shall any State deprive any person of life, liberty, or property, without
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     613 | due process of law; nor deny to any person within its jurisdiction the equal
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     614 | protection of the laws.
+         | ~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 52 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     610 | the State wherein they reside. No State shall make or enforce any law which
+     611 | shall abridge the privileges or immunities of citizens of the United States;
+         |                                 ^~~~~~~~~~ Did you mean to spell “immunities” this way?
+Suggest:
+  - Replace with: “immunity's”
+  - Replace with: “immensities”
+  - Replace with: “immunises”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     616 | The right of citizens of the United States, who are eighteen years of age or
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     617 | older, to vote shall not be denied or abridged by the United States or by any
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     618 | State on account of age, sex, race, color, or previous condition of servitude.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 44 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     620 | A Person charged in any State with Treason, Felony, or other Crime, who shall
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     621 | flee from Justice, and be found in another State, shall on Demand of the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     622 | executive Authority of the State from which he fled, be delivered up, to be
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     623 | removed to the State having Jurisdiction of the Crime.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 51 words long.
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     626 | whereof the party shall have been duly convicted, shall exist within the United
+         |                                                                          ^~~~~~~
+     627 | States, or any place subject to their jurisdiction. No Person held to Service
+         | ~~~~~~ When referring to national or international organizations, make sure to treat them as a proper noun.
+Suggest:
+  - Replace with: “United States”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     627 | States, or any place subject to their jurisdiction. No Person held to Service
+         |                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+     628 | or Labour in one State, under the Laws thereof, escaping into another, shall,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     629 | in Consequence of any Law or Regulation therein, be discharged from such
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     630 | Service or Labour, but shall be delivered up on Claim of the Party to whom such
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     631 | Service or Labour may be due.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 52 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     627 | States, or any place subject to their jurisdiction. No Person held to Service
+     628 | or Labour in one State, under the Laws thereof, escaping into another, shall,
+         |    ^~~~~~ Did you mean to spell “Labour” this way?
+Suggest:
+  - Replace with: “Labor”
+  - Replace with: “Labours”
+  - Replace with: “About”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     629 | in Consequence of any Law or Regulation therein, be discharged from such
+     630 | Service or Labour, but shall be delivered up on Claim of the Party to whom such
+         |            ^~~~~~ Did you mean to spell “Labour” this way?
+Suggest:
+  - Replace with: “Labor”
+  - Replace with: “Labours”
+  - Replace with: “About”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     630 | Service or Labour, but shall be delivered up on Claim of the Party to whom such
+     631 | Service or Labour may be due.
+         |            ^~~~~~ Did you mean to spell “Labour” this way?
+Suggest:
+  - Replace with: “Labor”
+  - Replace with: “Labours”
+  - Replace with: “About”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     635 | New States may be admitted by the Congress into this Union; but
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     636 | no new State shall be formed or erected within the Jurisdiction of any other
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     637 | State; nor any State be formed by the Junction of two or more States, or Parts
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     638 | of States, without the Consent of the Legislatures of the States concerned as
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     639 | well as of the Congress.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 60 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     641 | The Congress shall have Power to dispose of and make all needful Rules and
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     642 | Regulations respecting the Territory or other Property belonging to the United
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     643 | States; and nothing in this Constitution shall be so construed as to Prejudice
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     644 | any Claims of the United States, or of any particular State.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 49 words long.
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     642 | Regulations respecting the Territory or other Property belonging to the United
+         |                                                                         ^~~~~~~
+     643 | States; and nothing in this Constitution shall be so construed as to Prejudice
+         | ~~~~~~ When referring to national or international organizations, make sure to treat them as a proper noun.
+Suggest:
+  - Replace with: “United States”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     648 | The United States shall guarantee to every State in this Union
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     649 | a Republican Form of Government, and shall protect each of them against
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     650 | Invasion; and on Application of the Legislature, or of the Executive (when the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     651 | Legislature cannot be convened) against domestic Violence.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     658 | questioned. But neither the United States nor any State shall assume or pay any
+         |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     659 | debt or obligation incurred in aid of insurrection or rebellion against the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     660 | United States, or any claim for the loss or emancipation of any slave; but all
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     661 | such debts, obligations and claims shall be held illegal and void.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 51 words long.
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+     658 | questioned. But neither the United States nor any State shall assume or pay any
+     659 | debt or obligation incurred in aid of insurrection or rebellion against the
+         | ^~~~~~~ Did you mean the closed compound noun “debtor”?
+Suggest:
+  - Replace with: “debtor”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     663 | ## Article. V.
+         |             ^~ Did you mean to spell “V.” this way?
+Suggest:
+  - Replace with: “Vs.”
+  - Replace with: “V”
+  - Replace with: “Vb”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     665 | The Congress, whenever two thirds of both Houses shall deem it necessary, shall
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     666 | propose Amendments to this Constitution, or, on the Application of the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     667 | Legislatures of two thirds of the several States, shall call a Convention for
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     668 | proposing Amendments, which, in either Case, shall be valid to all Intents and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     669 | Purposes, as Part of this Constitution, when ratified by the Legislatures of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     670 | three fourths of the several States, or by Conventions in three fourths
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     671 | thereof, as the one or the other Mode of Ratification may be proposed by the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     672 | Congress; Provided that no Amendment which may be made prior to the Year One
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     673 | thousand eight hundred and eight shall in any Manner affect the first and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     674 | fourth Clauses in the Ninth Section of the first Article; and that no State,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     675 | without its Consent, shall be deprived of its equal Suffrage in the Senate.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 143 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     683 | This Constitution, and the Laws of the United States which shall be made in
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     684 | Pursuance thereof; and all Treaties made, or which shall be made, under the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     685 | Authority of the United States, shall be the supreme Law of the Land; and the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     686 | Judges in every State shall be bound thereby, any Thing in the Constitution or
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     687 | Laws of any State to the Contrary notwithstanding.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 64 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     689 | The Senators and Representatives before mentioned, and the Members of the
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     690 | several State Legislatures, and all executive and judicial Officers, both of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     691 | the United States and of the several States, shall be bound by Oath or
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     692 | Affirmation, to support this Constitution; but no religious Test shall ever be
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     693 | required as a Qualification to any Office or public Trust under the United
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     694 | States.
+         | ~~~~~~~ This sentence is 62 words long.
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     693 | required as a Qualification to any Office or public Trust under the United
+         |                                                                     ^~~~~~~
+     694 | States.
+         | ~~~~~~ When referring to national or international organizations, make sure to treat them as a proper noun.
+Suggest:
+  - Replace with: “United States”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     714 | first Page, The Word "Thirty" being partly written on an Erazure in the
+         |                                                          ^~~~~~~ Did you mean to spell “Erazure” this way?
+     715 | fifteenth Line of the first Page. The Words "is tried" being interlined between
+Suggest:
+  - Replace with: “Erasure”
+  - Replace with: “Azure”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+     721 | done in Convention by the Unanimous Consent of the States present the
+         | ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “D”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     721 | done in Convention by the Unanimous Consent of the States present the
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     722 | Seventeenth Day of September in the Year of our Lord one thousand seven hundred
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     723 | and Eighty seven and of the Independence of the United States of America the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 50 words long.
+     724 | Twelfth In witness whereof We have hereunto subscribed our Names,
+
+
+

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -1,0 +1,7413 @@
+Lint:    Spelling (63 priority)
+Message: |
+       3 | BY F. SCOTT FITZGERALD
+         |    ^~ Did you mean to spell “F.” this way?
+Suggest:
+  - Replace with: “Fa”
+  - Replace with: “Ff”
+  - Replace with: “Fr”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+       3 | BY F. SCOTT FITZGERALD
+         |       ^~~~~ Did you mean to spell “SCOTT” this way?
+Suggest:
+  - Replace with: “SEO's”
+  - Replace with: “Alcott”
+  - Replace with: “Lott”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+       3 | BY F. SCOTT FITZGERALD
+         |             ^~~~~~~~~~ Did you mean to spell “FITZGERALD” this way?
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+      15 | consequence, I’m inclined to reserve all judgments, a habit that has opened up
+      16 | many curious natures to me and also made me the victim of not a few veteran
+         |                            ^~~~~~~~ Consider using just `and`.
+Suggest:
+  - Replace with: “and”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      17 | bores. The abnormal mind is quick to detect and attach itself to this quality
+         |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      18 | when it appears in a normal person, and so it came about that in college I was
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      19 | unjustly accused of being a politician, because I was privy to the secret griefs
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      20 | of wild, unknown men. Most of the confidences were unsought—frequently I have
+         | ~~~~~~~~~~~~~~~~~~~~~ This sentence is 48 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      20 | of wild, unknown men. Most of the confidences were unsought—frequently I have
+         |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      21 | feigned sleep, preoccupation, or a hostile levity when I realized by some
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      22 | unmistakable sign that an intimate revelation was quivering on the horizon; for
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      23 | the intimate revelations of young men, or at least the terms in which they
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      24 | express them, are usually plagiaristic and marred by obvious suppressions.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 57 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      23 | the intimate revelations of young men, or at least the terms in which they
+      24 | express them, are usually plagiaristic and marred by obvious suppressions.
+         |                           ^~~~~~~~~~~~ Did you mean to spell “plagiaristic” this way?
+Suggest:
+  - Replace with: “plagiarist's”
+  - Replace with: “plagiarist”
+  - Replace with: “plagiarists”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      24 | express them, are usually plagiaristic and marred by obvious suppressions.
+         |                                                              ^~~~~~~~~~~~ Did you mean to spell “suppressions” this way?
+Suggest:
+  - Replace with: “suppression's”
+  - Replace with: “suppression”
+  - Replace with: “suppressors”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      27 | snobbishly repeat, a sense of the fundamental decencies is parcelled out
+         |                                                            ^~~~~~~~~ Did you mean “parceled”?
+      28 | unequally at birth.
+Suggest:
+  - Replace with: “parceled”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      32 | after a certain point I don’t care what it’s founded on. When I came back from
+         |                                                         ^~~~~~~~~~~~~~~~~~~~~~~
+      33 | the East last autumn I felt that I wanted the world to be in uniform and at a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      34 | sort of moral attention forever; I wanted no more riotous excursions with
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      35 | privileged glimpses into the human heart. Only Gatsby, the man who gives his
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      37 | everything for which I have an unaffected scorn. If personality is an unbroken
+         |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      38 | series of successful gestures, then there was something gorgeous about him, some
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      39 | heightened sensitivity to the promises of life, as if he were related to one of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      40 | those intricate machines that register earthquakes ten thousand miles away. This
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      40 | those intricate machines that register earthquakes ten thousand miles away. This
+         |                                                                            ^~~~~~
+      41 | responsiveness had nothing to do with that flabby impressionability which is
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      42 | dignified under the name of the “creative temperament”—it was an extraordinary
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      43 | gift for hope, a romantic readiness such as I have never found in any other
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      44 | person and which it is not likely I shall ever find again. No—Gatsby turned out
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 51 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      44 | person and which it is not likely I shall ever find again. No—Gatsby turned out
+         |                                                           ^~~~~~~~~~~~~~~~~~~~~~
+      45 | all right at the end; it is what preyed on Gatsby, what foul dust floated in the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      46 | wake of his dreams that temporarily closed out my interest in the abortive
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      47 | sorrows and short-winded elations of men.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      46 | wake of his dreams that temporarily closed out my interest in the abortive
+      47 | sorrows and short-winded elations of men.
+         |                          ^~~~~~~~ Did you mean to spell “elations” this way?
+Suggest:
+  - Replace with: “elation's”
+  - Replace with: “elation”
+  - Replace with: “relations”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      50 | three generations. The Carraways are something of a clan, and we have a
+         |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      51 | tradition that we’re descended from the Dukes of Buccleuch, but the actual
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      52 | founder of my line was my grandfather’s brother, who came here in fifty-one,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      53 | sent a substitute to the Civil War, and started the wholesale hardware business
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      54 | that my father carries on to-day.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 57 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      50 | three generations. The Carraways are something of a clan, and we have a
+         |                        ^~~~~~~~~ Did you mean “Caraways”?
+Suggest:
+  - Replace with: “Caraways”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      51 | tradition that we’re descended from the Dukes of Buccleuch, but the actual
+         |                                                  ^~~~~~~~~ Did you mean to spell “Buccleuch” this way?
+      52 | founder of my line was my grandfather’s brother, who came here in fifty-one,
+Suggest:
+  - Replace with: “Buckley's”
+  - Replace with: “Buckley”
+  - Replace with: “Nucleic”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      61 | restless. Instead of being the warm centre of the world, the Middle West now
+         |                                     ^~~~~~ Did you mean to spell “centre” this way?
+      62 | seemed like the ragged edge of the universe—so I decided to go East and learn
+Suggest:
+  - Replace with: “centred”
+  - Replace with: “centres”
+  - Replace with: “censure”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      69 | The practical thing was to find rooms in the city, but it was a warm season, and
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      70 | I had just left a country of wide lawns and friendly trees, so when a young man
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      71 | at the office suggested that we take a house together in a commuting town, it
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      72 | sounded like a great idea. He found the house, a weatherbeaten cardboard
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 54 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      72 | sounded like a great idea. He found the house, a weatherbeaten cardboard
+         |                                                  ^~~~~~~~~~~~~ Did you mean to spell “weatherbeaten” this way?
+      73 | bungalow at eighty a month, but at the last minute the firm ordered him to
+Suggest:
+  - Replace with: “weatherboard”
+  - Replace with: “weatherboards”
+  - Replace with: “weatherization”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      74 | Washington, and I went out to the country alone. I had a dog—at least I had him
+         |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      75 | for a few days until he ran away—and an old Dodge and a Finnish woman, who made
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      76 | my bed and cooked breakfast and muttered Finnish wisdom to herself over the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      77 | electric stove.
+         | ~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      93 | down out of the young breath-giving air. I bought a dozen volumes on banking and
+         |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      94 | credit and investment securities, and they stood on my shelf in red and gold
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      95 | like new money from the mint, promising to unfold the shining secrets that only
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      96 | Midas and Morgan and Mæcenas knew. And I had the high intention of reading many
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      95 | like new money from the mint, promising to unfold the shining secrets that only
+      96 | Midas and Morgan and Mæcenas knew. And I had the high intention of reading many
+         |                      ^~~~~~~ Did you mean to spell “Mæcenas” this way?
+Suggest:
+  - Replace with: “Mycenae”
+  - Replace with: “Macon's”
+  - Replace with: “Mycenae's”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+      97 | other books besides. I was rather literary in college—one year I wrote a series
+         |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      98 | of very solemn and obvious editorials for the Yale News—and now I was going to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      99 | bring back all such things into my life and become again that most limited of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     100 | all specialists, the “well-rounded man.” This isn’t just an epigram—life is much
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 49 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     106 | natural curiosities, two unusual formations of land. Twenty miles from the city
+         |                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     107 | a pair of enormous eggs, identical in contour and separated only by a courtesy
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     108 | bay, jut out into the most domesticated body of salt water in the Western
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     109 | hemisphere, the great wet barnyard of Long Island Sound. They are not perfect
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     119 | thousand a season. The one on my right was a colossal affair by any standard—it
+         |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     120 | was a factual imitation of some Hôtel de Ville in Normandy, with a tower on one
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     121 | side, spanking new under a thin beard of raw ivy, and a marble swimming pool,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     122 | and more than forty acres of lawn and garden. It was Gatsby’s mansion. Or,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 53 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     119 | thousand a season. The one on my right was a colossal affair by any standard—it
+     120 | was a factual imitation of some Hôtel de Ville in Normandy, with a tower on one
+         |                                 ^~~~~ Did you mean to spell “Hôtel” this way?
+Suggest:
+  - Replace with: “Hotel”
+  - Replace with: “Havel”
+  - Replace with: “Hegel”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     119 | thousand a season. The one on my right was a colossal affair by any standard—it
+     120 | was a factual imitation of some Hôtel de Ville in Normandy, with a tower on one
+         |                                       ^~ Did you mean to spell “de” this way?
+Suggest:
+  - Replace with: “d”
+  - Replace with: “db”
+  - Replace with: “dc”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     120 | was a factual imitation of some Hôtel de Ville in Normandy, with a tower on one
+         |                                          ^~~~~ Did you mean to spell “Ville” this way?
+     121 | side, spanking new under a thin beard of raw ivy, and a marble swimming pool,
+Suggest:
+  - Replace with: “Vile”
+  - Replace with: “Villa”
+  - Replace with: “Lille”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+     120 | was a factual imitation of some Hôtel de Ville in Normandy, with a tower on one
+         |                                          ^~~~~~~~ It seems these words would go better together.
+     121 | side, spanking new under a thin beard of raw ivy, and a marble swimming pool,
+Suggest:
+  - Replace with: “Villein”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     124 | of that name. My own house was an eyesore, but it was a small eyesore, and it
+         |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     125 | had been overlooked, so I had a view of the water, a partial view of my
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     126 | neighbor’s lawn, and the consoling proximity of millionaires—all for eighty
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     127 | dollars a month.
+         | ~~~~~~~~~~~~~~~~ This sentence is 44 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     131 | drove over there to have dinner with the Tom Buchanans. Daisy was my second
+         |                                              ^~~~~~~~~ Did you mean to spell “Buchanans” this way?
+Suggest:
+  - Replace with: “Buchanan's”
+  - Replace with: “Buchanan”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     135 | Her husband, among various physical accomplishments, had been one of the most
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     136 | powerful ends that ever played football at New Haven—a national figure in a way,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     137 | one of those men who reach such an acute limited excellence at twenty-one that
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     138 | everything afterward savors of anti-climax. His family were enormously
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 48 words long.
+
+
+
+Lint:    WordChoice (31 priority)
+Message: |
+     136 | powerful ends that ever played football at New Haven—a national figure in a way,
+         |                                            ^~~ Did you mean “knew” (the past tense of “know”)?
+     137 | one of those men who reach such an acute limited excellence at twenty-one that
+Suggest:
+  - Replace with: “Knew”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     138 | everything afterward savors of anti-climax. His family were enormously
+         |                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     139 | wealthy—even in college his freedom with money was a matter for reproach—but now
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     140 | he’d left Chicago and come East in a fashion that rather took your breath away:
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     141 | for instance, he’d brought down a string of polo ponies from Lake Forest. It was
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 47 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     145 | particular reason, and then drifted here and there unrestfully wherever people
+         |                                                    ^~~~~~~~~~~ Did you mean “restfully”?
+     146 | played polo and were rich together. This was a permanent move, said Daisy over
+Suggest:
+  - Replace with: “restfully”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     146 | played polo and were rich together. This was a permanent move, said Daisy over
+         |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     147 | the telephone, but I didn’t believe it—I had no sight into Daisy’s heart, but I
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     148 | felt that Tom would drift on forever seeking, a little wistfully, for the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     149 | dramatic turbulence of some irrecoverable football game.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 44 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     154 | the bay. The lawn started at the beach and ran toward the front door for a
+         |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     155 | quarter of a mile, jumping over sun-dials and brick walks and burning
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     156 | gardens—finally when it reached the house drifting up the side in bright vines
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     157 | as though from the momentum of its run. The front was broken by a line of French
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 49 words long.
+
+
+
+Lint:    WordChoice (31 priority)
+Message: |
+     162 | He had changed since his New Haven years. Now he was a sturdy straw-haired man
+         |                          ^~~ Did you mean “knew” (the past tense of “know”)?
+Suggest:
+  - Replace with: “Knew”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     165 | appearance of always leaning aggressively forward. Not even the effeminate swank
+         |                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     166 | of his riding clothes could hide the enormous power of that body—he seemed to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     167 | fill those glistening boots until he strained the top lacing, and you could see
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     168 | a great pack of muscle shifting when his shoulder moved under his thin coat. It
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 48 words long.
+
+
+
+Lint:    WordChoice (31 priority)
+Message: |
+     173 | toward people he liked—and there were men at New Haven who had hated his guts.
+         |                                              ^~~ Did you mean “knew” (the past tense of “know”)?
+Suggest:
+  - Replace with: “Knew”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     185 | Turning me around by one arm, he moved a broad flat hand along the front vista,
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     186 | including in its sweep a sunken Italian garden, a half acre of deep, pungent
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     187 | roses, and a snub-nosed motor-boat that bumped the tide offshore.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     189 | “It belonged to Demaine, the oil man.” He turned me around again, politely and
+         |                 ^~~~~~~ Did you mean to spell “Demaine” this way?
+Suggest:
+  - Replace with: “Deanne”
+  - Replace with: “Deming”
+  - Replace with: “Dewayne”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+     189 | “It belonged to Demaine, the oil man.” He turned me around again, politely and
+         |                              ^~~~~~~ Did you mean the closed compound noun “oilman”?
+Suggest:
+  - Replace with: “oilman”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     192 | We walked through a high hallway into a bright rosy-colored space, fragilely
+         |                                                                    ^~~~~~~~~ Did you mean to spell “fragilely” this way?
+     193 | bound into the house by French windows at either end. The windows were ajar and
+Suggest:
+  - Replace with: “fragile”
+  - Replace with: “facilely”
+  - Replace with: “fragiler”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     195 | into the house. A breeze blew through the room, blew curtains in at one end and
+         |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     196 | out the other like pale flags, twisting them up toward the frosted wedding-cake
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     197 | of the ceiling, and then rippled over the wine-colored rug, making a shadow on
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     198 | it as wind does on the sea.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 49 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     236 | speech is an arrangement of notes that will never be played again. Her face was
+         |                                                                   ^~~~~~~~~~~~~~
+     237 | sad and lovely with bright things in it, bright eyes and a bright passionate
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     238 | mouth, but there was an excitement in her voice that men who had cared for her
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     239 | found difficult to forget: a singing compulsion, a whispered “Listen,” a promise
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     240 | that she had done gay, exciting things just a while since and that there were
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     241 | gay, exciting things hovering in the next hour.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 68 words long.
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+     268 | “I’m a bond man.”
+         |        ^~~~~~~~ Did you mean the closed compound noun “bondman”?
+Suggest:
+  - Replace with: “bondman”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     322 | Slenderly, languidly, their hands set lightly on their hips, the two young women
+         | ^~~~~~~~~ Did you mean “Tenderly”?
+Suggest:
+  - Replace with: “Tenderly”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     334 | “All right,” said Daisy. ‘‘What’ll we plan?” She turned to me helplessly: ‘‘What
+         |                            ^~~~~~~ Did you mean “That'll”?
+Suggest:
+  - Replace with: “That'll”
+
+
+
+Lint:    Style (63 priority)
+Message: |
+     345 | do it. That’s what I get for marrying a brute of a man, a great, big, hulking
+         |                                         ^~~~~~~~~~ The word `of` is not needed here.
+     346 | physical specimen of a—”’
+Suggest:
+  - Replace with: “brute a”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     352 | Sometimes she and Miss Baker talked at once, unobtrusively and with a bantering
+     353 | inconsequence that was never quite chatter, that was as cool as their white
+         | ^~~~~~~~~~~~~ Did you mean “consequence”?
+Suggest:
+  - Replace with: “consequence”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     362 | “You make me feel uncivilized, Daisy,” I confessed on my second glass of corky
+         |                                                                          ^~~~~ Did you mean to spell “corky” this way?
+     363 | but rather impressive claret. “Can’t you talk about crops or something?”
+Suggest:
+  - Replace with: “cork”
+  - Replace with: “cocky”
+  - Replace with: “corks”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     378 | “Tom’s getting very profound,” said Daisy, with an expression of unthoughtful
+         |                                                                  ^~~~~~~~~~~~ Did you mean “thoughtful”?
+     379 | sadness. “He reads deep books with long words in them. What was that word we———”
+Suggest:
+  - Replace with: “thoughtful”
+
+
+
+Lint:    Style (31 priority)
+Message: |
+     394 | me again. ‘‘—And we’ve produced all the things that go to make civilization—oh,
+     395 | science and art, and all that. Do you see?”
+         | ^~~~~~~ An Oxford comma is necessary here.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     416 | For a moment the last sunshine fell with romantic affection upon her glowing
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     417 | face; her voice compelled me forward breathlessly as I listened—then the glow
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     418 | faded, each light deserting her with lingering regret, like children leaving a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     419 | pleasant street at dusk.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+     426 | “I love to see you at my table, Nick. You remind me of a—of a rose, an absolute
+         |                                                        ^ Incorrect indefinite article.
+     427 | rose. Doesn’t he?” She turned to Miss Baker for confirmation: “An absolute
+Suggest:
+  - Replace with: “an”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     464 | “It couldn’t be helped!” cried Daisy with tense gayety.
+         |                                                 ^~~~~~ Did you mean to spell “gayety” this way?
+Suggest:
+  - Replace with: “gaiety”
+  - Replace with: “gamely”
+  - Replace with: “gamete”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     474 | The telephone rang inside, startingly, and as Daisy shook her head decisively at
+         |                            ^~~~~~~~~~ Did you mean to spell “startingly” this way?
+Suggest:
+  - Replace with: “startlingly”
+  - Replace with: “searingly”
+  - Replace with: “slantingly”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     479 | thinking, but I doubt if even Miss Baker, who seemed to have mastered a certain
+     480 | hardy scepticism, was able utterly to put this fifth guest’s shrill metallic
+         |       ^~~~~~~~~~ Did you mean to spell “scepticism” this way?
+Suggest:
+  - Replace with: “skepticism”
+  - Replace with: “sceptic's”
+  - Replace with: “scepticism's”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     484 | The horses, needless to say, were not mentioned again. Tom and Miss Baker, with
+         |                                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~
+     485 | several feet of twilight between them, strolled back into the library, as if to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     486 | a vigil beside a perfectly tangible body, while, trying to look pleasantly
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     487 | interested and a little deaf, I followed Daisy around a chain of connecting
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     488 | verandas to the porch in front. In its deep gloom we sat down side by side on a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 50 words long.
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+     515 | hour old and Tom was God knows where. I woke up out of the ether with an utterly
+         |                                                                       ^~ Incorrect indefinite article.
+     516 | abandoned feeling, and asked the nurse right away if it was a boy or a girl. She
+Suggest:
+  - Replace with: “a”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     529 | the whole evening had been a trick of some sort to exact a contributary emotion
+         |                                                            ^~~~~~~~~~~~ Did you mean to spell “contributary” this way?
+     530 | from me. I waited, and sure enough, in a moment she looked at me with an
+Suggest:
+  - Replace with: “contributory”
+  - Replace with: “contributor”
+  - Replace with: “contributors”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     535 | end of the long couch and she read aloud to him from the Saturday Evening
+     536 | Post—the words, murmurous and uninflected, running together in a soothing tune.
+         |                               ^~~~~~~~~~~ Did you mean to spell “uninflected” this way?
+Suggest:
+  - Replace with: “uninfected”
+  - Replace with: “inflected”
+  - Replace with: “noninflected”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     551 | “Jordan’s going to play in the tournament tomorrow,” explained Daisy, “over at
+     552 | Westchester.”
+         | ^~~~~~~~~~~ Did you mean to spell “Westchester” this way?
+Suggest:
+  - Replace with: “Westminster”
+  - Replace with: “Winchester”
+  - Replace with: “Winchesters”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     565 | “I will. Good night, Mr. Carraway. See you anon.”
+         |                          ^~~~~~~~ Did you mean to spell “Carraway” this way?
+Suggest:
+  - Replace with: “Caraway”
+  - Replace with: “Faraway”
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+     583 | here this summer. I think the home influence will be very good for her.”
+         |                                                      ^~~~~~~~~ Vocabulary enhancement: use `excellent` instead of `very good`
+Suggest:
+  - Replace with: “excellent”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     592 | “Did you give Nick a little heart to heart talk on the veranda?” demanded Tom
+         |                                                        ^~~~~~~ Did you mean to spell “veranda” this way?
+Suggest:
+  - Replace with: “verandas”
+  - Replace with: “veranda's”
+  - Replace with: “Miranda”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     628 | Already it was deep summer on roadhouse roofs and in front of wayside garages,
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     629 | where new red gaspumps sat out in pools of light, and when I reached my estate
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     630 | at West Egg I ran the car under its shed and sat for a while on an abandoned
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     631 | grass roller in the yard. The wind had blown off, leaving a loud, bright night,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 53 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     628 | Already it was deep summer on roadhouse roofs and in front of wayside garages,
+     629 | where new red gaspumps sat out in pools of light, and when I reached my estate
+         |               ^~~~~~~~ Did you mean “gazumps”?
+Suggest:
+  - Replace with: “gazumps”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     633 | of the earth blew the frogs full of life. The silhouette of a moving cat wavered
+         |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     634 | across the moonlight, and turning my head to watch it, I saw that I was not
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     635 | alone—fifty feet away a figure had emerged from the shadow of my neighbor’s
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     636 | mansion and was standing with his hands in his pockets regarding the silver
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     637 | pepper of the stars. Something in his leisurely movements and the secure
+         | ~~~~~~~~~~~~~~~~~~~~ This sentence is 54 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     642 | do for an introduction. But I didn’t call to him, for he gave a sudden
+         |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     643 | intimation that he was content to be alone—he stretched out his arms toward the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     644 | dark water in a curious way, and, far as I was from him, I could have sworn he
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     645 | was trembling. Involuntarily I glanced seaward—and distinguished nothing except
+         | ~~~~~~~~~~~~~~ This sentence is 46 words long.
+
+
+
+Lint:    Style (31 priority)
+Message: |
+     645 | was trembling. Involuntarily I glanced seaward—and distinguished nothing except
+     646 | a single green light, minute and far away, that might have been the end of a
+         |                       ^~~~~~ An Oxford comma is necessary here.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     654 | certain desolate area of land. This is a valley of ashes—a fantastic farm where
+         |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     655 | ashes grow like wheat into ridges and hills and grotesque gardens; where ashes
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     656 | take the forms of houses and chimneys and rising smoke and, finally, with a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     657 | transcendent effort, of ash-gray men, who move dimly and already crumbling
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     658 | through the powdery air. Occasionally a line of gray cars crawls along an
+         | ~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 53 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     658 | through the powdery air. Occasionally a line of gray cars crawls along an
+         |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     659 | invisible track, gives out a ghastly creak, and comes to rest, and immediately
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     660 | the ash-gray men swarm up with leaden spades and stir up an impenetrable cloud,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     661 | which screens their obscure operations from your sight.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 45 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     664 | it, you perceive, after a moment, the eyes of Doctor T. J. Eckleburg. The eyes
+         |                                                      ^~ Did you mean to spell “T.” this way?
+Suggest:
+  - Replace with: “To”
+  - Replace with: “T”
+  - Replace with: “Ta”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     664 | it, you perceive, after a moment, the eyes of Doctor T. J. Eckleburg. The eyes
+         |                                                         ^~ Did you mean to spell “J.” this way?
+Suggest:
+  - Replace with: “Jg”
+  - Replace with: “J”
+  - Replace with: “JD”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     664 | it, you perceive, after a moment, the eyes of Doctor T. J. Eckleburg. The eyes
+         |                                                            ^~~~~~~~~ Did you mean to spell “Eckleburg” this way?
+Suggest:
+  - Replace with: “Excalibur”
+  - Replace with: “Vicksburg”
+  - Replace with: “Iceberg”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     664 | it, you perceive, after a moment, the eyes of Doctor T. J. Eckleburg. The eyes
+     665 | of Doctor T. J. Eckleburg are blue and gigantic—their retinas are one yard high.
+         |           ^~ Did you mean to spell “T.” this way?
+Suggest:
+  - Replace with: “To”
+  - Replace with: “T”
+  - Replace with: “Ta”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     665 | of Doctor T. J. Eckleburg are blue and gigantic—their retinas are one yard high.
+         |              ^~ Did you mean to spell “J.” this way?
+Suggest:
+  - Replace with: “Jg”
+  - Replace with: “J”
+  - Replace with: “JD”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     665 | of Doctor T. J. Eckleburg are blue and gigantic—their retinas are one yard high.
+         |                 ^~~~~~~~~ Did you mean to spell “Eckleburg” this way?
+Suggest:
+  - Replace with: “Excalibur”
+  - Replace with: “Vicksburg”
+  - Replace with: “Iceberg”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     669 | sank down himself into eternal blindness, or forgot them and moved away. But his
+     670 | eyes, dimmed a little by many paintless days, under sun and rain, brood on over
+         |                               ^~~~~~~~~ Did you mean to spell “paintless” this way?
+Suggest:
+  - Replace with: “pointless”
+  - Replace with: “painless”
+  - Replace with: “painters”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     673 | The valley of ashes is bounded on one side by a small foul river, and, when the
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     674 | drawbridge is up to let barges through, the passengers on waiting trains can
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     675 | stare at the dismal scene for as long as half an hour. There is always a halt
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     680 | acquaintances resented the fact that he turned up in popular cafés with her and,
+         |                                                              ^~~~~ Did you mean to spell “cafés” this way?
+     681 | leaving her at a table, sauntered about, chatting with whomsoever he knew.
+Suggest:
+  - Replace with: “caffs”
+  - Replace with: “cafes”
+  - Replace with: “cafe's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     683 | up to New York with Tom on the train one afternoon, and when we stopped by the
+     684 | ashheaps he jumped to his feet and, taking hold of my elbow, literally forced me
+         | ^~~~~~~~ Did you mean to spell “ashheaps” this way?
+Suggest:
+  - Replace with: “asthma's”
+  - Replace with: “airheads”
+  - Replace with: “ashcans”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     694 | hundred yards along the road under Doctor Eckleburg’s persistent stare. The only
+         |                                           ^~~~~~~~~~~ Did you mean to spell “Eckleburg’s” this way?
+Suggest:
+  - Replace with: “Excalibur's”
+  - Replace with: “Vicksburg's”
+  - Replace with: “Iceberg's”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+     695 | building in sight was a small block of yellow brick sitting on the edge of the
+     696 | waste land, a sort of compact Main Street ministering to it, and contiguous to
+         | ^~~~~~~~~~ Did you mean the closed compound noun “wasteland”?
+Suggest:
+  - Replace with: “wasteland”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     699 | garage—Repairs. George B. Wilson. Cars bought and sold.—and I followed Tom
+         |                        ^~ Did you mean to spell “B.” this way?
+Suggest:
+  - Replace with: “Bu”
+  - Replace with: “Be”
+  - Replace with: “Bf”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     702 | The interior was unprosperous and bare; the only car visible was the
+         |                  ^~~~~~~~~~~~ Did you mean “prosperous”?
+Suggest:
+  - Replace with: “prosperous”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     703 | dust-covered wreck of a Ford which crouched in a dim corner. It had occurred to
+         |                                                             ^~~~~~~~~~~~~~~~~~~~
+     704 | me that this shadow of a garage must be a blind, and that sumptuous and romantic
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     705 | apartments were concealed overhead, when the proprietor himself appeared in the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     706 | door of an office, wiping his hands on a piece of waste. He was a blond,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     706 | door of an office, wiping his hands on a piece of waste. He was a blond,
+     707 | spiritless man, anæmic, and faintly handsome. When he saw us a damp gleam of
+         |                 ^~~~~~ Did you mean to spell “anæmic” this way?
+Suggest:
+  - Replace with: “anemic”
+  - Replace with: “anemia”
+  - Replace with: “atomic”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     726 | footsteps on a stairs, and in a moment the thickish figure of a woman blocked
+         |                                            ^~~~~~~~ Did you mean to spell “thickish” this way?
+     727 | out the light from the office door. She was in the middle thirties, and faintly
+Suggest:
+  - Replace with: “thick's”
+  - Replace with: “thickest”
+  - Replace with: “thickos”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     728 | stout, but she carried her flesh sensuously as some women can. Her face, above a
+     729 | spotted dress of dark blue crêpe-de-chine, contained no facet or gleam of
+         |                            ^~~~~ Did you mean to spell “crêpe” this way?
+Suggest:
+  - Replace with: “crepe”
+  - Replace with: “crape”
+  - Replace with: “cope”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     728 | stout, but she carried her flesh sensuously as some women can. Her face, above a
+     729 | spotted dress of dark blue crêpe-de-chine, contained no facet or gleam of
+         |                                  ^~ Did you mean to spell “de” this way?
+Suggest:
+  - Replace with: “d”
+  - Replace with: “db”
+  - Replace with: “dc”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     756 | “Terrible place, isn’t it,” said Tom, exchanging a frown with Doctor Eckleburg.
+         |                                                                      ^~~~~~~~~ Did you mean to spell “Eckleburg” this way?
+Suggest:
+  - Replace with: “Excalibur”
+  - Replace with: “Vicksburg”
+  - Replace with: “Iceberg”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     768 | together, for Mrs. Wilson sat discreetly in another car. Tom deferred that much
+     769 | to the sensibilities of those East Eggers who might be on the train.
+         |                                    ^~~~~~ Did you mean to spell “Eggers” this way?
+Suggest:
+  - Replace with: “Eggo's”
+  - Replace with: “Engels”
+  - Replace with: “Edgers”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     784 | We backed up to a gray old man who bore an absurd resemblance to John D.
+         |                                                                       ^~ Did you mean to spell “D.” this way?
+Suggest:
+  - Replace with: “D”
+  - Replace with: “Dc”
+  - Replace with: “Do”
+
+
+
+Lint:    WordChoice (127 priority)
+Message: |
+     806 | “That dog?” He looked at it admiringly. “That dog will cost you ten dollars.”
+         |                                                             ^~~ The possessive version of this word is more common in this context.
+Suggest:
+  - Replace with: “your”
+  - Replace with: “you're a”
+  - Replace with: “you're an”
+
+
+
+Lint:    Style (31 priority)
+Message: |
+     819 | We drove over to Fifth Avenue, warm and soft, almost pastoral, on the summer
+         |                                ^~~~ An Oxford comma is necessary here.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     825 | “No, you don’t,” interposed Tom quickly. “Myrtle’ll be hurt if you don’t come up
+         |                                           ^~~~~~~~~ Did you mean “Myrtle's”?
+     826 | to the apartment. Won’t you, Myrtle?”
+Suggest:
+  - Replace with: “Myrtle's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     838 | “I’m going to have the McKees come up,” she announced as we rose in the
+         |                        ^~~~~~ Did you mean to spell “McKees” this way?
+Suggest:
+  - Replace with: “McKee's”
+  - Replace with: “McKee”
+  - Replace with: “McGee's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     842 | small bedroom, and a bath. The living-room was crowded to the doors with a set
+     843 | of tapestried furniture entirely too large for it, so that to move about was to
+         |    ^~~~~~~~~~ Did you mean “tapestries”?
+Suggest:
+  - Replace with: “tapestries”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     850 | Wilson was first concerned with the dog. A reluctant elevator-boy went for a box
+         |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     851 | full of straw and some milk, to which he added on his own initiative a tin of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     852 | large, hard dog-biscuits— one of which decomposed apathetically in the saucer of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     853 | milk all afternoon. Meanwhile Tom brought out a bottle of whiskey from a locked
+         | ~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     860 | and I went out to buy some at the drugstore on the corner. When I came back they
+         |                                                           ^~~~~~~~~~~~~~~~~~~~~~~
+     861 | had both disappeared, so I sat down discreetly in the living-room and read a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     862 | chapter of “Simon Called Peter”—either it was terrible stuff or the whiskey
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     863 | distorted things, because it didn’t make any sense to me.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+     877 | immoderately, repeated my question aloud, and told me she lived with a girl
+         |                                                                        ^~~~~
+     878 | friend at a hotel.
+         | ~~~~~~ Did you mean the closed compound noun “girlfriend”?
+Suggest:
+  - Replace with: “girlfriend”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     900 | last week to look at my feet, and when she gave me the bill you’d of thought she
+     901 | had my appendicitus out.”
+         |        ^~~~~~~~~~~~ Did you mean “appendicitis”?
+Suggest:
+  - Replace with: “appendicitis”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     905 | “Mrs. Eberhardt. She goes around looking at people’s feet in their own homes.”
+         |       ^~~~~~~~~ Did you mean “Bernhardt”?
+Suggest:
+  - Replace with: “Bernhardt”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     923 | “I should change the light,” he said after a moment. “I’d like to bring out the
+     924 | modelling of the features. And I’d try to get hold of all the back hair.”
+         | ^~~~~~~~~ Did you mean to spell “modelling” this way?
+Suggest:
+  - Replace with: “modeling”
+  - Replace with: “modellings”
+  - Replace with: “modelling's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     931 | “You McKees have something to drink,” he said. “Get some more ice and mineral
+         |      ^~~~~~ Did you mean to spell “McKees” this way?
+Suggest:
+  - Replace with: “McKee's”
+  - Replace with: “McKee”
+  - Replace with: “McGee's”
+
+
+
+Lint:    Repetition (63 priority)
+Message: |
+     950 | “Two studies. One of them I call ‘Montauk Point—The Gulls,’ and the other I call
+         |                      ^~~~~~ There are too many personal pronouns in sequence here.
+Suggest:
+  - Replace with: “them”
+  - Replace with: “I”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     950 | “Two studies. One of them I call ‘Montauk Point—The Gulls,’ and the other I call
+         |                                   ^~~~~~~ Did you mean “Montague”?
+     951 | ‘Montauk Point—The Sea.’”
+Suggest:
+  - Replace with: “Montague”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     950 | “Two studies. One of them I call ‘Montauk Point—The Gulls,’ and the other I call
+     951 | ‘Montauk Point—The Sea.’”
+         |  ^~~~~~~ Did you mean “Montague”?
+Suggest:
+  - Replace with: “Montague”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+     989 | studies of him.” His lips moved silently for a moment as he invented. “‘George
+     990 | B. Wilson at the Gasoline Pump,’ or something like that.”
+         | ^~ Did you mean to spell “B.” this way?
+Suggest:
+  - Replace with: “Bu”
+  - Replace with: “Be”
+  - Replace with: “Bf”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1029 | over twelve hundred dollars when we started, but we got gyped out of it all in
+         |                                                         ^~~~~ Did you mean to spell “gyped” this way?
+    1030 | two days in the private rooms. We had an awful time getting back, I can tell
+Suggest:
+  - Replace with: “gaped”
+  - Replace with: “gybed”
+  - Replace with: “gypped”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1037 | “I almost made a mistake, too,” she declared vigorously. “I almost married a
+    1038 | little kyke who’d been after me for years. I knew he was below me. Everybody
+         |        ^~~~ Did you mean to spell “kyke” this way?
+Suggest:
+  - Replace with: “kike”
+  - Replace with: “tyke”
+  - Replace with: “dyke”
+
+
+
+Lint:    Repetition (127 priority)
+Message: |
+    1065 | “The only crazy I was was when I married him. I knew right away I made a
+         |                   ^~~~~~~ Did you mean to repeat this word?
+Suggest:
+  - Replace with: “was”
+
+
+
+Lint:    WordChoice (31 priority)
+Message: |
+    1077 | janitor and sent him for some celebrated sandwiches, which were a complete
+         |                                                            ^~~~ Use the contraction or separate the words instead.
+    1078 | supper in themselves. I wanted to get out and walk eastward toward the park
+Suggest:
+  - Replace with: “we're”
+  - Replace with: “we are”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1078 | supper in themselves. I wanted to get out and walk eastward toward the park
+         |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1079 | through the soft twilight, but each time I tried to go I became entangled in
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1080 | some wild, strident argument which pulled me back, as if with ropes, into my
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1081 | chair. Yet high over the city our line of yellow windows must have contributed
+         | ~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    Repetition (63 priority)
+Message: |
+    1092 | eyes off him, but every time he looked at me I had to pretend to be looking at
+         |                                           ^~~~ There are too many personal pronouns in sequence here.
+    1093 | the advertisement over his head. When we came into the station he was next to
+Suggest:
+  - Replace with: “me”
+  - Replace with: “I”
+
+
+
+Lint:    Repetition (63 priority)
+Message: |
+    1095 | to call a policeman, but he knew I lied. I was so excited that when I got into a
+    1096 | taxi with him I didn’t hardly know I wasn’t getting into a subway train. All I
+         |           ^~~~~ There are too many personal pronouns in sequence here.
+Suggest:
+  - Replace with: “him”
+  - Replace with: “I”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1122 | Daisy! Dai———”
+         |        ^~~ Did you mean to spell “Dai” this way?
+Suggest:
+  - Replace with: “Day”
+  - Replace with: “Dab”
+  - Replace with: “Dad”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1128 | awoke from his doze and started in a daze toward the door. When he had gone half
+         |                                                           ^~~~~~~~~~~~~~~~~~~~~~~
+    1129 | way he turned around and stared at the scene—his wife and Catherine scolding and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1130 | consoling as they stumbled here and there among the crowded furniture with
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1131 | articles of aid, and the despairing figure on the couch, bleeding fluently, and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1132 | trying to spread a copy of Town Tattle over the tapestry scenes of Versailles.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 59 words long.
+
+
+
+Lint:    Formatting (63 priority)
+Message: |
+    1152 | “Beauty and the Beast . . . Loneliness . . . Old Grocery Horse . . . Brook’n
+         |                      ^ Unnecessary space at the end of the sentence.
+Suggest:
+  - Remove error
+
+
+
+Lint:    Formatting (63 priority)
+Message: |
+    1152 | “Beauty and the Beast . . . Loneliness . . . Old Grocery Horse . . . Brook’n
+         |                                       ^ Unnecessary space at the end of the sentence.
+Suggest:
+  - Remove error
+
+
+
+Lint:    Formatting (63 priority)
+Message: |
+    1152 | “Beauty and the Beast . . . Loneliness . . . Old Grocery Horse . . . Brook’n
+         |                                                               ^ Unnecessary space at the end of the sentence.
+Suggest:
+  - Remove error
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1152 | “Beauty and the Beast . . . Loneliness . . . Old Grocery Horse . . . Brook’n
+         |                                                                      ^~~~~~~ Did you mean to spell “Brook’n” this way?
+    1153 | Bridge . . .” Then I was lying half asleep in the cold lower level of the
+Suggest:
+  - Replace with: “Brook's”
+  - Replace with: “Brock's”
+  - Replace with: “Brooke's”
+
+
+
+Lint:    Formatting (63 priority)
+Message: |
+    1152 | “Beauty and the Beast . . . Loneliness . . . Old Grocery Horse . . . Brook’n
+    1153 | Bridge . . .” Then I was lying half asleep in the cold lower level of the
+         |       ^ Unnecessary space at the end of the sentence.
+Suggest:
+  - Remove error
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1160 | gardens men and girls came and went like moths among the whisperings and the
+         |                                                          ^~~~~~~~~~~ Did you mean to spell “whisperings” this way?
+    1161 | champagne and the stars. At high tide in the afternoon I watched his guests
+Suggest:
+  - Replace with: “whispering”
+  - Replace with: “whimpering”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1161 | champagne and the stars. At high tide in the afternoon I watched his guests
+         |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1162 | diving from the tower of his raft, or taking the sun on the hot sand of his
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1163 | beach while his two motor-boats slit the waters of the Sound, drawing aquaplanes
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1164 | over cataracts of foam. On week-ends his Rolls-Royce became an omnibus, bearing
+         | ~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 45 words long.
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+    1171 | Every Friday five crates of oranges and lemons arrived from a fruiterer in New
+         |                                                                            ^~~~
+    1172 | York—every Monday these same oranges and lemons left his back door in a pyramid
+         | ~~~~ Ensure proper capitalization of notable places that are significant regional centers, travel destinations, or have international importance.
+Suggest:
+  - Replace with: “New York”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    1172 | York—every Monday these same oranges and lemons left his back door in a pyramid
+         |                                                          ^~~~~~~~~ Did you mean the closed compound noun “backdoor”?
+    1173 | of pulpless halves. There was a machine in the kitchen which could extract the
+Suggest:
+  - Replace with: “backdoor”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1172 | York—every Monday these same oranges and lemons left his back door in a pyramid
+    1173 | of pulpless halves. There was a machine in the kitchen which could extract the
+         |    ^~~~~~~~ Did you mean to spell “pulpless” this way?
+Suggest:
+  - Replace with: “purple's”
+  - Replace with: “pullers”
+  - Replace with: “pullets”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1179 | enormous garden. On buffet tables, garnished with glistening hors-d’œuvre,
+         |                                                              ^~~~ Did you mean to spell “hors” this way?
+    1180 | spiced baked hams crowded against salads of harlequin designs and pastry pigs
+Suggest:
+  - Replace with: “hers”
+  - Replace with: “ho's”
+  - Replace with: “hobs”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1179 | enormous garden. On buffet tables, garnished with glistening hors-d’œuvre,
+         |                                                                   ^~~~~~~ Did you mean to spell “d’œuvre” this way?
+    1180 | spiced baked hams crowded against salads of harlequin designs and pastry pigs
+Suggest:
+  - Replace with: “demure”
+  - Replace with: “oeuvre”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1186 | By seven o’clock the orchestra has arrived, no thin five-piece affair, but a
+    1187 | whole pitful of oboes and trombones and saxophones and viols and cornets and
+         |       ^~~~~~ Did you mean to spell “pitful” this way?
+Suggest:
+  - Replace with: “pitiful”
+  - Replace with: “potful”
+  - Replace with: “painful”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1188 | piccolos, and low and high drums. The last swimmers have come in from the beach
+         |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1189 | now and are dressing up-stairs; the cars from New York are parked five deep in
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1190 | the drive, and already the halls and salons and verandas are gaudy with primary
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1191 | colors, and hair bobbed in strange new ways, and shawls beyond the dreams of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1192 | Castile. The bar is in full swing, and floating rounds of cocktails permeate the
+         | ~~~~~~~~ This sentence is 54 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1191 | colors, and hair bobbed in strange new ways, and shawls beyond the dreams of
+    1192 | Castile. The bar is in full swing, and floating rounds of cocktails permeate the
+         | ^~~~~~~ Did you mean to spell “Castile” this way?
+Suggest:
+  - Replace with: “Castle”
+  - Replace with: “Cassie”
+  - Replace with: “Castillo”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1192 | Castile. The bar is in full swing, and floating rounds of cocktails permeate the
+         |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1193 | garden outside, until the air is alive with chatter and laughter, and casual
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1194 | innuendo and introductions forgotten on the spot, and enthusiastic meetings
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1195 | between women who never knew each other’s names.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 44 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1200 | tipped out at a cheerful word. The groups change more swiftly, swell with new
+         |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1201 | arrivals, dissolve and form in the same breath; already there are wanderers,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1202 | confident girls who weave here and there among the stouter and more stable,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1203 | become for a sharp, joyous moment the centre of a group, and then, excited with
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1204 | triumph, glide on through the sea-change of faces and voices and color under the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1205 | constantly changing light.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 66 words long.
+
+
+
+Lint:    Style (31 priority)
+Message: |
+    1200 | tipped out at a cheerful word. The groups change more swiftly, swell with new
+    1201 | arrivals, dissolve and form in the same breath; already there are wanderers,
+         |           ^~~~~~~~ An Oxford comma is necessary here.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1202 | confident girls who weave here and there among the stouter and more stable,
+    1203 | become for a sharp, joyous moment the centre of a group, and then, excited with
+         |                                       ^~~~~~ Did you mean to spell “centre” this way?
+    1204 | triumph, glide on through the sea-change of faces and voices and color under the
+Suggest:
+  - Replace with: “centred”
+  - Replace with: “centres”
+  - Replace with: “censure”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1223 | I had been actually invited. A chauffeur in a uniform of robin’s-egg blue
+         |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1224 | crossed my lawn early that Saturday morning with a surprisingly formal note from
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1225 | his employer: the honor would be entirely Gatsby’s, it said, if I would attend
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1226 | his “little party” that night. He had seen me several times, and had intended to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1230 | Dressed up in white flannels I went over to his lawn a little after seven, and
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1231 | wandered around rather ill at ease among swirls and eddies of people I didn’t
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1232 | know—though here and there was a face I had noticed on the commuting train. I
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 45 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1240 | As soon as I arrived I made an attempt to find my host, but the two or three
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1241 | people of whom I asked his whereabouts stared at me in such an amazed way, and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1242 | denied so vehemently any knowledge of his movements, that I slunk off in the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1243 | direction of the cocktail table—the only place in the garden where a single man
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1244 | could linger without looking purposeless and alone.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 70 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1246 | I was on my way to get roaring drunk from sheer embarrassment when Jordan Baker
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1247 | came out of the house and stood at the head of the marble steps, leaning a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1248 | little backward and looking with contemptuous interest down into the garden.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1287 | and address—inside of a week I got a package from Croirier’s with a new evening
+         |                                                   ^~~~~~~~~~ Did you mean to spell “Croirier’s” this way?
+    1288 | gown in it.”
+Suggest:
+  - Replace with: “Currier's”
+  - Replace with: “Courier's”
+  - Replace with: “Crosier's”
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+    1307 | A thrill passed over all of us. The three Mr. Mumbles bent forward and listened
+         |                 ^~~~~~~~ Did you mean the closed compound `overall`?
+Suggest:
+  - Replace with: “overall”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1336 | West Egg, and carefully on guard against its spectroscopic gayety.
+         |                                                            ^~~~~~ Did you mean to spell “gayety” this way?
+Suggest:
+  - Replace with: “gaiety”
+  - Replace with: “gamely”
+  - Replace with: “gamete”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1346 | couldn’t find him from the top of the steps, and he wasn’t on the veranda. On a
+         |                                                                   ^~~~~~~ Did you mean to spell “veranda” this way?
+Suggest:
+  - Replace with: “verandas”
+  - Replace with: “veranda's”
+  - Replace with: “Miranda”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1347 | chance we tried an important-looking door, and walked into a high Gothic
+    1348 | library, panelled with carved English oak, and probably transported complete
+         |          ^~~~~~~~ Did you mean to spell “panelled” this way?
+Suggest:
+  - Replace with: “paneled”
+  - Replace with: “palled”
+  - Replace with: “Janelle”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1373 | Taking our scepticism for granted, he rushed to the bookcases and returned with
+         |            ^~~~~~~~~~ Did you mean to spell “scepticism” this way?
+Suggest:
+  - Replace with: “skepticism”
+  - Replace with: “sceptic's”
+  - Replace with: “scepticism's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1373 | Taking our scepticism for granted, he rushed to the bookcases and returned with
+    1374 | Volume One of the “Stoddard Lectures.”
+         |                    ^~~~~~~~ Did you mean to spell “Stoddard” this way?
+Suggest:
+  - Replace with: “Stoppard”
+  - Replace with: “Goddard”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1376 | “See!” he cried triumphantly. “It’s a bona-fide piece of printed matter. It
+         |                                       ^~~~ Did you mean to spell “bona” this way?
+Suggest:
+  - Replace with: “boa”
+  - Replace with: “bond”
+  - Replace with: “bone”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1376 | “See!” he cried triumphantly. “It’s a bona-fide piece of printed matter. It
+         |                                            ^~~~ Did you mean to spell “fide” this way?
+Suggest:
+  - Replace with: “fade”
+  - Replace with: “fife”
+  - Replace with: “file”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1377 | fooled me. This fella’s a regular Belasco. It’s a triumph. What thoroughness!
+         |                 ^~~~~~~ Did you mean to spell “fella’s” this way?
+Suggest:
+  - Replace with: “fell's”
+  - Replace with: “fellas”
+  - Replace with: “Bella's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1377 | fooled me. This fella’s a regular Belasco. It’s a triumph. What thoroughness!
+         |                                   ^~~~~~~ Did you mean to spell “Belasco” this way?
+Suggest:
+  - Replace with: “Bela's”
+  - Replace with: “Belau's”
+  - Replace with: “Basho”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1389 | “I was brought by a woman named Roosevelt,” he continued. “Mrs. Claud Roosevelt.
+         |                                                                 ^~~~~ Did you mean to spell “Claud” this way?
+Suggest:
+  - Replace with: “Clad”
+  - Replace with: “Claude”
+  - Replace with: “Claus”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1402 | There was dancing now on the canvas in the garden; old men pushing young girls
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1403 | backward in eternal graceless circles, superior couples holding each other
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1404 | tortuously, fashionably, and keeping in the corners—and a great number of single
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1405 | girls dancing individualistically or relieving the orchestra for a moment of the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1406 | burden of the banjo or the traps. By midnight the hilarity had increased. A
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 57 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1413 | trembling a little to the stiff, tinny drip of the banjoes on the lawn.
+         |                                                    ^~~~~~~ Did you mean to spell “banjoes” this way?
+Suggest:
+  - Replace with: “banjo's”
+  - Replace with: “banjos”
+  - Replace with: “bandies”
+
+
+
+Lint:    WordChoice (127 priority)
+Message: |
+    1428 | “I was in the Sixteenth until June nineteen-eighteen. I knew I’d seen you
+         |                                                                       ^~~ The possessive version of this word is more common in this context.
+    1429 | somewhere before.”
+Suggest:
+  - Replace with: “your”
+  - Replace with: “you're a”
+  - Replace with: “you're an”
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+    1457 | “I thought you knew, old sport. I’m afraid I’m not a very good host.”
+         |                                                      ^~~~~~~~~ Vocabulary enhancement: use `excellent` instead of `very good`
+Suggest:
+  - Replace with: “excellent”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1463 | prejudice in your favor. It understood you just so far as you wanted to be
+         |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1464 | understood, believed in you as you would like to believe in yourself, and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1465 | assured you that it had precisely the impression of you that, at your best, you
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1466 | hoped to convey. Precisely at that point it vanished—and I was looking at an
+         | ~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Style (31 priority)
+Message: |
+    1466 | hoped to convey. Precisely at that point it vanished—and I was looking at an
+    1467 | elegant young rough-neck, a year or two over thirty, whose elaborate formality
+         |                             ^~~~ An Oxford comma is necessary here.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    WordChoice (127 priority)
+Message: |
+    1514 | “Ladies and gentlemen,” he cried. “At the request of Mr. Gatsby we are going to
+    1515 | play for you Mr. Vladmir Tostoff’s latest work, which attracted so much
+         |          ^~~ The possessive version of this word is more common in this context.
+Suggest:
+  - Replace with: “your”
+  - Replace with: “you're a”
+  - Replace with: “you're an”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1515 | play for you Mr. Vladmir Tostoff’s latest work, which attracted so much
+         |                  ^~~~~~~ Did you mean “Vladimir”?
+Suggest:
+  - Replace with: “Vladimir”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1515 | play for you Mr. Vladmir Tostoff’s latest work, which attracted so much
+         |                          ^~~~~~~~~ Did you mean “Castoff's”?
+Suggest:
+  - Replace with: “Castoff's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1520 | “The piece is known,” he concluded lustily, “as ‘Vladmir Tostoff’s Jazz History
+         |                                                  ^~~~~~~ Did you mean “Vladimir”?
+    1521 | of the World.’”
+Suggest:
+  - Replace with: “Vladimir”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1520 | “The piece is known,” he concluded lustily, “as ‘Vladmir Tostoff’s Jazz History
+         |                                                          ^~~~~~~~~ Did you mean “Castoff's”?
+    1521 | of the World.’”
+Suggest:
+  - Replace with: “Castoff's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1523 | The nature of Mr. Tostoff’s composition eluded me, because just as it began my
+         |                   ^~~~~~~~~ Did you mean “Castoff's”?
+Suggest:
+  - Replace with: “Castoff's”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1529 | more correct as the fraternal hilarity increased. When the “Jazz History of the
+         |                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1530 | World” was over, girls were putting their heads on men’s shoulders in a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1531 | puppyish, convivial way, girls were swooning backward playfully into men’s arms,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1532 | even into groups, knowing that some one would arrest their falls—but no one
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1533 | swooned backward on Gatsby, and no French bob touched Gatsby’s shoulder, and no
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1534 | singing quartets were formed for Gatsby’s head for one link.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 67 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1530 | World” was over, girls were putting their heads on men’s shoulders in a
+    1531 | puppyish, convivial way, girls were swooning backward playfully into men’s arms,
+         | ^~~~~~~~ Did you mean to spell “puppyish” this way?
+Suggest:
+  - Replace with: “puppy's”
+  - Replace with: “purplish”
+  - Replace with: “uppish”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    1531 | puppyish, convivial way, girls were swooning backward playfully into men’s arms,
+    1532 | even into groups, knowing that some one would arrest their falls—but no one
+         |                                ^~~~~~~~ The auxiliary verb “would” implies the existence of the closed compound noun “someone”.
+Suggest:
+  - Replace with: “someone”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1574 | rent asunder by dissension. One of the men was talking with curious intensity to
+         |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1575 | a young actress, and his wife, after attempting to laugh at the situation in a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1576 | dignified and indifferent way, broke down entirely and resorted to flank
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1577 | attacks—at intervals she appeared suddenly at his side like an angry diamond,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1578 | and hissed: “You promised!” into his ear.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 53 words long.
+
+
+
+Lint:    Formatting (63 priority)
+Message: |
+    1612 | “It was . . . simply amazing,” she repeated abstractedly. “But I swore I
+         |        ^ Unnecessary space at the end of the sentence.
+Suggest:
+  - Remove error
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+    1612 | “It was . . . simply amazing,” she repeated abstractedly. “But I swore I
+         |               ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “S”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1615 | Sigourney Howard. . . . My aunt. . . .” She was hurrying off as she talked—her
+         | ^~~~~~~~~ Did you mean to spell “Sigourney” this way?
+Suggest:
+  - Replace with: “Gurney”
+  - Replace with: “Journey”
+  - Replace with: “Tourney”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1642 | scene. In the ditch beside the road, right side up, but violently shorn of one
+         |                                                                   ^~~~~ Did you mean to spell “shorn” this way?
+    1643 | wheel, rested a new coupé which had left Gatsby’s drive not two minutes before.
+Suggest:
+  - Replace with: “shore”
+  - Replace with: “short”
+  - Replace with: “shown”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1642 | scene. In the ditch beside the road, right side up, but violently shorn of one
+    1643 | wheel, rested a new coupé which had left Gatsby’s drive not two minutes before.
+         |                     ^~~~~ Did you mean to spell “coupé” this way?
+Suggest:
+  - Replace with: “coup”
+  - Replace with: “coupe”
+  - Replace with: “coups”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1683 | The shock that followed this declaration found voice in a sustained “Ah-h-h!” as
+    1684 | the door of the coupé swung slowly open. The crowd—it was now a crowd—stepped
+         |                 ^~~~~ Did you mean to spell “coupé” this way?
+Suggest:
+  - Replace with: “coup”
+  - Replace with: “coupe”
+  - Replace with: “coups”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1693 | “Wha’s matter?” he inquired calmly. “Did we run outa gas?”
+         |  ^~~~~ Did you mean to spell “Wha’s” this way?
+Suggest:
+  - Replace with: “W12's”
+  - Replace with: “WAL's”
+  - Replace with: “WNW's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1693 | “Wha’s matter?” he inquired calmly. “Did we run outa gas?”
+         |                                                 ^~~~ Did you mean to spell “outa” this way?
+Suggest:
+  - Replace with: “outta”
+  - Replace with: “out”
+  - Replace with: “outs”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1710 | “Wonder’ff tell me where there’s a gas’line station?”
+         |  ^~~~~~~~~ Did you mean to spell “Wonder’ff” this way?
+Suggest:
+  - Replace with: “Wonder's”
+  - Replace with: “Wonderbra”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1710 | “Wonder’ff tell me where there’s a gas’line station?”
+         |                                    ^~~~~~~~ Did you mean to spell “gas’line” this way?
+Suggest:
+  - Replace with: “gasoline”
+  - Replace with: “baseline”
+  - Replace with: “Vaseline”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1740 | potatoes and coffee. I even had a short affair with a girl who lived in Jersey
+         |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1741 | City and worked in the accounting department, but her brother began throwing
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1742 | mean looks in my direction, so when she went on her vacation in July I let it
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1743 | blow quietly away.
+         | ~~~~~~~~~~~~~~~~~~ This sentence is 45 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1759 | darkness. At the enchanted metropolitan twilight I felt a haunting loneliness
+         |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1760 | sometimes, and felt it in others—poor young clerks who loitered in front of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1761 | windows waiting until it was time for a solitary restaurant dinner—young clerks
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1762 | in the dusk, wasting the most poignant moments of night and life.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 49 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1764 | Again at eight o’clock, when the dark lanes of the Forties were lined five deep
+    1765 | with throbbing taxicabs, bound for the theatre district, I felt a sinking in my
+         |                                        ^~~~~~~ Did you mean to spell “theatre” this way?
+    1766 | heart. Forms leaned together in the taxis as they waited, and voices sang, and
+Suggest:
+  - Replace with: “theatres”
+  - Replace with: “theater”
+  - Replace with: “theatre's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1768 | unintelligible circles inside. Imagining that I, too, was hurrying toward gayety
+         |                                                                           ^~~~~~ Did you mean to spell “gayety” this way?
+    1769 | and sharing their intimate excitement, I wished them well.
+Suggest:
+  - Replace with: “gaiety”
+  - Replace with: “gamely”
+  - Replace with: “gamete”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1777 | found what it was. When we were on a house-party together up in Warwick, she
+         |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1778 | left a borrowed car out in the rain with the top down, and then lied about
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1779 | it—and suddenly I remembered the story about her that had eluded me that night
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1780 | at Daisy’s. At her first big golf tournament there was a row that nearly reached
+         | ~~~~~~~~~~~ This sentence is 45 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1789 | thought impossible. She was incurably dishonest. She wasn’t able to endure being
+         |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1790 | at a disadvantage and, given this unwillingness, I suppose she had begun dealing
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1791 | in subterfuges when she was very young in order to keep that cool, insolent
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1792 | smile turned to the world and yet satisfy the demands of her hard, jaunty body.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 48 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1837 | cocktails and his flowers. “One time he killed a man who had found out that he
+    1838 | was nephew to Von Hindenburg and second cousin to the devil. Reach me a rose,
+         |               ^~~ Did you mean to spell “Von” this way?
+Suggest:
+  - Replace with: “Vol”
+  - Replace with: “Yon”
+  - Replace with: “Con”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1848 | From East Egg, then, came the Chester Beckers and the Leeches, and a man named
+         |                                       ^~~~~~~ Did you mean to spell “Beckers” this way?
+    1849 | Bunsen, whom I knew at Yale, and Doctor Webster Civet, who was drowned last
+Suggest:
+  - Replace with: “Becker's”
+  - Replace with: “Backers”
+  - Replace with: “Bickers”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1850 | summer up in Maine. And the Hornbeams and the Willie Voltaires, and a whole clan
+         |                             ^~~~~~~~~ Did you mean to spell “Hornbeams” this way?
+Suggest:
+  - Replace with: “Hornbeam”
+  - Replace with: “Moonbeams”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1850 | summer up in Maine. And the Hornbeams and the Willie Voltaires, and a whole clan
+         |                                                      ^~~~~~~~~ Did you mean to spell “Voltaires” this way?
+    1851 | named Blackbuck, who always gathered in a corner and flipped up their noses like
+Suggest:
+  - Replace with: “Voltaire's”
+  - Replace with: “Voltaire”
+  - Replace with: “Solitaires”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1850 | summer up in Maine. And the Hornbeams and the Willie Voltaires, and a whole clan
+    1851 | named Blackbuck, who always gathered in a corner and flipped up their noses like
+         |       ^~~~~~~~~ Did you mean “Blackburn”?
+Suggest:
+  - Replace with: “Blackburn”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1852 | goats at whosoever came near. And the Ismays and the Chrysties (or rather Hubert
+         |                                       ^~~~~~ Did you mean to spell “Ismays” this way?
+    1853 | Auerbach and Mr. Chrystie’s wife), and Edgar Beaver, whose hair, they say,
+Suggest:
+  - Replace with: “Irma's”
+  - Replace with: “Dismays”
+  - Replace with: “Islams”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1852 | goats at whosoever came near. And the Ismays and the Chrysties (or rather Hubert
+         |                                                      ^~~~~~~~~ Did you mean to spell “Chrysties” this way?
+    1853 | Auerbach and Mr. Chrystie’s wife), and Edgar Beaver, whose hair, they say,
+Suggest:
+  - Replace with: “Christi's”
+  - Replace with: “Christie's”
+  - Replace with: “Christie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1852 | goats at whosoever came near. And the Ismays and the Chrysties (or rather Hubert
+    1853 | Auerbach and Mr. Chrystie’s wife), and Edgar Beaver, whose hair, they say,
+         | ^~~~~~~~ Did you mean to spell “Auerbach” this way?
+Suggest:
+  - Replace with: “Outreach”
+  - Replace with: “Bernbach”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1853 | Auerbach and Mr. Chrystie’s wife), and Edgar Beaver, whose hair, they say,
+         |                  ^~~~~~~~~~ Did you mean “Christi's”?
+Suggest:
+  - Replace with: “Christi's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1857 | knickerbockers, and had a fight with a bum named Etty in the garden. From
+         |                                                  ^~~~ Did you mean to spell “Etty” this way?
+Suggest:
+  - Replace with: “Etta”
+  - Replace with: “Betty”
+  - Replace with: “Getty”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1857 | knickerbockers, and had a fight with a bum named Etty in the garden. From
+    1858 | farther out on the Island came the Cheadles and the O. R. P. Schraeders, and the
+         |                                    ^~~~~~~~ Did you mean to spell “Cheadles” this way?
+Suggest:
+  - Replace with: “Charles”
+  - Replace with: “Headless”
+  - Replace with: “Beadles”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1858 | farther out on the Island came the Cheadles and the O. R. P. Schraeders, and the
+         |                                                     ^~ Did you mean to spell “O.” this way?
+Suggest:
+  - Replace with: “Os”
+  - Replace with: “O”
+  - Replace with: “OD”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1858 | farther out on the Island came the Cheadles and the O. R. P. Schraeders, and the
+         |                                                        ^~ Did you mean to spell “R.” this way?
+Suggest:
+  - Replace with: “Rm”
+  - Replace with: “R”
+  - Replace with: “Re”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1858 | farther out on the Island came the Cheadles and the O. R. P. Schraeders, and the
+         |                                                           ^~ Did you mean to spell “P.” this way?
+Suggest:
+  - Replace with: “Pt”
+  - Replace with: “Pa”
+  - Replace with: “Pf”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1858 | farther out on the Island came the Cheadles and the O. R. P. Schraeders, and the
+         |                                                              ^~~~~~~~~~ Did you mean to spell “Schraeders” this way?
+    1859 | Stonewall Jackson Abrams of Georgia, and the Fishguards and the Ripley Snells.
+Suggest:
+  - Replace with: “Schroeder's”
+  - Replace with: “Schroeder”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1859 | Stonewall Jackson Abrams of Georgia, and the Fishguards and the Ripley Snells.
+         |                                              ^~~~~~~~~~ Did you mean to spell “Fishguards” this way?
+Suggest:
+  - Replace with: “Fireguards”
+  - Replace with: “Wireguards”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1859 | Stonewall Jackson Abrams of Georgia, and the Fishguards and the Ripley Snells.
+         |                                                                        ^~~~~~ Did you mean to spell “Snells” this way?
+Suggest:
+  - Replace with: “Snell's”
+  - Replace with: “Snell”
+  - Replace with: “Knells”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1861 | the gravel drive that Mrs. Ulysses Swett’s automobile ran over his right hand.
+         |                                    ^~~~~~~ Did you mean to spell “Swett’s” this way?
+Suggest:
+  - Replace with: “Scott's”
+  - Replace with: “Sept's”
+  - Replace with: “Seth's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1862 | The Dancies came, too, and S. B. Whitebait, who was well over sixty, and Maurice
+         |     ^~~~~~~ Did you mean to spell “Dancies” this way?
+Suggest:
+  - Replace with: “Dannie's”
+  - Replace with: “Fancies”
+  - Replace with: “Danes”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1862 | The Dancies came, too, and S. B. Whitebait, who was well over sixty, and Maurice
+         |                            ^~ Did you mean to spell “S.” this way?
+Suggest:
+  - Replace with: “Sf”
+  - Replace with: “So”
+  - Replace with: “Sq”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1862 | The Dancies came, too, and S. B. Whitebait, who was well over sixty, and Maurice
+         |                               ^~ Did you mean to spell “B.” this way?
+Suggest:
+  - Replace with: “Bu”
+  - Replace with: “Be”
+  - Replace with: “Bf”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1862 | The Dancies came, too, and S. B. Whitebait, who was well over sixty, and Maurice
+    1863 | A. Flink, and the Hammerheads, and Beluga the tobacco importer, and Beluga’s
+         | ^~ Did you mean to spell “A.” this way?
+Suggest:
+  - Replace with: “Ax”
+  - Replace with: “A”
+  - Replace with: “Ab”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1863 | A. Flink, and the Hammerheads, and Beluga the tobacco importer, and Beluga’s
+         |    ^~~~~ Did you mean to spell “Flink” this way?
+Suggest:
+  - Replace with: “Flunk”
+  - Replace with: “Blink”
+  - Replace with: “Link”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1866 | From West Egg came the Poles and the Mulreadys and Cecil Roebuck and Cecil
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1867 | Schoen and Gulick the State senator and Newton Orchid, who controlled Films Par
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1868 | Excellence, and Eckhaust and Clyde Cohen and Don S. Schwartze (the son) and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1869 | Arthur McCarty, all connected with the movies in one way or another. And the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 52 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1866 | From West Egg came the Poles and the Mulreadys and Cecil Roebuck and Cecil
+         |                                      ^~~~~~~~~ Did you mean to spell “Mulreadys” this way?
+    1867 | Schoen and Gulick the State senator and Newton Orchid, who controlled Films Par
+Suggest:
+  - Replace with: “Already”
+  - Replace with: “Unready”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1866 | From West Egg came the Poles and the Mulreadys and Cecil Roebuck and Cecil
+    1867 | Schoen and Gulick the State senator and Newton Orchid, who controlled Films Par
+         | ^~~~~~ Did you mean to spell “Schoen” this way?
+Suggest:
+  - Replace with: “Chosen”
+  - Replace with: “Echoes”
+  - Replace with: “Echoed”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1866 | From West Egg came the Poles and the Mulreadys and Cecil Roebuck and Cecil
+    1867 | Schoen and Gulick the State senator and Newton Orchid, who controlled Films Par
+         |            ^~~~~~ Did you mean to spell “Gulick” this way?
+Suggest:
+  - Replace with: “Click”
+  - Replace with: “Flick”
+  - Replace with: “Lick”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1867 | Schoen and Gulick the State senator and Newton Orchid, who controlled Films Par
+    1868 | Excellence, and Eckhaust and Clyde Cohen and Don S. Schwartze (the son) and
+         |                 ^~~~~~~~ Did you mean “Exhaust”?
+Suggest:
+  - Replace with: “Exhaust”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1868 | Excellence, and Eckhaust and Clyde Cohen and Don S. Schwartze (the son) and
+         |                                                  ^~ Did you mean to spell “S.” this way?
+Suggest:
+  - Replace with: “Sf”
+  - Replace with: “So”
+  - Replace with: “Sq”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1868 | Excellence, and Eckhaust and Clyde Cohen and Don S. Schwartze (the son) and
+         |                                                     ^~~~~~~~~ Did you mean “Schwartz”?
+    1869 | Arthur McCarty, all connected with the movies in one way or another. And the
+Suggest:
+  - Replace with: “Schwartz”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1869 | Arthur McCarty, all connected with the movies in one way or another. And the
+    1870 | Catlips and the Bembergs and G. Earl Muldoon, brother to that Muldoon who
+         | ^~~~~~~ Did you mean “Cali's”?
+Suggest:
+  - Replace with: “Cali's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1869 | Arthur McCarty, all connected with the movies in one way or another. And the
+    1870 | Catlips and the Bembergs and G. Earl Muldoon, brother to that Muldoon who
+         |                 ^~~~~~~~ Did you mean to spell “Bembergs” this way?
+Suggest:
+  - Replace with: “Berber's”
+  - Replace with: “Berbers”
+  - Replace with: “Ember's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1869 | Arthur McCarty, all connected with the movies in one way or another. And the
+    1870 | Catlips and the Bembergs and G. Earl Muldoon, brother to that Muldoon who
+         |                              ^~ Did you mean to spell “G.” this way?
+Suggest:
+  - Replace with: “Gt”
+  - Replace with: “G”
+  - Replace with: “Gr”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1870 | Catlips and the Bembergs and G. Earl Muldoon, brother to that Muldoon who
+         |                                      ^~~~~~~ Did you mean to spell “Muldoon” this way?
+    1871 | afterward strangled his wife. Da Fontano the promoter came there, and Ed Legros
+Suggest:
+  - Replace with: “Mullion”
+  - Replace with: “Mauldin”
+  - Replace with: “Mellon”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1870 | Catlips and the Bembergs and G. Earl Muldoon, brother to that Muldoon who
+         |                                                               ^~~~~~~ Did you mean to spell “Muldoon” this way?
+    1871 | afterward strangled his wife. Da Fontano the promoter came there, and Ed Legros
+Suggest:
+  - Replace with: “Mullion”
+  - Replace with: “Mauldin”
+  - Replace with: “Mellon”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1871 | afterward strangled his wife. Da Fontano the promoter came there, and Ed Legros
+         |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1872 | and James B. (“Rot-Gut”) Ferret and the De Jongs and Ernest Lilly—they came to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1873 | gamble, and when Ferret wandered into the garden it meant he was cleaned out and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1874 | Associated Traction would have to fluctuate profitably next day.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 49 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1871 | afterward strangled his wife. Da Fontano the promoter came there, and Ed Legros
+         |                               ^~ Did you mean to spell “Da” this way?
+Suggest:
+  - Replace with: “D”
+  - Replace with: “Dab”
+  - Replace with: “Dad”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1871 | afterward strangled his wife. Da Fontano the promoter came there, and Ed Legros
+         |                                  ^~~~~~~ Did you mean “Montana”?
+Suggest:
+  - Replace with: “Montana”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1871 | afterward strangled his wife. Da Fontano the promoter came there, and Ed Legros
+         |                                                                          ^~~~~~ Did you mean to spell “Legros” this way?
+    1872 | and James B. (“Rot-Gut”) Ferret and the De Jongs and Ernest Lilly—they came to
+Suggest:
+  - Replace with: “Lear's”
+  - Replace with: “Negros”
+  - Replace with: “Lagos”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1871 | afterward strangled his wife. Da Fontano the promoter came there, and Ed Legros
+    1872 | and James B. (“Rot-Gut”) Ferret and the De Jongs and Ernest Lilly—they came to
+         |           ^~ Did you mean to spell “B.” this way?
+Suggest:
+  - Replace with: “Bu”
+  - Replace with: “Be”
+  - Replace with: “Bf”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1872 | and James B. (“Rot-Gut”) Ferret and the De Jongs and Ernest Lilly—they came to
+         |                                         ^~ Did you mean to spell “De” this way?
+    1873 | gamble, and when Ferret wandered into the garden it meant he was cleaned out and
+Suggest:
+  - Replace with: “D”
+  - Replace with: “Dc”
+  - Replace with: “Dev”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1872 | and James B. (“Rot-Gut”) Ferret and the De Jongs and Ernest Lilly—they came to
+         |                                            ^~~~~ Did you mean to spell “Jongs” this way?
+    1873 | gamble, and when Ferret wandered into the garden it meant he was cleaned out and
+Suggest:
+  - Replace with: “Jon's”
+  - Replace with: “Jonas”
+  - Replace with: “Jogs”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1876 | A man named Klipspringer was there so often and so long that he became known as
+         |             ^~~~~~~~~~~~ Did you mean to spell “Klipspringer” this way?
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1877 | “the boarder”—I doubt if he had any other home. Of theatrical people there were
+    1878 | Gus Waize and Horace O’Donavan and Lester Myer and George Duckweed and Francis
+         |     ^~~~~ Did you mean to spell “Waize” this way?
+Suggest:
+  - Replace with: “Waite”
+  - Replace with: “Maize”
+  - Replace with: “Waive”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1877 | “the boarder”—I doubt if he had any other home. Of theatrical people there were
+    1878 | Gus Waize and Horace O’Donavan and Lester Myer and George Duckweed and Francis
+         |                      ^~~~~~~~~ Did you mean to spell “O’Donavan” this way?
+Suggest:
+  - Replace with: “O'Donnell”
+  - Replace with: “Donovan”
+  - Replace with: “Okinawan”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1878 | Gus Waize and Horace O’Donavan and Lester Myer and George Duckweed and Francis
+         |                                           ^~~~ Did you mean to spell “Myer” this way?
+    1879 | Bull. Also from New York were the Chromes and the Backhyssons and the Dennickers
+Suggest:
+  - Replace with: “Mayer”
+  - Replace with: “Meyer”
+  - Replace with: “Myers”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1879 | Bull. Also from New York were the Chromes and the Backhyssons and the Dennickers
+         |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1880 | and Russel Betty and the Corrigans and the Kellehers and the Dewars and the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1881 | Scullys and S. W. Belcher and the Smirkes and the young Quinns, divorced now,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1882 | and Henry L. Palmetto, who killed himself by jumping in front of a subway train
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1883 | in Times Square.
+         | ~~~~~~~~~~~~~~~~ This sentence is 59 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1879 | Bull. Also from New York were the Chromes and the Backhyssons and the Dennickers
+         |                                                   ^~~~~~~~~~~ Did you mean “Jacksons”?
+    1880 | and Russel Betty and the Corrigans and the Kellehers and the Dewars and the
+Suggest:
+  - Replace with: “Jacksons”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1879 | Bull. Also from New York were the Chromes and the Backhyssons and the Dennickers
+         |                                                                       ^~~~~~~~~~ Did you mean to spell “Dennickers” this way?
+    1880 | and Russel Betty and the Corrigans and the Kellehers and the Dewars and the
+Suggest:
+  - Replace with: “Knickers”
+  - Replace with: “Nickers”
+  - Replace with: “Picnickers”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1879 | Bull. Also from New York were the Chromes and the Backhyssons and the Dennickers
+    1880 | and Russel Betty and the Corrigans and the Kellehers and the Dewars and the
+         |                          ^~~~~~~~~ Did you mean to spell “Corrigans” this way?
+Suggest:
+  - Replace with: “Cardigans”
+  - Replace with: “Corina's”
+  - Replace with: “Corrine's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1880 | and Russel Betty and the Corrigans and the Kellehers and the Dewars and the
+         |                                            ^~~~~~~~~ Did you mean to spell “Kellehers” this way?
+    1881 | Scullys and S. W. Belcher and the Smirkes and the young Quinns, divorced now,
+Suggest:
+  - Replace with: “Keller's”
+  - Replace with: “Kelley's”
+  - Replace with: “Kellie's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1880 | and Russel Betty and the Corrigans and the Kellehers and the Dewars and the
+         |                                                              ^~~~~~ Did you mean to spell “Dewars” this way?
+    1881 | Scullys and S. W. Belcher and the Smirkes and the young Quinns, divorced now,
+Suggest:
+  - Replace with: “Dewar's”
+  - Replace with: “Dewar”
+  - Replace with: “Dena's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1880 | and Russel Betty and the Corrigans and the Kellehers and the Dewars and the
+    1881 | Scullys and S. W. Belcher and the Smirkes and the young Quinns, divorced now,
+         | ^~~~~~~ Did you mean to spell “Scullys” this way?
+Suggest:
+  - Replace with: “Scull's”
+  - Replace with: “Sculley's”
+  - Replace with: “Sculls”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1880 | and Russel Betty and the Corrigans and the Kellehers and the Dewars and the
+    1881 | Scullys and S. W. Belcher and the Smirkes and the young Quinns, divorced now,
+         |             ^~ Did you mean to spell “S.” this way?
+Suggest:
+  - Replace with: “Sf”
+  - Replace with: “So”
+  - Replace with: “Sq”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1881 | Scullys and S. W. Belcher and the Smirkes and the young Quinns, divorced now,
+         |                ^~ Did you mean to spell “W.” this way?
+Suggest:
+  - Replace with: “We”
+  - Replace with: “WA”
+  - Replace with: “WC”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1881 | Scullys and S. W. Belcher and the Smirkes and the young Quinns, divorced now,
+         |                   ^~~~~~~ Did you mean to spell “Belcher” this way?
+Suggest:
+  - Replace with: “Beecher”
+  - Replace with: “Becker”
+  - Replace with: “Blucher”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1881 | Scullys and S. W. Belcher and the Smirkes and the young Quinns, divorced now,
+         |                                   ^~~~~~~ Did you mean to spell “Smirkes” this way?
+    1882 | and Henry L. Palmetto, who killed himself by jumping in front of a subway train
+Suggest:
+  - Replace with: “Smirk's”
+  - Replace with: “Smirks”
+  - Replace with: “Smirked”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1881 | Scullys and S. W. Belcher and the Smirkes and the young Quinns, divorced now,
+         |                                                         ^~~~~~ Did you mean to spell “Quinns” this way?
+    1882 | and Henry L. Palmetto, who killed himself by jumping in front of a subway train
+Suggest:
+  - Replace with: “Quinn's”
+  - Replace with: “Quinn”
+  - Replace with: “Qin's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1881 | Scullys and S. W. Belcher and the Smirkes and the young Quinns, divorced now,
+    1882 | and Henry L. Palmetto, who killed himself by jumping in front of a subway train
+         |           ^~ Did you mean to spell “L.” this way?
+Suggest:
+  - Replace with: “Lg”
+  - Replace with: “La”
+  - Replace with: “LC”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1885 | Benny McClenahan arrived always with four girls. They were never quite the same
+         |       ^~~~~~~~~~ Did you mean “McClain”?
+Suggest:
+  - Replace with: “McClain”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1887 | inevitably seemed they had been there before. I have forgotten their
+         |                                              ^~~~~~~~~~~~~~~~~~~~~~~~
+    1888 | names—Jaqueline, I think, or else Consuela, or Gloria or Judy or June, and their
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1889 | last names were either the melodious names of flowers and months or the sterner
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1890 | ones of the great American capitalists whose cousins, if pressed, they would
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1891 | confess themselves to be.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 49 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1887 | inevitably seemed they had been there before. I have forgotten their
+    1888 | names—Jaqueline, I think, or else Consuela, or Gloria or Judy or June, and their
+         |       ^~~~~~~~~ Did you mean to spell “Jaqueline” this way?
+Suggest:
+  - Replace with: “Jacqueline”
+  - Replace with: “Aquiline”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1887 | inevitably seemed they had been there before. I have forgotten their
+    1888 | names—Jaqueline, I think, or else Consuela, or Gloria or Judy or June, and their
+         |                                   ^~~~~~~~ Did you mean “Consuelo”?
+    1889 | last names were either the melodious names of flowers and months or the sterner
+Suggest:
+  - Replace with: “Consuelo”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1893 | In addition to all these I can remember that Faustina O’Brien came there at
+         |                                              ^~~~~~~~ Did you mean to spell “Faustina” this way?
+    1894 | least once and the Baedeker girls and young Brewer, who had his nose shot off in
+Suggest:
+  - Replace with: “Faustino”
+  - Replace with: “Faustian”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1895 | the war, and Mr. Albrucksburger and Miss Haag, his fiancée, and Ardita
+         |                  ^~~~~~~~~~~~~~ Did you mean to spell “Albrucksburger” this way?
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1895 | the war, and Mr. Albrucksburger and Miss Haag, his fiancée, and Ardita
+         |                                          ^~~~ Did you mean to spell “Haag” this way?
+    1896 | Fitz-Peters and Mr. P. Jewett, once head of the American Legion, and Miss
+Suggest:
+  - Replace with: “Hag”
+  - Replace with: “Haas”
+  - Replace with: “Ha's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1895 | the war, and Mr. Albrucksburger and Miss Haag, his fiancée, and Ardita
+         |                                                    ^~~~~~~ Did you mean to spell “fiancée” this way?
+    1896 | Fitz-Peters and Mr. P. Jewett, once head of the American Legion, and Miss
+Suggest:
+  - Replace with: “fiance”
+  - Replace with: “fiancee”
+  - Replace with: “finance”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1895 | the war, and Mr. Albrucksburger and Miss Haag, his fiancée, and Ardita
+         |                                                                 ^~~~~~ Did you mean to spell “Ardita” this way?
+    1896 | Fitz-Peters and Mr. P. Jewett, once head of the American Legion, and Miss
+Suggest:
+  - Replace with: “Akita”
+  - Replace with: “Anita”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1895 | the war, and Mr. Albrucksburger and Miss Haag, his fiancée, and Ardita
+    1896 | Fitz-Peters and Mr. P. Jewett, once head of the American Legion, and Miss
+         | ^~~~ Did you mean to spell “Fitz” this way?
+Suggest:
+  - Replace with: “Fit”
+  - Replace with: “Fritz”
+  - Replace with: “Ditz”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1896 | Fitz-Peters and Mr. P. Jewett, once head of the American Legion, and Miss
+         |                     ^~ Did you mean to spell “P.” this way?
+Suggest:
+  - Replace with: “Pt”
+  - Replace with: “Pa”
+  - Replace with: “Pf”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1896 | Fitz-Peters and Mr. P. Jewett, once head of the American Legion, and Miss
+         |                        ^~~~~~ Did you mean to spell “Jewett” this way?
+Suggest:
+  - Replace with: “Jewell”
+  - Replace with: “Jewess”
+  - Replace with: “Dewitt”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1911 | He was balancing himself on the dashboard of his car with that resourcefulness
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1912 | of movement that is so peculiarly American—that comes, I suppose, with the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1913 | absence of lifting work in youth and, even more, with the formless grace of our
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1914 | nervous, sporadic games. This quality was continually breaking through his
+         | ~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 44 words long.
+
+
+
+Lint:    WordChoice (127 priority)
+Message: |
+    1951 | “I’ll tell you God’s truth.” His right hand suddenly ordered divine retribution
+         |            ^~~ The possessive version of this word is more common in this context.
+Suggest:
+  - Replace with: “your”
+  - Replace with: “you're a”
+  - Replace with: “you're an”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1974 | “After that I lived like a young rajah in all the capitals of Europe—Paris,
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1975 | Venice, Rome—collecting jewels, chiefly rubies, hunting big game, painting a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1976 | little, things for myself only, and trying to forget something very sad that had
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1977 | happened to me long ago.”
+         | ~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 45 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1981 | “character” leaking sawdust at every pore as he pursued a tiger through the Bois
+         |                                                                             ^~~~ Did you mean to spell “Bois” this way?
+    1982 | de Boulogne.
+Suggest:
+  - Replace with: “Bogs”
+  - Replace with: “Boris”
+  - Replace with: “Bis”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1981 | “character” leaking sawdust at every pore as he pursued a tiger through the Bois
+    1982 | de Boulogne.
+         | ^~ Did you mean to spell “de” this way?
+Suggest:
+  - Replace with: “d”
+  - Replace with: “db”
+  - Replace with: “dc”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    1981 | “character” leaking sawdust at every pore as he pursued a tiger through the Bois
+    1982 | de Boulogne.
+         |    ^~~~~~~~ Did you mean “Cologne”?
+Suggest:
+  - Replace with: “Cologne”
+
+
+
+Lint:    Style (31 priority)
+Message: |
+    1988 | side of us where the infantry couldn’t advance. We stayed there two days and two
+    1989 | nights, a hundred and thirty men with sixteen Lewis guns, and when the infantry
+         |           ^~~~~~~ An Oxford comma is necessary here.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2006 | To my astonishment, the thing had an authentic look. “Orderi di Danilo,” ran the
+         |                                                       ^~~~~~ Did you mean to spell “Orderi” this way?
+    2007 | circular legend, “Montenegro, Nicolas Rex.”
+Suggest:
+  - Replace with: “Order”
+  - Replace with: “Oder”
+  - Replace with: “Orders”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2006 | To my astonishment, the thing had an authentic look. “Orderi di Danilo,” ran the
+         |                                                              ^~ Did you mean to spell “di” this way?
+    2007 | circular legend, “Montenegro, Nicolas Rex.”
+Suggest:
+  - Replace with: “d”
+  - Replace with: “db”
+  - Replace with: “dc”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2006 | To my astonishment, the thing had an authentic look. “Orderi di Danilo,” ran the
+         |                                                                 ^~~~~~ Did you mean to spell “Danilo” this way?
+    2007 | circular legend, “Montenegro, Nicolas Rex.”
+Suggest:
+  - Replace with: “Danial”
+  - Replace with: “Daniel”
+  - Replace with: “Daniels”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2011 | “Major Jay Gatsby,” I read, “For Valour Extraordinary.”
+         |                                  ^~~~~~ Did you mean to spell “Valour” this way?
+Suggest:
+  - Replace with: “Valor”
+  - Replace with: “Valium”
+  - Replace with: “Valois”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2014 | Trinity Quad—the man on my left is now the Earl of Doncaster.”
+         |                                                    ^~~~~~~~~ Did you mean to spell “Doncaster” this way?
+Suggest:
+  - Replace with: “Lancaster”
+  - Replace with: “Podcaster”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2021 | Grand Canal; I saw him opening a chest of rubies to ease, with their
+    2022 | crimson-lighted depths, the gnawings of his broken heart.
+         |                             ^~~~~~~~ Did you mean to spell “gnawings” this way?
+Suggest:
+  - Replace with: “gnawing”
+  - Replace with: “gratings”
+  - Replace with: “drawings”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2047 | ships, and sped along a cobbled slum lined with the dark, undeserted saloons of
+         |                                                           ^~~~~~~~~~ Did you mean to spell “undeserted” this way?
+    2048 | the faded-gilt nineteen-hundreds. Then the valley of ashes opened out on both
+Suggest:
+  - Replace with: “undeserved”
+  - Replace with: “undefeated”
+  - Replace with: “undesired”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2067 | Over the great bridge, with the sunlight through the girders making a constant
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2068 | flicker upon the moving cars, with the city rising up across the river in white
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2069 | heaps and sugar lumps all built with a wish out of non-olfactory money. The city
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2069 | heaps and sugar lumps all built with a wish out of non-olfactory money. The city
+    2070 | seen from the Queensboro Bridge is always the city seen for the first time, in
+         |               ^~~~~~~~~~ Did you mean “Greensboro”?
+Suggest:
+  - Replace with: “Greensboro”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2076 | Europe, and I was glad that the sight of Gatsby’s splendid car was included in
+    2077 | their sombre holiday. As we crossed Blackwell’s Island a limousine passed us,
+         |       ^~~~~~ Did you mean to spell “sombre” this way?
+Suggest:
+  - Replace with: “hombre”
+  - Replace with: “somber”
+  - Replace with: “some”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2078 | driven by a white chauffeur, in which sat three modish negroes, two bucks and a
+         |                                                        ^~~~~~~ Did you mean to spell “negroes” this way?
+    2079 | girl. I laughed aloud as the yolks of their eyeballs rolled toward us in haughty
+Suggest:
+  - Replace with: “Negroes”
+  - Replace with: “Negro's”
+  - Replace with: “Negros”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2091 | “Mr. Carraway, this is my friend Mr. Wolfshiem.”
+         |      ^~~~~~~~ Did you mean to spell “Carraway” this way?
+Suggest:
+  - Replace with: “Caraway”
+  - Replace with: “Faraway”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2091 | “Mr. Carraway, this is my friend Mr. Wolfshiem.”
+         |                                      ^~~~~~~~~ Did you mean “Bolshie”?
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2097 | “So I took one look at him,” said Mr. Wolfshiem, shaking my hand earnestly, “and
+         |                                       ^~~~~~~~~ Did you mean “Bolshie”?
+    2098 | what do you think I did?”
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2105 | “I handed the money to Katspaugh and I sid: ‘All right, Katspaugh, don’t pay him
+         |                        ^~~~~~~~~ Did you mean to spell “Katspaugh” this way?
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2105 | “I handed the money to Katspaugh and I sid: ‘All right, Katspaugh, don’t pay him
+         |                                        ^~~ Did you mean to spell “sid” this way?
+Suggest:
+  - Replace with: “sad”
+  - Replace with: “said”
+  - Replace with: “sic”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2105 | “I handed the money to Katspaugh and I sid: ‘All right, Katspaugh, don’t pay him
+         |                                                         ^~~~~~~~~ Did you mean to spell “Katspaugh” this way?
+    2106 | a penny till he shuts his mouth.’ He shut it then and there.”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2109 | whereupon Mr. Wolfshiem swallowed a new sentence he was starting and lapsed into
+         |               ^~~~~~~~~ Did you mean “Bolshie”?
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2109 | whereupon Mr. Wolfshiem swallowed a new sentence he was starting and lapsed into
+    2110 | a somnambulatory abstraction.
+         |   ^~~~~~~~~~~~~~ Did you mean “ambulatory”?
+Suggest:
+  - Replace with: “ambulatory”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    2112 | “Highballs?” asked the head waiter.
+         |                        ^~~~~~~~~~~ Did you mean the closed compound noun “headwaiter”?
+Suggest:
+  - Replace with: “headwaiter”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2114 | “This is a nice restaurant here,” said Mr. Wolfshiem, looking at the
+         |                                            ^~~~~~~~~ Did you mean “Bolshie”?
+    2115 | Presbyterian nymphs on the ceiling. “But I like across the street better!”
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2117 | “Yes, highballs,” agreed Gatsby, and then to Mr. Wolfshiem: “It’s too hot over
+         |                                                  ^~~~~~~~~ Did you mean “Bolshie”?
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2120 | “Hot and small—yes,” said Mr. Wolfshiem, “but full of memories.”
+         |                               ^~~~~~~~~ Did you mean “Bolshie”?
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2124 | “The old Metropole.”
+         |          ^~~~~~~~~ Did you mean to spell “Metropole” this way?
+Suggest:
+  - Replace with: “Metronome”
+  - Replace with: “Metropolis”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2126 | “The old Metropole,” brooded Mr. Wolfshiem gloomily. “Filled with faces dead and
+         |          ^~~~~~~~~ Did you mean to spell “Metropole” this way?
+Suggest:
+  - Replace with: “Metronome”
+  - Replace with: “Metropolis”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2126 | “The old Metropole,” brooded Mr. Wolfshiem gloomily. “Filled with faces dead and
+         |                                  ^~~~~~~~~ Did you mean “Bolshie”?
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2142 | “Sure he went.” Mr. Wolfshiem’s nose flashed at me indignantly. “He turned
+         |                     ^~~~~~~~~~~ Did you mean to spell “Wolfshiem’s” this way?
+Suggest:
+  - Replace with: “Welshmen's”
+  - Replace with: “Wolfe's”
+  - Replace with: “Wolsey's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2150 | understand you’re looking for a business gonnegtion.”
+         |                                          ^~~~~~~~~~ Did you mean “connection”?
+Suggest:
+  - Replace with: “connection”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2156 | “No?” Mr. Wolfshiem seemed disappointed.
+         |           ^~~~~~~~~ Did you mean “Bolshie”?
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2160 | “I beg your pardon,” said Mr. Wolfshiem, “I had a wrong man.”
+         |                               ^~~~~~~~~ Did you mean “Bolshie”?
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2162 | A succulent hash arrived, and Mr. Wolfshiem, forgetting the more sentimental
+         |                                   ^~~~~~~~~ Did you mean “Bolshie”?
+    2163 | atmosphere of the old Metropole, began to eat with ferocious delicacy. His eyes,
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2162 | A succulent hash arrived, and Mr. Wolfshiem, forgetting the more sentimental
+    2163 | atmosphere of the old Metropole, began to eat with ferocious delicacy. His eyes,
+         |                       ^~~~~~~~~ Did you mean to spell “Metropole” this way?
+Suggest:
+  - Replace with: “Metronome”
+  - Replace with: “Metropolis”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2181 | me with Mr. Wolfshiem at the table.
+         |             ^~~~~~~~~ Did you mean “Bolshie”?
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2183 | “He has to telephone,” said Mr. Wolfshiem, following him with his eyes. “Fine
+         |                                 ^~~~~~~~~ Did you mean “Bolshie”?
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2188 | “He’s an Oggsford man.”
+         |          ^~~~~~~~ Did you mean to spell “Oggsford” this way?
+Suggest:
+  - Replace with: “Oxford”
+  - Replace with: “Osborn”
+  - Replace with: “Osgood”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2192 | “He went to Oggsford College in England. You know Oggsford College?”
+         |             ^~~~~~~~ Did you mean to spell “Oggsford” this way?
+Suggest:
+  - Replace with: “Oxford”
+  - Replace with: “Osborn”
+  - Replace with: “Osgood”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2192 | “He went to Oggsford College in England. You know Oggsford College?”
+         |                                                   ^~~~~~~~ Did you mean to spell “Oggsford” this way?
+Suggest:
+  - Replace with: “Oxford”
+  - Replace with: “Osborn”
+  - Replace with: “Osgood”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    2212 | “Well!” I inspected them. “That’s a very interesting idea.”
+         |                                   ^~~~~~ The possessive noun implies ownership of the closed compound noun “Avery”.
+Suggest:
+  - Replace with: “Avery”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2218 | Mr. Wolfshiem drank his coffee with a jerk and got to his feet.
+         |     ^~~~~~~~~ Did you mean “Bolshie”?
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    WordChoice (127 priority)
+Message: |
+    2220 | “I have enjoyed my lunch,” he said, “and I’m going to run off from you two young
+         |                                                                    ^~~ The possessive version of this word is more common in this context.
+    2221 | men before I outstay my welcome.”
+Suggest:
+  - Replace with: “your”
+  - Replace with: “you're a”
+  - Replace with: “you're an”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2223 | “Don’t hurry, Meyer,” said Gatsby, without enthusiasm. Mr. Wolfshiem raised his
+         |                                                            ^~~~~~~~~ Did you mean “Bolshie”?
+    2224 | hand in a sort of benediction.
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2243 | “Meyer Wolfshiem? No, he’s a gambler.” Gatsby hesitated, then added coolly:
+         |        ^~~~~~~~~ Did you mean “Bolshie”?
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2269 | “Where’ve you been?” he demanded eagerly. “Daisy’s furious because you haven’t
+         |  ^~~~~~~~ Did you mean to spell “Where’ve” this way?
+Suggest:
+  - Replace with: “Where'd”
+  - Replace with: “Where's”
+  - Replace with: “Wherever”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2277 | “How’ve you been, anyhow?” demanded Tom of me. “How’d you happen to come up this
+         |  ^~~~~~ Did you mean to spell “How’ve” this way?
+Suggest:
+  - Replace with: “How're”
+  - Replace with: “Howe”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2291 | with rubber nobs on the soles that bit into the soft ground. I had on a new
+         |                                                             ^~~~~~~~~~~~~~~~
+    2292 | plaid skirt also that blew a little in the wind, and whenever this happened the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2293 | red, white, and blue banners in front of all the houses stretched out stiff and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2294 | said tut-tut-tut-tut, in a disapproving way.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 44 words long.
+
+
+
+Lint:    Repetition (63 priority)
+Message: |
+    2314 | girl wants to be looked at sometime, and because it seemed romantic to me I have
+         |                                                                        ^~~~ There are too many personal pronouns in sequence here.
+    2315 | remembered the incident ever since. His name was Jay Gatsby, and I didn’t lay
+Suggest:
+  - Replace with: “me”
+  - Replace with: “I”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2319 | That was nineteen-seventeen. By the next year I had a few beaux myself, and I
+         |                                                           ^~~~~ Did you mean to spell “beaux” this way?
+    2320 | began to play in tournaments, so I didn’t see Daisy very often. She went with a
+Suggest:
+  - Replace with: “beau”
+  - Replace with: “beaus”
+  - Replace with: “beaut”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2329 | By the next autumn she was gay again, gay as ever. She had a début after the
+         |                                                              ^~~~~ Did you mean to spell “début” this way?
+    2330 | armistice, and in February she was presumably engaged to a man from New Orleans.
+Suggest:
+  - Replace with: “debut”
+  - Replace with: “debit”
+  - Replace with: “debt”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2332 | than Louisville ever knew before. He came down with a hundred people in four
+         |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2333 | private cars, and hired a whole floor of the Muhlbach Hotel, and the day before
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2334 | the wedding he gave her a string of pearls valued at three hundred and fifty
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2335 | thousand dollars.
+         | ~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2333 | private cars, and hired a whole floor of the Muhlbach Hotel, and the day before
+         |                                              ^~~~~~~~ Did you mean to spell “Muhlbach” this way?
+    2334 | the wedding he gave her a string of pearls valued at three hundred and fifty
+Suggest:
+  - Replace with: “Fullback”
+  - Replace with: “Pullback”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2339 | dress—and as drunk as a monkey. She had a bottle of Sauterne in one hand and a
+         |                                                     ^~~~~~~~ Did you mean to spell “Sauterne” this way?
+    2340 | letter in the other.
+Suggest:
+  - Replace with: “Sauternes”
+  - Replace with: “Sterne”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2342 | “’Gratulate me,” she muttered. “Never had a drink before, but oh how I do enjoy
+         |   ^~~~~~~~~ Did you mean “Granulate”?
+Suggest:
+  - Replace with: “Granulate”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2349 | “Here, deares’.” She groped around in a wastebasket she had with her on the bed
+         |        ^~~~~~ Did you mean to spell “deares” this way?
+Suggest:
+  - Replace with: “dear's”
+  - Replace with: “deaves”
+  - Replace with: “dares”
+
+
+
+Lint:    Repetition (63 priority)
+Message: |
+    2351 | whoever they belong to. Tell ’em all Daisy’s change’ her mine. Say: ‘Daisy’s
+         |                                                      ^~~~~~~~ There are too many personal pronouns in sequence here.
+Suggest:
+  - Replace with: “her”
+  - Replace with: “mine”
+
+
+
+Lint:    Repetition (63 priority)
+Message: |
+    2351 | whoever they belong to. Tell ’em all Daisy’s change’ her mine. Say: ‘Daisy’s
+    2352 | change’ her mine!’”
+         |         ^~~~~~~~ There are too many personal pronouns in sequence here.
+Suggest:
+  - Replace with: “her”
+  - Replace with: “mine”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2360 | But she didn’t say another word. We gave her spirits of ammonia and put ice on
+         |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2361 | her forehead and hooked her back into her dress, and half an hour later, when we
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2362 | walked out of the room, the pearls were around her neck and the incident was
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2363 | over. Next day at five o’clock she married Tom Buchanan without so much as a
+         | ~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2373 | week after I left Santa Barbara Tom ran into a wagon on the Ventura road one
+         |                                                             ^~~~~~~ Did you mean to spell “Ventura” this way?
+    2374 | night, and ripped a front wheel off his car. The girl who was with him got into
+Suggest:
+  - Replace with: “Venture”
+  - Replace with: “Century”
+  - Replace with: “Denture”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2379 | saw them one spring in Cannes, and later in Deauville, and then they came back
+         |                                             ^~~~~~~~~ Did you mean to spell “Deauville” this way?
+    2380 | to Chicago to settle down. Daisy was popular in Chicago, as you know. They moved
+Suggest:
+  - Replace with: “Danville”
+  - Replace with: “Melville”
+  - Replace with: “Neville”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2395 | When Jordan Baker had finished telling all this we had left the Plaza for half
+    2396 | an hour and were driving in a victoria through Central Park. The sun had gone
+         |                               ^~~~~~~~ Did you mean to spell “victoria” this way?
+Suggest:
+  - Replace with: “Victoria”
+  - Replace with: “victor”
+  - Replace with: “victor's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2401 | > “I’m the Sheik of Araby. Your love belongs to me. At night when you’re asleep
+         |            ^~~~~ Did you mean to spell “Sheik” this way?
+Suggest:
+  - Replace with: “Sheikh”
+  - Replace with: “Sabik”
+  - Replace with: “Seiko”
+
+
+
+Lint:    WordChoice (31 priority)
+Message: |
+    2447 | “When I said you were a particular friend of Tom’s, he started to abandon the
+         |                  ^~~~ Use the contraction or separate the words instead.
+Suggest:
+  - Replace with: “we're”
+  - Replace with: “we are”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2455 | hard, limited person, who dealt in universal scepticism, and who leaned back
+         |                                              ^~~~~~~~~~ Did you mean to spell “scepticism” this way?
+    2456 | jauntily just within the circle of my arm. A phrase began to beat in my ears
+Suggest:
+  - Replace with: “skepticism”
+  - Replace with: “sceptic's”
+  - Replace with: “scepticism's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2467 | We passed a barrier of dark trees, and then the façade of Fifty-ninth Street, a
+         |                                                 ^~~~~~ Did you mean to spell “façade” this way?
+    2468 | block of delicate pale light, beamed down into the park. Unlike Gatsby and Tom
+Suggest:
+  - Replace with: “facade”
+  - Replace with: “fade”
+  - Replace with: “facades”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2492 | some of the rooms. Let’s go to Coney Island, old sport. In my car.”
+         |                                ^~~~~ Did you mean to spell “Coney” this way?
+Suggest:
+  - Replace with: “Cone”
+  - Replace with: “Conley”
+  - Replace with: “Corey”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2555 | “You wouldn’t have to do any business with Wolfshiem.” Evidently he thought that
+         |                                            ^~~~~~~~~ Did you mean “Bolshie”?
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2555 | “You wouldn’t have to do any business with Wolfshiem.” Evidently he thought that
+    2556 | I was shying away from the “gonnegtion” mentioned at lunch, but I assured him he
+         |                             ^~~~~~~~~~ Did you mean “connection”?
+Suggest:
+  - Replace with: “connection”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2561 | sleep as I entered my front door. So I don’t know whether or not Gatsby went to
+    2562 | Coney Island, or for how many hours he “glanced into rooms” while his house
+         | ^~~~~ Did you mean to spell “Coney” this way?
+Suggest:
+  - Replace with: “Cone”
+  - Replace with: “Conley”
+  - Replace with: “Corey”
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+    2594 | “Looks very good,” he remarked vaguely. “One of the papers said they thought the
+         |        ^~~~~~~~~ Vocabulary enhancement: use `excellent` instead of `very good`
+Suggest:
+  - Replace with: “excellent”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+    2603 | “Of course, of course! They’re fine!” and he added hollowly, “. . . old sport.”
+         |                                                                     ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “O”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2606 | thin drops swam like dew. Gatsby looked with vacant eyes through a copy of
+         |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2607 | Clay’s “Economics,” starting at the Finnish tread that shook the kitchen floor,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2608 | and peering toward the bleared windows from time to time as if a series of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2609 | invisible but alarming happenings were taking place outside. Finally he got up
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 44 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2607 | Clay’s “Economics,” starting at the Finnish tread that shook the kitchen floor,
+    2608 | and peering toward the bleared windows from time to time as if a series of
+         |                        ^~~~~~~ Did you mean to spell “bleared” this way?
+Suggest:
+  - Replace with: “blared”
+  - Replace with: “bleated”
+  - Replace with: “beard”
+
+
+
+Lint:    Style (31 priority)
+Message: |
+    2629 | The exhilarating ripple of her voice was a wild tonic in the rain. I had to
+    2630 | follow the sound of it for a moment, up and down, with my ear alone, before any
+         |                                      ^~ An Oxford comma is necessary here.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2638 | “That’s the secret of Castle Rackrent. Tell your chauffeur to go far away and
+         |                              ^~~~~~~~ Did you mean “Backrest”?
+Suggest:
+  - Replace with: “Backrest”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2641 | “Come back in an hour, Ferdie.” Then in a grave murmur: “His name is Ferdie.”
+         |                        ^~~~~~ Did you mean to spell “Ferdie” this way?
+Suggest:
+  - Replace with: “Fermi”
+  - Replace with: “Ferris”
+  - Replace with: “Freddie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2641 | “Come back in an hour, Ferdie.” Then in a grave murmur: “His name is Ferdie.”
+         |                                                                      ^~~~~~ Did you mean to spell “Ferdie” this way?
+Suggest:
+  - Replace with: “Fermi”
+  - Replace with: “Ferris”
+  - Replace with: “Freddie”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2673 | a strained counterfeit of perfect ease, even of boredom. His head leaned back so
+         |                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~
+    2674 | far that it rested against the face of a defunct mantelpiece clock, and from
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2675 | this position his distraught eyes stared down at Daisy, who was sitting,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2676 | frightened but graceful, on the edge of a stiff chair.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2737 | I walked out the back way—just as Gatsby had when he had made his nervous
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2738 | circuit of the house half an hour before—and ran for a huge black knotted tree,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2739 | whose massed leaves made a fabric against the rain. Once more it was pouring,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    2737 | I walked out the back way—just as Gatsby had when he had made his nervous
+         |                  ^~~~~~~~ Did you mean the closed compound noun “backway”?
+Suggest:
+  - Replace with: “backway”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2743 | steeple, for half an hour. A brewer had built it early in the “period” craze, a
+         |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2744 | decade before, and there was a story that he’d agreed to pay five years’ taxes
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2745 | on all the neighboring cottages if the owners would have their roofs thatched
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2746 | with straw. Perhaps their refusal took the heart out of his plan to Found a
+         | ~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    Style (31 priority)
+Message: |
+    2756 | it had seemed like the murmur of their voices, rising and swelling a little now
+         |                                                ^~~~~~ An Oxford comma is necessary here.
+    2757 | and then with gusts of emotion. But in the new silence I felt that silence had
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    2775 | twinkle-bells of sunshine in the room, he smiled like a weather man, like an
+         |                                                         ^~~~~~~~~~~ Did you mean the closed compound noun “weatherman”?
+    2776 | ecstatic patron of recurrent light, and repeated the news to Daisy. “What do you
+Suggest:
+  - Replace with: “weatherman”
+
+
+
+Lint:    Style (31 priority)
+Message: |
+    2823 | “I keep it always full of interesting people, night and day. People who do
+         |                                               ^~~~~ An Oxford comma is necessary here.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2826 | Instead of taking the short cut along the Sound we went down to the road and
+    2827 | entered by the big postern. With enchanting murmurs Daisy admired this aspect or
+         |                    ^~~~~~~ Did you mean to spell “postern” this way?
+Suggest:
+  - Replace with: “poster”
+  - Replace with: “posters”
+  - Replace with: “pastern”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2827 | entered by the big postern. With enchanting murmurs Daisy admired this aspect or
+         |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2828 | that of the feudal silhouette against the sky, admired the gardens, the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2829 | sparkling odor of jonquils and the frothy odor of hawthorn and plum blossoms and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2830 | the pale gold odor of kiss-me-at-the-gate. It was strange to reach the marble
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 44 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2840 | We went up-stairs, through period bedrooms swathed in rose and lavender silk and
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2841 | vivid with new flowers, through dressing-rooms and poolrooms, and bathrooms with
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2842 | sunken baths—intruding into one chamber where a dishevelled man in pajamas was
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2843 | doing liver exercises on the floor. It was Mr. Klipspringer, the ‘‘boarder.” I
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 45 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2842 | sunken baths—intruding into one chamber where a dishevelled man in pajamas was
+         |                                                 ^~~~~~~~~~~ Did you mean “disheveled”?
+    2843 | doing liver exercises on the floor. It was Mr. Klipspringer, the ‘‘boarder.” I
+Suggest:
+  - Replace with: “disheveled”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2843 | doing liver exercises on the floor. It was Mr. Klipspringer, the ‘‘boarder.” I
+         |                                                ^~~~~~~~~~~~ Did you mean to spell “Klipspringer” this way?
+
+
+
+Lint:    Style (31 priority)
+Message: |
+    2844 | had seen him wandering hungrily about the beach that morning. Finally we came to
+    2845 | Gatsby’s own apartment, a bedroom and a bath, and an Adam’s study, where we sat
+         |                           ^~~~~~~ An Oxford comma is necessary here.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2866 | intensity. Now, in the reaction, he was running down like an overwound clock.
+         |                                                              ^~~~~~~~~ Did you mean to spell “overwound” this way?
+Suggest:
+  - Replace with: “overground”
+  - Replace with: “overfond”
+  - Replace with: “overfund”
+
+
+
+Lint:    Style (31 priority)
+Message: |
+    2872 | “I’ve got a man in England who buys me clothes. He sends over a selection of
+    2873 | things at the beginning of each season, spring and fall.”
+         |                                         ^~~~~~ An Oxford comma is necessary here.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2875 | He took out a pile of shirts and began throwing them, one by one, before us,
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2876 | shirts of sheer linen and thick silk and fine flannel, which lost their folds as
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2877 | they fell and covered the table in many colored disarray. While we admired he
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2878 | brought more and the soft rich heap mounted higher—shirts with stripes and
+    2879 | scrolls and plaids in coral and applegreen and lavender and faint orange, with
+         |                                 ^~~~~~~~~~ Did you mean to spell “applegreen” this way?
+    2880 | monograms of Indian blue. Suddenly, with a strained sound, Daisy bent her head
+Suggest:
+  - Replace with: “Appleseed”
+  - Replace with: “allergen”
+  - Replace with: “appeared”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    2887 | After the house, we were to see the grounds and the swimming-pool, and the
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2888 | hydroplane and the midsummer flowers—but outside Gatsby’s window it began to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    2889 | rain again, so we stood in a row looking at the corrugated surface of the Sound.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2940 | “I know what we'll do,” said Gatsby, “we'll have Klipspringer play the piano.”
+         |                                                  ^~~~~~~~~~~~ Did you mean to spell “Klipspringer” this way?
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2949 | “I was asleep,” cried Mr. Klipspringer, in a spasm of embarrassment. “That is,
+         |                           ^~~~~~~~~~~~ Did you mean to spell “Klipspringer” this way?
+
+
+
+Lint:    Formatting (63 priority)
+Message: |
+    2950 | I’d been asleep. Then I got up . . .”
+         |                               ^ Unnecessary space at the end of the sentence.
+Suggest:
+  - Remove error
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2952 | “Klipspringer plays the piano,” said Gatsby, cutting him off. “Don’t you, Ewing,
+         |  ^~~~~~~~~~~~ Did you mean to spell “Klipspringer” this way?
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2955 | “I don’t play well. I don’t—I hardly play at all. I’m all out of prac———”
+         |                                                                  ^~~~ Did you mean to spell “prac” this way?
+Suggest:
+  - Replace with: “pray”
+  - Replace with: “prat”
+  - Replace with: “pram”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2965 | When Klipspringer had played “The Love Nest” he turned around on the bench and
+         |      ^~~~~~~~~~~~ Did you mean to spell “Klipspringer” this way?
+
+
+
+Lint:    WordChoice (127 priority)
+Message: |
+    2968 | “I’m all out of practice, you see. I told you I couldn’t play. I’m all out of
+         |                                           ^~~ The possessive version of this word is more common in this context.
+Suggest:
+  - Replace with: “your”
+  - Replace with: “you're a”
+  - Replace with: “you're an”
+
+
+
+Lint:    Repetition (63 priority)
+Message: |
+    2968 | “I’m all out of practice, you see. I told you I couldn’t play. I’m all out of
+         |                                           ^~~~~ There are too many personal pronouns in sequence here.
+Suggest:
+  - Replace with: “you”
+  - Replace with: “I”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    2968 | “I’m all out of practice, you see. I told you I couldn’t play. I’m all out of
+    2969 | prac—”
+         | ^~~~ Did you mean to spell “prac” this way?
+Suggest:
+  - Replace with: “pray”
+  - Replace with: “prat”
+  - Replace with: “pram”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    3020 | short of being news. Contemporary legends such as the “underground pipe-line to
+         |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3021 | Canada” attached themselves to him, and there was one persistent story that he
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3022 | didn’t live in a house at all, but in a boat that looked like a house and was
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3023 | moved secretly up and down the Long Island shore. Just why these inventions were
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 49 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3023 | moved secretly up and down the Long Island shore. Just why these inventions were
+    3024 | a source of satisfaction to James Gatz of North Dakota, isn’t easy to say.
+         |                                   ^~~~ Did you mean to spell “Gatz” this way?
+Suggest:
+  - Replace with: “Ga's”
+  - Replace with: “Gate”
+  - Replace with: “GHz”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3026 | James Gatz—that was really, or at least legally, his name. He had changed it at
+         |       ^~~~ Did you mean to spell “Gatz” this way?
+Suggest:
+  - Replace with: “Ga's”
+  - Replace with: “Gate”
+  - Replace with: “GHz”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    3029 | on Lake Superior. It was James Gatz who had been loafing along the beach that
+         |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3030 | afternoon in a torn green jersey and a pair of canvas pants, but it was already
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3031 | Jay Gatsby who borrowed a rowboat, pulled out to the Tuolomee, and informed Cody
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3032 | that a wind might catch him and break him up in half an hour.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 56 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3029 | on Lake Superior. It was James Gatz who had been loafing along the beach that
+         |                                ^~~~ Did you mean to spell “Gatz” this way?
+Suggest:
+  - Replace with: “Ga's”
+  - Replace with: “Gate”
+  - Replace with: “GHz”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3031 | Jay Gatsby who borrowed a rowboat, pulled out to the Tuolomee, and informed Cody
+         |                                                      ^~~~~~~~ Did you mean to spell “Tuolomee” this way?
+    3032 | that a wind might catch him and break him up in half an hour.
+Suggest:
+  - Replace with: “Togolese”
+  - Replace with: “Tolkien”
+  - Replace with: “Toltec”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3048 | were ignorant, of the others because they were hysterical about things which in
+    3049 | his overwhelming self-absorbtion he took for granted.
+         |                       ^~~~~~~~~~ Did you mean to spell “absorbtion” this way?
+Suggest:
+  - Replace with: “absorption”
+  - Replace with: “abortion”
+  - Replace with: “adsorption”
+
+
+
+Lint:    WordChoice (31 priority)
+Message: |
+    3057 | an outlet for his imagination; they were a satisfactory hint of the unreality of
+         |                                     ^~~~ Use the contraction or separate the words instead.
+Suggest:
+  - Replace with: “we're”
+  - Replace with: “we are”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    3073 | tried to separate him from his money. The none too savory ramifications by which
+    3074 | Ella Kaye, the newspaper woman, played Madame de Maintenon to his weakness and
+         |                ^~~~~~~~~~~~~~~ Did you mean the closed compound noun “newspaperwoman”?
+Suggest:
+  - Replace with: “newspaperwoman”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3074 | Ella Kaye, the newspaper woman, played Madame de Maintenon to his weakness and
+         |                                               ^~ Did you mean to spell “de” this way?
+    3075 | sent him to sea in a yacht, were common property of the turgid journalism
+Suggest:
+  - Replace with: “d”
+  - Replace with: “db”
+  - Replace with: “dc”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3074 | Ella Kaye, the newspaper woman, played Madame de Maintenon to his weakness and
+         |                                                  ^~~~~~~~~ Did you mean to spell “Maintenon” this way?
+    3075 | sent him to sea in a yacht, were common property of the turgid journalism
+Suggest:
+  - Replace with: “Maintop”
+  - Replace with: “Maine's”
+  - Replace with: “Mainer's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3076 | of 1902. He had been coasting along all too hospitable shores for five years
+    3077 | when he turned up as James Gatz’s destiny in Little Girl Bay.
+         |                            ^~~~~~ Did you mean to spell “Gatz’s” this way?
+Suggest:
+  - Replace with: “Ga's”
+  - Replace with: “Gaea's”
+  - Replace with: “Gael's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3079 | To young Gatz, resting on his oars and looking up at the railed deck, that yacht
+         |          ^~~~ Did you mean to spell “Gatz” this way?
+Suggest:
+  - Replace with: “Ga's”
+  - Replace with: “Gate”
+  - Replace with: “GHz”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3085 | and a yachting cap. And when the Tuolomee left for the West Indies and the
+         |                                  ^~~~~~~~ Did you mean to spell “Tuolomee” this way?
+    3086 | Barbary Coast Gatsby left too.
+Suggest:
+  - Replace with: “Togolese”
+  - Replace with: “Tolkien”
+  - Replace with: “Toltec”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    3088 | He was employed in a vague personal capacity—while he remained with Cody he was
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3089 | in turn steward, mate, skipper, secretary, and even jailor, for Dan Cody sober
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3090 | knew what lavish doings Dan Cody drunk might soon be about, and he provided for
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3091 | such contingencies by reposing more and more trust in Gatsby. The arrangement
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 53 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3089 | in turn steward, mate, skipper, secretary, and even jailor, for Dan Cody sober
+         |                                                     ^~~~~~ Did you mean to spell “jailor” this way?
+    3090 | knew what lavish doings Dan Cody drunk might soon be about, and he provided for
+Suggest:
+  - Replace with: “jailer”
+  - Replace with: “sailor”
+  - Replace with: “tailor”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    3096 | I remember the portrait of him up in Gatsby’s bedroom, a gray, florid man with a
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3097 | hard, empty face—the pioneer debauchee, who during one phase of American life
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3098 | brought back to the Eastern seaboard the savage violence of the frontier brothel
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3099 | and saloon. It was indirectly due to Cody that Gatsby drank so little. Sometimes
+         | ~~~~~~~~~~~ This sentence is 44 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3106 | left with his singularly appropriate education; the vague contour of Jay Gatsby
+    3107 | had filled out to the substantiality of a man.
+         |                       ^~~~~~~~~~~~~~ Did you mean “substantially”?
+Suggest:
+  - Replace with: “substantially”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    3116 | It was a halt, too, in my association with his affairs. For several weeks I
+         |                                                        ^~~~~~~~~~~~~~~~~~~~~
+    3117 | didn’t see him or hear his voice on the phone—mostly I was in New York, trotting
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3118 | around with Jordan and trying to ingratiate myself with her senile aunt—but
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3119 | finally I went over to his house one Sunday afternoon. I hadn’t been there two
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 44 words long.
+
+
+
+Lint:    WordChoice (31 priority)
+Message: |
+    3123 | They were a party of three on horseback—Tom and a man named Sloane and a pretty
+         |      ^~~~ Use the contraction or separate the words instead.
+Suggest:
+  - Replace with: “we're”
+  - Replace with: “we are”
+
+
+
+Lint:    Repetition (127 priority)
+Message: |
+    3135 | uneasy anyhow until he had given them something, realizing in a vague way that
+         |                                                                           ^~~~~
+    3136 | that was all they came for. Mr. Sloane wanted nothing. A lemonade? No, thanks. A
+         | ~~~~ Did you mean to repeat this word?
+Suggest:
+  - Replace with: “that”
+
+
+
+Lint:    Repetition (126 priority)
+Message: |
+    3135 | uneasy anyhow until he had given them something, realizing in a vague way that
+         |                                                                           ^~~~~
+    3136 | that was all they came for. Mr. Sloane wanted nothing. A lemonade? No, thanks. A
+         | ~~~~ “that that” sometimes means “that which”, which is clearer.
+Suggest:
+  - Replace with: “that which”
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+    3141 | “Very good roads around here.”
+         |  ^~~~~~~~~ Vocabulary enhancement: use `excellent` instead of `very good`
+Suggest:
+  - Replace with: “Excellent”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3180 | “Be ver’ nice,” said Mr. Sloane, without gratitude. “Well—think ought to be
+         |     ^~~ Did you mean to spell “ver” this way?
+Suggest:
+  - Replace with: “var”
+  - Replace with: “veer”
+  - Replace with: “verb”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    3235 | in my memory from Gatsby’s other parties that summer. There were the same
+         |                                                      ^~~~~~~~~~~~~~~~~~~~~
+    3236 | people, or at least the same sort of people, the same profusion of champagne,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3237 | the same many-colored, many-keyed commotion, but I felt an unpleasantness in the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3238 | air, a pervading harshness that hadn’t been there before. Or perhaps I had
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    WordChoice (31 priority)
+Message: |
+    3235 | in my memory from Gatsby’s other parties that summer. There were the same
+         |                                                             ^~~~ Use the contraction or separate the words instead.
+    3236 | people, or at least the same sort of people, the same profusion of champagne,
+Suggest:
+  - Replace with: “we're”
+  - Replace with: “we are”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    3238 | air, a pervading harshness that hadn’t been there before. Or perhaps I had
+         |                                                          ^~~~~~~~~~~~~~~~~~
+    3239 | merely grown used to it, grown to accept West Egg as a world complete in itself,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3240 | with its own standards and its own great figures, second to nothing because it
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3241 | had no consciousness of being so, and now I was looking at it again, through
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3242 | Daisy’s eyes. It is invariably saddening to look through new eyes at things upon
+         | ~~~~~~~~~~~~~ This sentence is 51 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3254 | “I’m looking around. I’m having a marvellous—”
+         |                                   ^~~~~~~~~~ Did you mean to spell “marvellous” this way?
+Suggest:
+  - Replace with: “marvelous”
+  - Replace with: “marvellously”
+
+
+
+Lint:    Style (63 priority)
+Message: |
+    3263 | “Perhaps you know that lady,” Gatsby indicated a gorgeous, scarcely human orchid
+         |                                                                           ^~~~~~~
+    3264 | of a woman who sat in state under a white-plum tree. Tom and Daisy stared, with
+         | ~~~~ The word `of` is not needed here.
+Suggest:
+  - Replace with: “orchid
+a”
+  - Replace with: “orchid a”
+
+
+
+Lint:    Formatting (63 priority)
+Message: |
+    3274 | “Mrs. Buchanan . . . and Mr. Buchanan—” After an instant’s hesitation he added:
+         |               ^ Unnecessary space at the end of the sentence.
+Suggest:
+  - Remove error
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+    3274 | “Mrs. Buchanan . . . and Mr. Buchanan—” After an instant’s hesitation he added:
+         |                      ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “A”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3316 | “Wha’?”
+         |  ^~~ Did you mean to spell “Wha” this way?
+Suggest:
+  - Replace with: “What”
+  - Replace with: “Wham”
+  - Replace with: “Aha”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3319 | at the local club to-morrow, spoke in Miss Baedeker’s defence:
+         |                                                       ^~~~~~~ Did you mean to spell “defence” this way?
+Suggest:
+  - Replace with: “defense”
+  - Replace with: “decency”
+  - Replace with: “deface”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    3337 | “Speak for yourself!” cried Miss Baedeker violently. “Your hand shakes. I
+         |                                                            ^~~~~~~~~~~ Did you mean the closed compound noun “handshakes”?
+Suggest:
+  - Replace with: “handshakes”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3349 | But the rest offended her—and inarguably, because it wasn’t a gesture but an
+         |                               ^~~~~~~~~~ Did you mean to spell “inarguably” this way?
+Suggest:
+  - Replace with: “inarguable”
+  - Replace with: “unarguably”
+  - Replace with: “arguably”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    3350 | emotion. She was appalled by West Egg, this unprecedented “place” that Broadway
+         |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3351 | had begotten upon a Long Island fishing village—appalled by its raw vigor that
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3352 | chafed under the old euphemisms and by the too obtrusive fate that herded its
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3353 | inhabitants along a short-cut from nothing to nothing. She saw something awful
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 48 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3389 | Daisy began to sing with the music in a husky, rythmic whisper, bringing out a
+         |                                                ^~~~~~~ Did you mean to spell “rythmic” this way?
+    3390 | meaning in each word that it had never had before and would never have again.
+Suggest:
+  - Replace with: “rhythmic”
+  - Replace with: “mythic”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    3414 | dim, incalculable hours? Perhaps some unbelievable guest would arrive, a person
+         |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3415 | infinitely rare and to be marvelled at, some authentically radiant young girl
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3416 | who with one fresh glance at Gatsby, one moment of magical encounter, would blot
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3417 | out those five years of unwavering devotion.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3414 | dim, incalculable hours? Perhaps some unbelievable guest would arrive, a person
+    3415 | infinitely rare and to be marvelled at, some authentically radiant young girl
+         |                           ^~~~~~~~~ Did you mean “marveled”?
+Suggest:
+  - Replace with: “marveled”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    3419 | I stayed late that night, Gatsby asked me to wait until he was free, and I
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3420 | lingered in the garden until the inevitable swimming party had run up, chilled
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3421 | and exalted, from the black beach, until the lights were extinguished in the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3422 | guest-rooms overhead. When he came down the steps at last the tanned skin was
+         | ~~~~~~~~~~~~~~~~~~~~~ This sentence is 45 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    3473 | humming out into the darkness and there was a stir and bustle among the stars.
+         |                                                                               ^
+    3474 | Out of the corner of his eye Gatsby saw that the blocks of the sidewalks really
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3475 | formed a ladder and mounted to a secret place above the trees—he could climb to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3476 | it, if he climbed alone, and once there he could suck on the pap of life, gulp
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3477 | down the incomparable milk of wonder.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 55 words long.
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    3479 | His heart beat faster and faster as Daisy’s white face came up to his own. He
+         |     ^~~~~~~~~~ Did you mean the closed compound noun “heartbeat”?
+Suggest:
+  - Replace with: “heartbeat”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3490 | them than a wisp of startled air. But they made no sound, and what I had almost
+    3491 | remembered was uncommunicable forever.
+         |                ^~~~~~~~~~~~~~ Did you mean to spell “uncommunicable” this way?
+Suggest:
+  - Replace with: “incommunicable”
+  - Replace with: “communicable”
+  - Replace with: “noncommunicable”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3496 | house failed to go on one Saturday night—and, as obscurely as it had begun, his
+    3497 | career as Trimalchio was over. Only gradually did I become aware that the
+         |           ^~~~~~~~~~ Did you mean to spell “Trimalchio” this way?
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3507 | “I hadn’t seen him around, and I was rather worried. Tell him Mr. Carraway came
+         |                                                                   ^~~~~~~~ Did you mean to spell “Carraway” this way?
+    3508 | over.”
+Suggest:
+  - Replace with: “Caraway”
+  - Replace with: “Faraway”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3512 | “Carraway.”
+         |  ^~~~~~~~ Did you mean to spell “Carraway” this way?
+Suggest:
+  - Replace with: “Caraway”
+  - Replace with: “Faraway”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3514 | “Carraway. All right, I'll tell him.”
+         |  ^~~~~~~~ Did you mean to spell “Carraway” this way?
+Suggest:
+  - Replace with: “Caraway”
+  - Replace with: “Faraway”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    3518 | My Finn informed me that Gatsby had dismissed every servant in his house a week
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3519 | ago and replaced them with half a dozen others, who never went into West Egg
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3520 | Village to be bribed by the tradesmen, but ordered moderate supplies over the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3521 | telephone. The grocery boy reported that the kitchen looked like a pigsty, and
+         | ~~~~~~~~~~ This sentence is 44 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3539 | “They’re some people Wolfshiem wanted to do something for. They’re all brothers
+         |                      ^~~~~~~~~ Did you mean “Bolshie”?
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    3553 | of the National Biscuit Company broke the simmering hush at noon. The straw
+         |                                                                  ^~~~~~~~~~~
+    3554 | seats of the car hovered on the edge of combustion; the woman next to me
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3555 | perspired delicately for a while into her white shirtwaist, and then, as her
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3556 | newspaper dampened under her fingers, lapsed despairingly into deep heat with a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3557 | desolate cry. Her pocket-book slapped to the floor.
+         | ~~~~~~~~~~~~~ This sentence is 44 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    3561 | I picked it up with a weary bend and handed it back to her, holding it at arm’s
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3562 | length and by the extreme tip of the corners to indicate that I had no designs
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3563 | upon it—but every one near by, including the woman, suspected me just the same.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 49 words long.
+
+
+
+Lint:    Formatting (63 priority)
+Message: |
+    3566 | Hot! . . . Hot! . . . Is it hot enough for you? Is it hot? Is it . . .?”
+         |                                                                 ^ Unnecessary space at the end of the sentence.
+Suggest:
+  - Remove error
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    3568 | My commutation ticket came back to me with a dark stain from his hand. That any
+         |                                                                             ^~~~
+    3569 | one should care in this heat whose flushed lips he kissed, whose head made damp
+         | ~~~ The auxiliary verb “should” implies the existence of the closed compound noun “anyone”.
+Suggest:
+  - Replace with: “anyone”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3572 | . . . Through the hall of the Buchanans’ house blew a faint wind, carrying the
+         |                               ^~~~~~~~~ Did you mean to spell “Buchanans” this way?
+Suggest:
+  - Replace with: “Buchanan's”
+  - Replace with: “Buchanan”
+
+
+
+Lint:    Formatting (63 priority)
+Message: |
+    3578 | What he really said was: “Yes . . . Yes . . . I’ll see.”
+         |                              ^ Unnecessary space at the end of the sentence.
+Suggest:
+  - Remove error
+
+
+
+Lint:    Formatting (63 priority)
+Message: |
+    3578 | What he really said was: “Yes . . . Yes . . . I’ll see.”
+         |                                        ^ Unnecessary space at the end of the sentence.
+Suggest:
+  - Remove error
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3599 | Gatsby stood in the centre of the crimson carpet and gazed around with
+         |                     ^~~~~~ Did you mean to spell “centre” this way?
+Suggest:
+  - Replace with: “centred”
+  - Replace with: “centres”
+  - Replace with: “censure”
+
+
+
+Lint:    Formatting (63 priority)
+Message: |
+    3606 | then, I won’t sell you the car at all. . . . I’m under no obligations to you at
+    3607 | all . . . and as for your bothering me about it at lunch time, I won’t stand
+         |    ^ Unnecessary space at the end of the sentence.
+Suggest:
+  - Remove error
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+    3607 | all . . . and as for your bothering me about it at lunch time, I won’t stand
+         |           ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “A”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3612 | “No, he’s not,” I assured her. “It’s a bona-fide deal. I happen to know about
+         |                                        ^~~~ Did you mean to spell “bona” this way?
+Suggest:
+  - Replace with: “boa”
+  - Replace with: “bond”
+  - Replace with: “bone”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3612 | “No, he’s not,” I assured her. “It’s a bona-fide deal. I happen to know about
+         |                                             ^~~~ Did you mean to spell “fide” this way?
+Suggest:
+  - Replace with: “fade”
+  - Replace with: “fife”
+  - Replace with: “file”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3640 | “Bles-sed pre-cious,” she crooned, holding out her arms. “Come to your own
+         |  ^~~~ Did you mean to spell “Bles” this way?
+Suggest:
+  - Replace with: “B's”
+  - Replace with: “BB's”
+  - Replace with: “BC's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3640 | “Bles-sed pre-cious,” she crooned, holding out her arms. “Come to your own
+         |       ^~~ Did you mean to spell “sed” this way?
+Suggest:
+  - Replace with: “sad”
+  - Replace with: “sea”
+  - Replace with: “sec”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3640 | “Bles-sed pre-cious,” she crooned, holding out her arms. “Come to your own
+         |               ^~~~~ Did you mean to spell “cious” this way?
+Suggest:
+  - Replace with: “pious”
+  - Replace with: “chorus”
+  - Replace with: “circus”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3646 | “The bles-sed pre-cious! Did mother get powder on your old yellowy hair? Stand
+         |      ^~~~ Did you mean to spell “bles” this way?
+Suggest:
+  - Replace with: “bless”
+  - Replace with: “bales”
+  - Replace with: “bees”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3646 | “The bles-sed pre-cious! Did mother get powder on your old yellowy hair? Stand
+         |           ^~~ Did you mean to spell “sed” this way?
+Suggest:
+  - Replace with: “sad”
+  - Replace with: “sea”
+  - Replace with: “sec”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3646 | “The bles-sed pre-cious! Did mother get powder on your old yellowy hair? Stand
+         |                   ^~~~~ Did you mean to spell “cious” this way?
+Suggest:
+  - Replace with: “pious”
+  - Replace with: “chorus”
+  - Replace with: “circus”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3646 | “The bles-sed pre-cious! Did mother get powder on your old yellowy hair? Stand
+    3647 | up now, and say—How-de-do.”
+         |                     ^~ Did you mean to spell “de” this way?
+Suggest:
+  - Replace with: “d”
+  - Replace with: “db”
+  - Replace with: “dc”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3672 | “Come, Pammy.”
+         |        ^~~~~ Did you mean to spell “Pammy” this way?
+Suggest:
+  - Replace with: “Mammy”
+  - Replace with: “Sammy”
+  - Replace with: “Tammy”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3677 | hand and was pulled out the door, just as Tom came back, preceding four gin
+    3678 | rickeys that clicked full of ice.
+         | ^~~~~~~ Did you mean to spell “rickeys” this way?
+Suggest:
+  - Replace with: “rickets”
+  - Replace with: “Rickey's”
+  - Replace with: “rice's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3693 | I went with them out to the veranda. On the green Sound, stagnant in the heat,
+         |                             ^~~~~~~ Did you mean to spell “veranda” this way?
+Suggest:
+  - Replace with: “verandas”
+  - Replace with: “veranda's”
+  - Replace with: “Miranda”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3709 | We had luncheon in the dining-room, darkened too against the heat, and drank
+    3710 | down nervous gayety with the cold ale.
+         |              ^~~~~~ Did you mean to spell “gayety” this way?
+Suggest:
+  - Replace with: “gaiety”
+  - Replace with: “gamely”
+  - Replace with: “gamete”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3712 | “What’ll we do with ourselves this afternoon?” cried Daisy, “and the day after
+         |  ^~~~~~~ Did you mean “That'll”?
+Suggest:
+  - Replace with: “That'll”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3809 | “Well, you take my coupé and let me drive your car to town.”
+         |                    ^~~~~ Did you mean to spell “coupé” this way?
+Suggest:
+  - Replace with: “coup”
+  - Replace with: “coupe”
+  - Replace with: “coups”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3828 | “You take Nick and Jordan. We’ll follow you in the coupé.”
+         |                                                    ^~~~~ Did you mean to spell “coupé” this way?
+Suggest:
+  - Replace with: “coup”
+  - Replace with: “coupe”
+  - Replace with: “coups”
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+    3841 | “You think I’m pretty dumb, don’t you?” he suggested. “Perhaps I am, but I have
+    3842 | a—almost a second sight, sometimes, that tells me what to do. Maybe you don’t
+         | ^ Incorrect indefinite article.
+Suggest:
+  - Replace with: “an”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3874 | while in silence. Then as Doctor T. J. Eckleburg’s faded eyes came into sight
+         |                                  ^~ Did you mean to spell “T.” this way?
+Suggest:
+  - Replace with: “To”
+  - Replace with: “T”
+  - Replace with: “Ta”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3874 | while in silence. Then as Doctor T. J. Eckleburg’s faded eyes came into sight
+         |                                     ^~ Did you mean to spell “J.” this way?
+Suggest:
+  - Replace with: “Jg”
+  - Replace with: “J”
+  - Replace with: “JD”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3874 | while in silence. Then as Doctor T. J. Eckleburg’s faded eyes came into sight
+         |                                        ^~~~~~~~~~~ Did you mean to spell “Eckleburg’s” this way?
+    3875 | down the road, I remembered Gatsby’s caution about gasoline.
+Suggest:
+  - Replace with: “Excalibur's”
+  - Replace with: “Vicksburg's”
+  - Replace with: “Iceberg's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3923 | The coupé flashed by us with a flurry of dust and the flash of a waving hand.
+         |     ^~~~~ Did you mean to spell “coupé” this way?
+Suggest:
+  - Replace with: “coup”
+  - Replace with: “coupe”
+  - Replace with: “coups”
+
+
+
+Lint:    Style (63 priority)
+Message: |
+    3923 | The coupé flashed by us with a flurry of dust and the flash of a waving hand.
+         |                                                       ^~~~~~~~~~ The word `of` is not needed here.
+Suggest:
+  - Replace with: “flash a”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    3937 | world, and the shock had made him physically sick. I stared at him and then at
+         |                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3938 | Tom, who had made a parallel discovery less than an hour before—and it occurred
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3939 | to me that there was no difference between men, in intelligence or race, so
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3940 | profound as the difference between the sick and the well. Wilson was so sick
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 46 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3948 | behind. Over the ashheaps the giant eyes of Doctor T. J. Eckleburg kept their
+         |                  ^~~~~~~~ Did you mean to spell “ashheaps” this way?
+Suggest:
+  - Replace with: “asthma's”
+  - Replace with: “airheads”
+  - Replace with: “ashcans”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3948 | behind. Over the ashheaps the giant eyes of Doctor T. J. Eckleburg kept their
+         |                                                    ^~ Did you mean to spell “T.” this way?
+Suggest:
+  - Replace with: “To”
+  - Replace with: “T”
+  - Replace with: “Ta”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3948 | behind. Over the ashheaps the giant eyes of Doctor T. J. Eckleburg kept their
+         |                                                       ^~ Did you mean to spell “J.” this way?
+Suggest:
+  - Replace with: “Jg”
+  - Replace with: “J”
+  - Replace with: “JD”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3948 | behind. Over the ashheaps the giant eyes of Doctor T. J. Eckleburg kept their
+         |                                                          ^~~~~~~~~ Did you mean to spell “Eckleburg” this way?
+    3949 | vigil, but I perceived, after a moment, that other eyes were regarding us with
+Suggest:
+  - Replace with: “Excalibur”
+  - Replace with: “Vicksburg”
+  - Replace with: “Iceberg”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    3955 | into her face like objects into a slowly developing picture. Her expression was
+         |                                                             ^~~~~~~~~~~~~~~~~~~~
+    3956 | curiously familiar—it was an expression I had often seen on women’s faces, but
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3957 | on Myrtle Wilson’s face it seemed purposeless and inexplicable until I realized
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3958 | that her eyes, wide with jealous terror, were fixed not on Tom, but on Jordan
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3959 | Baker, whom she took to be his wife.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 52 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    3963 | ago secure and inviolate, were slipping precipitately from his control. Instinct
+         |                                                                        ^~~~~~~~~~
+    3964 | made him step on the accelerator with the double purpose of overtaking Daisy and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3965 | leaving Wilson behind, and we sped along toward Astoria at fifty miles an hour,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3966 | until, among the spidery girders of the elevated, we came in sight of the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3967 | easy-going blue coupé.
+         | ~~~~~~~~~~~~~~~~~~~~~~ This sentence is 47 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3966 | until, among the spidery girders of the elevated, we came in sight of the
+    3967 | easy-going blue coupé.
+         |                 ^~~~~ Did you mean to spell “coupé” this way?
+Suggest:
+  - Replace with: “coup”
+  - Replace with: “coupe”
+  - Replace with: “coups”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3974 | The word “sensuous” had the effect of further disquieting Tom, but before he
+    3975 | could invent a protest the coupé came to a stop, and Daisy signalled us to draw
+         |                            ^~~~~ Did you mean to spell “coupé” this way?
+Suggest:
+  - Replace with: “coup”
+  - Replace with: “coupe”
+  - Replace with: “coups”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    3975 | could invent a protest the coupé came to a stop, and Daisy signalled us to draw
+         |                                                            ^~~~~~~~~ Did you mean to spell “signalled” this way?
+    3976 | up alongside.
+Suggest:
+  - Replace with: “signaled”
+  - Replace with: “signaler”
+  - Replace with: “signalised”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    3997 | The prolonged and tumultuous argument that ended by herding us into that room
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3998 | eludes me, though I have a sharp physical memory that, in the course of it, my
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    3999 | underwear kept climbing like a damp snake around my legs and intermittent beads
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4000 | of sweat raced cool across my back. The notion originated with Daisy’s
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 49 words long.
+
+
+
+Lint:    Formatting (63 priority)
+Message: |
+    4004 | thought, or pretended to think, that we were being very funny . . .
+         |                                                              ^ Unnecessary space at the end of the sentence.
+Suggest:
+  - Remove error
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4016 | “Well, we’d better telephone for an axe———”
+         |                                     ^~~ Did you mean to spell “axe” this way?
+Suggest:
+  - Replace with: “aye”
+  - Replace with: “ace”
+  - Replace with: “age”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4054 | “Biloxi,” he answered shortly.
+         |  ^~~~~~ Did you mean to spell “Biloxi” this way?
+Suggest:
+  - Replace with: “Biko's”
+  - Replace with: “Bilbo's”
+  - Replace with: “Biro's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4056 | “A man named Biloxi. ‘Blocks’ Biloxi, and he made boxes—that’s a fact—and he was
+         |              ^~~~~~ Did you mean to spell “Biloxi” this way?
+Suggest:
+  - Replace with: “Biko's”
+  - Replace with: “Bilbo's”
+  - Replace with: “Biro's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4056 | “A man named Biloxi. ‘Blocks’ Biloxi, and he made boxes—that’s a fact—and he was
+         |                               ^~~~~~ Did you mean to spell “Biloxi” this way?
+Suggest:
+  - Replace with: “Biko's”
+  - Replace with: “Bilbo's”
+  - Replace with: “Biro's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4056 | “A man named Biloxi. ‘Blocks’ Biloxi, and he made boxes—that’s a fact—and he was
+    4057 | from Biloxi, Tennessee.”
+         |      ^~~~~~ Did you mean to spell “Biloxi” this way?
+Suggest:
+  - Replace with: “Biko's”
+  - Replace with: “Bilbo's”
+  - Replace with: “Biro's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4064 | “I used to know a Bill Biloxi from Memphis,” I remarked.
+         |                        ^~~~~~ Did you mean to spell “Biloxi” this way?
+Suggest:
+  - Replace with: “Biko's”
+  - Replace with: “Bilbo's”
+  - Replace with: “Biro's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4066 | “That was his cousin. I knew his whole family history before he left. He gave me
+    4067 | an aluminum putter that I use to-day.”
+         |    ^~~~~~~~ Did you mean to spell “aluminum” this way?
+Suggest:
+  - Replace with: “aluminum's”
+  - Replace with: “alumnus”
+  - Replace with: “alumina”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4073 | “We're getting old,” said Daisy. “lf we were young we’d rise and dance.”
+         |                                   ^~ Did you mean to spell “lf” this way?
+Suggest:
+  - Replace with: “l”
+  - Replace with: “la”
+  - Replace with: “lb”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4075 | “Remember Biloxi,” Jordan warned her. ‘‘Where’d you know him, Tom?”
+         |           ^~~~~~ Did you mean to spell “Biloxi” this way?
+Suggest:
+  - Replace with: “Biko's”
+  - Replace with: “Bilbo's”
+  - Replace with: “Biro's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4077 | “Biloxi?” He concentrated with an effort. “I didn’t know him. He was a friend of
+         |  ^~~~~~ Did you mean to spell “Biloxi” this way?
+Suggest:
+  - Replace with: “Biko's”
+  - Replace with: “Bilbo's”
+  - Replace with: “Biro's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4083 | “Well, he said he knew you. He said he was raised in Louisville. Asa Bird
+         |                                                                  ^~~ Did you mean to spell “Asa” this way?
+    4084 | brought him around at the last minute and asked if we had room for him.”
+Suggest:
+  - Replace with: “Ask”
+  - Replace with: “Ada”
+  - Replace with: “Ala”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4093 | “Biloxi?”
+         |  ^~~~~~ Did you mean to spell “Biloxi” this way?
+Suggest:
+  - Replace with: “Biko's”
+  - Replace with: “Bilbo's”
+  - Replace with: “Biro's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4109 | “You must have gone there about the time Biloxi went to New Haven.”
+         |                                          ^~~~~~ Did you mean to spell “Biloxi” this way?
+Suggest:
+  - Replace with: “Biko's”
+  - Replace with: “Bilbo's”
+  - Replace with: “Biro's”
+
+
+
+Lint:    WordChoice (127 priority)
+Message: |
+    4115 | “I told you I went there,” said Gatsby.
+         |         ^~~ The possessive version of this word is more common in this context.
+Suggest:
+  - Replace with: “your”
+  - Replace with: “you're a”
+  - Replace with: “you're an”
+
+
+
+Lint:    Repetition (63 priority)
+Message: |
+    4115 | “I told you I went there,” said Gatsby.
+         |         ^~~~~ There are too many personal pronouns in sequence here.
+Suggest:
+  - Replace with: “you”
+  - Replace with: “I”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    4185 | At this point Jordan and I tried to go, but Tom and Gatsby insisted with
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4186 | competitive firmness that we remain—as though neither of them had anything to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4187 | conceal and it would be a privilege to partake vicariously of their emotions.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    WordChoice (127 priority)
+Message: |
+    4192 | “I told you what’s been going on,” said Gatsby. “Going on for five years—and you
+         |         ^~~ The possessive version of this word is more common in this context.
+Suggest:
+  - Replace with: “your”
+  - Replace with: “you're a”
+  - Replace with: “you're an”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    4209 | a mile of her unless you brought the groceries to the back door. But all the
+         |                                                       ^~~~~~~~~ Did you mean the closed compound noun “backdoor”?
+Suggest:
+  - Replace with: “backdoor”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    4227 | “Daisy, that’s all over now,” he said earnestly. “It doesn’t matter any more.
+         |                ^~~~~~~~ The possessive noun implies ownership of the closed compound noun “allover”.
+Suggest:
+  - Replace with: “allover”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4241 | “Not at Kapiolani?” demanded Tom suddenly.
+         |         ^~~~~~~~~ Did you mean to spell “Kapiolani” this way?
+Suggest:
+  - Replace with: “Kaitlin”
+  - Replace with: “Kaposi”
+  - Replace with: “Capillary”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4265 | Why—there’re things between Daisy and me that you’ll never know, things that
+         |     ^~~~~~~~ Did you mean to spell “there’re” this way?
+Suggest:
+  - Replace with: “there's”
+  - Replace with: “there'd”
+  - Replace with: “there'll”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4300 | “Who are you, anyhow?” broke out Tom. “You’re one of that bunch that hangs
+    4301 | around with Meyer Wolfshiem—that much I happen to know. I’ve made a little
+         |                   ^~~~~~~~~ Did you mean “Bolshie”?
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4307 | “He and this Wolfshiem bought up a lot of side-street drug-stores here and in
+         |              ^~~~~~~~~ Did you mean “Bolshie”?
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4321 | have you up on the betting laws too, but Wolfshiem scared him into shutting his
+         |                                          ^~~~~~~~~ Did you mean “Bolshie”?
+    4322 | mouth.”
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    4337 | defending his name against accusations that had not been made. But with every
+         |                                                               ^~~~~~~~~~~~~~~~
+    4338 | word she was drawing further and further into herself, so he gave that up, and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4339 | only the dead dream fought on as the afternoon slipped away, trying to touch
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4340 | what was no longer tangible, struggling unhappily, undespairingly, toward that
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4341 | lost voice across the room.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 47 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4340 | what was no longer tangible, struggling unhappily, undespairingly, toward that
+         |                                                    ^~~~~~~~~~~~~~ Did you mean “despairingly”?
+    4341 | lost voice across the room.
+Suggest:
+  - Replace with: “despairingly”
+
+
+
+Lint:    Repetition (127 priority)
+Message: |
+    4347 | Her frightened eyes told that whatever intentions, whatever courage she had had,
+         |                                                                         ^~~~~~~ Did you mean to repeat this word?
+    4348 | were definitely gone.
+Suggest:
+  - Replace with: “had”
+
+
+
+Lint:    WordChoice (127 priority)
+Message: |
+    4350 | “You two start on home, Daisy,” said Tom. “In Mr. Gatsby’s car.”
+         |  ^~~ The possessive version of this word is more common in this context.
+Suggest:
+  - Replace with: “Your”
+  - Replace with: “You're a”
+  - Replace with: “You're an”
+
+
+
+Lint:    Formatting (63 priority)
+Message: |
+    4373 | “No . . . I just remembered that to-day’s my birthday.”
+         |    ^ Unnecessary space at the end of the sentence.
+Suggest:
+  - Remove error
+
+
+
+Lint:    Style (63 priority)
+Message: |
+    4375 | I was thirty. Before me stretched the portentous, menacing road of a new decade.
+         |                                                            ^~~~~~~~~ The word `of` is not needed here.
+Suggest:
+  - Replace with: “road a”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4377 | It was seven o’clock when we got into the coupé with him and started for Long
+         |                                           ^~~~~ Did you mean to spell “coupé” this way?
+    4378 | Island. Tom talked incessantly, exulting and laughing, but his voice was as
+Suggest:
+  - Replace with: “coup”
+  - Replace with: “coupe”
+  - Replace with: “coups”
+
+
+
+Lint:    WordChoice (31 priority)
+Message: |
+    4380 | the elevated overhead. Human sympathy has its limits, and we were content to let
+         |                                                                              ^~~ To suggest an action, use 'let's' or 'let us'.
+    4381 | all their tragic arguments fade with the city lights behind. Thirty—the promise
+Suggest:
+  - Replace with: “let's”
+  - Replace with: “let us”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4391 | The young Greek, Michaelis, who ran the coffee joint beside the ashheaps was the
+         |                  ^~~~~~~~~ Did you mean “Michael”?
+Suggest:
+  - Replace with: “Michael”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4391 | The young Greek, Michaelis, who ran the coffee joint beside the ashheaps was the
+         |                                                                 ^~~~~~~~ Did you mean to spell “ashheaps” this way?
+    4392 | principal witness at the inquest. He had slept through the heat until after
+Suggest:
+  - Replace with: “asthma's”
+  - Replace with: “airheads”
+  - Replace with: “ashcans”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4394 | office—really sick, pale as his own pale hair and shaking all over. Michaelis
+         |                                                                     ^~~~~~~~~ Did you mean “Michael”?
+    4395 | advised him to go to bed, but Wilson refused, saying that he’d miss a lot of
+Suggest:
+  - Replace with: “Michael”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4402 | Michaelis was astonished; they had been neighbors for four years, and Wilson had
+         | ^~~~~~~~~ Did you mean “Michael”?
+Suggest:
+  - Replace with: “Michael”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4409 | So naturally Michaelis tried to find out what had happened, but Wilson wouldn’t
+         |              ^~~~~~~~~ Did you mean “Michael”?
+Suggest:
+  - Replace with: “Michael”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4412 | latter was getting uneasy, some workmen came past the door bound for his
+    4413 | restaurant, and Michaelis took the opportunity to get away, intending to come
+         |                 ^~~~~~~~~ Did you mean “Michael”?
+Suggest:
+  - Replace with: “Michael”
+
+
+
+Lint:    Style (31 priority)
+Message: |
+    4416 | he heard Mrs. Wilson’s voice, loud and scolding, down-stairs in the garage.
+         |                               ^~~~ An Oxford comma is necessary here.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4426 | the next bend. Mavromichaelis wasn’t even sure of its color—he told the first
+         |                ^~~~~~~~~~~~~~ Did you mean “Carmichael's”?
+Suggest:
+  - Replace with: “Carmichael's”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    4427 | policeman that it was light green. The other car, the one going toward New York,
+         |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4428 | came to rest a hundred yards beyond, and it’s driver hurried back to where
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4429 | Myrtle Wilson, her life violently extinguished, knelt in the road and mingled
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4430 | her thick dark blood with the dust.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4432 | Michaelis and this man reached her first, but when they had torn open her
+         | ^~~~~~~~~ Did you mean “Michael”?
+Suggest:
+  - Replace with: “Michael”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    4432 | Michaelis and this man reached her first, but when they had torn open her
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4433 | shirtwaist, still damp with perspiration, they saw that her left breast was
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4434 | swinging loose like a flap, and there was no need to listen for the heart
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4435 | beneath. The mouth was wide open and ripped a little at the corners, as though
+         | ~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4442 | “Wreck!” said Tom. “That’s good. Wilson’ll have a little business at last.”
+         |                                  ^~~~~~~~~ Did you mean “Wilson”?
+Suggest:
+  - Replace with: “Wilson”
+
+
+
+Lint:    Style (63 priority)
+Message: |
+    4450 | I became aware now of a hollow, wailing sound which issued incessantly from the
+         |                ^~~~~~~~ The word `of` is not needed here.
+Suggest:
+  - Replace with: “now a”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4451 | garage, a sound which as we got out of the coupé and walked toward the door
+         |                                            ^~~~~ Did you mean to spell “coupé” this way?
+    4452 | resolved itself into the words “Oh, my God!” uttered over and over in a gasping
+Suggest:
+  - Replace with: “coup”
+  - Replace with: “coupe”
+  - Replace with: “coups”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    4466 | Myrtle Wilson’s body, wrapped in a blanket, and then in another blanket, as
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4467 | though she suffered from a chill in the hot night, lay on a work-table by the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4468 | wall, and Tom, with his back to us, was bending over it, motionless. Next to him
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    4470 | a little book. At first I couldn’t find the source of the high, groaning words
+         |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4471 | that echoed clamorously through the bare garage—then I saw Wilson standing on
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4472 | the raised threshold of his office, swaying back and forth and holding to the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4473 | doorposts with both hands. Some man was talking to him in a low voice and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4470 | a little book. At first I couldn’t find the source of the high, groaning words
+    4471 | that echoed clamorously through the bare garage—then I saw Wilson standing on
+         |             ^~~~~~~~~~~ Did you mean to spell “clamorously” this way?
+Suggest:
+  - Replace with: “glamorously”
+  - Replace with: “clamorous”
+  - Replace with: “clangorously”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4479 | “Oh, my Ga-od! Oh, my Ga-od! Oh, Ga-od! Oh, my Ga-od!”
+         |            ^~ Did you mean to spell “od” this way?
+Suggest:
+  - Replace with: “odd”
+  - Replace with: “ode”
+  - Replace with: “of”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4479 | “Oh, my Ga-od! Oh, my Ga-od! Oh, Ga-od! Oh, my Ga-od!”
+         |                          ^~ Did you mean to spell “od” this way?
+Suggest:
+  - Replace with: “odd”
+  - Replace with: “ode”
+  - Replace with: “of”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4479 | “Oh, my Ga-od! Oh, my Ga-od! Oh, Ga-od! Oh, my Ga-od!”
+         |                                     ^~ Did you mean to spell “od” this way?
+Suggest:
+  - Replace with: “odd”
+  - Replace with: “ode”
+  - Replace with: “of”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4479 | “Oh, my Ga-od! Oh, my Ga-od! Oh, Ga-od! Oh, my Ga-od!”
+         |                                                   ^~ Did you mean to spell “od” this way?
+Suggest:
+  - Replace with: “odd”
+  - Replace with: “ode”
+  - Replace with: “of”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4484 | “M-a-v—” the policeman was saying, “—o———”
+         |                                      ^ Did you mean to spell “o” this way?
+Suggest:
+  - Replace with: “ob”
+  - Replace with: “of”
+  - Replace with: “oh”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4486 | “No, r—” corrected the man, “M-a-v-r-o———”
+         |                                      ^ Did you mean to spell “o” this way?
+Suggest:
+  - Replace with: “ob”
+  - Replace with: “of”
+  - Replace with: “oh”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4490 | “r—” said the policeman, “o———”
+         |                           ^ Did you mean to spell “o” this way?
+Suggest:
+  - Replace with: “ob”
+  - Replace with: “of”
+  - Replace with: “oh”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4499 | “Auto hit her. Ins’antly killed.”
+         |                ^~~~~~~~~ Did you mean “Instantly”?
+Suggest:
+  - Replace with: “Instantly”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4503 | “She ran out ina road. Son-of-a-bitch didn’t even stopus car.”
+         |              ^~~ Did you mean to spell “ina” this way?
+Suggest:
+  - Replace with: “int”
+  - Replace with: “in”
+  - Replace with: “inc”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4503 | “She ran out ina road. Son-of-a-bitch didn’t even stopus car.”
+         |                                                   ^~~~~~ Did you mean to spell “stopus” this way?
+Suggest:
+  - Replace with: “stop's”
+  - Replace with: “stops”
+  - Replace with: “stomp's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4505 | “There was two cars,” said Michaelis, “one comin’, one goin’, see?”
+         |                            ^~~~~~~~~ Did you mean “Michael”?
+Suggest:
+  - Replace with: “Michael”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4505 | “There was two cars,” said Michaelis, “one comin’, one goin’, see?”
+         |                                            ^~~~~ Did you mean to spell “comin” this way?
+Suggest:
+  - Replace with: “coin”
+  - Replace with: “comic”
+  - Replace with: “coming”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4505 | “There was two cars,” said Michaelis, “one comin’, one goin’, see?”
+         |                                                        ^~~~ Did you mean to spell “goin” this way?
+Suggest:
+  - Replace with: “gain”
+  - Replace with: “gin”
+  - Replace with: “going”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4509 | “One goin’ each way. Well, she”—his hand rose toward the blankets but stopped
+         |      ^~~~ Did you mean to spell “goin” this way?
+Suggest:
+  - Replace with: “gain”
+  - Replace with: “gin”
+  - Replace with: “going”
+
+
+
+Lint:    Miscellaneous (31 priority)
+Message: |
+    4510 | half way and fell to his side—“she ran out there an’ the one comin’ from N’York
+         |                                                  ^~ Incorrect indefinite article.
+    4511 | knock right into her, goin’ thirty or forty miles an hour.”
+Suggest:
+  - Replace with: “a”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4510 | half way and fell to his side—“she ran out there an’ the one comin’ from N’York
+         |                                                              ^~~~~ Did you mean to spell “comin” this way?
+    4511 | knock right into her, goin’ thirty or forty miles an hour.”
+Suggest:
+  - Replace with: “coin”
+  - Replace with: “comic”
+  - Replace with: “coming”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4510 | half way and fell to his side—“she ran out there an’ the one comin’ from N’York
+         |                                                                          ^~~~~~ Did you mean to spell “N’York” this way?
+    4511 | knock right into her, goin’ thirty or forty miles an hour.”
+Suggest:
+  - Replace with: “York”
+  - Replace with: “Nanook”
+  - Replace with: “Newark”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4510 | half way and fell to his side—“she ran out there an’ the one comin’ from N’York
+    4511 | knock right into her, goin’ thirty or forty miles an hour.”
+         |                       ^~~~ Did you mean to spell “goin” this way?
+Suggest:
+  - Replace with: “gain”
+  - Replace with: “gin”
+  - Replace with: “going”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4523 | “No, but the car passed me down the road, going faster’n forty. Going fifty,
+         |                                                 ^~~~~~~~ Did you mean to spell “faster’n” this way?
+Suggest:
+  - Replace with: “falter's”
+  - Replace with: “feaster's”
+  - Replace with: “fester's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4544 | New York. I was bringing you that coupé we’ve been talking about. That yellow
+         |                                   ^~~~~ Did you mean to spell “coupé” this way?
+Suggest:
+  - Replace with: “coup”
+  - Replace with: “coupe”
+  - Replace with: “coups”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4560 | “It’s a blue car, a coupé.”
+         |                     ^~~~~ Did you mean to spell “coupé” this way?
+Suggest:
+  - Replace with: “coup”
+  - Replace with: “coupe”
+  - Replace with: “coups”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4572 | “If somebody’ll come here and sit with him,” he snapped authoritatively. He
+         |     ^~~~~~~~~~~ Did you mean “somebody's”?
+Suggest:
+  - Replace with: “somebody's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4582 | Tom drove slowly until we were beyond the bend—then his foot came down hard, and
+    4583 | the coupé raced along through the night. In a little while I heard a low husky
+         |     ^~~~~ Did you mean to spell “coupé” this way?
+Suggest:
+  - Replace with: “coup”
+  - Replace with: “coupe”
+  - Replace with: “coups”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4588 | The Buchanans’ house floated suddenly toward us through the dark rustling trees.
+         |     ^~~~~~~~~ Did you mean to spell “Buchanans” this way?
+Suggest:
+  - Replace with: “Buchanan's”
+  - Replace with: “Buchanan”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4635 | the house in a moment; I wouldn’t have been surprised to see sinister faces, the
+    4636 | faces of “Wolfshiem’s people,” behind him in the dark shrubbery.
+         |           ^~~~~~~~~~~ Did you mean to spell “Wolfshiem’s” this way?
+Suggest:
+  - Replace with: “Welshmen's”
+  - Replace with: “Wolfe's”
+  - Replace with: “Wolsey's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4703 | I walked back along the border of the lawn, traversed the gravel softly, and
+    4704 | tiptoed up the veranda steps. The drawing-room curtains were open, and I saw
+         |                ^~~~~~~ Did you mean to spell “veranda” this way?
+Suggest:
+  - Replace with: “verandas”
+  - Replace with: “veranda's”
+  - Replace with: “Miranda”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    4738 | and I tossed half-sick between grotesque reality and savage, frightening dreams.
+         |                                                                                 ^
+    4739 | Toward dawn I heard a taxi go up Gatsby’s drive, and immediately I jumped out of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4740 | bed and began to dress—I felt that I had something to tell him, something to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4741 | warn him about, and morning would be too late.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    4768 | It was this night that he told me the strange story of his youth with Dan
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4769 | Cody—told it to me because “Jay Gatsby” had broken up like glass against Tom’s
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4770 | hard malice, and the long secret extravaganza was played out. I think that he
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    4780 | her as his tent out at camp was to him. There was a ripe mystery about it, a
+         |                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4781 | hint of bedrooms up-stairs more beautiful and cool than other bedrooms, of gay
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4782 | and radiant activities taking place through its corridors, and of romances that
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4783 | were not musty and laid away already in lavender but fresh and breathing and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4784 | redolent of this year’s shining motor-cars and of dances whose flowers were
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4785 | scarcely withered. It excited him, too, that many men had already loved Daisy—it
+         | ~~~~~~~~~~~~~~~~~~ This sentence is 63 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    4797 | pretenses. I don’t mean that he had traded on his phantom millions, but he had
+         |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4798 | deliberately given Daisy a sense of security; he let her believe that he was a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4799 | person from much the same strata as herself—that he was fully able to take care
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4800 | of her. As a matter of fact, he had no such facilities—he had no comfortable
+         | ~~~~~~~ This sentence is 47 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    4814 | kissed her curious and lovely mouth. She had caught a cold, and it made her
+         |                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4815 | voice huskier and more charming than ever, and Gatsby was overwhelmingly aware
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4816 | of the youth and mystery that wealth imprisons and preserves, of the freshness
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4817 | of many clothes, and of Daisy, gleaming like silver, safe and proud above the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4818 | hot struggles of the poor.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 53 words long.
+
+
+
+Lint:    Formatting (63 priority)
+Message: |
+    4822 | was in love with me too. She thought I knew a lot because I knew different
+    4823 | things from her . . . Well, there I was, ’way off my ambitions, getting deeper
+         |                ^ Unnecessary space at the end of the sentence.
+Suggest:
+  - Remove error
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    4832 | as if to give them a deep memory for the long parting the next day promised.
+         |                                                                             ^
+    4833 | They had never been closer in their month of love, nor communicated more
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4834 | profoundly one with another, than when she brushed silent lips against his
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4835 | coat’s shoulder or when he touched the end of her fingers, gently, as though she
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4836 | were asleep.
+         | ~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4850 | saxophones wailed the hopeless comment of the “Beale Street Blues” while a
+         |                                                ^~~~~ Did you mean to spell “Beale” this way?
+    4851 | hundred pairs of golden and silver slippers shuffled the shining dust. At the
+Suggest:
+  - Replace with: “Bale”
+  - Replace with: “Beadle”
+  - Replace with: “Berle”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    4856 | Through this twilight universe Daisy began to move again with the season;
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4857 | suddenly she was again keeping half a dozen dates a day with half a dozen men,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4858 | and drowsing asleep at dawn with the beads and chiffon of an evening dress
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    4859 | tangled among dying orchids on the floor beside her bed. And all the time
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 52 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4875 | “I don’t think she ever loved him.” Gatsby turned around from a window and
+    4876 | looked at me challengingly. “You must remember, old sport, she was very excited
+         |              ^~~~~~~~~~~~~ Did you mean “challenging”?
+Suggest:
+  - Replace with: “challenging”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4921 | “I’m going to drain the pool to-day, Mr. Gatsby. Leaves’ll start falling pretty
+         |                                                  ^~~~~~~~~ Did you mean to spell “Leaves’ll” this way?
+    4922 | soon, and then there’s always trouble with the pipes.”
+Suggest:
+  - Replace with: “Leakey's”
+  - Replace with: “Leave's”
+  - Replace with: “Leaven's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4943 | “I suppose Daisy’ll call too.” He looked at me anxiously, as if he hoped I’d
+         |            ^~~~~~~~ Did you mean “Daisy's”?
+Suggest:
+  - Replace with: “Daisy's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4980 | “I’ve left Daisy’s house,” she said. “I’m at Hempstead, and I’m going down to
+         |                                              ^~~~~~~~~ Did you mean to spell “Hempstead” this way?
+    4981 | Southampton this afternoon.”
+Suggest:
+  - Replace with: “Homestead”
+  - Replace with: “Bedstead”
+  - Replace with: “Demisted”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5015 | When I passed the ashheaps on the train that morning I had crossed deliberately
+         |                   ^~~~~~~~ Did you mean to spell “ashheaps” this way?
+Suggest:
+  - Replace with: “asthma's”
+  - Replace with: “airheads”
+  - Replace with: “ashcans”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    5016 | to the other side of the car. I supposed there’d be a curious crowd around there
+         |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5017 | all day with little boys searching for dark spots in the dust, and some
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5018 | garrulous man telling over and over what had happened, until it became less and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5019 | less real even to him and he could tell it no longer, and Myrtle Wilson’s tragic
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5020 | achievement was forgotten. Now I want to go back a little and tell what happened
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 56 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5034 | and closed the door. Michaelis and several other men were with him; first, four
+         |                      ^~~~~~~~~ Did you mean “Michael”?
+Suggest:
+  - Replace with: “Michael”
+
+
+
+Lint:    Style (31 priority)
+Message: |
+    5034 | and closed the door. Michaelis and several other men were with him; first, four
+         |                                                                            ^~~~ An Oxford comma is necessary here.
+    5035 | or five men, later two or three men. Still later Michaelis had to ask the last
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5035 | or five men, later two or three men. Still later Michaelis had to ask the last
+         |                                                  ^~~~~~~~~ Did you mean “Michael”?
+    5036 | stranger to wait there fifteen minutes longer, while he went back to his own
+Suggest:
+  - Replace with: “Michael”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    5041 | quieter and began to talk about the yellow car. He announced that he had a way
+         |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5042 | of finding out whom the yellow car belonged to, and then he blurted out that a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5043 | couple of months ago his wife had come from the city with her face bruised and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5044 | her nose swollen.
+         | ~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5047 | again in his groaning voice. Michaelis made a clumsy attempt to distract him.
+         |                              ^~~~~~~~~ Did you mean “Michael”?
+Suggest:
+  - Replace with: “Michael”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5057 | The hard brown beetles kept thudding against the dull light, and whenever
+    5058 | Michaelis heard a car go tearing along the road outside it sounded to him like
+         | ^~~~~~~~~ Did you mean “Michael”?
+Suggest:
+  - Replace with: “Michael”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    5057 | The hard brown beetles kept thudding against the dull light, and whenever
+    5058 | Michaelis heard a car go tearing along the road outside it sounded to him like
+         |                   ^~~~~~ Did you mean the closed compound noun “cargo”?
+Suggest:
+  - Replace with: “cargo”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    5059 | the car that hadn’t stopped a few hours before. He didn’t like to go into the
+         |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5060 | garage, because the work bench was stained where the body had been lying, so he
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5061 | moved uncomfortably around the office—he knew every object in it before
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5062 | morning—and from time to time sat down beside Wilson trying to keep him more
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5063 | quiet.
+         | ~~~~~~ This sentence is 50 words long.
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    5059 | the car that hadn’t stopped a few hours before. He didn’t like to go into the
+    5060 | garage, because the work bench was stained where the body had been lying, so he
+         |                     ^~~~~~~~~~ Did you mean the closed compound noun “workbench”?
+Suggest:
+  - Replace with: “workbench”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5087 | Michaelis opened the drawer nearest his hand. There was nothing in it but a
+         | ^~~~~~~~~ Did you mean “Michael”?
+Suggest:
+  - Replace with: “Michael”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5102 | Michaelis didn’t see anything odd in that, and he gave Wilson a dozen reasons
+         | ^~~~~~~~~ Did you mean “Michael”?
+Suggest:
+  - Replace with: “Michael”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5121 | Wilson shook his head. His eyes narrowed and his mouth widened slightly with the
+    5122 | ghost of a superior “Hm!”
+         |                      ^~ Did you mean to spell “Hm” this way?
+Suggest:
+  - Replace with: “H”
+  - Replace with: “Ham”
+  - Replace with: “He”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5128 | Michaelis had seen this too, but it hadn’t occurred to him that there was any
+         | ^~~~~~~~~ Did you mean “Michael”?
+Suggest:
+  - Replace with: “Michael”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5136 | He began to rock again, and Michaelis stood twisting the leash in his hand.
+         |                             ^~~~~~~~~ Did you mean “Michael”?
+Suggest:
+  - Replace with: “Michael”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5146 | Wilson’s glazed eyes turned out to the ashheaps, where small gray clouds took on
+         |                                        ^~~~~~~~ Did you mean to spell “ashheaps” this way?
+    5147 | fantastic shapes and scurried here and there in the faint dawn wind.
+Suggest:
+  - Replace with: “asthma's”
+  - Replace with: “airheads”
+  - Replace with: “ashcans”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5155 | Standing behind him, Michaelis saw with a shock that he was looking at the eyes
+         |                      ^~~~~~~~~ Did you mean “Michael”?
+Suggest:
+  - Replace with: “Michael”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5155 | Standing behind him, Michaelis saw with a shock that he was looking at the eyes
+    5156 | of Doctor T. J. Eckleburg, which had just emerged, pale and enormous, from the
+         |           ^~ Did you mean to spell “T.” this way?
+Suggest:
+  - Replace with: “To”
+  - Replace with: “T”
+  - Replace with: “Ta”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5156 | of Doctor T. J. Eckleburg, which had just emerged, pale and enormous, from the
+         |              ^~ Did you mean to spell “J.” this way?
+Suggest:
+  - Replace with: “Jg”
+  - Replace with: “J”
+  - Replace with: “JD”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5156 | of Doctor T. J. Eckleburg, which had just emerged, pale and enormous, from the
+         |                 ^~~~~~~~~ Did you mean to spell “Eckleburg” this way?
+Suggest:
+  - Replace with: “Excalibur”
+  - Replace with: “Vicksburg”
+  - Replace with: “Iceberg”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5161 | “That’s an advertisement,” Michaelis assured him. Something made him turn away
+         |                            ^~~~~~~~~ Did you mean “Michael”?
+Suggest:
+  - Replace with: “Michael”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    5162 | from the window and look back into the room. But Wilson stood there a long time,
+    5163 | his face close to the window pane, nodding into the twilight.
+         |                       ^~~~~~~~~~~ Did you mean the closed compound noun “windowpane”?
+Suggest:
+  - Replace with: “windowpane”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5165 | By six o’clock Michaelis was worn out, and grateful for the sound of a car
+         |                ^~~~~~~~~ Did you mean “Michael”?
+Suggest:
+  - Replace with: “Michael”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5168 | man ate together. Wilson was quieter now, and Michaelis went home to sleep; when
+         |                                               ^~~~~~~~~ Did you mean “Michael”?
+Suggest:
+  - Replace with: “Michael”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5171 | His movements—he was on foot all the time—were afterward traced to Port
+    5172 | Roosevelt and then to Gad’s Hill, where he bought a sandwich that he didn’t eat,
+         |                       ^~~~~ Did you mean to spell “Gad’s” this way?
+Suggest:
+  - Replace with: “Ga's”
+  - Replace with: “Gd's”
+  - Replace with: “Gab's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5173 | and a cup of coffee. He must have been tired and walking slowly, for he didn’t
+    5174 | reach Gad’s Hill until noon. Thus far there was no difficulty in accounting for
+         |       ^~~~~ Did you mean to spell “Gad’s” this way?
+Suggest:
+  - Replace with: “Ga's”
+  - Replace with: “Gd's”
+  - Replace with: “Gab's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5177 | hours he disappeared from view. The police, on the strength of what he said to
+    5178 | Michaelis, that he “had a way of finding out,” supposed that he spent that time
+         | ^~~~~~~~~ Did you mean “Michael”?
+Suggest:
+  - Replace with: “Michael”
+
+
+
+Lint:    Formatting (63 priority)
+Message: |
+    5204 | where poor ghosts, breathing dreams like air, drifted fortuitously about . . .
+         |                                                                         ^ Unnecessary space at the end of the sentence.
+Suggest:
+  - Remove error
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+    5205 | like that ashen, fantastic figure gliding toward him through the amorphous
+         | ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “L”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5208 | The chauffeur—he was one of Wolfshiem’s protégés—heard the shots—afterward he
+         |                             ^~~~~~~~~~~ Did you mean to spell “Wolfshiem’s” this way?
+Suggest:
+  - Replace with: “Welshmen's”
+  - Replace with: “Wolfe's”
+  - Replace with: “Wolsey's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5208 | The chauffeur—he was one of Wolfshiem’s protégés—heard the shots—afterward he
+         |                                         ^~~~~~~~ Did you mean “proteges”?
+    5209 | could only say that he hadn’t thought anything much about them. I drove from the
+Suggest:
+  - Replace with: “proteges”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    5230 | and out of Gatsby’s front door. A rope stretched across the main gate and a
+         |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5231 | policeman by it kept out the curious, but little boys soon discovered that they
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5232 | could enter through my yard, and there were always a few of them clustered
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5233 | open-mouthed about the pool. Some one with a positive manner, perhaps a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5239 | untrue. When Michaelis’s testimony at the inquest brought to light Wilson’s
+         |              ^~~~~~~~~~~ Did you mean to spell “Michaelis’s” this way?
+Suggest:
+  - Replace with: “Michael's”
+  - Replace with: “Michaela's”
+  - Replace with: “Michaelmas's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5240 | suspicions of his wife I thought the whole tale would shortly be served up in
+    5241 | racy pasquinade—but Catherine, who might have said anything, didn’t say a word.
+         |      ^~~~~~~~~~ Did you mean “masquerade”?
+Suggest:
+  - Replace with: “masquerade”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    5241 | racy pasquinade—but Catherine, who might have said anything, didn’t say a word.
+         |                                                                                ^
+    5242 | She showed a surprising amount of character about it too—looked at the coroner
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5243 | with determined eyes under that corrected brow of hers, and swore that her
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5244 | sister had never seen Gatsby, that her sister was completely happy with her
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5245 | husband, that her sister had been into no mischief whatever. She convinced
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 50 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    5253 | referred to me. At first I was surprised and confused; then, as he lay in his
+         |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5254 | house and didn’t move or breathe or speak, hour upon hour, it grew upon me that
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5255 | I was responsible, because no one else was interested—interested, I mean, with
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5256 | that intense personal interest to which every one has some vague right at the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5257 | end.
+         | ~~~~ This sentence is 57 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5279 | Meyer Wolfshiem’s name wasn’t in the phone book. The butler gave me his office
+         |       ^~~~~~~~~~~ Did you mean to spell “Wolfshiem’s” this way?
+Suggest:
+  - Replace with: “Welshmen's”
+  - Replace with: “Wolfe's”
+  - Replace with: “Wolsey's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5304 | Next morning I sent the butler to New York with a letter to Wolfshiem, which
+         |                                                             ^~~~~~~~~ Did you mean “Bolshie”?
+    5305 | asked for information and urged him to come out on the next train. That request
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5308 | neither a wire nor Mr. Wolfshiem arrived; no one arrived except more police and
+         |                        ^~~~~~~~~ Did you mean “Bolshie”?
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5309 | photographers and newspaper men. When the butler brought back Wolfshiem’s answer
+         |                                                               ^~~~~~~~~~~ Did you mean to spell “Wolfshiem’s” this way?
+    5310 | I began to have a feeling of defiance, of scornful solidarity between Gatsby and
+Suggest:
+  - Replace with: “Welshmen's”
+  - Replace with: “Wolfe's”
+  - Replace with: “Wolsey's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5313 | Dear Mr. Carraway. This has been one of the most terrible shocks of my life to
+         |          ^~~~~~~~ Did you mean to spell “Carraway” this way?
+Suggest:
+  - Replace with: “Caraway”
+  - Replace with: “Faraway”
+
+
+
+Lint:    Repetition (63 priority)
+Message: |
+    5313 | Dear Mr. Carraway. This has been one of the most terrible shocks of my life to
+    5314 | me I hardly can believe it that it is true at all. Such a mad act as that man
+         | ^~~~ There are too many personal pronouns in sequence here.
+Suggest:
+  - Replace with: “me”
+  - Replace with: “I”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5322 | >
+    5323 | > Meyer Wolfshiem
+         |         ^~~~~~~~~ Did you mean “Bolshie”?
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5327 | Let me know about the funeral etc do not know his family at all.
+         |                               ^~~ Did you mean to spell “etc” this way?
+Suggest:
+  - Replace with: “eta”
+  - Replace with: “etc.”
+  - Replace with: “etch”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5333 | “This is Slagle speaking . . .”
+         |          ^~~~~~ Did you mean to spell “Slagle” this way?
+Suggest:
+  - Replace with: “Beagle”
+  - Replace with: “Eagle”
+  - Replace with: “Plague”
+
+
+
+Lint:    Formatting (63 priority)
+Message: |
+    5333 | “This is Slagle speaking . . .”
+         |                         ^ Unnecessary space at the end of the sentence.
+Suggest:
+  - Remove error
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5341 | “Young Parke’s in trouble,” he said rapidly. “They picked him up when he handed
+         |        ^~~~~~~ Did you mean to spell “Parke’s” this way?
+Suggest:
+  - Replace with: “Parks's”
+  - Replace with: “Parker's”
+  - Replace with: “Paige's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5343 | numbers just five minutes before. What d’you know about that, hey? You never can
+         |                                        ^~~~~ Did you mean to spell “d’you” this way?
+Suggest:
+  - Replace with: “bayou”
+  - Replace with: “you”
+
+
+
+Lint:    Formatting (63 priority)
+Message: |
+    5349 | There was a long silence on the other end of the wire, followed by an
+    5350 | exclamation . . . then a quick squawk as the connection was broken.
+         |            ^ Unnecessary space at the end of the sentence.
+Suggest:
+  - Remove error
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+    5350 | exclamation . . . then a quick squawk as the connection was broken.
+         |                   ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “T”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5352 | I think it was on the third day that a telegram signed Henry C. Gatz arrived
+         |                                                              ^~ Did you mean to spell “C.” this way?
+Suggest:
+  - Replace with: “Cw”
+  - Replace with: “C”
+  - Replace with: “Ca”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5352 | I think it was on the third day that a telegram signed Henry C. Gatz arrived
+         |                                                                 ^~~~ Did you mean to spell “Gatz” this way?
+    5353 | from a town in Minnesota. It said only that the sender was leaving immediately
+Suggest:
+  - Replace with: “Ga's”
+  - Replace with: “Gate”
+  - Replace with: “GHz”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    5359 | hands he began to pull so incessantly at his sparse gray beard that I had
+         |                                                     ^~~~~~~~~~ Did you mean the closed compound noun “graybeard”?
+    5360 | difficulty in getting off his coat. He was on the point of collapse, so I took
+Suggest:
+  - Replace with: “graybeard”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5377 | “Carraway.”
+         |  ^~~~~~~~ Did you mean to spell “Carraway” this way?
+Suggest:
+  - Replace with: “Caraway”
+  - Replace with: “Faraway”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5385 | After a little while Mr. Gatz opened the door and came out, his mouth ajar, his
+         |                          ^~~~ Did you mean to spell “Gatz” this way?
+Suggest:
+  - Replace with: “Ga's”
+  - Replace with: “Gate”
+  - Replace with: “GHz”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5386 | face flushed slightly, his eyes leaking isolated and unpunctual tears. He had
+         |                                                      ^~~~~~~~~~ Did you mean “punctual”?
+Suggest:
+  - Replace with: “punctual”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    5386 | face flushed slightly, his eyes leaking isolated and unpunctual tears. He had
+         |                                                                       ^~~~~~~~
+    5387 | reached an age where death no longer has the quality of ghastly surprise, and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5388 | when he looked around him now for the first time and saw the height and splendor
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5389 | of the hall and the great rooms opening out from it into other rooms, his grief
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5390 | began to be mixed with an awed pride. I helped him to a bedroom up-stairs; while
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 56 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5396 | “Gatz is my name.”
+         |  ^~~~ Did you mean to spell “Gatz” this way?
+Suggest:
+  - Replace with: “Ga's”
+  - Replace with: “Gate”
+  - Replace with: “GHz”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5398 | “—Mr. Gatz. I thought you might want to take the body West.”
+         |       ^~~~ Did you mean to spell “Gatz” this way?
+Suggest:
+  - Replace with: “Ga's”
+  - Replace with: “Gate”
+  - Replace with: “GHz”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5412 | “If he’d of lived, he’d of been a great man. A man like James J. Hill. He’d of
+         |                                                               ^~ Did you mean to spell “J.” this way?
+Suggest:
+  - Replace with: “Jg”
+  - Replace with: “J”
+  - Replace with: “JD”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5423 | “This is Mr. Carraway,” I said.
+         |              ^~~~~~~~ Did you mean to spell “Carraway” this way?
+Suggest:
+  - Replace with: “Caraway”
+  - Replace with: “Faraway”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5425 | “Oh!” He sounded relieved. “This is Klipspringer.”
+         |                                     ^~~~~~~~~~~~ Did you mean to spell “Klipspringer” this way?
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5455 | and I’m sort of helpless without them. My address is care of B. F.———”
+         |                                                              ^~ Did you mean to spell “B.” this way?
+Suggest:
+  - Replace with: “Bu”
+  - Replace with: “Be”
+  - Replace with: “Bf”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5455 | and I’m sort of helpless without them. My address is care of B. F.———”
+         |                                                                 ^~ Did you mean to spell “F.” this way?
+Suggest:
+  - Replace with: “Fa”
+  - Replace with: “Ff”
+  - Replace with: “Fr”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5464 | The morning of the funeral I went up to New York to see Meyer Wolfshiem; I
+         |                                                               ^~~~~~~~~ Did you mean “Bolshie”?
+Suggest:
+  - Replace with: “Bolshie”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5472 | “Nobody’s in,” she said. “Mr. Wolfshiem’s gone to Chicago.”
+         |                               ^~~~~~~~~~~ Did you mean to spell “Wolfshiem’s” this way?
+Suggest:
+  - Replace with: “Welshmen's”
+  - Replace with: “Wolfe's”
+  - Replace with: “Wolsey's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5477 | “Please say that Mr. Carraway wants to see him.”
+         |                      ^~~~~~~~ Did you mean to spell “Carraway” this way?
+Suggest:
+  - Replace with: “Caraway”
+  - Replace with: “Faraway”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5481 | At this moment a voice, unmistakably Wolfshiem’s, called “Stella!” from the
+         |                                      ^~~~~~~~~~~ Did you mean to spell “Wolfshiem’s” this way?
+Suggest:
+  - Replace with: “Welshmen's”
+  - Replace with: “Wolfe's”
+  - Replace with: “Wolsey's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5500 | She vanished. In a moment Meyer Wolfsheim stood solemnly in the doorway, holding
+         |                                 ^~~~~~~~~ Did you mean to spell “Wolfsheim” this way?
+    5501 | out both hands. He drew me into his office, remarking in a reverent voice that
+Suggest:
+  - Replace with: “Waldheim”
+  - Replace with: “Wolfe's”
+  - Replace with: “Wilhelm”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5507 | First time I saw him was when he come into Winebrenner’s poolroom at Forty-third
+         |                                            ^~~~~~~~~~~~~ Did you mean to spell “Winebrenner’s” this way?
+    5508 | Street and asked for a job. He hadn’t eat anything for a couple of days. ‘Come
+Suggest:
+  - Replace with: “Windbreaker's”
+  - Replace with: “Icebreaker's”
+  - Replace with: “Tiebreaker's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5508 | Street and asked for a job. He hadn’t eat anything for a couple of days. ‘Come
+    5509 | on have some lunch with me,’ I sid. He ate more than four dollars’ worth of food
+         |                                ^~~ Did you mean to spell “sid” this way?
+Suggest:
+  - Replace with: “sad”
+  - Replace with: “said”
+  - Replace with: “sic”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5519 | was a fine-appearing, gentlemanly young man, and when he told me he was an
+    5520 | Oggsford I knew I could use him good. I got him to join up in the American
+         | ^~~~~~~~ Did you mean to spell “Oggsford” this way?
+Suggest:
+  - Replace with: “Oxford”
+  - Replace with: “Osborn”
+  - Replace with: “Osgood”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5552 | For a moment I thought he was going to suggest a “gonnegtion,” but he only
+         |                                                   ^~~~~~~~~~ Did you mean “connection”?
+    5553 | nodded and shook my hand.
+Suggest:
+  - Replace with: “connection”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5559 | drizzle. After changing my clothes I went next door and found Mr. Gatz walking
+         |                                                                   ^~~~ Did you mean to spell “Gatz” this way?
+    5560 | up and down excitedly in the hall. His pride in his son and in his son’s
+Suggest:
+  - Replace with: “Ga's”
+  - Replace with: “Gate”
+  - Replace with: “GHz”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5582 | pocket a ragged old copy of a book called “Hopalong Cassidy.”
+         |                                            ^~~~~~~~ Did you mean to spell “Hopalong” this way?
+Suggest:
+  - Replace with: “Along”
+  - Replace with: “Oblong”
+  - Replace with: “Coaling”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5601 | >
+    5602 | > No wasting time at Shafters or [a name, indecipherable] No more smokeing or
+         |                      ^~~~~~~~ Did you mean to spell “Shafters” this way?
+Suggest:
+  - Replace with: “Shaffer's”
+  - Replace with: “Shatters”
+  - Replace with: “Shifters”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5602 | > No wasting time at Shafters or [a name, indecipherable] No more smokeing or
+         |                                                                   ^~~~~~~~ Did you mean to spell “smokeing” this way?
+    5603 | > chewing. Bath every other day Read one improving book or magazine per week
+Suggest:
+  - Replace with: “smoking”
+  - Replace with: “shoeing”
+  - Replace with: “smocking”
+
+
+
+Lint:    Repetition (63 priority)
+Message: |
+    5613 | great for that. He told me I et like a hog once, and I beat him for it.”
+         |                         ^~~~ There are too many personal pronouns in sequence here.
+Suggest:
+  - Replace with: “me”
+  - Replace with: “I”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5613 | great for that. He told me I et like a hog once, and I beat him for it.”
+         |                              ^~ Did you mean to spell “et” this way?
+Suggest:
+  - Replace with: “e”
+  - Replace with: “ea”
+  - Replace with: “eat”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5629 | then Mr. Gatz and the minister and I in the limousine, and a little later four
+         |          ^~~~ Did you mean to spell “Gatz” this way?
+Suggest:
+  - Replace with: “Ga's”
+  - Replace with: “Gate”
+  - Replace with: “GHz”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5633 | looked around. It was the man with owl-eyed glasses whom I had found marvelling
+         |                                                                      ^~~~~~~~~~ Did you mean “marveling”?
+    5634 | over Gatsby’s books in the library one night three months before.
+Suggest:
+  - Replace with: “marveling”
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    5642 | message or a flower. Dimly I heard some one murmur “Blessed are the dead that
+    5643 | the rain falls on,” and then the owl-eyed man said “Amen to that,” in a brave
+         |     ^~~~~~~~~~ Did you mean the closed compound noun “rainfalls”?
+Suggest:
+  - Replace with: “rainfalls”
+
+
+
+Lint:    Capitalization (31 priority)
+Message: |
+    5653 | “Go on!” He started. “Why, my God! they used to go there by the hundreds.”
+         |                                    ^ This sentence does not start with a capital letter
+Suggest:
+  - Replace with: “T”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    5660 | from college at Christmas time. Those who went farther than Chicago would gather
+         |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5661 | in the old dim Union Street station at six o’clock of a December evening, with a
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5662 | few Chicago friends, already caught up into their own holiday gayeties, to bid
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5663 | them a hasty good-by. I remember the fur coats of the girls returning from Miss
+         | ~~~~~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5662 | few Chicago friends, already caught up into their own holiday gayeties, to bid
+         |                                                               ^~~~~~~~ Did you mean to spell “gayeties” this way?
+    5663 | them a hasty good-by. I remember the fur coats of the girls returning from Miss
+Suggest:
+  - Replace with: “gametes”
+  - Replace with: “gazettes”
+  - Replace with: “layettes”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    5663 | them a hasty good-by. I remember the fur coats of the girls returning from Miss
+         |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5664 | This-or-That’s and the chatter of frozen breath and the hands waving overhead as
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5665 | we caught sight of old acquaintances, and the matchings of invitations: “Are you
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5666 | going to the Ordways’? the Herseys’? the Schultzes’?” and the long green tickets
+         | ~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5665 | we caught sight of old acquaintances, and the matchings of invitations: “Are you
+         |                                               ^~~~~~~~~ Did you mean to spell “matchings” this way?
+Suggest:
+  - Replace with: “matching”
+  - Replace with: “catchings”
+  - Replace with: “machines”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5665 | we caught sight of old acquaintances, and the matchings of invitations: “Are you
+    5666 | going to the Ordways’? the Herseys’? the Schultzes’?” and the long green tickets
+         |              ^~~~~~~ Did you mean to spell “Ordways” this way?
+Suggest:
+  - Replace with: “Endways”
+  - Replace with: “Midways”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5666 | going to the Ordways’? the Herseys’? the Schultzes’?” and the long green tickets
+         |                            ^~~~~~~ Did you mean to spell “Herseys” this way?
+Suggest:
+  - Replace with: “Hersey's”
+  - Replace with: “Hersey”
+  - Replace with: “Hershey's”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5666 | going to the Ordways’? the Herseys’? the Schultzes’?” and the long green tickets
+         |                                          ^~~~~~~~~ Did you mean “Schultz”?
+Suggest:
+  - Replace with: “Schultz”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    5671 | When we pulled out into the winter night and the real snow, our snow, began to
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5672 | stretch out beside us and twinkle against the windows, and the dim lights of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5673 | small Wisconsin stations moved by, a sharp wild brace came suddenly into the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5674 | air. We drew in deep breaths of it as we walked back from dinner through the
+         | ~~~~ This sentence is 44 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    5678 | That’s my Middle West—not the wheat or the prairies or the lost Swede towns, but
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5679 | the thrilling returning trains of my youth, and the street lamps and sleigh
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5680 | bells in the frosty dark and the shadows of holly wreaths thrown by lighted
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5681 | windows on the snow. I am part of that, a little solemn with the feel of those
+         | ~~~~~~~~~~~~~~~~~~~~ This sentence is 47 words long.
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    5679 | the thrilling returning trains of my youth, and the street lamps and sleigh
+         |                                                     ^~~~~~~~~~~~ Did you mean the closed compound noun “streetlamps”?
+    5680 | bells in the frosty dark and the shadows of holly wreaths thrown by lighted
+Suggest:
+  - Replace with: “streetlamps”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5682 | long winters, a little complacent from growing up in the Carraway house in a
+         |                                                          ^~~~~~~~ Did you mean to spell “Carraway” this way?
+    5683 | city where dwellings are still called through decades by a family’s name. I see
+Suggest:
+  - Replace with: “Caraway”
+  - Replace with: “Faraway”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    5683 | city where dwellings are still called through decades by a family’s name. I see
+         |                                                                          ^~~~~~~
+    5684 | now that this has been a story of the West, after all—Tom and Gatsby, Daisy and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5685 | Jordan and I, were all Westerners, and perhaps we possessed some deficiency in
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5686 | common which made us subtly unadaptable to Eastern life.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    Style (31 priority)
+Message: |
+    5684 | now that this has been a story of the West, after all—Tom and Gatsby, Daisy and
+         |                                                                       ^~~~~ An Oxford comma is necessary here.
+    5685 | Jordan and I, were all Westerners, and perhaps we possessed some deficiency in
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5685 | Jordan and I, were all Westerners, and perhaps we possessed some deficiency in
+    5686 | common which made us subtly unadaptable to Eastern life.
+         |                             ^~~~~~~~~~~ Did you mean “adaptable”?
+Suggest:
+  - Replace with: “adaptable”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    5688 | Even when the East excited me most, even when I was most keenly aware of its
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5689 | superiority to the bored, sprawling, swollen towns beyond the Ohio, with their
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5690 | interminable inquisitions which spared only the children and the very old—even
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5691 | then it had always for me a quality of distortion. West Egg, especially, still
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 50 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5692 | figures in my more fantastic dreams. I see it as a night scene by El Greco: a
+         |                                                                   ^~ Did you mean to spell “El” this way?
+Suggest:
+  - Replace with: “Ea”
+  - Replace with: “Ed”
+  - Replace with: “Eel”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5692 | figures in my more fantastic dreams. I see it as a night scene by El Greco: a
+         |                                                                      ^~~~~ Did you mean to spell “Greco” this way?
+Suggest:
+  - Replace with: “Geo”
+  - Replace with: “Greece”
+  - Replace with: “Greek”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5693 | hundred houses, at once conventional and grotesque, crouching under a sullen,
+    5694 | overhanging sky and a lustreless moon. In the foreground four solemn men in
+         |                       ^~~~~~~~~~ Did you mean “lusterless”?
+Suggest:
+  - Replace with: “lusterless”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    5712 | She was dressed to play golf, and I remember thinking she looked like a good
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5713 | illustration, her chin raised a little jauntily, her hair the color of an autumn
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5714 | leaf, her face the same brown tint as the fingerless glove on her knee. When I
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Style (63 priority)
+Message: |
+    5713 | illustration, her chin raised a little jauntily, her hair the color of an autumn
+         |                                                               ^~~~~~~~~~~ The word `of` is not needed here.
+    5714 | leaf, her face the same brown tint as the fingerless glove on her knee. When I
+Suggest:
+  - Replace with: “color an”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5714 | leaf, her face the same brown tint as the fingerless glove on her knee. When I
+         |                                           ^~~~~~~~~~ Did you mean “linerless”?
+Suggest:
+  - Replace with: “linerless”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    5743 | One afternoon late in October I saw Tom Buchanan. He was walking ahead of me
+         |                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5744 | along Fifth Avenue in his alert, aggressive way, his hands out a little from his
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5745 | body as if to fight off interference, his head moving sharply here and there,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5746 | adapting itself to his restless eyes. Just as I slowed up to avoid overtaking
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    5775 | “And if you think I didn’t have my share of suffering—look here, when I went to
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5776 | give up that flat and saw that damn box of dog biscuits sitting there on the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5777 | sideboard, I sat down and cried like a baby. By God it was awful—”
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    5780 | entirely justified. It was all very careless and confused. They were careless
+         |                                                           ^~~~~~~~~~~~~~~~~~~~
+    5781 | people, Tom and Daisy—they smashed up things and creatures and then retreated
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5782 | back into their money or their vast carelessness, or whatever it was that kept
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5783 | them together, and let other people clean up the mess they had made. . . .
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 43 words long.
+
+
+
+Lint:    Style (31 priority)
+Message: |
+    5780 | entirely justified. It was all very careless and confused. They were careless
+    5781 | people, Tom and Daisy—they smashed up things and creatures and then retreated
+         |         ^~~ An Oxford comma is necessary here.
+Suggest:
+  - Insert “,”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    5791 | long as mine. One of the taxi drivers in the village never took a fare past the
+         |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5792 | entrance gate without stopping for a minute and pointing inside; perhaps it was
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5793 | he who drove Daisy and Gatsby over to East Egg the night of the accident, and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5794 | perhaps he had made a story about it all his own. I didn’t want to hear it and I
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 54 words long.
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    5797 | I spent my Saturday nights in New York because those gleaming, dazzling parties
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5798 | of his were with me so vividly that I could still hear the music and the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5799 | laughter, faint and incessant, from his garden, and the cars going up and down
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5800 | his drive. One night I did hear a material car there, and saw its lights stop at
+         | ~~~~~~~~~~ This sentence is 45 words long.
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5807 | out clearly in the moonlight, and I erased it, drawing my shoe raspingly along
+         |                                                                ^~~~~~~~~ Did you mean to spell “raspingly” this way?
+    5808 | the stone. Then I wandered down to the beach and sprawled out on the sand.
+Suggest:
+  - Replace with: “ragingly”
+  - Replace with: “rasping”
+  - Replace with: “dashingly”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    5814 | green breast of the new world. Its vanished trees, the trees that had made way
+         |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5815 | for Gatsby’s house, had once pandered in whispers to the last and greatest of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5816 | all human dreams; for a transitory enchanted moment man must have held his
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5817 | breath in the presence of this continent, compelled into an esthetic
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5818 | contemplation he neither understood nor desired, face to face for the last time
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    5819 | in history with something commensurate to his capacity for wonder.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 70 words long.
+
+
+
+Lint:    WordChoice (63 priority)
+Message: |
+    5817 | breath in the presence of this continent, compelled into an esthetic
+         |                                                          ^~~~~~~~~~~ It seems these words would go better together.
+    5818 | contemplation he neither understood nor desired, face to face for the last time
+Suggest:
+  - Replace with: “anesthetic”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5817 | breath in the presence of this continent, compelled into an esthetic
+         |                                                             ^~~~~~~~ Did you mean to spell “esthetic” this way?
+    5818 | contemplation he neither understood nor desired, face to face for the last time
+Suggest:
+  - Replace with: “aesthetic”
+  - Replace with: “aesthetics”
+  - Replace with: “pathetic”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    5828 | Gatsby believed in the green light, the orgastic future that year by year
+         |                                         ^~~~~~~~ Did you mean to spell “orgastic” this way?
+    5829 | recedes before us. It eluded us then, but that’s no matter—to-morrow we will run
+Suggest:
+  - Replace with: “orgasmic”
+  - Replace with: “orgiastic”
+  - Replace with: “organic”
+
+
+


### PR DESCRIPTION
# Motivation

Why I added snapshots:

1. They make it easy to see the impact of changes to lints (if the text corpus is large enough).
2. Changes in the tokenizer, dictionary, or PoS tagger that affect lints will also (likely) become visible.
3. It becomes easy to see when the span of a report is suboptimal/wrong.

# Description
Similar to the PoS tag snapshots, I added snapshots for the reports of all lints. Just like before, snapshots are automatically created and updated just by running the snapshot test.

Snapshots are formatted in a YAML-like syntax, and reports have a Rust-error-messages like syntax. Example:

```yml
Lint:    Spelling (63 priority)
Message: |
      46 | calculator in 1623. In 1673, Gottfried Leibniz demonstrated a digital mechanical
         |                              ^~~~~~~~~ Did you mean to spell “Gottfried” this way?
Suggest:
  - Replace with: “Lotteries”
  - Replace with: “Notified”
  - Replace with: “Pottered”
```

# How Has This Been Tested?
This is a test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes

# Notes

1. If you look through the snapshots, you'll see that long-sentence reports will sometimes start at the space or punctuation before the first word of the sentence. This is a bug in the lint, not the snapshot formatter.
2. The snapshots reveal several bugs and false positives. I recommend to look through them.
