### PR TITLE
Documentation updates

### DIFF
--- a/packages/web/src/routes/docs/contributors/chrome-extension/+page.md
+++ b/packages/web/src/routes/docs/contributors/chrome-extension/+page.md
@@ -54,4 +54,5 @@ It:
 
 ## Other Reading
 
+- [Putting Harper in the Browser: Technical Details](https://elijahpotter.dev/articles/putting_harper_in_your_browser)
 - [The Art of Exception](https://elijahpotter.dev/articles/the_art_of_exception)

--- a/packages/web/src/routes/docs/contributors/wordpress/+page.md
+++ b/packages/web/src/routes/docs/contributors/wordpress/+page.md
@@ -1,4 +1,6 @@
-# WordPress Plugin
+---
+title: WordPress Plugin
+---
 
 This page will describe most of what you need to know to build and develop the WordPress plugin locally.
 You do NOT need to have a WordPress installation on your machine (or hosted on a server, for that matter) to work on the Harper plugin.

--- a/packages/web/src/routes/docs/faq/+page.md
+++ b/packages/web/src/routes/docs/faq/+page.md
@@ -10,6 +10,8 @@ Do you want to use it within Obsidian? We have an [Obsidian plugin](/docs/integr
 
 Do you want to use it within WordPress? We have a [WordPress plugin](/docs/integrations/wordpress).
 
+Do you want to use it within your Browser? We have a [Chrome extension](/docs/integrations/chrome-extension). (Firefox add-on coming soon.)
+
 Do you want to use it within your code editor? We have documentation on how you can integrate with [Visual Studio Code and its forks](/docs/integrations/visual-studio-code), [Neovim](/docs/integrations/neovim), [Helix](/docs/integrations/helix), [Emacs](/docs/integrations/emacs), and [Zed](/docs/integrations/zed). If you're using a different code editor, then you can integrate directly with our language server, [`harper-ls`](/docs/integrations/language-server).
 
 Do you want to integrate it in your web app or your JavaScript/TypeScript codebase? You can use [`harper.js`](./harperjs/introduction).
@@ -25,10 +27,6 @@ We currently only support English and its dialects British, American, Canadian, 
 For `harper-ls` and our code editor integrations, we support a wide variety of programming languages. You can view all of them over at [the `harper-ls` documentation](/docs/integrations/language-server#Supported-Languages). We are entirely open to PRs that add support. If you just want to be able to run grammar checking on your code's comments, you can use [this PR as a model for what to do](https://github.com/Automattic/harper/pull/332).
 
 For `harper.js` and those that use it under the hood like our Obsidian plugin, we support plaintext and/or Markdown.
-
-## Is There a Chrome or Firefox Extension?
-
-Yes! You can [learn more about it here](/docs/integrations/chrome-extension)
 
 ## Where Did the Name Harper Come From?
 

--- a/packages/web/src/routes/docs/integrations/wordpress/+page.md
+++ b/packages/web/src/routes/docs/integrations/wordpress/+page.md
@@ -1,8 +1,10 @@
+---
+title: Harper for WordPress
+---
+
 <script>
     import {Button} from "flowbite-svelte"
 </script>
-
-# Harper for WordPress
 
 Harper is now ready to be installed to the nearest WordPress site near you.
 It's still early days, so expect bugs.


### PR DESCRIPTION
# Description

- Put Wordpess titles in frontmatter for conformity with the other docs and so that it's also included in the `title` element of the pages.
- Put browser extension details under "How Do I Use or Integrate Harper?" in the FAQ and clarify that the Firefox add-on is still in the works to prevent confusion as seen in #1224.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
