### PR TITLE
fix(chrome-ext): render on scroll

### DIFF
--- a/packages/chrome-plugin/src/Box.ts
+++ b/packages/chrome-plugin/src/Box.ts
@@ -60,3 +60,22 @@ export function isBoxInScreen(box: Box): boolean {
 
 	return false;
 }
+
+export function boxesOverlap(a: Box, b: Box): boolean {
+	return a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y;
+}
+
+export function domRectToBox(rect: DOMRect): Box {
+	return {
+		x: rect.x,
+		y: rect.y,
+		width: rect.width,
+		height: rect.height,
+	};
+}
+
+export function isBottomEdgeInBox(inner: Box, outer: Box): boolean {
+	const leftBottom: [number, number] = [inner.x, inner.y + inner.height];
+	const rightBottom: [number, number] = [inner.x + inner.width, inner.y + inner.height];
+	return isPointInBox(leftBottom, outer) && isPointInBox(rightBottom, outer);
+}

--- a/packages/chrome-plugin/src/Highlights.ts
+++ b/packages/chrome-plugin/src/Highlights.ts
@@ -115,6 +115,12 @@ export default class Highlights {
 			return scr.parentElement;
 		}
 
+		const qr = getQuillJsRoot(el);
+
+		if (qr != null) {
+			return qr.parentElement;
+		}
+
 		const lexicalRoot = getLexicalRoot(el);
 
 		if (lexicalRoot != null) {
@@ -180,6 +186,12 @@ function getTrixRoot(el: HTMLElement): HTMLElement | null {
  * If so, returns the root node of that instance. */
 function getShredditComposerRoot(el: HTMLElement): HTMLElement | null {
 	return findAncestor(el, (node: HTMLElement) => node.nodeName == 'SHREDDIT-COMPOSER');
+}
+
+/** Determines if a given node is a child of a Quill.js editor instance.
+ * If so, returns the root node of that instance. */
+function getQuillJsRoot(el: HTMLElement): HTMLElement | null {
+	return findAncestor(el, (node: HTMLElement) => node.classList.contains('ql-container'));
 }
 
 /**

--- a/packages/chrome-plugin/src/LintFramework.ts
+++ b/packages/chrome-plugin/src/LintFramework.ts
@@ -7,7 +7,7 @@ import computeLintBoxes from './computeLintBoxes';
 /** Events on an input (any kind) that can trigger a re-render. */
 const INPUT_EVENTS = ['focus', 'keyup', 'paste', 'change', 'scroll'];
 /** Events on the window that can trigger a re-render. */
-const PAGE_EVENTS = ['resize'];
+const PAGE_EVENTS = ['resize', 'scroll'];
 
 /** Orchestrates linting and rendering in response to events on the page. */
 export default class LintFramework {

--- a/packages/chrome-plugin/src/TextFieldRange.ts
+++ b/packages/chrome-plugin/src/TextFieldRange.ts
@@ -133,6 +133,15 @@ export default class TextFieldRange {
 		return arr;
 	}
 
+	getBoundingClientRect(): DOMRect | null {
+		this._updateMirrorText();
+		if (this.mirror == null) {
+			return null;
+		}
+
+		return this.mirror.getBoundingClientRect();
+	}
+
 	/**
 	 * Detaches (removes) the mirror element from the document.
 	 */

--- a/packages/chrome-plugin/src/TextFieldRange.ts
+++ b/packages/chrome-plugin/src/TextFieldRange.ts
@@ -1,3 +1,5 @@
+import { boxesOverlap, domRectToBox } from './Box';
+
 /** A version of the `Range` object that works for `<textarea />` and `<input />` elements. */
 export default class TextFieldRange {
 	field: HTMLTextAreaElement | HTMLInputElement;
@@ -35,26 +37,6 @@ export default class TextFieldRange {
 		this.mirror = document.createElement('div');
 		this.mirror.id = 'textfield-mirror';
 
-		// Compute the absolute position of the field.
-		const fieldRect = this.field.getBoundingClientRect();
-		const scrollTop = window.scrollY || document.documentElement.scrollTop;
-		const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
-
-		// Position the mirror exactly over the field.
-		Object.assign(this.mirror.style, {
-			top: `${fieldRect.top + scrollTop}px`,
-			left: `${fieldRect.left + scrollLeft}px`,
-			width: `${fieldRect.width}px`,
-			// Optionally, you might copy the height—useful if you need an exact overlay.
-			// height: `${fieldRect.height}px`,
-			// For a textarea, use "pre-wrap" (so line-breaks are preserved); for a single‑line input, use "pre"
-			whiteSpace: this.field.tagName.toLowerCase() === 'textarea' ? 'pre-wrap' : 'pre',
-			wordWrap: 'break-word',
-			visibility: 'hidden',
-			position: 'absolute',
-			pointerEvents: 'none',
-		});
-
 		// Copy necessary computed styles from the field (affecting text layout)
 		const computed: CSSStyleDeclaration = window.getComputedStyle(this.field);
 		// The properties below help ensure the mirror text has the same layout as the actual text.
@@ -80,12 +62,43 @@ export default class TextFieldRange {
 			this.mirror!.style[prop] = computed[prop];
 		});
 
+		// Compute the absolute position of the field.
+		const fieldRect = this.field.getBoundingClientRect();
+		const scrollTop = window.scrollY || document.documentElement.scrollTop;
+		const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
+
+		console.log(fieldRect);
+
+		// Position the mirror exactly over the field.
+		Object.assign(this.mirror.style, {
+			top: `${fieldRect.top + scrollTop}px`,
+			left: `${fieldRect.left + scrollLeft}px`,
+			width: `${fieldRect.width}px`,
+			height: `${fieldRect.height}px`,
+			overflow: 'scroll',
+			// For a textarea, use "pre-wrap" (so line-breaks are preserved); for a single‑line input, use "pre"
+			whiteSpace: this.field.tagName.toLowerCase() === 'textarea' ? 'pre-wrap' : 'pre',
+			wordWrap: 'break-word',
+			visibility: 'hidden',
+			position: 'absolute',
+			pointerEvents: 'none',
+		});
+
 		// Create the text node that will mirror the field's text.
 		this.mirrorTextNode = document.createTextNode('');
 		this.mirror.appendChild(this.mirrorTextNode);
 
+		// Needed for the scroll to work.
+		this._updateMirrorText();
+
 		// Append the mirror element to the document body.
 		document.body.appendChild(this.mirror);
+
+		this.mirror.scrollTo({
+			top: this.field.scrollTop,
+			left: this.field.scrollLeft,
+			behavior: 'instant',
+		});
 	}
 
 	/**
@@ -107,7 +120,17 @@ export default class TextFieldRange {
 		range.setStart(this.mirrorTextNode, this.startOffset);
 		range.setEnd(this.mirrorTextNode, this.endOffset);
 
-		return Array.from(range.getClientRects());
+		let arr = Array.from(range.getClientRects());
+
+		const fieldBox = domRectToBox(this.field.getBoundingClientRect());
+
+		// Filter out rectangles that should be hidden
+		arr = arr.filter((rect) => {
+			const box = domRectToBox(rect);
+			return boxesOverlap(box, fieldBox);
+		});
+
+		return arr;
 	}
 
 	/**

--- a/packages/chrome-plugin/src/background/index.ts
+++ b/packages/chrome-plugin/src/background/index.ts
@@ -52,6 +52,7 @@ async function enableDefaultDomains() {
 		'web.whatsapp.com',
 		'outlook.live.com',
 		'www.reddit.com',
+		'www.linkedin.com',
 	];
 
 	for (const item of defaultEnabledDomains) {

--- a/packages/chrome-plugin/src/computeLintBoxes.ts
+++ b/packages/chrome-plugin/src/computeLintBoxes.ts
@@ -1,4 +1,4 @@
-import type { LintBox } from './Box';
+import { type LintBox, domRectToBox, isBottomEdgeInBox } from './Box';
 import TextFieldRange from './TextFieldRange';
 import { getRangeForTextSpan } from './domUtils';
 import { type UnpackedLint, type UnpackedSuggestion, applySuggestion } from './unpackLint';
@@ -25,6 +25,7 @@ export default function computeLintBoxes(el: HTMLElement, lint: UnpackedLint): L
 	}
 
 	const targetRects = range.getClientRects();
+
 	range.detach();
 
 	const boxes: LintBox[] = [];
@@ -41,7 +42,13 @@ export default function computeLintBoxes(el: HTMLElement, lint: UnpackedLint): L
 		return [];
 	}
 
+	const elBox = domRectToBox(el.getBoundingClientRect());
+
 	for (const targetRect of targetRects) {
+		if (!isBottomEdgeInBox(targetRect, elBox)) {
+			continue;
+		}
+
 		boxes.push({
 			x: targetRect.x,
 			y: targetRect.y,

--- a/packages/chrome-plugin/src/computeLintBoxes.ts
+++ b/packages/chrome-plugin/src/computeLintBoxes.ts
@@ -25,7 +25,7 @@ export default function computeLintBoxes(el: HTMLElement, lint: UnpackedLint): L
 	}
 
 	const targetRects = range.getClientRects();
-
+	const elBox = domRectToBox(range.getBoundingClientRect());
 	range.detach();
 
 	const boxes: LintBox[] = [];
@@ -41,8 +41,6 @@ export default function computeLintBoxes(el: HTMLElement, lint: UnpackedLint): L
 	if (source == null) {
 		return [];
 	}
-
-	const elBox = domRectToBox(el.getBoundingClientRect());
 
 	for (const targetRect of targetRects) {
 		if (!isBottomEdgeInBox(targetRect, elBox)) {


### PR DESCRIPTION
# Issues 

There are no specific GitHub issues related to this PR. It fixes problems found through my own dogfooding.

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

There were some problems with grammatical errors being underlined outside the render box of `<textarea />` elements. They also did not follow any internal scroll.
This PR fixes both problems.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manual testing.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
