### PR TITLE
fix(obsidian): pretty-print the lint kind

### DIFF
--- a/packages/obsidian-plugin/src/index.ts
+++ b/packages/obsidian-plugin/src/index.ts
@@ -311,7 +311,7 @@ export default class HarperPlugin extends Plugin {
 						from: span.start,
 						to: span.end,
 						severity: 'error',
-						title: lint.lint_kind(),
+						title: lint.lint_kind_pretty(),
 						message: lint.message(),
 						ignore: async () => {
 							await this.harper.ignoreLint(text, lint);


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

This PR updates the Obsidian plugin to pretty-print the `LintKind` in the suggestion popup. It is subtle, but important.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

Before:

![image](https://github.com/user-attachments/assets/0e596996-4b74-4e3e-b419-8e9f954b6a3a)

After:

![image](https://github.com/user-attachments/assets/fae9aa89-3639-47b4-a904-0e00368c83f4)


# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually. See above.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
