### PR TITLE
fix(core): long sentence lint should start with word

### DIFF
--- a/harper-core/src/linting/long_sentences.rs
+++ b/harper-core/src/linting/long_sentences.rs
@@ -15,7 +15,10 @@ impl Linter for LongSentences {
 
             if word_count > 40 {
                 output.push(Lint {
-                    span: Span::new(sentence[0].span.start, sentence.last().unwrap().span.end),
+                    span: Span::new(
+                        sentence.first_word().unwrap().span.start,
+                        sentence.last().unwrap().span.end,
+                    ),
                     lint_kind: LintKind::Readability,
                     message: format!("This sentence is {} words long.", word_count),
                     ..Default::default()

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -27,7 +27,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
       21 | be late!” (when she thought it over afterwards, it occurred to her that she
-         |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       22 | ought to have wondered at this, but at the time it all seemed quite natural);
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       23 | but when the Rabbit actually took a watch out of its waistcoat-pocket, and
@@ -60,7 +60,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
       39 | next. First, she tried to look down and make out what she was coming to, but it
-         |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       40 | was too dark to see anything; then she looked at the sides of the well, and
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       41 | noticed that they were filled with cupboards and book-shelves; here and there
@@ -73,7 +73,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
       42 | she saw maps and pictures hung upon pegs. She took down a jar from one of the
-         |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       43 | shelves as she passed; it was labelled “ORANGE MARMALADE”, but to her great
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       44 | disappointment it was empty: she did not like to drop the jar for fear of
@@ -111,7 +111,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
       55 | centre of the earth. Let me see: that would be four thousand miles down, I
-         |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       56 | think—” (for, you see, Alice had learnt several things of this sort in her
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       57 | lessons in the schoolroom, and though this was not a very good opportunity for
@@ -243,7 +243,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      104 | open any of them. However, on the second time round, she came upon a low curtain
-         |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      105 | she had not noticed before, and behind it was a little door about fifteen inches
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      106 | high: she tried the little golden key in the lock, and to her great delight it
@@ -256,7 +256,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      111 | loveliest garden you ever saw. How she longed to get out of that dark hall, and
-         |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      112 | wander about among those beds of bright flowers and those cool fountains, but
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      113 | she could not even get her head through the doorway; “and even if my head would
@@ -288,7 +288,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      128 | to do that in a hurry. “No, I’ll look first,” she said, “and see whether it’s
-         |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      129 | marked ‘poison’ or not”; for she had read several nice little histories about
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      130 | children who had got burnt, and eaten up by wild beasts and other unpleasant
@@ -334,7 +334,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      146 | door into that lovely garden. First, however, she waited for a few minutes to
-         |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      147 | see if she was going to shrink any further: she felt a little nervous about
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      148 | this; “for it might end, you know,” said Alice to herself, “in my going out
@@ -354,10 +354,20 @@ Suggest:
 
 
 
+Lint:    Capitalization (31 priority)
+Message: |
+     154 | garden at once; but, alas for poor Alice! when she got to the door, she found
+         |                                           ^ This sentence does not start with a capital letter
+     155 | she had forgotten the little golden key, and when she went back to the table for
+Suggest:
+  - Replace with: “W”
+
+
+
 Lint:    Readability (127 priority)
 Message: |
      154 | garden at once; but, alas for poor Alice! when she got to the door, she found
-         |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      155 | she had forgotten the little golden key, and when she went back to the table for
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      156 | it, she found she could not possibly reach it: she could see it quite plainly
@@ -371,20 +381,10 @@ Message: |
 
 
 
-Lint:    Capitalization (31 priority)
-Message: |
-     154 | garden at once; but, alas for poor Alice! when she got to the door, she found
-         |                                           ^ This sentence does not start with a capital letter
-     155 | she had forgotten the little golden key, and when she went back to the table for
-Suggest:
-  - Replace with: “W”
-
-
-
 Lint:    Readability (127 priority)
 Message: |
      162 | sharply; “I advise you to leave off this minute!” She generally gave herself
-         |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      163 | very good advice, (though she very seldom followed it), and sometimes she
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      164 | scolded herself so severely as to bring tears into her eyes; and once she
@@ -411,7 +411,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      173 | beautifully marked in currants. “Well, I’ll eat it,” said Alice, “and if it
-         |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      174 | makes me grow larger, I can reach the key; and if it makes me grow smaller, I
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      175 | can creep under the door; so either way I’ll get into the garden, and I don’t
@@ -424,9 +424,8 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      178 | She ate a little bit, and said anxiously to herself, “Which way? Which way?”,
-         |                                                                            ^~~
      179 | holding her hand on the top of her head to feel which way it was growing, and
-         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      180 | she was quite surprised to find that she remained the same size: to be sure,
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      181 | this generally happens when one eats cake, but Alice had got so much into the
@@ -463,7 +462,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      194 | stockings for you now, dears? I’m sure I shan’t be able! I shall be a great deal
-         |                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                          ^~~~~~~~~~~~~~~~~~~~~~~~
      195 | too far off to trouble myself about you: you must manage the best way you
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      196 | can;—but I must be kind to them,” thought Alice, “or perhaps they won’t walk the
@@ -486,7 +485,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      227 | I’ve kept her waiting!” Alice felt so desperate that she was ready to ask help
-         |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      228 | of any one; so, when the Rabbit came near her, she began, in a low, timid voice,
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      229 | “If you please, sir—” The Rabbit started violently, dropped the white kid gloves
@@ -520,7 +519,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      249 | Rome—no, that’s all wrong, I’m certain! I must have been changed for Mabel! I’ll
-         |                                                                            ^~~~~~
+         |                                                                             ^~~~~
      250 | try and say ‘How doth the little—’” and she crossed her hands on her lap as if
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      251 | she were saying lessons, and began to repeat it, but her voice sounded hoarse
@@ -532,7 +531,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      260 | “I’m sure those are not the right words,” said poor Alice, and her eyes filled
-         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      261 | with tears again as she went on, “I must be Mabel after all, and I shall have to
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      262 | go and live in that poky little house, and have next to no toys to play with,
@@ -554,7 +553,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      273 | “How can I have done that?” she thought. “I must be growing small again.” She
-         |                                                                         ^~~~~~
+         |                                                                           ^~~~
      274 | got up and went to the table to measure herself by it, and found that, as nearly
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      275 | as she could guess, she was now about two feet high, and was going on shrinking
@@ -588,10 +587,8 @@ Suggest:
 
 Lint:    Readability (127 priority)
 Message: |
-     289 | into the sea, “and in that case I can go back by railway,” she said to herself.
-         |                                                                                ^
      290 | (Alice had been to the seaside once in her life, and had come to the general
-         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      291 | conclusion, that wherever you go to on the English coast you find a number of
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      292 | bathing machines in the sea, some children digging in the sand with wooden
@@ -617,7 +614,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      311 | Mouse!” (Alice thought this must be the right way of speaking to a mouse: she
-         |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      312 | had never done such a thing before, but she remembered having seen in her
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      313 | brother’s Latin Grammar, “A mouse—of a mouse—to a mouse—a mouse—O mouse!”) The
@@ -661,7 +658,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      330 | cats if you could only see her. She is such a dear quiet thing,” Alice went on,
-         |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      331 | half to herself, as she swam lazily about in the pool, “and she sits purring so
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      332 | nicely by the fire, licking her paws and washing her face—and she is such a nice
@@ -676,7 +673,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      346 | curly brown hair! And it’ll fetch things when you throw them, and it’ll sit up
-         |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      347 | and beg for its dinner, and all sorts of things—I can’t remember half of
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      348 | them—and it belongs to a farmer, you know, and he says it’s so useful, it’s
@@ -689,7 +686,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      355 | talk about cats or dogs either, if you don’t like them!” When the Mouse heard
-         |                                                        ^~~~~~~~~~~~~~~~~~~~~~~
+         |                                                          ^~~~~~~~~~~~~~~~~~~~~
      356 | this, it turned round and swam slowly back to her: its face was quite pale (with
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      357 | passion, Alice thought), and it said in a low trembling voice, “Let us get to
@@ -738,10 +735,8 @@ Message: |
 
 Lint:    Readability (127 priority)
 Message: |
-     374 | herself talking familiarly with them, as if she had known them all her life.
-         |                                                                             ^
      375 | Indeed, she had quite a long argument with the Lory, who at last turned sulky,
-         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      376 | and would only say, “I am older than you, and must know better;” and this Alice
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      377 | would not allow without knowing how old it was, and, as the Lory positively
@@ -906,7 +901,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      564 | wonder?” Alice guessed in a moment that it was looking for the fan and the pair
-         |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      565 | of white kid gloves, and she very good-naturedly began hunting about for them,
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      566 | but they were nowhere to be seen—everything seemed to have changed since her
@@ -990,7 +985,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      607 | Alas! it was too late to wish that! She went on growing, and growing, and very
-         |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      608 | soon had to kneel down on the floor: in another minute there was not even room
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      609 | for this, and she tried the effect of lying down with one elbow against the
@@ -1016,7 +1011,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      643 | came a little pattering of feet on the stairs. Alice knew it was the Rabbit
-         |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      644 | coming to look for her, and she trembled till she shook the house, quite
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      645 | forgetting that she was now about a thousand times as large as the Rabbit, and
@@ -1029,7 +1024,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      655 | snatch in the air. She did not get hold of anything, but she heard a little
-         |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      656 | shriek and a fall, and a crash of broken glass, from which she concluded that it
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      657 | was just possible it had fallen into a cucumber-frame, or something of the sort.
@@ -1211,7 +1206,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      755 | stretching out one paw, trying to touch her. “Poor little thing!” said Alice, in
-         |                                                                 ^~~~~~~~~~~~~~~~~
+         |                                                                   ^~~~~~~~~~~~~~~
      756 | a coaxing tone, and she tried hard to whistle to it; but she was terribly
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      757 | frightened all the time at the thought that it might be hungry, in which case it
@@ -1265,7 +1260,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      786 | the right thing to eat or drink under the circumstances. There was a large
-         |                                                         ^~~~~~~~~~~~~~~~~~~
+         |                                                          ^~~~~~~~~~~~~~~~~~
      787 | mushroom growing near her, about the same height as herself; and when she had
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      788 | looked under it, and on both sides of it, and behind it, it occurred to her that
@@ -1291,7 +1286,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      822 | “Well, perhaps you haven’t found it so yet,” said Alice; “but when you have to
-         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      823 | turn into a chrysalis—you will some day, you know—and then after that into a
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      824 | butterfly, I should think you’ll feel it a little queer, won’t you?”
@@ -1344,7 +1339,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      964 | “Come, my head’s free at last!” said Alice in a tone of delight, which changed
-         |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      965 | into alarm in another moment, when she found that her shoulders were nowhere to
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      966 | be found: all she could see, when she looked down, was an immense length of
@@ -1380,7 +1375,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      977 | about easily in any direction, like a serpent. She had just succeeded in curving
-         |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      978 | it down into a graceful zigzag, and was going to dive in among the leaves, which
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      979 | she found to be nothing but the tops of the trees under which she had been
@@ -1405,7 +1400,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     1007 | “And just as I’d taken the highest tree in the wood,” continued the Pigeon,
-         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1008 | raising its voice to a shriek, “and just as I was thinking I should be free of
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1009 | them at last, they must needs come wriggling down from the sky! Ugh, Serpent!”
@@ -1438,7 +1433,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     1042 | to stop and untwist it. After a while she remembered that she still held the
-         |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1043 | pieces of mushroom in her hands, and she set to work very carefully, nibbling
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1044 | first at one and then at the other, and growing sometimes taller and sometimes
@@ -1503,7 +1498,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     1165 | well to introduce some other subject of conversation. While she was trying to
-         |                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                       ^~~~~~~~~~~~~~~~~~~~~~~~
     1166 | fix on one, the cook took the cauldron of soup off the fire, and at once set to
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1167 | work throwing everything within her reach at the Duchess and the baby—the
@@ -1572,7 +1567,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     1220 | star-fish,” thought Alice. The poor little thing was snorting like a
-         |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1221 | steam-engine when she caught it, and kept doubling itself up and straightening
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1222 | itself out again, so that altogether, for the first minute or two, it was as
@@ -1596,7 +1591,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     1235 | what was the matter with it. There could be no doubt that it had a very turn-up
-         |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1236 | nose, much more like a snout than a real nose; also its eyes were getting
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1237 | extremely small for a baby: altogether Alice did not like the look of the thing
@@ -1609,7 +1604,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     1254 | made a dreadfully ugly child: but it makes rather a handsome pig, I think.” And
-         |                                                                           ^~~~~~
+         |                                                                             ^~~~
     1255 | she began thinking over other children she knew, who might do very well as pigs,
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1256 | and was just saying to herself, “if one only knew the right way to change them—”
@@ -1635,7 +1630,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     1348 | like ears and the roof was thatched with fur. It was so large a house, that she
-         |                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1349 | did not like to go nearer till she had nibbled some more of the lefthand bit of
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1350 | mushroom, and raised herself to about two feet high: even then she walked up
@@ -1787,10 +1782,8 @@ Message: |
 
 Lint:    Readability (127 priority)
 Message: |
-    1662 | taking the little golden key, and unlocking the door that led into the garden.
-         |                                                                               ^
     1663 | Then she went to work nibbling at the mushroom (she had kept a piece of it in
-         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1664 | her pocket) till she was about a foot high: then she walked down the little
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1665 | passage: and then—she found herself at last in the beautiful garden, among the
@@ -1816,7 +1809,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     1699 | Five and Seven said nothing, but looked at Two. Two began in a low voice, “Why
-         |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1700 | the fact is, you see, Miss, this here ought to have been a red rose-tree, and we
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1701 | put a white one in by mistake; and if the Queen was to find it out, we should
@@ -1879,7 +1872,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     1737 | “And who are these?” said the Queen, pointing to the three gardeners who were
-         |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1738 | lying round the rose-tree; for, you see, as they were lying on their faces, and
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1739 | the pattern on their backs was the same as the rest of the pack, she could not
@@ -1894,7 +1887,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     1813 | got settled down in a minute or two, and the game began. Alice thought she had
-         |                                                         ^~~~~~~~~~~~~~~~~~~~~~~
+         |                                                          ^~~~~~~~~~~~~~~~~~~~~~
     1814 | never seen such a curious croquet-ground in her life; it was all ridges and
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1815 | furrows; the balls were live hedgehogs, the mallets live flamingoes, and the
@@ -1986,7 +1979,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     1858 | “I don’t think they play at all fairly,” Alice began, in rather a complaining
-         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1859 | tone, “and they all quarrel so dreadfully one can’t hear oneself speak—and they
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1860 | don’t seem to have any rules in particular; at least, if there are, nobody
@@ -2026,7 +2019,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     1900 | she heard the Queen’s voice in the distance, screaming with passion. She had
-         |                                                                     ^~~~~~~~~
+         |                                                                      ^~~~~~~~
     1901 | already heard her sentence three of the players to be executed for having missed
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1902 | their turns, and she did not like the look of things at all, as the game was in
@@ -2124,7 +2117,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     1960 | “I won’t have any pepper in my kitchen at all. Soup does very well without—Maybe
-         |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1961 | it’s always pepper that makes people hot-tempered,” she went on, very much
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1962 | pleased at having found out a new kind of rule, “and vinegar that makes them
@@ -2206,7 +2199,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     2021 | “I quite agree with you,” said the Duchess; “and the moral of that is—‘Be what
-         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2022 | you would seem to be’—or if you’d like it put more simply—‘Never imagine
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2023 | yourself not to be otherwise than what it might appear to others that what you
@@ -2263,7 +2256,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     2069 | other players, and shouting “Off with his head!” or “Off with her head!” Those
-         |                                                                        ^~~~~~~~
+         |                                                                          ^~~~~~
     2070 | whom she sentenced were taken into custody by the soldiers, who of course had to
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2071 | leave off being arches to do this, so that by the end of half an hour or so
@@ -2494,7 +2487,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     2205 | “Well, there was Mystery,” the Mock Turtle replied, counting off the subjects on
-         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2206 | his flappers, “—Mystery, ancient and modern, with Seaography: then Drawling—the
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2207 | Drawling-master was an old conger-eel, that used to come once a week: he taught
@@ -2594,7 +2587,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     2252 | “You may not have lived much under the sea—” (“I haven’t,” said Alice)—“and
-         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2253 | perhaps you were never even introduced to a lobster—” (Alice began to say “I
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2254 | once tasted—” but checked herself hastily, and said “No, never”) “—so you can
@@ -2670,7 +2663,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     2286 | “Back to land again, and that’s all the first figure,” said the Mock Turtle,
-         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2287 | suddenly dropping his voice; and the two creatures, who had been jumping about
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2288 | like mad things all this time, sat down again very sadly and quietly, and looked
@@ -2829,7 +2822,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     2407 | wide, but she gained courage as she went on. Her listeners were perfectly quiet
-         |                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2408 | till she got to the part about her repeating “You are old, Father William,” to
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2409 | the Caterpillar, and the words all coming different, and then the Mock Turtle
@@ -2893,7 +2886,7 @@ Lint:    Readability (127 priority)
 Message: |
     2428 | >
     2429 | > (later editions continued as follows When the sands are all dry, he is gay as
-         |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2430 | > a lark, And will talk in contemptuous tones of the Shark, But, when the tide
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2431 | > rises and sharks are around, His voice has a timid and tremulous sound.)
@@ -3259,7 +3252,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     2511 | with a trumpet in one hand, and a scroll of parchment in the other. In the very
-         |                                                                    ^~~~~~~~~~~~~
+         |                                                                     ^~~~~~~~~~~~
     2512 | middle of the court was a table, with a large dish of tarts upon it: they looked
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2513 | so good, that it made Alice quite hungry to look at them—“I wish they’d get the
@@ -3326,7 +3319,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     2553 | opportunity of taking it away. She did it so quickly that the poor little juror
-         |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2554 | (it was Bill, the Lizard) could not make out at all what had become of it; so,
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2555 | after hunting all about for it, he was obliged to write with one finger for the
@@ -3378,7 +3371,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     2639 | “I’m a poor man, your Majesty,” the Hatter began, in a trembling voice, “—and I
-         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2640 | hadn’t begun my tea—not above a week or so—and what with the bread-and-butter
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
     2641 | getting so thin—and the twinkling of the tea—”
@@ -3397,7 +3390,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     2722 | “Well, if I must, I must,” the King said, with a melancholy air, and, after
-         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2723 | folding his arms and frowning at the cook till his eyes were nearly out of
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2724 | sight, he said in a deep voice, “What are tarts made of?”
@@ -3408,7 +3401,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     2747 | “Here!” cried Alice, quite forgetting in the flurry of the moment how large she
-         |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2748 | had grown in the last few minutes, and she jumped up in such a hurry that she
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2749 | tipped over the jury-box with the edge of her skirt, upsetting all the jurymen
@@ -3425,7 +3418,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     2754 | “Oh, I beg your pardon!” she exclaimed in a tone of great dismay, and began
-         |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2755 | picking them up again as quickly as she could, for the accident of the goldfish
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2756 | kept running in her head, and she had a vague sort of idea that they must be
@@ -3453,7 +3446,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     2907 | “All right, so far,” said the King, and he went on muttering over the verses to
-         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2908 | himself: “‘We know it to be true—’ that’s the jury, of course—‘I gave her one,
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 48 words long.
     2909 | they gave him two—’ why, that must be what he did with the tarts, you know—”
@@ -3463,7 +3456,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     2918 | spoke. (The unfortunate little Bill had left off writing on his slate with one
-         |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2919 | finger, as he found it made no mark; but he now hastily began again, using the
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2920 | ink, that was trickling down his face, as long as it lasted.)
@@ -3500,7 +3493,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     2951 | “Oh, I’ve had such a curious dream!” said Alice, and she told her sister, as
-         |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2952 | well as she could remember them, all these strange Adventures of hers that you
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2953 | have just been reading about; and when she had finished, her sister kissed her,

--- a/harper-core/tests/text/linters/Computer science.snap.yml
+++ b/harper-core/tests/text/linters/Computer science.snap.yml
@@ -68,7 +68,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
       59 | programmable.[note 2] In 1843, during the translation of a French article on the
-         |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       60 | Analytical Engine, Ada Lovelace wrote, in one of the many notes she included, an
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       61 | algorithm to compute the Bernoulli numbers, which is considered to be the first
@@ -147,7 +147,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
       74 | commands could be typed and the results printed automatically. In 1937, one
-         |                                                               ^~~~~~~~~~~~~~
+         |                                                                ^~~~~~~~~~~~~
       75 | hundred years after Babbage's impossible dream, Howard Aiken convinced IBM,
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       76 | which was making all kinds of punched card equipment and was also in the
@@ -408,7 +408,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      130 | been suggested. In Europe, terms derived from contracted translations of the
-         |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      131 | expression "automatic information" (e.g. "informazione automatica" in Italian)
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      132 | or "information and mathematics" are often used, e.g. informatique (French),
@@ -534,7 +534,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      154 | computing is a mathematical science. Early computer science was strongly
-         |                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      155 | influenced by the work of mathematicians such as Kurt Gödel, Alan Turing, John
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      156 | von Neumann, Rózsa Péter and Alonzo Church and there continues to be a useful
@@ -619,7 +619,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      162 | "software engineering" means, and how computer science is defined. David Parnas,
-         |                                                                   ^~~~~~~~~~~~~~~
+         |                                                                    ^~~~~~~~~~~~~~
      163 | taking a cue from the relationship between other engineering and science
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      164 | disciplines, has claimed that the principal focus of computer science is
@@ -687,7 +687,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      198 | way as bridges in civil engineering and airplanes in aerospace engineering. They
-         |                                                                            ^~~~~~
+         |                                                                             ^~~~~
      199 | also argue that while empirical sciences observe what presently exists, computer
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      200 | science observes what is possible to exist and while scientists discover laws
@@ -757,10 +757,21 @@ Suggest:
 
 
 
+Lint:    Spelling (63 priority)
+Message: |
+     216 | that they are theory, abstraction (modeling), and design. Amnon H. Eden
+         |                                                           ^~~~~ Did you mean to spell “Amnon” this way?
+Suggest:
+  - Replace with: “Amnion”
+  - Replace with: “Anon”
+  - Replace with: “Aaron”
+
+
+
 Lint:    Readability (127 priority)
 Message: |
      216 | that they are theory, abstraction (modeling), and design. Amnon H. Eden
-         |                                                          ^~~~~~~~~~~~~~~
+         |                                                           ^~~~~~~~~~~~~~
      217 | described them as the "rationalist paradigm" (which treats computer science as a
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      218 | branch of mathematics, which is prevalent in theoretical computer science, and
@@ -781,39 +792,11 @@ Message: |
 Lint:    Spelling (63 priority)
 Message: |
      216 | that they are theory, abstraction (modeling), and design. Amnon H. Eden
-         |                                                           ^~~~~ Did you mean to spell “Amnon” this way?
-Suggest:
-  - Replace with: “Amnion”
-  - Replace with: “Anon”
-  - Replace with: “Aaron”
-
-
-
-Lint:    Spelling (63 priority)
-Message: |
-     216 | that they are theory, abstraction (modeling), and design. Amnon H. Eden
          |                                                                 ^~ Did you mean to spell “H.” this way?
 Suggest:
   - Replace with: “Hi”
   - Replace with: “H”
   - Replace with: “He”
-
-
-
-Lint:    Readability (127 priority)
-Message: |
-     231 | implementing computing systems in hardware and software. CSAB, formerly called
-         |                                                         ^~~~~~~~~~~~~~~~~~~~~~~
-     232 | Computing Sciences Accreditation Board—which is made up of representatives of
-         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-     233 | the Association for Computing Machinery (ACM), and the IEEE Computer Society
-         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-     234 | (IEEE CS)—identifies four areas that it considers crucial to the discipline of
-         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-     235 | computer science: theory of computation, algorithms and data structures,
-         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-     236 | programming methodology and languages, and computer elements and architecture.
-         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 56 words long.
 
 
 
@@ -829,6 +812,23 @@ Suggest:
 
 
 
+Lint:    Readability (127 priority)
+Message: |
+     231 | implementing computing systems in hardware and software. CSAB, formerly called
+         |                                                          ^~~~~~~~~~~~~~~~~~~~~~
+     232 | Computing Sciences Accreditation Board—which is made up of representatives of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     233 | the Association for Computing Machinery (ACM), and the IEEE Computer Society
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     234 | (IEEE CS)—identifies four areas that it considers crucial to the discipline of
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     235 | computer science: theory of computation, algorithms and data structures,
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     236 | programming methodology and languages, and computer elements and architecture.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 56 words long.
+
+
+
 Lint:    Style (31 priority)
 Message: |
      235 | computer science: theory of computation, algorithms and data structures,
@@ -841,10 +841,8 @@ Suggest:
 
 Lint:    Readability (127 priority)
 Message: |
-     236 | programming methodology and languages, and computer elements and architecture.
-         |                                                                               ^
      237 | In addition to these four areas, CSAB also identifies fields such as software
-         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      238 | engineering, artificial intelligence, computer networking and communication,
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      239 | database systems, parallel computation, distributed computation, human–computer
@@ -922,7 +920,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      302 | safety or security is of utmost importance. Formal methods are best described as
-         |                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      303 | the application of a fairly broad variety of theoretical computer science
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      304 | fundamentals, in particular logic calculi, formal languages, automata theory,

--- a/harper-core/tests/text/linters/Part-of-speech tagging.snap.yml
+++ b/harper-core/tests/text/linters/Part-of-speech tagging.snap.yml
@@ -96,7 +96,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
       33 | as the more common plural noun. Grammatical context is one way to determine
-         |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       34 | this; semantic analysis can also be used to infer that "sailor" and "hatch"
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       35 | implicate "dogs" as 1) in the nautical context and 2) an action applied to the
@@ -411,7 +411,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      148 | expensive since it enumerated all possibilities. It sometimes had to resort to
-         |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      149 | backup methods when there were simply too many options (the Brown Corpus
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      150 | contains a case with 17 ambiguous words in a row, and there are words such as
@@ -476,19 +476,6 @@ Suggest:
 
 
 
-Lint:    Readability (127 priority)
-Message: |
-     162 | fields. DeRose used a table of pairs, while Church used a table of triples and a
-         |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-     163 | method of estimating the values for triples that were rare or nonexistent in the
-         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-     164 | Brown Corpus (an actual measurement of triple probabilities would require a much
-         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-     165 | larger corpus). Both methods achieved an accuracy of over 95%. DeRose's 1990
-         | ~~~~~~~~~~~~~~~ This sentence is 43 words long.
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
      162 | fields. DeRose used a table of pairs, while Church used a table of triples and a
@@ -497,6 +484,19 @@ Suggest:
   - Replace with: “Depose”
   - Replace with: “Defoe”
   - Replace with: “Denise”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+     162 | fields. DeRose used a table of pairs, while Church used a table of triples and a
+         |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     163 | method of estimating the values for triples that were rare or nonexistent in the
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     164 | Brown Corpus (an actual measurement of triple probabilities would require a much
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     165 | larger corpus). Both methods achieved an accuracy of over 95%. DeRose's 1990
+         | ~~~~~~~~~~~~~~~ This sentence is 43 words long.
 
 
 
@@ -527,7 +527,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      175 | semantics is required, but those proved negligibly rare. This convinced many in
-         |                                                         ^~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                          ^~~~~~~~~~~~~~~~~~~~~~~
      176 | the field that part-of-speech tagging could usefully be separated from the other
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      177 | levels of processing; this, in turn, simplified the theory and practice of

--- a/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
+++ b/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
@@ -50,7 +50,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
       17 | Representatives. Congress shall make no law respecting an establishment of
-         |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       18 | religion, or prohibiting the free exercise thereof; or abridging the freedom of
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       19 | speech, or of the press; or the right of the people peaceably to assemble, and
@@ -110,7 +110,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
       50 | excluding Indians not taxed. But when the right to vote at any election for the
-         |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       51 | choice of electors for President and Vice President of the United States,
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       52 | Representatives in Congress, the Executive and Judicial officers of a State, or
@@ -144,7 +144,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
       61 | in such Manner as they shall by Law direct. The Number of Representatives shall
-         |                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       62 | not exceed one for every thirty Thousand, but each State shall have at Least
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       63 | one Representative; and until such enumeration shall be made, the State of New
@@ -186,7 +186,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
       86 | they shall be divided as equally as may be into three Classes. The Seats of the
-         |                                                               ^~~~~~~~~~~~~~~~~~
+         |                                                                ^~~~~~~~~~~~~~~~~
       87 | Senators of the first Class shall be vacated at the Expiration of the second
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       88 | Year, of the second Class at the Expiration of the fourth Year, and of the
@@ -360,7 +360,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      155 | the United States. They shall in all Cases, except Treason, Felony and Breach
-         |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      156 | of the Peace, be privileged from Arrest during their Attendance at the Session
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      157 | of their respective Houses, and in going to and returning from the same; and
@@ -449,7 +449,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      181 | Objections at large on their Journal, and proceed to reconsider it. If after
-         |                                                                    ^~~~~~~~~~
+         |                                                                     ^~~~~~~~~
      182 | such Reconsideration two thirds of that House shall agree to pass the Bill, it
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      183 | shall be sent, together with the Objections, to the other House, by which it
@@ -464,7 +464,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      187 | against the Bill shall be entered on the Journal of each House respectively. If
-         |                                                                             ^~~~
+         |                                                                              ^~~
      188 | any Bill shall not be returned by the President within ten Days (Sundays
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      189 | excepted) after it shall have been presented to him, the Same shall be a Law,
@@ -840,7 +840,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      355 | by ballot, the President. But in choosing the President, the votes shall be
-         |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      356 | taken by states, the representation from each state having one vote; a quorum
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      357 | for this purpose shall consist of a member or members from two-thirds of the
@@ -853,7 +853,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      360 | elect shall have died, the Vice President elect shall become President. If a
-         |                                                                        ^~~~~~
+         |                                                                         ^~~~~
      361 | President shall not have been chosen before the time fixed for the beginning of
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      362 | his term, or if the President elect shall have failed to qualify, then the Vice
@@ -884,7 +884,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      372 | President whenever the right of choice shall have devolved upon them.]The
-         |                                                                      ^~~~~
+         |                                                                       ^~~~
      373 | person having the greatest number of votes as Vice-President, shall be the
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      374 | Vice-President, if such number be a majority of the whole number of Electors
@@ -943,7 +943,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      399 | be elected to the office of the President more than once. But this article
-         |                                                          ^~~~~~~~~~~~~~~~~~
+         |                                                           ^~~~~~~~~~~~~~~~~
      400 | shall not apply to any person holding the office of President when this article
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      401 | was proposed by the Congress, and shall not prevent any person who may be
@@ -1061,7 +1061,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      437 | purpose if not in session. If the Congress, within twenty-one days after
-         |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      438 | receipt of the latter written declaration, or, if Congress is not in session,
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      439 | within twenty-one days after Congress is required to assemble, determines by
@@ -1383,7 +1383,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      610 | the State wherein they reside. No State shall make or enforce any law which
-         |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      611 | shall abridge the privileges or immunities of citizens of the United States;
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      612 | nor shall any State deprive any person of life, liberty, or property, without
@@ -1445,7 +1445,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      627 | States, or any place subject to their jurisdiction. No Person held to Service
-         |                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~
      628 | or Labour in one State, under the Laws thereof, escaping into another, shall,
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      629 | in Consequence of any Law or Regulation therein, be discharged from such
@@ -1548,7 +1548,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      658 | questioned. But neither the United States nor any State shall assume or pay any
-         |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      659 | debt or obligation incurred in aid of insurrection or rebellion against the
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      660 | United States, or any claim for the loss or emancipation of any slave; but all

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -40,7 +40,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
       17 | bores. The abnormal mind is quick to detect and attach itself to this quality
-         |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       18 | when it appears in a normal person, and so it came about that in college I was
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       19 | unjustly accused of being a politician, because I was privy to the secret griefs
@@ -53,7 +53,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
       20 | of wild, unknown men. Most of the confidences were unsought—frequently I have
-         |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       21 | feigned sleep, preoccupation, or a hostile levity when I realized by some
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       22 | unmistakable sign that an intimate revelation was quivering on the horizon; for
@@ -101,7 +101,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
       32 | after a certain point I don’t care what it’s founded on. When I came back from
-         |                                                         ^~~~~~~~~~~~~~~~~~~~~~~
+         |                                                          ^~~~~~~~~~~~~~~~~~~~~~
       33 | the East last autumn I felt that I wanted the world to be in uniform and at a
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       34 | sort of moral attention forever; I wanted no more riotous excursions with
@@ -114,7 +114,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
       37 | everything for which I have an unaffected scorn. If personality is an unbroken
-         |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       38 | series of successful gestures, then there was something gorgeous about him, some
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       39 | heightened sensitivity to the promises of life, as if he were related to one of
@@ -127,7 +127,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
       40 | those intricate machines that register earthquakes ten thousand miles away. This
-         |                                                                            ^~~~~~
+         |                                                                             ^~~~~
       41 | responsiveness had nothing to do with that flabby impressionability which is
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       42 | dignified under the name of the “creative temperament”—it was an extraordinary
@@ -142,7 +142,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
       44 | person and which it is not likely I shall ever find again. No—Gatsby turned out
-         |                                                           ^~~~~~~~~~~~~~~~~~~~~~
+         |                                                            ^~~~~~~~~~~~~~~~~~~~~
       45 | all right at the end; it is what preyed on Gatsby, what foul dust floated in the
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       46 | wake of his dreams that temporarily closed out my interest in the abortive
@@ -167,7 +167,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
       50 | three generations. The Carraways are something of a clan, and we have a
-         |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       51 | tradition that we’re descended from the Dukes of Buccleuch, but the actual
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       52 | founder of my line was my grandfather’s brother, who came here in fifty-one,
@@ -240,7 +240,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
       74 | Washington, and I went out to the country alone. I had a dog—at least I had him
-         |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       75 | for a few days until he ran away—and an old Dodge and a Finnish woman, who made
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       76 | my bed and cooked breakfast and muttered Finnish wisdom to herself over the
@@ -253,7 +253,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
       93 | down out of the young breath-giving air. I bought a dozen volumes on banking and
-         |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       94 | credit and investment securities, and they stood on my shelf in red and gold
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       95 | like new money from the mint, promising to unfold the shining secrets that only
@@ -278,7 +278,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
       97 | other books besides. I was rather literary in college—one year I wrote a series
-         |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       98 | of very solemn and obvious editorials for the Yale News—and now I was going to
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       99 | bring back all such things into my life and become again that most limited of
@@ -291,7 +291,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      106 | natural curiosities, two unusual formations of land. Twenty miles from the city
-         |                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      107 | a pair of enormous eggs, identical in contour and separated only by a courtesy
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      108 | bay, jut out into the most domesticated body of salt water in the Western
@@ -304,7 +304,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      119 | thousand a season. The one on my right was a colossal affair by any standard—it
-         |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      120 | was a factual imitation of some Hôtel de Ville in Normandy, with a tower on one
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      121 | side, spanking new under a thin beard of raw ivy, and a marble swimming pool,
@@ -363,7 +363,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      124 | of that name. My own house was an eyesore, but it was a small eyesore, and it
-         |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      125 | had been overlooked, so I had a view of the water, a partial view of my
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      126 | neighbor’s lawn, and the consoling proximity of millionaires—all for eighty
@@ -409,7 +409,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      138 | everything afterward savors of anti-climax. His family were enormously
-         |                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      139 | wealthy—even in college his freedom with money was a matter for reproach—but now
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      140 | he’d left Chicago and come East in a fashion that rather took your breath away:
@@ -432,7 +432,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      146 | played polo and were rich together. This was a permanent move, said Daisy over
-         |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      147 | the telephone, but I didn’t believe it—I had no sight into Daisy’s heart, but I
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      148 | felt that Tom would drift on forever seeking, a little wistfully, for the
@@ -445,7 +445,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      154 | the bay. The lawn started at the beach and ran toward the front door for a
-         |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      155 | quarter of a mile, jumping over sun-dials and brick walks and burning
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      156 | gardens—finally when it reached the house drifting up the side in bright vines
@@ -467,7 +467,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      165 | appearance of always leaning aggressively forward. Not even the effeminate swank
-         |                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      166 | of his riding clothes could hide the enormous power of that body—he seemed to
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      167 | fill those glistening boots until he strained the top lacing, and you could see
@@ -532,7 +532,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      195 | into the house. A breeze blew through the room, blew curtains in at one end and
-         |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      196 | out the other like pale flags, twisting them up toward the frosted wedding-cake
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      197 | of the ceiling, and then rippled over the wine-colored rug, making a shadow on
@@ -545,7 +545,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      236 | speech is an arrangement of notes that will never be played again. Her face was
-         |                                                                   ^~~~~~~~~~~~~~
+         |                                                                    ^~~~~~~~~~~~~
      237 | sad and lovely with bright things in it, bright eyes and a bright passionate
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      238 | mouth, but there was an excitement in her voice that men who had cared for her
@@ -698,7 +698,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      484 | The horses, needless to say, were not mentioned again. Tom and Miss Baker, with
-         |                                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~
      485 | several feet of twilight between them, strolled back into the library, as if to
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      486 | a vigil beside a perfectly tangible body, while, trying to look pleasantly
@@ -812,7 +812,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      633 | of the earth blew the frogs full of life. The silhouette of a moving cat wavered
-         |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      634 | across the moonlight, and turning my head to watch it, I saw that I was not
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      635 | alone—fifty feet away a figure had emerged from the shadow of my neighbor’s
@@ -827,7 +827,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      642 | do for an introduction. But I didn’t call to him, for he gave a sudden
-         |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      643 | intimation that he was content to be alone—he stretched out his arms toward the
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      644 | dark water in a curious way, and, far as I was from him, I could have sworn he
@@ -850,7 +850,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      654 | certain desolate area of land. This is a valley of ashes—a fantastic farm where
-         |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      655 | ashes grow like wheat into ridges and hills and grotesque gardens; where ashes
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      656 | take the forms of houses and chimneys and rising smoke and, finally, with a
@@ -865,7 +865,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      658 | through the powdery air. Occasionally a line of gray cars crawls along an
-         |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      659 | invisible track, gives out a ghastly creak, and comes to rest, and immediately
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      660 | the ash-gray men swarm up with leaden spades and stir up an impenetrable cloud,
@@ -1033,7 +1033,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      703 | dust-covered wreck of a Ford which crouched in a dim corner. It had occurred to
-         |                                                             ^~~~~~~~~~~~~~~~~~~~
+         |                                                              ^~~~~~~~~~~~~~~~~~~
      704 | me that this shadow of a garage must be a blind, and that sumptuous and romantic
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      705 | apartments were concealed overhead, when the proprietor himself appeared in the
@@ -1179,7 +1179,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
      850 | Wilson was first concerned with the dog. A reluctant elevator-boy went for a box
-         |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      851 | full of straw and some milk, to which he added on his own initiative a tin of
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      852 | large, hard dog-biscuits— one of which decomposed apathetically in the saucer of
@@ -1192,7 +1192,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
      860 | and I went out to buy some at the drugstore on the corner. When I came back they
-         |                                                           ^~~~~~~~~~~~~~~~~~~~~~~
+         |                                                            ^~~~~~~~~~~~~~~~~~~~~~
      861 | had both disappeared, so I sat down discreetly in the living-room and read a
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      862 | chapter of “Simon Called Peter”—either it was terrible stuff or the whiskey
@@ -1344,7 +1344,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     1078 | supper in themselves. I wanted to get out and walk eastward toward the park
-         |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1079 | through the soft twilight, but each time I tried to go I became entangled in
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1080 | some wild, strident argument which pulled me back, as if with ropes, into my
@@ -1390,7 +1390,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     1128 | awoke from his doze and started in a daze toward the door. When he had gone half
-         |                                                           ^~~~~~~~~~~~~~~~~~~~~~~
+         |                                                            ^~~~~~~~~~~~~~~~~~~~~~
     1129 | way he turned around and stared at the scene—his wife and Catherine scolding and
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1130 | consoling as they stumbled here and there among the crowded furniture with
@@ -1465,7 +1465,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     1161 | champagne and the stars. At high tide in the afternoon I watched his guests
-         |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1162 | diving from the tower of his raft, or taking the sun on the hot sand of his
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1163 | beach while his two motor-boats slit the waters of the Sound, drawing aquaplanes
@@ -1546,7 +1546,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     1188 | piccolos, and low and high drums. The last swimmers have come in from the beach
-         |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1189 | now and are dressing up-stairs; the cars from New York are parked five deep in
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1190 | the drive, and already the halls and salons and verandas are gaudy with primary
@@ -1573,7 +1573,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     1192 | Castile. The bar is in full swing, and floating rounds of cocktails permeate the
-         |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1193 | garden outside, until the air is alive with chatter and laughter, and casual
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1194 | innuendo and introductions forgotten on the spot, and enthusiastic meetings
@@ -1586,7 +1586,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     1200 | tipped out at a cheerful word. The groups change more swiftly, swell with new
-         |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1201 | arrivals, dissolve and form in the same breath; already there are wanderers,
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1202 | confident girls who weave here and there among the stouter and more stable,
@@ -1626,7 +1626,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     1223 | I had been actually invited. A chauffeur in a uniform of robin’s-egg blue
-         |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1224 | crossed my lawn early that Saturday morning with a surprisingly formal note from
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1225 | his employer: the honor would be entirely Gatsby’s, it said, if I would attend
@@ -1855,7 +1855,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     1463 | prejudice in your favor. It understood you just so far as you wanted to be
-         |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1464 | understood, believed in you as you would like to believe in yourself, and
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1465 | assured you that it had precisely the impression of you that, at your best, you
@@ -1937,7 +1937,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     1529 | more correct as the fraternal hilarity increased. When the “Jazz History of the
-         |                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1530 | World” was over, girls were putting their heads on men’s shoulders in a
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1531 | puppyish, convivial way, girls were swooning backward playfully into men’s arms,
@@ -1976,7 +1976,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     1574 | rent asunder by dissension. One of the men was talking with curious intensity to
-         |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1575 | a young actress, and his wife, after attempting to laugh at the situation in a
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1576 | dignified and indifferent way, broke down entirely and resorted to flank
@@ -2099,7 +2099,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     1740 | potatoes and coffee. I even had a short affair with a girl who lived in Jersey
-         |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1741 | City and worked in the accounting department, but her brother began throwing
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1742 | mean looks in my direction, so when she went on her vacation in July I let it
@@ -2112,7 +2112,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     1759 | darkness. At the enchanted metropolitan twilight I felt a haunting loneliness
-         |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1760 | sometimes, and felt it in others—poor young clerks who loitered in front of
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1761 | windows waiting until it was time for a solitary restaurant dinner—young clerks
@@ -2150,7 +2150,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     1777 | found what it was. When we were on a house-party together up in Warwick, she
-         |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1778 | left a borrowed car out in the rain with the top down, and then lied about
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1779 | it—and suddenly I remembered the story about her that had eluded me that night
@@ -2163,7 +2163,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     1789 | thought impossible. She was incurably dishonest. She wasn’t able to endure being
-         |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1790 | at a disadvantage and, given this unwillingness, I suppose she had begun dealing
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1791 | in subterfuges when she was very young in order to keep that cool, insolent
@@ -2565,19 +2565,6 @@ Suggest:
 
 
 
-Lint:    Readability (127 priority)
-Message: |
-    1871 | afterward strangled his wife. Da Fontano the promoter came there, and Ed Legros
-         |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    1872 | and James B. (“Rot-Gut”) Ferret and the De Jongs and Ernest Lilly—they came to
-         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    1873 | gamble, and when Ferret wandered into the garden it meant he was cleaned out and
-         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    1874 | Associated Traction would have to fluctuate profitably next day.
-         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 49 words long.
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
     1871 | afterward strangled his wife. Da Fontano the promoter came there, and Ed Legros
@@ -2586,6 +2573,19 @@ Suggest:
   - Replace with: “D”
   - Replace with: “Dab”
   - Replace with: “Dad”
+
+
+
+Lint:    Readability (127 priority)
+Message: |
+    1871 | afterward strangled his wife. Da Fontano the promoter came there, and Ed Legros
+         |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1872 | and James B. (“Rot-Gut”) Ferret and the De Jongs and Ernest Lilly—they came to
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1873 | gamble, and when Ferret wandered into the garden it meant he was cleaned out and
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    1874 | Associated Traction would have to fluctuate profitably next day.
+         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 49 words long.
 
 
 
@@ -2692,7 +2692,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     1879 | Bull. Also from New York were the Chromes and the Backhyssons and the Dennickers
-         |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1880 | and Russel Betty and the Corrigans and the Kellehers and the Dewars and the
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1881 | Scullys and S. W. Belcher and the Smirkes and the young Quinns, divorced now,
@@ -2856,7 +2856,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     1887 | inevitably seemed they had been there before. I have forgotten their
-         |                                              ^~~~~~~~~~~~~~~~~~~~~~~~
+         |                                               ^~~~~~~~~~~~~~~~~~~~~~~
     1888 | names—Jaqueline, I think, or else Consuela, or Gloria or Judy or June, and their
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1889 | last names were either the melodious names of flowers and months or the sterner
@@ -3004,7 +3004,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     1974 | “After that I lived like a young rajah in all the capitals of Europe—Paris,
-         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1975 | Venice, Rome—collecting jewels, chiefly rubies, hunting big game, painting a
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1976 | little, things for myself only, and trying to forget something very sad that had
@@ -3507,7 +3507,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     2291 | with rubber nobs on the soles that bit into the soft ground. I had on a new
-         |                                                             ^~~~~~~~~~~~~~~~
+         |                                                              ^~~~~~~~~~~~~~~
     2292 | plaid skirt also that blew a little in the wind, and whenever this happened the
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2293 | red, white, and blue banners in front of all the houses stretched out stiff and
@@ -3555,7 +3555,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     2332 | than Louisville ever knew before. He came down with a hundred people in four
-         |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2333 | private cars, and hired a whole floor of the Muhlbach Hotel, and the day before
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2334 | the wedding he gave her a string of pearls valued at three hundred and fifty
@@ -3631,7 +3631,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     2360 | But she didn’t say another word. We gave her spirits of ammonia and put ice on
-         |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2361 | her forehead and hooked her back into her dress, and half an hour later, when we
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2362 | walked out of the room, the pearls were around her neck and the incident was
@@ -3785,7 +3785,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     2606 | thin drops swam like dew. Gatsby looked with vacant eyes through a copy of
-         |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2607 | Clay’s “Economics,” starting at the Finnish tread that shook the kitchen floor,
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2608 | and peering toward the bleared windows from time to time as if a series of
@@ -3851,7 +3851,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     2673 | a strained counterfeit of perfect ease, even of boredom. His head leaned back so
-         |                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                          ^~~~~~~~~~~~~~~~~~~~~~~~
     2674 | far that it rested against the face of a defunct mantelpiece clock, and from
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2675 | this position his distraught eyes stared down at Daisy, who was sitting,
@@ -3884,7 +3884,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     2743 | steeple, for half an hour. A brewer had built it early in the “period” craze, a
-         |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2744 | decade before, and there was a story that he’d agreed to pay five years’ taxes
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2745 | on all the neighboring cottages if the owners would have their roofs thatched
@@ -3938,7 +3938,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     2827 | entered by the big postern. With enchanting murmurs Daisy admired this aspect or
-         |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2828 | that of the feudal silhouette against the sky, admired the gardens, the
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2829 | sparkling odor of jonquils and the frothy odor of hawthorn and plum blossoms and
@@ -4128,7 +4128,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     3020 | short of being news. Contemporary legends such as the “underground pipe-line to
-         |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3021 | Canada” attached themselves to him, and there was one persistent story that he
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3022 | didn’t live in a house at all, but in a boat that looked like a house and was
@@ -4164,7 +4164,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     3029 | on Lake Superior. It was James Gatz who had been loafing along the beach that
-         |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3030 | afternoon in a torn green jersey and a pair of canvas pants, but it was already
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3031 | Jay Gatsby who borrowed a rowboat, pulled out to the Tuolomee, and informed Cody
@@ -4339,7 +4339,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     3116 | It was a halt, too, in my association with his affairs. For several weeks I
-         |                                                        ^~~~~~~~~~~~~~~~~~~~~
+         |                                                         ^~~~~~~~~~~~~~~~~~~~
     3117 | didn’t see him or hear his voice on the phone—mostly I was in New York, trotting
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3118 | around with Jordan and trying to ingratiate myself with her senile aunt—but
@@ -4404,7 +4404,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     3235 | in my memory from Gatsby’s other parties that summer. There were the same
-         |                                                      ^~~~~~~~~~~~~~~~~~~~~
+         |                                                       ^~~~~~~~~~~~~~~~~~~~
     3236 | people, or at least the same sort of people, the same profusion of champagne,
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3237 | the same many-colored, many-keyed commotion, but I felt an unpleasantness in the
@@ -4428,7 +4428,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     3238 | air, a pervading harshness that hadn’t been there before. Or perhaps I had
-         |                                                          ^~~~~~~~~~~~~~~~~~
+         |                                                           ^~~~~~~~~~~~~~~~~
     3239 | merely grown used to it, grown to accept West Egg as a world complete in itself,
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3240 | with its own standards and its own great figures, second to nothing because it
@@ -4526,7 +4526,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     3350 | emotion. She was appalled by West Egg, this unprecedented “place” that Broadway
-         |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3351 | had begotten upon a Long Island fishing village—appalled by its raw vigor that
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3352 | chafed under the old euphemisms and by the too obtrusive fate that herded its
@@ -4550,7 +4550,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     3414 | dim, incalculable hours? Perhaps some unbelievable guest would arrive, a person
-         |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3415 | infinitely rare and to be marvelled at, some authentically radiant young girl
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3416 | who with one fresh glance at Gatsby, one moment of magical encounter, would blot
@@ -4585,10 +4585,8 @@ Message: |
 
 Lint:    Readability (127 priority)
 Message: |
-    3473 | humming out into the darkness and there was a stir and bustle among the stars.
-         |                                                                               ^
     3474 | Out of the corner of his eye Gatsby saw that the blocks of the sidewalks really
-         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3475 | formed a ladder and mounted to a secret place above the trees—he could climb to
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3476 | it, if he climbed alone, and once there he could suck on the pap of life, gulp
@@ -4683,7 +4681,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     3553 | of the National Biscuit Company broke the simmering hush at noon. The straw
-         |                                                                  ^~~~~~~~~~~
+         |                                                                   ^~~~~~~~~~
     3554 | seats of the car hovered on the edge of combustion; the woman next to me
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3555 | perspired delicately for a while into her white shirtwaist, and then, as her
@@ -5028,7 +5026,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     3937 | world, and the shock had made him physically sick. I stared at him and then at
-         |                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3938 | Tom, who had made a parallel discovery less than an hour before—and it occurred
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3939 | to me that there was no difference between men, in intelligence or race, so
@@ -5086,7 +5084,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     3955 | into her face like objects into a slowly developing picture. Her expression was
-         |                                                             ^~~~~~~~~~~~~~~~~~~~
+         |                                                              ^~~~~~~~~~~~~~~~~~~
     3956 | curiously familiar—it was an expression I had often seen on women’s faces, but
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3957 | on Myrtle Wilson’s face it seemed purposeless and inexplicable until I realized
@@ -5101,7 +5099,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     3963 | ago secure and inviolate, were slipping precipitately from his control. Instinct
-         |                                                                        ^~~~~~~~~~
+         |                                                                         ^~~~~~~~~
     3964 | made him step on the accelerator with the double purpose of overtaking Daisy and
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3965 | leaving Wilson behind, and we sped along toward Astoria at fifty miles an hour,
@@ -5432,7 +5430,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     4337 | defending his name against accusations that had not been made. But with every
-         |                                                               ^~~~~~~~~~~~~~~~
+         |                                                                ^~~~~~~~~~~~~~~
     4338 | word she was drawing further and further into herself, so he gave that up, and
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     4339 | only the dead dream fought on as the afternoon slipped away, trying to touch
@@ -5596,7 +5594,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     4427 | policeman that it was light green. The other car, the one going toward New York,
-         |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     4428 | came to rest a hundred yards beyond, and it’s driver hurried back to where
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     4429 | Myrtle Wilson, her life violently extinguished, knelt in the road and mingled
@@ -5672,7 +5670,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     4470 | a little book. At first I couldn’t find the source of the high, groaning words
-         |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     4471 | that echoed clamorously through the bare garage—then I saw Wilson standing on
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     4472 | the raised threshold of his office, swaying back and forth and holding to the
@@ -5980,10 +5978,8 @@ Suggest:
 
 Lint:    Readability (127 priority)
 Message: |
-    4738 | and I tossed half-sick between grotesque reality and savage, frightening dreams.
-         |                                                                                 ^
     4739 | Toward dawn I heard a taxi go up Gatsby’s drive, and immediately I jumped out of
-         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     4740 | bed and began to dress—I felt that I had something to tell him, something to
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     4741 | warn him about, and morning would be too late.
@@ -6005,7 +6001,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     4780 | her as his tent out at camp was to him. There was a ripe mystery about it, a
-         |                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     4781 | hint of bedrooms up-stairs more beautiful and cool than other bedrooms, of gay
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     4782 | and radiant activities taking place through its corridors, and of romances that
@@ -6022,7 +6018,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     4797 | pretenses. I don’t mean that he had traded on his phantom millions, but he had
-         |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     4798 | deliberately given Daisy a sense of security; he let her believe that he was a
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     4799 | person from much the same strata as herself—that he was fully able to take care
@@ -6035,7 +6031,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     4814 | kissed her curious and lovely mouth. She had caught a cold, and it made her
-         |                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     4815 | voice huskier and more charming than ever, and Gatsby was overwhelmingly aware
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     4816 | of the youth and mystery that wealth imprisons and preserves, of the freshness
@@ -6059,10 +6055,8 @@ Suggest:
 
 Lint:    Readability (127 priority)
 Message: |
-    4832 | as if to give them a deep memory for the long parting the next day promised.
-         |                                                                             ^
     4833 | They had never been closer in their month of love, nor communicated more
-         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     4834 | profoundly one with another, than when she brushed silent lips against his
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     4835 | coat’s shoulder or when he touched the end of her fingers, gently, as though she
@@ -6154,7 +6148,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     5016 | to the other side of the car. I supposed there’d be a curious crowd around there
-         |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5017 | all day with little boys searching for dark spots in the dust, and some
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5018 | garrulous man telling over and over what had happened, until it became less and
@@ -6198,7 +6192,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     5041 | quieter and began to talk about the yellow car. He announced that he had a way
-         |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5042 | of finding out whom the yellow car belonged to, and then he blurted out that a
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5043 | couple of months ago his wife had come from the city with her face bruised and
@@ -6240,7 +6234,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     5059 | the car that hadn’t stopped a few hours before. He didn’t like to go into the
-         |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5060 | garage, because the work bench was stained where the body had been lying, so he
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5061 | moved uncomfortably around the office—he knew every object in it before
@@ -6478,7 +6472,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     5230 | and out of Gatsby’s front door. A rope stretched across the main gate and a
-         |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5231 | policeman by it kept out the curious, but little boys soon discovered that they
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5232 | could enter through my yard, and there were always a few of them clustered
@@ -6511,10 +6505,8 @@ Suggest:
 
 Lint:    Readability (127 priority)
 Message: |
-    5241 | racy pasquinade—but Catherine, who might have said anything, didn’t say a word.
-         |                                                                                ^
     5242 | She showed a surprising amount of character about it too—looked at the coroner
-         | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5243 | with determined eyes under that corrected brow of hers, and swore that her
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5244 | sister had never seen Gatsby, that her sister was completely happy with her
@@ -6527,7 +6519,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     5253 | referred to me. At first I was surprised and confused; then, as he lay in his
-         |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5254 | house and didn’t move or breathe or speak, hour upon hour, it grew upon me that
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5255 | I was responsible, because no one else was interested—interested, I mean, with
@@ -6749,7 +6741,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     5386 | face flushed slightly, his eyes leaking isolated and unpunctual tears. He had
-         |                                                                       ^~~~~~~~
+         |                                                                        ^~~~~~~
     5387 | reached an age where death no longer has the quality of ghastly surprise, and
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5388 | when he looked around him now for the first time and saw the height and splendor
@@ -7043,7 +7035,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     5660 | from college at Christmas time. Those who went farther than Chicago would gather
-         |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5661 | in the old dim Union Street station at six o’clock of a December evening, with a
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5662 | few Chicago friends, already caught up into their own holiday gayeties, to bid
@@ -7068,7 +7060,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     5663 | them a hasty good-by. I remember the fur coats of the girls returning from Miss
-         |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5664 | This-or-That’s and the chatter of frozen breath and the hands waving overhead as
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5665 | we caught sight of old acquaintances, and the matchings of invitations: “Are you
@@ -7170,7 +7162,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     5683 | city where dwellings are still called through decades by a family’s name. I see
-         |                                                                          ^~~~~~~
+         |                                                                           ^~~~~~
     5684 | now that this has been a story of the West, after all—Tom and Gatsby, Daisy and
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5685 | Jordan and I, were all Westerners, and perhaps we possessed some deficiency in
@@ -7278,7 +7270,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     5743 | One afternoon late in October I saw Tom Buchanan. He was walking ahead of me
-         |                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
     5744 | along Fifth Avenue in his alert, aggressive way, his hands out a little from his
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5745 | body as if to fight off interference, his head moving sharply here and there,
@@ -7291,7 +7283,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     5775 | “And if you think I didn’t have my share of suffering—look here, when I went to
-         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5776 | give up that flat and saw that damn box of dog biscuits sitting there on the
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5777 | sideboard, I sat down and cried like a baby. By God it was awful—”
@@ -7302,7 +7294,7 @@ Message: |
 Lint:    Readability (127 priority)
 Message: |
     5780 | entirely justified. It was all very careless and confused. They were careless
-         |                                                           ^~~~~~~~~~~~~~~~~~~~
+         |                                                            ^~~~~~~~~~~~~~~~~~~
     5781 | people, Tom and Daisy—they smashed up things and creatures and then retreated
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5782 | back into their money or their vast carelessness, or whatever it was that kept
@@ -7325,7 +7317,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     5791 | long as mine. One of the taxi drivers in the village never took a fare past the
-         |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5792 | entrance gate without stopping for a minute and pointing inside; perhaps it was
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5793 | he who drove Daisy and Gatsby over to East Egg the night of the accident, and
@@ -7363,7 +7355,7 @@ Suggest:
 Lint:    Readability (127 priority)
 Message: |
     5814 | green breast of the new world. Its vanished trees, the trees that had made way
-         |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5815 | for Gatsby’s house, had once pandered in whispers to the last and greatest of
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     5816 | all human dreams; for a transitory enchanted moment man must have held his


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->

Found by looking through #1228 

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

This PR changes the `LongSentences` lint to emit lints whose spans start at the first word, not the space before.

# Demo

Look at the snapshot tests to see the difference in output.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
