### PR TITLE
refactor: don't allocate when linting chunks

### DIFF
--- a/harper-core/src/linting/pattern_linter.rs
+++ b/harper-core/src/linting/pattern_linter.rs
@@ -45,13 +45,15 @@ where
     }
 }
 
-pub fn run_on_chunk(linter: &impl PatternLinter, chunk: &[Token], source: &[char]) -> Vec<Lint> {
-    let mut lints = Vec::new();
-
-    for match_span in linter.pattern().iter_matches(chunk, source) {
-        let lint = linter.match_to_lint(&chunk[match_span.start..match_span.end], source);
-        lints.extend(lint);
-    }
-
-    lints
+pub fn run_on_chunk(
+    linter: &impl PatternLinter,
+    chunk: &[Token],
+    source: &[char],
+) -> impl Iterator<Item = Lint> {
+    linter
+        .pattern()
+        .iter_matches(chunk, source)
+        .filter_map(|match_span| {
+            linter.match_to_lint(&chunk[match_span.start..match_span.end], source)
+        })
 }


### PR DESCRIPTION

# Description
I didn't like that `run_on_chunks` allocates a new `Vec` for every chunk with a lint in it. So I made it return an iterator instead.

This doesn't change the behavior of Harper in any way.

# How Has This Been Tested?
Hasn't been.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
