### PR TITLE
refactor: remove unnecessary Option in PhrasalVerbAsCompoundNoun

### DIFF
--- a/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
+++ b/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
@@ -139,10 +139,8 @@ impl Linter for PhrasalVerbAsCompoundNoun {
             }
 
             let message = match (phrasal_verb_is_verb, verb_part_is_verb) {
-                (true, _) => Some("This word should be a phrasal verb, not a compound noun."),
-                (false, true) => {
-                    Some("This word might be a phrasal verb rather than a compound noun.")
-                }
+                (true, _) => "This word should be a phrasal verb, not a compound noun.",
+                (false, true) => "This word might be a phrasal verb rather than a compound noun.",
                 _ => continue,
             };
 
@@ -176,7 +174,7 @@ impl Linter for PhrasalVerbAsCompoundNoun {
                 span: Span::new(token.span.start, token.span.end),
                 lint_kind: LintKind::WordChoice,
                 suggestions: vec![Suggestion::ReplaceWith(phrasal_verb.chars().collect())],
-                message: message.unwrap().to_string(),
+                message: message.to_string(),
                 priority: 63,
             });
         }


### PR DESCRIPTION
# Description
`message` was only ever assigned `Option::Some` values, so I removed the unnecessary `Option` wrapper.

# How Has This Been Tested?
Hasn't been.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
