### PR TITLE
feat: improve spell check suggestions by accounting for common misspellings

### DIFF
--- a/harper-core/src/linting/spell_check.rs
+++ b/harper-core/src/linting/spell_check.rs
@@ -6,7 +6,10 @@ use smallvec::ToSmallVec;
 use super::Suggestion;
 use super::{Lint, LintKind, Linter};
 use crate::document::Document;
-use crate::spell::{is_ou_misspelling, is_sz_misspelling, suggest_correct_spelling};
+use crate::spell::{
+    is_er_misspelling, is_ll_misspelling, is_ou_misspelling, is_sz_misspelling,
+    suggest_correct_spelling,
+};
 use crate::{CharString, CharStringExt, Dialect, Dictionary, TokenStringExt};
 
 pub struct SpellCheck<T>
@@ -87,6 +90,8 @@ impl<T: Dictionary> Linter for SpellCheck<T> {
                 // If the most likely suggestion is a common misspelling, ignore all others.
                 if is_ou_misspelling(most_likely, word_chars)
                     || is_sz_misspelling(most_likely, word_chars)
+                    || is_er_misspelling(most_likely, word_chars)
+                    || is_ll_misspelling(most_likely, word_chars)
                 {
                     possibilities.truncate(1);
                 }

--- a/harper-core/src/linting/spell_check.rs
+++ b/harper-core/src/linting/spell_check.rs
@@ -6,7 +6,7 @@ use smallvec::ToSmallVec;
 use super::Suggestion;
 use super::{Lint, LintKind, Linter};
 use crate::document::Document;
-use crate::spell::suggest_correct_spelling;
+use crate::spell::{is_ou_misspelling, is_sz_misspelling, suggest_correct_spelling};
 use crate::{CharString, CharStringExt, Dialect, Dictionary, TokenStringExt};
 
 pub struct SpellCheck<T>
@@ -26,39 +26,46 @@ impl<T: Dictionary> SpellCheck<T> {
             dialect,
         }
     }
-}
 
-impl<T: Dictionary> SpellCheck<T> {
-    fn cached_suggest_correct_spelling(&mut self, word: &[char]) -> Vec<CharString> {
+    const MAX_SUGGESTIONS: usize = 3;
+
+    fn suggest_correct_spelling(&mut self, word: &[char]) -> Vec<CharString> {
         if let Some(hit) = self.word_cache.get(word) {
-            return hit.clone();
+            hit.clone()
+        } else {
+            let suggestions = self.uncached_suggest_correct_spelling(word);
+            self.word_cache.put(word.into(), suggestions.clone());
+            suggestions
         }
-
+    }
+    fn uncached_suggest_correct_spelling(&self, word: &[char]) -> Vec<CharString> {
         // Back off until we find a match.
-        let mut suggestions = Vec::new();
-        let mut dist = 2;
+        for dist in 2..5 {
+            let mut suggestions: Vec<CharString> =
+                suggest_correct_spelling(word, 100, dist, &self.dictionary)
+                    .into_iter()
+                    .filter(|v| {
+                        // ignore entries outside the configured dialect
+                        self.dictionary
+                            .get_word_metadata(v)
+                            .unwrap()
+                            .dialect
+                            .is_none_or(|d| d == self.dialect)
+                    })
+                    .map(|v| v.to_smallvec())
+                    .collect();
 
-        while suggestions.is_empty() && dist < 5 {
-            suggestions = suggest_correct_spelling(word, 100, dist, &self.dictionary)
-                .into_iter()
-                .map(|v| v.to_smallvec())
-                .collect();
+            if !suggestions.is_empty() {
+                if suggestions.len() > Self::MAX_SUGGESTIONS {
+                    suggestions.resize_with(Self::MAX_SUGGESTIONS, || panic!());
+                }
 
-            dist += 1;
+                return suggestions;
+            }
         }
 
-        // Remove entries outside the configured dialect
-        suggestions.retain(|v| {
-            self.dictionary
-                .get_word_metadata(v)
-                .unwrap()
-                .dialect
-                .is_none_or(|d| d == self.dialect)
-        });
-
-        self.word_cache.put(word.into(), suggestions.clone());
-
-        suggestions
+        // no suggestions found
+        Vec::new()
     }
 }
 
@@ -78,10 +85,14 @@ impl<T: Dictionary> Linter for SpellCheck<T> {
                 }
             };
 
-            let mut possibilities = self.cached_suggest_correct_spelling(word_chars);
-
-            if possibilities.len() > 3 {
-                possibilities.resize_with(3, || panic!());
+            let mut possibilities = self.suggest_correct_spelling(word_chars);
+            if let Some(most_likely) = possibilities.first() {
+                // If the most likely suggestion is a common misspelling, ignore all others.
+                if is_ou_misspelling(most_likely, word_chars)
+                    || is_sz_misspelling(most_likely, word_chars)
+                {
+                    possibilities.truncate(1);
+                }
             }
 
             // If the misspelled word is capitalized, capitalize the results too.

--- a/harper-core/src/linting/spell_check.rs
+++ b/harper-core/src/linting/spell_check.rs
@@ -7,7 +7,7 @@ use super::Suggestion;
 use super::{Lint, LintKind, Linter};
 use crate::document::Document;
 use crate::spell::{
-    is_er_misspelling, is_ll_misspelling, is_ou_misspelling, is_sz_misspelling,
+    is_cksz_misspelling, is_er_misspelling, is_ll_misspelling, is_ou_misspelling,
     suggest_correct_spelling,
 };
 use crate::{CharString, CharStringExt, Dialect, Dictionary, TokenStringExt};
@@ -89,7 +89,7 @@ impl<T: Dictionary> Linter for SpellCheck<T> {
             if let Some(most_likely) = possibilities.first() {
                 // If the most likely suggestion is a common misspelling, ignore all others.
                 if is_ou_misspelling(most_likely, word_chars)
-                    || is_sz_misspelling(most_likely, word_chars)
+                    || is_cksz_misspelling(most_likely, word_chars)
                     || is_er_misspelling(most_likely, word_chars)
                     || is_ll_misspelling(most_likely, word_chars)
                 {

--- a/harper-core/src/linting/spell_check.rs
+++ b/harper-core/src/linting/spell_check.rs
@@ -41,7 +41,7 @@ impl<T: Dictionary> SpellCheck<T> {
     fn uncached_suggest_correct_spelling(&self, word: &[char]) -> Vec<CharString> {
         // Back off until we find a match.
         for dist in 2..5 {
-            let mut suggestions: Vec<CharString> =
+            let suggestions: Vec<CharString> =
                 suggest_correct_spelling(word, 100, dist, &self.dictionary)
                     .into_iter()
                     .filter(|v| {
@@ -53,13 +53,10 @@ impl<T: Dictionary> SpellCheck<T> {
                             .is_none_or(|d| d == self.dialect)
                     })
                     .map(|v| v.to_smallvec())
+                    .take(Self::MAX_SUGGESTIONS)
                     .collect();
 
             if !suggestions.is_empty() {
-                if suggestions.len() > Self::MAX_SUGGESTIONS {
-                    suggestions.resize_with(Self::MAX_SUGGESTIONS, || panic!());
-                }
-
                 return suggestions;
             }
         }

--- a/harper-core/tests/text/Spell.md
+++ b/harper-core/tests/text/Spell.md
@@ -1,0 +1,11 @@
+# Spell
+
+This document contains example sentences with misspelled words that we want to test the spell checker on.
+
+## Example Sentences
+
+My favourite color is blu.
+I must defend my honour!
+I recognize that you recognise me.
+I analyze how you infantilize me.
+I analyse how you infantilise me.

--- a/harper-core/tests/text/Spell.md
+++ b/harper-core/tests/text/Spell.md
@@ -9,3 +9,5 @@ I must defend my honour!
 I recognize that you recognise me.
 I analyze how you infantilize me.
 I analyse how you infantilise me.
+Careful, traveller!
+At the centre of the theatre I dropped a litre of coke.

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -322,12 +322,10 @@ Message: |
 Lint:    Spelling (63 priority)
 Message: |
      138 | finding it very nice, (it had, in fact, a sort of mixed flavour of cherry-tart,
-         |                                                         ^~~~~~~ Did you mean to spell “flavour” this way?
+         |                                                         ^~~~~~~ Did you mean “flavor”?
      139 | custard, pine-apple, roast turkey, toffee, and hot buttered toast,) she very
 Suggest:
   - Replace with: “flavor”
-  - Replace with: “flavours”
-  - Replace with: “favor”
 
 
 
@@ -1041,22 +1039,18 @@ Lint:    Spelling (63 priority)
 Message: |
      660 | voice she had never heard before, “Sure then I’m here! Digging for apples, yer
      661 | honour!”
-         | ^~~~~~ Did you mean to spell “honour” this way?
+         | ^~~~~~ Did you mean “honor”?
 Suggest:
   - Replace with: “honor”
-  - Replace with: “honours”
-  - Replace with: “honour's”
 
 
 
 Lint:    Spelling (63 priority)
 Message: |
      668 | “Sure, it’s an arm, yer honour!” (He pronounced it “arrum.”)
-         |                         ^~~~~~ Did you mean to spell “honour” this way?
+         |                         ^~~~~~ Did you mean “honor”?
 Suggest:
   - Replace with: “honor”
-  - Replace with: “honours”
-  - Replace with: “honour's”
 
 
 
@@ -1074,22 +1068,18 @@ Suggest:
 Lint:    Spelling (63 priority)
 Message: |
      672 | “Sure, it does, yer honour: but it’s an arm for all that.”
-         |                     ^~~~~~ Did you mean to spell “honour” this way?
+         |                     ^~~~~~ Did you mean “honor”?
 Suggest:
   - Replace with: “honor”
-  - Replace with: “honours”
-  - Replace with: “honour's”
 
 
 
 Lint:    Spelling (63 priority)
 Message: |
      677 | then; such as, “Sure, I don’t like it, yer honour, at all, at all!” “Do as I
-         |                                            ^~~~~~ Did you mean to spell “honour” this way?
+         |                                            ^~~~~~ Did you mean “honor”?
 Suggest:
   - Replace with: “honor”
-  - Replace with: “honours”
-  - Replace with: “honour's”
 
 
 
@@ -1855,11 +1845,9 @@ Lint:    Spelling (63 priority)
 Message: |
     1713 | they were all ornamented with hearts. Next came the guests, mostly Kings and
     1714 | Queens, and among them Alice recognised the White Rabbit: it was talking in a
-         |                              ^~~~~~~~~~ Did you mean to spell “recognised” this way?
+         |                              ^~~~~~~~~~ Did you mean “recognized”?
 Suggest:
   - Replace with: “recognized”
-  - Replace with: “recogniser”
-  - Replace with: “recognises”
 
 
 
@@ -2222,11 +2210,9 @@ Lint:    Spelling (63 priority)
 Message: |
     2048 | But here, to Alice’s great surprise, the Duchess’s voice died away, even in the
     2049 | middle of her favourite word ‘moral,’ and the arm that was linked into hers
-         |               ^~~~~~~~~ Did you mean to spell “favourite” this way?
+         |               ^~~~~~~~~ Did you mean “favorite”?
 Suggest:
   - Replace with: “favorite”
-  - Replace with: “favourites”
-  - Replace with: “favourite's”
 
 
 
@@ -3304,11 +3290,9 @@ Lint:    Spelling (63 priority)
 Message: |
     2547 | even make out that one of them didn’t know how to spell “stupid,” and that he
     2548 | had to ask his neighbour to tell him. “A nice muddle their slates’ll be in
-         |                ^~~~~~~~~ Did you mean to spell “neighbour” this way?
+         |                ^~~~~~~~~ Did you mean “neighbor”?
 Suggest:
   - Replace with: “neighbor”
-  - Replace with: “neighbours”
-  - Replace with: “neighbour's”
 
 
 
@@ -3626,12 +3610,10 @@ Suggest:
 Lint:    Spelling (63 priority)
 Message: |
     2988 | noises, would change (she knew) to the confused clamour of the busy
-         |                                                 ^~~~~~~ Did you mean to spell “clamour” this way?
+         |                                                 ^~~~~~~ Did you mean “clamor”?
     2989 | farm-yard—while the lowing of the cattle in the distance would take the place of
 Suggest:
   - Replace with: “clamor”
-  - Replace with: “clamours”
-  - Replace with: “glamour”
 
 
 

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -88,11 +88,9 @@ Message: |
 Lint:    Spelling (63 priority)
 Message: |
       43 | shelves as she passed; it was labelled “ORANGE MARMALADE”, but to her great
-         |                               ^~~~~~~~ Did you mean to spell “labelled” this way?
+         |                               ^~~~~~~~ Did you mean “labeled”?
 Suggest:
   - Replace with: “labeled”
-  - Replace with: “labeler”
-  - Replace with: “labelless”
 
 
 
@@ -100,11 +98,9 @@ Lint:    Spelling (63 priority)
 Message: |
       54 | I’ve fallen by this time?” she said aloud. “I must be getting somewhere near the
       55 | centre of the earth. Let me see: that would be four thousand miles down, I
-         | ^~~~~~ Did you mean to spell “centre” this way?
+         | ^~~~~~ Did you mean “center”?
 Suggest:
-  - Replace with: “centred”
-  - Replace with: “centres”
-  - Replace with: “censure”
+  - Replace with: “center”
 
 
 
@@ -1688,12 +1684,10 @@ Suggest:
 Lint:    Spelling (63 priority)
 Message: |
     1497 | The Hatter shook his head mournfully. “Not I!” he replied. “We quarrelled last
-         |                                                                ^~~~~~~~~~ Did you mean to spell “quarrelled” this way?
+         |                                                                ^~~~~~~~~~ Did you mean “quarreled”?
     1498 | March—just before he went mad, you know—” (pointing with his tea spoon at the
 Suggest:
   - Replace with: “quarreled”
-  - Replace with: “quarreler”
-  - Replace with: “quarrellers”
 
 
 

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -493,11 +493,9 @@ Lint:    Spelling (63 priority)
 Message: |
      229 | “If you please, sir—” The Rabbit started violently, dropped the white kid gloves
      230 | and the fan, and skurried away into the darkness as hard as he could go.
-         |                  ^~~~~~~~ Did you mean to spell `skurried` this way?
+         |                  ^~~~~~~~ Did you mean `scurried`?
 Suggest:
   - Replace with: “scurried”
-  - Replace with: “spurred”
-  - Replace with: “scurries”
 
 
 
@@ -2140,7 +2138,7 @@ Message: |
 Suggest:
   - Replace with: “this”
   - Replace with: “ti's”
-  - Replace with: “tbs”
+  - Replace with: “tic”
 
 
 
@@ -2152,7 +2150,7 @@ Message: |
 Suggest:
   - Replace with: “this”
   - Replace with: “ti's”
-  - Replace with: “tbs”
+  - Replace with: “tic”
 
 
 

--- a/harper-core/tests/text/linters/Difficult sentences.snap.yml
+++ b/harper-core/tests/text/linters/Difficult sentences.snap.yml
@@ -86,11 +86,9 @@ Suggest:
 Lint:    Spelling (63 priority)
 Message: |
      208 | My aim in travelling there was to find my missing friend.
-         |           ^~~~~~~~~~ Did you mean to spell “travelling” this way?
+         |           ^~~~~~~~~~ Did you mean “traveling”?
 Suggest:
   - Replace with: “traveling”
-  - Replace with: “travellings”
-  - Replace with: “travelling's”
 
 
 
@@ -252,11 +250,9 @@ Suggest:
 Lint:    Spelling (63 priority)
 Message: |
      366 | He travelled on false documents.
-         |    ^~~~~~~~~ Did you mean to spell “travelled” this way?
+         |    ^~~~~~~~~ Did you mean “traveled”?
 Suggest:
   - Replace with: “traveled”
-  - Replace with: “traveler”
-  - Replace with: “travailed”
 
 
 

--- a/harper-core/tests/text/linters/Difficult sentences.snap.yml
+++ b/harper-core/tests/text/linters/Difficult sentences.snap.yml
@@ -28,11 +28,9 @@ Suggest:
 Lint:    Spelling (63 priority)
 Message: |
       56 | He was protected by his body armour.
-         |                              ^~~~~~ Did you mean to spell “armour” this way?
+         |                              ^~~~~~ Did you mean “armor”?
 Suggest:
-  - Replace with: “amour”
   - Replace with: “armor”
-  - Replace with: “armours”
 
 
 
@@ -129,11 +127,9 @@ Suggest:
 Lint:    Spelling (63 priority)
 Message: |
      258 | I need to keep in with the neighbours in case I ever need a favour from them.
-         |                                                             ^~~~~~ Did you mean to spell “favour” this way?
+         |                                                             ^~~~~~ Did you mean “favor”?
 Suggest:
   - Replace with: “favor”
-  - Replace with: “favours”
-  - Replace with: “famous”
 
 
 
@@ -150,11 +146,9 @@ Suggest:
 Lint:    Spelling (63 priority)
 Message: |
      284 | This behaviour is typical of teenagers.
-         |      ^~~~~~~~~ Did you mean to spell “behaviour” this way?
+         |      ^~~~~~~~~ Did you mean “behavior”?
 Suggest:
   - Replace with: “behavior”
-  - Replace with: “behaviours”
-  - Replace with: “behaviour's”
 
 
 
@@ -269,11 +263,9 @@ Suggest:
 Lint:    Spelling (63 priority)
 Message: |
      398 | Who am I to criticise? I've done worse things myself.
-         |             ^~~~~~~~~ Did you mean to spell “criticise” this way?
+         |             ^~~~~~~~~ Did you mean “criticize”?
 Suggest:
-  - Replace with: “criticism”
   - Replace with: “criticize”
-  - Replace with: “criticised”
 
 
 

--- a/harper-core/tests/text/linters/Part-of-speech tagging.snap.yml
+++ b/harper-core/tests/text/linters/Part-of-speech tagging.snap.yml
@@ -588,12 +588,10 @@ Suggest:
 Lint:    Spelling (63 priority)
 Message: |
      201 | algorithm, Brill tagger, Constraint Grammar, and the Baum-Welch algorithm (also
-         |                                                           ^~~~~ Did you mean to spell `Welch` this way?
+         |                                                           ^~~~~ Did you mean `Welsh`?
      202 | known as the forward-backward algorithm). Hidden Markov model and visible Markov
 Suggest:
   - Replace with: “Welsh”
-  - Replace with: “Belch”
-  - Replace with: “Walsh”
 
 
 

--- a/harper-core/tests/text/linters/Spell.snap.yml
+++ b/harper-core/tests/text/linters/Spell.snap.yml
@@ -54,3 +54,39 @@ Suggest:
 
 
 
+Lint:    Spelling (63 priority)
+Message: |
+      12 | Careful, traveller!
+         |          ^~~~~~~~~ Did you mean “traveler”?
+Suggest:
+  - Replace with: “traveler”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      13 | At the centre of the theatre I dropped a litre of coke.
+         |        ^~~~~~ Did you mean “center”?
+Suggest:
+  - Replace with: “center”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      13 | At the centre of the theatre I dropped a litre of coke.
+         |                      ^~~~~~~ Did you mean “theater”?
+Suggest:
+  - Replace with: “theater”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      13 | At the centre of the theatre I dropped a litre of coke.
+         |                                          ^~~~~ Did you mean “liter”?
+Suggest:
+  - Replace with: “liter”
+
+
+

--- a/harper-core/tests/text/linters/Spell.snap.yml
+++ b/harper-core/tests/text/linters/Spell.snap.yml
@@ -1,0 +1,56 @@
+Lint:    Spelling (63 priority)
+Message: |
+       7 | My favourite color is blu.
+         |    ^~~~~~~~~ Did you mean “favorite”?
+Suggest:
+  - Replace with: “favorite”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+       7 | My favourite color is blu.
+         |                       ^~~ Did you mean to spell “blu” this way?
+Suggest:
+  - Replace with: “bl”
+  - Replace with: “blue”
+  - Replace with: “blur”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+       8 | I must defend my honour!
+         |                  ^~~~~~ Did you mean “honor”?
+Suggest:
+  - Replace with: “honor”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+       9 | I recognize that you recognise me.
+         |                      ^~~~~~~~~ Did you mean “recognize”?
+Suggest:
+  - Replace with: “recognize”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      11 | I analyse how you infantilise me.
+         |   ^~~~~~~ Did you mean “analyze”?
+Suggest:
+  - Replace with: “analyze”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+      11 | I analyse how you infantilise me.
+         |                   ^~~~~~~~~~~ Did you mean “infantilize”?
+Suggest:
+  - Replace with: “infantilize”
+
+
+

--- a/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
+++ b/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
@@ -16,12 +16,10 @@ Message: |
 Lint:    Spelling (63 priority)
 Message: |
        6 | establish Justice, insure domestic Tranquility, provide for the common defence,
-         |                                                                        ^~~~~~~ Did you mean to spell `defence` this way?
+         |                                                                        ^~~~~~~ Did you mean `defense`?
        7 | promote the general Welfare, and secure the Blessings of Liberty to ourselves
 Suggest:
   - Replace with: “defense”
-  - Replace with: “decency”
-  - Replace with: “deface”
 
 
 
@@ -531,12 +529,10 @@ Suggest:
 Lint:    Spelling (63 priority)
 Message: |
      203 | Imposts and Excises, to pay the Debts and provide for the common Defence and
-         |                                                                  ^~~~~~~ Did you mean to spell `Defence` this way?
+         |                                                                  ^~~~~~~ Did you mean `Defense`?
      204 | general Welfare of the United States; but all Duties, Imposts and Excises shall
 Suggest:
   - Replace with: “Defense”
-  - Replace with: “Fence”
-  - Replace with: “Terence”
 
 
 

--- a/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
+++ b/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
@@ -1461,11 +1461,9 @@ Lint:    Spelling (63 priority)
 Message: |
      627 | States, or any place subject to their jurisdiction. No Person held to Service
      628 | or Labour in one State, under the Laws thereof, escaping into another, shall,
-         |    ^~~~~~ Did you mean to spell “Labour” this way?
+         |    ^~~~~~ Did you mean “Labor”?
 Suggest:
   - Replace with: “Labor”
-  - Replace with: “Labours”
-  - Replace with: “About”
 
 
 
@@ -1473,11 +1471,9 @@ Lint:    Spelling (63 priority)
 Message: |
      629 | in Consequence of any Law or Regulation therein, be discharged from such
      630 | Service or Labour, but shall be delivered up on Claim of the Party to whom such
-         |            ^~~~~~ Did you mean to spell “Labour” this way?
+         |            ^~~~~~ Did you mean “Labor”?
 Suggest:
   - Replace with: “Labor”
-  - Replace with: “Labours”
-  - Replace with: “About”
 
 
 
@@ -1485,11 +1481,9 @@ Lint:    Spelling (63 priority)
 Message: |
      630 | Service or Labour, but shall be delivered up on Claim of the Party to whom such
      631 | Service or Labour may be due.
-         |            ^~~~~~ Did you mean to spell “Labour” this way?
+         |            ^~~~~~ Did you mean “Labor”?
 Suggest:
   - Replace with: “Labor”
-  - Replace with: “Labours”
-  - Replace with: “About”
 
 
 
@@ -1652,11 +1646,10 @@ Suggest:
 Lint:    Spelling (63 priority)
 Message: |
      714 | first Page, The Word "Thirty" being partly written on an Erazure in the
-         |                                                          ^~~~~~~ Did you mean to spell “Erazure” this way?
+         |                                                          ^~~~~~~ Did you mean “Erasure”?
      715 | fifteenth Line of the first Page. The Words "is tried" being interlined between
 Suggest:
   - Replace with: “Erasure”
-  - Replace with: “Azure”
 
 
 

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -1516,7 +1516,7 @@ Message: |
 Suggest:
   - Replace with: “hers”
   - Replace with: “ho's”
-  - Replace with: “hobs”
+  - Replace with: “hours”
 
 
 
@@ -3097,11 +3097,9 @@ Suggest:
 Lint:    Spelling (63 priority)
 Message: |
     2011 | “Major Jay Gatsby,” I read, “For Valour Extraordinary.”
-         |                                  ^~~~~~ Did you mean to spell “Valour” this way?
+         |                                  ^~~~~~ Did you mean “Valor”?
 Suggest:
   - Replace with: “Valor”
-  - Replace with: “Valium”
-  - Replace with: “Valois”
 
 
 

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -203,12 +203,10 @@ Suggest:
 Lint:    Spelling (63 priority)
 Message: |
       61 | restless. Instead of being the warm centre of the world, the Middle West now
-         |                                     ^~~~~~ Did you mean to spell “centre” this way?
+         |                                     ^~~~~~ Did you mean “center”?
       62 | seemed like the ragged edge of the universe—so I decided to go East and learn
 Suggest:
-  - Replace with: “centred”
-  - Replace with: “centres”
-  - Replace with: “censure”
+  - Replace with: “center”
 
 
 
@@ -341,12 +339,10 @@ Suggest:
 Lint:    Spelling (63 priority)
 Message: |
      120 | was a factual imitation of some Hôtel de Ville in Normandy, with a tower on one
-         |                                          ^~~~~ Did you mean to spell “Ville” this way?
+         |                                          ^~~~~ Did you mean “Vile”?
      121 | side, spanking new under a thin beard of raw ivy, and a marble swimming pool,
 Suggest:
   - Replace with: “Vile”
-  - Replace with: “Villa”
-  - Replace with: “Lille”
 
 
 
@@ -1236,11 +1232,9 @@ Lint:    Spelling (63 priority)
 Message: |
      923 | “I should change the light,” he said after a moment. “I’d like to bring out the
      924 | modelling of the features. And I’d try to get hold of all the back hair.”
-         | ^~~~~~~~~ Did you mean to spell “modelling” this way?
+         | ^~~~~~~~~ Did you mean “modeling”?
 Suggest:
   - Replace with: “modeling”
-  - Replace with: “modellings”
-  - Replace with: “modelling's”
 
 
 
@@ -1614,12 +1608,10 @@ Lint:    Spelling (63 priority)
 Message: |
     1202 | confident girls who weave here and there among the stouter and more stable,
     1203 | become for a sharp, joyous moment the centre of a group, and then, excited with
-         |                                       ^~~~~~ Did you mean to spell “centre” this way?
+         |                                       ^~~~~~ Did you mean “center”?
     1204 | triumph, glide on through the sea-change of faces and voices and color under the
 Suggest:
-  - Replace with: “centred”
-  - Replace with: “centres”
-  - Replace with: “censure”
+  - Replace with: “center”
 
 
 
@@ -1720,11 +1712,9 @@ Lint:    Spelling (63 priority)
 Message: |
     1347 | chance we tried an important-looking door, and walked into a high Gothic
     1348 | library, panelled with carved English oak, and probably transported complete
-         |          ^~~~~~~~ Did you mean to spell “panelled” this way?
+         |          ^~~~~~~~ Did you mean “paneled”?
 Suggest:
   - Replace with: “paneled”
-  - Replace with: “palled”
-  - Replace with: “Janelle”
 
 
 
@@ -2126,12 +2116,10 @@ Lint:    Spelling (63 priority)
 Message: |
     1764 | Again at eight o’clock, when the dark lanes of the Forties were lined five deep
     1765 | with throbbing taxicabs, bound for the theatre district, I felt a sinking in my
-         |                                        ^~~~~~~ Did you mean to spell “theatre” this way?
+         |                                        ^~~~~~~ Did you mean “theater”?
     1766 | heart. Forms leaned together in the taxis as they waited, and voices sang, and
 Suggest:
-  - Replace with: “theatres”
   - Replace with: “theater”
-  - Replace with: “theatre's”
 
 
 
@@ -3162,11 +3150,9 @@ Lint:    Spelling (63 priority)
 Message: |
     2076 | Europe, and I was glad that the sight of Gatsby’s splendid car was included in
     2077 | their sombre holiday. As we crossed Blackwell’s Island a limousine passed us,
-         |       ^~~~~~ Did you mean to spell “sombre” this way?
+         |       ^~~~~~ Did you mean “somber”?
 Suggest:
-  - Replace with: “hombre”
   - Replace with: “somber”
-  - Replace with: “some”
 
 
 
@@ -4441,10 +4427,9 @@ Message: |
 Lint:    Spelling (63 priority)
 Message: |
     3254 | “I’m looking around. I’m having a marvellous—”
-         |                                   ^~~~~~~~~~ Did you mean to spell “marvellous” this way?
+         |                                   ^~~~~~~~~~ Did you mean “marvelous”?
 Suggest:
   - Replace with: “marvelous”
-  - Replace with: “marvellously”
 
 
 
@@ -4753,11 +4738,9 @@ Suggest:
 Lint:    Spelling (63 priority)
 Message: |
     3599 | Gatsby stood in the centre of the crimson carpet and gazed around with
-         |                     ^~~~~~ Did you mean to spell “centre” this way?
+         |                     ^~~~~~ Did you mean “center”?
 Suggest:
-  - Replace with: “centred”
-  - Replace with: “centres”
-  - Replace with: “censure”
+  - Replace with: “center”
 
 
 
@@ -5136,12 +5119,10 @@ Suggest:
 Lint:    Spelling (63 priority)
 Message: |
     3975 | could invent a protest the coupé came to a stop, and Daisy signalled us to draw
-         |                                                            ^~~~~~~~~ Did you mean to spell “signalled” this way?
+         |                                                            ^~~~~~~~~ Did you mean “signaled”?
     3976 | up alongside.
 Suggest:
   - Replace with: “signaled”
-  - Replace with: “signaler”
-  - Replace with: “signalised”
 
 
 

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -683,11 +683,9 @@ Lint:    Spelling (63 priority)
 Message: |
      479 | thinking, but I doubt if even Miss Baker, who seemed to have mastered a certain
      480 | hardy scepticism, was able utterly to put this fifth guest’s shrill metallic
-         |       ^~~~~~~~~~ Did you mean to spell `scepticism` this way?
+         |       ^~~~~~~~~~ Did you mean `skepticism`?
 Suggest:
   - Replace with: “skepticism”
-  - Replace with: “sceptic's”
-  - Replace with: “scepticism's”
 
 
 
@@ -1711,11 +1709,9 @@ Suggest:
 Lint:    Spelling (63 priority)
 Message: |
     1373 | Taking our scepticism for granted, he rushed to the bookcases and returned with
-         |            ^~~~~~~~~~ Did you mean to spell `scepticism` this way?
+         |            ^~~~~~~~~~ Did you mean `skepticism`?
 Suggest:
   - Replace with: “skepticism”
-  - Replace with: “sceptic's”
-  - Replace with: “scepticism's”
 
 
 
@@ -3675,12 +3671,10 @@ Suggest:
 Lint:    Spelling (63 priority)
 Message: |
     2455 | hard, limited person, who dealt in universal scepticism, and who leaned back
-         |                                              ^~~~~~~~~~ Did you mean to spell `scepticism` this way?
+         |                                              ^~~~~~~~~~ Did you mean `skepticism`?
     2456 | jauntily just within the circle of my arm. A phrase began to beat in my ears
 Suggest:
   - Replace with: “skepticism”
-  - Replace with: “sceptic's”
-  - Replace with: “scepticism's”
 
 
 
@@ -4468,11 +4462,9 @@ Suggest:
 Lint:    Spelling (63 priority)
 Message: |
     3319 | at the local club to-morrow, spoke in Miss Baedeker’s defence:
-         |                                                       ^~~~~~~ Did you mean to spell `defence` this way?
+         |                                                       ^~~~~~~ Did you mean `defense`?
 Suggest:
   - Replace with: “defense”
-  - Replace with: “decency”
-  - Replace with: “deface”
 
 
 

--- a/harper-core/tests/text/tagged/Spell.md
+++ b/harper-core/tests/text/tagged/Spell.md
@@ -1,0 +1,22 @@
+> Spell
+# NSg/V
+>
+#
+> This document contains example sentences with misspelled words that    we  want  to test  the spell checker on  .
+# I/D  NSg/V    NPl      NSg/V   NPl       P    W?         NPl   N/I/C/D IPl NSg/V P  NSg/V D   NSg   NSg/V   J/P .
+>
+#
+> Example Sentences
+# NSg/V   NPl
+>
+#
+> My favourite color      is blu .
+# D  NSg/J/Br  NSg/V/J/Am VL W?  .
+> I   must  defend my honour !
+# ISg NSg/V NSg/V  D  NSg/Br .
+> I   recognize that    you recognise me        .
+# ISg V         N/I/C/D IPl V/Br      NPrSg/ISg .
+> I   analyze how   you infantilize me        .
+# ISg V       NSg/C IPl V           NPrSg/ISg .
+> I   analyse how   you infantilise me        .
+# ISg V/Br    NSg/C IPl ?           NPrSg/ISg .

--- a/harper-core/tests/text/tagged/Spell.md
+++ b/harper-core/tests/text/tagged/Spell.md
@@ -20,3 +20,7 @@
 # ISg V       NSg/C IPl V           NPrSg/ISg .
 > I   analyse how   you infantilise me        .
 # ISg V/Br    NSg/C IPl ?           NPrSg/ISg .
+> Careful , traveller !
+# J       . NSg/Br    .
+> At the centre of the theatre I   dropped a   litre  of coke    .
+# P  D   NSg/Br P  D   NSg/Br  ISg V/J     D/P NSg/Br P  NPrSg/V .

--- a/harper-core/tests/text/tagged/Spell.md
+++ b/harper-core/tests/text/tagged/Spell.md
@@ -3,11 +3,11 @@
 >
 #
 > This document contains example sentences with misspelled words that    we  want  to test  the spell checker on  .
-# I/D  NSg/V    NPl      NSg/V   NPl       P    W?         NPl   N/I/C/D IPl NSg/V P  NSg/V D   NSg   NSg/V   J/P .
+# I/D  NSg/V    V        NSg/V   NPl/V     P    V/J        NPl/V N/I/C/D IPl NSg/V P  NSg/V D   NSg   NSg/V   J/P .
 >
 #
 > Example Sentences
-# NSg/V   NPl
+# NSg/V   NPl/V
 >
 #
 > My favourite color      is blu .

--- a/packages/vscode-plugin/src/tests/suite/integration.test.ts
+++ b/packages/vscode-plugin/src/tests/suite/integration.test.ts
@@ -46,7 +46,7 @@ describe('Integration >', () => {
 					range: createRange(2, 26, 2, 32),
 				},
 				{
-					message: 'Did you mean to spell “realise” this way?',
+					message: 'Did you mean “realize”?',
 					range: createRange(4, 26, 4, 33),
 				},
 			),
@@ -112,7 +112,7 @@ describe('Integration >', () => {
 					range: createRange(2, 26, 2, 32),
 				},
 				{
-					message: 'Did you mean to spell “realise” this way?',
+					message: 'Did you mean “realize”?',
 					range: createRange(4, 26, 4, 33),
 				},
 			),


### PR DESCRIPTION
# Description
The fix for some dialect-based misspellings is very obvious. E.g. color ↔ colour and recognize ↔ recognise. So I changed the spell checker to **only** suggest the version of the word in the current dialect, if it detects an "ou↔o" or "s↔z" misspelling.

I also refactored and slightly optimized `SpellCheck::cached_suggest_correct_spelling`. It now only caches the words that will be suggested (without any excess) and generally works a bit more efficiently.

# Demo
See tests.

# How Has This Been Tested?
Using existing tests and a new document.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
