### PR TITLE
fix: fix indefinite article for "utter(ly)"

### DIFF
--- a/harper-core/src/linting/an_a.rs
+++ b/harper-core/src/linting/an_a.rs
@@ -141,6 +141,10 @@ fn starts_with_vowel(word: &[char]) -> bool {
         return true;
     }
 
+    if matches!(word, ['u', 't', 't', ..]) {
+        return true;
+    }
+
     if matches!(
         word,
         ['u', 't' | 'r' | 'n', ..] | ['e', 'u', 'r', ..] | ['u', 'w', ..] | ['u', 's', 'e', ..]

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -710,16 +710,6 @@ Message: |
 
 
 
-Lint:    Miscellaneous (31 priority)
-Message: |
-     515 | hour old and Tom was God knows where. I woke up out of the ether with an utterly
-         |                                                                       ^~ Incorrect indefinite article.
-     516 | abandoned feeling, and asked the nurse right away if it was a boy or a girl. She
-Suggest:
-  - Replace with: “a”
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
      529 | the whole evening had been a trick of some sort to exact a contributary emotion


### PR DESCRIPTION
# Description
I found that `AnA` incorrectly assigned "utterly" the article "a". In this PR, I changed the heuristic for guessing articles to fix this.

# Demo
See tests.

# How Has This Been Tested?
Existing tests cover this.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
