### PR TITLE
feat:definitive article→definite article

### DIFF
--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -1213,6 +1213,18 @@ pub fn lint_group() -> LintGroup {
             "The period of economic prosperity is called the `Gilded Age`.",
             "If referring to the period of economic prosperity, the correct term is `Gilded Age`."
         ),
+        "DefiniteArticle" => (
+            ["definitive article"],
+            ["definite article"],
+            "The correct term for `the` is `definite article`.",
+            "The name of the word `the` is `definite article`."
+        ),
+        "DefiniteArticles" => (
+            ["definitive articles"],
+            ["definite articles"],
+            "The correct term for `the` is `definite article`.",
+            "The name of the word `the` is `definite article`."
+        )
     });
 
     group.set_all_rules_to(Some(true));
@@ -2650,27 +2662,25 @@ mod tests {
         );
     }
 
-    // There's a bug when changing the length of title case phrases
-    // I believe there's a fix coming in a PR. Uncomment when fixed.
-    // #[test]
-    // fn corrects_gilded_age_capitalized() {
-    //     assert_suggestion_result(
-    //         "It is especially a reflection of the socio-economic patterns in the Guilded Age.",
-    //         lint_group(),
-    //         "It is especially a reflection of the socio-economic patterns in the Gilded Age.",
-    //     );
-    // }
+    #[test]
+    #[ignore = "There's a bug when changing the length of title case phrases.\nI believe there's a fix coming in a PR. Uncomment when fixed."]
+    fn corrects_gilded_age_capitalized() {
+        assert_suggestion_result(
+            "It is especially a reflection of the socio-economic patterns in the Guilded Age.",
+            lint_group(),
+            "It is especially a reflection of the socio-economic patterns in the Gilded Age.",
+        );
+    }
 
-    // Currently the correct spelling is suggested but the case is not changed.
-    // This maybe also be fixed in the coming PR mentioned above.
-    // #[test]
-    // fn corrects_gilded_age_lowercase() {
-    //     assert_suggestion_result(
-    //         "It is especially a reflection of the socio-economic patterns in the guilded age.",
-    //         lint_group(),
-    //         "It is especially a reflection of the socio-economic patterns in the Gilded Age.",
-    //     );
-    // }
+    #[test]
+    #[ignore = "Currently the correct spelling is suggested but the case is not changed.\nThis may also be fixed in the coming PR mentioned above."]
+    fn corrects_gilded_age_lowercase() {
+        assert_suggestion_result(
+            "It is especially a reflection of the socio-economic patterns in the guilded age.",
+            lint_group(),
+            "It is especially a reflection of the socio-economic patterns in the Gilded Age.",
+        );
+    }
 
     #[test]
     fn corrects_once_and_a_while() {
@@ -2678,6 +2688,34 @@ mod tests {
             "Every once and a while all the links on my page seem to stop working.",
             lint_group(),
             "Every once in a while all the links on my page seem to stop working.",
+        );
+    }
+
+    #[test]
+    fn corrects_definite_article() {
+        assert_suggestion_result(
+            "As for format of outputs: the spec defines the field as using the singular definitive article \"the\"",
+            lint_group(),
+            "As for format of outputs: the spec defines the field as using the singular definite article \"the\"",
+        );
+    }
+
+    #[test]
+    #[ignore = "Title case capitalization problem causes this one to fail too."]
+    fn corrects_definite_articles_title_case() {
+        assert_suggestion_result(
+            "01 Definitive Articles: De or Het. Before starting more complicated topics in Dutch grammar, you should be aware of the articles.",
+            lint_group(),
+            "01 Definite Articles: De or Het. Before starting more complicated topics in Dutch grammar, you should be aware of the articles.",
+        );
+    }
+
+    #[test]
+    fn corrects_definite_articles_lowercase() {
+        assert_suggestion_result(
+            ".. definitive articles -та /-ta/ and -те /-te/ (postfixed in Bulgarian).",
+            lint_group(),
+            ".. definite articles -та /-ta/ and -те /-te/ (postfixed in Bulgarian).",
         );
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

Also handles plural.
Also converted two commented-out tests to use `#[ignore]`

# How Has This Been Tested?

I added 3 unit tests using sentences sourced from GitHub.
One is `ignore`d though due to the way Harper tries to preserve the case of the original by uppercasing letters at specific indices instead of applying title case if the original used title case.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
