### PR TITLE
fix(obsidian): odd padding around message

### DIFF
--- a/packages/obsidian-plugin/src/index.ts
+++ b/packages/obsidian-plugin/src/index.ts
@@ -320,9 +320,9 @@ export default class HarperPlugin extends Plugin {
 						severity: 'error',
 						title: lint.lint_kind_pretty(),
 						renderMessage: (view) => {
-							const node = document.createElement('span');
+              const node = document.createElement('template');
 							node.innerHTML = lint.message_html();
-							return node;
+							return node.content;
 						},
 						ignore: async () => {
 							await this.harper.ignoreLint(text, lint);

--- a/packages/obsidian-plugin/src/index.ts
+++ b/packages/obsidian-plugin/src/index.ts
@@ -320,7 +320,7 @@ export default class HarperPlugin extends Plugin {
 						severity: 'error',
 						title: lint.lint_kind_pretty(),
 						renderMessage: (view) => {
-              const node = document.createElement('template');
+							const node = document.createElement('template');
 							node.innerHTML = lint.message_html();
 							return node.content;
 						},

--- a/packages/obsidian-plugin/src/lint.ts
+++ b/packages/obsidian-plugin/src/lint.ts
@@ -484,6 +484,12 @@ const baseTheme = EditorView.baseTheme({
 		marginTop: '8px',
 	},
 
+	'.cm-diagnosticText p': {
+    margin: '0px',
+    padding: '0px',
+    display: 'inline'
+	},
+
 	'.cm-diagnosticText code': {
 		borderRadius: '0.25rem',
 		backgroundColor: 'var(--background-secondary) !important',

--- a/packages/obsidian-plugin/src/lint.ts
+++ b/packages/obsidian-plugin/src/lint.ts
@@ -485,9 +485,9 @@ const baseTheme = EditorView.baseTheme({
 	},
 
 	'.cm-diagnosticText p': {
-    margin: '0px',
-    padding: '0px',
-    display: 'inline'
+		margin: '0px',
+		padding: '0px',
+		display: 'inline',
 	},
 
 	'.cm-diagnosticText code': {


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->

Created in #1240

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

In #1240, an odd amount of padding was introduced around the lint message. This PR returns it to the original amount of padding by assigning `<p />` tags the same properties as the `<span />`s that previously occupied that space.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

Before: 

![image](https://github.com/user-attachments/assets/23d8055d-755d-4134-a7d0-25bcfbc52b38)

After:
![image](https://github.com/user-attachments/assets/06396f55-56bf-4028-a025-76afee431f8b)


# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
