### PR TITLE
feat: adieu→ado

### DIFF
--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -1212,7 +1212,19 @@ pub fn lint_group() -> LintGroup {
             ["definite articles"],
             "The correct term for `the` is `definite article`.",
             "The name of the word `the` is `definite article`."
-        )
+        ),
+        "FurtherAdo" => (
+            ["further adieu"],
+            ["further ado"],
+            "Don't confuse the German `adieu`, meaning `farewell`, with the English `ado`, meaning `fuss`.",
+            "Corrects `adieu` to `ado`."
+        ),
+        "MuchAdo" => (
+            ["much adieu"],
+            ["much ado"],
+            "Don't confuse the German `adieu`, meaning `farewell`, with the English `ado`, meaning `fuss`.",
+            "Corrects `adieu` to `ado`."
+        ),
     });
 
     group.set_all_rules_to(Some(true));
@@ -2627,6 +2639,24 @@ mod tests {
             ".. definitive articles -та /-ta/ and -те /-te/ (postfixed in Bulgarian).",
             lint_group(),
             ".. definite articles -та /-ta/ and -те /-te/ (postfixed in Bulgarian).",
+        );
+    }
+
+    #[test]
+    fn corrects_further_ado() {
+        assert_suggestion_result(
+            "... but we finally hit a great spot, so without further adieu.",
+            lint_group(),
+            "... but we finally hit a great spot, so without further ado.",
+        );
+    }
+
+    #[test]
+    fn corrects_much_ado() {
+        assert_suggestion_result(
+            "After much adieu this functionality is now available.",
+            lint_group(),
+            "After much ado this functionality is now available.",
         );
     }
 }

--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -1216,13 +1216,13 @@ pub fn lint_group() -> LintGroup {
         "FurtherAdo" => (
             ["further adieu"],
             ["further ado"],
-            "Don't confuse the German `adieu`, meaning `farewell`, with the English `ado`, meaning `fuss`.",
+            "Don't confuse the French/German `adieu`, meaning `farewell`, with the English `ado`, meaning `fuss`.",
             "Corrects `adieu` to `ado`."
         ),
         "MuchAdo" => (
             ["much adieu"],
             ["much ado"],
-            "Don't confuse the German `adieu`, meaning `farewell`, with the English `ado`, meaning `fuss`.",
+            "Don't confuse the French/German `adieu`, meaning `farewell`, with the English `ado`, meaning `fuss`.",
             "Corrects `adieu` to `ado`."
         ),
     });


### PR DESCRIPTION
# Issues 
N/A

# Description

"Adieu" is a German word meaning farewell but it's become common for people to use it in place of the English word "ado" which means "fuss". I usually only occurs in a couple of contexts, so we can use `phrase_corrections`.

- further ado
- much ado

# How Has This Been Tested?

I added a unit test for each variant using a sentence found on GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
