### PR TITLE
feat: a fare bit→a fair bit

### DIFF
--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -1225,6 +1225,12 @@ pub fn lint_group() -> LintGroup {
             "Don't confuse the French/German `adieu`, meaning `farewell`, with the English `ado`, meaning `fuss`.",
             "Corrects `adieu` to `ado`."
         ),
+        "FairBit" => (
+            ["fare bit"],
+            ["fair bit"],
+            "A `decent amount` is a `fair bit`. `Fare` is the price of a ticket.",
+            "Corrects malapropisms of `a fair bit`."
+        ),
     });
 
     group.set_all_rules_to(Some(true));
@@ -2657,6 +2663,15 @@ mod tests {
             "After much adieu this functionality is now available.",
             lint_group(),
             "After much ado this functionality is now available.",
+        );
+    }
+
+    #[test]
+    fn corrects_fair_bit() {
+        assert_suggestion_result(
+            "I've read through a fare bit of the ecosystem framework, but I am not clear on what is modified...",
+            lint_group(),
+            "I've read through a fair bit of the ecosystem framework, but I am not clear on what is modified...",
         );
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

In a Facebook post I noticed somebody wrote "a fare bit". A fare is the price of a ticket. The expression should be "A fair bit" meaning "A decent amount".

I checked and found it on GitHub too. Sometimes missing the "a".

# How Has This Been Tested?

I added a unit test using a sentence found on GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
