### PR TITLE
fix(obsidian): move `max-height` css rule lower in the tree

### DIFF
--- a/packages/obsidian-plugin/src/lint.ts
+++ b/packages/obsidian-plugin/src/lint.ts
@@ -472,6 +472,7 @@ const baseTheme = EditorView.baseTheme({
 		display: 'flex',
 		flexDirection: 'column',
 		whiteSpace: 'pre-wrap',
+		maxHeight: 'calc(100% - var(--header-height)) !important',
 	},
 
 	'.cm-diagnosticTitle': {
@@ -520,7 +521,6 @@ const baseTheme = EditorView.baseTheme({
 		boxShadow: 'var(--shadow-s) !important',
 		zIndex: 'var(--layer-menu) !important',
 		userSelect: 'none !important',
-		maxHeight: 'calc(100% - var(--header-height)) !important',
 		overflow: 'hidden !important',
 	},
 


### PR DESCRIPTION
# Issues 

#1268

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

I've moved the `max-height` rule lower in the tree to avoid interfering with other plugins that instantiate tooltips.

It does not seem to negatively affect Harper's layout at all. 

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
