### PR TITLE
fix(ls): fix `position_to_index`

### DIFF
--- a/harper-ls/src/pos_conv.rs
+++ b/harper-ls/src/pos_conv.rs
@@ -121,7 +121,7 @@ mod tests {
         let source: Vec<_> = "This is a short test\n".chars().collect();
 
         let a = Position {
-            line: 1,
+            line: 0,
             character: 20,
         };
 
@@ -133,7 +133,7 @@ mod tests {
         let source: Vec<_> = "This is a short test".chars().collect();
 
         let a = Position {
-            line: 1,
+            line: 0,
             character: 20,
         };
 
@@ -146,11 +146,11 @@ mod tests {
 
         let range = Range {
             start: Position {
-                line: 1,
+                line: 0,
                 character: 9,
             },
             end: Position {
-                line: 1,
+                line: 0,
                 character: 10,
             },
         };

--- a/harper-ls/src/pos_conv.rs
+++ b/harper-ls/src/pos_conv.rs
@@ -67,7 +67,7 @@ fn position_to_index(source: &[char], position: Position) -> usize {
             .wrapping_add(position.character as usize)
     } else {
         // Character index is outside the bounds of the specified line.
-        // Return pointer to the last character of the line.
+        // Get pointer to the last character of the line.
         target_line.last().expect("line cannot be empty")
     };
 
@@ -174,8 +174,8 @@ mod tests {
         assert_eq!(out.end, 10);
     }
 
-    /// Ensures that `position_to_index` produces the correct result for an input `Position`
-    /// of `{ line: 1, character: 0 }`.
+    /// Ensures that `position_to_index` does not produce an incorrect index of 0 for an input
+    /// `Position` of `{ line: 1, character: 0 }`.
     /// Related to: https://github.com/Automattic/harper/issues/1253
     #[test]
     fn pos_to_index_correct_for_l1_c0() {
@@ -185,34 +185,35 @@ mod tests {
             character: 0,
         };
 
-        let out = position_to_index(&source, position);
-        assert_ne!(out, 0);
+        let out_index = position_to_index(&source, position);
+        assert_ne!(out_index, 0);
     }
 
-    /// Ensures `position_to_index` produces the correct result when indexing line 0.
+    /// Ensures `position_to_index` produces the correct result when indexing line 0 character 0.
     #[test]
-    fn off_by_one_check_line0() {
+    fn pos_to_index_off_by_one_check_l0_c0() {
         let source: Vec<_> = "abc\ndef\nghi\njkl".chars().collect();
         let position = Position {
             line: 0,
             character: 0,
         };
 
-        let out = position_to_index(&source, position);
-        assert_eq!(source[out], 'a');
+        let out_index = position_to_index(&source, position);
+        assert_eq!(source[out_index], 'a');
     }
 
     /// Ensures `position_to_index` produces the correct result when indexing a non-zero line and
     /// character.
     #[test]
-    fn off_by_one_check_non_zero_line() {
+    fn pos_to_index_off_by_one_check_l2_c1() {
         let source: Vec<_> = "abc\ndef\nghi\njkl".chars().collect();
         let position = Position {
             line: 2,
             character: 1,
         };
 
-        let out = position_to_index(&source, position);
-        assert_eq!(source[out], 'h');
+        let out_index = position_to_index(&source, position);
+        assert_eq!(source[out_index], 'h');
+    }
     }
 }

--- a/harper-ls/src/pos_conv.rs
+++ b/harper-ls/src/pos_conv.rs
@@ -215,5 +215,46 @@ mod tests {
         let out_index = position_to_index(&source, position);
         assert_eq!(source[out_index], 'h');
     }
+
+    /// Ensures `position_to_index` produces an index of 0 when indexing line 0 character 0 of
+    /// a source that contains only a newline (`\n`).
+    #[test]
+    fn pos_to_index_newline_only_l0_c0() {
+        let source: Vec<_> = "\n".chars().collect();
+        let position = Position {
+            line: 0,
+            character: 0,
+        };
+
+        let out_index = position_to_index(&source, position);
+        assert_eq!(out_index, 0);
+    }
+
+    /// Ensures `position_to_index` produces the last character index when indexing an out of
+    /// bounds line in a source that contains only newlines (`\n`).
+    #[test]
+    fn pos_to_index_newlines_only_l7_c0() {
+        let source: Vec<_> = "\n\n\n".chars().collect();
+        let position = Position {
+            line: 7,
+            character: 0,
+        };
+
+        let out_index = position_to_index(&source, position);
+        assert_eq!(out_index, 2);
+    }
+
+    /// Ensures `position_to_index` gives the last character of the line when indexing an out of
+    /// bounds character.
+    #[test]
+    fn pos_to_index_out_of_bounds_char() {
+        let source: Vec<_> = "abc\ndef\nghi\njkl".chars().collect();
+        let position = Position {
+            line: 3, // "jkl"
+            character: 8,
+        };
+
+        let out_index = position_to_index(&source, position);
+        assert_eq!(source[out_index], 'l');
     }
 }

--- a/harper-ls/src/pos_conv.rs
+++ b/harper-ls/src/pos_conv.rs
@@ -159,4 +159,19 @@ mod tests {
         assert_eq!(out.start, 9);
         assert_eq!(out.end, 10);
     }
+
+    /// Ensures that `position_to_index` produces the correct result for an input `Position`
+    /// of `{ line: 1, character: 0 }`.
+    /// Related to: https://github.com/Automattic/harper/issues/1253
+    #[test]
+    fn pos_to_index_correct_for_l1_c0() {
+        let source: Vec<_> = ". one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twenty-one twenty-two twenty-three twenty-four twenty-five twenty-six twenty-seven twenty-eight twenty-nine thirty thirty-one\n".chars().collect();
+        let position = Position {
+            line: 1,
+            character: 0,
+        };
+
+        let out = position_to_index(&source, position);
+        assert_ne!(out, 0);
+    }
 }

--- a/harper-ls/src/pos_conv.rs
+++ b/harper-ls/src/pos_conv.rs
@@ -148,10 +148,10 @@ mod tests {
 
         let a = Position {
             line: 0,
-            character: 20,
+            character: 19,
         };
 
-        assert_eq!(position_to_index(&source, a), 20);
+        assert_eq!(position_to_index(&source, a), 19);
     }
 
     #[test]

--- a/harper-ls/src/pos_conv.rs
+++ b/harper-ls/src/pos_conv.rs
@@ -174,4 +174,31 @@ mod tests {
         let out = position_to_index(&source, position);
         assert_ne!(out, 0);
     }
+
+    /// Ensures `position_to_index` produces the correct result when indexing line 0.
+    #[test]
+    fn off_by_one_check_line0() {
+        let source: Vec<_> = "abc\ndef\nghi\njkl".chars().collect();
+        let position = Position {
+            line: 0,
+            character: 0,
+        };
+
+        let out = position_to_index(&source, position);
+        assert_eq!(source[out], 'a');
+    }
+
+    /// Ensures `position_to_index` produces the correct result when indexing a non-zero line and
+    /// character.
+    #[test]
+    fn off_by_one_check_non_zero_line() {
+        let source: Vec<_> = "abc\ndef\nghi\njkl".chars().collect();
+        let position = Position {
+            line: 2,
+            character: 1,
+        };
+
+        let out = position_to_index(&source, position);
+        assert_eq!(source[out], 'h');
+    }
 }


### PR DESCRIPTION
# Issues 
(Hopefully) fixes #1253 

# Description
<!-- Please include a summary of the change. -->
This PR primarily seeks to resolve the crash mentioned in the aforementioned issue. The crash was caused because `position_to_index` would return an incorrect index of `0` as the `end` in `range_to_span` when processing the input mentioned in the issue. (The problematic position being `Position { line: 1, character: 0 }`.)

As I struggled to fully understand it, I opted to rewrite the `position_to_index` method. I was not able to find the desired/defined behavior of this method within documentation (particularly for edge-cases), so I conjured what I could from the existing tests.

The proposed new `position_to_index` uses a sort of "saturating" arithmetic. That is, if the requested line index is OOB, the last character of the `source` is returned. If the requested character index is OOB, the last character of the line is returned (assuming the line is in-bounds). (Because both the `line` and `character` indexes in `Position` are unsigned, we only really have to worry about them being too large.)

(I initially experimented with making `position_to_index` return an `Option<usize>` instead, but I felt it would require too many wide-reaching changes around the LSP behavior/code given the scope of this PR.)

Though I tried to avoid it to reduce the chance of breaking anything, I also had to adjust some existing tests to fix what seems to be erroneous expectations.

- In 4e4fbfd895947ed8c74670ef7b741c3b34b65c55, some tests are corrected to use 0-based line indexing to comply with [the documentation for `Position`](https://docs.rs/lsp-types/latest/lsp_types/struct.Position.html). Notably, for some tests, this also means we consider a `\n` to be part of the line it terminates. I'm not sure whether this is the behavior we want or not.
- In d8fe1676696141c2e53bfbc59d632a9d8f4a8a6e, the `end_of_file` test is adjusted to avoid expecting an index outside the bounds of `source`.

# How Has This Been Tested?
`cargo test`

`just precommit`

Brief manual testing of the modified `harper-ls` build with Neovim and VS Code. The crash mentioned in the issue no longer seemed to occur, and there did not appear to be any unexpected behavior with the highlighting of errors.

I added a handful of tests to try and ensure the behavior of `position_to_index` remains consistent, but I cannot say that the new implementation is 100% correct and resistant to edge-cases. Notably, I'm not sure if the input `Position` indexes `char`s in `source` directly, or if there are some UTF-16 complexities that need to be considered. The proposed implementation assumes the former, with the `Position` mapping to directly to a `char` within the source.

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
