### PR TITLE
fix: don't flag "can not" to join as a "compound noun"

### DIFF
--- a/harper-core/src/linting/compound_nouns/implied_instantiated_compound_nouns.rs
+++ b/harper-core/src/linting/compound_nouns/implied_instantiated_compound_nouns.rs
@@ -17,7 +17,7 @@ pub struct ImpliedInstantiatedCompoundNouns {
 impl Default for ImpliedInstantiatedCompoundNouns {
     fn default() -> Self {
         let split_pattern = Lrc::new(SplitCompoundWord::new(|meta| {
-            meta.is_noun() && !meta.is_proper_noun()
+            meta.is_noun() && !meta.is_proper_noun() && !meta.is_verb()
         }));
         let pattern = SequencePattern::default()
             .then(split_pattern.clone())

--- a/harper-core/src/linting/compound_nouns/mod.rs
+++ b/harper-core/src/linting/compound_nouns/mod.rs
@@ -302,4 +302,9 @@ mod tests {
             0,
         );
     }
+
+    #[test]
+    fn allow_can_not() {
+        assert_lint_count("Size can not be determined.", CompoundNouns::default(), 0);
+    }
 }


### PR DESCRIPTION
# Issues 

N/A

# Description

"Cannot" is valid word, but "can not" is also valid and, more importantly, it's not a compound noun.

It is marginally a noun though as in "cans and cannots", which is why it was detected.

Now this linter will only flag words when the joined result will be a noun but won't also be a verb.

# Demo

Before: 
<img width="1117" alt="Screenshot 2025-05-19 at 12 26 22 am" src="https://github.com/user-attachments/assets/36798abf-bbe5-4dc3-8ef8-cbbc64ea7e49" />

After: 
<img width="467" alt="image" src="https://github.com/user-attachments/assets/1e476e3b-f2e8-4f3a-82c6-b6a0fc61af65" />


# How Has This Been Tested?

I added a unit test using the sentence that brought this to my attention.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
