### PR TITLE
fix: 'a very' no longer flagged to change to 'Avery'

### DIFF
--- a/harper-core/src/linting/compound_nouns/implied_ownership_compound_nouns.rs
+++ b/harper-core/src/linting/compound_nouns/implied_ownership_compound_nouns.rs
@@ -45,12 +45,12 @@ impl PatternLinter for ImpliedOwnershipCompoundNouns {
         // "Let's" can technically be a possessive noun (of a lease, or a let in tennis, etc.)
         // but in practice it's almost always a contraction of "let us" before a verb
         // or a mistake for "lets", the 3rd person singular present form of "to let".
-        let word_apostrophe_s = matched_tokens[0].span.get_content(source);
-        if word_apostrophe_s
-            .iter()
-            .map(|&c| c.to_ascii_lowercase())
-            .eq(['l', 'e', 't', '\'', 's'].iter().copied())
-        {
+        let word_apostrophe_s = matched_tokens[0]
+            .span
+            .get_content_string(source)
+            .to_ascii_lowercase()
+            .replace('’', "'");
+        if word_apostrophe_s == "let's" || word_apostrophe_s == "that's" {
             return None;
         }
         let span = matched_tokens[2..].span()?;
@@ -82,9 +82,27 @@ mod tests {
     use crate::linting::tests::assert_lint_count;
 
     #[test]
-    fn does_not_flag_lets() {
+    fn lets_is_not_possessive() {
         assert_lint_count(
             "Let's check out this article.",
+            ImpliedOwnershipCompoundNouns::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn lets_is_not_possessive_typographic_apostrophe() {
+        assert_lint_count(
+            "“Let’s go on with the game,” the Queen said to Alice;",
+            ImpliedOwnershipCompoundNouns::default(),
+            0,
+        )
+    }
+
+    #[test]
+    fn thats_is_not_possessive() {
+        assert_lint_count(
+            "And you might not be thinking that that's a very big issue, but ...",
             ImpliedOwnershipCompoundNouns::default(),
             0,
         );

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -2202,15 +2202,6 @@ Suggest:
 
 
 
-Lint:    WordChoice (63 priority)
-Message: |
-    2061 | “Let’s go on with the game,” the Queen said to Alice; and Alice was too much
-         |        ^~~~~ The possessive noun implies ownership of the closed compound noun “goon”.
-Suggest:
-  - Replace with: “goon”
-
-
-
 Lint:    Readability (127 priority)
 Message: |
     2064 | The other guests had taken advantage of the Queen’s absence, and were resting in

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -3404,15 +3404,6 @@ Suggest:
 
 
 
-Lint:    WordChoice (63 priority)
-Message: |
-    2212 | “Well!” I inspected them. “That’s a very interesting idea.”
-         |                                   ^~~~~~ The possessive noun implies ownership of the closed compound noun “Avery”.
-Suggest:
-  - Replace with: “Avery”
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
     2218 | Mr. Wolfshiem drank his coffee with a jerk and got to his feet.
@@ -5334,15 +5325,6 @@ Message: |
          |                                                       ^~~~~~~~~ Did you mean the closed compound noun “backdoor”?
 Suggest:
   - Replace with: “backdoor”
-
-
-
-Lint:    WordChoice (63 priority)
-Message: |
-    4227 | “Daisy, that’s all over now,” he said earnestly. “It doesn’t matter any more.
-         |                ^~~~~~~~ The possessive noun implies ownership of the closed compound noun “allover”.
-Suggest:
-  - Replace with: “allover”
 
 
 


### PR DESCRIPTION
# Issues 
N/A

# Description

I had noticed for some time that `a very` was sometimes flagged and the suggested fix was `Avery`.
I finally investigated and the context was after `that's`, which the `implied_ownership_compound_nouns` linter treated as a possessive when it's actually a contraction.

While checking things out I realized the special case for `let's` only worked with the straight typewriter apostrophe but not the curved typography apostrophe. I added apostrophe and case normalization before checking the special case exceptions.

This fixed a couple of lints in the snapshots too.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

Before: 
<img width="980" alt="Screenshot 2025-05-19 at 3 38 01 pm" src="https://github.com/user-attachments/assets/bcb55ad4-39c8-4056-8fbe-7b53febd397d" />

After: 
<img width="535" alt="Screenshot 2025-05-19 at 5 59 21 pm" src="https://github.com/user-attachments/assets/8ba9cfab-32e2-498c-99b7-079f65dca459" />

# How Has This Been Tested?

I added a unit test for `that's` and a second one for `let's` that used the curved apostrophe: `let’s`.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
