### PR TITLE
fix: no longer prompt to change "new" to "knew" after possessives

### DIFF
--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -451,15 +451,6 @@ Message: |
 
 
 
-Lint:    WordChoice (31 priority)
-Message: |
-     162 | He had changed since his New Haven years. Now he was a sturdy straw-haired man
-         |                          ^~~ Did you mean “knew” (the past tense of “know”)?
-Suggest:
-  - Replace with: “Knew”
-
-
-
 Lint:    Readability (127 priority)
 Message: |
      165 | appearance of always leaning aggressively forward. Not even the effeminate swank


### PR DESCRIPTION
# Issues 
N/A

# Description

"Its", "his", and "her" are all pronouns but not the kind that come before verbs, those are "subject pronouns". These three are very common before adjectives like "new".

# Demo

Before: 
<img width="757" alt="Screenshot 2025-05-19 at 6 14 20 pm" src="https://github.com/user-attachments/assets/b2342283-b96c-49e2-b19f-d72dd3e2825a" />

After: 
<img width="530" alt="image" src="https://github.com/user-attachments/assets/0d7ba5f0-485f-4c18-acad-19b0975a2d2d" />

# How Has This Been Tested?

I added a unit test for "its" based on the sentence that drew my attention.
I made up sentences to make unit tests for "his" and "her".

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
