### PR TITLE
feat(core): make sentence capitalization replace whole word

### DIFF
--- a/harper-core/benches/parse_demo.rs
+++ b/harper-core/benches/parse_demo.rs
@@ -1,6 +1,7 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 use harper_core::linting::{LintGroup, Linter};
 use harper_core::{Dialect, Document, FstDictionary};
+use std::hint::black_box;
 
 static ESSAY: &str = include_str!("./essay.md");
 

--- a/harper-core/src/linting/sentence_capitalization.rs
+++ b/harper-core/src/linting/sentence_capitalization.rs
@@ -1,3 +1,5 @@
+use std::mem::replace;
+
 use super::Suggestion;
 use super::{Lint, LintKind, Linter};
 use crate::document::Document;
@@ -73,12 +75,15 @@ impl<T: Dictionary> Linter for SentenceCapitalization<T> {
                                 }
                             }
 
+                            let target_span = first_word.span;
+                            let mut replacement_chars =
+                                document.get_span_content(&target_span).to_vec();
+                            replacement_chars[0] = replacement_chars[0].to_ascii_uppercase();
+
                             lints.push(Lint {
-                                span: first_word.span.with_len(1),
+                                span: target_span,
                                 lint_kind: LintKind::Capitalization,
-                                suggestions: vec![Suggestion::ReplaceWith(
-                                    [first_char.to_ascii_uppercase()].to_vec(),
-                                )],
+                                suggestions: vec![Suggestion::ReplaceWith(replacement_chars)],
                                 priority: 31,
                                 message: "This sentence does not start with a capital letter"
                                     .to_string(),

--- a/harper-core/src/linting/sentence_capitalization.rs
+++ b/harper-core/src/linting/sentence_capitalization.rs
@@ -1,5 +1,3 @@
-use std::mem::replace;
-
 use super::Suggestion;
 use super::{Lint, LintKind, Linter};
 use crate::document::Document;

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -177,19 +177,19 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
       84 | ever eat a bat?” when suddenly, thump! thump! down she came upon a heap of
-         |                                        ^ This sentence does not start with a capital letter
+         |                                        ^~~~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “T”
+  - Replace with: “Thump”
 
 
 
 Lint:    Capitalization (31 priority)
 Message: |
       84 | ever eat a bat?” when suddenly, thump! thump! down she came upon a heap of
-         |                                               ^ This sentence does not start with a capital letter
+         |                                               ^~~~ This sentence does not start with a capital letter
       85 | sticks and dry leaves, and the fall was over.
 Suggest:
-  - Replace with: “D”
+  - Replace with: “Down”
 
 
 
@@ -229,10 +229,10 @@ Message: |
 Lint:    Capitalization (31 priority)
 Message: |
      102 | that it might belong to one of the doors of the hall; but, alas! either the
-         |                                                                  ^ This sentence does not start with a capital letter
+         |                                                                  ^~~~~~ This sentence does not start with a capital letter
      103 | locks were too large, or the key was too small, but at any rate it would not
 Suggest:
-  - Replace with: “E”
+  - Replace with: “Either”
 
 
 
@@ -351,10 +351,10 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
      154 | garden at once; but, alas for poor Alice! when she got to the door, she found
-         |                                           ^ This sentence does not start with a capital letter
+         |                                           ^~~~ This sentence does not start with a capital letter
      155 | she had forgotten the little golden key, and when she went back to the table for
 Suggest:
-  - Replace with: “W”
+  - Replace with: “When”
 
 
 
@@ -469,10 +469,10 @@ Message: |
 Lint:    Capitalization (31 priority)
 Message: |
      226 | himself as he came, “Oh! the Duchess, the Duchess! Oh! won’t she be savage if
-         |                                                        ^ This sentence does not start with a capital letter
+         |                                                        ^~~~~ This sentence does not start with a capital letter
      227 | I’ve kept her waiting!” Alice felt so desperate that she was ready to ask help
 Suggest:
-  - Replace with: “W”
+  - Replace with: “Won’t”
 
 
 
@@ -511,9 +511,9 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
      243 | all sorts of things, and she, oh! she knows such a very little! Besides, she’s
-         |                                   ^ This sentence does not start with a capital letter
+         |                                   ^~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “S”
+  - Replace with: “She”
 
 
 
@@ -546,9 +546,9 @@ Message: |
 Lint:    Capitalization (31 priority)
 Message: |
      263 | and oh! ever so many lessons to learn! No, I’ve made up my mind about it; if I’m
-         |         ^ This sentence does not start with a capital letter
+         |         ^~~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “E”
+  - Replace with: “Ever”
 
 
 
@@ -570,20 +570,20 @@ Message: |
 Lint:    Capitalization (31 priority)
 Message: |
      281 | garden!” and she ran with all speed back to the little door: but, alas! the
-         |                                                                         ^ This sentence does not start with a capital letter
+         |                                                                         ^~~ This sentence does not start with a capital letter
      282 | little door was shut again, and the little golden key was lying on the glass
 Suggest:
-  - Replace with: “T”
+  - Replace with: “The”
 
 
 
 Lint:    Capitalization (31 priority)
 Message: |
      287 | As she said these words her foot slipped, and in another moment, splash! she was
-         |                                                                          ^ This sentence does not start with a capital letter
+         |                                                                          ^~~ This sentence does not start with a capital letter
      288 | up to her chin in salt water. Her first idea was that she had somehow fallen
 Suggest:
-  - Replace with: “S”
+  - Replace with: “She”
 
 
 
@@ -1085,28 +1085,28 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
      688 | one; Bill’s got the other—Bill! fetch it here, lad!—Here, put ’em up at this
-         |                                 ^ This sentence does not start with a capital letter
+         |                                 ^~~~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “F”
+  - Replace with: “Fetch”
 
 
 
 Lint:    Capitalization (31 priority)
 Message: |
      690 | they’ll do well enough; don’t be particular—Here, Bill! catch hold of this
-         | ^ This sentence does not start with a capital letter
+         | ^~~~~~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “T”
+  - Replace with: “They’ll”
 
 
 
 Lint:    Capitalization (31 priority)
 Message: |
      690 | they’ll do well enough; don’t be particular—Here, Bill! catch hold of this
-         |                                                         ^ This sentence does not start with a capital letter
+         |                                                         ^~~~~ This sentence does not start with a capital letter
      691 | rope—Will the roof bear?—Mind that loose slate—Oh, it’s coming down! Heads
 Suggest:
-  - Replace with: “C”
+  - Replace with: “Catch”
 
 
 
@@ -1133,9 +1133,9 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
      694 | down—Here, Bill! the master says you’re to go down the chimney!”
-         |                  ^ This sentence does not start with a capital letter
+         |                  ^~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “T”
+  - Replace with: “The”
 
 
 
@@ -1517,45 +1517,45 @@ Message: |
 Lint:    Capitalization (31 priority)
 Message: |
     1200 | > “Wow! wow! wow!”
-         |         ^ This sentence does not start with a capital letter
+         |         ^~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “W”
+  - Replace with: “Wow”
 
 
 
 Lint:    Capitalization (31 priority)
 Message: |
     1200 | > “Wow! wow! wow!”
-         |              ^ This sentence does not start with a capital letter
+         |              ^~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “W”
+  - Replace with: “Wow”
 
 
 
 Lint:    Capitalization (31 priority)
 Message: |
     1211 | > “Wow! wow! wow!”
-         |         ^ This sentence does not start with a capital letter
+         |         ^~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “W”
+  - Replace with: “Wow”
 
 
 
 Lint:    Capitalization (31 priority)
 Message: |
     1211 | > “Wow! wow! wow!”
-         |              ^ This sentence does not start with a capital letter
+         |              ^~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “W”
+  - Replace with: “Wow”
 
 
 
 Lint:    Capitalization (31 priority)
 Message: |
     1213 | “Here! you may nurse it a bit, if you like!” the Duchess said to Alice, flinging
-         |        ^ This sentence does not start with a capital letter
+         |        ^~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “Y”
+  - Replace with: “You”
 
 
 
@@ -1685,9 +1685,9 @@ Message: |
 Lint:    Capitalization (31 priority)
 Message: |
     1481 | “Ah! that accounts for it,” said the Hatter. “He won’t stand beating. Now, if
-         |      ^ This sentence does not start with a capital letter
+         |      ^~~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “T”
+  - Replace with: “That”
 
 
 
@@ -2377,9 +2377,9 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
     2176 | “Ah! then yours wasn’t a really good school,” said the Mock Turtle in a tone of
-         |      ^ This sentence does not start with a capital letter
+         |      ^~~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “T”
+  - Replace with: “Then”
 
 
 

--- a/harper-core/tests/text/linters/Computer science.snap.yml
+++ b/harper-core/tests/text/linters/Computer science.snap.yml
@@ -902,9 +902,9 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
      262 | The famous P = NP? problem, one of the Millennium Prize Problems, is an open
-         |                    ^ This sentence does not start with a capital letter
+         |                    ^~~~~~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “P”
+  - Replace with: “Problem”
 
 
 
@@ -955,10 +955,10 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
      327 | is the lower bound on the complexity of fast Fourier transform algorithms? is
-         |                                                                            ^ This sentence does not start with a capital letter
+         |                                                                            ^~ This sentence does not start with a capital letter
      328 | one of the unsolved problems in theoretical computer science.
 Suggest:
-  - Replace with: “I”
+  - Replace with: “Is”
 
 
 
@@ -1119,9 +1119,9 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
      456 |   - print 1 at current location.
-         |     ^ This sentence does not start with a capital letter
+         |     ^~~~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “P”
+  - Replace with: “Print”
 
 
 
@@ -1160,18 +1160,18 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
      466 |   - selection: IF such-and-such is the case, THEN do this, ELSE do that;
-         |     ^ This sentence does not start with a capital letter
+         |     ^~~~~~~~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “S”
+  - Replace with: “Selection”
 
 
 
 Lint:    Capitalization (31 priority)
 Message: |
      467 |   - repetition: WHILE such-and-such is the case, DO this. The three rules of
-         |     ^ This sentence does not start with a capital letter
+         |     ^~~~~~~~~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “R”
+  - Replace with: “Repetition”
 
 
 

--- a/harper-core/tests/text/linters/Difficult sentences.snap.yml
+++ b/harper-core/tests/text/linters/Difficult sentences.snap.yml
@@ -1,18 +1,18 @@
 Lint:    Capitalization (31 priority)
 Message: |
       20 | at the bottom of the page; sitting at the table; at church; at sea
-         | ^ This sentence does not start with a capital letter
+         | ^~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “A”
+  - Replace with: “At”
 
 
 
 Lint:    Capitalization (31 priority)
 Message: |
       32 | men at work; children at play
-         | ^ This sentence does not start with a capital letter
+         | ^~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “M”
+  - Replace with: “Men”
 
 
 
@@ -37,9 +37,9 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
       76 | sold by the yard; cheaper if bought by the gross
-         | ^ This sentence does not start with a capital letter
+         | ^~~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “S”
+  - Replace with: “Sold”
 
 
 
@@ -66,9 +66,9 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
      160 | to account for one's whereabouts.
-         | ^ This sentence does not start with a capital letter
+         | ^~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “T”
+  - Replace with: “To”
 
 
 
@@ -104,9 +104,9 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
      254 | the in train (incoming train)
-         | ^ This sentence does not start with a capital letter
+         | ^~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “T”
+  - Replace with: “The”
 
 
 
@@ -203,18 +203,18 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
      316 | turn the television on
-         | ^ This sentence does not start with a capital letter
+         | ^~~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “T”
+  - Replace with: “Turn”
 
 
 
 Lint:    Capitalization (31 priority)
 Message: |
      322 | and so on.
-         | ^ This sentence does not start with a capital letter
+         | ^~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “A”
+  - Replace with: “And”
 
 
 
@@ -230,18 +230,18 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
      345 | tug on the rope; push hard on the door.
-         | ^ This sentence does not start with a capital letter
+         | ^~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “T”
+  - Replace with: “Tug”
 
 
 
 Lint:    Capitalization (31 priority)
 Message: |
      349 | to play on a violin or piano.
-         | ^ This sentence does not start with a capital letter
+         | ^~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “T”
+  - Replace with: “To”
 
 
 
@@ -288,27 +288,27 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
      449 | slain with robbers.
-         | ^ This sentence does not start with a capital letter
+         | ^~~~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “S”
+  - Replace with: “Slain”
 
 
 
 Lint:    Capitalization (31 priority)
 Message: |
      450 | cut with a knife
-         | ^ This sentence does not start with a capital letter
+         | ^~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “C”
+  - Replace with: “Cut”
 
 
 
 Lint:    Capitalization (31 priority)
 Message: |
      461 | overcome with happiness
-         | ^ This sentence does not start with a capital letter
+         | ^~~~~~~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “O”
+  - Replace with: “Overcome”
 
 
 

--- a/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
+++ b/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
@@ -1655,9 +1655,9 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
      721 | done in Convention by the Unanimous Consent of the States present the
-         | ^ This sentence does not start with a capital letter
+         | ^~~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “D”
+  - Replace with: “Done”
 
 
 

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -1967,9 +1967,9 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
     1612 | “It was . . . simply amazing,” she repeated abstractedly. “But I swore I
-         |               ^ This sentence does not start with a capital letter
+         |               ^~~~~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “S”
+  - Replace with: “Simply”
 
 
 
@@ -3735,9 +3735,9 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
     2603 | “Of course, of course! They’re fine!” and he added hollowly, “. . . old sport.”
-         |                                                                     ^ This sentence does not start with a capital letter
+         |                                                                     ^~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “O”
+  - Replace with: “Old”
 
 
 
@@ -4433,9 +4433,9 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
     3274 | “Mrs. Buchanan . . . and Mr. Buchanan—” After an instant’s hesitation he added:
-         |                      ^ This sentence does not start with a capital letter
+         |                      ^~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “A”
+  - Replace with: “And”
 
 
 
@@ -4730,9 +4730,9 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
     3607 | all . . . and as for your bothering me about it at lunch time, I won’t stand
-         |           ^ This sentence does not start with a capital letter
+         |           ^~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “A”
+  - Replace with: “And”
 
 
 
@@ -6374,9 +6374,9 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
     5205 | like that ashen, fantastic figure gliding toward him through the amorphous
-         | ^ This sentence does not start with a capital letter
+         | ^~~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “L”
+  - Replace with: “Like”
 
 
 
@@ -6601,9 +6601,9 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
     5350 | exclamation . . . then a quick squawk as the connection was broken.
-         |                   ^ This sentence does not start with a capital letter
+         |                   ^~~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “T”
+  - Replace with: “Then”
 
 
 
@@ -6958,9 +6958,9 @@ Suggest:
 Lint:    Capitalization (31 priority)
 Message: |
     5653 | “Go on!” He started. “Why, my God! they used to go there by the hundreds.”
-         |                                    ^ This sentence does not start with a capital letter
+         |                                    ^~~~ This sentence does not start with a capital letter
 Suggest:
-  - Replace with: “T”
+  - Replace with: “They”
 
 
 


### PR DESCRIPTION
# Description
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

It can sometimes be hard to click on just first letter in the word to fix its capitalization.
This PR changes the offending linter to span the entire first word, making it easier to select and fix.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually. Plus, the existing tests pass.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
