### PR TITLE
chore: sort and dedup lint group rules

### DIFF
--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -328,18 +328,12 @@ impl LintGroup {
         // Add all the more complex rules to the group.
         insert_struct_rule!(AdjectiveOfA, true);
         insert_struct_rule!(AnA, true);
+        insert_pattern_rule!(AskNoPreposition, true);
         insert_struct_rule!(AvoidCurses, true);
         insert_pattern_rule!(BackInTheDay, true);
         insert_pattern_rule!(BoringWords, false);
         insert_struct_rule!(CapitalizePersonalPronouns, true);
         insert_pattern_rule!(ChockFull, true);
-        insert_struct_rule!(SaveToSafe, true);
-        insert_struct_rule!(NailOnTheHead, true);
-        insert_struct_rule!(NominalWants, true);
-        insert_struct_rule!(ElsePossessive, true);
-        insert_pattern_rule!(WinPrize, true);
-        insert_pattern_rule!(AskNoPreposition, true);
-        insert_pattern_rule!(ItsContraction, true);
         insert_struct_rule!(CommaFixes, true);
         insert_struct_rule!(CompoundNouns, true);
         insert_pattern_rule!(Confident, true);
@@ -349,6 +343,7 @@ impl LintGroup {
         insert_pattern_rule!(DespiteOf, true);
         insert_pattern_rule!(DotInitialisms, true);
         insert_struct_rule!(EllipsisLength, true);
+        insert_struct_rule!(ElsePossessive, true);
         insert_pattern_rule!(ExpandTimeShorthands, true);
         insert_struct_rule!(FirstAidKit, true);
         insert_struct_rule!(ForNoun, true);
@@ -358,6 +353,7 @@ impl LintGroup {
         insert_struct_rule!(HopHope, true);
         insert_struct_rule!(HowTo, true);
         insert_pattern_rule!(HyphenateNumberDay, true);
+        insert_pattern_rule!(ItsContraction, true);
         insert_pattern_rule!(LeftRightHand, true);
         insert_struct_rule!(LetsConfusion, true);
         insert_pattern_rule!(Likewise, true);
@@ -367,6 +363,8 @@ impl LintGroup {
         insert_pattern_rule!(ModalOf, true);
         insert_pattern_rule!(MostNumber, true);
         insert_pattern_rule!(MultipleSequentialPronouns, true);
+        insert_struct_rule!(NailOnTheHead, true);
+        insert_struct_rule!(NominalWants, true);
         insert_struct_rule!(NoOxfordComma, false);
         insert_pattern_rule!(Nobody, true);
         insert_struct_rule!(NumberSuffixCapitalization, true);
@@ -381,12 +379,12 @@ impl LintGroup {
         insert_struct_rule!(PronounContraction, true);
         insert_struct_rule!(PronounKnew, true);
         insert_struct_rule!(RepeatedWords, true);
+        insert_struct_rule!(SaveToSafe, true);
         insert_pattern_rule!(SomewhatSomething, true);
         insert_struct_rule!(Spaces, true);
         insert_struct_rule!(SpelledNumbers, false);
         insert_pattern_rule!(ThatWhich, true);
         insert_pattern_rule!(TheHowWhy, true);
-        insert_struct_rule!(TheHowWhy, true);
         insert_struct_rule!(TheMy, true);
         insert_pattern_rule!(ThenThan, true);
         insert_struct_rule!(UnclosedQuotes, true);
@@ -395,6 +393,7 @@ impl LintGroup {
         insert_pattern_rule!(Whereas, true);
         insert_pattern_rule!(WidelyAccepted, true);
         insert_struct_rule!(WidelyAccepted, true);
+        insert_pattern_rule!(WinPrize, true);
         insert_struct_rule!(WordPressDotcom, true);
 
         out.add(


### PR DESCRIPTION
# Issues 
N/A

# Description

While trying to learn how to start using `lint_group` I noticed that the rules were partly but not fully alphabetized. And then I noticed the `TheHowWhy` rule was added twice! Once as a struct and once as a pattern. I'm surprised that didn't upset clippy or anything else.

# How Has This Been Tested?

`cargo test` still has no failures.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
