### PR TITLE
Added determiners to function

### DIFF
--- a/harper-core/src/document.rs
+++ b/harper-core/src/document.rs
@@ -224,6 +224,11 @@ impl Document {
                         "my", "your", "thy", "thine", "his", /*"her",*/ "its", "our", "their",
                         "whose", // "no" is also a determiner
                         "no",
+                        // List of Determiners from the 2003 "Longman Student Grammar of
+                        // Spoken and Written English" Chapter 4.5
+                        "all", "both", "half", "this", "that", "every", "each", "either", "neither",
+                        "any", "many", "some", "these", "those", "few", "enough", "several",
+                        "much",
                     ]))
                     .then_whitespace()
                     .then_verb(),

--- a/harper-core/src/document.rs
+++ b/harper-core/src/document.rs
@@ -226,9 +226,11 @@ impl Document {
                         "no",
                         // List of Determiners from the 2003 "Longman Student Grammar of
                         // Spoken and Written English" Chapter 4.5
-                        "all", "both", "half", "this", "that", "every", "each", "either", "neither",
+                        // But of these only "every" is never followed by a verb
+                        /*"all", "both", "half", "this", "that", "each", "either", "neither",
                         "any", "many", "some", "these", "those", "few", "enough", "several",
-                        "much",
+                        "much",*/
+                        "every",
                     ]))
                     .then_whitespace()
                     .then_verb(),


### PR DESCRIPTION
# Issues 
Determiners in addition to issue #1189 

# Description
Added a list of determiners from the 2003 edition of "Longman Student Grammar of Spoken and Written English". This list is non-exhaustive and only includes those determiners on page 65 listed as determiners for countable or uncountable nouns

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
Ran `just format` and `just precommit` with only the repeating word failing.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
