### PR TITLE
fix: solve part 1. of #1298 by making "that" a special case

### DIFF
--- a/harper-core/src/linting/nominal_wants.rs
+++ b/harper-core/src/linting/nominal_wants.rs
@@ -11,9 +11,21 @@ pub struct NominalWants {
 
 impl Default for NominalWants {
     fn default() -> Self {
+        // "That" can act as two kinds of pronoun: demonstrative and relative.
+        // As a demonstrative pronoun, it's third person singular.
+        // As a relative pronoun, it's behaves as any person:
+        // I am the one that wants to. He is the one that wants to.
+        fn is_applicable_pronoun(tok: &Token, src: &[char]) -> bool {
+            if tok.kind.is_pronoun() {
+                tok.span.get_content_string(src).to_lowercase() != "that"
+            } else {
+                false
+            }
+        }
+
         let miss = WordSet::new(&["wont", "wonts", "want", "wants"]);
         let pattern = SequencePattern::default()
-            .then_pronoun()
+            .then(is_applicable_pronoun)
             .then_whitespace()
             .then(miss);
         Self {
@@ -132,5 +144,14 @@ mod tests {
     #[test]
     fn ignores_correct_usage_he() {
         assert_lint_count("He wants to help.", NominalWants::default(), 0);
+    }
+
+    #[test]
+    fn ignores_correct_usage_that_1298() {
+        assert_lint_count(
+            "The projects that want to take it seriously are the best.",
+            NominalWants::default(),
+            0,
+        );
     }
 }


### PR DESCRIPTION
# Issues 

#1291 part 1.

# Description

I made "that" a special case because it can be at least two kinds of pronoun.
When "that" is a demonstrative pronoun it acts like a 3rd person and would take the "wants" form of the verb.
But when "that" is a relative pronoun it works with any grammatical number so either "want" or "wants" can come after it.
Since we can't realistically check if `that` is demonstrative or relative, or at least we don't do so yet, we will just not check it for agreement with the verb.

# Demo

Before: 
<img width="1206" alt="Screenshot 2025-05-20 at 5 52 48 pm" src="https://github.com/user-attachments/assets/11be83cf-a8bb-40ed-8841-38c416b8f793" />

After: 
<img width="1201" alt="image" src="https://github.com/user-attachments/assets/b6c5e68d-2632-48d0-aaa2-a00244469f72" />


# How Has This Been Tested?

I added a unit test using the sentence from #1298

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
