### PR TITLE
fix: solve part 2. of #1298 by allowing indefinite pronouns before "new"

### DIFF
--- a/harper-core/src/linting/pronoun_knew.rs
+++ b/harper-core/src/linting/pronoun_knew.rs
@@ -18,14 +18,13 @@ impl Default for PronounKnew {
         // But "its" commonly occurs before "new" and is a possessive pronoun. (Much more commonly a determiner)
         // Since "his" and "her" are possessive and object pronouns respectively, we ignore them too.
         let pronoun_pattern = |tok: &Token, source: &[char]| {
-            if tok.kind.is_pronoun() {
-                let pronorm = tok.span.get_content_string(source).to_lowercase();
-                // Personal pronouns that are not only/always subject pronouns.
-                return pronorm != "its" && pronorm != "his" && pronorm != "her"
-                    // Indefinite pronouns can come before adjectives.
-                    && pronorm != "every" && pronorm != "something" && pronorm != "nothing";
+            if !tok.kind.is_pronoun() {
+                return false;
             }
-            false
+
+            let pronorm = tok.span.get_content_string(source).to_lowercase();
+            let excluded = ["its", "his", "her", "every", "something", "nothing"];
+            !excluded.contains(&&*pronorm)
         };
 
         let pronoun_then_new = SequencePattern::default()

--- a/harper-core/src/linting/pronoun_knew.rs
+++ b/harper-core/src/linting/pronoun_knew.rs
@@ -20,7 +20,10 @@ impl Default for PronounKnew {
         let pronoun_pattern = |tok: &Token, source: &[char]| {
             if tok.kind.is_pronoun() {
                 let pronorm = tok.span.get_content_string(source).to_lowercase();
-                return pronorm != "its" && pronorm != "his" && pronorm != "her";
+                // Personal pronouns that are not only/always subject pronouns.
+                return pronorm != "its" && pronorm != "his" && pronorm != "her"
+                    // Indefinite pronouns can come before adjectives.
+                    && pronorm != "every" && pronorm != "something" && pronorm != "nothing";
             }
             false
         };
@@ -125,5 +128,10 @@ mod tests {
     #[test]
     fn does_not_flag_with_her() {
         assert_lint_count("Her new car is fast.", PronounKnew::default(), 0);
+    }
+
+    #[test]
+    fn does_not_flag_with_nothing_1298() {
+        assert_lint_count("This is nothing new.", PronounKnew::default(), 0);
     }
 }


### PR DESCRIPTION
# Issues 
2. in #1298

# Description

One type of pronoun is the "indefinite pronoun", including: "everything", "something", "nothing"
At least these three indefinite pronouns work before adjectives: "something old, something new".
These three rarely refer to people or animate entities that can be the subject of the verb "to know".

# Demo

Before: 
<img width="687" alt="Screenshot 2025-05-20 at 6 09 41 pm" src="https://github.com/user-attachments/assets/1a7f64fa-40fd-4f51-973d-a19bacfd09d7" />

After: 
<img width="689" alt="Screenshot 2025-05-20 at 6 11 47 pm" src="https://github.com/user-attachments/assets/6cf20b15-ccff-4ad1-82be-74628b558ddf" />

# How Has This Been Tested?

I used the OP's example from their issue as a new unit test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
