### PR TITLE
fix: solve part 3. of #1298 if it's following a noun+"and" it's probably a compound noun

### DIFF
--- a/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
+++ b/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
@@ -155,7 +155,6 @@ impl Linter for PhrasalVerbAsCompoundNoun {
                 if let TokenKind::Word(None) = &prev_tok.kind {
                     continue;
                 }
-                
             }
 
             let message = match confidence {

--- a/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
+++ b/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use super::{Lint, LintKind, Linter, Suggestion};
-use crate::{Dictionary, Document, FstDictionary, Span, TokenStringExt};
+use crate::{Dictionary, Document, FstDictionary, Span, TokenKind, TokenStringExt};
 
 /// Detect phrasal verbs written as compound nouns.
 pub struct PhrasalVerbAsCompoundNoun {
@@ -150,6 +150,12 @@ impl Linter for PhrasalVerbAsCompoundNoun {
                         }
                     }
                 }
+
+                // If the previous word is OOV, those are most commonly nouns
+                if let TokenKind::Word(None) = &prev_tok.kind {
+                    continue;
+                }
+                
             }
 
             let message = match confidence {
@@ -372,6 +378,15 @@ mod tests {
     fn dont_flag_list_of_nouns_1298() {
         assert_lint_count(
             "A printable format and layout.",
+            PhrasalVerbAsCompoundNoun::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_oov_nvim_plugin_1280() {
+        assert_lint_count(
+            "This is the nvim plugin for you.",
             PhrasalVerbAsCompoundNoun::default(),
             0,
         );


### PR DESCRIPTION
# Issues 
Fixes 3. in #1298
Fixes #1280

# Description

Solve part 3. of #1298 by checking if the compound noun is part of a list with other nouns by checking if there's a previous word that's a conjunction and a previous word to that that's a noun.

I also replaced the older custom helper functions and logic with the newer helpers I added to `Document` a couple of weeks ago.

It turned out that #1280 belongs here too. In that case the word before our focus is OOV (out of vocabulary, meaning novel, not in our dictionary). Such words are most often nouns so we treat those just like noun and a noun before a noun is legit: `neovim plugin` so we don't flag those now.

# Demo

1298 Before: 
<img width="1031" alt="Screenshot 2025-05-20 at 7 10 27 pm" src="https://github.com/user-attachments/assets/c77a2854-71c5-4daf-931f-c73ba0374841" />

1298 After: 
<img width="1031" alt="Screenshot 2025-05-20 at 7 11 23 pm" src="https://github.com/user-attachments/assets/b7b4085f-ee08-4650-9160-63ee2916fbca" />

1280 Before: 
<img width="788" alt="Screenshot 2025-05-21 at 1 42 43 pm" src="https://github.com/user-attachments/assets/16802600-997b-4f05-8671-0a1f82598c5a" />

1280 After: 
<img width="441" alt="Screenshot 2025-05-21 at 1 45 52 pm" src="https://github.com/user-attachments/assets/cf549039-796c-4a46-91b7-231e9efbb226" />

# How Has This Been Tested?

I added a new unit tests using the sentences of each OP.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
