### PR TITLE
Dictionary curation 2025 05 21

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -3400,6 +3400,7 @@ FDA/2
 FDIC/2M
 FDR/21M
 FEMA/2M
+FFT/1MS             # fast Fourier transform
 FHA/2M
 FICA/2M
 FIFO/1
@@ -5637,6 +5638,7 @@ LDC/1
 LED/1MS
 LG/12M
 LGB/51
+LGPL/12             # GNU Lesser General Public License
 LGBT/51
 LGBTQ/51
 LIFO/5
@@ -6186,7 +6188,8 @@ MO/215
 MOOC/1
 MOSFET/1MS          # transistor
 MP/125M             # military police; member of parliament
-MP3/1SM
+MP3/1SM             # audio format
+MP4/1SM             # audio/video format
 MPEG/21
 MRI/14M             # magnetic resonance imaging
 MS/12M
@@ -8390,7 +8393,7 @@ REM/1SM
 RF/12
 RFC/21S
 RFD/512
-RGB
+RGB                 # colour model
 RI/21
 RIF/14
 RIFA/2M
@@ -52246,12 +52249,15 @@ zymurgy/1M
 0s/~9               # not sure how well "words" starting with numbers are handled
 1s/~9               # not sure how well "words" starting with numbers are handled
 3D/5                # not sure how well "words" starting with numbers are handled
+AAC/1M              # audio format
 ACM/1M
 AGI/MS              # artificial general intelligence
 AMC/12MS            # old car brand
 AOC/2M              # US politician Alexandria Ocasio-Cortez
+ASM/1               # assembly language - should "asm" be included as well/instead?
 ASUS/2M
 ATF/1M              # automatic transmission fluid
+AVC/1M              # H.264 video format
 Akismet/2M
 Alexa/2M            # voice assistant
 Alexandre/2SM
@@ -52284,6 +52290,7 @@ CI/1SM              # continuous integration
 CISC/1M             # cpu architecture
 CMOS/1              # microchip process
 CMake/SM            # build tool
+CMYK                # colour model
 CQL/1
 CRC/1MS             # cyclic redundancy check
 CRDT/1SM
@@ -52299,6 +52306,7 @@ Crowdsignal/2M
 Cypher/21M
 DATETIME/1MS        # dictionaries prefer: datetime
 DBMS/12SM           # database management system
+DCT/1MS             # discrete cosine transform
 DEI
 DKIM/1SM
 DM/1MS4             # direct message
@@ -52316,6 +52324,7 @@ DirectX/2M
 Dreamcast/2MS       # game console
 EGR/                # exhaust gas recirculation
 EMR/12SM
+EPUB/12MS           # e-book format
 ESLint/2M
 EV/1SM              # electric vehicle
 ElasticSearch/SM
@@ -52390,8 +52399,11 @@ LEGO/1SM            # official trademark form of Lego
 LIDAR/1             # FIXME! elsewhere we have LiDAR
 LLM/1MS             # large language model
 LLVM/1M             # compiler system
+LOC/9               # source lines of code
+LSB/1MS2            # least significant bit/byte; Linux Standard Base
 LSP/1MS             # language server protocol
 LTS/1SM
+LUT/1MS             # lookup table
 LVM/SM
 Labriola/2SM
 LanguageTool/M      # grammar checker
@@ -52407,6 +52419,8 @@ Longreads/2M
 Lua/SM              # programming language
 MMX/1M              # multimedia extension
 MPC/21M
+MSB/1MS             # most significant bit/byte
+MSE/1MS             # mean squared error
 MSNBC/2M            # media company
 MSVC                # Microsoft Visual C++
 MTA/1SM
@@ -52433,6 +52447,7 @@ NLP/M
 NMI/1MS             # non-maskable interrupt
 NPC/SM
 NPM/SM
+NTP/1               # network time protocol
 NYTimes/SM
 NYU/2M
 Neo4J/21M
@@ -52462,6 +52477,7 @@ PCH/2M              # highway
 PDP/1SM             # old computer
 PII/1SM
 PKCS/SM
+POSIX/2M            # unix standard
 PRQL/1
 PTSD/1SM            # post-traumatic stress disorder
 PWA/21SM
@@ -52495,6 +52511,7 @@ SDK/1SM             # software development kit
 SDL/2M              # Simple DirectMedia Layer
 SIMD/1SM            # single instruction, multiple data
 SLA/1SM
+SLOC/9              # source lines of code
 SNL/2M              # Saturday Night Live
 SQLAlchemy/1
 SVG/21s             # scalable vector graphics
@@ -52515,6 +52532,7 @@ Subversion/1M       # version control
 Svelte/2M           # js framework
 Systemd/SM          # Linux system software
 TCP/52SM            # internet protocol
+TL;DR               # internet slang
 TODO                # FIXME! elsewhere in Harper we refer to Todo and to-do
 TOML/1M             # configuration file format
 TSMC/2M             # Taiwanese Semiconductor Manufacturing Company
@@ -52617,6 +52635,7 @@ raytracer/1         # dictionaries prefer: ray tracer
 roadmap/1MS         # overtook "road map" c. 2000 but not in dictionaries yet
 royale/~15SM        # !! please check and comment !! dictionaries only list noun sense type of custard
 s.t./~              # !! please check and comment !!
+sRGB/2M             # colour space
 scatterplot/14SMG   # dictionaries prefer: scatter plot
 scrollbar/1SM       # dictionaries prefer: scroll bar
 sioyek/SM           # !! please check and comment !!

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -7510,6 +7510,7 @@ O'Rourke/2M
 O'Toole/2M
 OAS/12M
 OB/15
+OBD/1MS             # on-board diagnostics
 OCR/214             # optical character recognition
 OD/14SM
 OE/2154
@@ -12127,7 +12128,7 @@ altruistic/5Q
 alum/~14SM
 alumina/1M
 aluminium/1M!_
-aluminum/~1M@
+aluminum/~1M@<
 alumna/1M
 alumnae/9
 alumni/~9
@@ -13662,6 +13663,7 @@ backstreet/~51S
 backstretch/1MS
 backstroke/~14MGDS
 backtalk/14M
+backtrace/1MS4DG
 backtrack/14SDG
 backup/~15MS
 backward/~51PSY
@@ -16933,7 +16935,7 @@ chapped/54
 chapping/4
 chappy/15S
 chapstick/1MS
-chapter/~14SM
+chapter/~14SMDG
 char/~41SM
 charabanc/14MS
 character/~14MS
@@ -19837,6 +19839,7 @@ cumbrous/5
 cumin/1M
 cummerbund/1MS
 cumming/~4
+cumulate/4SDG
 cumulative/~5Y
 cumuli/1
 cumulonimbi/1
@@ -20343,6 +20346,7 @@ decolletage/1SM
 decollete/5
 decompilation/1MS
 decompile/4SDG
+decompiler/1MS
 decongestant/1MS
 deconstructionism/1
 decor/1MS
@@ -21788,7 +21792,7 @@ downrank/4SDG
 downright/~5
 downriver/~5
 downsample/SMG
-downscale/54
+downscale/54SDG
 downshift/14SGD
 downside/~1MS
 downsize/4GDS
@@ -21947,7 +21951,8 @@ dripper/1MS
 dripping/~14SM
 drippy/5TR
 drivability/1M
-drive/~41RSMZGB
+drivable/5U
+drive/~41RSMZG
 drivel/14SZGMDR
 driveler/1M
 drivelled/4!@_
@@ -41512,6 +41517,7 @@ rerunning/4
 resale/1MSB
 resample/4GDS
 resat/4
+rescale/4SDG
 rescind/4SDG
 rescission/1M
 rescue/~41DRSMZG
@@ -45207,7 +45213,7 @@ specif/
 specifiable/5
 specific/~51MSQ
 specification/~1M
-specificity/~1M
+specificity/~1MS
 specified/~54U
 specify/~4XNZDRSG
 specimen/~1SM
@@ -45827,6 +45833,7 @@ steerage/1M
 steering/~41M
 steersman/1M
 steersmen/9
+steganography/1M
 stegosauri/1
 stegosaurus/1MS
 stein/~1SM
@@ -47598,7 +47605,7 @@ temperature/~1SM
 tempest/~14SM
 tempestuous/5YP
 tempestuousness/1M
-template/~14S
+template/~1M4SDG
 template's
 temple/~14SM
 tempo/~1SM
@@ -48440,6 +48447,7 @@ torpid/51Y
 torpidity/1M
 torpor/1M
 torque/~14MGDS
+torquey/5
 torrent/~154SM
 torrential/5
 torrid/5YP
@@ -48561,6 +48569,7 @@ trabecule/1
 trace/~14JDRSMZG
 traceability/1
 traceable/5U
+traceback/1MS
 tracer/~1M
 tracery/1SM
 trachea/1M
@@ -48668,6 +48677,8 @@ transcendent/~51
 transcendental/~15Y
 transcendentalism/1M
 transcendentalist/1SM
+transcode/4GDS1M
+transcoder/1MS
 transcontinental/~51
 transcribe/~4ZGDRS
 transcriber/1M
@@ -50009,7 +50020,7 @@ uproar/~14SM
 uproarious/5Y
 uproot/41GSD
 upsample/SMG
-upscale/~54
+upscale/~54SDG
 upset/~514SM
 upsetting/~415
 upshot/1SM
@@ -51947,7 +51958,7 @@ wunderkind/1S
 wurst/1SM
 wuss/14MS
 wussy/51RSMT
-x/~57
+x/~                 # removed `5` and `7` adjective and `conjunction`
 x64/1M
 x86/~1M
 xci
@@ -52000,6 +52011,7 @@ xylem/1M
 xylene/1
 xylophone/14SM
 xylophonist/1MS
+y
 y'all/84
 ya/~81
 yacht/~14SMDG
@@ -52262,6 +52274,7 @@ Bezos/2             # Surname, Amazon founder
 Bing/2M             # Microsoft product
 BitKeeper/1M        # version control
 BlasterHacks/SM
+Boxster/12MS        # car model
 BurpSuite/21MS
 C++/2SM             # programming language
 CCP/2S              # Chinese Communist Party
@@ -52322,6 +52335,7 @@ FireWire/MS         # trademark
 Firestore/M
 Foddy/SM
 Frankl/SM
+FreeBSD/2M          # operating system
 GLFW/2M
 GPL/2M              # GNU General Public License
 GPT/1SM             # generative pre-trained transformer
@@ -52423,6 +52437,7 @@ NYTimes/SM
 NYU/2M
 Neo4J/21M
 Neovim/M            # code editor
+NetBSD/2M           # operating system
 Netlify/M2          # cloud
 Nikolay/SM
 NixOS/M2
@@ -52435,6 +52450,8 @@ OAuth/M             # open authentication
 OCaml/M2            # programming language
 OG/1MS
 ORM/12S             # object-relational mapping
+OpenAI/2M
+OpenBSD/2M          # operating system
 OpenGL/SM           # open graphics library
 OpenMetrics/SM
 OpenPGP/SM
@@ -52580,6 +52597,7 @@ dotfile/~1SM        # not well covered by dictionaries.
 eVTOL/1MS
 filesystem/~SM      # dictionaries prefer: file system
 frontend/1SM        # dictionaries prefer: front end
+geofence/1MS4DG
 gRPC/2SM            # framework
 glymph/SM           # !! please check and comment !!
 gzip/4S             # GNU compression utility
@@ -52652,6 +52670,7 @@ built-in/1MS5
 built-up/5
 car bomb/1MS
 car-bomb/4
+carbon-intensive/5
 cash-strapped/5
 CD-ROM/1MS
 centre-left/5!@_
@@ -52891,6 +52910,8 @@ rack-mounted/5
 re-enable/4DSG
 real time/1M
 real-time/5
+real world/1M
+real-world/5
 red-eye/1M
 red wolf/1M
 red wolves/9
@@ -53088,6 +53109,9 @@ white out/4
 wipe out/4
 work around/4
 work out/4
+x-axis/1M
+y-axis/1M
+z-axis/1M
 
 # New entries may be added below this line
 # If you're not confident in using the affix annotations, add missing words here

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -2916,7 +2916,7 @@ Message: |
 Suggest:
   - Replace with: “H'm”
   - Replace with: “Ha”
-  - Replace with: “Hem”
+  - Replace with: “Ham”
 
 
 

--- a/harper-core/tests/text/linters/Computer science.snap.yml
+++ b/harper-core/tests/text/linters/Computer science.snap.yml
@@ -785,7 +785,7 @@ Message: |
      216 | that they are theory, abstraction (modeling), and design. Amnon H. Eden
          |                                                                 ^~ Did you mean to spell `H.` this way?
 Suggest:
-  - Replace with: “Hp”
+  - Replace with: “Hi”
   - Replace with: “H”
   - Replace with: “He”
 

--- a/harper-core/tests/text/linters/Computer science.snap.yml
+++ b/harper-core/tests/text/linters/Computer science.snap.yml
@@ -167,9 +167,9 @@ Message: |
       78 | ASCC/Harvard Mark I, based on Babbage's Analytical Engine, which itself used
          | ^~~~ Did you mean to spell `ASCC` this way?
 Suggest:
+  - Replace with: “AAC”
   - Replace with: “ABC”
   - Replace with: “ABCs”
-  - Replace with: “ACL”
 
 
 
@@ -654,7 +654,7 @@ Message: |
      182 | Newell and Herbert A. Simon argued in 1975,
          |                    ^~ Did you mean to spell `A.` this way?
 Suggest:
-  - Replace with: “Av”
+  - Replace with: “Aw”
   - Replace with: “Ab”
   - Replace with: “Ac”
 
@@ -1010,7 +1010,7 @@ Message: |
      394 | Johnson and Frederick P. Brooks Jr., members of the Machine Organization
          |                       ^~ Did you mean to spell `P.` this way?
 Suggest:
-  - Replace with: “Pp”
+  - Replace with: “Pt”
   - Replace with: “P”
   - Replace with: “Pa”
 

--- a/harper-core/tests/text/linters/Difficult sentences.snap.yml
+++ b/harper-core/tests/text/linters/Difficult sentences.snap.yml
@@ -271,7 +271,7 @@ Message: |
          |                                                               ^~ Did you mean to spell `PR` this way?
 Suggest:
   - Replace with: “Pro”
-  - Replace with: “Pa”
+  - Replace with: “P”
   - Replace with: “Par”
 
 

--- a/harper-core/tests/text/linters/Part-of-speech tagging.snap.yml
+++ b/harper-core/tests/text/linters/Part-of-speech tagging.snap.yml
@@ -29,8 +29,8 @@ Message: |
          |                                                    ^~ Did you mean to spell `E.` this way?
 Suggest:
   - Replace with: “E”
-  - Replace with: “Es”
-  - Replace with: “EC”
+  - Replace with: “Ea”
+  - Replace with: “Eh”
 
 
 
@@ -67,8 +67,8 @@ Message: |
          |                    ^~ Did you mean to spell `NN` this way?
 Suggest:
   - Replace with: “Nun”
+  - Replace with: “N”
   - Replace with: “Non”
-  - Replace with: “N1”
 
 
 

--- a/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
+++ b/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
@@ -39,7 +39,7 @@ Message: |
       11 | ## Article. I.
          |             ^~ Did you mean to spell `I.` this way?
 Suggest:
-  - Replace with: “Id”
+  - Replace with: “Ii”
   - Replace with: “IC”
   - Replace with: “IE”
 

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -858,7 +858,7 @@ Message: |
 Suggest:
   - Replace with: “Jr”
   - Replace with: “J”
-  - Replace with: “JD”
+  - Replace with: “Jg”
 
 
 
@@ -892,7 +892,7 @@ Message: |
 Suggest:
   - Replace with: “Jr”
   - Replace with: “J”
-  - Replace with: “JD”
+  - Replace with: “Jg”
 
 
 
@@ -981,7 +981,7 @@ Message: |
          |                        ^~ Did you mean to spell `B.` this way?
 Suggest:
   - Replace with: “Bu”
-  - Replace with: “Bi”
+  - Replace with: “Be”
   - Replace with: “Bk”
 
 
@@ -1094,9 +1094,9 @@ Message: |
      784 | We backed up to a gray old man who bore an absurd resemblance to John D.
          |                                                                       ^~ Did you mean to spell `D.` this way?
 Suggest:
-  - Replace with: “Dd”
   - Replace with: “D”
   - Replace with: “Db”
+  - Replace with: “Dc”
 
 
 
@@ -1265,7 +1265,7 @@ Message: |
          | ^~ Did you mean to spell `B.` this way?
 Suggest:
   - Replace with: “Bu”
-  - Replace with: “Bi”
+  - Replace with: “Be”
   - Replace with: “Bk”
 
 
@@ -2365,7 +2365,7 @@ Message: |
          |                               ^~ Did you mean to spell `B.` this way?
 Suggest:
   - Replace with: “Bu”
-  - Replace with: “Bi”
+  - Replace with: “Be”
   - Replace with: “Bk”
 
 
@@ -2500,9 +2500,9 @@ Message: |
     1870 | Catlips and the Bembergs and G. Earl Muldoon, brother to that Muldoon who
          |                              ^~ Did you mean to spell `G.` this way?
 Suggest:
+  - Replace with: “Gt”
   - Replace with: “Go”
   - Replace with: “Gr”
-  - Replace with: “Gs”
 
 
 
@@ -2582,7 +2582,7 @@ Message: |
          |           ^~ Did you mean to spell `B.` this way?
 Suggest:
   - Replace with: “Bu”
-  - Replace with: “Bi”
+  - Replace with: “Be”
   - Replace with: “Bk”
 
 
@@ -2803,9 +2803,9 @@ Message: |
     1882 | and Henry L. Palmetto, who killed himself by jumping in front of a subway train
          |           ^~ Did you mean to spell `L.` this way?
 Suggest:
-  - Replace with: “Lb”
+  - Replace with: “Lg”
   - Replace with: “L”
-  - Replace with: “La”
+  - Replace with: “LC”
 
 
 
@@ -4928,7 +4928,7 @@ Message: |
 Suggest:
   - Replace with: “Jr”
   - Replace with: “J”
-  - Replace with: “JD”
+  - Replace with: “Jg”
 
 
 
@@ -4997,7 +4997,7 @@ Message: |
 Suggest:
   - Replace with: “Jr”
   - Replace with: “J”
-  - Replace with: “JD”
+  - Replace with: “Jg”
 
 
 
@@ -6174,7 +6174,7 @@ Message: |
 Suggest:
   - Replace with: “H'm”
   - Replace with: “Ha”
-  - Replace with: “Hem”
+  - Replace with: “Ham”
 
 
 
@@ -6236,7 +6236,7 @@ Message: |
 Suggest:
   - Replace with: “Jr”
   - Replace with: “J”
-  - Replace with: “JD”
+  - Replace with: “Jg”
 
 
 
@@ -6574,7 +6574,7 @@ Message: |
 Suggest:
   - Replace with: “Cw”
   - Replace with: “C”
-  - Replace with: “Ca”
+  - Replace with: “Cc”
 
 
 
@@ -6674,7 +6674,7 @@ Message: |
 Suggest:
   - Replace with: “Jr”
   - Replace with: “J”
-  - Replace with: “JD”
+  - Replace with: “Jg”
 
 
 
@@ -6701,7 +6701,7 @@ Message: |
          |                                                              ^~ Did you mean to spell `B.` this way?
 Suggest:
   - Replace with: “Bu”
-  - Replace with: “Bi”
+  - Replace with: “Be”
   - Replace with: “Bk”
 
 

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -5,7 +5,7 @@ Message: |
 Suggest:
   - Replace with: “F”
   - Replace with: “Ff”
-  - Replace with: “Fr”
+  - Replace with: “Fl”
 
 
 
@@ -14,9 +14,9 @@ Message: |
        3 | BY F. SCOTT FITZGERALD
          |       ^~~~~ Did you mean to spell `SCOTT` this way?
 Suggest:
+  - Replace with: “Scot”
+  - Replace with: “SCM's”
   - Replace with: “SEO's”
-  - Replace with: “Alcott”
-  - Replace with: “Lott”
 
 
 
@@ -847,7 +847,7 @@ Message: |
 Suggest:
   - Replace with: “To”
   - Replace with: “T”
-  - Replace with: “Ta”
+  - Replace with: “Tb”
 
 
 
@@ -881,7 +881,7 @@ Message: |
 Suggest:
   - Replace with: “To”
   - Replace with: “T”
-  - Replace with: “Ta”
+  - Replace with: “Tb”
 
 
 
@@ -2288,7 +2288,7 @@ Message: |
     1858 | farther out on the Island came the Cheadles and the O. R. P. Schraeders, and the
          |                                                           ^~ Did you mean to spell `P.` this way?
 Suggest:
-  - Replace with: “Pp”
+  - Replace with: “Pt”
   - Replace with: “P”
   - Replace with: “Pa”
 
@@ -2376,7 +2376,7 @@ Message: |
     1863 | A. Flink, and the Hammerheads, and Beluga the tobacco importer, and Beluga’s
          | ^~ Did you mean to spell `A.` this way?
 Suggest:
-  - Replace with: “Av”
+  - Replace with: “Aw”
   - Replace with: “Ab”
   - Replace with: “Ac”
 
@@ -2535,7 +2535,7 @@ Message: |
     1871 | afterward strangled his wife. Da Fontano the promoter came there, and Ed Legros
          |                               ^~ Did you mean to spell `Da` this way?
 Suggest:
-  - Replace with: “Dab”
+  - Replace with: “D”
   - Replace with: “Dad”
   - Replace with: “Dam”
 
@@ -2803,9 +2803,9 @@ Message: |
     1882 | and Henry L. Palmetto, who killed himself by jumping in front of a subway train
          |           ^~ Did you mean to spell `L.` this way?
 Suggest:
-  - Replace with: “Lg”
-  - Replace with: “L”
-  - Replace with: “LC”
+  - Replace with: “Lo”
+  - Replace with: “La”
+  - Replace with: “Ll”
 
 
 
@@ -2925,7 +2925,7 @@ Message: |
     1896 | Fitz-Peters and Mr. P. Jewett, once head of the American Legion, and Miss
          |                     ^~ Did you mean to spell `P.` this way?
 Suggest:
-  - Replace with: “Pp”
+  - Replace with: “Pt”
   - Replace with: “P”
   - Replace with: “Pa”
 
@@ -4917,7 +4917,7 @@ Message: |
 Suggest:
   - Replace with: “To”
   - Replace with: “T”
-  - Replace with: “Ta”
+  - Replace with: “Tb”
 
 
 
@@ -4986,7 +4986,7 @@ Message: |
 Suggest:
   - Replace with: “To”
   - Replace with: “T”
-  - Replace with: “Ta”
+  - Replace with: “Tb”
 
 
 
@@ -6225,7 +6225,7 @@ Message: |
 Suggest:
   - Replace with: “To”
   - Replace with: “T”
-  - Replace with: “Ta”
+  - Replace with: “Tb”
 
 
 
@@ -6713,7 +6713,7 @@ Message: |
 Suggest:
   - Replace with: “F”
   - Replace with: “Ff”
-  - Replace with: “Fr”
+  - Replace with: “Fl”
 
 
 

--- a/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
+++ b/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
@@ -4486,8 +4486,8 @@
 # . NPrSg/V I/J/D NSg/I/V/J J/P   D   NPl   NPrSg/V/J/C . .
 >
 #
-> CHAPTER X         : The Lobster Quadrille
-# NSg/V   NPrSg/J/C . D   NSg/J   NSg/V/J
+> CHAPTER X       : The Lobster Quadrille
+# NSg/V   NPrSg/J . D   NSg/J   NSg/V/J
 >
 #
 > The Mock  Turtle sighed deeply , and drew  the back  of one       flapper across his   eyes .


### PR DESCRIPTION
# Issues 

#1307 

# Description

All missing vocab suggested by @ubitux in #1307 has been added along with the usual new words and affix fixes.

One important fix was that the entry for `aluminum` was missing the `<` flag for American English and only had the `@` flag for Canadian English. But it still gets flagged as wrong since the Canadian flag comes first and the metadata system currently only supports one dialect per entry even though the dictionary format supports multiple.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manual testing against the specific vocab in #1307

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
