### PR TITLE
chore: add 'togglable' to curated dict

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -48310,7 +48310,7 @@ together/~5P
 togetherness/1M
 togged/5
 togging/4
-toggle/14DSMG
+toggle/14DSMGB
 togs/14M
 toil/14MDRZGS
 toiler/1M


### PR DESCRIPTION

# Description

Adds 'togglable' to the curated dictionary by adding the `B` affix onto 'toggle'.

# How Has This Been Tested?

- `cargo test`
- Compiling and manually testing `harper-ls`.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
