### PR TITLE
fix: use community maintained fork of tower-lsp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,28 +145,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "auto_impl"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,11 +494,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
+ "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -624,6 +603,15 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
 
 [[package]]
 name = "fnv"
@@ -932,7 +920,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tower-lsp",
+ "tower-lsp-server",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1450,15 +1438,15 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.94.1"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
 dependencies = [
  "bitflags 1.3.2",
+ "fluent-uri",
  "serde",
  "serde_json",
  "serde_repr",
- "url",
 ]
 
 [[package]]
@@ -1698,26 +1686,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2015,7 +1983,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower 0.5.2",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2529,20 +2497,6 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
@@ -2563,13 +2517,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
-name = "tower-lsp"
-version = "0.20.0"
+name = "tower-lsp-server"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+checksum = "5fade4c658b63d11b623ddfa80821901e943a2923a010ae4a038661de42bd377"
 dependencies = [
- "async-trait",
- "auto_impl",
  "bytes",
  "dashmap",
  "futures",
@@ -2580,20 +2532,8 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
- "tower 0.4.13",
- "tower-lsp-macros",
+ "tower",
  "tracing",
-]
-
-[[package]]
-name = "tower-lsp-macros"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3018,7 +2958,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde",
 ]
 
 [[package]]

--- a/harper-ls/Cargo.toml
+++ b/harper-ls/Cargo.toml
@@ -14,7 +14,7 @@ harper-core = { path = "../harper-core", version = "0.38.0", features = ["concur
 harper-comments = { path = "../harper-comments", version = "0.38.0" }
 harper-typst = { path = "../harper-typst", version = "0.38.0" }
 harper-html = { path = "../harper-html", version = "0.38.0" }
-tower-lsp = "0.20.0"
+tower-lsp-server = "0.21.1"
 tokio = { version = "1.45.0", features = ["fs", "rt", "rt-multi-thread", "macros", "io-std", "io-util", "net"] }
 clap = { version = "4.5.38", features = ["derive"] }
 once_cell = "1.21.3"

--- a/harper-ls/src/config.rs
+++ b/harper-ls/src/config.rs
@@ -18,14 +18,14 @@ pub enum DiagnosticSeverity {
 
 impl DiagnosticSeverity {
     /// Converts `self` to the equivalent LSP type.
-    pub fn to_lsp(self) -> tower_lsp::lsp_types::DiagnosticSeverity {
+    pub fn to_lsp(self) -> tower_lsp_server::lsp_types::DiagnosticSeverity {
         match self {
-            DiagnosticSeverity::Error => tower_lsp::lsp_types::DiagnosticSeverity::ERROR,
-            DiagnosticSeverity::Warning => tower_lsp::lsp_types::DiagnosticSeverity::WARNING,
+            DiagnosticSeverity::Error => tower_lsp_server::lsp_types::DiagnosticSeverity::ERROR,
+            DiagnosticSeverity::Warning => tower_lsp_server::lsp_types::DiagnosticSeverity::WARNING,
             DiagnosticSeverity::Information => {
-                tower_lsp::lsp_types::DiagnosticSeverity::INFORMATION
+                tower_lsp_server::lsp_types::DiagnosticSeverity::INFORMATION
             }
-            DiagnosticSeverity::Hint => tower_lsp::lsp_types::DiagnosticSeverity::HINT,
+            DiagnosticSeverity::Hint => tower_lsp_server::lsp_types::DiagnosticSeverity::HINT,
         }
     }
 }

--- a/harper-ls/src/diagnostics.rs
+++ b/harper-ls/src/diagnostics.rs
@@ -4,8 +4,8 @@ use harper_core::linting::{Lint, Suggestion};
 use harper_core::{CharStringExt, Document};
 use harper_stats::RecordKind;
 use serde_json::Value;
-use tower_lsp::lsp_types::{
-    CodeAction, CodeActionKind, CodeActionOrCommand, Command, Diagnostic, TextEdit, Url,
+use tower_lsp_server::lsp_types::{
+    CodeAction, CodeActionKind, CodeActionOrCommand, Command, Diagnostic, TextEdit, Uri,
     WorkspaceEdit,
 };
 
@@ -25,7 +25,7 @@ pub fn lints_to_diagnostics(
 
 pub fn lint_to_code_actions<'a>(
     lint: &'a Lint,
-    url: &'a Url,
+    uri: &'a Uri,
     document: &Document,
     config: &CodeActionConfig,
 ) -> Vec<CodeActionOrCommand> {
@@ -54,7 +54,7 @@ pub fn lint_to_code_actions<'a>(
                     diagnostics: None,
                     edit: Some(WorkspaceEdit {
                         changes: Some(HashMap::from([(
-                            url.clone(),
+                            uri.clone(),
                             vec![TextEdit {
                                 range,
                                 new_text: replace_string,
@@ -82,7 +82,7 @@ pub fn lint_to_code_actions<'a>(
         title: "Ignore Harper error.".to_owned(),
         command: "HarperIgnoreLint".to_owned(),
         arguments: Some(vec![
-            serde_json::Value::String(url.to_string()),
+            serde_json::Value::String(uri.to_string()),
             serde_json::to_value(lint).unwrap(),
         ]),
     }));
@@ -93,13 +93,13 @@ pub fn lint_to_code_actions<'a>(
         results.push(CodeActionOrCommand::Command(Command::new(
             format!("Add \"{}\" to the global dictionary.", orig),
             "HarperAddToUserDict".to_string(),
-            Some(vec![orig.clone().into(), url.to_string().into()]),
+            Some(vec![orig.clone().into(), uri.to_string().into()]),
         )));
 
         results.push(CodeActionOrCommand::Command(Command::new(
             format!("Add \"{}\" to the file dictionary.", orig),
             "HarperAddToFileDict".to_string(),
-            Some(vec![orig.into(), url.to_string().into()]),
+            Some(vec![orig.into(), uri.to_string().into()]),
         )));
     }
 

--- a/harper-ls/src/document_state.rs
+++ b/harper-ls/src/document_state.rs
@@ -4,7 +4,7 @@ use crate::pos_conv::range_to_span;
 use harper_core::linting::{Lint, LintGroup, Linter};
 use harper_core::{Document, IgnoredLints, MergedDictionary, MutableDictionary, TokenKind};
 use harper_core::{Lrc, Token};
-use tower_lsp::lsp_types::{CodeActionOrCommand, Command, Diagnostic, Range, Url};
+use tower_lsp_server::lsp_types::{CodeActionOrCommand, Command, Diagnostic, Range, Uri};
 
 pub struct DocumentState {
     pub document: Document,
@@ -13,7 +13,7 @@ pub struct DocumentState {
     pub linter: LintGroup,
     pub language_id: Option<String>,
     pub ignored_lints: IgnoredLints,
-    pub url: Url,
+    pub uri: Uri,
 }
 
 impl DocumentState {
@@ -62,7 +62,7 @@ impl DocumentState {
             .into_iter()
             .filter(|lint| lint.span.overlaps_with(span))
             .flat_map(|lint| {
-                lint_to_code_actions(&lint, &self.url, &self.document, code_action_config)
+                lint_to_code_actions(&lint, &self.uri, &self.document, code_action_config)
             })
             .collect();
 
@@ -92,7 +92,7 @@ impl Default for DocumentState {
             linter: Default::default(),
             language_id: Default::default(),
             ignored_lints: Default::default(),
-            url: Url::parse("https://example.net").unwrap(),
+            uri: "https://example.net".parse().unwrap(),
         }
     }
 }

--- a/harper-ls/src/io_utils.rs
+++ b/harper-ls/src/io_utils.rs
@@ -1,17 +1,17 @@
 use anyhow::anyhow;
 use std::path::{Component, PathBuf};
 
-use tower_lsp::lsp_types::Url;
+use tower_lsp_server::{UriExt, lsp_types::Uri};
 
 /// Rewrites a path to a filename using the same conventions as
 /// [Neovim's undo-files](https://neovim.io/doc/user/options.html#'undodir').
-pub fn fileify_path(url: &Url) -> anyhow::Result<PathBuf> {
+pub fn fileify_path(uri: &Uri) -> anyhow::Result<PathBuf> {
     let mut rewritten = String::new();
 
     // We assume all URLs are local files and have a base.
-    for seg in url
+    for seg in uri
         .to_file_path()
-        .map_err(|_| anyhow!("Unable to convert URL to file path."))?
+        .ok_or_else(|| anyhow!("Unable to convert URI to file path."))?
         .components()
     {
         if !matches!(seg, Component::RootDir) {

--- a/harper-ls/src/main.rs
+++ b/harper-ls/src/main.rs
@@ -16,7 +16,7 @@ mod pos_conv;
 
 use backend::Backend;
 use clap::Parser;
-use tower_lsp::{LspService, Server};
+use tower_lsp_server::{LspService, Server};
 use tracing::{Level, error, info};
 use tracing_subscriber::FmtSubscriber;
 

--- a/harper-ls/src/pos_conv.rs
+++ b/harper-ls/src/pos_conv.rs
@@ -2,7 +2,7 @@
 //! Harper uses, and the Ranges that the LSP uses.
 
 use harper_core::Span;
-use tower_lsp::lsp_types::{Position, Range};
+use tower_lsp_server::lsp_types::{Position, Range};
 
 pub fn span_to_range(source: &[char], span: Span) -> Range {
     let start = index_to_position(source, span.start);
@@ -85,7 +85,7 @@ pub fn range_to_span(source: &[char], range: Range) -> Span {
 
 #[cfg(test)]
 mod tests {
-    use tower_lsp::lsp_types::{Position, Range};
+    use tower_lsp_server::lsp_types::{Position, Range};
 
     use super::{index_to_position, position_to_index, range_to_span};
 


### PR DESCRIPTION
`tower-lsp-server` is a community fork of `tower-lsp`, which appears to be unmaintained.

This fixes https://github.com/Automattic/harper/issues/139 (thanks to https://github.com/tower-lsp-community/tower-lsp-server/commit/5ac6bceb6d6283c3b7d101b32ca25a0f0a4c0b0e, which landed in `tower-lsp-server` v0.21.0).

Unfortunately, this wasn't a drop in replacement. `tower-lsp-server` has made some changes, and also depends on a completely different url/uri library. Here are the relevant changes:

- `tower-lsp-server`: https://github.com/tower-lsp-community/tower-lsp-server/blob/v0.21.1/CHANGELOG.md
- `lsp-types`'s url/uri change: https://github.com/gluon-lang/lsp-types/commit/e3d0ed287e85bc453d7f77a7c9e6d39620b8d1ef

# Issues 
<!-- Link any relevant GitHub issues here. -->

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?

`cargo test` passes, and I have manually tested that I can start/stop harper.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
