### PR TITLE
feat: as of lately→as of late

### DIFF
--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -1243,6 +1243,12 @@ pub fn lint_group() -> LintGroup {
             "The more standard, less colloquial form is `take it personally`.",
             "Corrects `take it personal` to `take it personally`."
         ),
+        "AsOfLate" => (
+            ["as of lately"],
+            ["as of late"],
+            "The standard form is `as of late`.",
+            "Corrects `as of lately` to `as of late`."
+        ),
     });
 
     group.set_all_rules_to(Some(true));
@@ -2708,5 +2714,14 @@ mod tests {
             lint_group(),
             "This is not personal, do not take it personally, we also think Thingsboard is a extraordinary tool (we are using in several scenarios in fact)",
         );
+    }
+
+    #[test]
+    fn corrects_as_of_lately() {
+        assert_suggestion_result(
+            "I haven't noticed any crashing with AMDGPU as of lately, so this looks to not be an issue anymore.",
+            lint_group(),
+            "I haven't noticed any crashing with AMDGPU as of late, so this looks to not be an issue anymore.",
+        )
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

I noticed somebody using "as of lately", did a search, and it seems to be common. Should be "as of late".

# How Has This Been Tested?

Unit test using a sentence from GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
