### PR TITLE
feat:amount for→account for/amount to

### DIFF
--- a/harper-core/src/linting/amounts_for.rs
+++ b/harper-core/src/linting/amounts_for.rs
@@ -1,0 +1,220 @@
+use crate::{
+    Lrc, Token, TokenStringExt,
+    patterns::{EitherPattern, ExactPhrase, Pattern, SequencePattern, WordSet},
+};
+
+use super::{Lint, LintKind, PatternLinter, Suggestion};
+
+pub struct AmountsFor {
+    pattern: Box<dyn Pattern>,
+}
+
+impl Default for AmountsFor {
+    fn default() -> Self {
+        let singular_context = WordSet::new(&["that", "which", "it", "this"]);
+
+        let singular_pattern = SequencePattern::default()
+            .then(singular_context)
+            .then_whitespace()
+            .then(Lrc::new(ExactPhrase::from_phrase("amounts for")));
+
+        let singular_context = WordSet::new(&[
+            "they", "can", "could", "may", "might", "must", "should", "will", "would",
+        ]);
+
+        let plural_pattern = SequencePattern::default()
+            .then(singular_context)
+            .then_whitespace()
+            .then(Lrc::new(ExactPhrase::from_phrase("amount for")));
+
+        Self {
+            pattern: Box::new(EitherPattern::new(vec![
+                Box::new(singular_pattern),
+                Box::new(plural_pattern),
+            ])),
+        }
+    }
+}
+
+impl PatternLinter for AmountsFor {
+    fn pattern(&self) -> &dyn Pattern {
+        self.pattern.as_ref()
+    }
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        let content = toks.span()?.get_content_string(src).to_lowercase();
+
+        if content.ends_with("amounts for") {
+            let span = toks[2..5].span()?;
+
+            eprintln!("span: '{}'", span.get_content_string(src));
+
+            return Some(Lint {
+                span,
+                lint_kind: LintKind::WordChoice,
+                suggestions: vec![
+                    Suggestion::replace_with_match_case(
+                        "amounts to".chars().collect(),
+                        span.get_content(src),
+                    ),
+                    Suggestion::replace_with_match_case(
+                        "accounts for".chars().collect(),
+                        span.get_content(src),
+                    ),
+                ],
+                message: "`amounts for` is not idiomatic English. You probably meant `amounts to` or `accounts for`.".to_owned(),
+                priority: 63,
+            });
+        }
+
+        if content.ends_with("amount for") {
+            let span = toks[2..5].span()?;
+
+            return Some(Lint {
+                span,
+                lint_kind: LintKind::WordChoice,
+                suggestions: vec![
+                    Suggestion::replace_with_match_case(
+                        "amount to".chars().collect(),
+                        span.get_content(src),
+                    ),
+                    Suggestion::replace_with_match_case(
+                        "account for".chars().collect(),
+                        span.get_content(src),
+                    ),
+                ],
+                message: "`amounts for` is not idiomatic English. You probably meant `amounts to` or `accounts for`.".to_owned(),
+                priority: 63,
+            });
+        }
+
+        None
+    }
+
+    fn description(&self) -> &str {
+        "Corrects `amounts for` to either `amounts to` or `accounts for`"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AmountsFor;
+    use crate::linting::tests::assert_top3_suggestion_result;
+
+    #[test]
+    fn corrects_that_amounts_for_to_amounts_to_entire_value() {
+        assert_top3_suggestion_result(
+            "Skyler stated the car wash is worth close to $800k, that amounts for the entire value of the company",
+            AmountsFor::default(),
+            "Skyler stated the car wash is worth close to $800k, that amounts to the entire value of the company",
+        );
+    }
+
+    #[test]
+    fn corrects_that_amounts_for_to_amounts_to_percent() {
+        assert_top3_suggestion_result(
+            "Together, that amounts for 1157 calls or 60% of the failures.",
+            AmountsFor::default(),
+            "Together, that amounts to 1157 calls or 60% of the failures.",
+        );
+    }
+
+    #[test]
+    fn corrects_that_amounts_for_to_accounts_for_setting_up() {
+        assert_top3_suggestion_result(
+            "One solution to this would be to have separate controllers but the amount of code that amounts for setting up, processing and calling",
+            AmountsFor::default(),
+            "One solution to this would be to have separate controllers but the amount of code that accounts for setting up, processing and calling",
+        );
+    }
+
+    #[test]
+    fn corrects_which_amounts_for_to_accounts_for_16k() {
+        assert_top3_suggestion_result(
+            "It has an offset of 0xC000 which amounts for the 16k.",
+            AmountsFor::default(),
+            "It has an offset of 0xC000 which accounts for the 16k.",
+        );
+    }
+
+    #[test]
+    fn corrects_this_amounts_for_to_accounts_for_large_part() {
+        assert_top3_suggestion_result(
+            "I'm pretty sure that this amounts for a large part of the speed I gained when typing, in addition to touch-typing.",
+            AmountsFor::default(),
+            "I'm pretty sure that this accounts for a large part of the speed I gained when typing, in addition to touch-typing.",
+        );
+    }
+
+    #[test]
+    fn corrects_they_amount_for_to_amount_to_16kb() {
+        assert_top3_suggestion_result(
+            "it is obvious that the messages are being held \"somewhere\" until they amount for 16kB and then the whole lot come at once.",
+            AmountsFor::default(),
+            "it is obvious that the messages are being held \"somewhere\" until they amount to 16kB and then the whole lot come at once.",
+        );
+    }
+
+    #[test]
+    fn corrects_which_amounts_for_to_amounts_to_10_minutes() {
+        assert_top3_suggestion_result(
+            "set a small TTL for your hostname (like 600 which amounts for 10 minutes).",
+            AmountsFor::default(),
+            "set a small TTL for your hostname (like 600 which amounts to 10 minutes).",
+        );
+    }
+
+    #[test]
+    fn corrects_it_amounts_for_to_amounts_to_redefinition() {
+        assert_top3_suggestion_result(
+            "included for convenience to get a Lorentz invariant result (it amounts for a redefinition of ap).",
+            AmountsFor::default(),
+            "included for convenience to get a Lorentz invariant result (it amounts to a redefinition of ap).",
+        );
+    }
+
+    #[test]
+    fn corrects_they_amount_for_to_amount_to_nothing() {
+        assert_top3_suggestion_result(
+            "Matter and antimatter are spread throughout the Universe, and in total, they amount for nothing",
+            AmountsFor::default(),
+            "Matter and antimatter are spread throughout the Universe, and in total, they amount to nothing",
+        );
+    }
+
+    #[test]
+    fn would_amount_for_to_amount_to_api_requests() {
+        assert_top3_suggestion_result(
+            "10% of 6,782,091 would amount for 678,209 API requests",
+            AmountsFor::default(),
+            "10% of 6,782,091 would amount to 678,209 API requests",
+        );
+    }
+
+    #[test]
+    fn will_amount_for_to_amount_to_relationships() {
+        assert_top3_suggestion_result(
+            "Consider this statistic from Gartner, that artificial intelligence will amount for 85% of customer relationships by 2020.",
+            AmountsFor::default(),
+            "Consider this statistic from Gartner, that artificial intelligence will amount to 85% of customer relationships by 2020.",
+        );
+    }
+
+    #[test]
+    fn should_amount_for_to_amount_to_half_pack() {
+        assert_top3_suggestion_result(
+            "It doesn't seem realistic that this single elite should amount for half the pack",
+            AmountsFor::default(),
+            "It doesn't seem realistic that this single elite should amount to half the pack",
+        );
+    }
+
+    #[test]
+    fn can_amount_for_to_amount_to_draw_calls() {
+        assert_top3_suggestion_result(
+            "That can amount for a lot of draw calls and work for the engine to cull. ",
+            AmountsFor::default(),
+            "That can amount to a lot of draw calls and work for the engine to cull. ",
+        );
+    }
+}

--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 
 use super::a_part::APart;
 use super::adjective_of_a::AdjectiveOfA;
+use super::amounts_for::AmountsFor;
 use super::an_a::AnA;
 use super::ask_no_preposition::AskNoPreposition;
 use super::avoid_curses::AvoidCurses;
@@ -335,6 +336,7 @@ impl LintGroup {
         // Add all the more complex rules to the group.
         insert_pattern_rule!(APart, true);
         insert_struct_rule!(AdjectiveOfA, true);
+        insert_pattern_rule!(AmountsFor, true);
         insert_struct_rule!(AnA, true);
         insert_pattern_rule!(AskNoPreposition, true);
         insert_struct_rule!(AvoidCurses, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -4,6 +4,7 @@
 
 mod a_part;
 mod adjective_of_a;
+mod amounts_for;
 mod an_a;
 mod ask_no_preposition;
 mod avoid_curses;
@@ -90,6 +91,7 @@ mod wordpress_dotcom;
 
 pub use a_part::APart;
 pub use adjective_of_a::AdjectiveOfA;
+pub use amounts_for::AmountsFor;
 pub use an_a::AnA;
 pub use ask_no_preposition::AskNoPreposition;
 pub use avoid_curses::AvoidCurses;


### PR DESCRIPTION
# Issues 
N/A

# Description

I'd never seen this before yesterday but it occurs all over the place when you look for it.
"amounts for" / "amount for" seem to be used for both "accounts for" and "amounts to".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I made a bunch of unit tests with sentences sourced from around the web.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
