### PR TITLE
fix(vscode-plugin): make test reliable with `waitForDiagnosticChange`

### DIFF
--- a/packages/vscode-plugin/src/tests/suite/languages.test.ts
+++ b/packages/vscode-plugin/src/tests/suite/languages.test.ts
@@ -2,9 +2,9 @@ import {
 	compareActualVsExpectedDiagnostics,
 	createExpectedDiagnostics,
 	createRange,
-	getActualDiagnostics,
-	openFile,
-	waitForUpdatesFromOpenedFile,
+	getUri,
+	openUri,
+	waitForDiagnosticsChange,
 } from './helper';
 
 describe('Languages >', () => {
@@ -49,11 +49,10 @@ describe('Languages >', () => {
 		{ type: 'TypeScript JSX', file: 'typescriptreact.tsx', row: 3, column: 7 },
 	].forEach((testCase) => {
 		it(`gives correct diagnostics for ${testCase.type} files`, async () => {
-			const uri = await openFile('languages', testCase.file);
-			await waitForUpdatesFromOpenedFile();
+			const uri = getUri('languages', testCase.file);
 
 			compareActualVsExpectedDiagnostics(
-				getActualDiagnostics(uri),
+				await waitForDiagnosticsChange(uri, async () => await openUri(uri)),
 				createExpectedDiagnostics({
 					message: 'Did you mean to spell `Errorz` this way?',
 					range: createRange(testCase.row, testCase.column, testCase.row, testCase.column + 6),


### PR DESCRIPTION
# Issues 
#1001

# Description
It has been a constant headache testing `vscode-plugin` since it's not quite easy to detect when VS Code actually finished updating diagnostics. #200 simply added a sleep function, but #1004 show it becomes problematic as the project gets complicated.

After some dabbling, it was clear to me that VS Code doesn't provide any API to detect it. The APIs don't provide any access to extension logs or intercept LSP response, which is understandable. It does provide the `languages. onDidChangeDiagnostics` listener, but it wasn't particularly useful since 1) it gets fired strangely too many times, 2) still not possible to detect when it stops, 3) sometimes doesn't get triggered at all. 

In this PR, `waitForDiagnosticChange` simply compares diagnostics before an action and after. It simply remembers the diagnostics before doing anything, and repeatedly check if the current diagnostics look different. Since it's possible they may be initially changed to `[]` then to an actual value, the function tries multiple times after a change is detected.

# Demo
N/A

# How Has This Been Tested?
Manually, https://github.com/kiding/harper/pull/4, and hopefully in this PR.

# Checklist
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
