### PR TITLE
fix(chrome-ext): dispatch input events on form els

### DIFF
--- a/packages/chrome-plugin/src/computeLintBoxes.ts
+++ b/packages/chrome-plugin/src/computeLintBoxes.ts
@@ -71,7 +71,9 @@ function replaceValue(el: HTMLElement, value: string) {
 	const lexicalRoot = getLexicalRoot(el);
 
 	if (isFormEl(el)) {
+		el.dispatchEvent(new InputEvent('beforeinput', { bubbles: true, data: value }));
 		el.value = value;
+		el.dispatchEvent(new InputEvent('input', { bubbles: true }));
 	} else if (slateRoot != null || lexicalRoot != null) {
 		replaceValueSpecial(el, value);
 	} else {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

This is just a tiny tweak that couldn't make it into #1317. Specifically, it fixes the Google Web Messaging app.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
