### PR TITLE
fix(ls): do not emit diagnostics on save

### DIFF
--- a/harper-ls/src/backend.rs
+++ b/harper-ls/src/backend.rs
@@ -24,10 +24,10 @@ use tower_lsp_server::lsp_types::{
     CodeActionOrCommand, CodeActionParams, CodeActionProviderCapability, CodeActionResponse,
     ConfigurationItem, Diagnostic, DidChangeConfigurationParams, DidChangeTextDocumentParams,
     DidChangeWatchedFilesParams, DidChangeWatchedFilesRegistrationOptions,
-    DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams,
-    ExecuteCommandOptions, ExecuteCommandParams, FileChangeType, FileSystemWatcher, GlobPattern,
-    InitializeParams, InitializeResult, InitializedParams, MessageType, PublishDiagnosticsParams,
-    Range, Registration, ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind,
+    DidCloseTextDocumentParams, DidOpenTextDocumentParams, ExecuteCommandOptions,
+    ExecuteCommandParams, FileChangeType, FileSystemWatcher, GlobPattern, InitializeParams,
+    InitializeResult, InitializedParams, MessageType, PublishDiagnosticsParams, Range,
+    Registration, ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind,
     TextDocumentSyncOptions, TextDocumentSyncSaveOptions, Uri, WatchKind,
 };
 use tower_lsp_server::{Client, LanguageServer, UriExt};

--- a/harper-ls/src/backend.rs
+++ b/harper-ls/src/backend.rs
@@ -480,15 +480,6 @@ impl LanguageServer for Backend {
         }
     }
 
-    async fn did_save(&self, params: DidSaveTextDocumentParams) {
-        self.update_document_from_file(&params.text_document.uri, None)
-            .await
-            .map_err(|err| error!("{err}"))
-            .err();
-
-        self.publish_diagnostics(&params.text_document.uri).await;
-    }
-
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
         self.update_document(
             &params.text_document.uri,


### PR DESCRIPTION
# Issues 

#1331

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

This PR changes `harper-ls`' behavior to skip the emission of diagnostics on save. Harper will still emit diagnostics on file change (and others), just not on save. 

Since VS Code (and others) block saving until diagnostics are received, this was causing noticeable productivity slowdowns when using the Harper VS Code Extension.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I will be dogfooding this while working today.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
