### PR TITLE
feat(ls): allow skipping the version check

### DIFF
--- a/harper-ls/src/main.rs
+++ b/harper-ls/src/main.rs
@@ -32,6 +32,9 @@ struct Args {
     /// Set to listen on standard input / output rather than TCP.
     #[arg(short, long, default_value_t = false)]
     stdio: bool,
+    /// Skip the debug version check.
+    #[arg(short, long, default_value_t = false)]
+    skip_version_check: bool,
 }
 
 // Setting worker threads to four means the process will use about five threads total
@@ -46,10 +49,12 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::subscriber::set_global_default(subscriber)?;
 
-    tokio::spawn(log_version_info());
-
     let args = Args::parse();
     let config = Config::default();
+
+    if !args.skip_version_check {
+        tokio::spawn(log_version_info());
+    }
 
     let (service, socket) = LspService::new(|client| Backend::new(client, config));
 

--- a/harper-ls/src/main.rs
+++ b/harper-ls/src/main.rs
@@ -33,7 +33,7 @@ struct Args {
     #[arg(short, long, default_value_t = false)]
     stdio: bool,
     /// Skip the debug version check.
-    #[arg(short, long, default_value_t = false)]
+    #[arg(long, default_value_t = false)]
     skip_version_check: bool,
 }
 


### PR DESCRIPTION
# Issues 

#1211

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

In #1204, we set up a system that breifly connects to `https://writewithharper.com` to get the latest Harper version, printing it alongside the current Harper verison. This happens to make debugging via logs easier when we don't have access to the full system.

This PR introduces a command-line flag for `harper-ls` (`--skip-version-check`) that skips this connection. 

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
