### PR TITLE
feat(ls): configurable max length

### DIFF
--- a/harper-ls/src/backend.rs
+++ b/harper-ls/src/backend.rs
@@ -206,13 +206,14 @@ impl Backend {
         self.pull_config().await;
 
         // Copy necessary configuration to avoid holding lock.
-        let (lint_config, markdown_options, isolate_english, dialect) = {
+        let (lint_config, markdown_options, isolate_english, dialect, max_file_length) = {
             let config = self.config.read().await;
             (
                 config.lint_config.clone(),
                 config.markdown_options,
                 config.isolate_english,
                 config.dialect,
+                config.max_file_length,
             )
         };
 
@@ -343,9 +344,8 @@ impl Backend {
                     parser = Box::new(IsolateEnglish::new(parser, doc_state.dict.clone()));
                 }
 
-                // Don't lint on large documents.
-                // This should eventually be configurable, but that isn't necessary yet.
-                if text.len() < 120_000 {
+                // Don't lint on documents larger than the configured maximum length.
+                if text.len() <= max_file_length {
                     doc_state.document = Document::new(text, &parser, &doc_state.dict);
                 }
             }

--- a/harper-ls/src/backend.rs
+++ b/harper-ls/src/backend.rs
@@ -347,6 +347,11 @@ impl Backend {
                 // Don't lint on documents larger than the configured maximum length.
                 if text.len() <= max_file_length {
                     doc_state.document = Document::new(text, &parser, &doc_state.dict);
+                } else {
+                    // Ensures that existing lints are cleared when we stop linting the file.
+                    // Otherwise, prior lints will remain, and they will quickly fall out of sync
+                    // with the document when it is edited.
+                    doc_state.document = Document::default();
                 }
             }
         }

--- a/harper-ls/src/config.rs
+++ b/harper-ls/src/config.rs
@@ -73,7 +73,7 @@ pub struct Config {
     pub isolate_english: bool,
     pub markdown_options: MarkdownOptions,
     pub dialect: Dialect,
-    /// Maximum number of characters a file can have before it is skipped.
+    /// Maximum length (in bytes) a file can have before it's skipped.
     /// Above this limit, the file will not be linted.
     pub max_file_length: usize,
 }

--- a/harper-ls/src/config.rs
+++ b/harper-ls/src/config.rs
@@ -73,6 +73,9 @@ pub struct Config {
     pub isolate_english: bool,
     pub markdown_options: MarkdownOptions,
     pub dialect: Dialect,
+    /// Maximum number of characters a file can have before it is skipped.
+    /// Above this limit, the file will not be linted.
+    pub max_file_length: usize,
 }
 
 impl Config {
@@ -152,6 +155,10 @@ impl Config {
             }
         }
 
+        if let Some(v) = value.get("maxFileLength") {
+            base.max_file_length = serde_json::from_value(v.clone())?;
+        }
+
         if let Some(v) = value.get("markdown") {
             if let Some(v) = v.get("IgnoreLinkTitle") {
                 base.markdown_options.ignore_link_title = serde_json::from_value(v.clone())?;
@@ -177,6 +184,7 @@ impl Default for Config {
             isolate_english: false,
             markdown_options: MarkdownOptions::default(),
             dialect: Dialect::American,
+            max_file_length: 120_000,
         }
     }
 }

--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -122,7 +122,7 @@
 					"scope": "resource",
 					"type": "number",
 					"default": 120000,
-					"description": "Maximum length of file to be linted. If a file has more characters than this, it will not be linted."
+					"description": "Maximum length of file to be linted (in bytes). If a file is larger than this, it will not be linted."
 				},
 				"harper.userDictPath": {
 					"scope": "resource",

--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -118,6 +118,12 @@
 					"default": false,
 					"description": "Skip linting link titles."
 				},
+				"harper.maxFileLength": {
+					"scope": "resource",
+					"type": "number",
+					"default": 120000,
+					"description": "Maximum length of file to be linted. If a file has more characters than this, it will not be linted."
+				},
 				"harper.userDictPath": {
 					"scope": "resource",
 					"type": "string",

--- a/packages/web/src/routes/docs/integrations/emacs/+page.md
+++ b/packages/web/src/routes/docs/integrations/emacs/+page.md
@@ -59,7 +59,8 @@ Additionally, you can also configure things like which linters to use or how you
                             :markdown (:IgnoreLinkTitle :json-false)
                             :diagnosticSeverity "hint"
                             :isolateEnglish :json-false
-                            :dialect "American")))
+                            :dialect "American"
+                            :maxFileLength 120000)))
 ```
 
 :::note

--- a/packages/web/src/routes/docs/integrations/helix/+page.md
+++ b/packages/web/src/routes/docs/integrations/helix/+page.md
@@ -45,6 +45,7 @@ fileDictPath = ""
 diagnosticSeverity = "hint"
 isolateEnglish = false
 dialect = "American"
+maxFileLength = 120000
 
 [language-server.harper-ls.config.harper-ls.linters]
 SpellCheck = true

--- a/packages/web/src/routes/docs/integrations/language-server/+page.md
+++ b/packages/web/src/routes/docs/integrations/language-server/+page.md
@@ -250,7 +250,7 @@ These configs are under the `markdown` key:
 | `diagnosticSeverity` | `"error"`, `"hint"`, `"information"`, `"warning"`       | `"hint"`      | Configures how severe diagnostics appear in your editor                                                                                                                   |
 | `isolateEnglish`     | `boolean`                                               | `false`       | In documents that are a mixture of English and another language, only lint English text. This feature is incredibly new and unstable. Do not expect it to work perfectly. |
 | `dialect`            | `"American"`, `"British"`, `"Australian"`, `"Canadian"` | `"American"`  | Set the dialect of English Harper should expect.                                                                                                                          |
-| `maxFileLength`      | `number`                                                | `120000`      | Maximum length of file to be linted (in characters). If a file is larger/longer than this, it will not be linted.                                                         |
+| `maxFileLength`      | `number`                                                | `120000`      | Maximum length of file to be linted (in bytes). If a file is larger/longer than this, it will not be linted.                                                              |
 
 ## Supported Languages
 

--- a/packages/web/src/routes/docs/integrations/language-server/+page.md
+++ b/packages/web/src/routes/docs/integrations/language-server/+page.md
@@ -163,7 +163,7 @@ In the above example, "spellcheckd", "this this", and other spelling or grammar 
 }
 ```
 
-## Directories 
+### Directories 
 
 | Config         | Type     | Default Value | Description                                                     |
 | -------------- | -------- | ------------- | --------------------------------------------------------------- |

--- a/packages/web/src/routes/docs/integrations/language-server/+page.md
+++ b/packages/web/src/routes/docs/integrations/language-server/+page.md
@@ -250,6 +250,7 @@ These configs are under the `markdown` key:
 | `diagnosticSeverity` | `"error"`, `"hint"`, `"information"`, `"warning"`       | `"hint"`      | Configures how severe diagnostics appear in your editor                                                                                                                   |
 | `isolateEnglish`     | `boolean`                                               | `false`       | In documents that are a mixture of English and another language, only lint English text. This feature is incredibly new and unstable. Do not expect it to work perfectly. |
 | `dialect`            | `"American"`, `"British"`, `"Australian"`, `"Canadian"` | `"American"`  | Set the dialect of English Harper should expect.                                                                                                                          |
+| `maxFileLength`      | `number`                                                | `120000`      | Maximum length of file to be linted (in characters). If a file is larger/longer than this, it will not be linted.                                                         |
 
 ## Supported Languages
 

--- a/packages/web/src/routes/docs/integrations/neovim/+page.md
+++ b/packages/web/src/routes/docs/integrations/neovim/+page.md
@@ -47,7 +47,8 @@ require('lspconfig').harper_ls.setup {
       },
       diagnosticSeverity = "hint",
       isolateEnglish = false,
-      dialect = "American"
+      dialect = "American",
+      maxFileLength = 120000
     }
   }
 }


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
Closes #1310

# Description
<!-- Please include a summary of the change. -->
This PR makes the max document length configurable. Currently, it is set to a hardcoded limit of 120,000 bytes.
<!-- Any details that you think are important to review this PR? -->
I have tried to update the documentation to reflect this change in all the relevant areas, however, it is possible that I missed some places. In addition, I'm not 100% confident that the updates I made to the documentation are technically correct, as I am not familiar with the configuration syntax of all our supported clients. I am also not sure if the changes I've made in `packages/vscode-plugin/package.json` are correct.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
- `cargo test`
- `just precommit`

Brief manual testing with VS Code and Neovim indicated that the feature works as expected. `harper-ls` would stop providing lints when the file was larger than the max length, and would resume when the file was shrunk again.  

~~However, there is a notable issue in that the existing lints do not seem to go away when `harper-ls` stops linting the file. Repeatedly going over and under the `maxFileLength` limit causes many outdated and incorrectly positioned lints to pile up.~~ Never mind, further testing seems to indicate that I misunderstood the problem. The lints do not continue to pile up, but they do remain after `harper-ls` stops linting the file, and can become incorrectly positioned if additional edits to the file are made afterwards. If the file is shrunk enough that `harper-ls` resumes linting it, the out of sync lints disappear. I'll see if I can find a way to clear existing lints before we stop linting the file. (Done/fixed in 2f9cab4fd8e7c61b2c8680479021c399686f9ec8)

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
