### PR TITLE
feat: unsurmountable→insurmountable, brutalness→brutality

### DIFF
--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -1260,7 +1260,19 @@ pub fn lint_group() -> LintGroup {
             ["points of view"],
             "The correct plural is `points of view`.",
             "Corrects pluralizing the wrong noun in `point of view`."
-        )
+        ),
+        "Insurmountable" => (
+            ["unsurmountable"],
+            ["insurmountable"],
+            "This word has a more standard, more common synonym.",
+            "Suggests the more standard and common synonym `insurmountable`."
+        ),
+        "Brutality" => (
+            ["brutalness"],
+            ["brutality"],
+            "This word has a more standard, more common synonym.",
+            "Suggests the more standard and common synonym `brutality`."
+        ),
     });
 
     group.set_all_rules_to(Some(true));
@@ -2743,6 +2755,24 @@ mod tests {
             "This will produce a huge amount of raw data, representing the region in multiple point of views.",
             lint_group(),
             "This will produce a huge amount of raw data, representing the region in multiple points of view.",
+        )
+    }
+
+    #[test]
+    fn corrects_brutalness() {
+        assert_suggestion_result(
+            "the mildness and brutalness of the story rises.",
+            lint_group(),
+            "the mildness and brutality of the story rises.",
+        )
+    }
+
+    #[test]
+    fn corrects_unsurmountable() {
+        assert_suggestion_result(
+            "That being said, if you find upgrading to newer versions to be unsurmountable, please open an issue.",
+            lint_group(),
+            "That being said, if you find upgrading to newer versions to be insurmountable, please open an issue.",
         )
     }
 }


### PR DESCRIPTION
# Issues 

N/A

# Description

While watching the latest ColdFusion video on YouTube I noticed two nonstandard words: "unsurmountabe" and "brutalness".

They are both in some dictionaries (but not Harper's) but they are orders of magnitude less common than "insurmountable" and "brutality".

# How Has This Been Tested?

I added a unit test for each from sentences found on GitHub or Stack Exchange.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
