### PR TITLE
build: add `release-debug` profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,9 @@ opt-level = 3
 # Stripping binaries triggers a bug in `wasm-opt`.
 # Disable it for now.
 # strip = true
+
+# Release profile with debug info.
+# Useful for debugging and profiling.
+[profile.release-debug]
+inherits = "release"
+debug = 2


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
This PR adds `release-debug`, a profile which inherits from `release` but adds debugging information. This is mostly useful for profiling, when we might want accurate release-level performance without sacrificing on useful debugging information.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->
For example, to build a `release-debug` build of `harper-cli`:
1. `cargo build --profile release-debug -p harper-cli`
2. Find the compiled binary under `harper/target/release-debug/`.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
- `cargo test`
- Manual testing to check that binaries were being built as expected.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
