### PR TITLE
fix: missing `the` from `SufficeItToSay` message

### DIFF
--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -1006,7 +1006,7 @@ pub fn lint_group() -> LintGroup {
         "SufficeItToSay" => (
             ["suffice to say"],
             ["suffice it to say"],
-            "`Suffice it to say` is more standard and more common variant.",
+            "`Suffice it to say` is the more standard and more common variant.",
             "Corrects `suffice to say` to `suffice it to say`."
         ),
         "LikeThePlague" => (


### PR DESCRIPTION
# Issues 
N/A

# Description

Fixes a typo in the message for the `SufficeItToSay` linter.

I went with
```
`Suffice it to say` is the more standard and more common variant.
```
but it could have also been fixed by changing it to:
```
`Suffice it to say` is more standard and more common.
```

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Read it again after fixing it. Then fixed it again (-:

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
