### PR TITLE
feat: `harper-cli compounds` command

### DIFF
--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -77,6 +77,9 @@ enum Args {
     },
     /// Print harper-core version.
     CoreVersion,
+    /// Emit a decompressed, line-separated list of the compounds in Harper's dictionary.
+    /// As long as there's either an open or hyphenated spelling.
+    Compounds,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -364,6 +367,58 @@ fn main() -> anyhow::Result<()> {
         }
         Args::CoreVersion => {
             println!("harper-core v{}", harper_core::core_version());
+            Ok(())
+        }
+        Args::Compounds => {
+            let mut compound_map: HashMap<String, Vec<String>> = HashMap::new();
+
+            // First pass: process open and hyphenated compounds
+            for word in dictionary.words_iter() {
+                if !word.contains(&' ') && !word.contains(&'-') {
+                    continue;
+                }
+
+                let normalized_key: String = word
+                    .iter()
+                    .filter(|&&c| c != ' ' && c != '-')
+                    .collect::<String>()
+                    .to_lowercase();
+
+                let word_str = word.iter().collect::<String>();
+                compound_map
+                    .entry(normalized_key)
+                    .or_default()
+                    .push(word_str);
+            }
+
+            // Second pass: process closed compounds
+            for word in dictionary.words_iter() {
+                if word.contains(&' ') || word.contains(&'-') {
+                    continue;
+                }
+
+                let normalized_key: String = word.iter().collect::<String>().to_lowercase();
+                if let Some(variants) = compound_map.get_mut(&normalized_key) {
+                    variants.push(word.iter().collect());
+                }
+            }
+
+            // Process and print results
+            let mut results: Vec<_> = compound_map
+                .into_iter()
+                .filter(|(_, v)| v.len() > 1)
+                .collect();
+            results.sort_by_key(|(k, _)| k.clone());
+
+            // Instead of moving `results` into the for loop, iterate over a reference to it
+            for (normalized, originals) in &results {
+                println!("\nVariants for '{}':", normalized);
+                for original in originals {
+                    println!("  - {}", original);
+                }
+            }
+
+            println!("\nFound {} compound word groups", results.len());
             Ok(())
         }
     }


### PR DESCRIPTION
# Issues 
N/A

# Description

Just a little tool to list all the compound word variants from the dictionary, as long as there is either an open or hyphenated variant it will then also be able to find the closed variants.

Can be helpful when working on compound noun linters and finding good examples to use in unit tests.

# Demo
```
Variants for 'checkout':
  - check out
  - checkout

Variants for 'cleanup':
  - clean up
  - cleanup

Variants for 'closedcircuit':
  - closed-circuit
  - closed circuit

Variants for 'comeback':
  - come back
  - comeback

Variants for 'companywide':
  - company-wide
  - companywide
```

# How Has This Been Tested?

Manual testing. It will be used to make tests for linters though.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
