### PR TITLE
fix: different messages for wrong word vs missing hyphen

### DIFF
--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -743,11 +743,10 @@ pub fn lint_group() -> LintGroup {
             "Use `worse` for comparing. (`Worst` is for the extreme case)",
             "Corrects `worst and worst` to `worse and worse` for proper comparative usage."
         ),
-
         "WorseCaseScenario" => (
             ["worse case scenario", "worse-case scenario", "worse-case-scenario"],
             ["worst-case scenario"],
-            "Use `worst` for referring to the worst possible scenario, and hyphenate `worst-case`. (`Worse` is for comparing)",
+            "Use `worse` for comparing. (`Worst` is for the extreme case)",
             "Corrects `worst-case scenario` when the hyphen is missing or `worse` is used instead of `worst`."
         ),
         "WorstCaseScenario" => (
@@ -756,7 +755,6 @@ pub fn lint_group() -> LintGroup {
             "Hyphenate `worst-case`.",
             "Corrects `worst-case scenario` when the hyphen is missing or `worse` is used instead of `worst`."
         ),
-
         "WorseThan" => (
             ["worst than"],
             ["worse than"],

--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -746,7 +746,7 @@ pub fn lint_group() -> LintGroup {
         "WorseCaseScenario" => (
             ["worse case scenario", "worse-case scenario", "worse-case-scenario"],
             ["worst-case scenario"],
-            "Use `worse` for comparing. (`Worst` is for the extreme case)",
+            "Use `worst` for referring to the worst possible scenario. (`Worse` is for comparing)",
             "Corrects `worst-case scenario` when the hyphen is missing or `worse` is used instead of `worst`."
         ),
         "WorstCaseScenario" => (

--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -743,13 +743,20 @@ pub fn lint_group() -> LintGroup {
             "Use `worse` for comparing. (`Worst` is for the extreme case)",
             "Corrects `worst and worst` to `worse and worse` for proper comparative usage."
         ),
+
         "WorseCaseScenario" => (
-            ["worse case scenario", "worse-case scenario", "worse-case-scenario",
-             "worst case scenario",                        "worst-case-scenario"],
+            ["worse case scenario", "worse-case scenario", "worse-case-scenario"],
             ["worst-case scenario"],
-            "Use `worst` for referring to the worst possible scenario. (`Worse` is for comparing)",
+            "Use `worst` for referring to the worst possible scenario, and hyphenate `worst-case`. (`Worse` is for comparing)",
             "Corrects `worst-case scenario` when the hyphen is missing or `worse` is used instead of `worst`."
         ),
+        "WorstCaseScenario" => (
+            ["worst case scenario", "worst-case-scenario"],
+            ["worst-case scenario"],
+            "Hyphenate `worst-case`.",
+            "Corrects `worst-case scenario` when the hyphen is missing or `worse` is used instead of `worst`."
+        ),
+
         "WorseThan" => (
             ["worst than"],
             ["worse than"],


### PR DESCRIPTION
# Issues 
N/A

# Description

While dogfooding I noticed a misleading message for a "worse/worst case scenario" lint since it fixes both "worse" instead of "worst" and also adds the hyphen between "worst" and "case" if it's missing.

# Demo

Before: 
<img width="960" alt="Screenshot 2025-06-01 at 7 19 00 pm" src="https://github.com/user-attachments/assets/429979ec-867e-47b4-9620-e2f49c4ce7b5" />

After: 
<img width="585" alt="Screenshot 2025-06-01 at 7 18 31 pm" src="https://github.com/user-attachments/assets/d478467f-84be-4b5e-ab7d-21df49978f53" />

# How Has This Been Tested?
Dogfooded on the same file. As can be seen in the screenshots.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
