### PR TITLE
fix(core): handle words with multiple dialects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,9 +179,12 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "blanket"
@@ -845,6 +848,7 @@ name = "harper-core"
 version = "0.40.0"
 dependencies = [
  "ammonia",
+ "bitflags 2.9.1",
  "blanket",
  "cached",
  "criterion",
@@ -1415,7 +1419,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "libc",
 ]
 
@@ -1750,7 +1754,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -1910,7 +1914,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -2519,7 +2523,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "bytes",
  "futures-util",
  "http",
@@ -3327,7 +3331,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/harper-core/Cargo.toml
+++ b/harper-core/Cargo.toml
@@ -31,6 +31,7 @@ foldhash = "0.1.5"
 strum_macros = "0.27.1"
 strum = "0.27.1"
 ammonia = "4.1.0"
+bitflags = { version = "2.9.1", features = ["serde"] }
 
 [dev-dependencies]
 criterion = { version = "0.6.0", default-features = false }

--- a/harper-core/affixes.json
+++ b/harper-core/affixes.json
@@ -833,7 +833,7 @@
 			"replacements": [],
 			"target": [],
 			"base_metadata": {
-				"dialect": "American"
+				"dialects": "AMERICAN"
 			}
 		},
 		"!": {
@@ -843,7 +843,7 @@
 			"replacements": [],
 			"target": [],
 			"base_metadata": {
-				"dialect": "British"
+				"dialects": "BRITISH"
 			}
 		},
 		"@": {
@@ -853,7 +853,7 @@
 			"replacements": [],
 			"target": [],
 			"base_metadata": {
-				"dialect": "Canadian"
+				"dialects": "CANADIAN"
 			}
 		},
 		"_": {
@@ -863,7 +863,7 @@
 			"replacements": [],
 			"target": [],
 			"base_metadata": {
-				"dialect": "Australian"
+				"dialects": "AUSTRALIAN"
 			}
 		}
 	}

--- a/harper-core/src/linting/spell_check.rs
+++ b/harper-core/src/linting/spell_check.rs
@@ -52,8 +52,8 @@ impl<T: Dictionary> SpellCheck<T> {
                         self.dictionary
                             .get_word_metadata(v)
                             .unwrap()
-                            .dialect
-                            .is_none_or(|d| d == self.dialect)
+                            .dialects
+                            .is_dialect_enabled(self.dialect)
                     })
                     .map(|v| v.to_smallvec())
                     .take(Self::MAX_SUGGESTIONS)
@@ -77,7 +77,7 @@ impl<T: Dictionary> Linter for SpellCheck<T> {
             let word_chars = document.get_span_content(&word.span);
 
             if let Some(metadata) = word.kind.as_word().unwrap() {
-                if metadata.dialect.is_none_or(|d| d == self.dialect)
+                if metadata.dialects.is_dialect_enabled(self.dialect)
                     && (self.dictionary.contains_exact_word(word_chars)
                         || self.dictionary.contains_exact_word(&word_chars.to_lower()))
                 {

--- a/harper-core/tests/pos_tags.rs
+++ b/harper-core/tests/pos_tags.rs
@@ -135,14 +135,16 @@ fn format_word_tag(word: &WordMetadata) -> String {
         add("P");
     }
 
-    if let Some(dialect) = word.dialect {
-        add(match dialect {
-            harper_core::Dialect::American => "Am",
-            harper_core::Dialect::British => "Br",
-            harper_core::Dialect::Canadian => "Ca",
-            harper_core::Dialect::Australian => "Au",
-        });
-    }
+    word.dialects.iter().for_each(|d| {
+        if let Ok(dialect) = harper_core::Dialect::try_from(d) {
+            add(match dialect {
+                harper_core::Dialect::American => "Am",
+                harper_core::Dialect::British => "Br",
+                harper_core::Dialect::Canadian => "Ca",
+                harper_core::Dialect::Australian => "Au",
+            });
+        }
+    });
 
     if tags.is_empty() {
         String::from("W?")

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -739,17 +739,6 @@ Suggest:
 
 
 
-Lint:    Spelling (63 priority)
-Message: |
-     592 | “Did you give Nick a little heart to heart talk on the veranda?” demanded Tom
-         |                                                        ^~~~~~~ Did you mean to spell `veranda` this way?
-Suggest:
-  - Replace with: “verandas”
-  - Replace with: “veranda's”
-  - Replace with: “Miranda”
-
-
-
 Lint:    Readability (127 priority)
 Message: |
      628 | Already it was deep summer on roadhouse roofs and in front of wayside garages,
@@ -1712,17 +1701,6 @@ Suggest:
   - Replace with: “gaiety”
   - Replace with: “gamely”
   - Replace with: “gamete”
-
-
-
-Lint:    Spelling (63 priority)
-Message: |
-    1346 | couldn’t find him from the top of the steps, and he wasn’t on the veranda. On a
-         |                                                                   ^~~~~~~ Did you mean to spell `veranda` this way?
-Suggest:
-  - Replace with: “verandas”
-  - Replace with: “veranda's”
-  - Replace with: “Miranda”
 
 
 
@@ -4934,17 +4912,6 @@ Suggest:
 
 Lint:    Spelling (63 priority)
 Message: |
-    3693 | I went with them out to the veranda. On the green Sound, stagnant in the heat,
-         |                             ^~~~~~~ Did you mean to spell `veranda` this way?
-Suggest:
-  - Replace with: “verandas”
-  - Replace with: “veranda's”
-  - Replace with: “Miranda”
-
-
-
-Lint:    Spelling (63 priority)
-Message: |
     3709 | We had luncheon in the dining-room, darkened too against the heat, and drank
     3710 | down nervous gayety with the cold ale.
          |              ^~~~~~ Did you mean to spell `gayety` this way?
@@ -5279,18 +5246,6 @@ Suggest:
   - Replace with: “Biko's”
   - Replace with: “Bilbo's”
   - Replace with: “Biro's”
-
-
-
-Lint:    Spelling (63 priority)
-Message: |
-    4066 | “That was his cousin. I knew his whole family history before he left. He gave me
-    4067 | an aluminum putter that I use to-day.”
-         |    ^~~~~~~~ Did you mean to spell `aluminum` this way?
-Suggest:
-  - Replace with: “aluminum's”
-  - Replace with: “alumnus”
-  - Replace with: “alumina”
 
 
 
@@ -5998,18 +5953,6 @@ Suggest:
   - Replace with: “Welshmen's”
   - Replace with: “Wolfe's”
   - Replace with: “Wolsey's”
-
-
-
-Lint:    Spelling (63 priority)
-Message: |
-    4703 | I walked back along the border of the lawn, traversed the gravel softly, and
-    4704 | tiptoed up the veranda steps. The drawing-room curtains were open, and I saw
-         |                ^~~~~~~ Did you mean to spell `veranda` this way?
-Suggest:
-  - Replace with: “verandas”
-  - Replace with: “veranda's”
-  - Replace with: “Miranda”
 
 
 

--- a/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
+++ b/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
@@ -39,7 +39,7 @@
 > much  out         of the way   to hear the Rabbit say   to itself , “ Oh      dear    ! Oh      dear    ! I   shall
 # N/I/J NSg/V/J/R/P P  D   NSg/J P  V    D   NSg    NSg/V P  I      . . NPrSg/V NSg/V/J . NPrSg/V NSg/V/J . ISg VX
 > be     late  ! ” ( when    she thought it        over      afterwards , it        occurred to her   that    she
-# NSg/VX NSg/J . . . NSg/I/C ISg NSg/V   NPrSg/ISg NSg/V/J/P R/Br       . NPrSg/ISg V        P  I/J/D N/I/C/D ISg
+# NSg/VX NSg/J . . . NSg/I/C ISg NSg/V   NPrSg/ISg NSg/V/J/P R/Ca/Au/Br . NPrSg/ISg V        P  I/J/D N/I/C/D ISg
 > ought    to have   wondered at this , but     at the time  it        all       seemed quite natural ) ;
 # NSg/I/VX P  NSg/VX V/J      P  I/D  . NSg/C/P P  D   NSg/J NPrSg/ISg NSg/I/J/C V/J    NSg   NSg/J   . .
 > but     when    the Rabbit actually took a   watch out         of its   waistcoat - pocket  , and
@@ -82,8 +82,8 @@
 # V/J     N/I/C/D IPl  NSg/V V/J    P    NPl/V     V/C NSg/V . NPl/V   . NSg/J/R V/C W?
 > she saw   maps  and pictures hung    upon pegs  . She took down      a   jar from one       of the
 # ISg NSg/V NPl/V V/C NPl/V    NPr/V/J P    NPl/V . ISg V    NSg/V/J/P D/P NSg P    NSg/I/V/J P  D
-> shelves as    she passed ; it        was labelled “ ORANGE    MARMALADE ” , but     to her   great
-# NPl     NSg/R ISg V/J    . NPrSg/ISg V   V/J/Br   . NPrSg/V/J NSg/V     . . NSg/C/P P  I/J/D NSg/J
+> shelves as    she passed ; it        was labelled     “ ORANGE    MARMALADE ” , but     to her   great
+# NPl     NSg/R ISg V/J    . NPrSg/ISg V   V/J/Ca/Au/Br . NPrSg/V/J NSg/V     . . NSg/C/P P  I/J/D NSg/J
 > disappointment it        was empty   : she did not   like        to drop  the jar for fear  of
 # NSg            NPrSg/ISg V   NSg/V/J . ISg V   NSg/C NSg/V/J/C/P P  NSg/V D   NSg C/P NSg/V P
 > killing somebody underneath , so        managed to put   it        into one       of the cupboards as
@@ -106,8 +106,8 @@
 # NSg/V/J/P . NSg/V/J/P . NSg/V/J/P . NSg/VX D   NSg  V     NSg/V/P P  D/P NSg . . ISg NSg/V  NSg/C N/I/J/D NPrPl
 > I’ve fallen by this time    ? ” she said aloud . “ I   must  be     getting somewhere near      the
 # W?   W?     P  I/D  NSg/V/J . . ISg V/J  J     . . ISg NSg/V NSg/VX NSg/V   NSg       NSg/V/J/P D
-> centre of the earth . Let   me        see   : that    would  be     four thousand miles down      , I
-# NSg/Br P  D   NPrSg . NSg/V NPrSg/ISg NSg/V . N/I/C/D NSg/VX NSg/VX NSg  NSg      NPrPl NSg/V/J/P . ISg
+> centre       of the earth . Let   me        see   : that    would  be     four thousand miles down      , I
+# NSg/Ca/Au/Br P  D   NPrSg . NSg/V NPrSg/ISg NSg/V . N/I/C/D NSg/VX NSg/VX NSg  NSg      NPrPl NSg/V/J/P . ISg
 > think — ” ( for , you see   , Alice had learnt several things of this sort  in her
 # NSg/V . . . C/P . IPl NSg/V . NPr   V   V      J/D     NPl/V  P  I/D  NSg/V P  I/J/D
 > lessons in the schoolroom , and though this was not   a   very good      opportunity for
@@ -272,8 +272,8 @@
 #
 > However , this bottle was not   marked “ poison , ” so        Alice ventured to taste   it        , and
 # C       . I/D  NSg/V  V   NSg/C V/J    . NSg/V  . . NSg/I/J/C NPr   V/J      P  NSg/V/J NPrSg/ISg . V/C
-> finding it        very nice      , ( it        had , in        fact , a   sort of mixed flavour  of cherry  - tart    ,
-# NSg/V   NPrSg/ISg J    NPrSg/V/J . . NPrSg/ISg V   . NPrSg/J/P NSg  . D/P NSg  P  V/J   NSg/V/Br P  NPrSg/J . NSg/V/J .
+> finding it        very nice      , ( it        had , in        fact , a   sort of mixed flavour        of cherry  - tart    ,
+# NSg/V   NPrSg/ISg J    NPrSg/V/J . . NPrSg/ISg V   . NPrSg/J/P NSg  . D/P NSg  P  V/J   NSg/V/Ca/Au/Br P  NPrSg/J . NSg/V/J .
 > custard , pine  - apple , roast   turkey  , toffee , and hot     buttered toast , ) she very
 # NSg     . NSg/V . NPrSg . NSg/V/J NPrSg/J . NSg/V  . V/C NSg/V/J V/J      NSg/V . . ISg J
 > soon finished it        off       .
@@ -1320,8 +1320,8 @@
 # NSg/J/P NSg/V/P D/P J     NSg/V . D   N$       . . NPrSg/V/J . NPrSg/V/J . NSg/C V   IPl . . V/C NSg/J/C D/P
 > voice she had never heard before , “ Sure then    I’m here    ! Digging for apples , yer
 # NSg   ISg V   V     V/J   C/P    . . J    NSg/J/C W?  NSg/J/R . NSg/V   C/P NPl    . J
-> honour   ! ”
-# NSg/V/Br . .
+> honour         ! ”
+# NSg/V/Ca/Au/Br . .
 >
 #
 > “ Digging for apples , indeed ! ” said the Rabbit angrily . “ Here    ! Come    and help  me
@@ -1334,16 +1334,16 @@
 # . NPrSg/V/J/C NPrSg/V NPrSg/ISg . NPrSg/V/J . N$     N/I/C/D P  D   NSg    . .
 >
 #
-> “ Sure , it’s an  arm   , yer honour   ! ” ( He      pronounced it        “ arrum . ” )
-# . J    . W?   D/P NSg/J . J   NSg/V/Br . . . NPr/ISg V/J        NPrSg/ISg . ?     . . .
+> “ Sure , it’s an  arm   , yer honour         ! ” ( He      pronounced it        “ arrum . ” )
+# . J    . W?   D/P NSg/J . J   NSg/V/Ca/Au/Br . . . NPr/ISg V/J        NPrSg/ISg . ?     . . .
 >
 #
 > “ An  arm   , you goose ! Who     ever saw   one       that    size  ? Why   , it        fills the whole window ! ”
 # . D/P NSg/J . IPl NSg/V . NPrSg/I J    NSg/V NSg/I/V/J N/I/C/D NSg/V . NSg/V . NPrSg/ISg NPl/V D   NSg/J NSg/V  . .
 >
 #
-> “ Sure , it        does  , yer honour   : but     it’s an  arm   for all       that    . ”
-# . J    . NPrSg/ISg NPl/V . J   NSg/V/Br . NSg/C/P W?   D/P NSg/J C/P NSg/I/J/C N/I/C/D . .
+> “ Sure , it        does  , yer honour         : but     it’s an  arm   for all       that    . ”
+# . J    . NPrSg/ISg NPl/V . J   NSg/V/Ca/Au/Br . NSg/C/P W?   D/P NSg/J C/P NSg/I/J/C N/I/C/D . .
 >
 #
 > “ Well    , it’s got no      business there , at any   rate  : go      and take  it        away ! ”
@@ -1352,8 +1352,8 @@
 #
 > There was a   long    silence after this , and Alice could  only hear whispers now         and
 # W?    V   D/P NPrSg/J NSg/V   J/P   I/D  . V/C NPr   NSg/VX W?   V    NPl/V    NPrSg/V/J/C V/C
-> then    ; such  as    , “ Sure , I   don’t like        it        , yer honour   , at    all       , at    all       ! ” “ Do     as    I
-# NSg/J/C . NSg/I NSg/R . . J    . ISg V     NSg/V/J/C/P NPrSg/ISg . J   NSg/V/Br . NSg/P NSg/I/J/C . NSg/P NSg/I/J/C . . . NSg/VX NSg/R ISg
+> then    ; such  as    , “ Sure , I   don’t like        it        , yer honour         , at    all       , at    all       ! ” “ Do     as    I
+# NSg/J/C . NSg/I NSg/R . . J    . ISg V     NSg/V/J/C/P NPrSg/ISg . J   NSg/V/Ca/Au/Br . NSg/P NSg/I/J/C . NSg/P NSg/I/J/C . . . NSg/VX NSg/R ISg
 > tell    you , you coward    ! ” and at    last    she spread out         her   hand  again , and made
 # NPrSg/V IPl . IPl NPrSg/V/J . . V/C NSg/P NSg/V/J ISg NSg/V  NSg/V/J/R/P I/J/D NSg/V P     . V/C NSg/V
 > another snatch in the air . This time    there were  two little    shrieks , and more
@@ -1766,8 +1766,8 @@
 # D   NSg    P  N/I/C/D . .
 >
 #
-> “ In my youth , ” said the sage  , as    he      shook   his   grey       locks , “ I   kept all       my limbs
-# . P  D  NSg   . . V/J  D   NSg/J . NSg/R NPr/ISg NSg/V/J ISg/D NPrSg/J/Br NPl/V . . ISg V    NSg/I/J/C D  NPl
+> “ In my youth , ” said the sage  , as    he      shook   his   grey             locks , “ I   kept all       my limbs
+# . P  D  NSg   . . V/J  D   NSg/J . NSg/R NPr/ISg NSg/V/J ISg/D NPrSg/J/Ca/Au/Br NPl/V . . ISg V    NSg/I/J/C D  NPl
 > very supple By the use of this ointment — one       shilling the box — Allow me        to sell
 # J    V/J    P  D   NSg P  I/D  NSg      . NSg/I/V/J NSg/V    D   NSg . V     NPrSg/ISg P  NSg/V
 > you a   couple ? ”
@@ -2993,7 +2993,7 @@
 >
 #
 > The Hatter shook   his   head    mournfully . “ Not   I   ! ” he      replied . “ We  quarrelled last
-# D   NSg    NSg/V/J ISg/D NPrSg/J R          . . NSg/C ISg . . NPr/ISg V/J     . . IPl V/Br       NSg/V/J
+# D   NSg    NSg/V/J ISg/D NPrSg/J R          . . NSg/C ISg . . NPr/ISg V/J     . . IPl V/Ca/Au/Br NSg/V/J
 > March   — just before he      went  mad   , you know  — ” ( pointing with his   tea spoon at the
 # NPrSg/V . V/J  C/P    NPr/ISg NSg/V N/V/J . IPl NSg/V . . . V        P    ISg/D NSg NSg/V P  D
 > March Hare    , ) “ — it        was at the great concert given     by the Queen   of Hearts , and I
@@ -3427,7 +3427,7 @@
 > they were  all       ornamented with hearts . Next    came    the guests , mostly Kings and
 # IPl  NSg/V NSg/I/J/C V/J        P    NPl/V  . NSg/J/P NSg/V/P D   NPl    . R      NPl/V V/C
 > Queens  , and among them Alice recognised the White   Rabbit : it        was talking in a
-# NPrSg/V . V/C P     N/I  NPr   V/J/Br     D   NPrSg/J NSg/V  . NPrSg/ISg V   V       P  D/P
+# NPrSg/V . V/C P     N/I  NPr   V/J/Au/Br  D   NPrSg/J NSg/V  . NPrSg/ISg V   V       P  D/P
 > hurried nervous manner , smiling at    everything that    was said , and went  by      without
 # J       J       NSg    . NSg/V/J NSg/P N/I/V      N/I/C/D V   V/J  . V/C NSg/V NSg/J/P C/P
 > noticing her   . Then    followed the Knave of Hearts , carrying the King’s crown   on a
@@ -3662,8 +3662,8 @@
 # NPrSg/ISg V   D/P J    V/J       NSg/V/J W?     .
 >
 #
-> The players all       played at    once  without waiting for turns , quarrelling all       the
-# D   NPl     NSg/I/J/C V/J    NSg/P NSg/C C/P     NSg/V   C/P NPl/V . NSg/V/Br    NSg/I/J/C D
+> The players all       played at    once  without waiting for turns , quarrelling    all       the
+# D   NPl     NSg/I/J/C V/J    NSg/P NSg/C C/P     NSg/V   C/P NPl/V . NSg/V/Ca/Au/Br NSg/I/J/C D
 > while   , and fighting for the hedgehogs ; and in a   very short       time    the Queen   was in
 # NSg/C/P . V/C NSg/V/J  C/P D   NPl       . V/C P  D/P J    NPrSg/V/J/P NSg/V/J D   NPrSg/J V   P
 > a   furious passion , and went  stamping about , and shouting “ Off       with his   head    ! ” or
@@ -4096,8 +4096,8 @@
 #
 > But     here    , to Alice’s great surprise , the Duchess’s voice died away , even    in the
 # NSg/C/P NSg/J/R . P  N$      NSg/J NSg/V    . D   N$        NSg/V V/J  V/J  . NSg/V/J P  D
-> middle of her   favourite  word  ‘          moral   , ’ and the arm   that    was linked into hers
-# NSg/J  P  I/J/D NSg/V/J/Br NSg/V Unlintable NSg/V/J . . V/C D   NSg/J N/I/C/D V   V/J    P    ISg
+> middle of her   favourite        word  ‘          moral   , ’ and the arm   that    was linked into hers
+# NSg/J  P  I/J/D NSg/V/J/Ca/Au/Br NSg/V Unlintable NSg/V/J . . V/C D   NSg/J N/I/C/D V   V/J    P    ISg
 > began to tremble . Alice looked up        , and there stood the Queen   in        front   of them ,
 # V     P  NSg/V   . NPr   V/J    NSg/V/J/P . V/C W?    V     D   NPrSg/J NPrSg/J/P NSg/V/J P  N/I  .
 > with her   arms  folded , frowning like        a   thunderstorm .
@@ -4134,8 +4134,8 @@
 # NPrSg/J R      V         N/I/C/D D/P N$       NSg/V/J NSg/VX NSg/V/J N/I  D     N/J   .
 >
 #
-> All       the time  they were  playing the Queen   never left      off       quarrelling with the
-# NSg/I/J/C D   NSg/J IPl  NSg/V V       D   NPrSg/J V     NPrSg/V/J NSg/V/J/P NSg/V/Br    P    D
+> All       the time  they were  playing the Queen   never left      off       quarrelling    with the
+# NSg/I/J/C D   NSg/J IPl  NSg/V V       D   NPrSg/J V     NPrSg/V/J NSg/V/J/P NSg/V/Ca/Au/Br P    D
 > other players , and shouting “ Off       with his   head    ! ” or      “ Off       with her   head      ! ” Those
 # NSg/J NPl     . V/C V        . NSg/V/J/P P    ISg/D NPrSg/J . . NPrSg/C . NSg/V/J/P P    I/J/D NPrSg/V/J . . I/D
 > whom she sentenced were  taken into custody by the soldiers , who     of course had to
@@ -5094,8 +5094,8 @@
 # D   NPl    NSg/V NSg/V   NSg/V/J/P . NSg/J  NPl/V  . . P  D     NPl    . V/C ISg NSg/VX
 > even    make  out         that    one       of them didn’t know  how   to spell “ stupid , ” and that    he
 # NSg/V/J NSg/V NSg/V/J/R/P N/I/C/D NSg/I/V/J P  N/I  V      NSg/V NSg/C P  NSg/V . NSg/J  . . V/C N/I/C/D NPr/ISg
-> had to ask   his   neighbour to tell    him . “ A   nice    muddle their slates’ll be     in
-# V   P  NSg/V ISg/D NSg/J/Br  P  NPrSg/V I   . . D/P NPrSg/J NSg/V  D     ?         NSg/VX NPrSg/J/P
+> had to ask   his   neighbour      to tell    him . “ A   nice    muddle their slates’ll be     in
+# V   P  NSg/V ISg/D NSg/J/Ca/Au/Br P  NPrSg/V I   . . D/P NPrSg/J NSg/V  D     ?         NSg/VX NPrSg/J/P
 > before the trial’s over      ! ” thought Alice .
 # C/P    D   N$      NSg/V/J/P . . NSg/V   NPr   .
 >
@@ -5857,7 +5857,7 @@
 >
 #
 > “ No      , no      ! ” said the Queen   . “ Sentence first   — verdict afterwards . ”
-# . NPrSg/P . NPrSg/P . . V/J  D   NPrSg/J . . NSg/V    NSg/V/J . NSg     R/Br       . .
+# . NPrSg/P . NPrSg/P . . V/J  D   NPrSg/J . . NSg/V    NSg/V/J . NSg     R/Ca/Au/Br . .
 >
 #
 > “ Stuff and nonsense ! ” said Alice loudly . “ The idea of having the sentence
@@ -5970,8 +5970,8 @@
 # NSg   . NPl/V . V/C D   N$      NSg/V/J NPl/V P  D   NSg   P  D   NPrSg    NSg/V . V/C
 > the sneeze of the baby  , the shriek of the Gryphon , and all       the other queer
 # D   NSg    P  D   NSg/J . D   NSg    P  D   ?       . V/C NSg/I/J/C D   NSg/J NSg/V/J
-> noises , would  change ( she knew ) to the confused clamour  of the busy
-# NPl/V  . NSg/VX NSg/V  . ISg V    . P  D   J        NSg/V/Br P  D   NSg/J
+> noises , would  change ( she knew ) to the confused clamour        of the busy
+# NPl/V  . NSg/VX NSg/V  . ISg V    . P  D   J        NSg/V/Ca/Au/Br P  D   NSg/J
 > farm  - yard  — while     the lowing of the cattle in the distance would  take  the place of
 # NSg/V . NSg/V . NSg/V/C/P D   N/J    P  D   NSg    P  D   NSg      NSg/VX NSg/V D   NSg   P
 > the Mock  Turtle’s heavy   sobs  .

--- a/harper-core/tests/text/tagged/Difficult sentences.md
+++ b/harper-core/tests/text/tagged/Difficult sentences.md
@@ -108,8 +108,8 @@
 # D   NSg/J  V   NSg/V/J P  D   NSg      .
 > The boat was swamped by the water .
 # D   NSg  V   V/J     P  D   NSg   .
-> He      was protected by his   body armour     .
-# NPr/ISg V   V/J       P  ISg/D NSg  NPrSg/V/Br .
+> He      was protected by his   body armour           .
+# NPr/ISg V   V/J       P  ISg/D NSg  NPrSg/V/Ca/Au/Br .
 > There was a   call by the unions for a   30 % pay     rise  .
 # W?    V   D/P NSg  P  D   NPl    C/P D/P #  . NSg/V/J NSg/V .
 > I   was aghast by      what  I   saw   .
@@ -412,8 +412,8 @@
 # NPrSg/J/P V         D   NSg    W?      . NPr/ISg NSg/V/J NPr/ISg V   NSg/V  ISg/D NSg          P  D   NSg         .
 > In        trying  to make  amends , she actually made  matters worse   .
 # NPrSg/J/P NSg/V/J P  NSg/V NPl/V  . ISg R        NSg/V W?      NSg/V/J .
-> My aim in        travelling there was to find  my missing friend    .
-# D  NSg NPrSg/J/P NSg/V/J/Br W?    V   P  NSg/V D  N/J     NPrSg/V/J .
+> My aim in        travelling       there was to find  my missing friend    .
+# D  NSg NPrSg/J/P NSg/V/J/Ca/Au/Br W?    V   P  NSg/V D  N/J     NPrSg/V/J .
 > My fat   rolls around in        folds .
 # D  NSg/J NPl/V J/P    NPrSg/J/P NPl/V .
 > The planes flew    over      in        waves .
@@ -512,8 +512,8 @@
 # NPrSg/J/P NSg/J/P NSg/V   . Unlintable NPrSg/J/P NSg/J/P NSg/V    . Unlintable NPrSg/J/P P  D   ?      P  I/J/D NSg/V
 > He      is very in        with the Joneses .
 # NPr/ISg VL J    NPrSg/J/P P    D   NPl     .
-> I   need   to keep  in        with the neighbours in        case    I   ever need   a   favour from them .
-# ISg NSg/VX P  NSg/V NPrSg/J/P P    D   NPl        NPrSg/J/P NPrSg/V ISg J    NSg/VX D/P NSg/Br P    N/I  .
+> I   need   to keep  in        with the neighbours in        case    I   ever need   a   favour       from them .
+# ISg NSg/VX P  NSg/V NPrSg/J/P P    D   NPl        NPrSg/J/P NPrSg/V ISg J    NSg/VX D/P NSg/Ca/Au/Br P    N/I  .
 > I   think that    bird      fancies you . You're in        there , mate  !
 # ISg NSg/V N/I/C/D NPrSg/V/J NPl/V   IPl . W?     NPrSg/J/P W?    . NSg/V .
 > I'm three drinks in        right     now         .
@@ -564,8 +564,8 @@
 # W?  W?     V        P  IPl .
 > He      told us      the story of his   journey to India .
 # NPr/ISg V    NPr/ISg D   NSg   P  ISg/D NSg     P  NPrSg .
-> This behaviour is typical of teenagers .
-# I/D  NSg/Br    VL NSg/J   P  W?        .
+> This behaviour    is typical of teenagers .
+# I/D  NSg/Ca/Au/Br VL NSg/J   P  W?        .
 > He      is a   friend  of mine    .
 # NPr/ISg VL D/P NPrSg/J P  NSg/I/V .
 > We  want  a   larger slice   of the cake .
@@ -596,8 +596,8 @@
 # IPl V   P  NSg/V  D   NSg  C/P     W?    V   D/P NSg J/P .
 > Some  of the cast  went  down      with flu , but     the show's still   on  .
 # I/J/R P  D   NSg/J NSg/V NSg/V/J/P P    NSg . NSg/C/P D   N$     NSg/V/J J/P .
-> That    TV  programme that    you wanted to watch is on  now         .
-# N/I/C/D NSg NSg/V/Br  N/I/C/D IPl V/J    P  NSg/V VL J/P NPrSg/V/J/C .
+> That    TV  programme   that    you wanted to watch is on  now         .
+# N/I/C/D NSg NSg/V/Au/Br N/I/C/D IPl V/J    P  NSg/V VL J/P NPrSg/V/J/C .
 > This is her   last    song . You're on  next    !
 # I/D  VL I/J/D NSg/V/J NSg  . W?     J/P NSg/J/P .
 > Are we  still   on  for tonight ?
@@ -728,8 +728,8 @@
 # D  NSg/J    NPl/V V   J/P NPrSg NPr     .
 > I'll pay     on  card  .
 # W?   NSg/V/J J/P NSg/V .
-> He      travelled on  false   documents .
-# NPr/ISg V/J/Br    J/P NSg/V/J NPl/V     .
+> He      travelled    on  false   documents .
+# NPr/ISg V/J/Ca/Au/Br J/P NSg/V/J NPl/V     .
 > They planned an  attack on  London .
 # IPl  V/J     D/P NSg/J  J/P NPr    .
 > The soldiers mutinied and turned their guns on their officers .
@@ -793,7 +793,7 @@
 > To err is human   .
 # P  V   VL NSg/V/J .
 > Who     am        I   to criticise ? I've done    worse   things myself .
-# NPrSg/I NPrSg/V/J ISg P  V/Br      . W?   NSg/V/J NSg/V/J NPl/V  I      .
+# NPrSg/I NPrSg/V/J ISg P  V/Au/Br   . W?   NSg/V/J NSg/V/J NPl/V  I      .
 > Precisely to get   away from you was why   I   did what  I   did .
 # R         P  NSg/V V/J  P    IPl V   NSg/V ISg V   NSg/I ISg V   .
 > I   need   some  more        books to read  and friends to go      partying with .

--- a/harper-core/tests/text/tagged/Part-of-speech tagging.md
+++ b/harper-core/tests/text/tagged/Part-of-speech tagging.md
@@ -424,8 +424,8 @@
 # NSg/V . I/D  NSg        NPl/V D   NPr  NSg/V NPrSg/V/J J/P I/J/R P  D   NPr  ?        NSg  .
 > so        the results are directly comparable . However , many    significant taggers are
 # NSg/I/J/C D   NPl     V   R/C      NSg/J      . C       . N/I/J/D NSg/J       NPl     V
-> not   included ( perhaps because of the labor    involved in        reconfiguring them for
-# NSg/C V/J      . NSg     C/P     P  D   NPrSg/Am V/J      NPrSg/J/P V             N/I  C/P
+> not   included ( perhaps because of the labor       involved in        reconfiguring them for
+# NSg/C V/J      . NSg     C/P     P  D   NPrSg/Am/Au V/J      NPrSg/J/P V             N/I  C/P
 > this particular dataset ) . Thus , it        should not   be     assumed that    the results
 # I/D  NSg/J      NSg     . . NSg  . NPrSg/ISg VX     NSg/C NSg/VX V/J     N/I/C/D D   NPl
 > reported here    are the best    that    can      be     achieved with a   given   approach ; nor   even

--- a/harper-core/tests/text/tagged/Spell.md
+++ b/harper-core/tests/text/tagged/Spell.md
@@ -10,17 +10,17 @@
 # NSg/V   NPl/V
 >
 #
-> My favourite color      is blu .
-# D  NSg/J/Br  NSg/V/J/Am VL W?  .
-> I   must  defend my honour !
-# ISg NSg/V NSg/V  D  NSg/Br .
+> My favourite      color      is blu .
+# D  NSg/J/Ca/Au/Br NSg/V/J/Am VL W?  .
+> I   must  defend my honour       !
+# ISg NSg/V NSg/V  D  NSg/Ca/Au/Br .
 > I   recognize that    you recognise me        .
-# ISg V         N/I/C/D IPl V/Br      NPrSg/ISg .
+# ISg V         N/I/C/D IPl V/Au/Br   NPrSg/ISg .
 > I   analyze how   you infantilize me        .
 # ISg V       NSg/C IPl V           NPrSg/ISg .
 > I   analyse how   you infantilise me        .
-# ISg V/Br    NSg/C IPl ?           NPrSg/ISg .
-> Careful , traveller !
-# J       . NSg/Br    .
-> At the centre of the theatre I   dropped a   litre  of coke    .
-# P  D   NSg/Br P  D   NSg/Br  ISg V/J     D/P NSg/Br P  NPrSg/V .
+# ISg V/Au/Br NSg/C IPl ?           NPrSg/ISg .
+> Careful , traveller    !
+# J       . NSg/Ca/Au/Br .
+> At the centre       of the theatre      I   dropped a   litre        of coke    .
+# P  D   NSg/Ca/Au/Br P  D   NSg/Ca/Au/Br ISg V/J     D/P NSg/Ca/Au/Br P  NPrSg/V .

--- a/harper-core/tests/text/tagged/The Constitution of the United States.md
+++ b/harper-core/tests/text/tagged/The Constitution of the United States.md
@@ -266,8 +266,8 @@
 #
 > Each House   may      determine the Rules of its   Proceedings , punish its   Members for
 # D    NPrSg/V NPrSg/VX V         D   NPl   P  ISg/D W?          . V      ISg/D NPl     C/P
-> disorderly Behaviour , and , with the Concurrence of two thirds , expel a   Member .
-# R          NSg/Br    . V/C . P    D   NSg         P  NSg NPl/V  . V     D/P NSg    .
+> disorderly Behaviour    , and , with the Concurrence of two thirds , expel a   Member .
+# R          NSg/Ca/Au/Br . V/C . P    D   NSg         P  NSg NPl/V  . V     D/P NSg    .
 >
 #
 > Each House   shall keep  a   Journal of its   Proceedings , and from time    to time
@@ -1102,8 +1102,8 @@
 # NSg/I/V/J NSg/V/J NSg/V/J . V/C NPrSg/J/P NSg/I NSg/J    NPl/V  NSg/R D   NPrSg    NPrSg/VX P    NSg/V/J P
 > time    ordain and establish . The Judges , both of the supreme and inferior Courts ,
 # NSg/V/J V      V/C V         . D   NPrPl  . I/C  P  D   NSg/J   V/C NSg/J    NPl/V  .
-> shall hold    their Offices during good      Behaviour , and shall , at    stated Times ,
-# VX    NSg/V/J D     NPl     V/P    NPrSg/V/J NSg/Br    . V/C VX    . NSg/P V/J    NPl/V .
+> shall hold    their Offices during good      Behaviour    , and shall , at    stated Times ,
+# VX    NSg/V/J D     NPl     V/P    NPrSg/V/J NSg/Ca/Au/Br . V/C VX    . NSg/P V/J    NPl/V .
 > receive for their Services , a   Compensation , which shall not   be     diminished
 # NSg/V   C/P D     NPl      . D/P NSg          . I/C   VX    NSg/C NSg/VX V/J
 > during their Continuance in        Office .
@@ -1304,14 +1304,14 @@
 # C       D   NSg/J VX    NSg/VX NSg/V W?   V/J       . VX    V     N/J/P  D   J
 > States  , or      any   place subject to their jurisdiction . No      Person held to Service
 # NPrSg/V . NPrSg/C I/R/D NSg/V NSg/V/J P  D     NSg          . NPrSg/P NSg    V    P  NSg/V
-> or      Labour     in        one       State , under   the Laws thereof , escaping into another , shall ,
-# NPrSg/C NPrSg/V/Br NPrSg/J/P NSg/I/V/J NSg/V . NSg/J/P D   NPl  W?      . V        P    I/D     . VX    .
+> or      Labour           in        one       State , under   the Laws thereof , escaping into another , shall ,
+# NPrSg/C NPrSg/V/Ca/Au/Br NPrSg/J/P NSg/I/V/J NSg/V . NSg/J/P D   NPl  W?      . V        P    I/D     . VX    .
 > in        Consequence of any   Law   or      Regulation therein , be     discharged from such
 # NPrSg/J/P NSg/V       P  I/R/D NSg/V NPrSg/C NSg/J      W?      . NSg/VX V/J        P    NSg/I
-> Service or      Labour     , but     shall be     delivered up        on  Claim of the Party to whom such
-# NSg/V   NPrSg/C NPrSg/V/Br . NSg/C/P VX    NSg/VX V/J       NSg/V/J/P J/P NSg/V P  D   NSg/J P  I    NSg/I
-> Service or      Labour     may      be     due   .
-# NSg/V   NPrSg/C NPrSg/V/Br NPrSg/VX NSg/VX NSg/J .
+> Service or      Labour           , but     shall be     delivered up        on  Claim of the Party to whom such
+# NSg/V   NPrSg/C NPrSg/V/Ca/Au/Br . NSg/C/P VX    NSg/VX V/J       NSg/V/J/P J/P NSg/V P  D   NSg/J P  I    NSg/I
+> Service or      Labour           may      be     due   .
+# NSg/V   NPrSg/C NPrSg/V/Ca/Au/Br NPrSg/VX NSg/VX NSg/J .
 >
 #
 > Section . 3 .

--- a/harper-core/tests/text/tagged/The Great Gatsby.md
+++ b/harper-core/tests/text/tagged/The Great Gatsby.md
@@ -50,8 +50,8 @@
 # V         NPl       VL D/P NSg/J  P  NSg/J    NPrSg/V . ISg NPrSg/V/J NSg/V/J D/P NPrSg/I/J J      P
 > missing something if    I   forget that    , as    my father snobbishly suggested , and I
 # V       NSg/I/V/J NSg/C ISg V      N/I/C/D . NSg/R D  NPrSg  R          V/J       . V/C ISg
-> snobbishly repeat , a   sense of the fundamental decencies is parcelled out
-# R          NSg/V  . D/P NSg   P  D   NSg/J       NPl       VL V/Br      NSg/V/J/R/P
+> snobbishly repeat , a   sense of the fundamental decencies is parcelled  out
+# R          NSg/V  . D/P NSg   P  D   NSg/J       NPl       VL V/Ca/Au/Br NSg/V/J/R/P
 > unequally at    birth   .
 # R         NSg/P NSg/V/J .
 >
@@ -118,8 +118,8 @@
 # V/C D/P NPrSg/I/J J     ISg V/J          P  N/I/C/D V/J     NSg/J    NSg       NSg/V/J NSg/R
 > the Great War   . I   enjoyed the counter - raid  so        thoroughly that    I   came    back
 # D   NSg/J NSg/V . ISg V/J     D   NSg/J   . NSg/V NSg/I/J/C R          N/I/C/D ISg NSg/V/P NSg/V/J
-> restless . Instead of being   the warm  centre   of the world , the Middle West      now
-# J        . W?      P  NSg/V/C D   NSg/J NSg/V/Br P  D   NSg   . D   NSg/J  NPrSg/V/J NPrSg/V/J/C
+> restless . Instead of being   the warm  centre         of the world , the Middle West      now
+# J        . W?      P  NSg/V/C D   NSg/J NSg/V/Ca/Au/Br P  D   NSg   . D   NSg/J  NPrSg/V/J NPrSg/V/J/C
 > seemed like        the ragged edge  of the universe — so        I   decided to go      East    and learn
 # V/J    NSg/V/J/C/P D   J      NSg/V P  D   NPrSg    . NSg/I/J/C ISg NSg/V/J P  NSg/V/J NPrSg/J V/C NSg/V
 > the bond    business . Everybody I   knew was in the bond    business , so        I   supposed it
@@ -957,7 +957,7 @@
 > thinking , but     I   doubt if    even    Miss  Baker   , who     seemed to have   mastered a   certain
 # V        . NSg/C/P ISg NSg/V NSg/C NSg/V/J NSg/V NPrSg/J . NPrSg/I V/J    P  NSg/VX V/J      D/P I/J
 > hardy   scepticism , was able    utterly to put   this fifth   guest’s shrill  metallic
-# NPrSg/J NSg/Br     . V   NSg/V/J R       P  NSg/V I/D  NSg/V/J N$      NSg/V/J NSg/J
+# NPrSg/J NSg/Au/Br  . V   NSg/V/J R       P  NSg/V I/D  NSg/V/J N$      NSg/V/J NSg/J
 > urgency out         of mind  . To a   certain temperament the situation might    have   seemed
 # NSg     NSg/V/J/R/P P  NSg/V . P  D/P I/J     NSg         D   NSg       NSg/VX/J NSg/VX V/J
 > intriguing — my own   instinct was to telephone immediately for the police .
@@ -1180,8 +1180,8 @@
 # NPrSg/V/J . . . .
 >
 #
-> “ Did you give  Nick    a   little    heart to heart talk  on the veranda ? ” demanded Tom
-# . V   IPl NSg/V NPrSg/V D/P NPrSg/I/J NSg/V P  NSg/V NSg/V P  D   NSg/Br  . . V/J      NPrSg/V
+> “ Did you give  Nick    a   little    heart to heart talk  on the veranda      ? ” demanded Tom
+# . V   IPl NSg/V NPrSg/V D/P NPrSg/I/J NSg/V P  NSg/V NSg/V P  D   NSg/Am/Ca/Br . . V/J      NPrSg/V
 > suddenly .
 # R        .
 >
@@ -1717,7 +1717,7 @@
 > Wilson called up        several people on the telephone ; then    there were  no      cigarettes ,
 # NPr    V/J    NSg/V/J/P J/D     NSg/V  P  D   NSg       . NSg/J/C W?    NSg/V NPrSg/P NPl        .
 > and I   went  out         to buy   some  at the drugstore on the corner . When    I   came    back    they
-# V/C ISg NSg/V NSg/V/J/R/P P  NSg/V I/J/R P  D   NSg/Am    P  D   NSg/J  . NSg/I/C ISg NSg/V/P NSg/V/J IPl
+# V/C ISg NSg/V NSg/V/J/R/P P  NSg/V I/J/R P  D   NSg/Am/Ca P  D   NSg/J  . NSg/I/C ISg NSg/V/P NSg/V/J IPl
 > had both disappeared , so        I   sat     down      discreetly in the living - room    and read  a
 # V   I/C  V/J         . NSg/I/J/C ISg NSg/V/J NSg/V/J/P R          P  D   NSg/J  . NSg/V/J V/C NSg/V D/P
 > chapter of “ Simon Called Peter     ” — either it        was terrible stuff or      the whiskey
@@ -1844,8 +1844,8 @@
 #
 > “ I   should change the light , ” he      said after a   moment . “ I’d like        to bring out         the
 # . ISg VX     NSg/V  D   NSg/J . . NPr/ISg V/J  J/P   D/P NSg    . . W?  NSg/V/J/C/P P  V     NSg/V/J/R/P D
-> modelling of the features . And I’d try     to get   hold    of all       the back  hair  . ”
-# NSg/Br    P  D   NPl      . V/C W?  NSg/V/J P  NSg/V NSg/V/J P  NSg/I/J/C D   NSg/J NSg/V . .
+> modelling    of the features . And I’d try     to get   hold    of all       the back  hair  . ”
+# NSg/Ca/Au/Br P  D   NPl      . V/C W?  NSg/V/J P  NSg/V NSg/V/J P  NSg/I/J/C D   NSg/J NSg/V . .
 >
 #
 > “ I   wouldn’t think of changing the light , ” cried Mrs . McKee . “ I   think it’s — — — ”
@@ -2402,8 +2402,8 @@
 # NPl      . NSg/V    V/C NSg/V P  D   I/J  NSg/V/J . W?      W?    V   W?        .
 > confident girls who     weave here    and there among the stouter and more        stable  ,
 # NSg/J     NPl/V NPrSg/I NSg/V NSg/J/R V/C W?    P     D   J       V/C NPrSg/I/V/J NSg/V/J .
-> become for a   sharp   , joyous moment the centre of a   group , and then    , excited with
-# V      C/P D/P NPrSg/J . J      NSg    D   NSg/Br P  D/P NSg   . V/C NSg/J/C . V/J     P
+> become for a   sharp   , joyous moment the centre       of a   group , and then    , excited with
+# V      C/P D/P NPrSg/J . J      NSg    D   NSg/Ca/Au/Br P  D/P NSg   . V/C NSg/J/C . V/J     P
 > triumph , glide on  through the sea - change of faces and voices and color      under   the
 # NSg/V   . NSg/V J/P NSg/J/P D   NSg . NSg/V  P  NPl/V V/C NPl/V  V/C NSg/V/J/Am NSg/J/P D
 > constantly changing light   .
@@ -2688,12 +2688,12 @@
 #
 > The bar   , where we  glanced first   , was crowded , but     Gatsby was not   there . She
 # D   NSg/P . NSg/C IPl V/J     NSg/V/J . V   V/J     . NSg/C/P NPr    V   NSg/C W?    . ISg
-> couldn’t find  him from the top   of the steps , and he      wasn’t on the veranda . On a
-# V        NSg/V I   P    D   NSg/J P  D   NPl   . V/C NPr/ISg V      P  D   NSg/Br  . P  D/P
+> couldn’t find  him from the top   of the steps , and he      wasn’t on the veranda      . On a
+# V        NSg/V I   P    D   NSg/J P  D   NPl   . V/C NPr/ISg V      P  D   NSg/Am/Ca/Br . P  D/P
 > chance  we  tried an  important - looking door  , and walked into a   high  Gothic
 # NPrSg/J IPl V/J   D/P J         . V       NSg/V . V/C V/J    P    D/P NSg/J NPrSg/J
-> library , panelled with carved English   oak     , and probably transported complete
-# NSg     . V/J/Br   P    V/J    NPrSg/V/J NSg/V/J . V/C R        V/J         NSg/V/J
+> library , panelled     with carved English   oak     , and probably transported complete
+# NSg     . V/J/Ca/Au/Br P    V/J    NPrSg/V/J NSg/V/J . V/C R        V/J         NSg/V/J
 > from some  ruin  overseas .
 # P    I/J/R NSg/V W?       .
 >
@@ -2743,7 +2743,7 @@
 >
 #
 > Taking  our scepticism for granted , he      rushed to the bookcases and returned with
-# NSg/V/J D   NSg/Br     C/P V/J     . NPr/ISg V/J    P  D   NPl       V/C V/J      P
+# NSg/V/J D   NSg/Au/Br  C/P V/J     . NPr/ISg V/J    P  D   NPl       V/C V/J      P
 > Volume One       of the “ Stoddard Lectures . ”
 # NSg/V  NSg/I/V/J P  D   . ?        NPl/V    . .
 >
@@ -3526,8 +3526,8 @@
 #
 > Again at    eight o’clock , when    the dark  lanes of the Forties were  lined five deep
 # P     NSg/P NSg/J W?      . NSg/I/C D   NSg/J NPl   P  D   NPl     NSg/V V/J   NSg  NSg/J
-> with throbbing taxicabs , bound   for the theatre district , I   felt    a   sinking in my
-# P    NSg/V/J   NPl/V    . NSg/V/J C/P D   NSg/Br  NSg/V/J  . ISg NSg/V/J D/P N/J     P  D
+> with throbbing taxicabs , bound   for the theatre      district , I   felt    a   sinking in my
+# P    NSg/V/J   NPl/V    . NSg/V/J C/P D   NSg/Ca/Au/Br NSg/V/J  . ISg NSg/V/J D/P N/J     P  D
 > heart . Forms leaned together in the taxis as    they waited , and voices sang    , and
 # NSg   . NPl/V V/J    J        P  D   NPl   NSg/R IPl  V/J    . V/C NPl/V  NPrSg/V . V/C
 > there was laughter from unheard jokes , and lighted cigarettes made
@@ -4018,8 +4018,8 @@
 # . NSg/V NPrSg/ISg . .
 >
 #
-> “ Major     Jay   Gatsby , ” I   read  , “ For Valour Extraordinary . ”
-# . NPrSg/V/J NPrSg NPr    . . ISg NSg/V . . C/P NSg/Br NSg/J         . .
+> “ Major     Jay   Gatsby , ” I   read  , “ For Valour       Extraordinary . ”
+# . NPrSg/V/J NPrSg NPr    . . ISg NSg/V . . C/P NSg/Ca/Au/Br NSg/J         . .
 >
 #
 > “ Here’s another thing I   always carry . A   souvenir of Oxford days . It        was taken in
@@ -4150,8 +4150,8 @@
 # V/J    NSg/V/J/R/P NSg/P NPr/ISg P    D   NSg/J  NPl/V V/C NPrSg/V/J/P NSg/J NPl/V P  J
 > Europe , and I   was glad    that    the sight of Gatsby’s splendid car was included in
 # NPr    . V/C ISg V   NSg/V/J N/I/C/D D   NSg   P  N$       J        NSg V   V/J      P
-> their sombre   holiday . As    we  crossed Blackwell’s Island a   limousine passed us      ,
-# D     NSg/J/Br NPrSg/V . NSg/R IPl V/J     N$          NSg/V  D/P NSg       V/J    NPr/ISg .
+> their sombre         holiday . As    we  crossed Blackwell’s Island a   limousine passed us      ,
+# D     NSg/J/Ca/Au/Br NPrSg/V . NSg/R IPl V/J     N$          NSg/V  D/P NSg       V/J    NPr/ISg .
 > driven by a   white   chauffeur , in        which sat     three modish negroes , two bucks and a
 # V/J    P  D/P NPrSg/J NSg/V     . NPrSg/J/P I/C   NSg/V/J NSg   J      NSg     . NSg NPl/V V/C D/P
 > girl . I   laughed aloud as    the yolks of their eyeballs rolled toward us      in        haughty
@@ -4907,7 +4907,7 @@
 > Suddenly I   wasn’t thinking of Daisy and Gatsby any   more        , but     of this clean   ,
 # R        ISg V      V        P  NPrSg V/C NPr    I/R/D NPrSg/I/V/J . NSg/C/P P  I/D  NSg/V/J .
 > hard    , limited person , who     dealt in        universal scepticism , and who     leaned back
-# NSg/V/J . NSg/V/J NSg/V  . NPrSg/I V     NPrSg/J/P NSg/J     NSg/Br     . V/C NPrSg/I V/J    NSg/V/J
+# NSg/V/J . NSg/V/J NSg/V  . NPrSg/I V     NPrSg/J/P NSg/J     NSg/Au/Br  . V/C NPrSg/I V/J    NSg/V/J
 > jauntily just within the circle of my arm   . A   phrase began to beat    in my ears
 # R        V/J  N/J/P  D   NSg    P  D  NSg/J . D/P NSg    V     P  NSg/V/J P  D  NPl
 > with a   sort of heady excitement : ‘          ‘          There are only the pursued , the pursuing , the
@@ -5681,7 +5681,7 @@
 > vivid with new     flowers , through dressing - rooms and poolrooms , and bathrooms with
 # NSg/J P    NSg/V/J NPrPl/V . NSg/J/P NSg/V    . NPl/V V/C NPl       . V/C NPl/V     P
 > sunken baths — intruding into one       chamber where a   dishevelled man       in        pajamas was
-# W?     NSg/V . V         P    NSg/I/V/J NSg/V   NSg/C D/P J/Br        NPrSg/V/J NPrSg/J/P NSg     V
+# W?     NSg/V . V         P    NSg/I/V/J NSg/V   NSg/C D/P J/Ca/Au/Br  NPrSg/V/J NPrSg/J/P NSg     V
 > doing liver exercises on the floor . It        was Mr  . Klipspringer , the ‘          ‘          boarder . ” I
 # NSg/V NSg/J NPl/V     P  D   NSg   . NPrSg/ISg V   NSg . ?            . D   Unlintable Unlintable NSg/J   . . ISg
 > had seen  him wandering hungrily about the beach that    morning . Finally we  came    to
@@ -6505,7 +6505,7 @@
 >
 #
 > “ I’m looking around . I’m having a   marvellous — ”
-# . W?  V       J/P    . W?  V      D/P J/Br       . .
+# . W?  V       J/P    . W?  V      D/P J/Ca/Au/Br . .
 >
 #
 > “ You must  see   the faces of many    people you’ve heard about . ”
@@ -6826,8 +6826,8 @@
 # D   NSg  N/I/C/D V/J    P  NSg/VX NSg/V   I/J/D NSg/V/J NSg/J/P . NSg/I NSg/VX V      NPrSg/V/J/C P  D
 > dim   , incalculable hours ? Perhaps some  unbelievable guest would  arrive , a   person
 # NSg/J . J            NPl   . NSg     I/J/R J            NSg/V NSg/VX V      . D/P NSg
-> infinitely rare    and to be     marvelled at    , some  authentically radiant young     girl
-# R          NSg/V/J V/C P  NSg/VX V/Br      NSg/P . I/J/R R             NSg/J   NPrSg/V/J NSg/V
+> infinitely rare    and to be     marvelled  at    , some  authentically radiant young     girl
+# R          NSg/V/J V/C P  NSg/VX V/Ca/Au/Br NSg/P . I/J/R R             NSg/J   NPrSg/V/J NSg/V
 > who     with one       fresh   glance at    Gatsby , one       moment of magical encounter , would  blot
 # NPrSg/I P    NSg/I/V/J NSg/V/J NSg/V  NSg/P NPr    . NSg/I/V/J NSg    P  J       NSg/V     . NSg/VX NSg/V
 > out         those five years of unwavering devotion .
@@ -7194,8 +7194,8 @@
 # R              ISg V/J   ISg/D NSg   . NSg/V/J . V/J     . NSg/J . P  D   NPrSg NSg/V     .
 >
 #
-> Gatsby stood in the centre of the crimson carpet and gazed around with
-# NPr    V     P  D   NSg/Br P  D   NSg/J   NSg/V  V/C V/J   J/P    P
+> Gatsby stood in the centre       of the crimson carpet and gazed around with
+# NPr    V     P  D   NSg/Ca/Au/Br P  D   NSg/J   NSg/V  V/C V/J   J/P    P
 > fascinated eyes  . Daisy watched him and laughed , her   sweet     , exciting laugh ; a
 # V/J        NPl/V . NPrSg V/J     I   V/C V/J     . I/J/D NPrSg/V/J . NSg/V/J  NSg/V . D/P
 > tiny  gust  of powder rose      from her   bosom   into the air .
@@ -7382,8 +7382,8 @@
 # NSg   . .
 >
 #
-> I   went  with them out         to the veranda . On the green   Sound   , stagnant in the heat ,
-# ISg NSg/V P    N/I  NSg/V/J/R/P P  D   NSg/Br  . P  D   NPrSg/J NSg/V/J . J        P  D   NSg  .
+> I   went  with them out         to the veranda      . On the green   Sound   , stagnant in the heat ,
+# ISg NSg/V P    N/I  NSg/V/J/R/P P  D   NSg/Am/Ca/Br . P  D   NPrSg/J NSg/V/J . J        P  D   NSg  .
 > one       small     sail  crawled slowly toward the fresher sea . Gatsby’s eyes  followed it
 # NSg/I/V/J NPrSg/V/J NSg/V V/J     R      J/P    D   J       NSg . N$       NPl/V V/J      NPrSg/ISg
 > momentarily ; he      raised his   hand and pointed across the bay   .
@@ -7946,8 +7946,8 @@
 #
 > The word “ sensuous ” had the effect of further disquieting Tom     , but     before he
 # D   NSg  . J        . V   D   NSg    P  V/J     V           NPrSg/V . NSg/C/P C/P    NPr/ISg
-> could  invent a   protest the coupé came    to a   stop , and Daisy signalled us      to draw
-# NSg/VX V      D/P NSg     D   ?     NSg/V/P P  D/P NSg  . V/C NPrSg V/Br      NPr/ISg P  NSg/V
+> could  invent a   protest the coupé came    to a   stop , and Daisy signalled  us      to draw
+# NSg/VX V      D/P NSg     D   ?     NSg/V/P P  D/P NSg  . V/C NPrSg V/Ca/Au/Br NPr/ISg P  NSg/V
 > up        alongside .
 # NSg/V/J/P P         .
 >
@@ -8028,8 +8028,8 @@
 # . W?    V      I/R/D NPrSg/I/V/J . .
 >
 #
-> “ Well    , we’d better   telephone for an  axe    — — — ”
-# . NSg/V/J . W?   NSg/VX/J NSg/V     C/P D/P NSg/Br . . . .
+> “ Well    , we’d better   telephone for an  axe          — — — ”
+# . NSg/V/J . W?   NSg/VX/J NSg/V     C/P D/P NSg/Ca/Au/Br . . . .
 >
 #
 > “ The thing to do     is to forget about the heat , ” said Tom     impatiently . “ You make
@@ -8130,8 +8130,8 @@
 #
 > “ That    was his   cousin . I   knew his   whole family history before he      left      . He      gave me
 # . N/I/C/D V   ISg/D NSg    . ISg V    ISg/D NSg/J NSg/J  NSg     C/P    NPr/ISg NPrSg/V/J . NPr/ISg V    NPrSg/ISg
-> an  aluminum putter  that    I   use   to - day   . ”
-# D/P NSg/Ca   NSg/V/J N/I/C/D ISg NSg/V P  . NPrSg . .
+> an  aluminum  putter  that    I   use   to - day   . ”
+# D/P NSg/Am/Ca NSg/V/J N/I/C/D ISg NSg/V P  . NPrSg . .
 >
 #
 > The music had died down      as    the ceremony began and now         a   long    cheer floated in        at
@@ -9404,8 +9404,8 @@
 #
 > I   walked back    along the border of the lawn , traversed the gravel softly , and
 # ISg V/J    NSg/V/J P     D   NSg    P  D   NSg  . V/J       D   NSg/J  R      . V/C
-> tiptoed up        the veranda steps . The drawing - room    curtains were  open    , and I   saw
-# V/J     NSg/V/J/P D   NSg/Br  NPl/V . D   NSg     . NSg/V/J NPl/V    NSg/V NSg/V/J . V/C ISg NSg/V
+> tiptoed up        the veranda      steps . The drawing - room    curtains were  open    , and I   saw
+# V/J     NSg/V/J/P D   NSg/Am/Ca/Br NPl/V . D   NSg     . NSg/V/J NPl/V    NSg/V NSg/V/J . V/C ISg NSg/V
 > that    the room  was empty   . Crossing the porch where we  had dined that    June night
 # N/I/C/D D   NSg/J V   NSg/V/J . NSg/V/J  D   NSg   NSg/C IPl V   V/J   N/I/C/D NPr  NSg/V
 > three months before , I   came    to a   small   rectangle of light   which I   guessed was
@@ -11261,7 +11261,7 @@
 > stop  and then    the sound of some  one       splashing after us      over      the soggy ground  . I
 # NSg/V V/C NSg/J/C D   NSg/J P  I/J/R NSg/I/V/J V         J/P   NPr/ISg NSg/V/J/P D   J     NSg/V/J . ISg
 > looked around . It        was the man     with owl   - eyed glasses whom I   had found marvelling
-# V/J    J/P    . NPrSg/ISg V   D   NPrSg/J P    NSg/V . V/J  NPl/V   I    ISg V   NSg/V NSg/V/Br
+# V/J    J/P    . NPrSg/ISg V   D   NPrSg/J P    NSg/V . V/J  NPl/V   I    ISg V   NSg/V NSg/V/Ca/Au/Br
 > over      Gatsby’s books in the library one       night three months before .
 # NSg/V/J/P N$       NPl/V P  D   NSg     NSg/I/V/J NSg/V NSg   NSg    C/P    .
 >
@@ -11383,7 +11383,7 @@
 > hundred houses , at    once  conventional and grotesque , crouching under   a   sullen ,
 # NSg     NPl/V  . NSg/P NSg/C NSg/J        V/C NSg/J     . V         NSg/J/P D/P NSg/J  .
 > overhanging sky   and a   lustreless moon    . In the foreground four solemn men in
-# V           NSg/V V/C D/P J/Br       NPrSg/V . P  D   NSg        NSg  J      NSg NPrSg/J/P
+# V           NSg/V V/C D/P J/Ca/Au/Br NPrSg/V . P  D   NSg        NSg  J      NSg NPrSg/J/P
 > dress suits are walking along the sidewalk with a   stretcher on  which lies  a
 # NSg/V NPl/V V   NSg/V/J P     D   NSg      P    D/P NSg/J     J/P I/C   NPl/V D/P
 > drunken woman in a   white   evening dress . Her   hand  , which dangles over      the side  ,


### PR DESCRIPTION
# Issues 
Closes #1337

# Description
<!-- Please include a summary of the change. -->
This PR adds proper handling for words that correspond to multiple dialects. This fixes the issue reported in #1337, as the dialects defined for a word no longer conflict with each other.
<!-- Any details that you think are important to review this PR? -->
This adds the `bitflags` dependency to store the activated dialects as a bitfield in `WordMetadata`. As an alternative, it should not be too difficult to switch to using something like a boolean array instead if preferable.
<!-- Are there other PRs related to this one? -->

# How Has This Been Tested?
- `cargo test`
- `just precommit`

I did some brief manual testing with the modified builds of `harper-ls` and `harper-cli` with seemingly succesful results. Switching dialects in VS Code showed that "aluminum" would be linted as a spelling error if the dialect was set to British or Australian, whereas "Aluminium" would be linted as such if the dialect was set to Canadian or American. The snapshots look promising as well. Still, this does feel like a pretty wide-reaching change, so I can't be 100% certain this doesn't break something.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
