### PR TITLE
feat:a couple of more→a couple more

### DIFF
--- a/harper-core/src/linting/phrase_corrections.rs
+++ b/harper-core/src/linting/phrase_corrections.rs
@@ -1290,6 +1290,12 @@ pub fn lint_group() -> LintGroup {
             "The phrase is `peace of mind`, meaning `calm`. A `piece` is a `part` of something.",
             "Corrects `piece of mind` to `peace of mind`."
         ),
+        "ACoupleMore" => (
+            ["a couple of more"],
+            ["a couple more"],
+            "The correct wording is `a couple more`, without the `of`.",
+            "Corrects `a couple of more` to `a couple more`."
+        ),
     });
 
     group.set_all_rules_to(Some(true));
@@ -2808,6 +2814,15 @@ mod tests {
             "A Discord bot that gives you piece of mind knowing you are free from obnoxious intrusions in a Discord Voice Channel",
             lint_group(),
             "A Discord bot that gives you peace of mind knowing you are free from obnoxious intrusions in a Discord Voice Channel",
+        )
+    }
+
+    #[test]
+    fn corrects_a_couple_of_more() {
+        assert_suggestion_result(
+            "There are a couple of more rules that could be added, how can I contribute?",
+            lint_group(),
+            "There are a couple more rules that could be added, how can I contribute?",
         )
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

Somewhere I noticed somebody using "a couple of more" instead of just "a couple more".
It turns out to be very common. ("a few of more" however is not common.)

# How Has This Been Tested?
I added a unit test using a sentence from GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
