### PR TITLE
feat: update untitled handling

### DIFF
--- a/harper-ls/src/backend.rs
+++ b/harper-ls/src/backend.rs
@@ -105,6 +105,14 @@ impl Backend {
     }
 
     async fn load_ignored_lints(&self, uri: &Uri) -> Result<IgnoredLints> {
+        // VS Code's unsaved documents have "untitled" scheme
+        if uri
+            .scheme()
+            .is_some_and(|scheme| scheme.eq_lowercase("untitled"))
+        {
+            return Ok(IgnoredLints::new());
+        }
+
         Ok(load_ignored_lints(
             self.get_ignored_lints_path(uri)
                 .await

--- a/packages/vscode-plugin/src/extension.ts
+++ b/packages/vscode-plugin/src/extension.ts
@@ -30,15 +30,11 @@ const clientOptions: LanguageClientOptions = {
 		},
 		executeCommand(command, args, next) {
 			if (
-				['HarperAddToUserDict', 'HarperAddToFileDict'].includes(command) &&
+				['HarperAddToUserDict', 'HarperAddToFileDict', 'HarperIgnoreLint'].includes(command) &&
 				args.find((a) => typeof a === 'string' && a.startsWith('untitled:'))
 			) {
 				window
-					.showInformationMessage(
-						'Save the file to add words to the dictionary.',
-						'Save File',
-						'Dismiss',
-					)
+					.showInformationMessage('Save the file to execute this command.', 'Save File', 'Dismiss')
 					.then((selected) => {
 						if (selected === 'Save File') {
 							commands.executeCommand('workbench.action.files.save');


### PR DESCRIPTION
# Issues 

#1365

# Description

Currently, the crash happens when `harper-ls` starts up because somewhere down the line `tower-lsp-server`'s `UriExt::to_file_path` gets called and panics on Windows machines when passed an untitled URI, as they don't have an authority.

I traced the flow and put checks so that `UriExt::to_file_path` doesn't get called with an untitled URI. This affects the ignore lints feature we currently have and changes it's flow a bit:

- When running `HarperIgnoreLint`, like for `HarperAddToUserDict` and `HarperAddToFileDict`, the extension now prompts the user to save the file before the command can be run.
- When loading ignored lints, if the URI passed is an untitled URI, it just returns an empty `IgnoredLints` instance.

Though tower-lsp-community/tower-lsp-server#53 should fix `tower-lsp-server`'s issue of panicking when passed a URI without an authority, I think this new handling of ignoring lints for untitled files is better and should be kept for the following reasons:

- Untitled files are meant to be ephemeral, so anything persistent that points to it would probably go stale fast.
- VS Code doesn't open untitled files with unique names, so when saving ignored lints, they get saved like so: `path/to/harper-ls/ignored_lints/Untitled-1%`, which means the same ignore file could point to multiple files since the first untitled file opened in any workspace is named `Untitled-1` and the number just gets incremented with every new untitled file opened.

There's still one instance where `harper-ls` could crash because of this bug, and that's on `did_change_configuration`. However, that should be resolved when tower-lsp-community/tower-lsp-server#53 gets merged. At the very least, `harper-ls` won't just crash on start up and changing settings/configs is rare enough that the churn probably won't be as bad while we wait for the fix.

# How Has This Been Tested?

Manually. Unfortunately, even if the logic should hold up, I don't have a Windows machine to test if this truly prevents the crash, so I'd appreciate it if anyone with a Windows machine can check.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
