### PR TITLE
feat: fix nonstandard variants of two idioms

### DIFF
--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -1311,6 +1311,18 @@ pub fn lint_group() -> LintGroup {
             "The correct wording is `a couple more`, without the `of`.",
             "Corrects `a couple of more` to `a couple more`."
         ),
+        "AllOfASudden" => (
+            ["all of the sudden"],
+            ["all of a sudden"],
+            "The phrase is `all of a sudden`, meaning `unexpectedly`.",
+            "Corrects `all of the sudden` to `all of a sudden`."
+        ),
+        "LowHangingFruit" => (
+            ["low hanging fruit", "low hanging fruits", "low-hanging fruits"],
+            ["low-hanging fruit"],
+            "The standard form is `low-hanging fruit` with a hyphen and singular form.",
+            "Corrects non-standard variants of `low-hanging fruit`."
+        )
     });
 
     group.set_all_rules_to(Some(true));

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -1545,3 +1545,39 @@ fn corrects_a_couple_of_more() {
         "There are a couple more rules that could be added, how can I contribute?",
     )
 }
+
+#[test]
+fn corrects_all_of_a_sudden() {
+    assert_suggestion_result(
+        "On an app that has been released since December, all of the sudden around February 5th ANRs started going up.",
+        lint_group(),
+        "On an app that has been released since December, all of a sudden around February 5th ANRs started going up.",
+    )
+}
+
+#[test]
+fn corrects_low_hanging_fruit() {
+    assert_suggestion_result(
+        "If you add me as a collaborator i can start merging some of the low hanging fruit.",
+        lint_group(),
+        "If you add me as a collaborator i can start merging some of the low-hanging fruit.",
+    )
+}
+
+#[test]
+fn corrects_low_hanging_fruits_hyphen() {
+    assert_suggestion_result(
+        "Field guide to gather low-hanging fruits.",
+        lint_group(),
+        "Field guide to gather low-hanging fruit.",
+    )
+}
+
+#[test]
+fn corrects_low_hanging_fruits_space() {
+    assert_suggestion_result(
+        "Will search for low hanging fruits and useful information for escalation on a compromised workstation.",
+        lint_group(),
+        "Will search for low-hanging fruit and useful information for escalation on a compromised workstation.",
+    )
+}


### PR DESCRIPTION
# Issues 
N/A

# Description

Two common non-standard variants of common English idioms:
- all of **the** sudden (regional variant used by some native speakers)
- low-hanging **fruits** (non-native speakers who think every noun has to have a plural)

As a bonus, the hyphen is added to `low-hanging fruit` too.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Unit tests using sentences from GitHub are added.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
