### PR TITLE
chore: re-sort phrase corrections

### DIFF
--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -688,6 +688,18 @@ pub fn lint_group() -> LintGroup {
             "Did you mean `I am`?",
             "Fixes the incorrect spacing in `I a m` to properly form `I am`."
         ),
+        "IAmAgreement" => (
+            ["I are"],
+            ["I am"],
+            "The first-person singular pronoun `I` requires the verb form `am`; `are` belongs to second-person or plural contexts.",
+            "Corrects `I are` to `I am`."
+        ),
+        "IDo" => (
+            ["I does"],
+            ["I do"],
+            "`I` pairs with the bare verb `do`; the –s inflection `does` is reserved for third-person singular subjects.",
+            "Corrects `I does` to `I do`."
+        ),
         "InAndOfItself" => (
             ["in of itself"],
             ["in and of itself"],
@@ -1316,18 +1328,6 @@ pub fn lint_group() -> LintGroup {
             ["worst ever"],
             "Use `worst` for the extreme case. (`Worse` is for comparing)",
             "Corrects `worse ever` to `worst ever` for proper comparative usage."
-        ),
-        "IAmAgreement" => (
-            ["I are"],
-            ["I am"],
-            "The first-person singular pronoun `I` requires the verb form `am`; `are` belongs to second-person or plural contexts.",
-            "Corrects `I are` to `I am`."
-        ),
-        "IDo" => (
-            ["I does"],
-            ["I do"],
-            "`I` pairs with the bare verb `do`; the –s inflection `does` is reserved for third-person singular subjects.",
-            "Corrects `I does` to `I do`."
         ),
     });
 

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -931,6 +931,26 @@ fn hunger_pain() {
 // IAm
 // -none-
 
+// IAmAgreement
+#[test]
+fn corrects_i_are() {
+    assert_suggestion_result(
+        "I are really happy about this release.",
+        lint_group(),
+        "I am really happy about this release.",
+    );
+}
+
+// IDo
+#[test]
+fn corrects_i_does() {
+    assert_suggestion_result(
+        "I does enjoy writing Rust.",
+        lint_group(),
+        "I do enjoy writing Rust.",
+    );
+}
+
 // InAndOfItself
 #[test]
 fn detect_atomic_in_of_itself() {
@@ -1917,22 +1937,4 @@ fn detect_worst_ever_real_world() {
 #[test]
 fn now_on_hold() {
     assert_lint_count("Those are now on hold for month.", lint_group(), 0);
-}
-
-#[test]
-fn corrects_i_are() {
-    assert_suggestion_result(
-        "I are really happy about this release.",
-        lint_group(),
-        "I am really happy about this release.",
-    );
-}
-
-#[test]
-fn corrects_i_does() {
-    assert_suggestion_result(
-        "I does enjoy writing Rust.",
-        lint_group(),
-        "I do enjoy writing Rust.",
-    );
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

Sorts the new phrase correction linters into alphabetical order.
As a bonus we can see that there are `IAm` and `IAmAgreement` linters which do different things.

# How Has This Been Tested?
All tests still pass.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
