### PR TITLE
docs: add page for Firefox + update FAQ

### DIFF
--- a/packages/web/src/routes/docs/faq/+page.md
+++ b/packages/web/src/routes/docs/faq/+page.md
@@ -7,10 +7,8 @@ title: Frequently Asked Questions
 That depends on your use case.
 
 Do you want to use it within Obsidian? We have an [Obsidian plugin](/docs/integrations/obsidian).
-
 Do you want to use it within WordPress? We have a [WordPress plugin](/docs/integrations/wordpress).
-
-Do you want to use it within your Browser? We have a [Chrome extension](/docs/integrations/chrome-extension). (Firefox add-on coming soon.)
+Do you want to use it within your Browser? We have a [Chrome extension](/docs/integrations/chrome-extension) and a [Firefox plugin](https://addons.mozilla.org/en-US/firefox/addon/private-grammar-checker-harper/). 
 
 Do you want to use it within your code editor? We have documentation on how you can integrate with [Visual Studio Code and its forks](/docs/integrations/visual-studio-code), [Neovim](/docs/integrations/neovim), [Helix](/docs/integrations/helix), [Emacs](/docs/integrations/emacs), [Zed](/docs/integrations/zed) and [Sublime Text](/docs/integrations/sublime-text). If you're using a different code editor, then you can integrate directly with our language server, [`harper-ls`](/docs/integrations/language-server).
 

--- a/packages/web/src/routes/docs/faq/+page.md
+++ b/packages/web/src/routes/docs/faq/+page.md
@@ -8,7 +8,7 @@ That depends on your use case.
 
 Do you want to use it within Obsidian? We have an [Obsidian plugin](/docs/integrations/obsidian).
 Do you want to use it within WordPress? We have a [WordPress plugin](/docs/integrations/wordpress).
-Do you want to use it within your Browser? We have a [Chrome extension](/docs/integrations/chrome-extension) and a [Firefox plugin](https://addons.mozilla.org/en-US/firefox/addon/private-grammar-checker-harper/). 
+Do you want to use it within your Browser? We have a [Chrome extension](/docs/integrations/chrome-extension) and a [Firefox plugin](/docs/integrations/firefox-extension). 
 
 Do you want to use it within your code editor? We have documentation on how you can integrate with [Visual Studio Code and its forks](/docs/integrations/visual-studio-code), [Neovim](/docs/integrations/neovim), [Helix](/docs/integrations/helix), [Emacs](/docs/integrations/emacs), [Zed](/docs/integrations/zed) and [Sublime Text](/docs/integrations/sublime-text). If you're using a different code editor, then you can integrate directly with our language server, [`harper-ls`](/docs/integrations/language-server).
 

--- a/packages/web/src/routes/docs/integrations/firefox-extension/+page.md
+++ b/packages/web/src/routes/docs/integrations/firefox-extension/+page.md
@@ -1,0 +1,13 @@
+---
+title: The Harper Firefox Extension
+---
+
+Harper is available for the millions who rely on Firefox for fast, private, and independent browsing.
+Unlike most grammar tools, Harper's Firefox extension performs all analysis locally—never sending your text to the cloud.
+Emails, chat messages, blog posts, and comments benefit from real-time grammar improvements, with your privacy intact.
+
+![A screenshot of the Firefox extension in use.](/images/chrome_extension_github.png)
+
+To install, head to the [Firefox Add-ons site](https://addons.mozilla.org/en-US/firefox/addon/private-grammar-checker-harper/) and select 'Add to Firefox'.
+
+Curious how it works? The Firefox extension runs entirely on [`harper.js`](/docs/harperjs/introduction), our open-source JavaScript library.

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -68,6 +68,10 @@ export default defineConfig({
 									to: '/docs/integrations/chrome-extension',
 								},
 								{
+									title: 'Firefox Extension',
+									to: '/docs/integrations/firefox-extension',
+								},
+								{
 									title: 'WordPress',
 									to: '/docs/integrations/wordpress',
 								},


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
#1224
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

This PR updates the FAQ to direct people to our Firefox integration, as well as adding a special page for the Firefox extension.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

![image](https://github.com/user-attachments/assets/df736351-14e5-4b79-8470-a0a26eb082c2)


# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
