### PR TITLE
fix(core): use POS tags for `PronounKnew` accuracy

### DIFF
--- a/harper-core/src/linting/pronoun_knew.rs
+++ b/harper-core/src/linting/pronoun_knew.rs
@@ -1,3 +1,5 @@
+use harper_brill::UPOS;
+
 use crate::expr::Expr;
 use crate::expr::LongestMatchOf;
 use crate::expr::SequenceExpr;
@@ -21,7 +23,7 @@ impl Default for PronounKnew {
         // But "its" commonly occurs before "new" and is a possessive pronoun. (Much more commonly a determiner)
         // Since "his" and "her" are possessive and object pronouns respectively, we ignore them too.
         let pronoun_pattern = |tok: &Token, source: &[char]| {
-            if !tok.kind.is_pronoun() {
+            if !tok.kind.is_upos(UPOS::PRON) {
                 return false;
             }
 
@@ -135,5 +137,46 @@ mod tests {
     #[test]
     fn does_not_flag_with_nothing_1298() {
         assert_lint_count("This is nothing new.", PronounKnew::default(), 0);
+    }
+
+    #[test]
+    fn issue_1381_tricks() {
+        assert_lint_count("To learn some new tricks.", PronounKnew::default(), 0);
+    }
+
+    #[test]
+    fn issue_1381_template() {
+        assert_lint_count(
+            "Let's build this new template function.",
+            PronounKnew::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn issue_1381_file() {
+        assert_lint_count(
+            "Move the function definition inside of that new file.",
+            PronounKnew::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn fixes_i_knew_what() {
+        assert_suggestion_result(
+            "I new what to do.",
+            PronounKnew::default(),
+            "I knew what to do.",
+        );
+    }
+
+    #[test]
+    fn fixes_she_knew_what() {
+        assert_suggestion_result(
+            "She new what to do.",
+            PronounKnew::default(),
+            "She knew what to do.",
+        );
     }
 }

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -135,16 +135,6 @@ Suggest:
 
 
 
-Lint:    WordChoice (31 priority)
-Message: |
-      67 | have to ask them what the name of the country is, you know. Please, Ma’am, is
-      68 | this New Zealand or Australia?” (and she tried to curtsey as she spoke—fancy
-         |      ^~~ Did you mean “knew” (the past tense of “know”)?
-Suggest:
-  - Replace with: “Knew”
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
       68 | this New Zealand or Australia?” (and she tried to curtsey as she spoke—fancy

--- a/harper-core/tests/text/linters/Difficult sentences.snap.yml
+++ b/harper-core/tests/text/linters/Difficult sentences.snap.yml
@@ -65,6 +65,15 @@ Suggest:
 
 
 
+Lint:    WordChoice (31 priority)
+Message: |
+     130 | Clear the shelves for our new Christmas stock!
+         |                           ^~~ Did you mean “knew” (the past tense of “know”)?
+Suggest:
+  - Replace with: “knew”
+
+
+
 Lint:    Capitalization (31 priority)
 Message: |
      160 | to account for one's whereabouts.

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -1873,6 +1873,15 @@ Suggest:
 
 
 
+Lint:    WordChoice (31 priority)
+Message: |
+    1446 | “Much better.” I turned again to my new acquaintance. “This is an unusual party
+         |                                     ^~~ Did you mean “knew” (the past tense of “know”)?
+Suggest:
+  - Replace with: “knew”
+
+
+
 Lint:    Miscellaneous (31 priority)
 Message: |
     1457 | “I thought you knew, old sport. I’m afraid I’m not a very good host.”


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->

Fixes #1381

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->
 
As suggested by @hippietrail, this PR uses the output of the Brill tagger to improve the accuracy of the `PronounKnew` linter. I believe it is a good example of using the API, if anyone is curious.

Notice that it _does_ create some new false-positives, but I think they are less likely to occur and my further improvements to the NP chunker should catch them soon.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Additional unit tests

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
