### PR TITLE
feat: make including bad forms optional

### DIFF
--- a/harper-core/src/expr/reflexive_pronoun.rs
+++ b/harper-core/src/expr/reflexive_pronoun.rs
@@ -34,7 +34,9 @@ impl ReflexivePronoun {
     /// Matches only the correct forms: "myself", "yourself", "himself", "herself", "itself",
     /// "ourselves", "yourselves", and "themselves".
     pub fn standard() -> Self {
-        Self { include_common_errors: false }
+        Self {
+            include_common_errors: false,
+        }
     }
 
     /// Creates a matcher that includes non-standard but commonly used reflexive pronouns.
@@ -42,7 +44,9 @@ impl ReflexivePronoun {
     /// In addition to standard forms, matches common errors like "hisself", "theirself",
     /// and other non-standard forms that are frequently seen in user-generated content.
     pub fn with_common_errors() -> Self {
-        Self { include_common_errors: true }
+        Self {
+            include_common_errors: true,
+        }
     }
 }
 
@@ -59,7 +63,10 @@ impl Expr for ReflexivePronoun {
 
 #[cfg(test)]
 mod tests {
-    use crate::{expr::{reflexive_pronoun::BAD_REFLEXIVE_PRONOUNS, ExprExt, ReflexivePronoun}, Document, TokenKind};
+    use crate::{
+        Document, TokenKind,
+        expr::{ExprExt, ReflexivePronoun, reflexive_pronoun::BAD_REFLEXIVE_PRONOUNS},
+    };
 
     // These are considered grammatically correct, or are at least in `dictionary.dict`.
     // The tests below check if this changes so we can update this `Expr`
@@ -130,7 +137,8 @@ mod tests {
 
     #[test]
     fn ensure_standard_ctor_includes_myself() {
-        let doc = Document::new_plain_english_curated("If you want something done, do it yourself.");
+        let doc =
+            Document::new_plain_english_curated("If you want something done, do it yourself.");
         let rp = ReflexivePronoun::standard();
         let matches = rp.iter_matches_in_doc(&doc);
         assert_eq!(matches.count(), 1);
@@ -138,7 +146,9 @@ mod tests {
 
     #[test]
     fn ensure_default_ctor_includes_myself() {
-        let doc = Document::new_plain_english_curated("I wanted a reflexive pronoun module, so I wrote one myself.");
+        let doc = Document::new_plain_english_curated(
+            "I wanted a reflexive pronoun module, so I wrote one myself.",
+        );
         let rp = ReflexivePronoun::default();
         let matches = rp.iter_matches_in_doc(&doc);
         assert_eq!(matches.count(), 1);

--- a/harper-core/src/expr/reflexive_pronoun.rs
+++ b/harper-core/src/expr/reflexive_pronoun.rs
@@ -14,21 +14,52 @@ const BAD_REFLEXIVE_PRONOUNS: &[&str] = &[
     "themself",
 ];
 
-#[derive(Default)]
-pub struct ReflexivePronoun;
+/// Matches reflexive pronouns with configurable strictness.
+///
+/// By default, only matches standard English reflexive pronouns. Use `with_common_errors()` to include
+/// frequently encountered non-standard forms like "hisself" or "theirself".
+pub struct ReflexivePronoun {
+    include_common_errors: bool,
+}
+
+impl Default for ReflexivePronoun {
+    fn default() -> Self {
+        Self::standard()
+    }
+}
+
+impl ReflexivePronoun {
+    /// Creates a matcher for standard English reflexive pronouns.
+    ///
+    /// Matches only the correct forms: "myself", "yourself", "himself", "herself", "itself",
+    /// "ourselves", "yourselves", and "themselves".
+    pub fn standard() -> Self {
+        Self { include_common_errors: false }
+    }
+
+    /// Creates a matcher that includes non-standard but commonly used reflexive pronouns.
+    ///
+    /// In addition to standard forms, matches common errors like "hisself", "theirself",
+    /// and other non-standard forms that are frequently seen in user-generated content.
+    pub fn with_common_errors() -> Self {
+        Self { include_common_errors: true }
+    }
+}
 
 impl Expr for ReflexivePronoun {
     fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span> {
         let good_pronouns = |token: &Token, _: &[char]| token.kind.is_reflexive_pronoun();
-        let bad_pronouns = WordSet::new(BAD_REFLEXIVE_PRONOUNS);
-        let expr = LongestMatchOf::new(vec![Box::new(good_pronouns), Box::new(bad_pronouns)]);
+        let mut expr = LongestMatchOf::new(vec![Box::new(good_pronouns)]);
+        if self.include_common_errors {
+            expr.add(WordSet::new(BAD_REFLEXIVE_PRONOUNS));
+        }
         expr.run(cursor, tokens, source)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{Document, TokenKind, expr::reflexive_pronoun::BAD_REFLEXIVE_PRONOUNS};
+    use crate::{expr::{reflexive_pronoun::BAD_REFLEXIVE_PRONOUNS, ExprExt, ReflexivePronoun}, Document, TokenKind};
 
     // These are considered grammatically correct, or are at least in `dictionary.dict`.
     // The tests below check if this changes so we can update this `Expr`
@@ -95,5 +126,45 @@ mod tests {
         test_pronoun("weselves");
         test_pronoun("usself");
         test_pronoun("usselves");
+    }
+
+    #[test]
+    fn ensure_standard_ctor_includes_myself() {
+        let doc = Document::new_plain_english_curated("If you want something done, do it yourself.");
+        let rp = ReflexivePronoun::standard();
+        let matches = rp.iter_matches_in_doc(&doc);
+        assert_eq!(matches.count(), 1);
+    }
+
+    #[test]
+    fn ensure_default_ctor_includes_myself() {
+        let doc = Document::new_plain_english_curated("I wanted a reflexive pronoun module, so I wrote one myself.");
+        let rp = ReflexivePronoun::default();
+        let matches = rp.iter_matches_in_doc(&doc);
+        assert_eq!(matches.count(), 1);
+    }
+
+    #[test]
+    fn ensure_with_common_errors_includes_hisself() {
+        let doc = Document::new_plain_english_curated("He teached hisself English.");
+        let rp = ReflexivePronoun::with_common_errors();
+        let matches = rp.iter_matches_in_doc(&doc);
+        assert_eq!(matches.count(), 1);
+    }
+
+    #[test]
+    fn ensure_standard_ctor_excludes_hisself() {
+        let doc = Document::new_plain_english_curated("Was he pleased with hisself?");
+        let rp = ReflexivePronoun::standard();
+        let matches = rp.iter_matches_in_doc(&doc);
+        assert_eq!(matches.count(), 0);
+    }
+
+    #[test]
+    fn ensure_default_ctor_excludes_theirself() {
+        let doc = Document::new_plain_english_curated("They look at theirself in the mirror.");
+        let rp = ReflexivePronoun::default();
+        let matches = rp.iter_matches_in_doc(&doc);
+        assert_eq!(matches.count(), 0);
     }
 }

--- a/harper-core/src/linting/shoot_oneself_in_the_foot.rs
+++ b/harper-core/src/linting/shoot_oneself_in_the_foot.rs
@@ -20,7 +20,7 @@ impl Default for ShootOneselfInTheFoot {
         let pattern = SequenceExpr::default()
             .then(verb_forms)
             .t_ws()
-            .then(ReflexivePronoun)
+            .then(ReflexivePronoun::default())
             .t_ws()
             .then_preposition()
             .t_ws()


### PR DESCRIPTION
# Issues 
N/A

# Description

Replaces the `new` ctor with `standard` and `with_common_errors` ctors, much like those for `inflection_of_need` and `inflection_of_want` in #1423 

# How Has This Been Tested?

Unit tests have been added to make sure the nonstandard reflexive pronouns like `hisself` and `theirselves` work with the `with_common_errors` ctor and do not work with the `standard` ctor.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
