### PR TITLE
feat: as it so happens→as it happens / on route→en route

### DIFF
--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -112,6 +112,12 @@ pub fn lint_group() -> LintGroup {
             "Use `as far back as` for referring to a time in the past.",
             "Corrects nonstandard `as early back as` to `as far back as`."
         ),
+        "AsItHappens" => (
+            ["as it so happens"],
+            ["as it happens"],
+            "Did you mean `as it happens`?",
+            "Corrects `as it so happens` to `as it happens`."
+        ),
         "AsOfLate" => (
             ["as of lately"],
             ["as of late"],
@@ -364,6 +370,12 @@ pub fn lint_group() -> LintGroup {
             ["en masse"],
             "Did you mean `en masse`?",
             "Detects variants like `on mass` or `in mass` and suggests `en masse`."
+        ),
+        "EnRoute" => (
+            ["on route to", "in route to", "on-route to", "in-route to"],
+            ["en route to", "en-route to"],
+            "Did you mean `en route`?",
+            "Detects variants like `on route` or `in route` and suggests `en route`."
         ),
         "EverPresent" => (
             ["ever present"],

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -1,5 +1,6 @@
 use crate::linting::tests::{
     assert_lint_count, assert_nth_suggestion_result, assert_suggestion_result,
+    assert_top3_suggestion_result,
 };
 
 use super::lint_group;
@@ -136,6 +137,16 @@ fn detect_as_early_back_as_real_world() {
         "skin overrides also supports a wide variety of minecraft versions - as early back as 1.14.4.",
         lint_group(),
         "skin overrides also supports a wide variety of minecraft versions - as far back as 1.14.4.",
+    );
+}
+
+// AsItHappens
+#[test]
+fn correct_as_it_happens() {
+    assert_suggestion_result(
+        "As it so happens, we have language currently in review that basically states that a major version break means backwards incompatibility ...",
+        lint_group(),
+        "As it happens, we have language currently in review that basically states that a major version break means backwards incompatibility ...",
     );
 }
 
@@ -452,6 +463,44 @@ fn detect_each_and_everyone_real_world() {
 #[test]
 fn in_mass() {
     assert_suggestion_result("in mass", lint_group(), "en masse");
+}
+
+// EnRoute
+#[test]
+fn on_route() {
+    assert_suggestion_result("on route to", lint_group(), "en route to");
+}
+
+#[test]
+fn in_route() {
+    assert_suggestion_result("in route to", lint_group(), "en route to");
+}
+
+#[test]
+fn on_route_real_world() {
+    assert_suggestion_result(
+        "vehicles may already be on route to one end of a Shipment",
+        lint_group(),
+        "vehicles may already be en route to one end of a Shipment",
+    );
+}
+
+#[test]
+fn on_hyphen_route_real_world() {
+    assert_top3_suggestion_result(
+        "I ultimately just want a slight preference for matches that are on-route to correct cases like the above.",
+        lint_group(),
+        "I ultimately just want a slight preference for matches that are en-route to correct cases like the above.",
+    );
+}
+
+#[test]
+fn in_route_real_world() {
+    assert_suggestion_result(
+        "TF-South is in route to conduct SSE on the strike.",
+        lint_group(),
+        "TF-South is en route to conduct SSE on the strike.",
+    );
 }
 
 // EverPresent


### PR DESCRIPTION
# Issues 
N/A

# Description

A friend suggested I make a linter for "on route" and research revealed people also use "in route" and that both "en route" and "en-route" are correct.

It turns out that "on route" / "in route" on their own would very often be false positives but that "en route" is most often followed by "to", so the linter actually only checks for "on route to" / "in route to" and will have some false negatives, mostly at the end of sentences.

In a YouTube video I heard somebody say "as it so happens" which sounded wrong to me. I did some checking and it is indeed a new 21st century error for "as it happens".

"As it so happens" is surely a result of cross-pollinating "it so happens" and "as it happens" but the linter doesn't suggest "It so happens" since that's probably context dependent and would require a full linter rather than an entry in `phrase_corrections`.

# How Has This Been Tested?

I added unit tests for each variant using sentences from GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
