### PR TITLE
feat: at/in the spur of the moment

### DIFF
--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -953,10 +953,10 @@ pub fn lint_group() -> LintGroup {
             "Replaces the nonstandard `on second though` with the common idiom `on second thought` to indicate reconsideration."
         ),
         "OnTheSpurOfTheMoment" => (
-            ["on the spurt of the moment"],
+            ["on the spurt of the moment", "at the spur of the moment", "in the spur of the moment"],
             ["on the spur of the moment"],
             "Use the correct phrase for acting spontaneously.",
-            "Ensures the correct use of `on the spur of the moment`, avoiding confusion with the incorrect `spurt` variation."
+            "Ensures the correct use of `on the spur of the moment`, avoiding nonstandard variations."
         ),
         "OperativeSystem" => (
             ["operative system"],

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -1408,7 +1408,29 @@ fn on_second_thought_no_false_positive() {
 }
 
 // OnTheSpurOfTheMoment
-// -none-
+fn fix_on_the_spurt_of_the_moment() {
+    assert_suggestion_result(
+        "Quite often in the spurt of the moment, someone will say something which they think is witty.",
+        lint_group(),
+        "Quite often on the spur of the moment, someone will say something which they think is witty.",
+    );
+}
+
+fn fix_at_the_spur_of_the_moment() {
+    assert_suggestion_result(
+        "but at the spur of the moment, I'd say that ansible-lint should work exactly like ansible",
+        lint_group(),
+        "but on the spur of the moment, I'd say that ansible-lint should work exactly like ansible",
+    );
+}
+
+fn fix_in_the_spur_of_the_moment() {
+    assert_suggestion_result(
+        "an assortment of things I started yesterday in the spur of the moment",
+        lint_group(),
+        "an assortment of things I started yesterday on the spur of the moment",
+    );
+}
 
 // OperatingSystem
 #[test]


### PR DESCRIPTION
# Issues 
N/A

# Description

I noticed "at the spur of the moment used somewhere" and checked that the standard idiom is "on the spur of the moment". Further research found that "in the spur of the moment" is also around.

This PR fixes these two and also adds a unit test for the "on the spurt of the moment" variant already present but without a test.

# How Has This Been Tested?

Unit tests using sentences sourced from GitHub or Medium.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
