### PR TITLE
feat: don't pass unused `dialect` to `Linter`s that don't use them

### DIFF
--- a/harper-core/src/linting/inflected_verb_after_to.rs
+++ b/harper-core/src/linting/inflected_verb_after_to.rs
@@ -1,4 +1,4 @@
-use crate::{Dialect, Dictionary, Document, Span, TokenStringExt};
+use crate::{Dictionary, Document, Span, TokenStringExt};
 
 use super::{Lint, LintKind, Linter, Suggestion};
 
@@ -7,15 +7,11 @@ where
     T: Dictionary,
 {
     dictionary: T,
-    dialect: Dialect,
 }
 
 impl<T: Dictionary> InflectedVerbAfterTo<T> {
-    pub fn new(dictionary: T, dialect: Dialect) -> Self {
-        Self {
-            dictionary,
-            dialect,
-        }
+    pub fn new(dictionary: T) -> Self {
+        Self { dictionary }
     }
 }
 
@@ -134,7 +130,7 @@ impl<T: Dictionary> Linter for InflectedVerbAfterTo<T> {
 mod tests {
     use super::InflectedVerbAfterTo;
     use crate::{
-        Dialect, FstDictionary,
+        FstDictionary,
         linting::tests::{assert_lint_count, assert_suggestion_result},
     };
 
@@ -142,7 +138,7 @@ mod tests {
     fn dont_flag_to_check_both_verb_and_noun() {
         assert_lint_count(
             "to check",
-            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            InflectedVerbAfterTo::new(FstDictionary::curated()),
             0,
         );
     }
@@ -151,7 +147,7 @@ mod tests {
     fn dont_flag_to_checks_both_verb_and_noun() {
         assert_lint_count(
             "to checks",
-            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            InflectedVerbAfterTo::new(FstDictionary::curated()),
             0,
         );
     }
@@ -160,7 +156,7 @@ mod tests {
     fn dont_flag_to_cheques_not_a_verb() {
         assert_lint_count(
             "to cheques",
-            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            InflectedVerbAfterTo::new(FstDictionary::curated()),
             0,
         );
     }
@@ -170,7 +166,7 @@ mod tests {
     fn flag_to_checking() {
         assert_lint_count(
             "to checking",
-            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            InflectedVerbAfterTo::new(FstDictionary::curated()),
             1,
         );
     }
@@ -179,7 +175,7 @@ mod tests {
     fn dont_flag_check_ed() {
         assert_lint_count(
             "to checked",
-            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            InflectedVerbAfterTo::new(FstDictionary::curated()),
             0,
         );
     }
@@ -188,7 +184,7 @@ mod tests {
     fn dont_flag_noun_belief_s() {
         assert_lint_count(
             "to beliefs",
-            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            InflectedVerbAfterTo::new(FstDictionary::curated()),
             0,
         );
     }
@@ -197,7 +193,7 @@ mod tests {
     fn dont_flag_noun_meat_s() {
         assert_lint_count(
             "to meats",
-            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            InflectedVerbAfterTo::new(FstDictionary::curated()),
             0,
         );
     }
@@ -207,7 +203,7 @@ mod tests {
     fn check_993_suggestions() {
         assert_suggestion_result(
             "A location-agnostic structure that attempts to captures the context and content that a Lint occurred.",
-            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            InflectedVerbAfterTo::new(FstDictionary::curated()),
             "A location-agnostic structure that attempts to capture the context and content that a Lint occurred.",
         );
     }
@@ -216,7 +212,7 @@ mod tests {
     fn dont_flag_embarrass_not_in_dictionary() {
         assert_lint_count(
             "Second I'm going to embarrass you for a.",
-            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            InflectedVerbAfterTo::new(FstDictionary::curated()),
             0,
         );
     }
@@ -225,7 +221,7 @@ mod tests {
     fn corrects_exist_s() {
         assert_suggestion_result(
             "A valid solution is expected to exists.",
-            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            InflectedVerbAfterTo::new(FstDictionary::curated()),
             "A valid solution is expected to exist.",
         );
     }
@@ -235,7 +231,7 @@ mod tests {
     fn corrects_es_ending() {
         assert_suggestion_result(
             "I need it to catches every exception.",
-            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            InflectedVerbAfterTo::new(FstDictionary::curated()),
             "I need it to catch every exception.",
         );
     }
@@ -244,7 +240,7 @@ mod tests {
     fn corrects_ed_ending() {
         assert_suggestion_result(
             "I had to expanded my horizon.",
-            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            InflectedVerbAfterTo::new(FstDictionary::curated()),
             "I had to expand my horizon.",
         );
     }
@@ -253,7 +249,7 @@ mod tests {
     fn flags_expire_d() {
         assert_lint_count(
             "I didn't know it was going to expired.",
-            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            InflectedVerbAfterTo::new(FstDictionary::curated()),
             1,
         );
     }
@@ -262,7 +258,7 @@ mod tests {
     fn corrects_explain_ed() {
         assert_suggestion_result(
             "To explained the rules to the team.",
-            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            InflectedVerbAfterTo::new(FstDictionary::curated()),
             "To explain the rules to the team.",
         );
     }
@@ -272,7 +268,7 @@ mod tests {
     fn corrects_explor_ed() {
         assert_suggestion_result(
             "I went to explored distant galaxies.",
-            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            InflectedVerbAfterTo::new(FstDictionary::curated()),
             "I went to explore distant galaxies.",
         );
     }
@@ -281,7 +277,7 @@ mod tests {
     fn cant_flag_express_ed_also_noun() {
         assert_lint_count(
             "I failed to clearly expressed my point.",
-            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            InflectedVerbAfterTo::new(FstDictionary::curated()),
             0,
         );
     }
@@ -291,7 +287,7 @@ mod tests {
         // adj "able" before "to" works with "to", making "to" part of an infinitive verb
         assert_suggestion_result(
             "I was able to feigned ignorance.",
-            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            InflectedVerbAfterTo::new(FstDictionary::curated()),
             "I was able to feign ignorance.",
         );
     }
@@ -301,7 +297,7 @@ mod tests {
         // Hypothesis: when before "to" is not an adj, assume "to" is a preposition
         assert_lint_count(
             "Comparison to Expected Results",
-            InflectedVerbAfterTo::new(FstDictionary::curated(), Dialect::American),
+            InflectedVerbAfterTo::new(FstDictionary::curated()),
             0,
         );
     }

--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -444,13 +444,13 @@ impl LintGroup {
 
         out.add(
             "InflectedVerbAfterTo",
-            InflectedVerbAfterTo::new(dictionary.clone(), dialect),
+            InflectedVerbAfterTo::new(dictionary.clone()),
         );
         out.config.set_rule_enabled("InflectedVerbAfterTo", true);
 
         out.add(
             "SentenceCapitalization",
-            SentenceCapitalization::new(dictionary.clone(), dialect),
+            SentenceCapitalization::new(dictionary.clone()),
         );
         out.config.set_rule_enabled("SentenceCapitalization", true);
 

--- a/harper-core/src/linting/sentence_capitalization.rs
+++ b/harper-core/src/linting/sentence_capitalization.rs
@@ -1,22 +1,18 @@
 use super::Suggestion;
 use super::{Lint, LintKind, Linter};
 use crate::document::Document;
-use crate::{Dialect, Dictionary, Token, TokenKind, TokenStringExt};
+use crate::{Dictionary, Token, TokenKind, TokenStringExt};
 
 pub struct SentenceCapitalization<T>
 where
     T: Dictionary,
 {
     dictionary: T,
-    dialect: Dialect,
 }
 
 impl<T: Dictionary> SentenceCapitalization<T> {
-    pub fn new(dictionary: T, dialect: Dialect) -> Self {
-        Self {
-            dictionary,
-            dialect,
-        }
+    pub fn new(dictionary: T) -> Self {
+        Self { dictionary }
     }
 }
 
@@ -121,7 +117,7 @@ fn is_full_sentence(toks: &[Token]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Dialect, FstDictionary};
+    use crate::FstDictionary;
 
     use super::super::tests::assert_lint_count;
     use super::SentenceCapitalization;
@@ -130,7 +126,7 @@ mod tests {
     fn catches_basic() {
         assert_lint_count(
             "there is no way she is not guilty.",
-            SentenceCapitalization::new(FstDictionary::curated(), Dialect::American),
+            SentenceCapitalization::new(FstDictionary::curated()),
             1,
         )
     }
@@ -139,7 +135,7 @@ mod tests {
     fn no_period() {
         assert_lint_count(
             "there is no way she is not guilty",
-            SentenceCapitalization::new(FstDictionary::curated(), Dialect::American),
+            SentenceCapitalization::new(FstDictionary::curated()),
             1,
         )
     }
@@ -148,7 +144,7 @@ mod tests {
     fn two_sentence() {
         assert_lint_count(
             "i have complete conviction in this. she is absolutely guilty",
-            SentenceCapitalization::new(FstDictionary::curated(), Dialect::American),
+            SentenceCapitalization::new(FstDictionary::curated()),
             2,
         )
     }
@@ -157,7 +153,7 @@ mod tests {
     fn start_with_number() {
         assert_lint_count(
             "53 is the length of the longest word.",
-            SentenceCapitalization::new(FstDictionary::curated(), Dialect::American),
+            SentenceCapitalization::new(FstDictionary::curated()),
             0,
         );
     }
@@ -166,7 +162,7 @@ mod tests {
     fn ignores_unlintable() {
         assert_lint_count(
             "[`misspelled_word`] is assumed to be quite small (n < 100). ",
-            SentenceCapitalization::new(FstDictionary::curated(), Dialect::American),
+            SentenceCapitalization::new(FstDictionary::curated()),
             0,
         )
     }
@@ -175,7 +171,7 @@ mod tests {
     fn unfazed_unlintable() {
         assert_lint_count(
             "the linter should not be affected by `this` unlintable.",
-            SentenceCapitalization::new(FstDictionary::curated(), Dialect::American),
+            SentenceCapitalization::new(FstDictionary::curated()),
             1,
         )
     }
@@ -184,7 +180,7 @@ mod tests {
     fn unfazed_ellipsis() {
         assert_lint_count(
             "the linter should not be affected by... that ellipsis.",
-            SentenceCapitalization::new(FstDictionary::curated(), Dialect::American),
+            SentenceCapitalization::new(FstDictionary::curated()),
             1,
         )
     }
@@ -193,7 +189,7 @@ mod tests {
     fn unfazed_comma() {
         assert_lint_count(
             "the linter should not be affected by, that comma.",
-            SentenceCapitalization::new(FstDictionary::curated(), Dialect::American),
+            SentenceCapitalization::new(FstDictionary::curated()),
             1,
         )
     }
@@ -202,7 +198,7 @@ mod tests {
     fn issue_228_allows_labels() {
         assert_lint_count(
             "python lsp (fork of pyright)",
-            SentenceCapitalization::new(FstDictionary::curated(), Dialect::American),
+            SentenceCapitalization::new(FstDictionary::curated()),
             0,
         )
     }
@@ -212,7 +208,7 @@ mod tests {
         // Some words are marked as proper nouns in `dictionary.dict` but are lower camel case.
         assert_lint_count(
             "macOS 16 could be called something like Redwood or Shasta",
-            SentenceCapitalization::new(FstDictionary::curated(), Dialect::American),
+            SentenceCapitalization::new(FstDictionary::curated()),
             0,
         )
     }
@@ -222,7 +218,7 @@ mod tests {
     fn uppercase_unamerican_at_start() {
         assert_lint_count(
             "un-American starts with a lowercase letter and contains an uppercase letter, but is not a proper noun or trademark.",
-            SentenceCapitalization::new(FstDictionary::curated(), Dialect::American),
+            SentenceCapitalization::new(FstDictionary::curated()),
             1,
         )
     }
@@ -237,7 +233,7 @@ mod tests {
                 "continent use npm to share and borrow packages, and many organizations use npm to ",
                 "manage private development as well."
             ),
-            SentenceCapitalization::new(FstDictionary::curated(), Dialect::American),
+            SentenceCapitalization::new(FstDictionary::curated()),
             0,
         )
     }
@@ -247,7 +243,7 @@ mod tests {
         // A very few words are not considered proper nouns but still start with a lowercase letter that shouldn't be uppercased at the start of a sentence.
         assert_lint_count(
             "mRNA is synthesized from the coding sequence of a gene during the transcriptional process.",
-            SentenceCapitalization::new(FstDictionary::curated(), Dialect::American),
+            SentenceCapitalization::new(FstDictionary::curated()),
             0,
         )
     }


### PR DESCRIPTION
# Issues 
N/A

# Description

While looking into how to use the dialect setting inside a `Linter` I found these two `Linter`s which
`InflectedVerbAfterTo` and `SentenceCapitalization` accept a `dictionary` and `dialect` pair in their ctors but, unlike `SpellCheck`, which they are surely based on, they don't use the `dialect`. This PR removes it.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

All `cargo test` passes 100% clean.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
