### PR TITLE
feat(chrome-ext): add configuration options

### DIFF
--- a/packages/chrome-plugin/src/ProtocolClient.ts
+++ b/packages/chrome-plugin/src/ProtocolClient.ts
@@ -51,6 +51,14 @@ export default class ProtocolClient {
 		await chrome.runtime.sendMessage({ kind: 'setDomainStatus', enabled, domain });
 	}
 
+	public static async getDefaultEnabled(): Promise<boolean> {
+		return (await chrome.runtime.sendMessage({ kind: 'getDefaultStatus' })).enabled;
+	}
+
+	public static async setDefaultEnabled(enabled: boolean): Promise<void> {
+		await chrome.runtime.sendMessage({ kind: 'setDefaultStatus', enabled });
+	}
+
 	public static async addToUserDictionary(word: string): Promise<void> {
 		this.lintCache.clear();
 		await chrome.runtime.sendMessage({ kind: 'addToUserDictionary', word });

--- a/packages/chrome-plugin/src/ProtocolClient.ts
+++ b/packages/chrome-plugin/src/ProtocolClient.ts
@@ -44,6 +44,7 @@ export default class ProtocolClient {
 	}
 
 	public static async getDomainEnabled(domain: string): Promise<boolean> {
+		this.lintCache.clear();
 		return (await chrome.runtime.sendMessage({ kind: 'getDomainStatus', domain })).enabled;
 	}
 
@@ -52,6 +53,7 @@ export default class ProtocolClient {
 	}
 
 	public static async getDefaultEnabled(): Promise<boolean> {
+		this.lintCache.clear();
 		return (await chrome.runtime.sendMessage({ kind: 'getDefaultStatus' })).enabled;
 	}
 
@@ -59,9 +61,18 @@ export default class ProtocolClient {
 		await chrome.runtime.sendMessage({ kind: 'setDefaultStatus', enabled });
 	}
 
-	public static async addToUserDictionary(word: string): Promise<void> {
+	public static async addToUserDictionary(words: string[]): Promise<void> {
 		this.lintCache.clear();
-		await chrome.runtime.sendMessage({ kind: 'addToUserDictionary', word });
+		await chrome.runtime.sendMessage({ kind: 'addToUserDictionary', words });
+	}
+
+	public static async setUserDictionary(words: string[]): Promise<void> {
+		this.lintCache.clear();
+		await chrome.runtime.sendMessage({ kind: 'setUserDictionary', words });
+	}
+
+	public static async getUserDictionary(): Promise<string[]> {
+		return (await chrome.runtime.sendMessage({ kind: 'getUserDictionary' })).words;
 	}
 
 	public static async ignoreHash(hash: string): Promise<void> {

--- a/packages/chrome-plugin/src/SuggestionBox.ts
+++ b/packages/chrome-plugin/src/SuggestionBox.ts
@@ -53,7 +53,7 @@ function addToDictionary(box: LintBox): any {
 		{
 			className: 'harper-btn',
 			onclick: () => {
-				ProtocolClient.addToUserDictionary(box.lint.problem_text);
+				ProtocolClient.addToUserDictionary([box.lint.problem_text]);
 			},
 			title: 'Add word to user dictionary',
 			'aria-label': 'Add word to user dictionary',

--- a/packages/chrome-plugin/src/options/Options.svelte
+++ b/packages/chrome-plugin/src/options/Options.svelte
@@ -91,7 +91,10 @@ function configStringToValue(str: string): boolean | undefined | null {
 
       <div class="space-y-5">
         <div class="flex items-center justify-between">
-          <span class="font-medium">Enable on New Sites by Default</span>
+          <div class="flex flex-col">
+            <span class="font-medium">Enable on New Sites by Default</span>
+            <span class="font-light">Can make some apps behave abnormally.</span>
+          </div>
           <input type="checkbox" bind:checked={defaultEnabled}/>
         </div>
       </div>

--- a/packages/chrome-plugin/src/options/Options.svelte
+++ b/packages/chrome-plugin/src/options/Options.svelte
@@ -10,6 +10,7 @@ let searchQuery = $state('');
 let searchQueryLower = $derived(searchQuery.toLowerCase());
 let dialect = $state(Dialect.American);
 let defaultEnabled = $state(false);
+let userDict = $state('');
 
 $effect(() => {
 	ProtocolClient.setLintConfig(lintConfig);
@@ -21,6 +22,11 @@ $effect(() => {
 
 $effect(() => {
 	ProtocolClient.setDefaultEnabled(defaultEnabled);
+});
+
+$effect(() => {
+	console.log('hit');
+	ProtocolClient.setUserDictionary(stringToDict(userDict));
 });
 
 ProtocolClient.getLintConfig().then((l) => {
@@ -37,6 +43,10 @@ ProtocolClient.getDialect().then((d) => {
 
 ProtocolClient.getDefaultEnabled().then((d) => {
 	defaultEnabled = d;
+});
+
+ProtocolClient.getUserDictionary().then((d) => {
+	userDict = dictToString(d);
 });
 
 function configValueToString(value: boolean | undefined): string {
@@ -62,6 +72,19 @@ function configStringToValue(str: string): boolean | undefined | null {
 	}
 
 	throw 'Fell through case';
+}
+
+/** Converts the content of a text area to viable dictionary values. */
+export function stringToDict(s: string): string[] {
+	return s
+		.split('\n')
+		.map((s) => s.trim())
+		.filter((v) => v.length > 0);
+}
+
+/** Converts the content of a text area to viable dictionary values. */
+export function dictToString(values: string[]): string {
+	return values.map((v) => v.trim()).join('\n');
 }
 </script>
 
@@ -96,6 +119,16 @@ function configStringToValue(str: string): boolean | undefined | null {
             <span class="font-light">Can make some apps behave abnormally.</span>
           </div>
           <input type="checkbox" bind:checked={defaultEnabled}/>
+        </div>
+      </div>
+
+      <div class="space-y-5">
+        <div class="flex items-center justify-between">
+          <div class="flex flex-col">
+            <span class="font-medium">User Dictionary</span>
+            <span class="font-light">Each word should be on its own line.</span>
+          </div>
+          <textarea bind:value={userDict} />
         </div>
       </div>
 

--- a/packages/chrome-plugin/src/options/Options.svelte
+++ b/packages/chrome-plugin/src/options/Options.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { Button, Input, Select, Toggle } from 'flowbite-svelte';
+import { Button, Checkbox, Input, Select, Toggle } from 'flowbite-svelte';
 import { Dialect, type LintConfig } from 'harper.js';
 import logo from '/logo.png';
 import ProtocolClient from '../ProtocolClient';
@@ -9,6 +9,7 @@ let lintDescriptions: Record<string, string> = $state({});
 let searchQuery = $state('');
 let searchQueryLower = $derived(searchQuery.toLowerCase());
 let dialect = $state(Dialect.American);
+let defaultEnabled = $state(false);
 
 $effect(() => {
 	ProtocolClient.setLintConfig(lintConfig);
@@ -16,6 +17,10 @@ $effect(() => {
 
 $effect(() => {
 	ProtocolClient.setDialect(dialect);
+});
+
+$effect(() => {
+	ProtocolClient.setDefaultEnabled(defaultEnabled);
 });
 
 ProtocolClient.getLintConfig().then((l) => {
@@ -28,6 +33,10 @@ ProtocolClient.getLintDescriptions().then((d) => {
 
 ProtocolClient.getDialect().then((d) => {
 	dialect = d;
+});
+
+ProtocolClient.getDefaultEnabled().then((d) => {
+	defaultEnabled = d;
 });
 
 function configValueToString(value: boolean | undefined): string {
@@ -79,6 +88,14 @@ function configStringToValue(str: string): boolean | undefined | null {
           </Select>
         </div>
       </div>
+
+      <div class="space-y-5">
+        <div class="flex items-center justify-between">
+          <span class="font-medium">Enable on New Sites by Default</span>
+          <input type="checkbox" bind:checked={defaultEnabled}/>
+        </div>
+      </div>
+
     </section>
 
     <!-- ── RULES ─────────────────────────────── -->

--- a/packages/chrome-plugin/src/protocol.ts
+++ b/packages/chrome-plugin/src/protocol.ts
@@ -9,7 +9,9 @@ export type Request =
 	| SetDialectRequest
 	| GetDialectRequest
 	| SetDomainStatusRequest
+	| SetDefaultStatusRequest
 	| GetDomainStatusRequest
+	| GetDefaultStatusRequest
 	| AddToUserDictionaryRequest
 	| IgnoreLintRequest;
 
@@ -19,7 +21,8 @@ export type Response =
 	| UnitResponse
 	| GetLintDescriptionsResponse
 	| GetDialectResponse
-	| GetDomainStatusResponse;
+	| GetDomainStatusResponse
+	| GetDefaultStatusResponse;
 
 export type LintRequest = {
 	kind: 'lint';
@@ -80,9 +83,23 @@ export type GetDomainStatusResponse = {
 	enabled: boolean;
 };
 
+export type GetDefaultStatusRequest = {
+	kind: 'getDefaultStatus';
+};
+
+export type GetDefaultStatusResponse = {
+	kind: 'getDefaultStatus';
+	enabled: boolean;
+};
+
 export type SetDomainStatusRequest = {
 	kind: 'setDomainStatus';
 	domain: string;
+	enabled: boolean;
+};
+
+export type SetDefaultStatusRequest = {
+	kind: 'setDefaultStatus';
 	enabled: boolean;
 };
 

--- a/packages/chrome-plugin/src/protocol.ts
+++ b/packages/chrome-plugin/src/protocol.ts
@@ -13,7 +13,9 @@ export type Request =
 	| GetDomainStatusRequest
 	| GetDefaultStatusRequest
 	| AddToUserDictionaryRequest
-	| IgnoreLintRequest;
+	| SetUserDictionaryRequest
+	| IgnoreLintRequest
+	| GetUserDictionaryRequest;
 
 export type Response =
 	| LintResponse
@@ -22,7 +24,8 @@ export type Response =
 	| GetLintDescriptionsResponse
 	| GetDialectResponse
 	| GetDomainStatusResponse
-	| GetDefaultStatusResponse;
+	| GetDefaultStatusResponse
+	| GetUserDictionaryResponse;
 
 export type LintRequest = {
 	kind: 'lint';
@@ -105,7 +108,21 @@ export type SetDefaultStatusRequest = {
 
 export type AddToUserDictionaryRequest = {
 	kind: 'addToUserDictionary';
-	word: string;
+	words: string[];
+};
+
+export type SetUserDictionaryRequest = {
+	kind: 'setUserDictionary';
+	words: string[];
+};
+
+export type GetUserDictionaryRequest = {
+	kind: 'getUserDictionary';
+};
+
+export type GetUserDictionaryResponse = {
+	kind: 'getUserDictionary';
+	words: string[];
 };
 
 export type IgnoreLintRequest = {


### PR DESCRIPTION
# Issues 

Implements #1426

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

This PR adds two new settings:

- A global default enable (like as described in #1426)
- Custom dictionary editing

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->
![image](https://github.com/user-attachments/assets/170dcbe8-6c69-4651-b76f-c919e66bb5f6)

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
