### PR TITLE
fix(core): we cannot respect `spellcheck="off"`

### DIFF
--- a/packages/chrome-plugin/src/contentScript/index.ts
+++ b/packages/chrome-plugin/src/contentScript/index.ts
@@ -19,10 +19,6 @@ function scan() {
 	});
 
 	$('[contenteditable="true"],[contenteditable]').each(function () {
-		if (this.spellcheck == false) {
-			return;
-		}
-
 		const leafs = leafNodes(this);
 
 		for (const leaf of leafs) {


### PR DESCRIPTION
# Issues 

#1459 

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

We cannot ignore fields with `spellcheck=off` without significantly impairing Harper's ability to help.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
