### PR TITLE
feat(core): create linter for discourse markers

### DIFF
--- a/harper-core/src/linting/discourse_markers.rs
+++ b/harper-core/src/linting/discourse_markers.rs
@@ -1,0 +1,225 @@
+use crate::expr::Expr;
+use crate::patterns::WordSet;
+use crate::{Document, Lrc, Span, Token, TokenStringExt};
+
+use super::{Lint, LintKind, Linter, Suggestion};
+
+pub struct DiscourseMarkers {
+    expr: WordSet,
+}
+
+impl DiscourseMarkers {
+    pub fn new() -> Self {
+        Self {
+            expr: WordSet::new(&[
+                "however",
+                "therefore",
+                "meanwhile",
+                "furthermore",
+                "nevertheless",
+                "consequently",
+                "thus",
+                "instead",
+                "moreover",
+                "alternatively",
+                "frankly",
+            ]),
+        }
+    }
+
+    fn lint_sentence(&self, sent: &[Token], source: &[char]) -> Option<Lint> {
+        let first_word_idx = sent.iter_word_indices().next()?;
+
+        let first_word = &sent[first_word_idx];
+        let subq_tok = sent.get(first_word_idx + 1)?;
+
+        if !subq_tok.kind.is_whitespace() {
+            return None;
+        }
+
+        if self.expr.run(first_word_idx, sent, source).is_some() {
+            Some(Lint {
+                span: first_word.span,
+                lint_kind: LintKind::Punctuation,
+                suggestions: vec![Suggestion::InsertAfter(vec![','])],
+                message: "Discourse markers at the beginning of a sentence should be followed by a comma.".into(),
+                priority: 31,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl Default for DiscourseMarkers {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Linter for DiscourseMarkers {
+    fn lint(&mut self, document: &Document) -> Vec<Lint> {
+        document
+            .iter_sentences()
+            .flat_map(|sent| self.lint_sentence(sent, document.get_source()))
+            .collect()
+    }
+
+    fn description(&self) -> &str {
+        "Flags sentences that begin with a discourse marker but omit the required following comma."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_lint_count, assert_no_lints, assert_suggestion_result};
+
+    use super::DiscourseMarkers;
+
+    #[test]
+    fn corrects_frankly() {
+        assert_suggestion_result(
+            "Frankly I think he is wrong.",
+            DiscourseMarkers::default(),
+            "Frankly, I think he is wrong.",
+        );
+    }
+
+    #[test]
+    fn corrects_however() {
+        assert_suggestion_result(
+            "However I disagree with your conclusion.",
+            DiscourseMarkers::default(),
+            "However, I disagree with your conclusion.",
+        );
+    }
+
+    #[test]
+    fn corrects_therefore() {
+        assert_suggestion_result(
+            "Therefore we must act now.",
+            DiscourseMarkers::default(),
+            "Therefore, we must act now.",
+        );
+    }
+
+    #[test]
+    fn corrects_meanwhile() {
+        assert_suggestion_result(
+            "Meanwhile preparations continued in the background.",
+            DiscourseMarkers::default(),
+            "Meanwhile, preparations continued in the background.",
+        );
+    }
+
+    #[test]
+    fn corrects_furthermore() {
+        assert_suggestion_result(
+            "Furthermore this approach reduces complexity.",
+            DiscourseMarkers::default(),
+            "Furthermore, this approach reduces complexity.",
+        );
+    }
+
+    #[test]
+    fn corrects_nevertheless() {
+        assert_suggestion_result(
+            "Nevertheless we persevered despite the odds.",
+            DiscourseMarkers::default(),
+            "Nevertheless, we persevered despite the odds.",
+        );
+    }
+
+    #[test]
+    fn corrects_consequently() {
+        assert_suggestion_result(
+            "Consequently the system halted unexpectedly.",
+            DiscourseMarkers::default(),
+            "Consequently, the system halted unexpectedly.",
+        );
+    }
+
+    #[test]
+    fn corrects_thus() {
+        assert_suggestion_result(
+            "Thus we arrive at the final verdict.",
+            DiscourseMarkers::default(),
+            "Thus, we arrive at the final verdict.",
+        );
+    }
+
+    #[test]
+    fn corrects_instead() {
+        assert_suggestion_result(
+            "Instead he chose a different path.",
+            DiscourseMarkers::default(),
+            "Instead, he chose a different path.",
+        );
+    }
+
+    #[test]
+    fn corrects_moreover() {
+        assert_suggestion_result(
+            "Moreover this solution is more efficient.",
+            DiscourseMarkers::default(),
+            "Moreover, this solution is more efficient.",
+        );
+    }
+
+    #[test]
+    fn corrects_alternatively() {
+        assert_suggestion_result(
+            "Alternatively we could defer the decision.",
+            DiscourseMarkers::default(),
+            "Alternatively, we could defer the decision.",
+        );
+    }
+
+    #[test]
+    fn no_suggestion_if_comma_present() {
+        assert_no_lints(
+            "However, I disagree with your point.",
+            DiscourseMarkers::default(),
+        );
+    }
+
+    #[test]
+    fn no_lint_for_mid_sentence_marker() {
+        assert_no_lints(
+            "I said however I would consider it.",
+            DiscourseMarkers::default(),
+        );
+    }
+
+    #[test]
+    fn preserves_whitespace() {
+        assert_suggestion_result(
+            "However   I disagree.",
+            DiscourseMarkers::default(),
+            "However,   I disagree.",
+        );
+    }
+
+    #[test]
+    fn corrects_semicolon_case() {
+        assert_suggestion_result(
+            "However I disagree.",
+            DiscourseMarkers::default(),
+            "However, I disagree.",
+        );
+    }
+
+    #[test]
+    fn corrects_multiple_sentences() {
+        assert_suggestion_result(
+            "However I disagree. Therefore I propose an alternative.",
+            DiscourseMarkers::default(),
+            "However, I disagree. Therefore, I propose an alternative.",
+        );
+    }
+
+    #[test]
+    fn allows_single_word_sentence() {
+        assert_no_lints("Thus", DiscourseMarkers::default());
+    }
+}

--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -29,6 +29,7 @@ use super::compound_nouns::CompoundNouns;
 use super::confident::Confident;
 use super::correct_number_suffix::CorrectNumberSuffix;
 use super::despite_of::DespiteOf;
+use super::discourse_markers::DiscourseMarkers;
 use super::dot_initialisms::DotInitialisms;
 use super::ellipsis_length::EllipsisLength;
 use super::else_possessive::ElsePossessive;
@@ -379,6 +380,7 @@ impl LintGroup {
         insert_pattern_rule!(BoringWords, false);
         insert_struct_rule!(CapitalizePersonalPronouns, true);
         insert_pattern_rule!(ChockFull, true);
+        insert_struct_rule!(DiscourseMarkers, true);
         insert_pattern_rule!(WayTooAdjective, true);
         insert_pattern_rule!(HavePronoun, true);
         insert_pattern_rule!(PronounInflectionBe, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -23,6 +23,7 @@ mod correct_number_suffix;
 mod currency_placement;
 mod dashes;
 mod despite_of;
+mod discourse_markers;
 mod dot_initialisms;
 mod ellipsis_length;
 mod else_possessive;
@@ -126,6 +127,7 @@ pub use correct_number_suffix::CorrectNumberSuffix;
 pub use currency_placement::CurrencyPlacement;
 pub use dashes::Dashes;
 pub use despite_of::DespiteOf;
+pub use discourse_markers::DiscourseMarkers;
 pub use dot_initialisms::DotInitialisms;
 pub use ellipsis_length::EllipsisLength;
 pub use everyday::Everyday;
@@ -235,6 +237,11 @@ pub mod tests {
 
     use super::Linter;
     use crate::{Document, FstDictionary, parsers::PlainEnglish};
+
+    #[track_caller]
+    pub fn assert_no_lints(text: &str, mut linter: impl Linter) {
+        assert_lint_count(text, linter, 0);
+    }
 
     #[track_caller]
     pub fn assert_lint_count(text: &str, mut linter: impl Linter, count: usize) {

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -1523,6 +1523,15 @@ Suggest:
 
 
 
+Lint:    Punctuation (31 priority)
+Message: |
+    1304 | I’m angry. Therefore I’m mad.”
+         |            ^~~~~~~~~ Discourse markers at the beginning of a sentence should be followed by a comma.
+Suggest:
+  - Insert “,”
+
+
+
 Lint:    Readability (127 priority)
 Message: |
     1348 | like ears and the roof was thatched with fur. It was so large a house, that she

--- a/harper-core/tests/text/linters/Computer science.snap.yml
+++ b/harper-core/tests/text/linters/Computer science.snap.yml
@@ -972,6 +972,15 @@ Suggest:
 
 
 
+Lint:    Punctuation (31 priority)
+Message: |
+     360 | maintenance. For example software testing, systems engineering, technical debt
+         |              ^~~~~~~~~~~ Discourse markers at the beginning of a sentence should be followed by a comma.
+Suggest:
+  - Insert “,”
+
+
+
 Lint:    Spelling (63 priority)
 Message: |
      371 | semiotics, electrical engineering, philosophy of mind, neurophysiology, and
@@ -1185,6 +1194,16 @@ Suggest:
   - Replace with: “got”
   - Replace with: “goo”
   - Replace with: “gore”
+
+
+
+Lint:    Punctuation (31 priority)
+Message: |
+     490 |   the data fields of the object with which they are associated. Thus
+         |                                                                 ^~~~ Discourse markers at the beginning of a sentence should be followed by a comma.
+     491 |   object-oriented computer programs are made out of objects that interact with
+Suggest:
+  - Insert “,”
 
 
 

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -219,6 +219,15 @@ Suggest:
 
 
 
+Lint:    Punctuation (31 priority)
+Message: |
+      61 | restless. Instead of being the warm centre of the world, the Middle West now
+         |           ^~~~~~~ Discourse markers at the beginning of a sentence should be followed by a comma.
+Suggest:
+  - Insert “,”
+
+
+
 Lint:    Spelling (63 priority)
 Message: |
       61 | restless. Instead of being the warm centre of the world, the Middle West now
@@ -1191,6 +1200,15 @@ Message: |
 
 
 
+Lint:    Punctuation (31 priority)
+Message: |
+     853 | milk all afternoon. Meanwhile Tom brought out a bottle of whiskey from a locked
+         |                     ^~~~~~~~~ Discourse markers at the beginning of a sentence should be followed by a comma.
+Suggest:
+  - Insert “,”
+
+
+
 Lint:    Readability (127 priority)
 Message: |
      860 | and I went out to buy some at the drugstore on the corner. When I came back they
@@ -1736,6 +1754,16 @@ Suggest:
 
 
 
+Lint:    Punctuation (31 priority)
+Message: |
+    1333 | person to a greater or lesser degree. Instead of rambling this party had
+         |                                       ^~~~~~~ Discourse markers at the beginning of a sentence should be followed by a comma.
+    1334 | preserved a dignified homogeneity, and assumed to itself the function of
+Suggest:
+  - Insert “,”
+
+
+
 Lint:    Spelling (63 priority)
 Message: |
     1336 | West Egg, and carefully on guard against its spectroscopic gayety.
@@ -2229,6 +2257,16 @@ Message: |
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1792 | smile turned to the world and yet satisfy the demands of her hard, jaunty body.
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 48 words long.
+
+
+
+Lint:    Punctuation (31 priority)
+Message: |
+    1824 | perspiration appeared on her upper lip. Nevertheless there was a vague
+         |                                         ^~~~~~~~~~~~ Discourse markers at the beginning of a sentence should be followed by a comma.
+    1825 | understanding that had to be tactfully broken off before I was free.
+Suggest:
+  - Insert “,”
 
 
 
@@ -3989,6 +4027,15 @@ Suggest:
 
 
 
+Lint:    Punctuation (31 priority)
+Message: |
+    2826 | Instead of taking the short cut along the Sound we went down to the road and
+         | ^~~~~~~ Discourse markers at the beginning of a sentence should be followed by a comma.
+Suggest:
+  - Insert “,”
+
+
+
 Lint:    Spelling (63 priority)
 Message: |
     2826 | Instead of taking the short cut along the Sound we went down to the road and
@@ -4399,6 +4446,15 @@ Message: |
          |                       ^~~~~~~~~~~~~~ Did you mean `substantially`?
 Suggest:
   - Replace with: “substantially”
+
+
+
+Lint:    Punctuation (31 priority)
+Message: |
+    3111 | faintly true. Moreover he told it to me at a time of confusion, when I had
+         |               ^~~~~~~~ Discourse markers at the beginning of a sentence should be followed by a comma.
+Suggest:
+  - Insert “,”
 
 
 
@@ -5038,6 +5094,15 @@ Message: |
          | ^ Incorrect indefinite article.
 Suggest:
   - Replace with: “an”
+
+
+
+Lint:    Punctuation (31 priority)
+Message: |
+    3864 | “Nevertheless he’s an Oxford man.”
+         |  ^~~~~~~~~~~~ Discourse markers at the beginning of a sentence should be followed by a comma.
+Suggest:
+  - Insert “,”
 
 
 
@@ -6054,6 +6119,16 @@ Message: |
 
 
 
+Lint:    Punctuation (31 priority)
+Message: |
+    4789 | But he knew that he was in Daisy’s house by a colossal accident. However
+         |                                                                  ^~~~~~~ Discourse markers at the beginning of a sentence should be followed by a comma.
+    4790 | glorious might be his future as Jay Gatsby, he was at present a penniless young
+Suggest:
+  - Insert “,”
+
+
+
 Lint:    Readability (127 priority)
 Message: |
     4797 | pretenses. I don’t mean that he had traded on his phantom millions, but he had
@@ -6485,6 +6560,15 @@ Suggest:
   - Replace with: “Ga's”
   - Replace with: “Gd's”
   - Replace with: “Gag's”
+
+
+
+Lint:    Punctuation (31 priority)
+Message: |
+    5174 | reach Gad’s Hill until noon. Thus far there was no difficulty in accounting for
+         |                              ^~~~ Discourse markers at the beginning of a sentence should be followed by a comma.
+Suggest:
+  - Insert “,”
 
 
 
@@ -7461,6 +7545,15 @@ Message: |
          |                                           ^~~~~~~~~~ Did you mean `linerless`?
 Suggest:
   - Replace with: “linerless”
+
+
+
+Lint:    Punctuation (31 priority)
+Message: |
+    5721 | “Nevertheless you did throw me over,” said Jordan suddenly. ‘‘You threw me over
+         |  ^~~~~~~~~~~~ Discourse markers at the beginning of a sentence should be followed by a comma.
+Suggest:
+  - Insert “,”
 
 
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

This PR adds a lint to make sure people use correct punctuation for higher-level discourse markers.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

See unit tests for expected behavior.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Unit tests

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
