### PR TITLE
feat(cli): allow direct text (non-file) input

### DIFF
--- a/harper-cli/Cargo.toml
+++ b/harper-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "harper-cli"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 repository = "https://github.com/automattic/harper"
 

--- a/harper-cli/src/input.rs
+++ b/harper-cli/src/input.rs
@@ -1,0 +1,67 @@
+use std::{borrow::Cow, io::Read, path::PathBuf};
+
+use harper_core::{
+    Dictionary, Document,
+    parsers::{MarkdownOptions, PlainEnglish},
+};
+
+/// Represents an input/source passed via the command line. For example, this can be a file, or
+/// text passed via the command line directly.
+#[derive(Clone, Debug)]
+pub(super) enum Input {
+    /// File (path) input.
+    File(PathBuf),
+    /// Direct text input, via the command line.
+    Text(String),
+}
+impl Input {
+    /// Loads the contained file/string into a conventional format. Returns a `Result` containing
+    /// a tuple of a `Document` and its corresponding source text as a string.
+    pub(super) fn load(
+        &self,
+        markdown_options: MarkdownOptions,
+        dictionary: &impl Dictionary,
+    ) -> anyhow::Result<(Document, String)> {
+        match self {
+            Input::File(file) => super::load_file(file, markdown_options, dictionary),
+            Input::Text(s) => Ok((Document::new(s, &PlainEnglish, dictionary), s.clone())),
+        }
+    }
+
+    /// Gets a human-readable identifier for the input. For example, this can be a filename, or
+    /// simply the string `"<input>"`.
+    #[must_use]
+    pub(super) fn get_identifier(&self) -> Cow<str> {
+        match self {
+            Input::File(file) => file
+                .file_name()
+                .map_or(Cow::from("<file>"), |file_name| file_name.to_string_lossy()),
+            Input::Text(_) => Cow::from("<input>"),
+        }
+    }
+
+    /// Tries to construct an `Input` by reading standard input. This will fail if the standard
+    /// input cannot be read.
+    pub(super) fn try_from_stdin() -> anyhow::Result<Self> {
+        let mut buf = String::new();
+        std::io::stdin().lock().read_to_string(&mut buf)?;
+        Ok(Self::from(buf))
+    }
+}
+// This allows this type to be directly used with clap as an argument.
+// https://docs.rs/clap/latest/clap/macro.value_parser.html
+impl From<String> for Input {
+    /// Converts the given string into an `Input`. `Input` is automatically set to the correct variant
+    /// depending on whether `input_string` is a valid file path or not.
+    fn from(input_string: String) -> Self {
+        if let Ok(metadata) = std::fs::metadata(&input_string)
+            && metadata.is_file()
+        {
+            // Input is a valid file path.
+            Self::File(input_string.into())
+        } else {
+            // Input is not a valid file path, we assume it's intended to be a string.
+            Self::Text(input_string)
+        }
+    }
+}

--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -137,12 +137,14 @@ fn main() -> anyhow::Result<()> {
             let mut merged_dict = MergedDictionary::new();
             merged_dict.add_dictionary(dictionary);
 
+            // Attempt to load user dictionary.
             match load_dict(&user_dict_path) {
                 Ok(user_dict) => merged_dict.add_dictionary(Arc::new(user_dict)),
                 Err(err) => println!("{}: {}", user_dict_path.display(), err),
             }
 
             if let Input::File(ref file) = input {
+                // Only attempt to load file dictionary if input is a file.
                 let file_dict_path = file_dict_path.join(file_dict_name(file));
                 match load_dict(&file_dict_path) {
                     Ok(file_dict) => merged_dict.add_dictionary(Arc::new(file_dict)),
@@ -150,6 +152,7 @@ fn main() -> anyhow::Result<()> {
                 }
             }
 
+            // Load the file/text.
             let (doc, source) = input.load(markdown_options, &merged_dict)?;
 
             let mut linter = LintGroup::new_curated(Arc::new(merged_dict), dialect);
@@ -209,6 +212,7 @@ fn main() -> anyhow::Result<()> {
             input,
             include_newlines,
         } => {
+            // Load the file/text.
             let (doc, source) = input.load(markdown_options, &dictionary)?;
 
             let primary_color = Color::Blue;

--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -731,8 +731,7 @@ impl Input {
         match self {
             Input::File(file) => file
                 .file_name()
-                .map(|file_name| file_name.to_string_lossy())
-                .unwrap_or(Cow::from("<file>")),
+                .map_or(Cow::from("<file>"), |file_name| file_name.to_string_lossy()),
             Input::Text(_) => Cow::from("<input>"),
         }
     }

--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -1,10 +1,9 @@
 #![doc = include_str!("../README.md")]
 
 use hashbrown::HashMap;
-use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fs::File;
-use std::io::{BufReader, Read};
+use std::io::BufReader;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::{fs, process};
@@ -24,6 +23,9 @@ use harper_literate_haskell::LiterateHaskellParser;
 use harper_pos_utils::{BrillChunker, BrillTagger};
 use harper_stats::Stats;
 use serde::Serialize;
+
+mod input;
+use input::Input;
 
 /// A debugging tool for the Harper grammar checker.
 #[derive(Debug, Parser)]
@@ -711,65 +713,4 @@ fn file_dict_name(path: &Path) -> PathBuf {
     }
 
     rewritten.into()
-}
-
-/// Represents an input/source passed via the command line. For example, this can be a file, or
-/// text passed via the command line directly.
-#[derive(Clone, Debug)]
-enum Input {
-    /// File (path) input.
-    File(PathBuf),
-    /// Direct text input, via the command line.
-    Text(String),
-}
-impl Input {
-    /// Loads the contained file/string into a conventional format. Returns a `Result` containing
-    /// a tuple of a `Document` and its corresponding source text as a string.
-    fn load(
-        &self,
-        markdown_options: MarkdownOptions,
-        dictionary: &impl Dictionary,
-    ) -> anyhow::Result<(Document, String)> {
-        match self {
-            Input::File(file) => load_file(file, markdown_options, dictionary),
-            Input::Text(s) => Ok((Document::new(s, &PlainEnglish, dictionary), s.clone())),
-        }
-    }
-
-    /// Gets a human-readable identifier for the input. For example, this can be a filename, or
-    /// simply the string `"<input>"`.
-    #[must_use]
-    fn get_identifier(&self) -> Cow<str> {
-        match self {
-            Input::File(file) => file
-                .file_name()
-                .map_or(Cow::from("<file>"), |file_name| file_name.to_string_lossy()),
-            Input::Text(_) => Cow::from("<input>"),
-        }
-    }
-
-    /// Tries to construct an `Input` by reading standard input. This will fail if the standard
-    /// input cannot be read.
-    fn try_from_stdin() -> anyhow::Result<Self> {
-        let mut buf = String::new();
-        std::io::stdin().lock().read_to_string(&mut buf)?;
-        Ok(Self::from(buf))
-    }
-}
-// This allows this type to be directly used with clap as an argument.
-// https://docs.rs/clap/latest/clap/macro.value_parser.html
-impl From<String> for Input {
-    /// Converts the given string into an `Input`. `Input` is automatically set to the correct variant
-    /// depending on whether `input_string` is a valid file path or not.
-    fn from(input_string: String) -> Self {
-        if let Ok(metadata) = std::fs::metadata(&input_string)
-            && metadata.is_file()
-        {
-            // Input is a valid file path.
-            Self::File(input_string.into())
-        } else {
-            // Input is not a valid file path, we assume it's intended to be a string.
-            Self::Text(input_string)
-        }
-    }
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
Allows source/input text to be passed directly as a command line argument for some `harper-cli` commands.
This includes: 
- `lint`
- `parse`
- `spans`
<!-- Any details that you think are important to review this PR? -->
This should hopefully make it easier to debug short snippets of text, as it would no longer be necessary to first place them into a file. For instance, it makes it possible to run `lint` like so: `harper-cli lint 'This is an example sentence'`.

This also upgrades `harper-cli` to Rust 2024 (from 2021).

# How Has This Been Tested?
Manual testing of the modified commands.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
