### PR TITLE
feat: add `LintKind` colours to the Playwright HTML report

### DIFF
--- a/packages/chrome-plugin/src/lintKindColor.ts
+++ b/packages/chrome-plugin/src/lintKindColor.ts
@@ -1,28 +1,29 @@
-export default function lintKindColor(lintKindKey: string): string {
-	switch (lintKindKey) {
-		case 'Capitalization':
-			return '#540D6E'; // Deep purple
-		case 'Enhancement':
-			return '#0EAD69'; // Green
-		case 'Formatting':
-			return '#7D3C98'; // Amethyst purple
-		case 'Miscellaneous':
-			return '#3BCEAC'; // Turquoise
-		case 'Punctuation':
-			return '#D4850F'; // Dark orange
-		case 'Readability':
-			return '#2E8B57'; // Sea green
-		case 'Regionalism':
-			return '#C061CB'; // Vibrant purple
-		case 'Repetition':
-			return '#00A67C'; // Green-cyan
-		case 'Spelling':
-			return '#EE4266'; // Pink-red
-		case 'Style':
-			return '#FFD23F'; // Yellow
-		case 'WordChoice':
-			return '#228B22'; // Forest green
-		default:
-			throw new Error(`Unexpected lint kind: ${lintKindKey}`);
+// First, define the color map as a constant
+const LINT_KIND_COLORS = {
+	'Capitalization': '#540D6E',  // Deep purple
+	'Enhancement': '#0EAD69',     // Green
+	'Formatting': '#7D3C98',      // Amethyst purple
+	'Miscellaneous': '#3BCEAC',   // Turquoise
+	'Punctuation': '#D4850F',     // Dark orange
+	'Readability': '#2E8B57',     // Sea green
+	'Regionalism': '#C061CB',     // Vibrant purple
+	'Repetition': '#00A67C',      // Green-cyan
+	'Spelling': '#EE4266',        // Pink-red
+	'Style': '#FFD23F',           // Yellow
+	'WordChoice': '#228B22'       // Forest green
+  } as const;
+  
+  // Export the type for the lint kind keys
+  export type LintKind = keyof typeof LINT_KIND_COLORS;
+  
+  // Export the array of all lint kind names
+  export const LINT_KINDS = Object.keys(LINT_KIND_COLORS) as LintKind[];
+  
+  // The main function that uses the map
+  export default function lintKindColor(lintKindKey: LintKind): string {
+	const color = LINT_KIND_COLORS[lintKindKey];
+	if (!color) {
+	  throw new Error(`Unexpected lint kind: ${lintKindKey}`);
 	}
-}
+	return color;
+  }

--- a/packages/chrome-plugin/src/lintKindColor.ts
+++ b/packages/chrome-plugin/src/lintKindColor.ts
@@ -1,29 +1,29 @@
 // First, define the color map as a constant
 const LINT_KIND_COLORS = {
-	'Capitalization': '#540D6E',  // Deep purple
-	'Enhancement': '#0EAD69',     // Green
-	'Formatting': '#7D3C98',      // Amethyst purple
-	'Miscellaneous': '#3BCEAC',   // Turquoise
-	'Punctuation': '#D4850F',     // Dark orange
-	'Readability': '#2E8B57',     // Sea green
-	'Regionalism': '#C061CB',     // Vibrant purple
-	'Repetition': '#00A67C',      // Green-cyan
-	'Spelling': '#EE4266',        // Pink-red
-	'Style': '#FFD23F',           // Yellow
-	'WordChoice': '#228B22'       // Forest green
-  } as const;
-  
-  // Export the type for the lint kind keys
-  export type LintKind = keyof typeof LINT_KIND_COLORS;
-  
-  // Export the array of all lint kind names
-  export const LINT_KINDS = Object.keys(LINT_KIND_COLORS) as LintKind[];
-  
-  // The main function that uses the map
-  export default function lintKindColor(lintKindKey: LintKind): string {
+	Capitalization: '#540D6E', // Deep purple
+	Enhancement: '#0EAD69', // Green
+	Formatting: '#7D3C98', // Amethyst purple
+	Miscellaneous: '#3BCEAC', // Turquoise
+	Punctuation: '#D4850F', // Dark orange
+	Readability: '#2E8B57', // Sea green
+	Regionalism: '#C061CB', // Vibrant purple
+	Repetition: '#00A67C', // Green-cyan
+	Spelling: '#EE4266', // Pink-red
+	Style: '#FFD23F', // Yellow
+	WordChoice: '#228B22', // Forest green
+} as const;
+
+// Export the type for the lint kind keys
+export type LintKind = keyof typeof LINT_KIND_COLORS;
+
+// Export the array of all lint kind names
+export const LINT_KINDS = Object.keys(LINT_KIND_COLORS) as LintKind[];
+
+// The main function that uses the map
+export default function lintKindColor(lintKindKey: LintKind): string {
 	const color = LINT_KIND_COLORS[lintKindKey];
 	if (!color) {
-	  throw new Error(`Unexpected lint kind: ${lintKindKey}`);
+		throw new Error(`Unexpected lint kind: ${lintKindKey}`);
 	}
 	return color;
-  }
+}

--- a/packages/chrome-plugin/tests/lint-kinds.spec.ts
+++ b/packages/chrome-plugin/tests/lint-kinds.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+import lintKindColor, { LINT_KINDS } from '../src/lintKindColor';
+
+test('display lint kind colors', async ({}, testInfo) => {
+  // Generate color boxes for each lint kind
+  const colorBoxes = LINT_KINDS.map(kind => {
+    const color = lintKindColor(kind);
+    return `<div class="color-box" style="background-color: ${color}">${kind}</div>`;
+  }).join('\n');
+  
+  const htmlContent = `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <title>Lint Kind Colors</title>
+      <style>
+        body { 
+          font-family: Arial, sans-serif; 
+          padding: 20px;
+          background: #f5f5f5;
+        }
+        h1 { 
+          color: #333; 
+          margin-top: 0;
+        }
+        .container {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 10px;
+          margin-top: 20px;
+        }
+        .color-box {
+          padding: 10px 20px;
+          border-radius: 4px;
+          color: white;
+          font-weight: bold;
+          box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+      </style>
+    </head>
+    <body>
+      <h1>Lint Kind Colors</h1>
+      <div class="container">
+        ${colorBoxes}
+      </div>
+    </body>
+    </html>
+  `;
+
+  // Attach the HTML report
+  await testInfo.attach('lint-colors.html', {
+    body: htmlContent,
+    contentType: 'text/html'
+  });
+});

--- a/packages/chrome-plugin/tests/lint-kinds.spec.ts
+++ b/packages/chrome-plugin/tests/lint-kinds.spec.ts
@@ -1,14 +1,14 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import lintKindColor, { LINT_KINDS } from '../src/lintKindColor';
 
 test('display lint kind colors', async ({}, testInfo) => {
-  // Generate color boxes for each lint kind
-  const colorBoxes = LINT_KINDS.map(kind => {
-    const color = lintKindColor(kind);
-    return `<div class="color-box" style="background-color: ${color}">${kind}</div>`;
-  }).join('\n');
-  
-  const htmlContent = `
+	// Generate color boxes for each lint kind
+	const colorBoxes = LINT_KINDS.map((kind) => {
+		const color = lintKindColor(kind);
+		return `<div class="color-box" style="background-color: ${color}">${kind}</div>`;
+	}).join('\n');
+
+	const htmlContent = `
     <!DOCTYPE html>
     <html>
     <head>
@@ -47,9 +47,9 @@ test('display lint kind colors', async ({}, testInfo) => {
     </html>
   `;
 
-  // Attach the HTML report
-  await testInfo.attach('lint-colors.html', {
-    body: htmlContent,
-    contentType: 'text/html'
-  });
+	// Attach the HTML report
+	await testInfo.attach('lint-colors.html', {
+		body: htmlContent,
+		contentType: 'text/html',
+	});
 });

--- a/packages/web/src/lib/lintKindColor.ts
+++ b/packages/web/src/lib/lintKindColor.ts
@@ -1,28 +1,29 @@
-export default function lintKindColor(lintKindKey: string): string {
-	switch (lintKindKey) {
-		case 'Capitalization':
-			return '#540D6E'; // Deep purple
-		case 'Enhancement':
-			return '#0EAD69'; // Green
-		case 'Formatting':
-			return '#7D3C98'; // Amethyst purple
-		case 'Miscellaneous':
-			return '#3BCEAC'; // Turquoise
-		case 'Punctuation':
-			return '#D4850F'; // Dark orange
-		case 'Readability':
-			return '#2E8B57'; // Sea green
-		case 'Regionalism':
-			return '#C061CB'; // Vibrant purple
-		case 'Repetition':
-			return '#00A67C'; // Green-cyan
-		case 'Spelling':
-			return '#EE4266'; // Pink-red
-		case 'Style':
-			return '#FFD23F'; // Yellow
-		case 'WordChoice':
-			return '#228B22'; // Forest green
-		default:
-			throw new Error(`Unexpected lint kind: ${lintKindKey}`);
+// First, define the color map as a constant
+const LINT_KIND_COLORS = {
+	'Capitalization': '#540D6E',  // Deep purple
+	'Enhancement': '#0EAD69',     // Green
+	'Formatting': '#7D3C98',      // Amethyst purple
+	'Miscellaneous': '#3BCEAC',   // Turquoise
+	'Punctuation': '#D4850F',     // Dark orange
+	'Readability': '#2E8B57',     // Sea green
+	'Regionalism': '#C061CB',     // Vibrant purple
+	'Repetition': '#00A67C',      // Green-cyan
+	'Spelling': '#EE4266',        // Pink-red
+	'Style': '#FFD23F',           // Yellow
+	'WordChoice': '#228B22'       // Forest green
+  } as const;
+  
+  // Export the type for the lint kind keys
+  export type LintKind = keyof typeof LINT_KIND_COLORS;
+  
+  // Export the array of all lint kind names
+  export const LINT_KINDS = Object.keys(LINT_KIND_COLORS) as LintKind[];
+  
+  // The main function that uses the map
+  export default function lintKindColor(lintKindKey: LintKind): string {
+	const color = LINT_KIND_COLORS[lintKindKey];
+	if (!color) {
+	  throw new Error(`Unexpected lint kind: ${lintKindKey}`);
 	}
-}
+	return color;
+  }

--- a/packages/web/src/lib/lintKindColor.ts
+++ b/packages/web/src/lib/lintKindColor.ts
@@ -1,29 +1,29 @@
 // First, define the color map as a constant
 const LINT_KIND_COLORS = {
-	'Capitalization': '#540D6E',  // Deep purple
-	'Enhancement': '#0EAD69',     // Green
-	'Formatting': '#7D3C98',      // Amethyst purple
-	'Miscellaneous': '#3BCEAC',   // Turquoise
-	'Punctuation': '#D4850F',     // Dark orange
-	'Readability': '#2E8B57',     // Sea green
-	'Regionalism': '#C061CB',     // Vibrant purple
-	'Repetition': '#00A67C',      // Green-cyan
-	'Spelling': '#EE4266',        // Pink-red
-	'Style': '#FFD23F',           // Yellow
-	'WordChoice': '#228B22'       // Forest green
-  } as const;
-  
-  // Export the type for the lint kind keys
-  export type LintKind = keyof typeof LINT_KIND_COLORS;
-  
-  // Export the array of all lint kind names
-  export const LINT_KINDS = Object.keys(LINT_KIND_COLORS) as LintKind[];
-  
-  // The main function that uses the map
-  export default function lintKindColor(lintKindKey: LintKind): string {
+	Capitalization: '#540D6E', // Deep purple
+	Enhancement: '#0EAD69', // Green
+	Formatting: '#7D3C98', // Amethyst purple
+	Miscellaneous: '#3BCEAC', // Turquoise
+	Punctuation: '#D4850F', // Dark orange
+	Readability: '#2E8B57', // Sea green
+	Regionalism: '#C061CB', // Vibrant purple
+	Repetition: '#00A67C', // Green-cyan
+	Spelling: '#EE4266', // Pink-red
+	Style: '#FFD23F', // Yellow
+	WordChoice: '#228B22', // Forest green
+} as const;
+
+// Export the type for the lint kind keys
+export type LintKind = keyof typeof LINT_KIND_COLORS;
+
+// Export the array of all lint kind names
+export const LINT_KINDS = Object.keys(LINT_KIND_COLORS) as LintKind[];
+
+// The main function that uses the map
+export default function lintKindColor(lintKindKey: LintKind): string {
 	const color = LINT_KIND_COLORS[lintKindKey];
 	if (!color) {
-	  throw new Error(`Unexpected lint kind: ${lintKindKey}`);
+		throw new Error(`Unexpected lint kind: ${lintKindKey}`);
 	}
 	return color;
-  }
+}


### PR DESCRIPTION
# Issues 
N/A

# Description

Adds a visualization of the `LintKind` colours as an `attachment` to the HTML Playwright report.

To achieve this I changed `chrome-plugin/tests/lint-kinds.spec.ts` (and `web/src/lib/lintKindColor.ts`) to use a Typescript Object to map from `LintKind` names to colours, which is exported, and then imported into `chrome-plugin/tests/lint-kinds.spec.ts`

As far as I can tell I've done this correctly and the web and chrome versions work as before.

# Demo

![Screenshot 2025-06-30 at 2 08 06 pm](https://github.com/user-attachments/assets/50351963-cf5b-4049-9e33-0cd8b0c684eb)

----

![Screenshot 2025-06-30 at 2 08 24 pm](https://github.com/user-attachments/assets/80ae02d1-8405-45ee-bd0f-9afb8d055379)

----

![Screenshot 2025-06-30 at 2 08 34 pm](https://github.com/user-attachments/assets/2c46331c-f1bb-4641-9ca9-3947d3a3324d)

# How Has This Been Tested?
Manual testing.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
