### PR TITLE
fix: fix issue 1495

### DIFF
--- a/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
+++ b/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
@@ -34,7 +34,7 @@ impl Linter for PhrasalVerbAsCompoundNoun {
         let mut lints = Vec::new();
         for i in document.iter_noun_indices() {
             // It would be handy if there could be a dict flag for nouns which are compounds of phrasal verbs.
-            // Instead let's use a few heuristics.
+            // Instead, let's use a few heuristics.
             let token = document.get_token(i).unwrap();
             // * Can't also be a proper noun or a real verb.
             if token.kind.is_proper_noun() || token.kind.is_verb() {
@@ -139,7 +139,13 @@ impl Linter for PhrasalVerbAsCompoundNoun {
                 }
 
                 // "dictionary lookup" is not a mistake but "couples breakup" is.
-                if prev_tok.kind.is_noun() && !prev_tok.kind.is_plural_noun() {
+                // But "settings plugin" is not.
+                if prev_tok.kind.is_noun() && !prev_tok.kind.is_plural_noun()
+                    || prev_tok
+                        .span
+                        .get_content(document.get_source())
+                        .eq_ignore_ascii_case_chars(&['s', 'e', 't', 't', 'i', 'n', 'g', 's'])
+                {
                     continue;
                 }
 
@@ -406,6 +412,15 @@ mod tests {
     fn dont_flag_all_caps() {
         assert_lint_count(
             "I WILL NEVER BREAKUP WITH GYM. WE JUST SEEM TO WORKOUT.",
+            PhrasalVerbAsCompoundNoun::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn false_positive_issue_1495() {
+        assert_lint_count(
+            "Color schemes are available by using the Style Settings plugin.",
             PhrasalVerbAsCompoundNoun::default(),
             0,
         );


### PR DESCRIPTION
# Issues 
#1495 

# Description

Fixes issue #1495 by hardcoding a single-entry whitelist of plural nouns that can form compound nouns, starting with "settings".

# How Has This Been Tested?

A unit test was added with the failing case: "Color schemes are available by using the Style Settings plugin."

There are numerous ways this could be built upon:
- Add a `dictionary.dict` annotation flag for nouns like "settings" that compound with plural forms.
- Add a whitelist as a module in `harper-core` that linters can call.
- Add more `.is_xxx` methods to `WordMetadata` and/or `TokenKind` such as `is_uppercase`, `is_first_word_in_sentence` - these wouldn't have panned out in this case - see the comment in the bug report. But maybe `is_compoundable_plural`?
- `Pattern` or `Expr` for `CompoundNoun` that has such heuristics built-in.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
