### PR TITLE
fix: fixes a bug in `SequenceExpr` found when using the `Optional` `Expr` in a linter

### DIFF
--- a/harper-core/src/expr/sequence_expr.rs
+++ b/harper-core/src/expr/sequence_expr.rs
@@ -50,15 +50,20 @@ impl Expr for SequenceExpr {
 
         for cur_expr in &self.exprs {
             let out = cur_expr.run(cursor, tokens, source)?;
-
-            window.expand_to_include(out.start);
-            window.expand_to_include(out.end.checked_sub(1).unwrap_or(out.start));
-
-            if out.start < cursor {
-                cursor = out.start;
-            } else {
-                cursor = out.end;
+        
+            // Only expand the window if the match actually covers some tokens
+            if out.end > out.start {
+                window.expand_to_include(out.start);
+                window.expand_to_include(out.end.checked_sub(1).unwrap_or(out.start));
             }
+        
+            // Only advance cursor if we actually matched something
+            if out.end > cursor {
+                cursor = out.end;
+            } else if out.start < cursor {
+                cursor = out.start;
+            }
+            // If both start and end are equal to cursor, don't move the cursor
         }
 
         Some(window)


### PR DESCRIPTION

# Issues 

No issue but see this Discord thread where I found it and tried to figure it out: [1391388089372643489](https://discord.com/channels/1335035237213671495/1335035237213671498/1391388089372643489)

# Description

While working on #1514 using the newish `Optional` `Expr` for the first I found that some tests were not doing what I expected and I noticed they were actually crashing.

Some work with an LLM led to this fix. I don't necessarily trust the LLM's findings but it made my new linter behave as expected matching the results from a different `Expr` that matched equivalent runs of tokens.

# How Has This Been Tested?

I couldn't think of a good unit test, so just manual testing.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
