### PR TITLE
feat: dict curation & concise snapshot dialects

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -22543,7 +22543,7 @@ elasticity/~Ng
 elasticize/VdSG
 elate/VJdSGn
 elated/JVY
-elation/Ng
+elation/Nmg
 elbow/~NVSgdG
 elbowroom/Ng
 elder/~JNVSgY
@@ -22565,7 +22565,7 @@ electric/~JNS
 electrical/~JNY
 electrician/NgS
 electricity/~Ng
-electrification/~Ng
+electrification/~Nmg
 electrifier/Ng
 electrify/VZnd>S
 electrifying/JVNY
@@ -22618,7 +22618,7 @@ elephantiasis/Ng
 elephantine/J
 elev
 elevate/~VJXdSGn
-elevation/~Ng
+elevation/~Nwg
 elevator/~NVgS
 eleven/~NSgH
 elevens/NS
@@ -22628,12 +22628,12 @@ elf/~NVg
 elfin/NJ
 elfish/J
 elicit/~VJSdG
-elicitation/Ng
+elicitation/Nwg
 elide/VdSG
 eligibility/~Nig
 eligible/~JN
 eliminate/~VXdSGn
-elimination/~Ng
+elimination/~Nwg
 eliminator/~NS
 elision/NgS
 elite/~JNSg
@@ -22672,7 +22672,7 @@ elvish/J
 em/~NIS
 em's
 emaciate/VJGndS
-emaciation/Ng
+emaciation/Nmg
 email/~NVSgdG
 emanate/VXdSGn
 emanation/Ng
@@ -22837,7 +22837,7 @@ enc/N
 encamp/VLSGd
 encampment/~NgS
 encapsulate/VXGndS
-encapsulation/Ng
+encapsulation/Nwg
 encase/VLdSG
 encasement/Ng
 encephalitic/J
@@ -23102,10 +23102,10 @@ entwine/VdSG
 enum/NSg
 enumerable/J
 enumerate/VdSGnX
-enumeration/~Ng
+enumeration/~Nwg
 enumerator/NSg
 enunciate/VdSGn
-enunciation/Ng
+enunciation/Nwg
 enuresis/Ng
 envelop/VSLd>ZG
 envelope/~NVSg
@@ -23292,7 +23292,7 @@ erythrocyte/NSg
 erythromycin/N
 escalade/NVSdGg
 escalate/~VedSGn
-escalation/~Neg
+escalation/~Nweg
 escalations/N
 escalator/~NVgS
 escalatory/J
@@ -23512,7 +23512,7 @@ ewer/Ng
 ex/~NVJgS
 exabyte/NgS
 exacerbate/VGndS
-exacerbation/Ng
+exacerbation/Nwg
 exact/~JVSpd>YTG
 exacting/JVY
 exaction/Ng
@@ -23744,7 +23744,7 @@ expertness/Ng
 expiate/VGndS
 expiation/Ng
 expiatory/J
-expiration/~Ng
+expiration/~Nwg
 expire/~VdSG
 expired/~VJU
 expiry/~Ng
@@ -23875,7 +23875,7 @@ extraordinaire/JN
 extraordinarily/~R
 extraordinary/~JNp
 extrapolate/VXGndS
-extrapolation/~Ng
+extrapolation/~Nwg
 extrasensory/J
 extraterrestrial/~JNgS
 extraterritorial/J
@@ -23974,9 +23974,9 @@ factoid/NSg
 factor/~NVrSdG
 factor's
 factorial/~NJgS
-factorisation/N!_
+factorisation/NwS!_
 factorise/VGdS!_
-factorization/~N
+factorization/~NwS
 factorize/VGdS
 factory/~NJSg
 factotum/NSg
@@ -24320,7 +24320,7 @@ fennel/Ng
 fentanyl/Ng
 feral/~JN
 ferment/~VNWegS
-fermentation/~Ng
+fermentation/~NwSg
 fermented/~VJ
 fermenting/V
 fermion/NgS
@@ -24528,7 +24528,7 @@ filthiness/Ng
 filthy/~JV>pT
 filtrate/NViGndS
 filtrate's
-filtration/~Nig
+filtration/~NwSig
 fin/~NVSg>
 finagle/Vd>SZG
 finagler/Ng
@@ -25250,7 +25250,7 @@ form's
 formal/~JNSgY
 formaldehyde/Ng
 formalin/N
-formalisation/Ng!_
+formalisation/NwSg!_
 formalise/VGdS!_
 formalism/~Ng
 formalist/NJgS
@@ -25384,7 +25384,7 @@ fragile/~JN>T
 fragility/NgS
 fragment/~NVGgdS
 fragmentary/~Jg
-fragmentation/~Ng
+fragmentation/~Nmg
 fragrance/~NVgS
 fragrant/~JY
 frail/~JNV>YTp
@@ -25649,8 +25649,8 @@ fugitive/~NJVgS
 fugue/~NVSg
 fuhrer/NSg
 fulcrum/NgS
-fulfil/VSL!_
-fulfill/~VLdGS
+fulfil/VSL!_@
+fulfill/~VLdGS<@
 fulfilled/~VJU
 fulfilling/~JVNU
 fulfillment/~Ng
@@ -26181,7 +26181,7 @@ germicidal/J
 germicide/NgS
 germinal/~Jg
 germinate/~VGndS
-germination/~Ng
+germination/~NwSg
 germophobe/NgS
 germophobia/Ng
 gerontocracy/Ng
@@ -27907,7 +27907,7 @@ hermitian/~J
 hernia/NSg
 hernial/J
 herniate/VGndS
-herniation/Ng
+herniation/NwSg
 hero/~Ng
 heroes/~N
 heroic/~JNSQ
@@ -28659,7 +28659,7 @@ hwy/~N
 hyacinth/Ng
 hyacinths/N
 hybrid/~NJSg
-hybridisation/Ng!_
+hybridisation/NwSg!_
 hybridise/VdSG!_
 hybridism/Ng
 hybridization/~Ng
@@ -28974,7 +28974,7 @@ imbroglio/NSg
 imbue/VdSG
 imitable/Ji
 imitate/~VdSGnvX
-imitation/~Ng
+imitation/~NwSg
 imitative/JpY
 imitativeness/Ng
 imitator/NSg
@@ -29300,7 +29300,7 @@ incel/NgS
 incendiary/~JNSg
 incense/~NVgGdS
 incentive/~NgES
-incentivization/Ng
+incentivization/NwSg
 incentivize/VGdSE
 inception/~NSg
 incessant/~JY
@@ -29925,7 +29925,7 @@ intercity/~JN
 intercollegiate/~JN
 intercom/NVSg
 intercommunicate/VdSGn
-intercommunication/Ng
+intercommunication/Nmg
 interconnect/~VNGdS
 interconnectedness/N
 interconnection/~NSg
@@ -30233,7 +30233,7 @@ ironwood/NgS
 ironwork/Ng
 irony/~NJSg
 irradiate/JVdSGn
-irradiation/~Ng
+irradiation/~NwSg
 irrational/~JNSgY
 irrationality/Ng
 irreclaimable/J
@@ -30732,7 +30732,7 @@ just/~JV>YpT        # removed `1` noun. archaic and interferes with linter heuri
 justice/~NigS
 justifiable/~JU
 justifiably/UR
-justification/~Ng
+justification/~NwSg
 justified/~JVU
 justify/~VXGdSn
 justifyingly/R
@@ -31798,7 +31798,7 @@ liminal/J
 liminality/NgS
 limit/~NJVeSZGd>
 limit's
-limitation/~Neg
+limitation/~NwSeg
 limitations/~N
 limited/~VJNUY
 limiter's
@@ -32485,12 +32485,12 @@ magnesium/~Ng
 magnet/~NgS
 magnetic/~JQ
 magnetisable/J!_
-magnetisation/Neg!_
+magnetisation/NwSeg!_
 magnetise/VeGdS!_
 magnetism/~Ng
 magnetite/Ng
 magnetizable/J
-magnetization/Neg
+magnetization/NwSeg
 magnetize/VeGdS
 magneto/~NSg
 magnetohydrodynamic/J
@@ -32930,7 +32930,7 @@ mastitis/N
 mastodon/NSg
 mastoid/JNSg
 masturbate/VGndS
-masturbation/Ng
+masturbation/Nmg
 masturbatory/J
 mat/~NVJSZGgd>
 matador/~NSg
@@ -33118,7 +33118,7 @@ medial/~JNrY
 median/~NJgS
 mediate/~VJrdSGn
 mediated/~VU
-mediation/~Nrg
+mediation/~NwSrg
 mediator/~NgS
 medic/~JNSg
 medicaid/g
@@ -33779,7 +33779,7 @@ misbehavior/Ng
 misbehaviour/Ng!@_
 misc/~J
 miscalculate/VdSXGn
-miscalculation/Ng
+miscalculation/NwSg
 miscall/VNdSG
 miscarriage/~NgS
 miscarry/VGdS
@@ -34836,10 +34836,10 @@ narrowness/Ng
 narwhal/NgS
 nary/J
 nasal/~JNSgY
-nasalisation/Ng!_
+nasalisation/NwSg!_
 nasalise/VdSG!_
 nasality/Ng
-nasalization/Ng
+nasalization/NwSg
 nasalize/VdSG
 nascence/Nrg
 nascent/~Jr
@@ -35415,7 +35415,7 @@ nondeterminism/N
 nondeterministic/J
 nondisciplinary/J
 nondisclosure/Ng
-nondiscrimination/Ng
+nondiscrimination/Nmg
 nondiscriminatory/J
 nondramatic/J
 nondrinker/NgS
@@ -35781,7 +35781,7 @@ nugget/~NVSg
 nuisance/~NgS
 nuke/~NVgGdS
 null/~NJVSdGB
-nullification/Ng
+nullification/NwSg
 nullify/VndSG
 nullity/Ng
 numb/~JVZTGpd>YS
@@ -36423,7 +36423,7 @@ orison/NSg
 ormolu/NJVg
 ornament/~NVSGgd
 ornamental/~JN
-ornamentation/~Nwg
+ornamentation/~NwSg
 ornate/~JVYp
 ornateness/Nmg
 orneriness/Nmg
@@ -36956,7 +36956,7 @@ oviparous/J
 ovoid/JNgS
 ovular/JN
 ovulate/VJdSGn
-ovulation/~Ng
+ovulation/~NwSg
 ovule/NgS
 ovum/Ng
 ow/~
@@ -37270,10 +37270,10 @@ paralegal/NgS
 parallax/~NVgS
 parallel/~JNVSGgd
 paralleled/~VU
-parallelisation/N!_
+parallelisation/NwSg!_
 parallelised/J!_
 parallelism/NgS
-parallelization/N
+parallelization/NwSg
 parallelize/VdSGB
 parallelogram/~NSg
 paralyse/VdSG!_
@@ -37895,7 +37895,7 @@ perfectness/Ng
 perfidious/JY
 perfidy/NSg
 perforate/VJGnXdS
-perforation/Ng
+perforation/NwSg
 perforce/V
 perform/~VSd>ZG
 performance/~NSg
@@ -38881,10 +38881,10 @@ pokey/~JNgS
 poky/NJT>
 pol/~NSGgd
 polar/~JN
-polarisation/Neg!_
+polarisation/NwSeg!_
 polarise/VedSG!_
 polarity/~NSg
-polarization/~Neg
+polarization/~NwSeg
 polarize/VedSG
 pole/~NVgS
 poleaxe/NVGdS
@@ -39415,7 +39415,7 @@ prefab/JNVSg
 prefabbed/V
 prefabbing/V
 prefabricate/VdSGn
-prefabrication/Ng
+prefabrication/Nmg
 preface/~NVdSgG
 prefatory/J
 prefect/~NSg
@@ -40208,7 +40208,7 @@ pulpwood/Ng
 pulpy/J>pT
 pulsar/~NSg
 pulsate/VXGndS
-pulsation/Ng
+pulsation/NwSg
 pulse/~NVrgGdS
 pulverisation/Ng!_
 pulverise/VdSG!_
@@ -40637,7 +40637,7 @@ radian/NS
 radiance/~Ng
 radiant/~JNY
 radiate/~VJNdSGnX
-radiation/~Ng
+radiation/~NwSg
 radiative/~J
 radiator/~NSg
 radical/~JNSgYp
@@ -41008,8 +41008,8 @@ recalcitrant/JN
 recant/VSdG
 recantation/NSg
 recap/~VNgS
-recapitalisation/N!_
-recapitalization/N
+recapitalisation/NwSg!_
+recapitalization/NwSg
 recce/NJVS
 recd
 receipt/~NVSgdG
@@ -41302,14 +41302,14 @@ regrind/VGS
 reground/V
 regroup/NVdGS
 regular/~JNgYS
-regularisation/Ng!_
+regularisation/NwSg!_
 regularise/VdSG!_
 regularity/~NSg
-regularization/Ng
+regularization/NwSg
 regularize/VdSG
 regulate/~VedSGnv
 regulated/~VJU
-regulation/~NJeg
+regulation/~NwSJeg
 regulations/~N
 regulator/~NgS
 regulatory/~J
@@ -41526,7 +41526,7 @@ repletion/Ng
 replica/~NSg
 replicant/NgS
 replicate/~VNJdSGnX
-replication/~Ng
+replication/~NwSg
 replicator/NS
 repo/~NVSg
 repoliticise/VdSG!_
@@ -42327,7 +42327,7 @@ ruffled/VJU
 rug/~NVJSg
 rugby/~NVg
 rugged/~JVpT>Y
-ruggedization/Ng
+ruggedization/NwSg
 ruggedize/VdSG
 ruggedness/Ng
 rugger/N
@@ -42689,7 +42689,7 @@ sateen/Ng
 satellite/~NVdSgG
 satiable/Ji
 satiate/VJGndS
-satiation/Ng
+satiation/Nmg
 satiety/Ng
 satin/~NJVg
 satinwood/NSg
@@ -43463,7 +43463,7 @@ sensitive/~JNSgYp
 sensitiveness/Nmg
 sensitivities/N
 sensitivity/~Nwig
-sensitization/Neg
+sensitization/NwSeg
 sensitize/VedSG
 sensor/~NSg
 sensory/~JN
@@ -45721,14 +45721,14 @@ stagecoach/~NVgS
 stagecraft/Ng
 stagehand/NgS
 stagestruck/J
-stagflation/Ng
+stagflation/NwSg
 stagger/NVgdGS
 staggering/~VJNY
 staging/~VNg
 stagnancy/Ng
 stagnant/~JY
 stagnate/VJdSGn
-stagnation/~Ng
+stagnation/~NwSg
 stagy/J>T
 staid/JVp>YT
 staidness/Ng
@@ -46457,7 +46457,7 @@ subjectivity/~Ng
 subjectivization/Ng
 subjoin/VNGdS
 subjugate/VJGndS
-subjugation/~Ng
+subjugation/~NwSg
 subjunctive/~JNSg
 sublease/NVgGdS
 sublet/VNSg
@@ -47268,7 +47268,7 @@ taboo/~NJVgdSG
 tabor/~NVgS
 tabular/JN
 tabulate/VNJdSGnX
-tabulation/Ng
+tabulation/NwSg
 tabulator/NSg
 tachograph/N
 tachographs/N
@@ -48831,7 +48831,7 @@ translucence/Ng
 translucency/~Ng
 translucent/~JY
 transmigrate/VGndS
-transmigration/Ng
+transmigration/NwSg
 transmissible/J
 transmission/~NgS
 transmit/~VS
@@ -49095,10 +49095,10 @@ trivalent/JN
 trivet/NgS
 trivia/~Ng
 trivial/~JNY
-trivialisation/Ng!_
+trivialisation/NwSg!_
 trivialise/VGdS!_
 triviality/NSg
-trivialization/Ng
+trivialization/NwSg
 trivialize/VGdS
 trivium/Ng
 trochaic/JN
@@ -49847,7 +49847,7 @@ unicellular/JN
 unicorn/~NVJSg
 unicycle/NVSg
 unidirectional/JN
-unification/~Nrg
+unification/~NwSrg
 unifier/NgS
 uniform/~NJVSgdYG
 uniformity/~Ng
@@ -50284,7 +50284,7 @@ valiance/Ng
 valiant/~JNY
 valid/~JY
 validate/~ViGndS
-validation/~Nig
+validation/~NwSig
 validations/N
 validator/NgS
 validity/~Nig
@@ -50475,9 +50475,9 @@ verandah/NSg_
 verapamil/N
 verb/~NVKgS
 verbal/~JNVgYS
-verbalisation/Ng!_
+verbalisation/NwSg!_
 verbalise/VGdS!_
-verbalization/Ng
+verbalization/NwSg
 verbalize/VGdS
 verbatim/~JN
 verbena/NSg
@@ -50715,8 +50715,8 @@ virility/Ng
 virologist/NSg
 virology/~Ng
 virtual/~JNY
-virtualisation/N!_
-virtualization/~N
+virtualisation/NwSg!_
+virtualization/~NwSg
 virtue/~NSg
 virtuosity/Ng
 virtuoso/~NJg

--- a/harper-core/tests/pos_tags.rs
+++ b/harper-core/tests/pos_tags.rs
@@ -46,7 +46,9 @@
 //!   - Conjunctions are denoted by `C`.
 //!   - Determiners are denoted by `D`.
 //!   - Prepositions are denoted by `P`.
-//!   - Dialects are denoted by `Am`, `Br`, `Ca`, or `Au`.
+//!   - Dialects are denoted by `Am`, `Br`, `Ca`, or `Au` for individual
+//!     dialects, or `NoAm` for North America (US and Canada)
+//!     or `Comm` for Commonwealth (UK, Australia, and Canada).
 //!   - Swear words are denoted by `B` (for bad).
 //!   - Noun phrase membership is denoted by `+`
 //!
@@ -62,7 +64,7 @@
 //! - All other token kinds are denoted by their variant name.
 use std::borrow::Cow;
 
-use harper_core::{Degree, Document, FstDictionary, TokenKind, WordMetadata};
+use harper_core::{Degree, Dialect, Document, FstDictionary, TokenKind, WordMetadata};
 
 mod snapshot;
 
@@ -161,18 +163,8 @@ fn format_word_tag(word: &WordMetadata) -> String {
         add("P", &mut tags);
     }
 
-    word.dialects.iter().for_each(|d| {
-        if let Ok(dialect) = harper_core::Dialect::try_from(d) {
-            add(
-                match dialect {
-                    harper_core::Dialect::American => "Am",
-                    harper_core::Dialect::British => "Br",
-                    harper_core::Dialect::Canadian => "Ca",
-                    harper_core::Dialect::Australian => "Au",
-                },
-                &mut tags,
-            );
-        }
+    get_dialect_annotations(word).into_iter().for_each(|tag| {
+        add(tag, &mut tags);
     });
 
     add_switch(&mut tags, word.np_member, "+", "");
@@ -187,6 +179,45 @@ fn format_word_tag(word: &WordMetadata) -> String {
         tags
     }
 }
+
+/// Returns a vector of dialect annotation strings for the given word.
+/// Handles both individual dialects and special groupings (NoAm, Comm).
+fn get_dialect_annotations(word: &WordMetadata) -> Vec<&'static str> {
+    let mut annotations = Vec::new();
+    let mut north_america = false;
+    let mut commonwealth = false;
+
+    let en_au = word.dialects.is_dialect_enabled_strict(Dialect::Australian);
+    let en_ca = word.dialects.is_dialect_enabled_strict(Dialect::Canadian);
+    let en_gb = word.dialects.is_dialect_enabled_strict(Dialect::British);
+    let en_us = word.dialects.is_dialect_enabled_strict(Dialect::American);
+
+    // Dialect groups in alphabetical order
+    if en_gb && en_au && en_ca {
+        annotations.push("Comm");
+        commonwealth = true;
+    }
+    if en_us && en_ca {
+        annotations.push("NoAm");
+        north_america = true;
+    }
+    // Individual dialects in alphabetical order
+    if en_us && !north_america {
+        annotations.push("Am");
+    }
+    if en_au && !commonwealth {
+        annotations.push("Au");
+    }
+    if en_gb && !commonwealth {
+        annotations.push("Br");
+    }
+    if en_ca && !north_america && !commonwealth {
+        annotations.push("Ca");
+    }
+
+    annotations
+}
+
 fn format_tag(kind: &TokenKind) -> Cow<'static, str> {
     match kind {
         TokenKind::Word(word) => {

--- a/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
+++ b/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
@@ -39,7 +39,7 @@
 > much    out         of the way    to hear the Rabbit say   to itself , “ Oh    dear    ! Oh    dear    ! I    shall
 # NSg/I/J NSg/V/J/R/P P  D+  NSg/J+ P  V    D+  NSg/V+ NSg/V P  ISg+   . . NPr/V NSg/V/J . NPr/V NSg/V/J . ISg+ VX
 > be     late  ! ” ( when    she  thought it       over      afterwards , it       occurred to her     that         she
-# NSg/VX NSg/J . . . NSg/I/C ISg+ NSg/V   NPr/ISg+ NSg/V/J/P R/Ca/Au/Br . NPr/ISg+ V        P  ISg/D$+ NSg/I/C/Ddem ISg+
+# NSg/VX NSg/J . . . NSg/I/C ISg+ NSg/V   NPr/ISg+ NSg/V/J/P R/Comm     . NPr/ISg+ V        P  ISg/D$+ NSg/I/C/Ddem ISg+
 > ought    to have   wondered at    this    , but     at    the time     it       all       seemed quite natural ) ;
 # NSg/I/VX P  NSg/VX V/J      NSg/P I/Ddem+ . NSg/C/P NSg/P D+  NSg/V/J+ NPr/ISg+ NSg/I/J/C V/J    NSg   NSg/J   . .
 > but     when    the Rabbit actually took a   watch out         of its     waistcoat - pocket  , and
@@ -82,8 +82,8 @@
 # V/J     NSg/I/C/Ddem IPl+ NSg/V V/J    P    NPl/V     V/C NSg/V+ . NPl/V   . NSg/J/R V/C +
 > she  saw   maps  and pictures hung    upon pegs  . She  took down      a   jar   from one       of the
 # ISg+ NSg/V NPl/V V/C NPl/V+   NPr/V/J P+   NPl/V . ISg+ V    NSg/V/J/P D/P NSg/V P    NSg/I/V/J P  D+
-> shelves as    she  passed ; it       was labelled     “ ORANGE  MARMALADE ” , but     to her     great
-# NPl/V+  NSg/R ISg+ V/J    . NPr/ISg+ V   V/J/Ca/Au/Br . NPr/V/J NSg/V     . . NSg/C/P P  ISg/D$+ NSg/J+
+> shelves as    she  passed ; it       was labelled “ ORANGE  MARMALADE ” , but     to her     great
+# NPl/V+  NSg/R ISg+ V/J    . NPr/ISg+ V   V/J/Comm . NPr/V/J NSg/V     . . NSg/C/P P  ISg/D$+ NSg/J+
 > disappointment it       was empty   : she  did not   like        to drop  the jar   for fear  of
 # NSg+           NPr/ISg+ V   NSg/V/J . ISg+ V   NSg/C NSg/V/J/C/P P  NSg/V D   NSg/V C/P NSg/V P
 > killing somebody underneath , so        managed to put   it       into one       of the cupboards as
@@ -106,8 +106,8 @@
 # NSg/V/J/P . NSg/V/J/P . NSg/V/J/P . NSg/VX D   NSg/V R     NSg/V/P P  D/P+ NSg/V+ . . ISg+ NSg/V  NSg/C NSg/I/J/D+ NPrPl+
 > I’ve fallen by      this    time     ? ” she  said aloud . “ I    must  be     getting somewhere near      the
 # W?   W?     NSg/J/P I/Ddem+ NSg/V/J+ . . ISg+ V/J+ J     . . ISg+ NSg/V NSg/VX NSg/V   NSg       NSg/V/J/P D
-> centre         of the earth  . Let   me       see   : that          would  be     four thousand miles  down      , I
-# NSg/V/Ca/Au/Br P  D+  NPr/V+ . NSg/V NPr/ISg+ NSg/V . NSg/I/C/Ddem+ NSg/VX NSg/VX NSg  NSg      NPrPl+ NSg/V/J/P . ISg+
+> centre     of the earth  . Let   me       see   : that          would  be     four thousand miles  down      , I
+# NSg/V/Comm P  D+  NPr/V+ . NSg/V NPr/ISg+ NSg/V . NSg/I/C/Ddem+ NSg/VX NSg/VX NSg  NSg      NPrPl+ NSg/V/J/P . ISg+
 > think — ” ( for , you    see   , Alice had learnt several things of this    sort   in      her
 # NSg/V . . . C/P . ISgPl+ NSg/V . NPr+  V   V      J/D     NPl/V  P  I/Ddem+ NSg/V+ NPr/J/P ISg/D$+
 > lessons in      the schoolroom , and though this    was not   a   very good    opportunity for
@@ -272,8 +272,8 @@
 #
 > However , this   bottle was not   marked “ poison , ” so        Alice ventured to taste   it       , and
 # C       . I/Ddem NSg/V+ V   NSg/C V/J    . NSg/V+ . . NSg/I/J/C NPr+  V/J      P  NSg/V/J NPr/ISg+ . V/C
-> finding it       very nice    , ( it       had , in      fact , a   sort  of mixed flavour        of cherry - tart    ,
-# NSg/V   NPr/ISg+ J/R  NPr/V/J . . NPr/ISg+ V   . NPr/J/P NSg+ . D/P NSg/V P  V/J   NSg/V/Ca/Au/Br P  NPr/J  . NSg/V/J .
+> finding it       very nice    , ( it       had , in      fact , a   sort  of mixed flavour    of cherry - tart    ,
+# NSg/V   NPr/ISg+ J/R  NPr/V/J . . NPr/ISg+ V   . NPr/J/P NSg+ . D/P NSg/V P  V/J   NSg/V/Comm P  NPr/J  . NSg/V/J .
 > custard , pine  - apple , roast    turkey , toffee , and hot     buttered toast  , ) she  very
 # NSg     . NSg/V . NPr   . NSg/V/J+ NPr/J+ . NSg/V  . V/C NSg/V/J V/J+     NSg/V+ . . ISg+ J/R
 > soon finished it      off       .
@@ -772,8 +772,8 @@
 # . V    . . V/J  D+  NSg/V+ P    D/P+ J+        NSg/V+ . . V   ISgPl+ NSg/I/J/C NSg/V/J . I/Ddem+ VL D
 > driest thing I    know   . Silence all       round     , if    you    please ! ‘          William the Conqueror ,
 # W?     NSg/V ISg+ NSg/V+ . NSg/V+  NSg/I/J/C NSg/V/J/P . NSg/C ISgPl+ V      . Unlintable NPr+    D   NSg       .
-> whose cause    was favoured     by      the pope   , was soon submitted to by      the English  , who
-# I+    NSg/V/C+ V   V/J/Ca/Au/Br NSg/J/P D+  NPr/V+ . V   J/R  V         P  NSg/J/P D+  NPr/V/J+ . NPr/I+
+> whose cause    was favoured by      the pope   , was soon submitted to by      the English  , who
+# I+    NSg/V/C+ V   V/J/Comm NSg/J/P D+  NPr/V+ . V   J/R  V         P  NSg/J/P D+  NPr/V/J+ . NPr/I+
 > wanted leaders , and had been  of late  much    accustomed to usurpation and conquest .
 # V/J    +       . V/C V   NSg/V P  NSg/J NSg/I/J V/J        P  NSg        V/C NSg/V+   .
 > Edwin and Morcar , the earls of Mercia and Northumbria — ’ ”
@@ -1320,8 +1320,8 @@
 # NSg/J/P+ NSg/V/P+ D/P V/J   NSg/V+ . D   NSg$     . . NPr/V/J+ . NPr/V/J+ . NSg/C V   ISgPl+ . . V/C NSg/J/C D/P+
 > voice  she  had never heard before , “ Sure then    I’m here    ! Digging for apples , yer
 # NSg/V+ ISg+ V   R     V/J   C/P    . . J    NSg/J/C W?  NSg/J/R . NSg/V   C/P NPl    . J+
-> honour          ! ”
-# NSg/V/Ca/Au/Br+ . .
+> honour      ! ”
+# NSg/V/Comm+ . .
 >
 #
 > “ Digging for apples , indeed ! ” said the Rabbit angrily . “ Here    ! Come    and help  me
@@ -1334,16 +1334,16 @@
 # . NPr/V/J/C NPr/V NPr/ISg . NPr/V/J+ . NSg$   NSg/I/C/Ddem+ NPr/J/P D+  NSg/V+ . .
 >
 #
-> “ Sure , it’s an   arm      , yer honour          ! ” ( He       pronounced it       “ arrum . ” )
-# . J    . W?   D/P+ NSg/V/J+ . J+  NSg/V/Ca/Au/Br+ . . . NPr/ISg+ V/J        NPr/ISg+ . ?     . . .
+> “ Sure , it’s an   arm      , yer honour      ! ” ( He       pronounced it       “ arrum . ” )
+# . J    . W?   D/P+ NSg/V/J+ . J+  NSg/V/Comm+ . . . NPr/ISg+ V/J        NPr/ISg+ . ?     . . .
 >
 #
 > “ An   arm     , you    goose  ! Who    ever saw   one       that          size   ? Why   , it       fills the whole  window ! ”
 # . D/P+ NSg/V/J . ISgPl+ NSg/V+ . NPr/I+ J    NSg/V NSg/I/V/J NSg/I/C/Ddem+ NSg/V+ . NSg/V . NPr/ISg+ NPl/V D+  NSg/J+ NSg/V+ . .
 >
 #
-> “ Sure , it       does  , yer honour          : but     it’s an  arm     for all        that          . ”
-# . J    . NPr/ISg+ NPl/V . J+  NSg/V/Ca/Au/Br+ . NSg/C/P W?   D/P NSg/V/J C/P NSg/I/J/C+ NSg/I/C/Ddem+ . .
+> “ Sure , it       does  , yer honour      : but     it’s an  arm     for all        that          . ”
+# . J    . NPr/ISg+ NPl/V . J+  NSg/V/Comm+ . NSg/C/P W?   D/P NSg/V/J C/P NSg/I/J/C+ NSg/I/C/Ddem+ . .
 >
 #
 > “ Well    , it’s got no     business there , at    any    rate   : go      and take  it       away ! ”
@@ -1352,8 +1352,8 @@
 #
 > There was a   long    silence after this    , and Alice could  only  hear whispers now       and
 # +     V   D/P NPr/V/J NSg/V   J/P   I/Ddem+ . V/C NPr+  NSg/VX J/R/C V    NPl/V    NPr/V/J/C V/C
-> then    ; such  as    , “ Sure , I    don’t like        it       , yer honour          , at    all       , at    all       ! ” “ Do     as    I
-# NSg/J/C . NSg/I NSg/R . . J    . ISg+ V     NSg/V/J/C/P NPr/ISg+ . J+  NSg/V/Ca/Au/Br+ . NSg/P NSg/I/J/C . NSg/P NSg/I/J/C . . . NSg/VX NSg/R ISg+
+> then    ; such  as    , “ Sure , I    don’t like        it       , yer honour      , at    all       , at    all       ! ” “ Do     as    I
+# NSg/J/C . NSg/I NSg/R . . J    . ISg+ V     NSg/V/J/C/P NPr/ISg+ . J+  NSg/V/Comm+ . NSg/P NSg/I/J/C . NSg/P NSg/I/J/C . . . NSg/VX NSg/R ISg+
 > tell  you    , you    coward  ! ” and at    last    she  spread out         her     hand   again , and made
 # NPr/V ISgPl+ . ISgPl+ NPr/V/J . . V/C NSg/P NSg/V/J ISg+ NSg/V  NSg/V/J/R/P ISg/D$+ NSg/V+ P     . V/C NSg/V
 > another snatch in      the air    . This    time     there were  two  little   shrieks , and more
@@ -1766,8 +1766,8 @@
 # D   NSg/V  P  NSg/I/C/Ddem . .
 >
 #
-> “ In      my  youth , ” said the sage    , as    he       shook   his     grey              locks  , “ I    kept all       my  limbs
-# . NPr/J/P D$+ NSg+  . . V/J  D   NSg/V/J . NSg/R NPr/ISg+ NSg/V/J ISg/D$+ NPr/V/J/Ca/Au/Br+ NPl/V+ . . ISg+ V    NSg/I/J/C D$+ NPl/V+
+> “ In      my  youth , ” said the sage    , as    he       shook   his     grey          locks  , “ I    kept all       my  limbs
+# . NPr/J/P D$+ NSg+  . . V/J  D   NSg/V/J . NSg/R NPr/ISg+ NSg/V/J ISg/D$+ NPr/V/J/Comm+ NPl/V+ . . ISg+ V    NSg/I/J/C D$+ NPl/V+
 > very supple By      the use   of this    ointment — one       shilling the box    — Allow me       to sell
 # J/R  V/J    NSg/J/P D   NSg/V P  I/Ddem+ NSg      . NSg/I/V/J NSg/V    D+  NSg/V+ . V     NPr/ISg+ P  NSg/V
 > you    a    couple   ? ”
@@ -2993,7 +2993,7 @@
 >
 #
 > The Hatter shook   his     head     mournfully . “ Not   I    ! ” he       replied . “ We   quarrelled last
-# D   NSg/V  NSg/V/J ISg/D$+ NPr/V/J+ R+         . . NSg/C ISg+ . . NPr/ISg+ V/J+    . . IPl+ V/Ca/Au/Br NSg/V/J
+# D   NSg/V  NSg/V/J ISg/D$+ NPr/V/J+ R+         . . NSg/C ISg+ . . NPr/ISg+ V/J+    . . IPl+ V/Comm     NSg/V/J
 > March  — just before he       went  mad     , you    know  — ” ( pointing with his     tea    spoon at    the
 # NPr/V+ . V/J  C/P    NPr/ISg+ NSg/V NSg/V/J . ISgPl+ NSg/V . . . V        P    ISg/D$+ NSg/V+ NSg/V NSg/P D+
 > March  Hare     , ) “ — it       was at    the great  concert given     by      the Queen   of Hearts , and I
@@ -3662,8 +3662,8 @@
 # NPr/ISg+ V   D/P J/R  V/J       NSg/V/J+ +      .
 >
 #
-> The players all       played at    once  without waiting for turns , quarrelling    all       the
-# D+  NPl     NSg/I/J/C V/J    NSg/P NSg/C C/P     NSg/V   C/P NPl/V . NSg/V/Ca/Au/Br NSg/I/J/C D
+> The players all       played at    once  without waiting for turns , quarrelling all       the
+# D+  NPl     NSg/I/J/C V/J    NSg/P NSg/C C/P     NSg/V   C/P NPl/V . NSg/V/Comm  NSg/I/J/C D
 > while     , and fighting for the hedgehogs ; and in      a   very short     time     the Queen    was in
 # NSg/V/C/P . V/C NSg/V/J  C/P D   NPl/V     . V/C NPr/J/P D/P J/R  NPr/V/J/P NSg/V/J+ D+  NPr/V/J+ V   NPr/J/P
 > a   furious passion , and went  stamping about , and shouting “ Off       with his     head     ! ” or
@@ -4096,8 +4096,8 @@
 #
 > But     here    , to Alice’s great  surprise , the Duchess’s voice  died away , even    in      the
 # NSg/C/P NSg/J/R . P  NSg$    NSg/J+ NSg/V+   . D+  NSg$+     NSg/V+ V/J  V/J  . NSg/V/J NPr/J/P D
-> middle  of her     favourite         word   ‘          moral   , ’ and the arm      that          was linked into hers
-# NSg/V/J P  ISg/D$+ NSg/V/J/Ca/Au/Br+ NSg/V+ Unlintable NSg/V/J . . V/C D+  NSg/V/J+ NSg/I/C/Ddem+ V   V/J    P    ISg+
+> middle  of her     favourite     word   ‘          moral   , ’ and the arm      that          was linked into hers
+# NSg/V/J P  ISg/D$+ NSg/V/J/Comm+ NSg/V+ Unlintable NSg/V/J . . V/C D+  NSg/V/J+ NSg/I/C/Ddem+ V   V/J    P    ISg+
 > began to tremble . Alice looked up        , and there stood the Queen    in      front   of them     ,
 # V     P+ NSg/V   . NPr+  V/J    NSg/V/J/P . V/C +     V     D+  NPr/V/J+ NPr/J/P NSg/V/J P  NSg/IPl+ .
 > with her     arms   folded , frowning like        a   thunderstorm .
@@ -4134,8 +4134,8 @@
 # NPr/V/J+ R      V         NSg/I/C/Ddem D/P+ NSg$+    NSg/V/J+ NSg/VX NSg/V/J NSg/IPl+ D$+   V+    .
 >
 #
-> All       the time    they were  playing the Queen    never left    off       quarrelling    with the
-# NSg/I/J/C D+  NSg/V/J IPl+ NSg/V V       D+  NPr/V/J+ R     NPr/V/J NSg/V/J/P NSg/V/Ca/Au/Br P    D+
+> All       the time    they were  playing the Queen    never left    off       quarrelling with the
+# NSg/I/J/C D+  NSg/V/J IPl+ NSg/V V       D+  NPr/V/J+ R     NPr/V/J NSg/V/J/P NSg/V/Comm  P    D+
 > other    players , and shouting “ Off       with his     head     ! ” or    “ Off       with her     head     ! ” Those
 # NSg/V/J+ NPl+    . V/C V+       . NSg/V/J/P P    ISg/D$+ NPr/V/J+ . . NPr/C . NSg/V/J/P P    ISg/D$+ NPr/V/J+ . . I/Ddem+
 > whom she  sentenced were  taken into custody by      the soldiers , who   of course had to
@@ -5094,8 +5094,8 @@
 # D   NPl    NSg/V NSg/V   NSg/V/J/P . NSg/J  NPl/V+ . . J/P D$+   NPl/V  . V/C ISg+ NSg/VX
 > even    make  out         that         one       of them     didn’t know  how   to spell “ stupid , ” and that         he
 # NSg/V/J NSg/V NSg/V/J/R/P NSg/I/C/Ddem NSg/I/V/J P  NSg/IPl+ V      NSg/V NSg/C P  NSg/V . NSg/J  . . V/C NSg/I/C/Ddem NPr/ISg+
-> had to ask   his     neighbour         to tell  him  . “ A   nice    muddle their slates’ll be     in
-# V   P  NSg/V ISg/D$+ NSg/V/J/Ca/Au/Br+ P  NPr/V ISg+ . . D/P NPr/V/J NSg/V+ D$+   ?         NSg/VX NPr/J/P
+> had to ask   his     neighbour     to tell  him  . “ A   nice    muddle their slates’ll be     in
+# V   P  NSg/V ISg/D$+ NSg/V/J/Comm+ P  NPr/V ISg+ . . D/P NPr/V/J NSg/V+ D$+   ?         NSg/VX NPr/J/P
 > before the trial’s over      ! ” thought Alice .
 # C/P    D   NSg$    NSg/V/J/P . . NSg/V   NPr+  .
 >
@@ -5856,8 +5856,8 @@
 # NSg/I/C/Ddem+ NPr+ .
 >
 #
-> “ No     , no     ! ” said the Queen    . “ Sentence first   — verdict afterwards  . ”
-# . NPr/P+ . NPr/P+ . . V/J  D+  NPr/V/J+ . . NSg/V+   NSg/V/J . NSg+    R/Ca/Au/Br+ . .
+> “ No     , no     ! ” said the Queen    . “ Sentence first   — verdict afterwards . ”
+# . NPr/P+ . NPr/P+ . . V/J  D+  NPr/V/J+ . . NSg/V+   NSg/V/J . NSg+    R/Comm+    . .
 >
 #
 > “ Stuff and nonsense ! ” said Alice loudly . “ The idea of having the sentence
@@ -5941,7 +5941,7 @@
 > The long    grass rustled at    her     feet as    the White    Rabbit hurried by      — the frightened
 # D+  NPr/V/J NPr/V V/J     NSg/P ISg/D$+ NPl+ NSg/R D+  NPr/V/J+ NSg/V+ V/J     NSg/J/P . D+  V/J+
 > Mouse  splashed his     way    through the neighbouring pool   — she  could  hear the rattle
-# NSg/V+ V/J      ISg/D$+ NSg/J+ NSg/J/P D+  V/Ca/Au/Br+  NSg/V+ . ISg+ NSg/VX V    D   NSg/V
+# NSg/V+ V/J      ISg/D$+ NSg/J+ NSg/J/P D+  V/Comm+      NSg/V+ . ISg+ NSg/VX V    D   NSg/V
 > of the teacups as    the March  Hare    and his     friends shared their never - ending meal  ,
 # P  D   NPl     NSg/R D+  NPr/V+ NSg/V/J V/C ISg/D$+ NPl/V+  V/J    D$+   R     . NSg/V  NSg/V .
 > and the shrill  voice of the Queen    ordering off       her     unfortunate guests to
@@ -5970,8 +5970,8 @@
 # NSgPl+ . NPl/V . V/C D   NSg$    NSg/V/J NPl/V P  D   NSg/V P  D+  NPr/V+   NSg/V+ . V/C
 > the sneeze of the baby     , the shriek of the Gryphon , and all       the other    queer
 # D   NSg/V  P  D+  NSg/V/J+ . D   NSg/V  P  D   ?       . V/C NSg/I/J/C D+  NSg/V/J+ NSg/V/J+
-> noises , would  change ( she  knew ) to the confused clamour        of the busy
-# NPl/V+ . NSg/VX NSg/V+ . ISg+ V    . P  D   V/J      NSg/V/Ca/Au/Br P  D   NSg/V/J+
+> noises , would  change ( she  knew ) to the confused clamour    of the busy
+# NPl/V+ . NSg/VX NSg/V+ . ISg+ V    . P  D   V/J      NSg/V/Comm P  D   NSg/V/J+
 > farm   - yard  — while     the lowing of the cattle in      the distance would  take  the place of
 # NSg/V+ . NSg/V . NSg/V/C/P D   V      P  D   NSg/V  NPr/J/P D+  NSg/V+   NSg/VX NSg/V D   NSg/V P
 > the Mock    Turtle’s heavy    sobs   .

--- a/harper-core/tests/text/tagged/Computer science.md
+++ b/harper-core/tests/text/tagged/Computer science.md
@@ -405,7 +405,7 @@
 > Proponents of classifying computer science as    a   mathematical discipline argue
 # NPl        P  V           NSg/V+   NSg/V   NSg/R D/P J            NSg/V+     V
 > that         computer programs are physical realizations of mathematical entities and
-# NSg/I/C/Ddem NSg/V+   NPl/V+   V   NSg/J    NPl/Am/Ca    P  J            NPl      V/C
+# NSg/I/C/Ddem NSg/V+   NPl/V+   V   NSg/J    NPl/NoAm     P  J            NPl      V/C
 > programs that          can    be     deductively reasoned through mathematical formal methods .
 # NPl/V+   NSg/I/C/Ddem+ NPr/VX NSg/VX R           V/J      NSg/J/P J+           NSg/J+ NPl/V+  .
 > Computer scientists Edsger W. Dijkstra and Tony  Hoare regard instructions for
@@ -675,7 +675,7 @@
 > designs as    complete aircraft . Notable in      electrical and electronic circuit
 # NPl/V   NSg/R NSg/V/J+ NSgPl+   . NSg/J   NPr/J/P NSg/J      V/C J          NSg/V+
 > design are SPICE , as    well    as    software for physical realization of new     ( or
-# NSg/V+ V   NSg/V . NSg/R NSg/V/J NSg/R NSg      C/P NSg/J    NSg/Am/Ca   P  NSg/V/J . NPr/C
+# NSg/V+ V   NSg/V . NSg/R NSg/V/J NSg/R NSg      C/P NSg/J    NSg/NoAm    P  NSg/V/J . NPr/C
 > modified ) designs . The latter includes essential design software for integrated
 # NSg/V/J  . NPl/V+  . D   NSg/J  NPl/V    NSg/J     NSg/V+ NSg      C/P V/J+
 > circuits .

--- a/harper-core/tests/text/tagged/Difficult sentences.md
+++ b/harper-core/tests/text/tagged/Difficult sentences.md
@@ -108,8 +108,8 @@
 # D+  NSg/V/J+ V   NSg/V/J NSg/J/P D+  NSg/V+   .
 > The boat   was swamped by      the water  .
 # D+  NSg/V+ V   V/J     NSg/J/P D+  NSg/V+ .
-> He       was protected by      his     body   armour          .
-# NPr/ISg+ V   V/J       NSg/J/P ISg/D$+ NSg/V+ NPr/V/Ca/Au/Br+ .
+> He       was protected by      his     body   armour      .
+# NPr/ISg+ V   V/J       NSg/J/P ISg/D$+ NSg/V+ NPr/V/Comm+ .
 > There was a   call  by      the unions for a   30 % pay     rise   .
 # +     V   D/P NSg/V NSg/J/P D   NPl/V  C/P D/P #  . NSg/V/J NSg/V+ .
 > I    was aghast by      what   I    saw    .
@@ -412,8 +412,8 @@
 # NPr/J/P V         D   NSg    W?      . NPr/ISg+ NSg/V/J NPr/ISg+ V   NSg/V  ISg/D$+ NSg+         P  D+  NSg+        .
 > In      trying  to make  amends , she  actually made  matters worse    .
 # NPr/J/P NSg/V/J P  NSg/V NPl/V  . ISg+ R        NSg/V +       NSg/V/J+ .
-> My  aim    in      travelling       there was to find  my  missing friend   .
-# D$+ NSg/V+ NPr/J/P NSg/V/J/Ca/Au/Br +     V   P  NSg/V D$+ V       NPr/V/J+ .
+> My  aim    in      travelling   there was to find  my  missing friend   .
+# D$+ NSg/V+ NPr/J/P NSg/V/J/Comm +     V   P  NSg/V D$+ V       NPr/V/J+ .
 > My  fat      rolls around in      folds  .
 # D$+ NSg/V/J+ NPl/V J/P    NPr/J/P NPl/V+ .
 > The planes flew    over      in      waves  .
@@ -494,8 +494,8 @@
 # VL+ NSg . NPr/V NPr/J/P .
 > Little  by      little  I    pushed the snake into the basket , until finally all       of it       was in      .
 # NPr/I/J NSg/J/P NPr/I/J ISg+ V/J    D   NPr/V P    D+  NSg/V+ . C/P   R       NSg/I/J/C P  NPr/ISg+ V+  NPr/J/P .
-> The bullet is about five centimetres   in      .
-# D+  NSg/V+ VL J/P   NSg+ NPl/Ca/Au/Br+ NPr/J/P .
+> The bullet is about five centimetres in      .
+# D+  NSg/V+ VL J/P   NSg+ NPl/Comm+   NPr/J/P .
 > If    the tennis ball   bounces on  the line   then    it's in      .
 # NSg/C D+  NSg/V+ NPr/V+ NPl/V   J/P D+  NSg/V+ NSg/J/C W?   NPr/J/P .
 > I've discovered why   the TV   wasn't working – the plug   wasn't in      !
@@ -512,8 +512,8 @@
 # NPr/J/P NSg/J/P NSg/V+  . Unlintable NPr/J/P NSg/J/P NSg/V+   . Unlintable NPr/J/P P  D   ?      P  ISg/D$+ NSg/V+
 > He       is very in      with the Joneses .
 # NPr/ISg+ VL J/R  NPr/J/P P    D+  NPl/V+  .
-> I    need   to keep  in      with the neighbours      in      case   I    ever need   a   favour         from them     .
-# ISg+ NSg/VX P  NSg/V NPr/J/P P    D+  NPl/V/Ca/Au/Br+ NPr/J/P NPr/V+ ISg+ J    NSg/VX D/P NSg/V/Ca/Au/Br P    NSg/IPl+ .
+> I    need   to keep  in      with the neighbours  in      case   I    ever need   a   favour     from them     .
+# ISg+ NSg/VX P  NSg/V NPr/J/P P    D+  NPl/V/Comm+ NPr/J/P NPr/V+ ISg+ J    NSg/VX D/P NSg/V/Comm P    NSg/IPl+ .
 > I    think that          bird     fancies you    . You're in      there , mate  !
 # ISg+ NSg/V NSg/I/C/Ddem+ NPr/V/J+ NPl/V   ISgPl+ . W?     NPr/J/P W?    . NSg/V .
 > I'm three drinks in      right    now        .
@@ -564,8 +564,8 @@
 # W?  R      V        P  ISgPl+ .
 > He       told us       the story of his     journey to India .
 # NPr/ISg+ V    NPr/IPl+ D   NSg/V P  ISg/D$+ NSg/V+  P  NPr+  .
-> This    behaviour     is typical of teenagers .
-# I/Ddem+ NSg/Ca/Au/Br+ VL NSg/J   P  +         .
+> This    behaviour is typical of teenagers .
+# I/Ddem+ NSg/Comm+ VL NSg/J   P  +         .
 > He       is a   friend  of mine     .
 # NPr/ISg+ VL D/P NPr/V/J P  NSg/I/V+ .
 > We   want  a   larger slice   of the cake   .
@@ -728,8 +728,8 @@
 # D$+ NSg/V/J/Am+ NPl/V+ V   J/P NPr+ NPr+    .
 > I'll pay     on  card   .
 # W?   NSg/V/J J/P NSg/V+ .
-> He       travelled    on  false    documents .
-# NPr/ISg+ V/J/Ca/Au/Br J/P NSg/V/J+ NPl/V+    .
+> He       travelled on  false    documents .
+# NPr/ISg+ V/J/Comm  J/P NSg/V/J+ NPl/V+    .
 > They planned an  attack  on  London .
 # IPl+ V/J     D/P NSg/V/J J/P NPr+   .
 > The soldiers mutinied and turned their guns   on  their officers .

--- a/harper-core/tests/text/tagged/Spell.US.md
+++ b/harper-core/tests/text/tagged/Spell.US.md
@@ -19,59 +19,59 @@
 >
 #
 > Afterwards .
-# R/Ca/Au/Br .
+# R/Comm     .
 >
 #
-> Centre          .
-# NSg/V/Ca/Au/Br+ .
+> Centre      .
+# NSg/V/Comm+ .
 >
 #
-> Labelled      .
-# V/J/Ca/Au/Br+ .
+> Labelled  .
+# V/J/Comm+ .
 >
 #
-> Flavour         .
-# NSg/V/Ca/Au/Br+ .
+> Flavour     .
+# NSg/V/Comm+ .
 >
 #
-> Favoured      .
-# V/J/Ca/Au/Br+ .
+> Favoured  .
+# V/J/Comm+ .
 >
 #
-> Honour          .
-# NSg/V/Ca/Au/Br+ .
+> Honour      .
+# NSg/V/Comm+ .
 >
 #
-> Grey              .
-# NPr/V/J/Ca/Au/Br+ .
+> Grey          .
+# NPr/V/J/Comm+ .
 >
 #
-> Quarrelled  .
-# V/Ca/Au/Br+ .
+> Quarrelled .
+# V/Comm+    .
 >
 #
-> Quarrelling     .
-# NSg/V/Ca/Au/Br+ .
+> Quarrelling .
+# NSg/V/Comm+ .
 >
 #
 > Recognised .
 # V/J/Au/Br+ .
 >
 #
-> Neighbour         .
-# NSg/V/J/Ca/Au/Br+ .
+> Neighbour     .
+# NSg/V/J/Comm+ .
 >
 #
 > Neighbouring .
-# V/Ca/Au/Br+  .
+# V/Comm+      .
 >
 #
-> Clamour         .
-# NSg/V/Ca/Au/Br+ .
+> Clamour     .
+# NSg/V/Comm+ .
 >
 #
-> Theatre       .
-# NSg/Ca/Au/Br+ .
+> Theatre   .
+# NSg/Comm+ .
 >
 #
 > Analyse .

--- a/harper-core/tests/text/tagged/Spell.md
+++ b/harper-core/tests/text/tagged/Spell.md
@@ -10,17 +10,17 @@
 # NSg/V+  NPl/V
 >
 #
-> My  favourite        color      is  blu .
-# D$+ NSg/V/J/Ca/Au/Br NSg/V/J/Am VL+ W?  .
-> I    must  defend my  honour          !
-# ISg+ NSg/V NSg/V  D$+ NSg/V/Ca/Au/Br+ .
+> My  favourite    color      is  blu .
+# D$+ NSg/V/J/Comm NSg/V/J/Am VL+ W?  .
+> I    must  defend my  honour      !
+# ISg+ NSg/V NSg/V  D$+ NSg/V/Comm+ .
 > I    recognize that         you    recognise me       .
 # ISg+ V         NSg/I/C/Ddem ISgPl+ V/Au/Br   NPr/ISg+ .
 > I    analyze how   you    infantilize me       .
 # ISg+ V       NSg/C ISgPl+ V           NPr/ISg+ .
 > I    analyse how   you    infantilise me       .
 # ISg+ V/Au/Br NSg/C ISgPl+ ?           NPr/ISg+ .
-> Careful , traveller     !
-# J       . NSg/Ca/Au/Br+ .
-> At    the centre         of the theatre       I    dropped a   litre        of coke   .
-# NSg/P D   NSg/V/Ca/Au/Br P  D+  NSg/Ca/Au/Br+ ISg+ V/J     D/P NSg/Ca/Au/Br P  NPr/V+ .
+> Careful , traveller !
+# J       . NSg/Comm+ .
+> At    the centre     of the theatre   I    dropped a   litre    of coke   .
+# NSg/P D   NSg/V/Comm P  D+  NSg/Comm+ ISg+ V/J     D/P NSg/Comm P  NPr/V+ .

--- a/harper-core/tests/text/tagged/The Constitution of the United States.md
+++ b/harper-core/tests/text/tagged/The Constitution of the United States.md
@@ -6,8 +6,8 @@
 #
 > We   the People of the United States   , in      Order  to form  a   more      perfect  Union   ,
 # IPl+ D   NSg/V  P  D+  V/J+   NPrPl/V+ . NPr/J/P NSg/V+ P  NSg/V D/P NPr/I/V/J NSg/V/J+ NPr/V/J .
-> establish Justice , insure domestic Tranquility , provide for the common   defence       ,
-# V         NPr+    . V      NSg/J+   NSg         . V       C/P D+  NSg/V/J+ NSg/Ca/Au/Br+ .
+> establish Justice , insure domestic Tranquility , provide for the common   defence   ,
+# V         NPr+    . V      NSg/J+   NSg         . V       C/P D+  NSg/V/J+ NSg/Comm+ .
 > promote the general  Welfare , and secure the Blessings of Liberty to ourselves
 # NSg/V   D+  NSg/V/J+ NSg/V+  . V/C V/J    D   W?        P  NSg+    P  IPl+
 > and our Posterity , do     ordain and establish this    Constitution for the United
@@ -237,7 +237,7 @@
 > thereof ; but     the Congress may    at    any   time    by      Law    make  or    alter such
 # W?      . NSg/C/P D+  NPr/V+   NPr/VX NSg/P I/R/D NSg/V/J NSg/J/P NSg/V+ NSg/V NPr/C NSg/V NSg/I+
 > Regulations , except as    to the Places of chusing Senators .
-# NSg+        . V/C/P  NSg/R P  D   NPl/V  P  ?       NPl+     .
+# NPl+        . V/C/P  NSg/R P  D   NPl/V  P  ?       NPl+     .
 >
 #
 > The Congress shall assemble at    least once  in      every year , and such  meeting shall
@@ -266,8 +266,8 @@
 #
 > Each House may    determine the Rules of its     Proceedings , punish its     Members for
 # D+   NPr/V NPr/VX V         D   NPl/V P  ISg/D$+ +           . V      ISg/D$+ NPl/V   C/P
-> disorderly Behaviour     , and , with the Concurrence of two  thirds , expel a   Member .
-# R+         NSg/Ca/Au/Br+ . V/C . P    D   NSg         P  NSg+ NPl/V+ . V     D/P NSg/V+ .
+> disorderly Behaviour , and , with the Concurrence of two  thirds , expel a   Member .
+# R+         NSg/Comm+ . V/C . P    D   NSg         P  NSg+ NPl/V+ . V     D/P NSg/V+ .
 >
 #
 > Each House shall keep  a   Journal of its     Proceedings , and from time     to time
@@ -381,7 +381,7 @@
 > be     repassed by      two thirds of the Senate and House of Representatives , according
 # NSg/VX ?        NSg/J/P NSg NPl/V  P  D+  NPr    V/C NPr/V P  NPl+            . V/J
 > to the Rules and Limitations prescribed in      the Case  of a    Bill   .
-# P  D   NPl/V V/C NSg+        V/J        NPr/J/P D   NPr/V P  D/P+ NPr/V+ .
+# P  D   NPl/V V/C NPl+        V/J        NPr/J/P D   NPr/V P  D/P+ NPr/V+ .
 >
 #
 > Section . 8 .
@@ -390,8 +390,8 @@
 #
 > The Congress shall have   Power    To lay     and collect Taxes , Duties ,
 # D+  NPr/V+   VX    NSg/VX NSg/V/J+ P  NSg/V/J V/C NSg/V/J NPl/V . NPl    .
-> Imposts and Excises , to pay     the Debts and provide for the common   Defence       and
-# NPl     V/C NPl/V   . P  NSg/V/J D+  NPl+  V/C V       C/P D+  NSg/V/J+ NSg/Ca/Au/Br+ V/C
+> Imposts and Excises , to pay     the Debts and provide for the common   Defence   and
+# NPl     V/C NPl/V   . P  NSg/V/J D+  NPl+  V/C V       C/P D+  NSg/V/J+ NSg/Comm+ V/C
 > general Welfare of the United States   ; but     all        Duties , Imposts and Excises shall
 # NSg/V/J NSg/V   P  D+  V/J+   NPrPl/V+ . NSg/C/P NSg/I/J/C+ NPl    . NPl     V/C NPl/V   VX
 > be     uniform throughout the United States  ;
@@ -480,8 +480,8 @@
 #
 > To define  and punish Piracies and Felonies committed on  the high     Seas , and
 # P  NSg/V/J V/C V      ?        V/C NPl      V/J       J/P D+  NSg/V/J+ NPl+ . V/C
-> Offences     against the Law   of Nations ;
-# NPl/Ca/Au/Br C/P     D   NSg/V P  NPl+    .
+> Offences against the Law   of Nations ;
+# NPl/Comm C/P     D   NSg/V P  NPl+    .
 >
 #
 >
@@ -1012,8 +1012,8 @@
 # NSg/V   . P  D   NSg/J     NSg/V/J NPr/J/P D    P  D+  NSg/J+    NPl+        . P
 > any   Subject  relating to the Duties of their respective Offices , and he       shall
 # I/R/D NSg/V/J+ V        P  D   NPl    P  D$+   J+         NPl/V+  . V/C NPr/ISg+ VX
-> have   Power    to grant Reprieves and Pardons for Offences     against the United
-# NSg/VX NSg/V/J+ P  NPr/V NPl/V     V/C NPl/V   C/P NPl/Ca/Au/Br C/P     D+  V/J+
+> have   Power    to grant Reprieves and Pardons for Offences against the United
+# NSg/VX NSg/V/J+ P  NPr/V NPl/V     V/C NPl/V   C/P NPl/Comm C/P     D+  V/J+
 > States   , except in      Cases of Impeachment .
 # NPrPl/V+ . V/C/P  NPr/J/P NPl/V P  NSg         .
 >
@@ -1102,8 +1102,8 @@
 # NSg/I/V/J NSg/V/J+ NSg/V/J+ . V/C NPr/J/P NSg/I NSg/J    NPl/V+ NSg/R D+  NPr/V+   NPr/VX P    NSg/V/J+ P
 > time    ordain and  establish . The Judges   , both of the supreme and inferior Courts ,
 # NSg/V/J V      V/C+ V+        . D+  NPrPl/V+ . I/C  P  D   NSg/V/J V/C NSg/J+   NPl/V+ .
-> shall hold    their Offices during good     Behaviour     , and shall , at    stated Times  ,
-# VX    NSg/V/J D$+   NPl/V+  V/P    NPr/V/J+ NSg/Ca/Au/Br+ . V/C VX    . NSg/P V/J    NPl/V+ .
+> shall hold    their Offices during good     Behaviour , and shall , at    stated Times  ,
+# VX    NSg/V/J D$+   NPl/V+  V/P    NPr/V/J+ NSg/Comm+ . V/C VX    . NSg/P V/J    NPl/V+ .
 > receive for their Services , a    Compensation , which shall not   be     diminished
 # NSg/V   C/P D$+   NPl/V+   . D/P+ NSg+         . I/C+  VX    NSg/C NSg/VX V/J
 > during their Continuance in      Office .
@@ -1141,7 +1141,7 @@
 > have   appellate Jurisdiction , both as    to Law   and Fact , with such   Exceptions , and
 # NSg/VX J         NSg+         . I/C  NSg/R P  NSg/V V/C NSg+ . P    NSg/I+ NPl+       . V/C
 > under   such  Regulations as    the Congress shall make  .
-# NSg/J/P NSg/I NSg+        NSg/R D+  NPr/V+   VX+   NSg/V .
+# NSg/J/P NSg/I NPl+        NSg/R D+  NPr/V+   VX+   NSg/V .
 >
 #
 > The Trial   of all        Crimes , except in      Cases of Impeachment , shall be     by      Jury     ; and
@@ -1304,14 +1304,14 @@
 # C       D+  NSg/V/J+ VX    NSg/VX NSg/V W?   V/J       . VX    V     NSg/J/P D+  V/J+
 > States   , or    any   place  subject to their jurisdiction . No     Person held to Service
 # NPrPl/V+ . NPr/C I/R/D NSg/V+ NSg/V/J P  D$+   NSg+         . NPr/P+ NSg/V+ V    P  NSg/V
-> or    Labour          in      one        State  , under   the Laws   thereof , escaping into another , shall ,
-# NPr/C NPr/V/Ca/Au/Br+ NPr/J/P NSg/I/V/J+ NSg/V+ . NSg/J/P D+  NPl/V+ W?      . V        P    I/D     . VX    .
+> or    Labour      in      one        State  , under   the Laws   thereof , escaping into another , shall ,
+# NPr/C NPr/V/Comm+ NPr/J/P NSg/I/V/J+ NSg/V+ . NSg/J/P D+  NPl/V+ W?      . V        P    I/D     . VX    .
 > in      Consequence of any   Law   or    Regulation therein , be     discharged from such
 # NPr/J/P NSg/V       P  I/R/D NSg/V NPr/C NSg/J+     W?      . NSg/VX V/J        P    NSg/I
-> Service or    Labour          , but     shall be     delivered up        on  Claim of the Party    to whom such
-# NSg/V   NPr/C NPr/V/Ca/Au/Br+ . NSg/C/P VX    NSg/VX V/J       NSg/V/J/P J/P NSg/V P  D+  NSg/V/J+ P  I+   NSg/I
-> Service or    Labour          may     be      due   .
-# NSg/V   NPr/C NPr/V/Ca/Au/Br+ NPr/VX+ NSg/VX+ NSg/J .
+> Service or    Labour      , but     shall be     delivered up        on  Claim of the Party    to whom such
+# NSg/V   NPr/C NPr/V/Comm+ . NSg/C/P VX    NSg/VX V/J       NSg/V/J/P J/P NSg/V P  D+  NSg/V/J+ P  I+   NSg/I
+> Service or    Labour      may     be      due   .
+# NSg/V   NPr/C NPr/V/Comm+ NPr/VX+ NSg/VX+ NSg/J .
 >
 #
 > Section . 3 .
@@ -1333,7 +1333,7 @@
 > The Congress shall have   Power    to dispose of and make  all       needful Rules and
 # D+  NPr/V+   VX    NSg/VX NSg/V/J+ P  NSg/V   P  V/C NSg/V NSg/I/J/C NSg/J   NPl/V V/C
 > Regulations respecting the Territory or    other    Property belonging to the United
-# NSg+        V          D+  NSg       NPr/C NSg/V/J+ NSg/V+   NSg/V     P  D+  V/J+
+# NPl+        V          D+  NSg       NPr/C NSg/V/J+ NSg/V+   NSg/V     P  D+  V/J+
 > States   ; and nothing in      this    Constitution shall be     so        construed as    to Prejudice
 # NPrPl/V+ . V/C NSg/I/J NPr/J/P I/Ddem+ NPr+         VX    NSg/VX NSg/I/J/C V/J       NSg/R P  NSg/V/J+
 > any   Claims of the United States   , or    of any    particular State  .

--- a/harper-core/tests/text/tagged/The Great Gatsby.md
+++ b/harper-core/tests/text/tagged/The Great Gatsby.md
@@ -38,8 +38,8 @@
 # R        V/J     P  NSg/V/C D/P NSg        . C/P     ISg+ V   NSg/J P  D   NSg/V/J NPl/V
 > of wild    , unknown  men  . Most    of the confidences were  unsought — frequently I    have
 # P  NSg/V/J . NSg/V/J+ NSg+ . NSg/I/J P  D   NPl         NSg/V V        . R          ISg+ NSg/VX
-> feigned sleep  , preoccupation , or    a   hostile levity when    I    realized  by      some
-# V/J     NSg/V+ . NSg           . NPr/C D/P NSg/J   NSg    NSg/I/C ISg+ V/J/Am/Ca NSg/J/P I/J/R+
+> feigned sleep  , preoccupation , or    a   hostile levity when    I    realized by      some
+# V/J     NSg/V+ . NSg           . NPr/C D/P NSg/J   NSg    NSg/I/C ISg+ V/J/NoAm NSg/J/P I/J/R+
 > unmistakable sign   that         an   intimate revelation was quivering on  the horizon ; for
 # J+           NSg/V+ NSg/I/C/Ddem D/P+ NSg/V/J+ NPr        V   V         J/P D+  NSg+    . C/P
 > the intimate revelations of young    men  , or    at    least the terms  in      which they
@@ -50,8 +50,8 @@
 # V         NPl+      VL D/P NSg/V/J P  NSg/J+   NPr/V+ . ISg+ NPr/V/J NSg/V/J D/P NPr/I/J J      P
 > missing something  if    I    forget that          , as    my  father snobbishly suggested , and I
 # V       NSg/I/V/J+ NSg/C ISg+ V      NSg/I/C/Ddem+ . NSg/R D$+ NPr/V+ R          V/J       . V/C ISg+
-> snobbishly repeat , a   sense of the fundamental decencies is parcelled  out
-# R          NSg/V  . D/P NSg/V P  D   NSg/J       NPl       VL V/Ca/Au/Br NSg/V/J/R/P
+> snobbishly repeat , a   sense of the fundamental decencies is parcelled out
+# R          NSg/V  . D/P NSg/V P  D   NSg/J       NPl       VL V/Comm    NSg/V/J/R/P
 > unequally at    birth    .
 # R         NSg/P NSg/V/J+ .
 >
@@ -118,8 +118,8 @@
 # V/C D/P NPr/I/J J     ISg+ V/J          NPr/J/P NSg/I/C/Ddem+ V/J     NSg/J    NSg+      NSg/V/J NSg/R
 > the Great  War    . I    enjoyed the counter  - raid  so        thoroughly that         I    came    back
 # D+  NSg/J+ NSg/V+ . ISg+ V/J     D   NSg/V/J+ . NSg/V NSg/I/J/C R          NSg/I/C/Ddem ISg+ NSg/V/P NSg/V/J
-> restless . Instead of being   the warm    centre         of the world  , the Middle   West     now
-# J+       . W?      P  NSg/V/C D   NSg/V/J NSg/V/Ca/Au/Br P  D+  NSg/V+ . D+  NSg/V/J+ NPr/V/J+ NPr/V/J/C
+> restless . Instead of being   the warm    centre     of the world  , the Middle   West     now
+# J+       . W?      P  NSg/V/C D   NSg/V/J NSg/V/Comm P  D+  NSg/V+ . D+  NSg/V/J+ NPr/V/J+ NPr/V/J/C
 > seemed like        the ragged edge  of the universe — so        I    decided to go      East   and learn
 # V/J    NSg/V/J/C/P D   V/J    NSg/V P  D+  NPr+     . NSg/I/J/C ISg+ NSg/V/J P  NSg/V/J NPr/J+ V/C NSg/V
 > the bond     business . Everybody I    knew was in      the bond     business , so        I    supposed it
@@ -281,7 +281,7 @@
 > for instance , he’d brought down      a   string of polo ponies from Lake   Forest . It       was
 # C/P NSg/V+   . W?   V       NSg/V/J/P D/P NSg/V  P  NPr+ NPl/V  P    NSg/V+ NPr/V+ . NPr/ISg+ V
 > hard    to realize that         a   man     in      my  own      generation was wealthy enough to do     that         .
-# NSg/V/J P  V/Am/Ca NSg/I/C/Ddem D/P NPr/V/J NPr/J/P D$+ NSg/V/J+ NSg+       V   NSg/J   NSg/I  P  NSg/VX NSg/I/C/Ddem .
+# NSg/V/J P  V/NoAm  NSg/I/C/Ddem D/P NPr/V/J NPr/J/P D$+ NSg/V/J+ NSg+       V   NSg/J   NSg/I  P  NSg/VX NSg/I/C/Ddem .
 >
 #
 > Why   they came    East   I    don’t know  . They had spent a   year in      France for no
@@ -972,8 +972,8 @@
 # D/P NSg/V P      D/P R         NSg/J    NSg/V . NSg/V/C/P . NSg/V/J P  NSg/V R
 > interested and a    little   deaf    , I    followed Daisy around a   chain of connecting
 # V/J        V/C D/P+ NPr/I/J+ NSg/V/J . ISg+ V/J      NPr+  J/P    D/P NSg/V P  V
-> verandas     to the porch in      front    . In      its     deep  gloom we   sat     down      side    by      side     on  a
-# NPl/Am/Ca/Br P  D+  NSg+  NPr/J/P NSg/V/J+ . NPr/J/P ISg/D$+ NSg/J NSg/V IPl+ NSg/V/J NSg/V/J/P NSg/V/J NSg/J/P NSg/V/J+ J/P D/P
+> verandas    to the porch in      front    . In      its     deep  gloom we   sat     down      side    by      side     on  a
+# NPl/NoAm/Br P  D+  NSg+  NPr/J/P NSg/V/J+ . NPr/J/P ISg/D$+ NSg/J NSg/V IPl+ NSg/V/J NSg/V/J/P NSg/V/J NSg/J/P NSg/V/J+ J/P D/P
 > wicker settee .
 # NSg/J+ NSg+   .
 >
@@ -1180,8 +1180,8 @@
 # NPr/V/J . . . .
 >
 #
-> “ Did you    give  Nick   a   little  heart to heart talk  on  the veranda       ? ” demanded Tom
-# . V   ISgPl+ NSg/V NPr/V+ D/P NPr/I/J NSg/V P  NSg/V NSg/V J/P D+  NSg/Am/Ca/Br+ . . V/J      NPr/V+
+> “ Did you    give  Nick   a   little  heart to heart talk  on  the veranda      ? ” demanded Tom
+# . V   ISgPl+ NSg/V NPr/V+ D/P NPr/I/J NSg/V P  NSg/V NSg/V J/P D+  NSg/NoAm/Br+ . . V/J      NPr/V+
 > suddenly .
 # R+       .
 >
@@ -1459,7 +1459,7 @@
 > beauty   , but     there was an  immediately perceptible vitality about her     as    if    the
 # NSg/V/J+ . NSg/C/P +     V   D/P R           NSg/J       NSg      J/P   ISg/D$+ NSg/R NSg/C D
 > nerves of her     body   were  continually smouldering . She  smiled slowly and , walking
-# NPl/V  P  ISg/D$+ NSg/V+ NSg/V R+          V/Ca/Au/Br  . ISg+ V/J    R      V/C . NSg/V/J
+# NPl/V  P  ISg/D$+ NSg/V+ NSg/V R+          V/Comm      . ISg+ V/J    R      V/C . NSg/V/J
 > through her     husband as    if    he       were  a   ghost   , shook   hands  with Tom    , looking him
 # NSg/J/P ISg/D$+ NSg/V+  NSg/R NSg/C NPr/ISg+ NSg/V D/P NSg/V/J . NSg/V/J NPl/V+ P    NPr/V+ . V       ISg+
 > flush    in      the eye    . Then    she  wet     her     lips   , and without turning around spoke to her
@@ -1844,8 +1844,8 @@
 #
 > “ I    should change the light    , ” he       said after a    moment . “ I’d like        to bring out         the
 # . ISg+ VX     NSg/V  D+  NSg/V/J+ . . NPr/ISg+ V/J  J/P   D/P+ NSg+   . . W?  NSg/V/J/C/P P  V     NSg/V/J/R/P D
-> modelling      of the features . And I’d try     to get   hold    of all       the back     hair   . ”
-# NSg/V/Ca/Au/Br P  D+  NPl/V+   . V/C W?  NSg/V/J P  NSg/V NSg/V/J P  NSg/I/J/C D+  NSg/V/J+ NSg/V+ . .
+> modelling  of the features . And I’d try     to get   hold    of all       the back     hair   . ”
+# NSg/V/Comm P  D+  NPl/V+   . V/C W?  NSg/V/J P  NSg/V NSg/V/J P  NSg/I/J/C D+  NSg/V/J+ NSg/V+ . .
 >
 #
 > “ I    wouldn’t think of changing the light    , ” cried Mrs  . McKee . “ I    think it’s — — — ”
@@ -2376,8 +2376,8 @@
 # NPl      . V/C NSg/V/J V/C NSg/V/J+ NPl/V+ . D   NSg/V/J NPl      NSg/VX NSg/V/P NPr/J/P P    D+  NPr/V+
 > now       and are dressing up        - stairs ; the cars from New      York are parked five deep  in
 # NPr/V/J/C V/C V   NSg/V    NSg/V/J/P . NPl    . D+  NPl+ P    NSg/V/J+ NPr+ V   V/J    NSg  NSg/J NPr/J/P
-> the drive  , and already the halls and salons and verandas     are gaudy with primary
-# D+  NSg/V+ . V/C W?      D   NPl   V/C NPl+   V/C NPl/Am/Ca/Br V   NSg/J P    NSg/V/J+
+> the drive  , and already the halls and salons and verandas    are gaudy with primary
+# D+  NSg/V+ . V/C W?      D   NPl   V/C NPl+   V/C NPl/NoAm/Br V   NSg/J P    NSg/V/J+
 > colors    , and hair   bobbed in      strange new      ways , and shawls beyond the dreams of
 # NPl/V/Am+ . V/C NSg/V+ V/J    NPr/J/P NSg/V/J NSg/V/J+ NPl+ . V/C NPl/V  NSg/P  D   NPl/V  P+
 > Castile . The bar      is in      full    swing , and floating rounds of cocktails permeate the
@@ -2402,8 +2402,8 @@
 # NPl      . NSg/V    V/C NSg/V+ NPr/J/P D+  I/J+ NSg/V/J+ . W?      +     V   W?        .
 > confident girls who    weave here    and there among the stouter and more      stable  ,
 # NSg/J     NPl/V NPr/I+ NSg/V NSg/J/R V/C W?    P     D   J       V/C NPr/I/V/J NSg/V/J .
-> become for a   sharp   , joyous moment the centre         of a    group  , and then    , excited with
-# V      C/P D/P NPr/V/J . J      NSg+   D   NSg/V/Ca/Au/Br P  D/P+ NSg/V+ . V/C NSg/J/C . V/J     P
+> become for a   sharp   , joyous moment the centre     of a    group  , and then    , excited with
+# V      C/P D/P NPr/V/J . J      NSg+   D   NSg/V/Comm P  D/P+ NSg/V+ . V/C NSg/J/C . V/J     P
 > triumph , glide on  through the sea  - change of faces and voices and color       under   the
 # NSg/V+  . NSg/V J/P NSg/J/P D   NSg+ . NSg/V  P  NPl/V V/C NPl/V  V/C NSg/V/J/Am+ NSg/J/P D
 > constantly changing light   .
@@ -2688,12 +2688,12 @@
 #
 > The bar     , where we   glanced first   , was crowded , but     Gatsby was not    there . She
 # D+  NSg/V/P . NSg/C IPl+ V/J     NSg/V/J . V   V/J     . NSg/C/P NPr    V   NSg/C+ W?    . ISg+
-> couldn’t find  him  from the top     of the steps  , and he       wasn’t on  the veranda       . On  a
-# V        NSg/V ISg+ P    D   NSg/V/J P  D+  NPl/V+ . V/C NPr/ISg+ V      J/P D+  NSg/Am/Ca/Br+ . J/P D/P+
+> couldn’t find  him  from the top     of the steps  , and he       wasn’t on  the veranda      . On  a
+# V        NSg/V ISg+ P    D   NSg/V/J P  D+  NPl/V+ . V/C NPr/ISg+ V      J/P D+  NSg/NoAm/Br+ . J/P D/P+
 > chance   we   tried an  important - looking door  , and walked into a   high    Gothic
 # NPr/V/J+ IPl+ V/J   D/P J         . V       NSg/V . V/C V/J    P    D/P NSg/V/J NPr/J+
-> library , panelled     with carved English  oak      , and probably transported complete
-# NSg+    . V/J/Ca/Au/Br P    V/J    NPr/V/J+ NSg/V/J+ . V/C R        V/J         NSg/V/J
+> library , panelled with carved English  oak      , and probably transported complete
+# NSg+    . V/J/Comm P    V/J    NPr/V/J+ NSg/V/J+ . V/C R        V/J         NSg/V/J
 > from some   ruin   overseas .
 # P    I/J/R+ NSg/V+ W?       .
 >
@@ -3526,8 +3526,8 @@
 #
 > Again at    eight o’clock , when    the dark    lanes of the Forties were  lined five deep
 # P     NSg/P NSg/J W?      . NSg/I/C D   NSg/V/J NPl   P  D+  NPl+    NSg/V V/J   NSg  NSg/J
-> with throbbing taxicabs , bound   for the theatre       district , I    felt    a   sinking in      my
-# P    NSg/V/J   NPl/V    . NSg/V/J C/P D+  NSg/Ca/Au/Br+ NSg/V/J+ . ISg+ NSg/V/J D/P V       NPr/J/P D$+
+> with throbbing taxicabs , bound   for the theatre   district , I    felt    a   sinking in      my
+# P    NSg/V/J   NPl/V    . NSg/V/J C/P D+  NSg/Comm+ NSg/V/J+ . ISg+ NSg/V/J D/P V       NPr/J/P D$+
 > heart  . Forms  leaned together in      the taxis  as    they waited , and voices sang  , and
 # NSg/V+ . NPl/V+ V/J    J        NPr/J/P D+  NPl/V+ NSg/R IPl+ V/J    . V/C NPl/V+ NPr/V . V/C
 > there was laughter from unheard jokes  , and lighted cigarettes made
@@ -4018,8 +4018,8 @@
 # . NSg/V NPr/ISg . .
 >
 #
-> “ Major   Jay Gatsby , ” I    read  , “ For Valour        Extraordinary . ”
-# . NPr/V/J NPr NPr    . . ISg+ NSg/V . . C/P NSg/Ca/Au/Br+ NSg/J+        . .
+> “ Major   Jay Gatsby , ” I    read  , “ For Valour    Extraordinary . ”
+# . NPr/V/J NPr NPr    . . ISg+ NSg/V . . C/P NSg/Comm+ NSg/J+        . .
 >
 #
 > “ Here’s another thing  I    always carry . A   souvenir of Oxford days . It       was taken in
@@ -4150,8 +4150,8 @@
 # V/J    NSg/V/J/R/P NSg/P NPr/IPl P    D+  NSg/J+ NPl/V+ V/C NPr/V/J/P NSg/J NPl/V P  J+
 > Europe , and I    was glad    that         the sight of Gatsby’s splendid car  was included in
 # NPr+   . V/C ISg+ V   NSg/V/J NSg/I/C/Ddem D   NSg/V P  NSg$     J        NSg+ V   V/J      NPr/J/P
-> their sombre           holiday . As    we   crossed Blackwell’s Island a   limousine passed us       ,
-# D$+   NSg/V/J/Ca/Au/Br NPr/V+  . NSg/R IPl+ V/J     NSg$        NSg/V+ D/P NSg       V/J    NPr/IPl+ .
+> their sombre       holiday . As    we   crossed Blackwell’s Island a   limousine passed us       ,
+# D$+   NSg/V/J/Comm NPr/V+  . NSg/R IPl+ V/J     NSg$        NSg/V+ D/P NSg       V/J    NPr/IPl+ .
 > driven by      a   white    chauffeur , in      which sat     three modish negroes , two bucks and a
 # V/J    NSg/J/P D/P NPr/V/J+ NSg/V     . NPr/J/P I/C+  NSg/V/J NSg   J      NSg     . NSg NPl/V V/C D/P+
 > girl   . I    laughed aloud as    the yolks of their eyeballs rolled toward us       in      haughty
@@ -4631,7 +4631,7 @@
 > eyes   on  him  again for over      four years — even    after I'd met him  on  Long     Island I
 # NPl/V+ J/P ISg+ P     C/P NSg/V/J/P NSg  NPl+  . NSg/V/J J/P   W?  V   ISg+ J/P NPr/V/J+ NSg/V+ ISg+
 > didn’t realize it       was the same man     .
-# V      V/Am/Ca NPr/ISg+ V   D   I/J+ NPr/V/J .
+# V      V/NoAm  NPr/ISg+ V   D   I/J+ NPr/V/J .
 >
 #
 > That          was nineteen - seventeen . By      the next     year I    had a   few   beaux myself , and I
@@ -5091,7 +5091,7 @@
 >
 #
 > I    realize now       that         under   different circumstances that          conversation might    have
-# ISg+ V/Am/Ca NPr/V/J/C NSg/I/C/Ddem NSg/J/P NSg/J+    NPl/V+        NSg/I/C/Ddem+ NSg/V+       NSg/VX/J NSg/VX
+# ISg+ V/NoAm  NPr/V/J/C NSg/I/C/Ddem NSg/J/P NSg/J+    NPl/V+        NSg/I/C/Ddem+ NSg/V+       NSg/VX/J NSg/VX
 > been  one       of the crises of my  life   . But     , because the offer    was obviously and
 # NSg/V NSg/I/V/J P  D   NSg    P  D$+ NSg/V+ . NSg/C/P . C/P     D+  NSg/V/J+ V   R         V/C
 > tactlessly for a   service to be     rendered , I    had no    choice except to cut     him off
@@ -5544,8 +5544,8 @@
 # . W?   V/J+    V       . .
 >
 #
-> “ Has it       ? ” When    he       realized  what   I    was talking about , that         there were
-# . V   NPr/ISg+ . . NSg/I/C NPr/ISg+ V/J/Am/Ca NSg/I+ ISg+ V   V       J/P   . NSg/I/C/Ddem +     NSg/V
+> “ Has it       ? ” When    he       realized what   I    was talking about , that         there were
+# . V   NPr/ISg+ . . NSg/I/C NPr/ISg+ V/J/NoAm NSg/I+ ISg+ V   V       J/P   . NSg/I/C/Ddem +     NSg/V
 > twinkle - bells of sunshine in      the room     , he       smiled like        a    weather  man      , like        an
 # NSg/V   . NPl/V P  NSg/J+   NPr/J/P D+  NSg/V/J+ . NPr/ISg+ V/J    NSg/V/J/C/P D/P+ NSg/V/J+ NPr/V/J+ . NSg/V/J/C/P D/P
 > ecstatic patron of recurrent light    , and repeated the news   to Daisy . “ What   do     you
@@ -5608,8 +5608,8 @@
 #
 > I    think he      hardly knew what   he       was saying , for when    I    asked him  what   business he
 # ISg+ NSg/V NPr/ISg R      V    NSg/I+ NPr/ISg+ V   NSg/V  . C/P NSg/I/C ISg+ V/J   ISg+ NSg/I+ NSg/J+   NPr/ISg+
-> was in      he      answered : ‘          ‘          That’s my  affair , ” before he       realized  that         it       wasn’t an
-# V   NPr/J/P NPr/ISg V/J      . Unlintable Unlintable NSg$   D$+ NSg+   . . C/P    NPr/ISg+ V/J/Am/Ca NSg/I/C/Ddem NPr/ISg+ V      D/P+
+> was in      he      answered : ‘          ‘          That’s my  affair , ” before he       realized that         it       wasn’t an
+# V   NPr/J/P NPr/ISg V/J      . Unlintable Unlintable NSg$   D$+ NSg+   . . C/P    NPr/ISg+ V/J/NoAm NSg/I/C/Ddem NPr/ISg+ V      D/P+
 > appropriate reply .
 # V/J+        NSg/V .
 >
@@ -5680,8 +5680,8 @@
 # IPl+ NSg/V NSg/V/J/P . NPl    . NSg/J/P NSg/V/J+ NPl+     J/Am    NPr/J/P NPr/V/J V/C NSg/V/J  NSg/V+ V/C
 > vivid with new      flowers  , through dressing - rooms and poolrooms , and bathrooms with
 # NSg/J P    NSg/V/J+ NPrPl/V+ . NSg/J/P NSg/V+   . NPl/V V/C NPl       . V/C NPl/V+    P
-> sunken baths  — intruding into one       chamber where a   dishevelled  man     in      pajamas was
-# W?     NSg/V+ . V         P    NSg/I/V/J NSg/V+  NSg/C D/P V/J/Ca/Au/Br NPr/V/J NPr/J/P NPl     V
+> sunken baths  — intruding into one       chamber where a   dishevelled man     in      pajamas was
+# W?     NSg/V+ . V         P    NSg/I/V/J NSg/V+  NSg/C D/P V/J/Comm    NPr/V/J NPr/J/P NPl     V
 > doing liver  exercises on  the floor  . It       was Mr   . Klipspringer , the ‘          ‘          boarder . ” I
 # NSg/V NSg/J+ NPl/V     J/P D+  NSg/V+ . NPr/ISg+ V   NSg+ . ?            . D   Unlintable Unlintable NSg/J+  . . ISg+
 > had seen  him  wandering hungrily about the beach  that          morning . Finally we   came    to
@@ -6267,7 +6267,7 @@
 > He       was profoundly affected by      the fact that          Tom    was there . But     he       would  be
 # NPr/ISg+ V   R          NSg/V/J  NSg/J/P D+  NSg+ NSg/I/C/Ddem+ NPr/V+ V+  W?    . NSg/C/P NPr/ISg+ NSg/VX NSg/VX
 > uneasy  anyhow until he       had given     them     something , realizing in      a   vague    way    that
-# NSg/V/J J      C/P   NPr/ISg+ V   NSg/V/J/P NSg/IPl+ NSg/I/V/J . V/Am/Ca   NPr/J/P D/P NSg/V/J+ NSg/J+ NSg/I/C/Ddem+
+# NSg/V/J J      C/P   NPr/ISg+ V   NSg/V/J/P NSg/IPl+ NSg/I/V/J . V/NoAm    NPr/J/P D/P NSg/V/J+ NSg/J+ NSg/I/C/Ddem+
 > that          was all       they came     for . Mr   . Sloane wanted nothing  . A    lemonade ? No     , thanks . A
 # NSg/I/C/Ddem+ V   NSg/I/J/C IPl+ NSg/V/P+ C/P . NSg+ . NPr    V/J+   NSg/I/J+ . D/P+ NSg+     . NPr/P+ . NPl/V+ . D/P
 > little  champagne ? Nothing at    all       , thanks . . . . I’m sorry   — — —
@@ -6504,8 +6504,8 @@
 # . NSg/V J/P    . . V/J+      NPr
 >
 #
-> “ I’m looking around . I’m having a   marvellous  — ”
-# . W?  V+      J/P    . W?  V      D/P J/Ca/Au/Br+ . .
+> “ I’m looking around . I’m having a   marvellous — ”
+# . W?  V+      J/P    . W?  V      D/P J/Comm+    . .
 >
 #
 > “ You    must  see   the faces of many       people you’ve heard about . ”
@@ -6634,8 +6634,8 @@
 #
 > A   massive and lethargic woman  , who    had been  urging Daisy to play  golf   with her
 # D/P NSg/J   V/C J         NSg/V+ . NPr/I+ V   NSg/V V+     NPr+  P  NSg/V NSg/V+ P    ISg/D$+
-> at    the local club  to - morrow , spoke in      Miss  Baedeker’s defence       :
-# NSg/P D   NSg/J NSg/V P  . NPr/V  . NSg/V NPr/J/P NSg/V NSg$       NSg/Ca/Au/Br+ .
+> at    the local club  to - morrow , spoke in      Miss  Baedeker’s defence   :
+# NSg/P D   NSg/J NSg/V P  . NPr/V  . NSg/V NPr/J/P NSg/V NSg$       NSg/Comm+ .
 >
 #
 > “ Oh    , she’s all        right   now        . When    she’s had five or    six cocktails she  always starts
@@ -6826,8 +6826,8 @@
 # D+  NSg+ NSg/I/C/Ddem+ V/J    P  NSg/VX NSg/V   ISg/D$+ NSg/V/J NSg/J/P . NSg/I+ NSg/VX V      NPr/V/J/C NPr/J/P D
 > dim     , incalculable hours ? Perhaps some   unbelievable guest  would  arrive , a    person
 # NSg/V/J . J            NPl+  . NSg     I/J/R+ J            NSg/V+ NSg/VX V      . D/P+ NSg/V+
-> infinitely rare    and to be     marvelled  at    , some   authentically radiant young   girl
-# R          NSg/V/J V/C P  NSg/VX V/Ca/Au/Br NSg/P . I/J/R+ R             NSg/J   NPr/V/J NSg/V+
+> infinitely rare    and to be     marvelled at    , some   authentically radiant young   girl
+# R          NSg/V/J V/C P  NSg/VX V/Comm    NSg/P . I/J/R+ R             NSg/J   NPr/V/J NSg/V+
 > who   with one       fresh   glance at    Gatsby , one       moment of magical encounter , would  blot
 # NPr/I P    NSg/I/V/J NSg/V/J NSg/V  NSg/P NPr    . NSg/I/V/J NSg    P  J+      NSg/V+    . NSg/VX NSg/V
 > out         those  five years of unwavering devotion .
@@ -7194,8 +7194,8 @@
 # R              ISg+ V/J   ISg/D$+ NSg/V+ . NSg/V/J . V/J     . NSg/J . NSg/P D+  NPr+ NSg/V+    .
 >
 #
-> Gatsby stood in      the centre         of the crimson  carpet and gazed around with
-# NPr    V     NPr/J/P D   NSg/V/Ca/Au/Br P  D+  NSg/V/J+ NSg/V+ V/C V/J   J/P    P+
+> Gatsby stood in      the centre     of the crimson  carpet and gazed around with
+# NPr    V     NPr/J/P D   NSg/V/Comm P  D+  NSg/V/J+ NSg/V+ V/C V/J   J/P    P+
 > fascinated eyes   . Daisy watched him  and laughed , her     sweet   , exciting laugh  ; a
 # V/J        NPl/V+ . NPr+  V/J     ISg+ V/C V/J     . ISg/D$+ NPr/V/J . NSg/V/J  NSg/V+ . D/P
 > tiny  gust  of powder rose    from her     bosom    into the air    .
@@ -7382,8 +7382,8 @@
 # NSg/V+ . .
 >
 #
-> I    went  with them     out         to the veranda       . On  the green    Sound    , stagnant in      the heat   ,
-# ISg+ NSg/V P    NSg/IPl+ NSg/V/J/R/P P  D+  NSg/Am/Ca/Br+ . J/P D+  NPr/V/J+ NSg/V/J+ . J        NPr/J/P D+  NSg/V+ .
+> I    went  with them     out         to the veranda      . On  the green    Sound    , stagnant in      the heat   ,
+# ISg+ NSg/V P    NSg/IPl+ NSg/V/J/R/P P  D+  NSg/NoAm/Br+ . J/P D+  NPr/V/J+ NSg/V/J+ . J        NPr/J/P D+  NSg/V+ .
 > one       small   sail   crawled slowly toward the fresher sea  . Gatsby’s eyes   followed it
 # NSg/I/V/J NPr/V/J NSg/V+ V/J     R      J/P    D+  J+      NSg+ . NSg$     NPl/V+ V/J      NPr/ISg+
 > momentarily ; he       raised his     hand   and pointed across the bay      .
@@ -7675,7 +7675,7 @@
 >
 #
 > He       looked at    me       keenly , realizing that         Jordan and I    must  have   known   all       along .
-# NPr/ISg+ V/J    NSg/P NPr/ISg+ R      . V/Am/Ca   NSg/I/C/Ddem NPr    V/C ISg+ NSg/V NSg/VX NSg/V/J NSg/I/J/C P     .
+# NPr/ISg+ V/J    NSg/P NPr/ISg+ R      . V/NoAm    NSg/I/C/Ddem NPr    V/C ISg+ NSg/V NSg/VX NSg/V/J NSg/I/J/C P     .
 >
 #
 > “ You    think I’m pretty  dumb , don’t you    ? ” he       suggested . “ Perhaps I    am      , but     I    have
@@ -7866,8 +7866,8 @@
 #
 > The relentless beating heat   was beginning to confuse me       and I    had a   bad     moment
 # D   J          NSg/V   NSg/V+ V   NSg/V/J+  P  NSg/V   NPr/ISg+ V/C ISg+ V   D/P NSg/V/J NSg+
-> there before I    realized  that         so        far     his     suspicions hadn’t alighted on  Tom    . He
-# +     C/P    ISg+ V/J/Am/Ca NSg/I/C/Ddem NSg/I/J/C NSg/V/J ISg/D$+ NPl/V      V      V/J      J/P NPr/V+ . NPr/ISg+
+> there before I    realized that         so        far     his     suspicions hadn’t alighted on  Tom    . He
+# +     C/P    ISg+ V/J/NoAm NSg/I/C/Ddem NSg/I/J/C NSg/V/J ISg/D$+ NPl/V      V      V/J      J/P NPr/V+ . NPr/ISg+
 > had discovered that         Myrtle had some  sort  of life   apart from him  in      another
 # V   V/J        NSg/I/C/Ddem NPr    V   I/J/R NSg/V P  NSg/V+ J     P    ISg+ NPr/J/P I/D+
 > world  , and the shock    had made  him  physically sick     . I    stared at    him  and then    at
@@ -7911,7 +7911,7 @@
 > curiously familiar — it       was an   expression I    had often seen  on  women’s faces  , but
 # R         NSg/J    . NPr/ISg+ V   D/P+ NSg+       ISg+ V   R     NSg/V J/P NSg$+   NPl/V+ . NSg/C/P
 > on  Myrtle Wilson’s face   it       seemed purposeless and inexplicable until I    realized
-# J/P NPr    NSg$     NSg/V+ NPr/ISg+ V/J    J           V/C J            C/P   ISg+ V/J/Am/Ca
+# J/P NPr    NSg$     NSg/V+ NPr/ISg+ V/J    J           V/C J            C/P   ISg+ V/J/NoAm
 > that         her     eyes   , wide  with jealous terror , were  fixed not   on  Tom    , but     on  Jordan
 # NSg/I/C/Ddem ISg/D$+ NPl/V+ . NSg/J P    V/J+    NSg+   . NSg/V V/J   NSg/C J/P NPr/V+ . NSg/C/P J/P NPr+
 > Baker  , whom she  took to be     his     wife     .
@@ -7946,8 +7946,8 @@
 #
 > The word  “ sensuous ” had the effect of further disquieting Tom    , but     before he
 # D+  NSg/V . J        . V   D   NSg/V  P  V/J     V           NPr/V+ . NSg/C/P C/P    NPr/ISg+
-> could  invent a   protest the coupé came    to a    stop   , and Daisy signalled  us       to draw
-# NSg/VX V      D/P NSg/V+  D   ?     NSg/V/P P  D/P+ NSg/V+ . V/C NPr+  V/Ca/Au/Br NPr/IPl+ P  NSg/V
+> could  invent a   protest the coupé came    to a    stop   , and Daisy signalled us       to draw
+# NSg/VX V      D/P NSg/V+  D   ?     NSg/V/P P  D/P+ NSg/V+ . V/C NPr+  V/Comm    NPr/IPl+ P  NSg/V
 > up        alongside .
 # NSg/V/J/P P         .
 >
@@ -8130,8 +8130,8 @@
 #
 > “ That          was his     cousin . I    knew his     whole  family history before he       left     . He       gave me
 # . NSg/I/C/Ddem+ V   ISg/D$+ NSg/V+ . ISg+ V    ISg/D$+ NSg/J+ NSg/J+ NSg+    C/P    NPr/ISg+ NPr/V/J+ . NPr/ISg+ V    NPr/ISg+
-> an   aluminum   putter  that         I   use   to - day  . ”
-# D/P+ NSg/Am/Ca+ NSg/V/J NSg/I/C/Ddem ISg NSg/V P  . NPr+ . .
+> an   aluminum  putter  that         I   use   to - day  . ”
+# D/P+ NSg/NoAm+ NSg/V/J NSg/I/C/Ddem ISg NSg/V P  . NPr+ . .
 >
 #
 > The music   had died down      as    the ceremony began and now       a   long    cheer floated in      at
@@ -8468,8 +8468,8 @@
 #
 > She  hesitated . Her     eyes   fell    on  Jordan and me       with a   sort  of appeal , as    though
 # ISg+ V/J+      . ISg/D$+ NPl/V+ NSg/V/J J/P NPr    V/C NPr/ISg+ P    D/P NSg/V P  NSg/V+ . NSg/R V/C
-> she  realized  at    last    what   she  was doing — and as    though she  had never , all       along ,
-# ISg+ V/J/Am/Ca NSg/P NSg/V/J NSg/I+ ISg+ V   NSg/V . V/C NSg/R V/C    ISg+ V   R     . NSg/I/J/C P     .
+> she  realized at    last    what   she  was doing — and as    though she  had never , all       along ,
+# ISg+ V/J/NoAm NSg/P NSg/V/J NSg/I+ ISg+ V   NSg/V . V/C NSg/R V/C    ISg+ V   R     . NSg/I/J/C P     .
 > intended doing anything at    all        . But     it       was done     now       . It       was too late  .
 # NSg/V/J  NSg/V NSg/I/V+ NSg/P NSg/I/J/C+ . NSg/C/P NPr/ISg+ V   NSg/V/J+ NPr/V/J/C . NPr/ISg+ V   +   NSg/J .
 >
@@ -8705,7 +8705,7 @@
 >
 #
 > “ Go      on  . He       won’t annoy you    . I    think he       realizes that         his     presumptuous little
-# . NSg/V/J J/P . NPr/ISg+ V     NSg/V ISgPl+ . ISg+ NSg/V NPr/ISg+ V/Am/Ca  NSg/I/C/Ddem ISg/D$+ J            NPr/I/J
+# . NSg/V/J J/P . NPr/ISg+ V     NSg/V ISgPl+ . ISg+ NSg/V NPr/ISg+ V/NoAm   NSg/I/C/Ddem ISg/D$+ J            NPr/I/J
 > flirtation is  over      . ”
 # NSg+       VL+ NSg/V/J/P . .
 >
@@ -9404,8 +9404,8 @@
 #
 > I    walked back    along the border of the lawn   , traversed the gravel   softly , and
 # ISg+ V/J    NSg/V/J P     D   NSg/V  P  D+  NSg/V+ . V/J       D+  NSg/V/J+ R      . V/C
-> tiptoed up        the veranda       steps  . The drawing - room    curtains were  open    , and I    saw
-# V/J     NSg/V/J/P D+  NSg/Am/Ca/Br+ NPl/V+ . D   NSg/V+  . NSg/V/J NPl/V    NSg/V NSg/V/J . V/C ISg+ NSg/V
+> tiptoed up        the veranda      steps  . The drawing - room    curtains were  open    , and I    saw
+# V/J     NSg/V/J/P D+  NSg/NoAm/Br+ NPl/V+ . D   NSg/V+  . NSg/V/J NPl/V    NSg/V NSg/V/J . V/C ISg+ NSg/V
 > that         the room     was empty    . Crossing the porch where we   had dined that         June night
 # NSg/I/C/Ddem D+  NSg/V/J+ V+  NSg/V/J+ . NSg/V/J  D+  NSg+  NSg/C IPl+ V   V/J   NSg/I/C/Ddem NPr+ NSg/V+
 > three months before , I    came    to a   small   rectangle of light    which I    guessed was
@@ -9611,7 +9611,7 @@
 > committed himself to the following of a    grail . He       knew that         Daisy was
 # V/J       ISg+    P  D   NSg/V/J/P P  D/P+ NSg+  . NPr/ISg+ V    NSg/I/C/Ddem NPr+  V
 > extraordinary , but     he       didn’t realize just how   extraordinary a   “ nice    ” girl   could
-# NSg/J         . NSg/C/P NPr/ISg+ V      V/Am/Ca V/J  NSg/C NSg/J         D/P . NPr/V/J . NSg/V+ NSg/VX+
+# NSg/J         . NSg/C/P NPr/ISg+ V      V/NoAm  V/J  NSg/C NSg/J         D/P . NPr/V/J . NSg/V+ NSg/VX+
 > be     . She  vanished into her     rich     house  , into her     rich    , full     life   , leaving
 # NSg/VX . ISg+ V/J      P    ISg/D$+ NPr/V/J+ NPr/V+ . P    ISg/D$+ NPr/V/J . NSg/V/J+ NSg/V+ . V
 > Gatsby — nothing  . He       felt    married to her     , that          was all       .
@@ -10280,8 +10280,8 @@
 # I/Ddem+ V   D/P NSg/V/J NPr/V . NPr/ISg+ V   NSg    J    NSg/I/C/Ddem NPr+   V   NPr/P+ NPr/V/J+ . +     V
 > not   enough of him  for his     wife     . He       was glad    a   little  later when    he       noticed a
 # NSg/C NSg/I  P  ISg+ C/P ISg/D$+ NSg/V/J+ . NPr/ISg+ V   NSg/V/J D/P NPr/I/J J     NSg/I/C NPr/ISg+ V/J     D/P
-> change in      the room     , a   blue    quickening by      the window , and realized  that          dawn
-# NSg/V  NPr/J/P D+  NSg/V/J+ . D/P NSg/V/J V          NSg/J/P D+  NSg/V+ . V/C V/J/Am/Ca NSg/I/C/Ddem+ NPr/V+
+> change in      the room     , a   blue    quickening by      the window , and realized that          dawn
+# NSg/V  NPr/J/P D+  NSg/V/J+ . D/P NSg/V/J V          NSg/J/P D+  NSg/V+ . V/C V/J/NoAm NSg/I/C/Ddem+ NPr/V+
 > wasn’t far     off       . About five o’clock it       was blue    enough outside   to snap    off       the
 # V      NSg/V/J NSg/V/J/P . J/P   NSg  W?      NPr/ISg+ V   NSg/V/J NSg/I  NSg/V/J/P P  NSg/V/J NSg/V/J/P D+
 > light    .
@@ -11261,7 +11261,7 @@
 > stop  and then    the sound   of some  one        splashing after us       over      the soggy ground   . I
 # NSg/V V/C NSg/J/C D   NSg/V/J P  I/J/R NSg/I/V/J+ V         J/P   NPr/IPl+ NSg/V/J/P D+  J+    NSg/V/J+ . ISg+
 > looked around . It       was the man     with owl    - eyed glasses whom I    had found marvelling
-# V/J+   J/P    . NPr/ISg+ V   D   NPr/V/J P    NSg/V+ . V/J  NPl/V   I+   ISg+ V   NSg/V NSg/V/Ca/Au/Br
+# V/J+   J/P    . NPr/ISg+ V   D   NPr/V/J P    NSg/V+ . V/J  NPl/V   I+   ISg+ V   NSg/V NSg/V/Comm
 > over      Gatsby’s books  in      the library one       night  three months before .
 # NSg/V/J/P NSg$     NPl/V+ NPr/J/P D+  NSg+    NSg/I/V/J NSg/V+ NSg+  NSg+   C/P+   .
 >
@@ -11382,8 +11382,8 @@
 # NPl/V   NPr/J/P D$+ NPr/I/V/J NSg/J+    NPl/V+ . ISg+ NSg/V NPr/ISg+ NSg/R D/P NSg/V+ NSg/V NSg/J/P ?  ?     . D/P
 > hundred houses , at    once  conventional and grotesque , crouching under   a   sullen  ,
 # NSg     NPl/V+ . NSg/P NSg/C NSg/J        V/C NSg/J     . V         NSg/J/P D/P NSg/V/J .
-> overhanging sky    and a   lustreless  moon   . In      the foreground four solemn men in
-# V           NSg/V+ V/C D/P J/Ca/Au/Br+ NPr/V+ . NPr/J/P D+  NSg/V+     NSg  J      NSg NPr/J/P
+> overhanging sky    and a   lustreless moon   . In      the foreground four solemn men in
+# V           NSg/V+ V/C D/P J/Comm+    NPr/V+ . NPr/J/P D+  NSg/V+     NSg  J      NSg NPr/J/P
 > dress  suits are walking along the sidewalk with a   stretcher on  which lies  a
 # NSg/V+ NPl/V V   NSg/V/J P     D+  NSg+     P    D/P NSg/V/J   J/P I/C+  NPl/V D/P
 > drunken woman in      a   white    evening dress  . Her     hand   , which dangles over      the side     ,

--- a/harper-core/tests/text/tagged/this and that.md
+++ b/harper-core/tests/text/tagged/this and that.md
@@ -1,5 +1,5 @@
 > " This    " and " that          " are common  and fulfill multiple purposes in      everyday English  .
-# . I/Ddem+ . V/C . NSg/I/C/Ddem+ . V   NSg/V/J V/C V       NSg/J    NPl/V    NPr/J/P NSg/J+   NPr/V/J+ .
+# . I/Ddem+ . V/C . NSg/I/C/Ddem+ . V   NSg/V/J V/C V/NoAm  NSg/J    NPl/V    NPr/J/P NSg/J+   NPr/V/J+ .
 > As    such  , disambiguating them     is  necessary .
 # NSg/R NSg/I . V              NSg/IPl+ VL+ NSg/J     .
 >


### PR DESCRIPTION
# Issues 
N/A

# Description

- marking more abstract nouns for plurality and countability
- updated the dialect annotation in the snapshots to use `NoAm` and `Comm` for groupsing of US+Canadian English and UK+Canadian+Australian English

# How Has This Been Tested?

For the new dialect annotations, just looking at the snapshot diffs.
For the dictionary curation, looking at the snapshot diffs is also the best way.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
