### PR TITLE
refactor: towards regex-style captures

### DIFF
--- a/harper-core/src/expr/mod.rs
+++ b/harper-core/src/expr/mod.rs
@@ -148,3 +148,7 @@ where
         LongestMatchOf::new(vec![Box::new(self), Box::new(other)])
     }
 }
+
+pub struct MatchInfo<'a> {
+    pub matched_tokens: &'a [Token],
+}

--- a/harper-core/src/linting/a_part.rs
+++ b/harper-core/src/linting/a_part.rs
@@ -1,8 +1,9 @@
 use crate::expr::Expr;
 use crate::expr::FixedPhrase;
 use crate::expr::LongestMatchOf;
+use crate::expr::MatchInfo;
 use crate::{
-    Token, TokenStringExt,
+    TokenStringExt,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
 };
 
@@ -30,7 +31,8 @@ impl ExprLinter for APart {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let span = matched_tokens.span()?;
         let text: String = span.get_content(source).iter().collect();
         let text_lower = text.to_lowercase();

--- a/harper-core/src/linting/am_in_the_morning.rs
+++ b/harper-core/src/linting/am_in_the_morning.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Lrc, Span, Token, TokenStringExt,
-    expr::{Expr, FixedPhrase, LongestMatchOf, SequenceExpr},
+    Lrc, Span, TokenStringExt,
+    expr::{Expr, FixedPhrase, LongestMatchOf, MatchInfo, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
     patterns::WordSet,
 };
@@ -50,7 +50,8 @@ impl ExprLinter for AmInTheMorning {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         let all_after_number_span = toks[0..].span()?;
         let am_pm_idx = if toks[0].kind.is_whitespace() { 1 } else { 0 };
 

--- a/harper-core/src/linting/amounts_for.rs
+++ b/harper-core/src/linting/amounts_for.rs
@@ -1,8 +1,9 @@
 use crate::expr::Expr;
 use crate::expr::FixedPhrase;
 use crate::expr::LongestMatchOf;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
-use crate::{Lrc, Token, TokenStringExt, patterns::WordSet};
+use crate::{Lrc, TokenStringExt, patterns::WordSet};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -42,7 +43,8 @@ impl ExprLinter for AmountsFor {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         let content = toks.span()?.get_content_string(src).to_lowercase();
 
         if content.ends_with("amounts for") {

--- a/harper-core/src/linting/another_thing_coming.rs
+++ b/harper-core/src/linting/another_thing_coming.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Token, TokenStringExt,
-    expr::{Expr, FixedPhrase, SequenceExpr},
+    TokenStringExt,
+    expr::{Expr, FixedPhrase, MatchInfo, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
     patterns::WordSet,
 };
@@ -27,7 +27,8 @@ impl ExprLinter for AnotherThingComing {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         Some(Lint {
             span: toks[2..].span()?,
             lint_kind: LintKind::WordChoice,

--- a/harper-core/src/linting/another_think_coming.rs
+++ b/harper-core/src/linting/another_think_coming.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Token, TokenStringExt,
-    expr::{Expr, FixedPhrase, SequenceExpr},
+    TokenStringExt,
+    expr::{Expr, FixedPhrase, MatchInfo, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
     patterns::WordSet,
 };
@@ -27,7 +27,8 @@ impl ExprLinter for AnotherThinkComing {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         Some(Lint {
             span: toks[2..].span()?,
             lint_kind: LintKind::WordChoice,

--- a/harper-core/src/linting/ask_no_preposition.rs
+++ b/harper-core/src/linting/ask_no_preposition.rs
@@ -1,7 +1,8 @@
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::{
-    Span, Token,
+    Span,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
     patterns::WordSet,
 };
@@ -36,7 +37,8 @@ impl ExprLinter for AskNoPreposition {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         if toks.len() < 5 {
             return None;
         }

--- a/harper-core/src/linting/back_in_the_day.rs
+++ b/harper-core/src/linting/back_in_the_day.rs
@@ -1,9 +1,10 @@
 use crate::expr::Expr;
 use crate::expr::FixedPhrase;
+use crate::expr::MatchInfo;
 use crate::expr::OwnedExprExt;
 use crate::expr::SequenceExpr;
 use crate::{
-    Lrc, Token, TokenStringExt,
+    Lrc, TokenStringExt,
     patterns::{Pattern, WordSet},
 };
 
@@ -38,7 +39,8 @@ impl ExprLinter for BackInTheDay {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         if let Some(tail) = matched_tokens.get(8..) {
             if self.exceptions.matches(tail, source).is_some() {
                 return None;

--- a/harper-core/src/linting/boring_words.rs
+++ b/harper-core/src/linting/boring_words.rs
@@ -1,5 +1,5 @@
-use crate::expr::{Expr, WordExprGroup};
-use crate::{Token, TokenStringExt};
+use crate::TokenStringExt;
+use crate::expr::{Expr, MatchInfo, WordExprGroup};
 
 use super::{ExprLinter, Lint, LintKind};
 
@@ -28,7 +28,8 @@ impl ExprLinter for BoringWords {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let matched_word = matched_tokens.span()?.get_content_string(source);
 
         Some(Lint {

--- a/harper-core/src/linting/chock_full.rs
+++ b/harper-core/src/linting/chock_full.rs
@@ -1,7 +1,8 @@
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::expr::SpaceOrHyphen;
-use crate::{Token, TokenStringExt, patterns::WordSet};
+use crate::{TokenStringExt, patterns::WordSet};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -27,7 +28,8 @@ impl ExprLinter for ChockFull {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_toks: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_toks = match_info.matched_tokens;
         let span = matched_toks.span()?;
 
         Some(Lint {

--- a/harper-core/src/linting/compound_nouns/compound_noun_after_det_adj.rs
+++ b/harper-core/src/linting/compound_nouns/compound_noun_after_det_adj.rs
@@ -1,5 +1,6 @@
 use crate::expr::All;
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::MergeableWords;
 use crate::expr::SequenceExpr;
 use crate::{CharStringExt, TokenStringExt, linting::ExprLinter};
@@ -59,7 +60,8 @@ impl ExprLinter for CompoundNounAfterDetAdj {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let span = matched_tokens[2..].span()?;
         let orig = span.get_content(source);
         // If the pattern matched, this will not return `None`.

--- a/harper-core/src/linting/compound_nouns/compound_noun_after_possessive.rs
+++ b/harper-core/src/linting/compound_nouns/compound_noun_after_possessive.rs
@@ -1,13 +1,12 @@
 use crate::expr::All;
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::MergeableWords;
 use crate::expr::SequenceExpr;
 use crate::patterns::AnyPattern;
 use crate::{CharStringExt, Lrc, TokenStringExt, linting::ExprLinter};
 
 use super::{Lint, LintKind, Suggestion, is_content_word, predicate};
-
-use crate::Token;
 
 /// Looks for closed compound nouns which can be condensed due to their position after a
 /// possessive noun (which implies ownership).
@@ -56,7 +55,8 @@ impl ExprLinter for CompoundNounAfterPossessive {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         // "Let's" can technically be a possessive noun (of a lease, or a let in tennis, etc.)
         // but in practice it's almost always a contraction of "let us" before a verb
         // or a mistake for "lets", the 3rd person singular present form of "to let".

--- a/harper-core/src/linting/compound_nouns/compound_noun_before_aux_verb.rs
+++ b/harper-core/src/linting/compound_nouns/compound_noun_before_aux_verb.rs
@@ -1,13 +1,12 @@
 use crate::expr::All;
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::MergeableWords;
 use crate::expr::SequenceExpr;
 use crate::patterns::AnyPattern;
 use crate::{CharStringExt, Lrc, TokenStringExt, linting::ExprLinter};
 
 use super::{Lint, LintKind, Suggestion, is_content_word, predicate};
-
-use crate::Token;
 
 /// Two adjacent words separated by whitespace that if joined would be a valid noun.
 pub struct CompoundNounBeforeAuxVerb {
@@ -48,7 +47,8 @@ impl ExprLinter for CompoundNounBeforeAuxVerb {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let span = matched_tokens[0..3].span()?;
         let orig = span.get_content(source);
         // If the pattern matched, this will not return `None`.

--- a/harper-core/src/linting/confident.rs
+++ b/harper-core/src/linting/confident.rs
@@ -1,4 +1,5 @@
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::OwnedExprExt;
 use crate::expr::SequenceExpr;
 use crate::{Token, patterns::Word};
@@ -32,7 +33,8 @@ impl ExprLinter for Confident {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], _source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, _source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let span = matched_tokens.last()?.span;
 
         Some(Lint {

--- a/harper-core/src/linting/dashes.rs
+++ b/harper-core/src/linting/dashes.rs
@@ -1,7 +1,8 @@
+use crate::TokenStringExt;
 use crate::expr::Expr;
 use crate::expr::LongestMatchOf;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
-use crate::{Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -33,7 +34,8 @@ impl ExprLinter for Dashes {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], _source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, _source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let span = matched_tokens.span()?;
         let lint_kind = LintKind::Formatting;
 

--- a/harper-core/src/linting/despite_of.rs
+++ b/harper-core/src/linting/despite_of.rs
@@ -1,6 +1,7 @@
+use crate::TokenStringExt;
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
-use crate::{Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -25,7 +26,8 @@ impl ExprLinter for DespiteOf {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched = match_info.matched_tokens;
         let span = matched.span()?;
         let matched = span.get_content(source);
 

--- a/harper-core/src/linting/dot_initialisms.rs
+++ b/harper-core/src/linting/dot_initialisms.rs
@@ -1,10 +1,11 @@
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::expr::WordExprGroup;
 use hashbrown::HashMap;
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
-use crate::{Token, TokenStringExt};
+use crate::TokenStringExt;
 
 pub struct DotInitialisms {
     expr: Box<dyn Expr>,
@@ -39,7 +40,8 @@ impl ExprLinter for DotInitialisms {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let found_word_tok = matched_tokens.first()?;
         let found_word = found_word_tok.span.get_content_string(source);
 

--- a/harper-core/src/linting/else_possessive.rs
+++ b/harper-core/src/linting/else_possessive.rs
@@ -1,8 +1,8 @@
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::OwnedExprExt;
 use crate::expr::SequenceExpr;
 use crate::{
-    Token,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
     patterns::WordSet,
 };
@@ -40,7 +40,8 @@ impl ExprLinter for ElsePossessive {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], _src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, _src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         let offender = toks.last()?;
         Some(Lint {
             span: offender.span,

--- a/harper-core/src/linting/everyday.rs
+++ b/harper-core/src/linting/everyday.rs
@@ -2,6 +2,7 @@ use super::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::expr::All;
 use crate::expr::Expr;
 use crate::expr::LongestMatchOf;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::{Lrc, Punctuation, Token, TokenKind, TokenStringExt, patterns::Word};
 
@@ -171,7 +172,8 @@ impl ExprLinter for Everyday {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         // Helper functions make the match tables more compact and readable.
         let norm = |i: usize| toks[i].span.get_content_string(src).to_lowercase();
         let isws = |i: usize| toks[i].kind.is_whitespace();

--- a/harper-core/src/linting/expand_time_shorthands.rs
+++ b/harper-core/src/linting/expand_time_shorthands.rs
@@ -1,10 +1,10 @@
 use crate::expr::Expr;
 use crate::expr::LongestMatchOf;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use std::sync::Arc;
 
 use super::{ExprLinter, Lint, LintKind};
-use crate::Token;
 use crate::linting::Suggestion;
 use crate::patterns::{ImpliesQuantity, WordSet};
 
@@ -64,7 +64,8 @@ impl ExprLinter for ExpandTimeShorthands {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let offending_span = matched_tokens.last()?.span;
         let implies_plural = ImpliesQuantity::implies_plurality(matched_tokens.first()?, source);
 

--- a/harper-core/src/linting/few_units_of_time_ago.rs
+++ b/harper-core/src/linting/few_units_of_time_ago.rs
@@ -1,4 +1,5 @@
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::expr::TimeUnitExpr;
 use crate::{
@@ -46,7 +47,8 @@ impl ExprLinter for FewUnitsOfTimeAgo {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         let mut span = None;
 
         for tok in toks.iter().take(3) {

--- a/harper-core/src/linting/first_aid_kit.rs
+++ b/harper-core/src/linting/first_aid_kit.rs
@@ -1,7 +1,7 @@
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::{
-    Token,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
     patterns::WordSet,
 };
@@ -28,7 +28,8 @@ impl ExprLinter for FirstAidKit {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let tokens = match_info.matched_tokens;
         let typo_token = tokens.last()?;
         let typo_span = typo_token.span;
         let typo_text = typo_span.get_content(source);

--- a/harper-core/src/linting/for_noun.rs
+++ b/harper-core/src/linting/for_noun.rs
@@ -1,10 +1,8 @@
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::OwnedExprExt;
 use crate::expr::SequenceExpr;
-use crate::{
-    Token,
-    patterns::{NominalPhrase, Word},
-};
+use crate::patterns::{NominalPhrase, Word};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -29,7 +27,8 @@ impl ExprLinter for ForNoun {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let span = matched_tokens.first()?.span;
         let problem_chars = span.get_content(source);
 

--- a/harper-core/src/linting/have_pronoun.rs
+++ b/harper-core/src/linting/have_pronoun.rs
@@ -1,5 +1,5 @@
 use crate::Token;
-use crate::expr::{AnchorStart, Expr, SequenceExpr};
+use crate::expr::{AnchorStart, Expr, MatchInfo, SequenceExpr};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -28,7 +28,8 @@ impl ExprLinter for HavePronoun {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         // First real word in the match is always "has".
         let has_tok = toks.iter().find(|t| t.kind.is_word())?;
         let span = has_tok.span;

--- a/harper-core/src/linting/hedging.rs
+++ b/harper-core/src/linting/hedging.rs
@@ -1,8 +1,9 @@
+use crate::TokenStringExt;
 use crate::expr::Expr;
 use crate::expr::FixedPhrase;
 use crate::expr::LongestMatchOf;
+use crate::expr::MatchInfo;
 use crate::linting::{ExprLinter, Lint, LintKind};
-use crate::{Token, TokenStringExt};
 
 /// A linter that detects hedging language.
 pub struct Hedging {
@@ -28,7 +29,8 @@ impl ExprLinter for Hedging {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], _source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, _source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let span = matched_tokens.span()?;
         Some(Lint {
             span,

--- a/harper-core/src/linting/hereby.rs
+++ b/harper-core/src/linting/hereby.rs
@@ -1,6 +1,7 @@
+use crate::TokenStringExt;
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
-use crate::{Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -27,7 +28,8 @@ impl ExprLinter for Hereby {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let span = matched_tokens[0..3].span()?;
         let orig_chars = span.get_content(source);
         Some(Lint {

--- a/harper-core/src/linting/hop_hope/to_hop.rs
+++ b/harper-core/src/linting/hop_hope/to_hop.rs
@@ -1,10 +1,11 @@
 use super::super::{ExprLinter, Lint, LintKind};
+use crate::char_string::char_string;
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::linting::Suggestion;
 use crate::patterns::WordSet;
 use crate::{CharString, CharStringExt};
-use crate::{Token, char_string::char_string};
 
 pub struct ToHop {
     expr: Box<dyn Expr>,
@@ -43,7 +44,8 @@ impl ExprLinter for ToHop {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let offending_word = &matched_tokens[0];
         let word_chars = offending_word.span.get_content(source);
         let word = word_chars.to_string();

--- a/harper-core/src/linting/hop_hope/to_hope.rs
+++ b/harper-core/src/linting/hop_hope/to_hope.rs
@@ -1,9 +1,10 @@
 use super::super::{ExprLinter, Lint, LintKind};
+use crate::char_string::char_string;
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::linting::Suggestion;
 use crate::patterns::WordSet;
-use crate::{Token, char_string::char_string};
 
 pub struct ToHope {
     expr: Box<dyn Expr>,
@@ -29,7 +30,8 @@ impl ExprLinter for ToHope {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let offending_word = &matched_tokens[2];
         let word_chars = offending_word.span.get_content(source);
 

--- a/harper-core/src/linting/hope_youre.rs
+++ b/harper-core/src/linting/hope_youre.rs
@@ -1,6 +1,5 @@
 use crate::{
-    Token,
-    expr::SequenceExpr,
+    expr::{MatchInfo, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
     patterns::WordSet,
 };
@@ -35,7 +34,8 @@ impl ExprLinter for HopeYoure {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         let your_tok = toks.get(2)?;
         let span = your_tok.span;
         let original = span.get_content(src);

--- a/harper-core/src/linting/how_to.rs
+++ b/harper-core/src/linting/how_to.rs
@@ -2,6 +2,7 @@ use harper_brill::UPOS;
 
 use crate::expr::All;
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::OwnedExprExt;
 use crate::expr::SequenceExpr;
 use crate::{
@@ -56,7 +57,8 @@ impl ExprLinter for HowTo {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], _src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, _src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         let span = toks[0..2].span()?;
         let fix: Vec<char> = "to ".chars().collect();
 

--- a/harper-core/src/linting/hyphenate_number_day.rs
+++ b/harper-core/src/linting/hyphenate_number_day.rs
@@ -1,7 +1,8 @@
 use crate::expr::Expr;
 use crate::expr::LongestMatchOf;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
-use crate::{Token, patterns::NominalPhrase};
+use crate::patterns::NominalPhrase;
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -41,7 +42,8 @@ impl ExprLinter for HyphenateNumberDay {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], _source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, _source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let number = matched_tokens[0].kind.as_number()?;
         let space = &matched_tokens[1];
 

--- a/harper-core/src/linting/in_on_the_cards.rs
+++ b/harper-core/src/linting/in_on_the_cards.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Dialect, Token,
-    expr::{Expr, FixedPhrase, LongestMatchOf, SequenceExpr},
+    Dialect,
+    expr::{Expr, FixedPhrase, LongestMatchOf, MatchInfo, SequenceExpr},
     linting::{LintKind, Suggestion},
     patterns::{InflectionOfBe, WordSet},
 };
@@ -43,7 +43,8 @@ impl ExprLinter for InOnTheCards {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         let prep_span = toks[2].span;
         let prep = prep_span.get_content(src);
 

--- a/harper-core/src/linting/initialism_linter.rs
+++ b/harper-core/src/linting/initialism_linter.rs
@@ -1,7 +1,7 @@
-use crate::expr::Expr;
+use crate::expr::{Expr, MatchInfo};
 use itertools::Itertools;
 
-use crate::{Token, patterns::Word};
+use crate::patterns::Word;
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -33,7 +33,8 @@ impl ExprLinter for InitialismLinter {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let tok = matched_tokens.first()?;
         let source = tok.span.get_content(source);
 

--- a/harper-core/src/linting/it_is.rs
+++ b/harper-core/src/linting/it_is.rs
@@ -1,4 +1,5 @@
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::{
     Token,
@@ -67,7 +68,8 @@ impl ExprLinter for ItIs {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let tokens = match_info.matched_tokens;
         let its_token = &tokens[0];
         let span = its_token.span;
         let text = span.get_content(source);

--- a/harper-core/src/linting/it_would_be.rs
+++ b/harper-core/src/linting/it_would_be.rs
@@ -1,8 +1,8 @@
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::OwnedExprExt;
 use crate::expr::SequenceExpr;
 use crate::{
-    Token,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
     patterns::WordSet,
 };
@@ -68,7 +68,8 @@ impl ExprLinter for ItWouldBe {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], _src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, _src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         let pronoun = &toks[2];
         let span = pronoun.span;
 

--- a/harper-core/src/linting/left_right_hand.rs
+++ b/harper-core/src/linting/left_right_hand.rs
@@ -1,6 +1,7 @@
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
-use crate::{Token, patterns::WordSet};
+use crate::patterns::WordSet;
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -28,7 +29,8 @@ impl ExprLinter for LeftRightHand {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], _source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, _source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let space = &matched_tokens[1];
 
         Some(Lint {

--- a/harper-core/src/linting/less_worse.rs
+++ b/harper-core/src/linting/less_worse.rs
@@ -1,6 +1,6 @@
-use crate::expr::{Expr, SequenceExpr, SpaceOrHyphen};
+use crate::expr::{Expr, MatchInfo, SequenceExpr, SpaceOrHyphen};
 use crate::patterns::WordSet;
-use crate::{CharStringExt, Token, TokenStringExt};
+use crate::{CharStringExt, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -26,7 +26,8 @@ impl ExprLinter for LessWorse {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         if toks.len() != 3 {
             return None;
         }

--- a/harper-core/src/linting/lets_confusion/let_us_redundancy.rs
+++ b/harper-core/src/linting/lets_confusion/let_us_redundancy.rs
@@ -1,6 +1,7 @@
+use crate::TokenStringExt;
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
-use crate::{Token, TokenStringExt};
 
 use crate::linting::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -28,7 +29,8 @@ impl ExprLinter for LetUsRedundancy {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let template = matched_tokens.span()?.get_content(source);
         let pronoun = matched_tokens.last()?.span.get_content_string(source);
 

--- a/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
+++ b/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
@@ -1,5 +1,6 @@
 use crate::expr::Expr;
 use crate::expr::LongestMatchOf;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::{
     Token,
@@ -62,7 +63,8 @@ impl ExprLinter for NoContractionWithVerb {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let (let_string, verb_string) = (
             matched_tokens[0].span.get_content_string(source),
             matched_tokens[2].span.get_content_string(source),

--- a/harper-core/src/linting/likewise.rs
+++ b/harper-core/src/linting/likewise.rs
@@ -1,7 +1,8 @@
+use crate::TokenStringExt;
 use crate::expr::All;
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
-use crate::{Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -33,7 +34,8 @@ impl ExprLinter for Likewise {
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let span = matched_tokens.span()?;
         let orig_chars = span.get_content(source);
         Some(Lint {

--- a/harper-core/src/linting/map_phrase_linter.rs
+++ b/harper-core/src/linting/map_phrase_linter.rs
@@ -1,10 +1,11 @@
 use super::{ExprLinter, Lint, LintKind};
+use crate::TokenStringExt;
 use crate::expr::Expr;
 use crate::expr::FixedPhrase;
 use crate::expr::LongestMatchOf;
+use crate::expr::MatchInfo;
 use crate::expr::SimilarToPhrase;
 use crate::linting::Suggestion;
-use crate::{Token, TokenStringExt};
 
 pub struct MapPhraseLinter {
     description: String,
@@ -90,7 +91,8 @@ impl ExprLinter for MapPhraseLinter {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let span = matched_tokens.span()?;
         let matched_text = span.get_content(source);
 

--- a/harper-core/src/linting/modal_of.rs
+++ b/harper-core/src/linting/modal_of.rs
@@ -1,7 +1,8 @@
 use crate::expr::Expr;
 use crate::expr::LongestMatchOf;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
-use crate::{Lrc, Token, TokenStringExt, patterns::WordSet};
+use crate::{Lrc, TokenStringExt, patterns::WordSet};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -67,7 +68,8 @@ impl ExprLinter for ModalOf {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_toks: &[Token], source_chars: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source_chars: &[char]) -> Option<Lint> {
+        let matched_toks = match_info.matched_tokens;
         let modal_index = match matched_toks.len() {
             // Without context, always an error from the start
             3 => 0,

--- a/harper-core/src/linting/most_number.rs
+++ b/harper-core/src/linting/most_number.rs
@@ -1,7 +1,8 @@
 use crate::expr::All;
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
-use crate::{Token, TokenStringExt, patterns::WordSet};
+use crate::{TokenStringExt, patterns::WordSet};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -39,7 +40,8 @@ impl ExprLinter for MostNumber {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         let most_amt_num_span = toks[0..3].span()?;
         let noun_string = toks[2].span.get_content_string(source);
         let superlatives = if noun_string == "amount" {

--- a/harper-core/src/linting/multiple_sequential_pronouns.rs
+++ b/harper-core/src/linting/multiple_sequential_pronouns.rs
@@ -1,10 +1,11 @@
 use super::Suggestion;
 use super::expr_linter::ExprLinter;
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::linting::LintKind;
 use crate::patterns::WordSet;
-use crate::{CharStringExt, Lint, Lrc, Token, TokenStringExt};
+use crate::{CharStringExt, Lint, Lrc, TokenStringExt};
 
 /// Linter that checks if multiple pronouns are being used right after each
 /// other. This is a common mistake to make during the revision process.
@@ -80,7 +81,8 @@ impl ExprLinter for MultipleSequentialPronouns {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let mut suggestions = Vec::new();
 
         if matched_tokens.len() == 3 {

--- a/harper-core/src/linting/nail_on_the_head.rs
+++ b/harper-core/src/linting/nail_on_the_head.rs
@@ -1,7 +1,7 @@
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::{
-    Token,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
     patterns::WordSet,
 };
@@ -32,7 +32,8 @@ impl ExprLinter for NailOnTheHead {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], _src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, _src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         let offender = toks.last()?;
         Some(Lint {
             span: offender.span,

--- a/harper-core/src/linting/no_match_for.rs
+++ b/harper-core/src/linting/no_match_for.rs
@@ -1,6 +1,6 @@
 use crate::{
-    CharStringExt, Token, TokenStringExt,
-    expr::{Expr, FirstMatchOf, SequenceExpr},
+    CharStringExt, TokenStringExt,
+    expr::{Expr, FirstMatchOf, MatchInfo, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
     patterns::{InflectionOfBe, WordSet},
 };
@@ -39,7 +39,8 @@ impl ExprLinter for NoMatchFor {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         let prep_tok = toks.last()?;
         let prep_chars = prep_tok.span.get_content(src);
         if prep_chars.eq_ignore_ascii_case_chars(&['f', 'o', 'r']) {

--- a/harper-core/src/linting/nobody.rs
+++ b/harper-core/src/linting/nobody.rs
@@ -1,6 +1,7 @@
+use crate::TokenStringExt;
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
-use crate::{Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -26,7 +27,8 @@ impl ExprLinter for Nobody {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let span = matched_tokens[0..3].span()?;
         let orig_chars = span.get_content(source);
         Some(Lint {

--- a/harper-core/src/linting/nominal_wants.rs
+++ b/harper-core/src/linting/nominal_wants.rs
@@ -1,4 +1,5 @@
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::{
     Token,
@@ -54,7 +55,8 @@ impl ExprLinter for NominalWants {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         let subject = toks.first()?;
         let offender = toks.last()?;
 

--- a/harper-core/src/linting/noun_instead_of_verb.rs
+++ b/harper-core/src/linting/noun_instead_of_verb.rs
@@ -1,7 +1,8 @@
 use crate::expr::Expr;
 use crate::expr::LongestMatchOf;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
-use crate::{Lrc, Token, TokenStringExt, patterns::WordSet};
+use crate::{Lrc, TokenStringExt, patterns::WordSet};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -99,7 +100,8 @@ impl ExprLinter for NounInsteadOfVerb {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         eprintln!("🏃 '{}' 🏃", toks.span()?.get_content_string(src));
         // If we have the next word token, try to rule out compound nouns
         if toks.len() > 4 {

--- a/harper-core/src/linting/of_course.rs
+++ b/harper-core/src/linting/of_course.rs
@@ -1,7 +1,7 @@
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::{
-    Token,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
     patterns::WordSet,
 };
@@ -29,7 +29,8 @@ impl ExprLinter for OfCourse {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched = match_info.matched_tokens;
         // Skip if the word before “of” is “kind” or “sort” → “kind of curse” is valid.
         if let Some(of_idx) = matched.first().map(|t| t.span.start) {
             if let Some(prev) = source.get(..of_idx).map(|src| {

--- a/harper-core/src/linting/one_and_the_same.rs
+++ b/harper-core/src/linting/one_and_the_same.rs
@@ -1,8 +1,9 @@
 use crate::expr::Expr;
 use crate::expr::FixedPhrase;
 use crate::expr::LongestMatchOf;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
-use crate::{Lrc, Token, TokenStringExt, patterns::WordSet};
+use crate::{Lrc, TokenStringExt, patterns::WordSet};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -42,7 +43,8 @@ impl ExprLinter for OneAndTheSame {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let phrase = if matched_tokens.last()?.span.get_content(source) == ['a', 's'] {
             matched_tokens[0..matched_tokens.len() - 2].span()?
         } else {

--- a/harper-core/src/linting/open_compounds.rs
+++ b/harper-core/src/linting/open_compounds.rs
@@ -1,5 +1,6 @@
 use crate::expr::Expr;
 use crate::expr::LongestMatchOf;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::{Lrc, Token, patterns::WordSet};
 
@@ -69,7 +70,8 @@ impl ExprLinter for OpenCompounds {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_toks: &[Token], source_chars: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source_chars: &[char]) -> Option<Lint> {
+        let matched_toks = match_info.matched_tokens;
         // Because we don't have anything like regex captures we need to find which token matched which compound
         let index = self
             .compound_to_phrase

--- a/harper-core/src/linting/open_the_light.rs
+++ b/harper-core/src/linting/open_the_light.rs
@@ -1,8 +1,9 @@
 use crate::expr::Expr;
 use crate::expr::LongestMatchOf;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::{
-    Lrc, Token, TokenStringExt,
+    Lrc, TokenStringExt,
     linting::{LintKind, Suggestion},
     patterns::WordSet,
 };
@@ -62,7 +63,8 @@ impl ExprLinter for OpenTheLight {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         // If I try to do this in the Pattern, the shorter pattern matches, without the context token.
         if toks.len() == 7 {
             let device_tok = &toks[toks.len() - 3];

--- a/harper-core/src/linting/out_of_date.rs
+++ b/harper-core/src/linting/out_of_date.rs
@@ -1,7 +1,8 @@
+use crate::TokenStringExt;
 use crate::expr::Expr;
 use crate::expr::FixedPhrase;
 use crate::expr::LongestMatchOf;
-use crate::{Token, TokenStringExt};
+use crate::expr::MatchInfo;
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -28,7 +29,8 @@ impl ExprLinter for OutOfDate {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let span = matched_tokens.span()?;
         let problem_text = span.get_content(source);
 

--- a/harper-core/src/linting/oxymorons.rs
+++ b/harper-core/src/linting/oxymorons.rs
@@ -1,8 +1,9 @@
+use crate::TokenStringExt;
 use crate::expr::Expr;
 use crate::expr::FixedPhrase;
 use crate::expr::LongestMatchOf;
+use crate::expr::MatchInfo;
 use crate::linting::{ExprLinter, Lint, LintKind};
-use crate::{Token, TokenStringExt};
 
 /// A linter that flags oxymoronic phrases.
 pub struct Oxymorons {
@@ -55,7 +56,8 @@ impl ExprLinter for Oxymorons {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let span = matched_tokens.span()?;
         let matched_text: String = span.get_content(source).iter().collect();
         Some(Lint {

--- a/harper-core/src/linting/pique_interest.rs
+++ b/harper-core/src/linting/pique_interest.rs
@@ -1,6 +1,7 @@
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
-use crate::{CharString, CharStringExt, Token, char_string::char_string, patterns::WordSet};
+use crate::{CharString, CharStringExt, char_string::char_string, patterns::WordSet};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -44,7 +45,8 @@ impl ExprLinter for PiqueInterest {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let span = matched_tokens[0].span;
         let word = span.get_content_string(source).to_lowercase();
         let correct = Self::to_correct(&word)?;

--- a/harper-core/src/linting/possessive_noun.rs
+++ b/harper-core/src/linting/possessive_noun.rs
@@ -4,6 +4,7 @@ use crate::Dictionary;
 use crate::Token;
 use crate::expr::All;
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::patterns::UPOSSet;
 use crate::patterns::WordSet;
@@ -63,7 +64,8 @@ where
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], _source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, _source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let last_kind = &matched_tokens.last()?.kind;
 
         if last_kind.is_upos(UPOS::ADV) {

--- a/harper-core/src/linting/possessive_your.rs
+++ b/harper-core/src/linting/possessive_your.rs
@@ -1,5 +1,6 @@
 use crate::Token;
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
@@ -32,7 +33,8 @@ impl ExprLinter for PossessiveYour {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let span = matched_tokens.first()?.span;
         let orig_chars = span.get_content(source);
 

--- a/harper-core/src/linting/pronoun_contraction/avoid_contraction.rs
+++ b/harper-core/src/linting/pronoun_contraction/avoid_contraction.rs
@@ -1,5 +1,6 @@
 use crate::Token;
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 
 use super::super::{ExprLinter, Lint, LintKind, Suggestion};
@@ -28,7 +29,8 @@ impl ExprLinter for AvoidContraction {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let word = matched_tokens[0].span.get_content(source);
 
         Some(Lint {

--- a/harper-core/src/linting/pronoun_contraction/should_contract.rs
+++ b/harper-core/src/linting/pronoun_contraction/should_contract.rs
@@ -1,6 +1,7 @@
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
-use crate::{CharStringExt, Token, patterns::WordSet};
+use crate::{CharStringExt, patterns::WordSet};
 
 use crate::Lint;
 use crate::linting::{ExprLinter, LintKind, Suggestion};
@@ -46,7 +47,8 @@ impl ExprLinter for ShouldContract {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let mistake = matched_tokens[0].span.get_content(source);
 
         Some(Lint {

--- a/harper-core/src/linting/pronoun_inflection_be.rs
+++ b/harper-core/src/linting/pronoun_inflection_be.rs
@@ -5,6 +5,7 @@ use crate::Token;
 use crate::expr::All;
 use crate::expr::AnchorStart;
 use crate::expr::ExprMap;
+use crate::expr::MatchInfo;
 use crate::expr::{Expr, SequenceExpr};
 use crate::patterns::UPOSSet;
 
@@ -107,7 +108,8 @@ impl ExprLinter for PronounInflectionBe {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let span = matched_tokens.last()?.span;
 
         // Determine the correct inflection of "be".

--- a/harper-core/src/linting/pronoun_knew.rs
+++ b/harper-core/src/linting/pronoun_knew.rs
@@ -2,6 +2,7 @@ use harper_brill::UPOS;
 
 use crate::expr::Expr;
 use crate::expr::LongestMatchOf;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::{
     Token,
@@ -64,7 +65,8 @@ impl ExprLinter for PronounKnew {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let tokens = match_info.matched_tokens;
         let typo_token = tokens.last()?;
         let typo_span = typo_token.span;
         let typo_text = typo_span.get_content(source);

--- a/harper-core/src/linting/proper_noun_capitalization_linters.rs
+++ b/harper-core/src/linting/proper_noun_capitalization_linters.rs
@@ -1,12 +1,12 @@
-use crate::expr::{Expr, ExprMap, FixedPhrase};
+use crate::expr::{Expr, ExprMap, FixedPhrase, MatchInfo};
 use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
 
 use super::{ExprLinter, LintGroup};
 use super::{Lint, LintKind, Suggestion};
+use crate::TokenStringExt;
 use crate::parsers::PlainEnglish;
 use crate::{Dictionary, Document};
-use crate::{Token, TokenStringExt};
 use std::sync::Arc;
 
 /// A linter that corrects the capitalization of multi-word proper nouns.
@@ -69,7 +69,8 @@ impl<D: Dictionary + 'static> ExprLinter for ProperNounCapitalizationLinter<D> {
         &self.pattern_map
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let canonical_case = self.pattern_map.lookup(0, matched_tokens, source).unwrap();
 
         let mut broken = false;

--- a/harper-core/src/linting/redundant_additive_adverbs.rs
+++ b/harper-core/src/linting/redundant_additive_adverbs.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Lrc, Token, TokenStringExt,
-    expr::{Expr, FirstMatchOf, FixedPhrase, SequenceExpr},
+    Lrc, TokenStringExt,
+    expr::{Expr, FirstMatchOf, FixedPhrase, MatchInfo, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
     patterns::WordSet,
 };
@@ -39,7 +39,8 @@ impl ExprLinter for RedundantAdditiveAdverbs {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         let phrase_string = toks.span()?.get_content_string(src).to_lowercase();
 
         // Rule out `also too` as in `This is also too slow`.

--- a/harper-core/src/linting/regionalisms.rs
+++ b/harper-core/src/linting/regionalisms.rs
@@ -1,7 +1,7 @@
 use crate::{
     Dialect::{self, American, Australian, British, Canadian},
-    Token, TokenStringExt,
-    expr::{Expr, FirstMatchOf, FixedPhrase},
+    TokenStringExt,
+    expr::{Expr, FirstMatchOf, FixedPhrase, MatchInfo},
     linting::{Lint, LintKind, Suggestion},
 };
 
@@ -461,7 +461,8 @@ impl ExprLinter for Regionalisms {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         let span = toks.span()?;
         let flagged_term_chars = span.get_content(src);
         let flagged_term_string = span.get_content_string(src).to_lowercase();

--- a/harper-core/src/linting/save_to_safe.rs
+++ b/harper-core/src/linting/save_to_safe.rs
@@ -1,8 +1,8 @@
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::OwnedExprExt;
 use crate::expr::SequenceExpr;
 use crate::{
-    Token,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
     patterns::{InflectionOfBe, Word},
 };
@@ -32,7 +32,8 @@ impl ExprLinter for SaveToSafe {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         let save_tok = &toks.get(2)?;
         let verb_tok = &toks.get(4)?;
         let verb = verb_tok.span.get_content_string(src).to_lowercase();

--- a/harper-core/src/linting/shoot_oneself_in_the_foot.rs
+++ b/harper-core/src/linting/shoot_oneself_in_the_foot.rs
@@ -1,6 +1,6 @@
 use crate::{
-    CharStringExt, Span, Token,
-    expr::{Expr, ReflexivePronoun, SequenceExpr},
+    CharStringExt, Span,
+    expr::{Expr, MatchInfo, ReflexivePronoun, SequenceExpr},
     linting::Suggestion,
     patterns::WordSet,
 };
@@ -38,7 +38,8 @@ impl ExprLinter for ShootOneselfInTheFoot {
         self.pattern.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         let pron = &toks.get(2)?.span.get_content(src);
         let prep = &toks.get(4)?.span.get_content(src);
         let det = &toks.get(6)?.span.get_content(src);

--- a/harper-core/src/linting/since_duration.rs
+++ b/harper-core/src/linting/since_duration.rs
@@ -1,8 +1,9 @@
 use crate::expr::Expr;
 use crate::expr::LongestMatchOf;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::expr::SpelledNumberExpr;
-use crate::{Lrc, Token, TokenStringExt, patterns::WordSet};
+use crate::{Lrc, TokenStringExt, patterns::WordSet};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -63,7 +64,8 @@ impl ExprLinter for SinceDuration {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         let last = toks.last()?;
         if last.span.get_content_string(src).to_lowercase() == "ago" {
             return None;

--- a/harper-core/src/linting/somewhat_something.rs
+++ b/harper-core/src/linting/somewhat_something.rs
@@ -1,5 +1,5 @@
-use crate::Token;
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
@@ -27,7 +27,8 @@ impl ExprLinter for SomewhatSomething {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let span = matched_tokens.first()?.span;
         let og = span.get_content(source);
 

--- a/harper-core/src/linting/take_serious.rs
+++ b/harper-core/src/linting/take_serious.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Token, TokenStringExt,
-    expr::{Expr, SequenceExpr},
+    TokenStringExt,
+    expr::{Expr, MatchInfo, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
     patterns::{NominalPhrase, WordSet},
 };
@@ -39,7 +39,8 @@ impl ExprLinter for TakeSerious {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let whole_phrase_span = matched_tokens.span()?;
         let all_but_last_token = matched_tokens[..matched_tokens.len() - 1].span()?;
 

--- a/harper-core/src/linting/that_which.rs
+++ b/harper-core/src/linting/that_which.rs
@@ -1,9 +1,10 @@
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::expr::WordExprGroup;
 use itertools::Itertools;
 
-use crate::{Lrc, Token, TokenStringExt};
+use crate::{Lrc, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -36,7 +37,8 @@ impl ExprLinter for ThatWhich {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let suggestion = format!(
             "{} which",
             matched_tokens[0]

--- a/harper-core/src/linting/the_how_why.rs
+++ b/harper-core/src/linting/the_how_why.rs
@@ -1,8 +1,9 @@
 use crate::expr::Expr;
 use crate::expr::LongestMatchOf;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::{
-    Token, TokenStringExt,
+    TokenStringExt,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
 };
 
@@ -64,7 +65,8 @@ impl ExprLinter for TheHowWhy {
         &self.expr
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let the_token_span = matched_tokens[0..2].span()?;
         let question_word_token = matched_tokens.get(2)?;
         let question_word = question_word_token.span.get_content(source);

--- a/harper-core/src/linting/the_my.rs
+++ b/harper-core/src/linting/the_my.rs
@@ -1,9 +1,10 @@
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::expr::Expr;
 use crate::expr::LongestMatchOf;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::{
-    CharStringExt, Token, TokenStringExt,
+    CharStringExt, TokenStringExt,
     patterns::{Word, WordSet},
 };
 
@@ -40,7 +41,8 @@ impl ExprLinter for TheMy {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let span = matched_tokens.span().unwrap();
         let span_content = span.get_content(source);
 

--- a/harper-core/src/linting/then_than.rs
+++ b/harper-core/src/linting/then_than.rs
@@ -3,6 +3,7 @@ use crate::Token;
 use crate::expr::All;
 use crate::expr::Expr;
 use crate::expr::LongestMatchOf;
+use crate::expr::MatchInfo;
 use crate::expr::OwnedExprExt;
 use crate::expr::SequenceExpr;
 use crate::linting::Suggestion;
@@ -76,7 +77,8 @@ impl ExprLinter for ThenThan {
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         // For both "stupider then X" and "more stupid then X", "then" is 3rd last token.
         let span = matched_tokens[matched_tokens.len() - 3].span;
         let offending_text = span.get_content(source);

--- a/harper-core/src/linting/thing_think.rs
+++ b/harper-core/src/linting/thing_think.rs
@@ -1,6 +1,5 @@
 use crate::{
-    Token,
-    expr::{Expr, FixedPhrase, LongestMatchOf, SequenceExpr},
+    expr::{Expr, FixedPhrase, LongestMatchOf, MatchInfo, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
     patterns::WordSet,
 };
@@ -81,7 +80,8 @@ impl ExprLinter for ThingThink {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         let thing_span = toks.last()?.span;
 
         Some(Lint {

--- a/harper-core/src/linting/touristic.rs
+++ b/harper-core/src/linting/touristic.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Token, TokenStringExt,
-    expr::{Expr, LongestMatchOf, SequenceExpr},
+    TokenStringExt,
+    expr::{Expr, LongestMatchOf, MatchInfo, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
 };
 
@@ -93,7 +93,8 @@ impl ExprLinter for Touristic {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         let tok_span_content_string = toks.span()?.get_content_string(src);
         let tok_span_content_string = tok_span_content_string.to_lowercase();
 

--- a/harper-core/src/linting/use_genitive.rs
+++ b/harper-core/src/linting/use_genitive.rs
@@ -1,10 +1,11 @@
 use crate::expr::Expr;
 use crate::expr::LongestMatchOf;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::expr::WordExprGroup;
 use crate::linting::{ExprLinter, LintKind, Suggestion};
 use crate::patterns::Word;
-use crate::{Lint, Lrc, Token};
+use crate::{Lint, Lrc};
 
 // Looks for places where the genitive case _isn't_ being used, and should be.
 pub struct UseGenitive {
@@ -62,7 +63,8 @@ impl ExprLinter for UseGenitive {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], _source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, _source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         Some(Lint {
             span: matched_tokens[2].span,
             lint_kind: LintKind::Miscellaneous,

--- a/harper-core/src/linting/was_aloud.rs
+++ b/harper-core/src/linting/was_aloud.rs
@@ -1,7 +1,7 @@
 use super::{ExprLinter, Lint, LintKind};
-use crate::Token;
 use crate::TokenStringExt;
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::linting::Suggestion;
 use crate::patterns::WordSet;
@@ -28,7 +28,8 @@ impl ExprLinter for WasAloud {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let verb = matched_tokens[0].span.get_content_string(source);
 
         Some(Lint {

--- a/harper-core/src/linting/way_too_adjective.rs
+++ b/harper-core/src/linting/way_too_adjective.rs
@@ -1,7 +1,6 @@
 use harper_brill::UPOS;
 
-use crate::Token;
-use crate::expr::{All, Expr, OwnedExprExt, SequenceExpr};
+use crate::expr::{All, Expr, MatchInfo, OwnedExprExt, SequenceExpr};
 use crate::patterns::{UPOSSet, WordSet};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
@@ -42,7 +41,8 @@ impl ExprLinter for WayTooAdjective {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         let to_tok = toks.get(2)?;
         let span = to_tok.span;
         let original = span.get_content(src);

--- a/harper-core/src/linting/whereas.rs
+++ b/harper-core/src/linting/whereas.rs
@@ -1,6 +1,7 @@
+use crate::TokenStringExt;
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
-use crate::{Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -26,7 +27,8 @@ impl ExprLinter for Whereas {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         let span = matched_tokens.span()?;
         let orig_chars = span.get_content(source);
 

--- a/harper-core/src/linting/widely_accepted.rs
+++ b/harper-core/src/linting/widely_accepted.rs
@@ -1,7 +1,7 @@
 use crate::expr::Expr;
+use crate::expr::MatchInfo;
 use crate::expr::SequenceExpr;
 use crate::{
-    Token,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
     patterns::{Word, WordSet},
 };
@@ -26,7 +26,8 @@ impl ExprLinter for WidelyAccepted {
         &self.expr
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, source: &[char]) -> Option<Lint> {
+        let matched_tokens = match_info.matched_tokens;
         // We only need to replace the `wide` token with `widely`.
         let wide_token = matched_tokens.first()?;
         let wide_chars = wide_token.span.get_content(source);

--- a/harper-core/src/linting/win_prize.rs
+++ b/harper-core/src/linting/win_prize.rs
@@ -1,7 +1,7 @@
-use crate::expr::SequenceExpr;
 use crate::expr::{Expr, OwnedExprExt};
+use crate::expr::{MatchInfo, SequenceExpr};
 use crate::{
-    Lrc, Token,
+    Lrc,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
     patterns::WordSet,
 };
@@ -37,7 +37,8 @@ impl ExprLinter for WinPrize {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, match_info: MatchInfo<'_>, src: &[char]) -> Option<Lint> {
+        let toks = match_info.matched_tokens;
         let candidate = toks.last()?;
         let raw = candidate.span.get_content_string(src).to_lowercase();
         let repl = match raw.as_str() {


### PR DESCRIPTION
# Issues 
N/A

# Description

Start work on unnamed capture support:

Instead of directly passing the slice of matched tokens, pass a `MatchInfo` that wraps them and will be able to include other info.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
