### PR TITLE
fix(chrome-ext): don't run on disabled inputs

### DIFF
--- a/justfile
+++ b/justfile
@@ -289,7 +289,7 @@ dogfood:
   done
 
 # Test everything.
-test: test-harperjs test-vscode test-obsidian test-chrome-plugin
+test: test-harperjs test-vscode test-obsidian test-chrome-plugin test-firefox-plugin
   cargo test
 
 # Use `harper-cli` to parse a provided file and print out the resulting tokens.

--- a/packages/chrome-plugin/src/contentScript/index.ts
+++ b/packages/chrome-plugin/src/contentScript/index.ts
@@ -7,7 +7,7 @@ const fw = new LintFramework();
 
 function scan() {
 	$('textarea:visible').each(function () {
-		if (this.getAttribute('data-enable-grammarly') == 'false') {
+		if (this.getAttribute('data-enable-grammarly') == 'false' || this.disabled || this.readOnly) {
 			return;
 		}
 

--- a/packages/chrome-plugin/src/contentScript/index.ts
+++ b/packages/chrome-plugin/src/contentScript/index.ts
@@ -15,6 +15,10 @@ function scan() {
 	});
 
 	$('input[type="text"][spellcheck="true"]').each(function () {
+		if (this.disabled || this.readOnly) {
+			return;
+		}
+
 		fw.addTarget(this as HTMLInputElement);
 	});
 

--- a/packages/chrome-plugin/tests/pages/simple_inputs_disabled.html
+++ b/packages/chrome-plugin/tests/pages/simple_inputs_disabled.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+
+<body>
+  <h1>disabled Textarea</h1>
+  <textarea rows="5" cols="33" disabled>tis iss a mispeled sentce</textarea>
+
+  <h1>readonly Textarea</h1>
+  <textarea rows="5" cols="33" readonly>tis iss a mispeled sentce</textarea>
+
+  <h1>readonly + disabled Textarea</h1>
+  <textarea rows="5" cols="33" disabled readonly>tis iss a mispeled sentce</textarea>
+
+  <h1>disabled Input</h1>
+  <input type="text" spellcheck="true" disabled value="This is an test">
+
+  <h1>readonly Input</h1>
+  <input type="text" spellcheck="true" readonly value="This is an test">
+
+  <h1>readonly + disabled Input</h1>
+  <input type="text" spellcheck="true" readonly disabled value="This is an test">
+</body>
+
+</html>

--- a/packages/chrome-plugin/tests/simple_inputs_disabled.spec.ts
+++ b/packages/chrome-plugin/tests/simple_inputs_disabled.spec.ts
@@ -1,0 +1,13 @@
+import { test } from './fixtures';
+import { assertHarperHighlightBoxes } from './testUtils';
+
+const TEST_PAGE_URL = 'http://localhost:8081/simple_inputs_disabled.html';
+
+test('Ignores disabled and readonly inputs', async ({ page }, testInfo) => {
+	await page.goto(TEST_PAGE_URL);
+
+	await page.waitForTimeout(6000);
+
+	// All inputs on this page are disabled or read-only, so no lint boxes should be drawn.
+	await assertHarperHighlightBoxes(page, []);
+});


### PR DESCRIPTION
# Issues 

Addresses #1524 

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

This PR checks that textareas an inputs are not disabled or readonly before linting them.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Additional integration tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
