### PR TITLE
feat(cli): add `annotate-tokens` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,6 +840,8 @@ dependencies = [
  "hashbrown 0.15.4",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
 ]
 
 [[package]]

--- a/harper-cli/Cargo.toml
+++ b/harper-cli/Cargo.toml
@@ -19,6 +19,8 @@ harper-typst = { path = "../harper-typst", version = "0.49.0" }
 hashbrown = "0.15.4"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+strum = "0.27.1"
+strum_macros = "0.27.1"
 
 [features]
 default = []

--- a/harper-cli/src/annotate_tokens.rs
+++ b/harper-cli/src/annotate_tokens.rs
@@ -35,12 +35,11 @@ impl Annotation {
             AnnotationType::Upos => {
                 // Only annotate words (with word metadata) for `AnnotationType::Upos`.
                 if let TokenKind::Word(Some(metadata)) = &token.kind {
+                    let pos_tag = metadata.pos_tag;
                     Some(Self {
                         span,
-                        annotation_text: serde_json::to_string_pretty(&metadata.pos_tag).unwrap(),
-                        color: metadata
-                            .pos_tag
-                            .map_or(Color::Red, get_color_for_enum_variant),
+                        annotation_text: pos_tag.map_or("NONE".to_owned(), |upos| upos.to_string()),
+                        color: pos_tag.map_or(Color::Red, get_color_for_enum_variant),
                     })
                 } else {
                     // Not a word, or a word with no metadata.

--- a/harper-cli/src/annotate_tokens.rs
+++ b/harper-cli/src/annotate_tokens.rs
@@ -3,7 +3,7 @@ use clap::ValueEnum;
 use harper_core::{Document, Span, Token, TokenKind};
 use strum::IntoEnumIterator;
 
-/// Represents an annotation that may be converted to a `Label` and displayed.
+/// Represents an annotation.
 pub(super) struct Annotation {
     /// The range the annotation covers in the source. For instance, this might be a single word.
     span: Span,
@@ -13,7 +13,7 @@ pub(super) struct Annotation {
     color: Color,
 }
 impl Annotation {
-    /// Converts the annotation into an `ariadne::Label`.
+    /// Converts the annotation into an [`ariadne::Label`].
     #[must_use]
     pub(super) fn into_label(
         self,
@@ -24,7 +24,7 @@ impl Annotation {
             .with_color(self.color)
     }
 
-    /// Constructs an `Annotation` from the given `token` based on the given `annotation_type`.
+    /// Constructs an [`Annotation`] from the given `token` based on the given `annotation_type`.
     ///
     /// This will return `None` when the `token` should not be annotated according to
     /// `annotation_type`.
@@ -33,8 +33,8 @@ impl Annotation {
         let span = token.span;
         match annotation_type {
             AnnotationType::Upos => {
-                // Only annotate words (with word metadata) for `AnnotationType::Upos`.
                 if let TokenKind::Word(Some(metadata)) = &token.kind {
+                    // Only annotate words (with word metadata) for `AnnotationType::Upos`.
                     let pos_tag = metadata.pos_tag;
                     Some(Self {
                         span,
@@ -49,7 +49,7 @@ impl Annotation {
         }
     }
 
-    /// Gets an iterator of `Annotation` for a given document. The annotations will be based on
+    /// Gets an iterator of [`Annotation`] for a given document. The annotations will be based on
     /// `annotation_type`.
     fn iter_from_document(
         annotation_type: AnnotationType,
@@ -62,8 +62,8 @@ impl Annotation {
 
     /// Gets an iterator of annotation `Label` from the given document.
     ///
-    /// This is similar to `self::iter_from_document`, but this additionally converts
-    /// the `Annotation` into `ariadne::Label` for convenience.
+    /// This is similar to [`self::iter_from_document()`], but this additionally converts
+    /// the [`Annotation`] into [`ariadne::Label`] for convenience.
     pub(super) fn iter_labels_from_document<'inpt_id>(
         annotation_type: AnnotationType,
         document: &Document,

--- a/harper-cli/src/annotate_tokens.rs
+++ b/harper-cli/src/annotate_tokens.rs
@@ -23,6 +23,7 @@ impl Annotation {
             .with_message(self.annotation_text)
             .with_color(self.color)
     }
+
     /// Gets an iterator of annotation `Label` from the given document.
     ///
     /// This is similar to [`self::iter_from_document()`], but this additionally converts

--- a/harper-cli/src/annotate_tokens.rs
+++ b/harper-cli/src/annotate_tokens.rs
@@ -23,6 +23,18 @@ impl Annotation {
             .with_message(self.annotation_text)
             .with_color(self.color)
     }
+    /// Gets an iterator of annotation `Label` from the given document.
+    ///
+    /// This is similar to [`self::iter_from_document()`], but this additionally converts
+    /// the [`Annotation`] into [`ariadne::Label`] for convenience.
+    pub(super) fn iter_labels_from_document<'inpt_id>(
+        annotation_type: AnnotationType,
+        document: &Document,
+        input_identifier: &'inpt_id str,
+    ) -> impl Iterator<Item = Label<(&'inpt_id str, std::ops::Range<usize>)>> {
+        Self::iter_from_document(annotation_type, document)
+            .map(|annotation| annotation.into_label(input_identifier))
+    }
 
     /// Constructs an [`Annotation`] from the given `token` based on the given `annotation_type`.
     ///
@@ -58,19 +70,6 @@ impl Annotation {
         document
             .tokens()
             .filter_map(move |token| Self::from_token(annotation_type, token))
-    }
-
-    /// Gets an iterator of annotation `Label` from the given document.
-    ///
-    /// This is similar to [`self::iter_from_document()`], but this additionally converts
-    /// the [`Annotation`] into [`ariadne::Label`] for convenience.
-    pub(super) fn iter_labels_from_document<'inpt_id>(
-        annotation_type: AnnotationType,
-        document: &Document,
-        input_identifier: &'inpt_id str,
-    ) -> impl Iterator<Item = Label<(&'inpt_id str, std::ops::Range<usize>)>> {
-        Self::iter_from_document(annotation_type, document)
-            .map(|annotation| annotation.into_label(input_identifier))
     }
 }
 

--- a/harper-cli/src/annotate_tokens.rs
+++ b/harper-cli/src/annotate_tokens.rs
@@ -1,0 +1,99 @@
+use ariadne::{Color, Label};
+use clap::ValueEnum;
+use harper_core::{Document, Span, Token, TokenKind};
+use strum::IntoEnumIterator;
+
+/// Represents an annotation that may be converted to a `Label` and displayed.
+pub(super) struct Annotation {
+    /// The range the annotation covers in the source. For instance, this might be a single word.
+    span: Span,
+    /// The message displayed by the annotation.
+    annotation_text: String,
+    /// The color of the annotation.
+    color: Color,
+}
+impl Annotation {
+    /// Converts the annotation into an `ariadne::Label`.
+    #[must_use]
+    pub(super) fn into_label(
+        self,
+        input_identifier: &str,
+    ) -> Label<(&str, std::ops::Range<usize>)> {
+        Label::new((input_identifier, self.span.into()))
+            .with_message(self.annotation_text)
+            .with_color(self.color)
+    }
+
+    /// Constructs an `Annotation` from the given `token` based on the given `annotation_type`.
+    ///
+    /// This will return `None` when the `token` should not be annotated according to
+    /// `annotation_type`.
+    #[must_use]
+    fn from_token(annotation_type: AnnotationType, token: &Token) -> Option<Self> {
+        let span = token.span;
+        match annotation_type {
+            AnnotationType::Upos => {
+                // Only annotate words (with word metadata) for `AnnotationType::Upos`.
+                if let TokenKind::Word(Some(metadata)) = &token.kind {
+                    Some(Self {
+                        span,
+                        annotation_text: serde_json::to_string_pretty(&metadata.pos_tag).unwrap(),
+                        color: metadata
+                            .pos_tag
+                            .map_or(Color::Red, get_color_for_enum_variant),
+                    })
+                } else {
+                    // Not a word, or a word with no metadata.
+                    None
+                }
+            }
+        }
+    }
+
+    /// Gets an iterator of `Annotation` for a given document. The annotations will be based on
+    /// `annotation_type`.
+    fn iter_from_document(
+        annotation_type: AnnotationType,
+        document: &Document,
+    ) -> impl Iterator<Item = Self> {
+        document
+            .tokens()
+            .filter_map(move |token| Self::from_token(annotation_type, token))
+    }
+
+    /// Gets an iterator of annotation `Label` from the given document.
+    ///
+    /// This is similar to `self::iter_from_document`, but this additionally converts
+    /// the `Annotation` into `ariadne::Label` for convenience.
+    pub(super) fn iter_labels_from_document<'inpt_id>(
+        annotation_type: AnnotationType,
+        document: &Document,
+        input_identifier: &'inpt_id str,
+    ) -> impl Iterator<Item = Label<(&'inpt_id str, std::ops::Range<usize>)>> {
+        Self::iter_from_document(annotation_type, document)
+            .map(|annotation| annotation.into_label(input_identifier))
+    }
+}
+
+/// Represents how the tokens should be annotated.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub(super) enum AnnotationType {
+    /// UPOS (part of speech)
+    Upos,
+}
+
+/// Gets a random `Color` for an enum variant.
+///
+/// A given enum variant's color is consistent, meaning it will not change throughout multiple
+/// calls of this function or multiple runs of the application.
+#[must_use]
+fn get_color_for_enum_variant<T: IntoEnumIterator + PartialEq>(variant_to_color: T) -> Color {
+    // Using a lower than default `min_brightness` to hopefully create more distinguishable colors.
+    let mut color_gen = ariadne::ColorGenerator::from_state([31715, 3528, 21854], 0.2);
+    T::iter()
+        // Note: `ColorGenerator` does not implement `Iterator`, so we can't just zip it.
+        .map(|enum_variant| (enum_variant, color_gen.next()))
+        .find(|(enum_variant, _)| *enum_variant == variant_to_color)
+        .unwrap()
+        .1
+}

--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -27,6 +27,9 @@ use serde::Serialize;
 mod input;
 use input::Input;
 
+mod annotate_tokens;
+use annotate_tokens::{Annotation, AnnotationType};
+
 /// A debugging tool for the Harper grammar checker.
 #[derive(Debug, Parser)]
 #[command(version, about)]
@@ -68,6 +71,15 @@ enum Args {
         /// Include newlines in the output
         #[arg(short, long)]
         include_newlines: bool,
+    },
+    /// Parse a provided document and annotate its tokens.
+    AnnotateTokens {
+        /// The text or file you wish to parse. If not provided, it will be read from standard
+        /// input.
+        input: Option<Input>,
+        /// How the tokens should be annotated.
+        #[arg(value_enum, default_value_t = AnnotationType::Upos)]
+        annotation_type: AnnotationType,
     },
     /// Get the metadata associated with a particular word.
     Metadata { word: String },
@@ -265,6 +277,35 @@ fn main() -> anyhow::Result<()> {
 
             let report = report_builder.finish();
             report.print((&input_identifier, Source::from(source)))?;
+
+            Ok(())
+        }
+        Args::AnnotateTokens {
+            input,
+            annotation_type,
+        } => {
+            // Try to read from standard input if `input` was not provided.
+            let input = input.unwrap_or_else(|| Input::try_from_stdin().unwrap());
+
+            // Load the file/text.
+            let (doc, source) = input.load(markdown_options, &dictionary)?;
+
+            let input_identifier = input.get_identifier();
+
+            let mut report_builder = Report::build(
+                ReportKind::Custom("AnnotateTokens", Color::Blue),
+                &*input_identifier,
+                0,
+            );
+
+            report_builder = report_builder.with_labels(Annotation::iter_labels_from_document(
+                annotation_type,
+                &doc,
+                &input_identifier,
+            ));
+
+            let report = report_builder.finish();
+            report.print((&*input_identifier, Source::from(source)))?;
 
             Ok(())
         }

--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -78,7 +78,7 @@ enum Args {
         /// input.
         input: Option<Input>,
         /// How the tokens should be annotated.
-        #[arg(value_enum, default_value_t = AnnotationType::Upos)]
+        #[arg(short, long, value_enum, default_value_t = AnnotationType::Upos)]
         annotation_type: AnnotationType,
     },
     /// Get the metadata associated with a particular word.

--- a/harper-pos-utils/src/upos.rs
+++ b/harper-pos-utils/src/upos.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use is_macro::Is;
 use serde::{Deserialize, Serialize};
 use strum_macros::{AsRefStr, EnumIter};
@@ -80,5 +82,29 @@ impl UPOS {
 
     pub fn is_nominal(&self) -> bool {
         matches!(self, Self::NOUN | Self::PROPN | Self::PRON)
+    }
+}
+
+impl Display for UPOS {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let desc = match self {
+            UPOS::ADJ => "Adjective",
+            UPOS::ADP => "Adposition",
+            UPOS::ADV => "Adverb",
+            UPOS::AUX => "Auxiliary",
+            UPOS::CCONJ => "Coordinating conjunction",
+            UPOS::DET => "Determiner",
+            UPOS::INTJ => "Interjection",
+            UPOS::NOUN => "Noun",
+            UPOS::NUM => "Numeral",
+            UPOS::PART => "Particle",
+            UPOS::PRON => "Pronoun",
+            UPOS::PROPN => "Proper noun",
+            UPOS::PUNCT => "Punctuation",
+            UPOS::SCONJ => "Subordinating conjunction",
+            UPOS::SYM => "Symbol",
+            UPOS::VERB => "Verb",
+        };
+        write!(f, "{desc}")
     }
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
Adds a harper-cli command to annotate tokens. This should hopefully make it easier to view and analyze the way we parse tokens. My primary motivation for this was to make it easier to view how certain sentences are parsed via the POS tagger. To the best of my knowledge, currently the only way to get this information is via the `parse` command, whose output (unless processed externally) is not very human-readable.

<!-- Any details that you think are important to review this PR? -->
Though this currently only supports UPOS annotations, I tried to make this command as easily extensible as possible. To add a new annotation method, one would just have add the respective variant to `AnnotationType`, and add that variant to the match statement in `Annotation::from_token()`.

Some potential improvements include:
- Allowing `AnnotationType` to contain arguments/parameters. This could allow for the merging of the `spans` command into `annotate-tokens` (as an `AnnotationType`).
- Ensuring that distinctive colors are generated in `get_color_for_enum_variant()`. The implementation currently uses `ariadne::ColorGenerator`, which is simple to use, but does not guarantee that the colors generated are distinguishable from one another.

<!-- Are there other PRs related to this one? -->

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->
<img width="856" height="509" alt="image" src="https://github.com/user-attachments/assets/1dceba95-5371-4096-a22a-6f3eb4d286b0" />


# How Has This Been Tested?
- `cargo test`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
