### PR TITLE
fix(chrome-ext): don't interfere with the Gutenberg rendering process

### DIFF
--- a/packages/chrome-plugin/src/Highlights.ts
+++ b/packages/chrome-plugin/src/Highlights.ts
@@ -4,6 +4,7 @@ import { type LintBox, isBoxInScreen } from './Box';
 import RenderBox from './RenderBox';
 import {
 	getCMRoot,
+	getGutenbergRoot,
 	getLexicalRoot,
 	getMediumRoot,
 	getNotionRoot,
@@ -138,6 +139,7 @@ export default class Highlights {
 			getQuillJsRoot,
 			getLexicalRoot,
 			getP2Root,
+			getGutenbergRoot,
 			getTrixRoot,
 		];
 

--- a/packages/chrome-plugin/src/editorUtils.ts
+++ b/packages/chrome-plugin/src/editorUtils.ts
@@ -21,6 +21,14 @@ export function getP2Root(el: HTMLElement): HTMLElement | null {
 	return findAncestor(el, (node: HTMLElement) => node.classList.contains('p2-editor'));
 }
 
+/** Determines if a given node is a child of a Gutenberg editor instance.
+ * If so, returns the root node of that instance. */
+export function getGutenbergRoot(el: HTMLElement): HTMLElement | null {
+	return findAncestor(el, (node: HTMLElement) =>
+		node.classList.contains('block-editor-block-canvas'),
+	);
+}
+
 /** Determines if a given node is a child of a Lexical editor instance.
  * If so, returns the root node of that instance. */
 export function getLexicalRoot(el: HTMLElement): HTMLElement | null {


### PR DESCRIPTION
# Issues 

DM from a fellow Automattician.

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

Harper was inserting its highlights into the DOM _inside_ the Gutenberg editor, which mean that they ended up as part of the rendered page. This PR moves those highlights to _just outside_ the editor, so Z-indexing still works as expected and we don't have any unwanted DOM nodes in published pages.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
