### PR TITLE
fix(chrome-ext): properly place highlights relative to Draft.js root

### DIFF
--- a/packages/chrome-plugin/src/Highlights.ts
+++ b/packages/chrome-plugin/src/Highlights.ts
@@ -4,6 +4,7 @@ import { type LintBox, isBoxInScreen } from './Box';
 import RenderBox from './RenderBox';
 import {
 	getCMRoot,
+	getDraftRoot,
 	getLexicalRoot,
 	getMediumRoot,
 	getNotionRoot,
@@ -129,6 +130,7 @@ export default class Highlights {
 		}
 
 		const queries = [
+			getDraftRoot,
 			getPMRoot,
 			getCMRoot,
 			getNotionRoot,

--- a/packages/chrome-plugin/src/background/index.ts
+++ b/packages/chrome-plugin/src/background/index.ts
@@ -78,6 +78,7 @@ async function enableDefaultDomains() {
 		'localhost',
 		'writewithharper.com',
 		'prosemirror.net',
+		'draftjs.org',
 	];
 
 	for (const item of defaultEnabledDomains) {

--- a/packages/chrome-plugin/src/editorUtils.ts
+++ b/packages/chrome-plugin/src/editorUtils.ts
@@ -36,6 +36,12 @@ export function getSlateRoot(el: HTMLElement): HTMLElement | null {
 	return findAncestor(el, (node: HTMLElement) => node.getAttribute('data-slate-editor') == 'true');
 }
 
+/** Determines if a given node is a child of a Draft.js editor instance.
+ * If so, returns the root node of that instance. */
+export function getDraftRoot(el: HTMLElement): HTMLElement | null {
+	return findAncestor(el, (node: HTMLElement) => node.classList.contains('DraftEditor-root'));
+}
+
 /** Determines if a given node is a child of a Trix editor instance.
  * If so, returns the root node of that instance. */
 export function getTrixRoot(el: HTMLElement): HTMLElement | null {


### PR DESCRIPTION
# Issues 

Fixes issue with `x.com` from #1395.

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

Erroneous newlines were being inserted due to the highlight host's proximity to the text's DOM nodes. I've moved them to be adjacent to the Draft.js editor itself.	

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.	

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
