### PR TITLE
refactor(core): adjust to reduce ambiguity

### DIFF
--- a/harper-core/src/patterns/word.rs
+++ b/harper-core/src/patterns/word.rs
@@ -3,12 +3,12 @@ use super::SingleTokenPattern;
 use crate::{CharString, Token};
 
 /// Matches a predefined word.
-///
-/// Note that any capitalization of the contained word will result in a match.
 #[derive(Clone)]
 pub struct Word {
+    /// The word to match.
     word: CharString,
-    exact: bool,
+    /// Determines whether the match is case-sensitive.
+    case_sensitive: bool,
 }
 
 impl Word {
@@ -16,27 +16,30 @@ impl Word {
     pub fn new(word: &'static str) -> Self {
         Self {
             word: word.chars().collect(),
-            exact: false,
+            case_sensitive: false,
         }
     }
     /// Matches the provided word, ignoring case.
     pub fn from_chars(word: &[char]) -> Self {
         Self {
             word: word.iter().copied().collect(),
-            exact: false,
+            case_sensitive: false,
         }
     }
 
     /// Matches the provided word, ignoring case.
     pub fn from_char_string(word: CharString) -> Self {
-        Self { word, exact: false }
+        Self {
+            word,
+            case_sensitive: false,
+        }
     }
 
     /// Matches the provided word, case-sensitive.
     pub fn new_exact(word: &'static str) -> Self {
         Self {
             word: word.chars().collect(),
-            exact: true,
+            case_sensitive: true,
         }
     }
 }
@@ -51,7 +54,7 @@ impl SingleTokenPattern for Word {
         }
 
         let chars = token.span.get_content(source);
-        if self.exact {
+        if self.case_sensitive {
             chars == self.word.as_slice()
         } else {
             chars

--- a/harper-core/src/patterns/word.rs
+++ b/harper-core/src/patterns/word.rs
@@ -19,6 +19,7 @@ impl Word {
             case_sensitive: false,
         }
     }
+
     /// Matches the provided word, ignoring case.
     pub fn from_chars(word: &[char]) -> Self {
         Self {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
Attempts to reduce ambiguity and improve readability in `patterns::word::Word` by:
- Renaming `exact` to `case_sensitive`
- Adding and updating documentation
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

# How Has This Been Tested?
- `cargo test`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
