### PR TITLE
feat: extend→extent when used as noun

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -117,6 +117,16 @@ pub fn lint_group() -> LintGroup {
             "The correct names for the `!` punctuation are `exclamation mark` and `exclamation point`.",
             "Corrects the eggcorn `explanation mark/point` to `exclamation mark/point`."
         ),
+        "ExtendOrExtent" => (
+            &[
+                ("a certain extend", "a certain extent"),
+                ("to an extend", "to an extent"),
+                ("to some extend", "to some extent"),
+                ("to the extend that", "to the extent that")
+            ],
+            "Use `extent` for the noun and `extend` for the verb.",
+            "Corrects `extend` to `extent` when the context is a noun."
+        ),
         "HaveGone" => (
             &[
                 ("had went", "had gone"),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -131,6 +131,44 @@ fn detect_explanation_point_real_world() {
     );
 }
 
+// ExtendOrExtent
+
+#[test]
+fn correct_certain_extend() {
+    assert_suggestion_result(
+        "This is a PowerShell script to automate client pentests / checkups - at least to a certain extend.",
+        lint_group(),
+        "This is a PowerShell script to automate client pentests / checkups - at least to a certain extent.",
+    );
+}
+
+#[test]
+fn correct_to_the_extend() {
+    assert_suggestion_result(
+        "Our artifacts are carefully documented and well-structured to the extend that reuse is facilitated.",
+        lint_group(),
+        "Our artifacts are carefully documented and well-structured to the extent that reuse is facilitated.",
+    );
+}
+
+#[test]
+fn correct_to_some_extend() {
+    assert_suggestion_result(
+        "Hi, I'm new to Pydantic and to some extend python, and I have a question that I haven't been able to figure out from the Docs.",
+        lint_group(),
+        "Hi, I'm new to Pydantic and to some extent python, and I have a question that I haven't been able to figure out from the Docs.",
+    );
+}
+
+#[test]
+fn correct_to_an_extend() {
+    assert_suggestion_result(
+        "It mimics (to an extend) the way in which Chrome requests SSO cookies with the Windows 10 accounts extension.",
+        lint_group(),
+        "It mimics (to an extent) the way in which Chrome requests SSO cookies with the Windows 10 accounts extension.",
+    );
+}
+
 // HaveGone
 
 #[test]


### PR DESCRIPTION
# Issues 
N/A

# Description

Phrase set corrections to correct "extend" used when "extent" is meant.

# How Has This Been Tested?

I added unit tests using sentences found on GitHub for four common contexts.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
