### PR TITLE
feat: support quantifier as type of determiner

### DIFF
--- a/harper-core/annotations.json
+++ b/harper-core/annotations.json
@@ -658,6 +658,14 @@
 				"determiner": {}
 			}
 		},
+		"q": {
+			"#": "quantifier property",
+			"metadata": {
+				"determiner": {
+					"is_quantifier": true
+				}
+			}
+		},
 		"R": {
 			"#": "adverb property",
 			"metadata": {

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -12030,7 +12030,7 @@ alkalise/VdSG!_
 alkalize/VdSG
 alkaloid/NJSg
 alkyd/NgS
-all/~INCJg
+all/~INCJgDq
 allay/VNGdS
 allegation/~NgS
 allege/~VGdS
@@ -12667,7 +12667,7 @@ anvil/~NVgS
 anxiety/~NSg
 anxious/~JYp
 anxiousness/Ng
-any/~IRD            # removed `5` adjective. it's determiner/pronoun/adverb only
+any/~IRDq           # removed `5` adjective. it's determiner/pronoun/adverb only
 anybody/~ISg
 anyhow/~J
 anymore/~
@@ -15265,7 +15265,7 @@ botanist/~NSg
 botany/~Ng
 botch/VNd>SZGg
 botcher/Ng
-both/~IC
+both/~ICDq
 bother/~VNSgdG
 botheration/N
 bothered/~JVU
@@ -22260,7 +22260,7 @@ eBay/OVg
 eMusic/g
 eSIM/NgS
 ea/~N
-each/~D
+each/~Dq
 eager/~JVNpT>Y
 eagerness/Ng
 eagle/~NVgS
@@ -23482,7 +23482,7 @@ everglade/NSg
 evergreen/~JNVSg
 everlasting/~JNgYS
 evermore/~
-every/~D
+every/~Dq
 everybody/~Ig
 everyday/~JN
 everyone/~Ig
@@ -24394,7 +24394,8 @@ feudalistic/J
 fever/~NVSgd
 feverish/JYp
 feverishness/Ng
-few/~ITpg>
+few/~ITpgDq
+fewer/Dqc
 fewness/Ng
 fey/~JN
 fez/~Ng
@@ -31951,7 +31952,7 @@ litter/~NVJgd>SZG
 litterateur/NgS
 litterbug/NgS
 litterer/Ng
-little/~JINgT>p
+little/~JINgT>pDq
 littleness/Ng
 littoral/~JNSg
 liturgical/~JY
@@ -32758,7 +32759,7 @@ manumitted/V
 manumitting/V
 manure/~VNgGdS
 manuscript/~JNgS
-many/~IJgD
+many/~IJgDq
 map/~NVrS
 map's
 maple/~NSg
@@ -34284,7 +34285,7 @@ morbidity/Ng
 morbidness/Ng
 mordancy/Ng
 mordant/JNVSgY
-more/~IJNVS
+more/~IJNVSDq
 moreish/J
 morel/~NSg
 moreover/~
@@ -34334,7 +34335,7 @@ mosquitoes/~N9
 moss/~NVgS
 mossback/NSg
 mossy/JNT>
-most/~JINgY
+most/~JINgYDq
 mot/~NSg
 mote/NVKeXSvn
 mote's
@@ -34459,7 +34460,7 @@ mt/~JN
 mtg/N
 mtge/N
 mu/~NSg
-much/~JIgp
+much/~JIgpDq
 mucilage/Nmg
 mucilaginous/J
 muck/NmVgdSG
@@ -34562,7 +34563,7 @@ multiparty/J
 multiphonics/Ng
 multiplanetary/J
 multiplayer/~JNg
-multiple/~JNgS
+multiple/~JNgSDq
 multiplex/~JNVZGgd>S
 multiplexer/Ng
 multiplicand/NgS
@@ -43621,7 +43622,7 @@ seventieth/JNg
 seventieths/N
 seventy/~SgH
 sever/~VETGdS
-several/~JYD
+several/~JYDq
 severance/NSg
 severe/~JYp>
 severeness/Ng
@@ -45044,7 +45045,7 @@ somberness/Ng
 sombre/JNVpY!@_
 sombreness/Ng!@_
 sombrero/NgS
-some/~IRJ
+some/~IRJDq
 somebody/~INSg
 someday/~
 somehow/~
@@ -52472,7 +52473,7 @@ Golang/Sg           # programming language
 Goleman/Sg
 Gradle/Sg           # build tool
 Grafana/Sg
-Grammarly/Og         # grammar checker
+Grammarly/Og        # grammar checker
 Grandey/Sg
 GraphQL/Og
 Graphviz/Sg

--- a/harper-core/src/linting/pronoun_contraction/should_contract.rs
+++ b/harper-core/src/linting/pronoun_contraction/should_contract.rs
@@ -21,7 +21,7 @@ impl Default for ShouldContract {
                 SequenceExpr::default()
                     .then(WordSet::new(&["your", "were"]))
                     .then_whitespace()
-                    .then_determiner()
+                    .then(|tok: &Token, _: &[char]| tok.kind.is_non_quantifier_determiner())
                     .then_whitespace()
                     .then_adjective(),
             ),

--- a/harper-core/src/spell/mutable_dictionary.rs
+++ b/harper-core/src/spell/mutable_dictionary.rs
@@ -267,16 +267,42 @@ mod tests {
         assert!(dict.contains_word_str("This"));
     }
 
-    // TODO "this" is a determiner when used similarly to "the"
-    // TODO but when used alone it's a "demonstrative pronoun"
-    // TODO Harper previously wrongly classified it as a noun
-    // TODO .is_determiner() is not yet implemented
-    // #[test]
-    // fn this_is_determiner() {
-    //     let dict = MutableDictionary::curated();
-    //     assert!(dict.get_word_metadata_str("this").unwrap().is_determiner());
-    //     assert!(dict.get_word_metadata_str("This").unwrap().is_determiner());
-    // }
+    #[test]
+    fn this_is_determiner() {
+        let dict = MutableDictionary::curated();
+        assert!(dict.get_word_metadata_str("this").unwrap().is_determiner());
+        assert!(dict.get_word_metadata_str("This").unwrap().is_determiner());
+    }
+
+    #[test]
+    fn several_is_quantifier() {
+        let dict = MutableDictionary::curated();
+        assert!(
+            dict.get_word_metadata_str("several")
+                .unwrap()
+                .is_quantifier_determiner()
+        );
+    }
+
+    #[test]
+    fn few_is_quantifier() {
+        let dict = MutableDictionary::curated();
+        assert!(
+            dict.get_word_metadata_str("few")
+                .unwrap()
+                .is_quantifier_determiner()
+        );
+    }
+
+    #[test]
+    fn fewer_is_quantifier() {
+        let dict = MutableDictionary::curated();
+        assert!(
+            dict.get_word_metadata_str("fewer")
+                .unwrap()
+                .is_quantifier_determiner()
+        );
+    }
 
     #[test]
     fn than_is_conjunction() {

--- a/harper-core/src/token_kind.rs
+++ b/harper-core/src/token_kind.rs
@@ -104,6 +104,8 @@ impl TokenKind {
         is_determiner,
         is_demonstrative_determiner,
         is_possessive_determiner,
+        is_quantifier_determiner,
+        is_non_quantifier_determiner,
 
         // Conjunction methods
         is_conjunction,

--- a/harper-core/src/word_metadata.rs
+++ b/harper-core/src/word_metadata.rs
@@ -312,7 +312,7 @@ impl WordMetadata {
         // Singular and countable default to true, so their metadata queries are not generated.
         noun has proper, plural, mass, possessive.
         pronoun has personal, singular, plural, possessive, reflexive, subject, object.
-        determiner has demonstrative, possessive.
+        determiner has demonstrative, possessive, quantifier.
         verb has linking, auxiliary.
         conjunction has.
         adjective has.
@@ -632,6 +632,7 @@ impl PronounData {
 pub struct DeterminerData {
     pub is_demonstrative: Option<bool>,
     pub is_possessive: Option<bool>,
+    pub is_quantifier: Option<bool>,
 }
 
 impl DeterminerData {
@@ -640,6 +641,7 @@ impl DeterminerData {
         Self {
             is_demonstrative: self.is_demonstrative.or(other.is_demonstrative),
             is_possessive: self.is_possessive.or(other.is_possessive),
+            is_quantifier: self.is_quantifier.or(other.is_quantifier),
         }
     }
 }

--- a/harper-core/tests/pos_tags.rs
+++ b/harper-core/tests/pos_tags.rs
@@ -161,6 +161,7 @@ fn format_word_tag(word: &WordMetadata) -> String {
         let mut tag = String::from("D");
         add_bool(&mut tag, "$", determiner.is_possessive);
         add_bool(&mut tag, "dem", determiner.is_demonstrative);
+        add_bool(&mut tag, "q", determiner.is_quantifier);
         add(&tag, &mut tags);
     }
     if word.preposition {

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -2012,16 +2012,6 @@ Suggest:
 
 
 
-Lint:    WordChoice (63 priority)
-Message: |
-    1531 | puppyish, convivial way, girls were swooning backward playfully into men’s arms,
-    1532 | even into groups, knowing that some one would arrest their falls—but no one
-         |                                ^~~~~~~~ Did you mean the closed compound noun “someone”?
-Suggest:
-  - Replace with: “someone”
-
-
-
 Lint:    Miscellaneous (31 priority)
 Message: |
     1531 | puppyish, convivial way, girls were swooning backward playfully into men’s arms,
@@ -6545,16 +6535,6 @@ Suggest:
 
 
 
-Lint:    WordChoice (63 priority)
-Message: |
-    5181 | easier, surer way of finding out what he wanted to know. By half-past two he was
-    5182 | in West Egg, where he asked some one the way to Gatsby’s house. So by that time
-         |                             ^~~~~~~~ Did you mean the closed compound noun “someone”?
-Suggest:
-  - Replace with: “someone”
-
-
-
 Lint:    Miscellaneous (31 priority)
 Message: |
     5181 | easier, surer way of finding out what he wanted to know. By half-past two he was
@@ -7251,16 +7231,6 @@ Message: |
     5634 | over Gatsby’s books in the library one night three months before.
 Suggest:
   - Replace with: “marveling”
-
-
-
-Lint:    WordChoice (63 priority)
-Message: |
-    5642 | message or a flower. Dimly I heard some one murmur “Blessed are the dead that
-         |                                    ^~~~~~~~ Did you mean the closed compound noun “someone”?
-    5643 | the rain falls on,” and then the owl-eyed man said “Amen to that,” in a brave
-Suggest:
-  - Replace with: “someone”
 
 
 


### PR DESCRIPTION
# Issues 
Inspired by #1562 

# Description

Quantifiers are a subclass of determiners: "some", "several", "all", "each", "many", "multiple".

There's a new `q` annotation flag handled by `dictionary.dict` and `annotations.json`.
While adding `q` in the dictionary I found a few determiners that were missing the `D` flag.

Adding these had some run-on effects with the POS tag snapshots. So I changed the `should_contract` linter that changes `were` to `we're` to only check for a determiner that is not a quantifier.
As a bonus it also stopped the false positive that was flagging old-fashioned `some one` to be changed to `someone` (and calling it a noun in the process).

# How Has This Been Tested?

I added some basic unit tests to make sure the a couple of words are detected as quantifiers.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
