### PR TITLE
feat: IIRC correctly→IIRC

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -4753,6 +4753,7 @@ IDF/Og              # Israel's military
 IE/ONJ
 IED/N               # improvised explosive device
 IEEE/O              # standards organization
+IIRC                # If I recall correctly
 IKEA/Og             # furniture company
 IL/NO
 IMF/Og              # International Monetary Fund

--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -733,6 +733,11 @@ pub fn lint_group() -> LintGroup {
             "Use the correct phrase for someone who perseveres.",
             "Ensures the correct use of `real trouper`, distinguishing it from `trooper`, which refers to a soldier or police officer."
         ),
+        "RedundantIIRC" => (
+            ["if IIRC", "IIRC correctly"], ["IIRC"],
+            "`IIRC` already means 'if I recall correctly', so adding 'if' or 'correctly' is redundant.",
+            "Flags redundant use of 'if' or 'correctly' with 'IIRC', since 'IIRC' already stands for 'if I recall correctly'."
+        ),
         "RifeWith" => (
             ["ripe with"],
             ["rife with"],

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -1005,6 +1005,35 @@ fn corrects_points_of_view() {
 // RealTrouper
 // -none-
 
+// RedundantIIRC
+#[test]
+#[ignore = "The bug in replace_with_match_case erroneously generates `iiRC`."]
+fn correct_if_iirc_caps() {
+    assert_suggestion_result(
+        "This is due to the fact that if IIRC up to 2 processes mpirun will bind to core and then it will be socket.",
+        lint_group(),
+        "This is due to the fact that IIRC up to 2 processes mpirun will bind to core and then it will be socket.",
+    );
+}
+
+#[test]
+fn correct_if_iirc() {
+    assert_suggestion_result(
+        "if iirc getting it to work with the SQLite storage engine was turning into a whole project and we decided to punt it",
+        lint_group(),
+        "iirc getting it to work with the SQLite storage engine was turning into a whole project and we decided to punt it",
+    );
+}
+
+#[test]
+fn correct_iirc_correctly() {
+    assert_suggestion_result(
+        "IIRC correctly, someone on the Home Assistant forums went as far as discovering that RS-485 was being used.",
+        lint_group(),
+        "IIRC, someone on the Home Assistant forums went as far as discovering that RS-485 was being used.",
+    );
+}
+
 // RifeWith
 // -none-
 


### PR DESCRIPTION
# Issues 
N/A

# Description

I noticed myself type "if IIRC" and a quick search revealed I'm not alone and that "IIRC correctly" is even more common.
This fixes both.

(I also had to add `IIRC` to `dictionary.dict`.)

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I added a few unit tests using sentences found on GitHub.

I did have to `#ignore` a test affected by the case-matching bug in `replace_with_match_case` though. 

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
