### PR TITLE
fix: add ofcourse→of course phrase correction

### DIFF
--- a/harper-core/src/linting/of_course.rs
+++ b/harper-core/src/linting/of_course.rs
@@ -1,3 +1,8 @@
+//! Corrects "of curse/corse" to "of course" while ignoring phrases like "kind of curse".
+//!
+//! See also:
+//! - `OfCourse` in `phrase_corrections` for "off course" / "o course" / "ofcourse" → "of course" corrections.
+
 use crate::expr::Expr;
 use crate::expr::SequenceExpr;
 use crate::{

--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -640,10 +640,11 @@ pub fn lint_group() -> LintGroup {
             "Corrects `no to` to `not to`, ensuring proper negation."
         ),
         "OfCourse" => (
-            ["off course", "o course"],
-            ["Of course"],
+            // See also: `of_course.rs` for "of curse/corse" → "of course" corrections
+            ["off course", "o course", "ofcourse"],
+            ["of course"],
             "Did you mean `of course`?",
-            "Detects the non‐idiomatic phrase `off course` and suggests the correct form `of course`."
+            "Detects the common mistake `off course` and suggests the correct form `of course`."
         ),
         "OffTheCuff" => (
             ["off the cuff"],

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -870,6 +870,7 @@ fn detect_nerve_racking_no_hyphen() {
 // -none-
 
 // OfCourse
+// See also: tests in `of_course.rs` for "of curse/corse" → "of course" corrections
 #[test]
 fn off_course() {
     assert_suggestion_result(
@@ -885,6 +886,15 @@ fn o_course() {
         "Yes, o course we should do that.",
         lint_group(),
         "Yes, of course we should do that.",
+    );
+}
+
+#[test]
+fn ofcourse() {
+    assert_suggestion_result(
+        "Ofcourse, I like other languages.. uzulla has 183 repositories available.",
+        lint_group(),
+        "Of course, I like other languages.. uzulla has 183 repositories available.",
     );
 }
 


### PR DESCRIPTION
# Issues 
N/A

# Description

Linting the READMEs of trending GitHub repos I noticed "ofcourse" only flagged as a spelling mistake, despite us having a linter for "of course".

In fact it turns out we have two of them, so I also added comments linking the 2 `of course` linters. The standalone one that handles "of curse" and "of corse" ⇔ this phrase corrections one that handles "off course", "o course", and now "ofcourse".

# How Has This Been Tested?

I added a unit test with the first example found on GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
