### PR TITLE
feat: get worst→get worse; become worst→become worse

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -271,7 +271,17 @@ pub fn lint_group() -> LintGroup {
             &[
                 // worst -> worse
                 (&["a lot worst", "alot worst"], &["a lot worse"]),
+
+                (&["become worst"], &["become worse"]),
+                (&["became worst"], &["became worse"]),
+                (&["becomes worst"], &["becomes worse"]),
+                (&["becoming worst"], &["becoming worse"]),
                 (&["far worst"], &["far worse"]),
+                (&["get worst"], &["get worse"]),
+                (&["gets worst"], &["gets worse"]),
+                (&["getting worst"], &["getting worse"]),
+                (&["got worst"], &["got worse"]),
+                (&["gotten worst"], &["gotten worse"]),
                 (&["much worst"], &["much worse"]),
                 (&["turn for the worst"], &["turn for the worse"]),
                 (&["worst and worst", "worse and worst", "worst and worse"], &["worse and worse"]),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -1,4 +1,6 @@
-use crate::linting::tests::{assert_nth_suggestion_result, assert_suggestion_result};
+use crate::linting::tests::{
+    assert_lint_count, assert_nth_suggestion_result, assert_suggestion_result,
+};
 
 use super::lint_group;
 
@@ -779,6 +781,43 @@ fn detect_a_lot_worse_real_world() {
     );
 }
 
+// -become worst-
+#[test]
+fn fix_became_worst() {
+    assert_suggestion_result(
+        "The problem became worst lately.",
+        lint_group(),
+        "The problem became worse lately.",
+    );
+}
+
+#[test]
+fn fix_become_worst() {
+    assert_suggestion_result(
+        "But results seems stay at one place or become worst.",
+        lint_group(),
+        "But results seems stay at one place or become worse.",
+    );
+}
+
+#[test]
+fn fix_becomes_worst() {
+    assert_suggestion_result(
+        "This becomes worst if you have an x64 dll and an x86 dll that you don't have thier source codes and want to use them in same project!",
+        lint_group(),
+        "This becomes worse if you have an x64 dll and an x86 dll that you don't have thier source codes and want to use them in same project!",
+    );
+}
+
+#[test]
+fn fix_becoming_worst() {
+    assert_suggestion_result(
+        "France is becoming worst than the Five Eyes",
+        lint_group(),
+        "France is becoming worse than the Five Eyes",
+    );
+}
+
 // -far worse-
 #[test]
 fn detect_far_worse_atomic() {
@@ -791,6 +830,65 @@ fn detect_far_worse_real_world() {
         "I mainly use Firefox (personal preference) and have noticed it has far worst performance than Chrome",
         lint_group(),
         "I mainly use Firefox (personal preference) and have noticed it has far worse performance than Chrome",
+    );
+}
+
+// -get worst-
+#[test]
+fn fix_get_worse() {
+    assert_suggestion_result(
+        "and the problem appears to get worst with 2025.5.1 and 2025.5.2.",
+        lint_group(),
+        "and the problem appears to get worse with 2025.5.1 and 2025.5.2.",
+    );
+}
+
+#[test]
+fn fix_gets_worse() {
+    assert_suggestion_result(
+        "It just starts after about 15 minutes of work and gradually gets worst.",
+        lint_group(),
+        "It just starts after about 15 minutes of work and gradually gets worse.",
+    );
+}
+
+#[test]
+#[ignore = "This kind of false positive is probably too subtle to detect"]
+fn dont_flag_getting_worst() {
+    // Here "getting" probably belongs to "I am getting" rather than "getting worst".
+    // Which would not be an error but "I am getting the worst accuracy" would be better.
+    // TODO: Maybe a noun following "getting" is enough context?
+    assert_lint_count(
+        "I am getting worst accuracy on the same dataste and 3 different models.",
+        lint_group(),
+        0,
+    );
+}
+
+#[test]
+fn fix_getting_worst() {
+    assert_suggestion_result(
+        "But, as I said, it is getting worst...",
+        lint_group(),
+        "But, as I said, it is getting worse...",
+    );
+}
+
+#[test]
+fn fix_got_worst() {
+    assert_suggestion_result(
+        "typescript support got worst.",
+        lint_group(),
+        "typescript support got worse.",
+    );
+}
+
+#[test]
+fn fix_gotten_worst() {
+    assert_suggestion_result(
+        "Has Claude gotten worst?",
+        lint_group(),
+        "Has Claude gotten worse?",
     );
 }
 


### PR DESCRIPTION
# Issues 
#525

# Description

Add two more phrase set corrections to `WorseOrWorst` for "get worse" and "become worse" in all verb inflections.

Note that I've spotted one source of false positives: "I am **getting worst accuracy** on the same dataste and 3 different models."
In this case "worst" can be an adjective paired with the noun "accuracy" just as well as it can be an adverb paired with "getting".
If this turns out to be common we would want to split this one out into an `ExprLinter` that takes the following word into account to disambiguate.

I've included an `#ignore`d test with this pointed out in a comment.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

A unit test has been created for each variation sourced from GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
