### PR TITLE
fix: remove `ThereIsAny` linter, sort others

### DIFF
--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -388,6 +388,12 @@ pub fn lint_group() -> LintGroup {
             "A more vivid adjective would better capture extreme cold.",
             "Encourages vivid writing by suggesting `freezing` instead of weaker expressions like `very cold.`"
         ),
+        "FromTheGetGo" => (
+            ["from the get go"],
+            ["from the get-go"],
+            "Use the hyphenated form: `from the get-go`.",
+            "Ensures `from the get-go` is correctly hyphenated, preserving the idiom’s meaning of ‘from the very beginning’."
+        ),
         "GildedAge" => (
             ["guilded age"],
             ["Gilded Age"],
@@ -865,12 +871,6 @@ pub fn lint_group() -> LintGroup {
             "Use `the other` or `another`, not both.",
             "Corrects `the another`."
         ),
-        "ThereIsAny" => (
-            ["there any"],
-            ["there is any"],
-            "Insert `is` for correct grammar.",
-            "Replaces `there any` with `there is any`."
-        ),
         "ThoughtProcess" => (
             ["though process"],
             ["thought process"],
@@ -969,12 +969,6 @@ pub fn lint_group() -> LintGroup {
             ["wrought iron"],
             "Prefer the standard term `wrought iron`.",
             "`Wrought iron` is low-carbon, malleable iron used for decorative work; variants like `rod iron` or `rot iron` are phonetic misspellings that may confuse readers."
-        ),
-        "FromTheGetGo" => (
-            ["from the get go"],
-            ["from the get-go"],
-            "Use the hyphenated form: `from the get-go`.",
-            "Ensures `from the get-go` is correctly hyphenated, preserving the idiom’s meaning of ‘from the very beginning’."
         ),
     });
 

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -195,6 +195,30 @@ fn baited_breath() {
 // BeenThere
 // -none-
 
+// BeforeHand
+#[test]
+fn corrects_before_hand() {
+    assert_suggestion_result(
+        "Let me know before hand if you will attend.",
+        lint_group(),
+        "Let me know beforehand if you will attend.",
+    );
+}
+
+#[test]
+fn corrects_before_hand_hyphen() {
+    assert_suggestion_result(
+        "I prepared the documents before-hand.",
+        lint_group(),
+        "I prepared the documents beforehand.",
+    );
+}
+
+#[test]
+fn allows_beforehand() {
+    assert_lint_count("We finished the preparations beforehand.", lint_group(), 0);
+}
+
 // BestRegards
 // -none-
 
@@ -1335,6 +1359,7 @@ fn thanks_a_lot_clean() {
     assert_lint_count("thanks a lot", lint_group(), 0);
 }
 
+// WroughtIron
 #[test]
 fn corrects_rod_iron() {
     assert_suggestion_result(
@@ -1356,27 +1381,4 @@ fn corrects_rot_iron() {
 #[test]
 fn allows_wrought_iron() {
     assert_lint_count("She specialized in wrought iron artwork.", lint_group(), 0);
-}
-
-#[test]
-fn corrects_before_hand() {
-    assert_suggestion_result(
-        "Let me know before hand if you will attend.",
-        lint_group(),
-        "Let me know beforehand if you will attend.",
-    );
-}
-
-#[test]
-fn corrects_before_hand_hyphen() {
-    assert_suggestion_result(
-        "I prepared the documents before-hand.",
-        lint_group(),
-        "I prepared the documents beforehand.",
-    );
-}
-
-#[test]
-fn allows_beforehand() {
-    assert_lint_count("We finished the preparations beforehand.", lint_group(), 0);
 }


### PR DESCRIPTION
# Issues 

#1586

# Description

Seems this linter only flags false positives. See the linked issue thread.

Rather than move the linter from `phrase_corrections` to an `ExprLinter` it seems best to just remove it.

I also sorted a couple more recently added lints in `phrase_corrections` alphabetically.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
