### PR TITLE
feat: ahead an→ahead and

### DIFF
--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -46,6 +46,12 @@ pub fn lint_group() -> LintGroup {
             "When describafterg a timeframe, use `a while`.",
             "Corrects the missing article after `after while` or `after awhile`, forming `after a while`."
         ),
+        "AheadAnd" => (
+            ["ahead an"],
+            ["ahead and"],
+            "Did you make a typo? Shouldn't it be `and`?",
+            "Corrects `an` to `and` after `ahead`."
+        ),
         "AllOfASudden" => (
             ["all of the sudden"],
             ["all of a sudden"],

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -25,6 +25,16 @@ fn correct_after_while() {
     );
 }
 
+// AheadAnd
+#[test]
+fn correct_ahead_and() {
+    assert_suggestion_result(
+        "If it's important, go ahead an open an issue.",
+        lint_group(),
+        "If it's important, go ahead and open an issue.",
+    );
+}
+
 // AllOfASudden
 #[test]
 fn corrects_all_of_a_sudden() {


### PR DESCRIPTION
# Issues 
N/A

# Description

I just saw a typo in our Discord that Harper doesn't catch:
- If it's important, **go ahead an** open an issue so we can track implementation progress.

This turns out to be very common and since I found no non-typo occurrences of "ahead an" I just made it a `phrase_correction` after "ahead".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I added a unit test based on the above sentence.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
