### PR TITLE
feat: like as if→like / as if

### DIFF
--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -597,6 +597,12 @@ pub fn lint_group() -> LintGroup {
             "Did you mean `let alone`?",
             "Changes `let along` to `let alone`."
         ),
+        "LikeAsIf" => (
+            ["like as if"],
+            ["like", "as if"],
+            "Avoid redundancy. Use either `like` or `as if`.",
+            "Corrects redundant `like as if` to `like` or `as if`."
+        ),
         "LikeThePlague" => (
             ["like a plague"],
             ["like the plague"],

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -782,6 +782,16 @@ fn let_along() {
     assert_suggestion_result("let along", lint_group(), "let alone");
 }
 
+// LikeAsIf
+#[test]
+fn correct_like_as_if() {
+    assert_top3_suggestion_result(
+        "And looks like as if linux-personality hasn't got any changes for 8 years.",
+        lint_group(),
+        "And looks as if linux-personality hasn't got any changes for 8 years.",
+    );
+}
+
 // LikeThePlague
 #[test]
 fn correct_like_a_plague() {


### PR DESCRIPTION
# Issues 
N/A

# Description

I noticed "like as if" for the first time yesterday. After some Googling it seems it can always be replaced by either "like" or "as if" and I didn't spot any false positives.

Includes a unit test using a sentence from GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
