### PR TITLE
feat: remaining inflections of rise the question→raise

### DIFF
--- a/harper-core/src/linting/amounts_for.rs
+++ b/harper-core/src/linting/amounts_for.rs
@@ -48,8 +48,6 @@ impl ExprLinter for AmountsFor {
         if content.ends_with("amounts for") {
             let span = toks[2..5].span()?;
 
-            eprintln!("span: '{}'", span.get_content_string(src));
-
             return Some(Lint {
                 span,
                 lint_kind: LintKind::WordChoice,

--- a/harper-core/src/linting/noun_instead_of_verb.rs
+++ b/harper-core/src/linting/noun_instead_of_verb.rs
@@ -1,7 +1,7 @@
 use crate::expr::Expr;
 use crate::expr::SequenceExpr;
 use crate::expr::{FirstMatchOf, LongestMatchOf};
-use crate::{Lrc, Token, TokenStringExt, patterns::WordSet};
+use crate::{Lrc, Token, patterns::WordSet};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -100,7 +100,6 @@ impl ExprLinter for NounInsteadOfVerb {
     }
 
     fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
-        eprintln!("🏃 '{}' 🏃", toks.span()?.get_content_string(src));
         // If we have the next word token, try to rule out compound nouns
         if toks.len() > 4 {
             let following_tok = &toks[4];

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -253,7 +253,7 @@ pub fn lint_group() -> LintGroup {
                 (&["rise the question"], &["raise the question"]),
                 (&["rises the question"], &["raises the question"]),
                 (&["risen the question", "rose the question"], &["raised the question"]),
-                (&["rising the question"], &["rising the question"])
+                (&["rising the question"], &["raising the question"])
             ],
             "Use `raise` instead of `rise` when referring to the act of asking a question.",
             "Corrects `rise the question` to `raise the question`."

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -33,7 +33,6 @@ pub fn lint_group() -> LintGroup {
             $($name:expr => ($input_correction_multi_pairs:expr, $message:expr, $description:expr)),+ $(,)?
         }) => {
             $(
-                // eprintln!("💗 {:?}", $name);
                 $group.add_expr_linter(
                     $name,
                     Box::new(
@@ -253,7 +252,8 @@ pub fn lint_group() -> LintGroup {
             &[
                 (&["rise the question"], &["raise the question"]),
                 (&["rises the question"], &["raises the question"]),
-
+                (&["risen the question", "rose the question"], &["raised the question"]),
+                (&["rising the question"], &["rising the question"])
             ],
             "Use `raise` instead of `rise` when referring to the act of asking a question.",
             "Corrects `rise the question` to `raise the question`."

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -718,6 +718,36 @@ fn detect_raises_the_question() {
     );
 }
 
+// -raising the question-
+#[test]
+fn detect_raising_the_question() {
+    assert_suggestion_result(
+        "as soon as a infoHash query is performed, a Torrent file is retried, rising the question of:",
+        lint_group(),
+        "as soon as a infoHash query is performed, a Torrent file is retried, raising the question of:",
+    );
+}
+
+// -rose the question-
+#[test]
+fn detect_rose_the_question() {
+    assert_suggestion_result(
+        "Here is an example that rose the question at first: What works.",
+        lint_group(),
+        "Here is an example that raised the question at first: What works.",
+    );
+}
+
+// -risen the question-
+#[test]
+fn detect_risen_the_question() {
+    assert_suggestion_result(
+        "That has risen the question in my mind if it is still possible to embed your own Flash player on Facebook today?",
+        lint_group(),
+        "That has raised the question in my mind if it is still possible to embed your own Flash player on Facebook today?",
+    );
+}
+
 // WholeEntire
 
 #[test]


### PR DESCRIPTION
# Issues 
N/A

# Description

I came across somebody saying "rise the question" on YouTube and found that we already lint it, but only for "rise" and "rises".
The adds "rose", "risen", and "rising" the question, with examples from the internet used in unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
