### PR TITLE
feat: make due with → make do with

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -185,6 +185,16 @@ pub fn lint_group() -> LintGroup {
             "Traditionally `invest` uses the preposition `in`.",
             "`Invest` is traditionally followed by 'in,' not `into.`"
         ),
+        "MakeDoWith" => (
+            &[
+                ("make due with", "make do with"),
+                ("made due with", "made do with"),
+                ("makes due with", "makes do with"),
+                ("making due with", "making do with"),
+            ],
+            "Use `do` instead of `due` when referring to a resource scarcity.",
+            "Corrects `make due` to `make do` when followed by `with`."
+        ),
         "MootPoint" => (
             &[
                 ("mute point", "moot point"),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -391,6 +391,44 @@ fn corrects_invests_into() {
     );
 }
 
+// MakeDoWith
+
+#[test]
+fn corrects_make_due_with() {
+    assert_suggestion_result(
+        "For now, I can make due with a bash script I have",
+        lint_group(),
+        "For now, I can make do with a bash script I have",
+    );
+}
+
+#[test]
+fn corrects_made_due_with() {
+    assert_suggestion_result(
+        "I made due with using actions.push for now but will try to do a codepen soon",
+        lint_group(),
+        "I made do with using actions.push for now but will try to do a codepen soon",
+    );
+}
+
+#[test]
+fn corrects_makes_due_with() {
+    assert_suggestion_result(
+        "but the code makes due with what is available",
+        lint_group(),
+        "but the code makes do with what is available",
+    );
+}
+
+#[test]
+fn corrects_making_due_with() {
+    assert_suggestion_result(
+        "I've been making due with the testMultiple script I wrote above.",
+        lint_group(),
+        "I've been making do with the testMultiple script I wrote above.",
+    );
+}
+
 // MootPoint
 
 // -point is mute-


### PR DESCRIPTION
# Issues 

#499

# Description

Flags the common mistake of "due" when "do" is meant in the context "make do with".
All inflections of the verb "make" are handled.

# How Has This Been Tested?

I found a sentence with each inflection on GitHub and turned them into unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
