### PR TITLE
refactor: typed spans

### DIFF
--- a/harper-cli/src/annotate_tokens.rs
+++ b/harper-cli/src/annotate_tokens.rs
@@ -6,7 +6,7 @@ use strum::IntoEnumIterator;
 /// Represents an annotation.
 pub(super) struct Annotation {
     /// The range the annotation covers in the source. For instance, this might be a single word.
-    span: Span,
+    span: Span<char>,
     /// The message displayed by the annotation.
     annotation_text: String,
     /// The color of the annotation.

--- a/harper-comments/src/comment_parsers/mod.rs
+++ b/harper-comments/src/comment_parsers/mod.rs
@@ -13,7 +13,7 @@ pub use unit::Unit;
 
 /// Get the span of a tree-sitter-produced comment that doesn't include the
 /// comment openers and closers.
-fn without_initiators(source: &[char]) -> Span {
+fn without_initiators(source: &[char]) -> Span<char> {
     // Skip over the comment start characters
     let actual_start = source
         .iter()

--- a/harper-core/src/document.rs
+++ b/harper-core/src/document.rs
@@ -31,7 +31,7 @@ impl Document {
     /// Locate all the tokens that intersect a provided span.
     ///
     /// Desperately needs optimization.
-    pub fn token_indices_intersecting(&self, span: Span) -> Vec<usize> {
+    pub fn token_indices_intersecting(&self, span: Span<char>) -> Vec<usize> {
         self.tokens()
             .enumerate()
             .filter_map(|(idx, tok)| tok.span.overlaps_with(span).then_some(idx))
@@ -41,7 +41,7 @@ impl Document {
     /// Locate all the tokens that intersect a provided span and convert them to [`FatToken`]s.
     ///
     /// Desperately needs optimization.
-    pub fn fat_tokens_intersecting(&self, span: Span) -> Vec<FatToken> {
+    pub fn fat_tokens_intersecting(&self, span: Span<char>) -> Vec<FatToken> {
         let indices = self.token_indices_intersecting(span);
 
         indices
@@ -313,19 +313,16 @@ impl Document {
         self.fat_tokens().map(|t| t.into())
     }
 
-    pub fn get_span_content(&self, span: &Span) -> &[char] {
+    pub fn get_span_content(&self, span: &Span<char>) -> &[char] {
         span.get_content(&self.source)
     }
 
-    pub fn get_span_content_str(&self, span: &Span) -> String {
+    pub fn get_span_content_str(&self, span: &Span<char>) -> String {
         String::from_iter(self.get_span_content(span))
     }
 
     pub fn get_full_string(&self) -> String {
-        self.get_span_content_str(&Span {
-            start: 0,
-            end: self.source.len(),
-        })
+        self.get_span_content_str(&Span::new(0, self.source.len()))
     }
 
     pub fn get_full_content(&self) -> &[char] {
@@ -662,7 +659,7 @@ impl TokenStringExt for Document {
         self.tokens.first_non_whitespace()
     }
 
-    fn span(&self) -> Option<Span> {
+    fn span(&self) -> Option<Span<char>> {
         self.tokens.span()
     }
 

--- a/harper-core/src/expr/all.rs
+++ b/harper-core/src/expr/all.rs
@@ -21,8 +21,8 @@ impl All {
 }
 
 impl Expr for All {
-    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span> {
-        let mut longest: Option<Span> = None;
+    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span<Token>> {
+        let mut longest: Option<Span<Token>> = None;
 
         for expr in self.children.iter() {
             let window = expr.run(cursor, tokens, source)?;

--- a/harper-core/src/expr/expr_map.rs
+++ b/harper-core/src/expr/expr_map.rs
@@ -74,7 +74,7 @@ impl<T> Expr for ExprMap<T>
 where
     T: LSend,
 {
-    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span> {
+    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span<Token>> {
         self.rows
             .iter()
             .filter_map(|row| row.key.run(cursor, tokens, source))

--- a/harper-core/src/expr/first_match_of.rs
+++ b/harper-core/src/expr/first_match_of.rs
@@ -21,7 +21,7 @@ impl FirstMatchOf {
 }
 
 impl Expr for FirstMatchOf {
-    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span> {
+    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span<Token>> {
         self.exprs
             .iter()
             .find_map(|p| p.run(cursor, tokens, source))

--- a/harper-core/src/expr/fixed_phrase.rs
+++ b/harper-core/src/expr/fixed_phrase.rs
@@ -62,7 +62,7 @@ impl FixedPhrase {
 }
 
 impl Expr for FixedPhrase {
-    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span> {
+    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span<Token>> {
         self.inner.run(cursor, tokens, source)
     }
 }

--- a/harper-core/src/expr/longest_match_of.rs
+++ b/harper-core/src/expr/longest_match_of.rs
@@ -17,8 +17,8 @@ impl LongestMatchOf {
 }
 
 impl Expr for LongestMatchOf {
-    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span> {
-        let mut longest: Option<Span> = None;
+    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span<Token>> {
+        let mut longest: Option<Span<Token>> = None;
 
         for expr in self.exprs.iter() {
             let Some(window) = expr.run(cursor, tokens, source) else {

--- a/harper-core/src/expr/mergeable_words.rs
+++ b/harper-core/src/expr/mergeable_words.rs
@@ -60,7 +60,7 @@ impl MergeableWords {
 }
 
 impl Expr for MergeableWords {
-    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span> {
+    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span<Token>> {
         let inner_match = self.inner.run(cursor, tokens, source)?;
 
         if inner_match.len() != 3 {

--- a/harper-core/src/expr/optional.rs
+++ b/harper-core/src/expr/optional.rs
@@ -18,7 +18,7 @@ impl Optional {
 }
 
 impl Expr for Optional {
-    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span> {
+    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span<Token>> {
         let res = self.inner.run(cursor, tokens, source);
 
         if res.is_none() {

--- a/harper-core/src/expr/reflexive_pronoun.rs
+++ b/harper-core/src/expr/reflexive_pronoun.rs
@@ -51,7 +51,7 @@ impl ReflexivePronoun {
 }
 
 impl Expr for ReflexivePronoun {
-    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span> {
+    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span<Token>> {
         let good_pronouns = |token: &Token, _: &[char]| token.kind.is_reflexive_pronoun();
         let mut expr = FirstMatchOf::new(vec![Box::new(good_pronouns)]);
         if self.include_common_errors {

--- a/harper-core/src/expr/repeating.rs
+++ b/harper-core/src/expr/repeating.rs
@@ -19,7 +19,7 @@ impl Repeating {
 }
 
 impl Expr for Repeating {
-    fn run(&self, mut cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span> {
+    fn run(&self, mut cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span<Token>> {
         let mut window = Span::new_with_len(cursor, 0);
         let mut repetition = 0;
 

--- a/harper-core/src/expr/sequence_expr.rs
+++ b/harper-core/src/expr/sequence_expr.rs
@@ -56,7 +56,7 @@ impl Expr for SequenceExpr {
     /// Run the expression starting at an index, returning the total matched window.
     ///
     /// If any step returns `None`, the entire expression does as well.
-    fn run(&self, mut cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span> {
+    fn run(&self, mut cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span<Token>> {
         let mut window = Span::new_with_len(cursor, 0);
 
         for cur_expr in &self.exprs {

--- a/harper-core/src/expr/similar_to_phrase.rs
+++ b/harper-core/src/expr/similar_to_phrase.rs
@@ -58,7 +58,7 @@ impl SimilarToPhrase {
 }
 
 impl Expr for SimilarToPhrase {
-    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span> {
+    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span<Token>> {
         if self.phrase.run(cursor, tokens, source).is_some() {
             return None;
         }

--- a/harper-core/src/expr/space_or_hyphen.rs
+++ b/harper-core/src/expr/space_or_hyphen.rs
@@ -9,7 +9,7 @@ use super::Expr;
 pub struct SpaceOrHyphen;
 
 impl Expr for SpaceOrHyphen {
-    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span> {
+    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span<Token>> {
         FirstMatchOf::new(vec![
             Box::new(WhitespacePattern),
             Box::new(|tok: &Token, _source: &[char]| tok.kind.is_hyphen()),

--- a/harper-core/src/expr/spelled_number_expr.rs
+++ b/harper-core/src/expr/spelled_number_expr.rs
@@ -9,7 +9,7 @@ use super::{Expr, SequenceExpr};
 pub struct SpelledNumberExpr;
 
 impl Expr for SpelledNumberExpr {
-    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span> {
+    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span<Token>> {
         if tokens.is_empty() {
             return None;
         }
@@ -70,13 +70,13 @@ impl Expr for SpelledNumberExpr {
 mod tests {
     use super::SpelledNumberExpr;
     use crate::expr::ExprExt;
-    use crate::{Document, Span};
+    use crate::{Document, Span, Token};
 
     trait SpanVecExt {
         fn to_strings(&self, doc: &Document) -> Vec<String>;
     }
 
-    impl SpanVecExt for Vec<Span> {
+    impl SpanVecExt for Vec<Span<Token>> {
         fn to_strings(&self, doc: &Document) -> Vec<String> {
             self.iter()
                 .map(|sp| {

--- a/harper-core/src/expr/time_unit_expr.rs
+++ b/harper-core/src/expr/time_unit_expr.rs
@@ -15,7 +15,7 @@ use super::Expr;
 pub struct TimeUnitExpr;
 
 impl Expr for TimeUnitExpr {
-    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span> {
+    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span<Token>> {
         if tokens.is_empty() {
             return None;
         }

--- a/harper-core/src/expr/word_expr_group.rs
+++ b/harper-core/src/expr/word_expr_group.rs
@@ -39,7 +39,7 @@ impl<E> Expr for WordExprGroup<E>
 where
     E: Expr,
 {
-    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span> {
+    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span<Token>> {
         let first = tokens.get(cursor)?;
         if !first.kind.is_word() {
             return None;

--- a/harper-core/src/linting/lint.rs
+++ b/harper-core/src/linting/lint.rs
@@ -11,7 +11,7 @@ use super::{LintKind, Suggestion};
 pub struct Lint {
     /// The location in the source text the error lies.
     /// Important for automatic lint resolution through [`Self::suggestions`].
-    pub span: Span,
+    pub span: Span<char>,
     /// The general category the lint belongs to.
     /// Mostly used for UI elements in integrations.
     pub lint_kind: LintKind,

--- a/harper-core/src/linting/suggestion.rs
+++ b/harper-core/src/linting/suggestion.rs
@@ -53,7 +53,7 @@ impl Suggestion {
     }
 
     /// Apply a suggestion to a given text.
-    pub fn apply(&self, span: Span, source: &mut Vec<char>) {
+    pub fn apply(&self, span: Span<char>, source: &mut Vec<char>) {
         match self {
             Self::ReplaceWith(chars) => {
                 // Avoid allocation if possible

--- a/harper-core/src/mask/mod.rs
+++ b/harper-core/src/mask/mod.rs
@@ -19,11 +19,11 @@ pub struct Mask {
     // Right now, there aren't any use-cases where we can't treat this as a stack.
     //
     // Assumed that no elements overlap and exist in sorted order.
-    pub(self) allowed: Vec<Span>,
+    pub(self) allowed: Vec<Span<char>>,
 }
 
-impl FromIterator<Span> for Mask {
-    fn from_iter<T: IntoIterator<Item = Span>>(iter: T) -> Self {
+impl FromIterator<Span<char>> for Mask {
+    fn from_iter<T: IntoIterator<Item = Span<char>>>(iter: T) -> Self {
         let allowed = iter
             .into_iter()
             .sorted_by_key(|span| span.start)
@@ -49,12 +49,12 @@ impl Mask {
     pub fn iter_allowed<'a>(
         &'a self,
         source: &'a [char],
-    ) -> impl Iterator<Item = (Span, &'a [char])> {
+    ) -> impl Iterator<Item = (Span<char>, &'a [char])> {
         self.allowed.iter().map(|s| (*s, s.get_content(source)))
     }
 
     /// Mark a span of the text as allowed.
-    pub fn push_allowed(&mut self, allowed: Span) {
+    pub fn push_allowed(&mut self, allowed: Span<char>) {
         if let Some(last) = self.allowed.last_mut() {
             assert!(
                 allowed.start >= last.end,

--- a/harper-core/src/parsers/mask.rs
+++ b/harper-core/src/parsers/mask.rs
@@ -32,7 +32,7 @@ where
 
         let mut tokens: Vec<Token> = Vec::new();
 
-        let mut last_allowed: Option<Span> = None;
+        let mut last_allowed: Option<Span<char>> = None;
 
         for (span, content) in mask.iter_allowed(source) {
             // Check for a line break separating the current chunk from the preceding one.

--- a/harper-core/src/patterns/mod.rs
+++ b/harper-core/src/patterns/mod.rs
@@ -41,10 +41,10 @@ pub trait Pattern: LSend {
 }
 
 pub trait PatternExt {
-    fn iter_matches(&self, tokens: &[Token], source: &[char]) -> impl Iterator<Item = Span>;
+    fn iter_matches(&self, tokens: &[Token], source: &[char]) -> impl Iterator<Item = Span<Token>>;
 
     /// Search through all tokens to locate all non-overlapping pattern matches.
-    fn find_all_matches(&self, tokens: &[Token], source: &[char]) -> Vec<Span> {
+    fn find_all_matches(&self, tokens: &[Token], source: &[char]) -> Vec<Span<Token>> {
         self.iter_matches(tokens, source).collect()
     }
 }
@@ -53,7 +53,7 @@ impl<P> PatternExt for P
 where
     P: Pattern + ?Sized,
 {
-    fn iter_matches(&self, tokens: &[Token], source: &[char]) -> impl Iterator<Item = Span> {
+    fn iter_matches(&self, tokens: &[Token], source: &[char]) -> impl Iterator<Item = Span<Token>> {
         MatchIter::new(self, tokens, source)
     }
 }
@@ -81,7 +81,7 @@ impl<P> Iterator for MatchIter<'_, '_, '_, P>
 where
     P: Pattern + ?Sized,
 {
-    type Item = Span;
+    type Item = Span<Token>;
 
     fn next(&mut self) -> Option<Self::Item> {
         while self.index < self.tokens.len() {
@@ -124,11 +124,11 @@ impl<F: LSend + Fn(&Token, &[char]) -> bool> SingleTokenPattern for F {
 }
 
 pub trait DocPattern {
-    fn find_all_matches_in_doc(&self, document: &Document) -> Vec<Span>;
+    fn find_all_matches_in_doc(&self, document: &Document) -> Vec<Span<Token>>;
 }
 
 impl<P: PatternExt> DocPattern for P {
-    fn find_all_matches_in_doc(&self, document: &Document) -> Vec<Span> {
+    fn find_all_matches_in_doc(&self, document: &Document) -> Vec<Span<Token>> {
         self.find_all_matches(document.get_tokens(), document.get_source())
     }
 }

--- a/harper-core/src/patterns/nominal_phrase.rs
+++ b/harper-core/src/patterns/nominal_phrase.rs
@@ -37,13 +37,13 @@ impl Pattern for NominalPhrase {
 mod tests {
     use super::super::DocPattern;
     use super::NominalPhrase;
-    use crate::{Document, Span, patterns::Pattern};
+    use crate::{Document, Span, Token, patterns::Pattern};
 
     trait SpanVecExt {
         fn to_strings(&self, doc: &Document) -> Vec<String>;
     }
 
-    impl SpanVecExt for Vec<Span> {
+    impl SpanVecExt for Vec<Span<Token>> {
         fn to_strings(&self, doc: &Document) -> Vec<String> {
             self.iter()
                 .map(|sp| {
@@ -104,7 +104,9 @@ mod tests {
         dbg!(matches.to_strings(&doc));
 
         for span in &matches {
-            let gc = span.get_content(doc.get_source());
+            let gc = span
+                .to_char_span(doc.get_tokens())
+                .get_content(doc.get_source());
             dbg!(gc);
         }
 

--- a/harper-core/src/span.rs
+++ b/harper-core/src/span.rs
@@ -20,6 +20,13 @@ pub struct Span<T> {
 }
 
 impl<T> Span<T> {
+    /// Represents an empty [`Span`].
+    pub const EMPTY: Self = Self {
+        start: 0,
+        end: 0,
+        span_type: PhantomData,
+    };
+
     /// Creates a new [`Span`] with the provided start and end indices.
     ///
     /// # Panics
@@ -41,15 +48,6 @@ impl<T> Span<T> {
         Self {
             start,
             end: start + len,
-            span_type: PhantomData,
-        }
-    }
-
-    /// Creates an empty [`Span`].
-    pub fn empty() -> Self {
-        Self {
-            start: 0,
-            end: 0,
             span_type: PhantomData,
         }
     }
@@ -184,7 +182,7 @@ impl Span<Token> {
     /// this span is required.
     pub fn to_char_span(&self, source_document_tokens: &[Token]) -> Span<char> {
         if self.is_empty() {
-            Span::empty()
+            Span::EMPTY
         } else {
             let target_tokens = &source_document_tokens[self.start..self.end];
             Span::new(
@@ -268,7 +266,7 @@ mod tests {
         let doc = Document::new_plain_english_curated("Hello world!");
 
         // Empty span.
-        let token_span = Span::empty();
+        let token_span = Span::EMPTY;
         let converted = token_span.to_char_span(doc.get_tokens());
         assert!(converted.is_empty());
 

--- a/harper-core/src/span.rs
+++ b/harper-core/src/span.rs
@@ -6,6 +6,14 @@ use crate::Token;
 
 /// A window in a [`T`] sequence.
 ///
+/// Note that the range covered by a [`Span`] is end-exclusive, meaning that the end index is not
+/// included in the range covered by the [`Span`]. If you're familiar with the Rust range syntax,
+/// you could say the span covers the equivalent of `start..end`, *not* `start..=end`.
+///
+/// For a [`Span`] to be correct, its end index must be greater than or equal to its start
+/// index. Creating or using a [`Span`] which does not follow this rule may lead to unexpected
+/// behavior or panics.
+///
 /// Although specific to `harper.js`, [this page may clear up any questions you have](https://writewithharper.com/docs/harperjs/spans).
 #[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct Span<T> {
@@ -20,7 +28,7 @@ pub struct Span<T> {
 }
 
 impl<T> Span<T> {
-    /// Represents an empty [`Span`].
+    /// An empty [`Span`].
     pub const EMPTY: Self = Self {
         start: 0,
         end: 0,

--- a/harper-core/src/token.rs
+++ b/harper-core/src/token.rs
@@ -6,13 +6,13 @@ use crate::{FatToken, Span, TokenKind};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct Token {
     /// The characters the token represents.
-    pub span: Span,
+    pub span: Span<char>,
     /// The parsed value.
     pub kind: TokenKind,
 }
 
 impl Token {
-    pub fn new(span: Span, kind: TokenKind) -> Self {
+    pub fn new(span: Span<char>, kind: TokenKind) -> Self {
         Self { span, kind }
     }
 

--- a/harper-core/src/token_string_ext.rs
+++ b/harper-core/src/token_string_ext.rs
@@ -53,7 +53,7 @@ pub trait TokenStringExt {
     fn first_non_whitespace(&self) -> Option<&Token>;
     /// Grab the span that represents the beginning of the first element and the
     /// end of the last element.
-    fn span(&self) -> Option<Span>;
+    fn span(&self) -> Option<Span<char>>;
 
     create_decl_for!(adjective);
     create_decl_for!(apostrophe);
@@ -140,7 +140,7 @@ impl TokenStringExt for [Token] {
         if w_idx < u_idx { Some(word) } else { None }
     }
 
-    fn span(&self) -> Option<Span> {
+    fn span(&self) -> Option<Span<char>> {
         let min_max = self
             .iter()
             .flat_map(|v| [v.span.start, v.span.end].into_iter())

--- a/harper-ls/src/pos_conv.rs
+++ b/harper-ls/src/pos_conv.rs
@@ -4,7 +4,7 @@
 use harper_core::Span;
 use tower_lsp_server::lsp_types::{Position, Range};
 
-pub fn span_to_range(source: &[char], span: Span) -> Range {
+pub fn span_to_range(source: &[char], span: Span<char>) -> Range {
     let start = index_to_position(source, span.start);
     let end = index_to_position(source, span.end);
 
@@ -76,7 +76,7 @@ fn position_to_index(source: &[char], position: Position) -> usize {
     (target_char_pointer as usize - source.as_ptr() as usize) / size_of::<char>()
 }
 
-pub fn range_to_span(source: &[char], range: Range) -> Span {
+pub fn range_to_span(source: &[char], range: Range) -> Span<char> {
     let start = position_to_index(source, range.start);
     let end = position_to_index(source, range.end);
 

--- a/harper-typst/src/typst_translator.rs
+++ b/harper-typst/src/typst_translator.rs
@@ -20,10 +20,7 @@ macro_rules! def_token {
         let end_char_loc = start.push_to(range.end).char;
 
         Some(vec![Token {
-            span: harper_core::Span {
-                start: start.char,
-                end: end_char_loc,
-            },
+            span: harper_core::Span::new(start.char, end_char_loc),
             kind: $kind,
         }])
     }};

--- a/harper-wasm/src/lib.rs
+++ b/harper-wasm/src/lib.rs
@@ -531,18 +531,18 @@ impl Span {
     }
 
     pub fn len(&self) -> usize {
-        Into::<harper_core::Span>::into(*self).len()
+        Into::<harper_core::Span<char>>::into(*self).len()
     }
 }
 
-impl From<Span> for harper_core::Span {
+impl From<Span> for harper_core::Span<char> {
     fn from(value: Span) -> Self {
         harper_core::Span::new(value.start, value.end)
     }
 }
 
-impl From<harper_core::Span> for Span {
-    fn from(value: harper_core::Span) -> Self {
+impl From<harper_core::Span<char>> for Span {
+    fn from(value: harper_core::Span<char>) -> Self {
         Span::new(value.start, value.end)
     }
 }


### PR DESCRIPTION
# Issues 
(Partially) related to #1226 

# Description
<!-- Please include a summary of the change. -->
Adds a generic type parameter to `Span` (via `PhantomData`).
<!-- Any details that you think are important to review this PR? -->
Currently, `Span` appears to be used for 3 distinct types throughout the codebase (`char`, `Token`, and `u8`). With these differences not being clearly communicated via type signature (and oftentimes not even documentation), it can be very easy to confuse different uses of `Span`. These changes should hopefully make things clearer, make it more difficult to accidentally use one type of span as another, and reduce the potential burden of having to describe and redescribe these nuances in the documentation.

This also makes it possible to implement specific functionality for certain types of `Span`, like the `to_char_span()` function implemented for `Span<token>`.

Surprisingly, these changes only revealed a single case of `Span` type confusion in the codebase: https://github.com/Automattic/harper/blob/9bbe9b7051d03beb91b0c626174915b6314ffcb0/harper-core/src/patterns/nominal_phrase.rs#L107-L107

(`span` is a token span, but it's used to index/subslice `doc.get_source()`, which returns a char slice. This has been fixed in this PR.)
<!-- Are there other PRs related to this one? -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
- `cargo test`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
