### PR TITLE
feat(core): add rule to convert `it an` -> `it's an`

### DIFF
--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -980,7 +980,7 @@ pub fn lint_group() -> LintGroup {
             ["it an"],
             ["it's an", "it is an"],
             "Add the missing verb.",
-            "`it an` omits the copular verb; use **`it's an`** or **`it is an`** to supply `is` and keep the correct article before a vowel sound."
+            "`it an` omits the verb; use **`it's an`** or **`it is an`** to supply `is` and keep the correct article before a vowel sound."
         ),
     });
 

--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -976,6 +976,12 @@ pub fn lint_group() -> LintGroup {
             "Prefer the standard term `wrought iron`.",
             "`Wrought iron` is low-carbon, malleable iron used for decorative work; variants like `rod iron` or `rot iron` are phonetic misspellings that may confuse readers."
         ),
+        "ItAn" => (
+            ["it an"],
+            ["it's an", "it is an"],
+            "Add the missing verb.",
+            "`it an` omits the copular verb; use **`it's an`** or **`it is an`** to supply `is` and keep the correct article before a vowel sound."
+        ),
     });
 
     group.set_all_rules_to(Some(true));

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -1392,3 +1392,12 @@ fn corrects_rot_iron() {
 fn allows_wrought_iron() {
     assert_lint_count("She specialized in wrought iron artwork.", lint_group(), 0);
 }
+
+#[test]
+fn fixes_blog_post() {
+    assert_suggestion_result(
+        "It an efficient way to get from layer one to layer five.",
+        lint_group(),
+        "It is an efficient way to get from layer one to layer five.",
+    );
+}


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->

Found as I was writing a blog post.

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

Phrase correction to convert the incorrect `it an` -> `it's an`

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Additional unit test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
