### PR TITLE
chore: marking mass nouns

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -48587,7 +48587,7 @@ tool's
 toolbar/~NSg
 toolbox/~NgS
 toolchain/NgS
-toolkit/~N
+toolkit/~NgS
 toolless/J
 toolmaker/NgS
 toolshed/NgS
@@ -52024,6 +52024,7 @@ wordily/R
 wordiness/Nmg
 wording/~NVSg
 wordless/JY
+wordlist/NgS
 wordplay/Nmg
 wordsmith/N0V
 wordsmiths/N9V
@@ -52535,6 +52536,8 @@ CRC/NgS             # cyclic redundancy check
 CRDT/NSg
 CRM/NOSg
 CTE/NS
+CTF/NSg             # capture the flag
+CVE/NSg             # Common Vulnerabilities and Exposures
 Captcha/OSg
 ChatGPT/Og          # OpenAI product
 ClickHouse/g
@@ -52934,6 +52937,7 @@ hoster/NgS
 hostname/NSg
 hotwire/VBG         # dictionaries prefer: hot-wire
 i18n/Nm             # internationalization
+infosec/NmG         # information security
 jQuery/Og
 labriola/Sg         # !! please check and comment !! - should be uppercase surname?
 linkification/Nmg
@@ -52944,6 +52948,7 @@ nullish/J
 olds/~              # common in phrasing such as "twenty year olds"
 pandoc/Sg           # !! please check and comment !! elsewhere we have Pandoc
 pastebin/NgS
+pentester/NSg       # penetration tester
 pre/~PNV            # !! please check and comment !! dictionaries only list prefix pre-
 quadtree/NgS        # data structure
 quicksort/NgSVdG    # algo
@@ -53184,6 +53189,7 @@ lesser-known/J
 line break/NgS
 live action/N
 load-bearing/J
+lock picking/Nmg
 long-term/J
 longer-term/J>
 loosey-goosey/J
@@ -53267,6 +53273,7 @@ Pascal case/Nmg
 Pax Americana/Og
 peer review/NgSdG
 peer-reviewed/J
+pen test/NgS
 per capita/JR
 Petri dish/NgS
 petty bourgeois/Ng
@@ -53393,6 +53400,7 @@ walk through/V
 walk-through/J
 walkie-talkie/NgS
 Wall Streeter/NgS
+war game/NgS
 Wayback Machine/Og
 weapons-grade/J
 web app/NgS
@@ -53408,6 +53416,7 @@ well-respected/J
 well-timed/J
 well-trodden/J
 well-used/J
+white paper/NgS
 Wi-Fi/Ng
 wishy-washy/J
 working-class/NJgS

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -207,7 +207,7 @@ Aida/Og
 Aiken/Og
 Aileen/Og
 Aimee/Og
-Ainu/NJOg           # ethnicity, language
+Ainu/NmJOg          # ethnicity, language
 Airedale/ONgS
 Aires/g
 Aisha/Og
@@ -1785,7 +1785,7 @@ Canopus/ONg
 Cantabrigian/JNg
 Canterbury/Og
 Canton/Og
-Cantonese/JNg
+Cantonese/JNmg
 Cantor/Og
 Cantrell/Og
 Cantu/Og
@@ -2097,7 +2097,7 @@ Chimu/g
 Chin/Og
 China/ONg
 Chinatown/NOg
-Chinese/JONg
+Chinese/JONmg
 Chinook/ONgS
 Chipewyan/NOg
 Chippendale/Og
@@ -2618,7 +2618,7 @@ Danial/Og
 Daniel/ONSg
 Danielle/Og
 Daniels/Og
-Danish/OJNg
+Danish/OJNmg
 Dannie/Og
 Danny/Og
 Danone/g
@@ -3004,7 +3004,7 @@ Dusseldorf/Og
 Dustbuster/g
 Dustin/Og
 Dusty/Og
-Dutch/JONVg
+Dutch/JONmVg
 Dutchman/NOg
 Dutchmen/9g
 Dutchwoman/N
@@ -3219,7 +3219,7 @@ Endymion/Og
 Eng/g
 Engels/Og
 England/Og
-English/JNOVg>S
+English/JNwOVg>S
 Englishman/Ng
 Englishmen/9g
 Englishwoman/Ng
@@ -3653,7 +3653,7 @@ Freemasonry/OSg
 Freetown/Og
 Freida/g
 Fremont/Og
-French/ONJVgS
+French/ONwJVgS
 Frenchman/Ng
 Frenchmen/9g
 Frenchwoman/Ng
@@ -3893,7 +3893,7 @@ Gerardo/g
 Gerber/Og
 Gere/Og
 Geritol/g
-German/NOJgS
+German/NwOJgS
 Germanic/OJNg
 Germany/Og
 Geronimo/Og
@@ -4594,6 +4594,7 @@ Hohenzollern/ONJg
 Hohhot/Og
 Hohokam/Og
 Hokkaido/ONg
+Hokkien/ONmg
 Hokusai/g
 Holbein/g
 Holcomb/Og
@@ -4953,7 +4954,7 @@ Isuzu/ONg           # car brand
 It/ON
 Itaipu/Og
 Ital/N
-Italian/JNSg
+Italian/JNwSg
 Italianate/JV
 Italy/Og
 Itasca/Og
@@ -5048,7 +5049,7 @@ January/OSg
 Janus/Og
 Jap/ONJVSg
 Japan/Og
-Japanese/JNOgS
+Japanese/JNwOgS
 Japura/g
 Jared/Og
 Jarlsberg/ONg
@@ -5561,7 +5562,7 @@ Koppel/g
 Koran/NOgS
 Koranic/J
 Korea/Og
-Korean/JONSg
+Korean/JONwSg
 Kornberg/g
 Kory/Og
 Korzybski/g
@@ -6322,7 +6323,7 @@ Malamud/Og
 Malaprop/g
 Malawi/Og
 Malawian/NJSg
-Malay/JNOgS
+Malay/JNwOgS
 Malaya/Og
 Malayalam/Og
 Malayan/NJOgS
@@ -6981,7 +6982,7 @@ Monet/Og
 MongoDB/g           # trademark
 Mongol/NJOSg
 Mongolia/Og
-Mongolian/JNSg
+Mongolian/JNwSg
 Mongolic/OJg
 Mongoloid/N
 Monica/Og
@@ -7476,7 +7477,7 @@ Northwest/Sg
 Norton/ONgS
 Norw
 Norway/ONg
-Norwegian/NJSg
+Norwegian/NwJSg
 Norwich/Og
 Nosferatu/Ng
 Nostradamus/ONg
@@ -9517,7 +9518,7 @@ Spam/Og
 Span/O
 Spanglish/O
 Spaniard/NSg
-Spanish/JONg
+Spanish/JONmg
 Sparks/Og
 Sparta/Og
 Spartacus/Og
@@ -9748,7 +9749,7 @@ Swed/On
 Swede/NSg
 Sweden/Og
 Swedenborg/Og
-Swedish/OJg
+Swedish/OmJg
 Sweeney/Og
 Sweet/Og
 Swift/Og
@@ -9970,7 +9971,7 @@ Th/NOg              # thorium
 Thackeray/Og
 Thad/Og
 Thaddeus/Og
-Thai/JNSg
+Thai/JNwSg
 Thailand/Og
 Thales/Og
 Thalia/Og
@@ -10546,7 +10547,7 @@ Vientiane/Og
 Vietcong/ONg
 Vietminh/Og
 Vietnam/ONg
-Vietnamese/JNOg
+Vietnamese/JNw09Og
 Vijayanagar/Og
 Vijayawada/Og
 Viking/NOgS
@@ -11382,7 +11383,7 @@ acculturation/Ng
 accumulate/~VJXGnvdS
 accumulation/~Ng
 accumulator/~NgS
-accuracy/~NigS
+accuracy/~NwigS
 accurate/~JiY
 accurateness/Ng
 accursed/JVp
@@ -11891,7 +11892,7 @@ ahchoo/
 ahead/~
 ahem/V
 ahoy/VN
-aid/~NVSgdG
+aid/~NwVSgdG
 aide/~NSg
 aided/~VU
 aigrette/NgS
@@ -12025,7 +12026,7 @@ alight/~VJGdS
 align/~VrLGdS
 aligned/~VJU
 aligner/NgS
-alignment/~NrgS
+alignment/~NwrgS
 alike/~JU
 aliment/NVgdSG
 alimentary/J
@@ -12967,7 +12968,7 @@ arisen/~V
 aristocracy/~NSg
 aristocrat/~NSg
 aristocratic/~JQ
-arithmetic/~NJg
+arithmetic/~NmJg
 arithmetical/JNY
 arithmetician/NgS
 ark/~NSg
@@ -16099,7 +16100,7 @@ cajole/VNZGLd>S
 cajolement/Ng
 cajoler/Ng
 cajolery/Ng
-cake/~NVdSgG
+cake/~NwVdSgG
 cakewalk/NVSg
 cal/~N
 calabash/NgS
@@ -18300,7 +18301,7 @@ communicable/Ji
 communicably/R
 communicant/NJgS
 communicate/~VGnvdSX
-communication/~Ng
+communication/~NwSg
 communicative/JU
 communicator/~NSg
 communion/~Ng
@@ -18449,7 +18450,7 @@ computerisation/Ng!_
 computerise/VGdS!_
 computerization/Ng
 computerize/VGdS
-computing/~NVg
+computing/~NmVg
 comrade/~NVSgY
 comradeship/Ng
 con/~VNJGSg
@@ -20848,7 +20849,7 @@ desiccation/Ng
 desiccator/NSg
 desiderata/N
 desideratum/Ng
-design/~NVrSdG
+design/~NwVrSdG
 designate/~JVdSGnX
 designation/~Ng
 designator/NSg
@@ -23797,7 +23798,7 @@ explainability/Ng
 explainable/J
 explained/~VU
 explainer/NgS
-explanation/~NgS
+explanation/~NwgS
 explanatory/~J
 expletive/JNgS
 explicable/Ji
@@ -24836,13 +24837,13 @@ flatworm/NSg
 flaunt/VNgdSG
 flaunting/VJNY
 flautist/NSg!@_
-flavor/~NVgdSGz<
+flavor/~NwVgdSGz<
 flavored/~JVU<
 flavorful/J<
 flavoring/NVg<
 flavorless/J<
 flavorsome/J<
-flavour/NVSgdzG!@_
+flavour/NwVSgdzG!@_
 flavoured/JVU!@_
 flavourful/J!@_
 flavouring/NVg!@_
@@ -27319,7 +27320,7 @@ halal/~JVg
 halberd/NSg
 halcyon/~NJ
 hale/~JNVi^Gd>S
-half/~NJVPg
+half/~N0wJVPg
 halfback/~NVSg
 halfcourt/
 halfhearted/JpY
@@ -31807,7 +31808,7 @@ lighthouse/~NgS
 lighting's
 lightly/~R
 lightness/~Ng
-lightning/~NJVgdS
+lightning/~NmJV
 lightproof/J
 lightsaber/NgS
 lightship/NgS
@@ -31904,7 +31905,7 @@ lingual/~JN
 linguine/Ng
 linguist/~NSg
 linguistic/~JSQ
-linguistics/~Ng
+linguistics/~Nmg
 liniment/NVSg
 lining/~NVg
 link/~NVgdSG
@@ -32583,7 +32584,7 @@ maidenhair/Ng
 maidenhead/~NSg
 maidenhood/Ng
 maidservant/NSg
-mail/~NVzgd>SZG
+mail/~NwVzgd>SZG
 mailbag/NSg
 mailbomb/NVGSd
 mailbox/~NgS
@@ -35637,7 +35638,7 @@ nonseasonal/J
 nonsectarian/JN
 nonsecular/J
 nonsegregated/J
-nonsense/~NVJg
+nonsense/~NmVJg
 nonsensical/~JY
 nonsensitive/J
 nonsequential/JY
@@ -37710,7 +37711,7 @@ payware/Nmg
 pct/~N
 pd/~
 pea/~NSg
-peace/~NVSg
+peace/~NwVSg
 peaceable/J
 peaceably/R
 peaceful/~JNpY
@@ -38451,7 +38452,7 @@ picturesqueness/Nmg
 piddle/NVgGdS
 piddly/J
 pidgin/~NgS
-pie/~NVSg
+pie/~NwVSg
 piebald/JNgS
 piece/~NVdSgG
 piecemeal/JVN
@@ -39230,7 +39231,7 @@ possibility/~NSg
 possible/~JNSg
 possibly/~R
 possum/~NVSg
-post/~NVPZGgd>Sz
+post/~NwVPZGgd>Sz
 postage/~Ng
 postal/~J
 postbag/NS
@@ -39917,7 +39918,7 @@ programme/NVBzd>SgZG
 programme/!_
 programmed/~VJre
 programmer/~NgS
-programming/~NVSg
+programming/~NmVg
 progress/~NVgdSGv
 progression/~NgS
 progressive/~JNpgYS
@@ -41703,6 +41704,8 @@ rescind/VSdG
 rescission/Ng
 rescue/~VNd>SgZG
 reseal/VB
+research/NmgVdGS
+researcher/NgS
 resemble/~VdSG
 resend/VNSGd
 resent/~VLSdG
@@ -43059,7 +43062,7 @@ schwa/NVgS
 sci/~N
 sciatic/JN
 sciatica/Ng
-science/~NVWgS
+science/~NwVWgS
 scientific/~JUQ
 scientism/Ng
 scientist/~NSg
@@ -43290,7 +43293,7 @@ seance/NVSg
 seaplane/~NSg
 seaport/~NgS
 sear/JVNGgdS
-search/~NVrZGgd>S
+search/~NVZGgd>S
 searchable/~JNU
 searcher/Nrg
 searching/~VJNmY
@@ -44819,7 +44822,7 @@ smokescreen/NSg
 smokestack/NSg
 smokey/~JN
 smokiness/Ng
-smoking/~VJNg
+smoking/~VJNmg
 smoky/~J>^p
 smolder/VNSGgd
 smooch/NVgdSG
@@ -46988,7 +46991,7 @@ supplicate/VGdS
 supplication/Ng
 supplier/~Ng
 supply/~VNZGd>SgXn
-support/~VNgd>SBZGv
+support/~VNwgd>SBZGv
 supportable/JUi
 supported/~JVU
 supporter/~Ng
@@ -51158,7 +51161,7 @@ wanted/~JVU
 wanton/~JNVgdYSpG
 wantonness/Ng
 wapiti/NgS
-war/~NVSg
+war/~NwVSg
 warble/VNgZGd>S
 warbler/~Ng
 warbonnet/NSg
@@ -51431,7 +51434,7 @@ weigh/~VNrGd
 weigh's
 weighbridge/NS
 weighs/~Vr
-weight/~NVgdSzG
+weight/~NwVgdSzG
 weighted/~VJU
 weightily/R
 weightiness/Ng
@@ -52127,7 +52130,7 @@ wrap's
 wraparound/JNSg
 wrapped/~VJU
 wrapper/~NSg
-wrapping/~NVgS
+wrapping/~NwVgS
 wrasse/NgS
 wrath/~NVJg
 wrathful/JY

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -12659,8 +12659,8 @@ antisocial/JNY
 antispasmodic/JNgS
 antisubmarine/J
 antitank/J
-antitheses/9
-antithesis/~Ng
+antitheses/N9
+antithesis/~N0g
 antithetic/JN
 antithetical/JY
 antitoxin/NgS
@@ -14675,7 +14675,7 @@ biorhythm/NgS
 bioscience/NgS
 biosensor/NS
 biosphere/~NSg
-biosynthesis/~N
+biosynthesis/~Nm
 biosynthetic/J
 biotech/~N
 biotechnological/J
@@ -28836,8 +28836,8 @@ hypotenuse/NgS
 hypothalami/N
 hypothalamus/~Ng
 hypothermia/~Ng
-hypotheses/~9
-hypothesis/~Ng
+hypotheses/~N9
+hypothesis/~N0g
 hypothesise/V!_
 hypothesize/VdSG
 hypothetical/~JNYS
@@ -33458,8 +33458,8 @@ metastatic/J
 metatarsal/JNgS
 metatarsi/N
 metatarsus/Ng
-metatheses/9
-metathesis/Ng
+metatheses/N9
+metathesis/N0g
 metaverse/NgS
 mete/VNJgZGd>S
 metempsychoses/N
@@ -37422,7 +37422,7 @@ paren/NgS           # informal: parenthesis
 parent/~NVGgdS
 parentage/~Ng
 parental/~JN
-parentheses/~9
+parentheses/~N9
 parenthesis/N0g
 parenthesise/V!_
 parenthesize/VdSG
@@ -38365,7 +38365,7 @@ photostat/NVSg
 photostatic/J
 photostatted/V
 photostatting/V
-photosynthesis/~Ng
+photosynthesis/~Nmg
 photosynthesise/V!_
 photosynthesize/VGdS
 photosynthetic/J
@@ -40063,8 +40063,8 @@ prosper/~VGSd
 prosperity/~Ng
 prosperous/~JY
 prostate/~NJgS
-prostheses/9
-prosthesis/~Ng
+prostheses/N9
+prosthesis/~N0g
 prosthetic/~JNgSQ
 prostitute/~VJNgGndS
 prostitution/~Ng
@@ -47328,7 +47328,7 @@ syntactic/~J
 syntactical/JY
 syntax/~Ng
 syntheses/9
-synthesis/~Ng
+synthesis/~Nmg
 synthesise/V!_
 synthesize/~VZGd>S
 synthesizer/~Ng
@@ -48095,8 +48095,8 @@ thermostatic/JQ
 thesauri/N
 thesaurus/NgS
 these/~IDM
-theses/~9g
-thesis/~Ng
+theses/~N9
+thesis/~N0g
 thespian/JNSg
 theta/~NSg
 thew/NVgS

--- a/harper-core/src/linting/noun_countability.rs
+++ b/harper-core/src/linting/noun_countability.rs
@@ -68,9 +68,9 @@ impl ExprLinter for NounCountability {
 
         // 3 tokens means the phrase was at the end of a chunk/sentence.
         // 5 tokens means the phrase was in the middle of a chunk/sentence.
-        // If it's in the middle then we check if the next word token is a noun.
+        // If it's in the middle then we check if the next word token is a noun or OOV.
         // Since the last token of our phrase is the mass noun, this would make it part of a compound noun.
-        if toks.len() == 5 && toks.last()?.kind.is_noun() {
+        if toks.len() == 5 && (toks.last()?.kind.is_noun() || toks.last()?.kind.is_oov()) {
             return None;
         }
 

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -849,9 +849,9 @@ Message: |
      664 | it, you perceive, after a moment, the eyes of Doctor T. J. Eckleburg. The eyes
          |                                                      ^~ Did you mean to spell `T.` this way?
 Suggest:
+  - Replace with: “Tr”
   - Replace with: “T”
   - Replace with: “Tb”
-  - Replace with: “Ti”
 
 
 
@@ -883,9 +883,9 @@ Message: |
      665 | of Doctor T. J. Eckleburg are blue and gigantic—their retinas are one yard high.
          |           ^~ Did you mean to spell `T.` this way?
 Suggest:
+  - Replace with: “Tr”
   - Replace with: “T”
   - Replace with: “Tb”
-  - Replace with: “Ti”
 
 
 
@@ -5083,9 +5083,9 @@ Message: |
     3874 | while in silence. Then as Doctor T. J. Eckleburg’s faded eyes came into sight
          |                                  ^~ Did you mean to spell `T.` this way?
 Suggest:
+  - Replace with: “Tr”
   - Replace with: “T”
   - Replace with: “Tb”
-  - Replace with: “Ti”
 
 
 
@@ -5152,9 +5152,9 @@ Message: |
     3948 | behind. Over the ashheaps the giant eyes of Doctor T. J. Eckleburg kept their
          |                                                    ^~ Did you mean to spell `T.` this way?
 Suggest:
+  - Replace with: “Tr”
   - Replace with: “T”
   - Replace with: “Tb”
-  - Replace with: “Ti”
 
 
 
@@ -6436,9 +6436,9 @@ Message: |
     5156 | of Doctor T. J. Eckleburg, which had just emerged, pale and enormous, from the
          |           ^~ Did you mean to spell `T.` this way?
 Suggest:
+  - Replace with: “Tr”
   - Replace with: “T”
   - Replace with: “Tb”
-  - Replace with: “Ti”
 
 
 
@@ -6854,7 +6854,7 @@ Message: |
     5352 | I think it was on the third day that a telegram signed Henry C. Gatz arrived
          |                                                              ^~ Did you mean to spell `C.` this way?
 Suggest:
-  - Replace with: “Cw”
+  - Replace with: “Cu”
   - Replace with: “C”
   - Replace with: “Cc”
 

--- a/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
+++ b/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
@@ -238,8 +238,8 @@
 #
 > There seemed to be     no    use   in      waiting by      the little      door   , so        she  went  back    to the
 # +     V/J    P  NSg/VX NPr/P NSg/V NPr/J/P NSg/V+  NSg/J/P D+  NPr/I/J/Dq+ NSg/V+ . NSg/I/J/C ISg+ NSg/V NSg/V/J P  D+
-> table  , half       hoping she  might     find  another key     on  it       , or    at    any    rate   a   book  of
-# NSg/V+ . NSg/V/J/P+ V      ISg+ NᴹSg/VX/J NSg/V I/D     NPr/V/J J/P NPr/ISg+ . NPr/C NSg/P I/R/Dq NSg/V+ D/P NSg/V P
+> table  , half        hoping she  might     find  another key     on  it       , or    at    any    rate   a   book  of
+# NSg/V+ . N🅪Sg/V/J/P+ V      ISg+ NᴹSg/VX/J NSg/V I/D     NPr/V/J J/P NPr/ISg+ . NPr/C NSg/P I/R/Dq NSg/V+ D/P NSg/V P
 > rules for shutting people up        like        telescopes : this    time      she  found a   little
 # NPl/V C/P NSg/V    NSg/V+ NSg/V/J/P NSg/V/J/C/P NPl/V      . I/Ddem+ N🅪Sg/V/J+ ISg+ NSg/V D/P NPr/I/J/Dq
 > bottle on  it       , ( “ which certainly was not   here    before , ” said Alice , ) and round     the
@@ -272,8 +272,8 @@
 #
 > However , this   bottle was not   marked “ poison , ” so        Alice ventured to taste   it       , and
 # C       . I/Ddem NSg/V+ V   NSg/C V/J    . NSg/V+ . . NSg/I/J/C NPr+  V/J      P  NSg/V/J NPr/ISg+ . V/C
-> finding it       very nice    , ( it       had , in      fact , a   sort  of mixed flavour    of cherry - tart    ,
-# NSg/V   NPr/ISg+ J/R  NPr/V/J . . NPr/ISg+ V   . NPr/J/P NSg+ . D/P NSg/V P  V/J   NSg/V/Comm P  NPr🅪/J . NSg/V/J .
+> finding it       very nice    , ( it       had , in      fact , a   sort  of mixed flavour     of cherry - tart    ,
+# NSg/V   NPr/ISg+ J/R  NPr/V/J . . NPr/ISg+ V   . NPr/J/P NSg+ . D/P NSg/V P  V/J   N🅪Sg/V/Comm P  NPr🅪/J . NSg/V/J .
 > custard , pine  - apple , roast    turkey  , toffee , and hot     buttered toast  , ) she  very
 # N🅪Sg    . NSg/V . NPr🅪  . NSg/V/J+ NPr🅪/J+ . NSg/V  . V/C NSg/V/J V/J+     NSg/V+ . . ISg+ J/R
 > soon finished it      off       .
@@ -340,8 +340,8 @@
 #
 > Soon her     eye   fell    on  a   little     glass   box    that          was lying   under   the table  : she
 # J/R  ISg/D$+ NSg/V NSg/V/J J/P D/P NPr/I/J/Dq NPr🅪/V+ NSg/V+ NSg/I/C/Ddem+ V   NSg/V/J NSg/J/P D+  NSg/V+ . ISg+
-> opened it       , and found in      it       a   very small   cake  , on  which the words  “ EAT ME       ” were
-# V/J    NPr/ISg+ . V/C NSg/V NPr/J/P NPr/ISg+ D/P J/R  NPr/V/J NSg/V . J/P I/C+  D+  NPl/V+ . V   NPr/ISg+ . NSg/V
+> opened it       , and found in      it       a   very small   cake   , on  which the words  “ EAT ME       ” were
+# V/J    NPr/ISg+ . V/C NSg/V NPr/J/P NPr/ISg+ D/P J/R  NPr/V/J N🅪Sg/V . J/P I/C+  D+  NPl/V+ . V   NPr/ISg+ . NSg/V
 > beautifully marked in      currants . “ Well    , I’ll eat it       , ” said Alice , “ and if    it
 # R           V/J    NPr/J/P NPl      . . NSg/V/J . W?   V   NPr/ISg+ . . V/J  NPr   . . V/C NSg/C NPr/ISg+
 > makes me      grow larger , I    can    reach the key     ; and if    it       makes me      grow smaller , I
@@ -358,16 +358,16 @@
 # NSg/V   ISg/D$+ NSg/V+ J/P D   NSg/V/J P  ISg/D$+ NPr/V/J+ P  NSg/I/V I/C+  NSg/J+ NPr/ISg+ V   NSg/V   . V/C
 > she  was quite surprised to find  that         she  remained the same size   : to be     sure ,
 # ISg+ V   NSg   V/J       P  NSg/V NSg/I/C/Ddem ISg+ V/J      D+  I/J+ NSg/V+ . P  NSg/VX J    .
-> this    generally happens when    one       eats cake   , but     Alice had got so        much       into the
-# I/Ddem+ R         V       NSg/I/C NSg/I/V/J V    NSg/V+ . NSg/C/P NPr+  V   V   NSg/I/J/C NSg/I/J/Dq P    D
+> this    generally happens when    one       eats cake    , but     Alice had got so        much       into the
+# I/Ddem+ R         V       NSg/I/C NSg/I/V/J V    N🅪Sg/V+ . NSg/C/P NPr+  V   V   NSg/I/J/C NSg/I/J/Dq P    D
 > way   of expecting nothing  but     out         - of - the - way   things to happen , that         it       seemed
 # NSg/J P  V         NSg/I/J+ NSg/C/P NSg/V/J/R/P . P  . D   . NSg/J NPl/V  P  V      . NSg/I/C/Ddem NPr/ISg+ V/J
 > quite dull and stupid for life   to go      on  in      the common   way   .
 # NSg   V/J  V/C NSg/J  C/P NSg/V+ P  NSg/V/J J/P NPr/J/P D+  NSg/V/J+ NSg/J .
 >
 #
-> So        she  set     to work  , and very soon finished off       the cake   .
-# NSg/I/J/C ISg+ NPr/V/J P  NSg/V . V/C J/R  J/R  V/J      NSg/V/J/P D+  NSg/V+ .
+> So        she  set     to work  , and very soon finished off       the cake    .
+# NSg/I/J/C ISg+ NPr/V/J P  NSg/V . V/C J/R  J/R  V/J      NSg/V/J/P D+  N🅪Sg/V+ .
 >
 #
 > CHAPTER II : The Pool  of Tears
@@ -376,8 +376,8 @@
 #
 > “ Curiouser and curiouser ! ” cried Alice ( she  was so        much       surprised , that         for the
 # . ?         V/C ?         . . V/J   NPr+  . ISg+ V   NSg/I/J/C NSg/I/J/Dq V/J       . NSg/I/C/Ddem C/P D+
-> moment she  quite forgot how   to speak good    English  ) ; “ now       I’m opening out         like
-# NSg+   ISg+ NSg   V      NSg/C P  NSg/V NPr/V/J NPr/V/J+ . . . NPr/V/J/C W?  NSg/V/J NSg/V/J/R/P NSg/V/J/C/P
+> moment she  quite forgot how   to speak good    English   ) ; “ now       I’m opening out         like
+# NSg+   ISg+ NSg   V      NSg/C P  NSg/V NPr/V/J NPr🅪/V/J+ . . . NPr/V/J/C W?  NSg/V/J NSg/V/J/R/P NSg/V/J/C/P
 > the largest telescope that          ever was ! Good    - bye     , feet ! ” ( for when    she  looked down
 # D+  JS+     NSg/V+    NSg/I/C/Ddem+ J    V   . NPr/V/J . NSg/J/P . NPl+ . . . C/P NSg/I/C ISg+ V/J    NSg/V/J/P
 > at    her     feet , they seemed to be     almost out         of sight  , they were  getting so        far
@@ -408,8 +408,8 @@
 # NSg$    NPr/V/J NSg/V . NSg . . NSg       . NSg/V/J/P D   NSg/V  . . P    NSg$+   NPr🅪/V+ . .
 >
 #
-> Oh    dear    , what   nonsense I’m talking ! ”
-# NPr/V NSg/V/J . NSg/I+ NSg/V/J+ W?  V       . .
+> Oh    dear    , what   nonsense  I’m talking ! ”
+# NPr/V NSg/V/J . NSg/I+ NᴹSg/V/J+ W?  V       . .
 >
 #
 > Just then    her     head     struck against the roof  of the hall : in      fact she  was now       more
@@ -434,8 +434,8 @@
 # NᴹSg/VX/J NSg/V/J NSg/V I/Ddem+ . . . P  NSg/V/J J/P V      NPr/J/P I/Ddem+ NSg/J+ . NSg/V I/Ddem+ NSg+   . ISg+ NPr/V
 > you    ! ” But     she  went  on  all          the same , shedding gallons of tears  , until there was a
 # ISgPl+ . . NSg/C/P ISg+ NSg/V J/P NSg/I/J/C/Dq D   I/J  . NSg/V    NPl     P  NPl/V+ . C/P   +     V   D/P
-> large pool  all          round     her     , about four inches deep  and reaching half       down      the
-# NSg/J NSg/V NSg/I/J/C/Dq NSg/V/J/P ISg/D$+ . J/P   NSg  NPl/V+ NSg/J V/C V        NSg/V/J/P+ NSg/V/J/P D
+> large pool  all          round     her     , about four inches deep  and reaching half        down      the
+# NSg/J NSg/V NSg/I/J/C/Dq NSg/V/J/P ISg/D$+ . J/P   NSg  NPl/V+ NSg/J V/C V        N🅪Sg/V/J/P+ NSg/V/J/P D
 > hall .
 # NPr+ .
 >
@@ -578,8 +578,8 @@
 # P    D+  NSg . . V/C NPr/J/P NSg/I/C/Ddem+ NPr/V+ ISg+ NPr/VX NSg/V/J NSg/V/J NSg/J/P NSg+    . . ISg+ V/J  P  ISg+    .
 > ( Alice had been  to the seaside once  in      her     life   , and had come    to the general
 # . NPr+  V   NSg/V P  D   NPr/J   NSg/C NPr/J/P ISg/D$+ NSg/V+ . V/C V   NSg/V/P P  D+  NSg/V/J+
-> conclusion , that          wherever you    go      to on  the English  coast  you    find  a   number   of
-# NSg+       . NSg/I/C/Ddem+ C        ISgPl+ NSg/V/J P  J/P D+  NPr/V/J+ NSg/V+ ISgPl+ NSg/V D/P NSg/V/JC P
+> conclusion , that          wherever you    go      to on  the English   coast  you    find  a   number   of
+# NSg+       . NSg/I/C/Ddem+ C        ISgPl+ NSg/V/J P  J/P D+  NPr🅪/V/J+ NSg/V+ ISgPl+ NSg/V D/P NSg/V/JC P
 > bathing machines in      the sea  , some     children digging in      the sand     with wooden
 # NSg/V   NPl/V    NPr/J/P D+  NSg+ . I/J/R/Dq NPl+     NSg/V   NPr/J/P D+  NSg/V/J+ P    J+
 > spades , then    a   row   of lodging houses , and behind  them     a    railway station . )
@@ -630,14 +630,14 @@
 # ISg/D$+ NPr/I/J/Dq+ NPl/V+ . NSg/C/P NPr/ISg+ V/J  NSg/I/J+ .
 >
 #
-> “ Perhaps it       doesn’t understand English  , ” thought Alice ; “ I    daresay it’s a    French
-# . NSg     NPr/ISg+ V       V          NPr/V/J+ . . NSg/V   NPr+  . . ISg+ V       W?   D/P+ NPr/V/J+
+> “ Perhaps it       doesn’t understand English   , ” thought Alice ; “ I    daresay it’s a    French
+# . NSg     NPr/ISg+ V       V          NPr🅪/V/J+ . . NSg/V   NPr+  . . ISg+ V       W?   D/P+ NPr🅪/V/J+
 > mouse , come    over      with William the Conqueror . ” ( For , with all          her     knowledge of
 # NSg/V . NSg/V/P NSg/V/J/P P    NPr+    D+  NSg       . . . C/P . P    NSg/I/J/C/Dq ISg/D$+ NᴹSg      P
 > history , Alice had no     very clear   notion how   long    ago anything had happened . ) So
 # N🅪Sg+   . NPr+  V   NPr/P+ J/R  NSg/V/J NSg+   NSg/C NPr/V/J J/P NSg/I/V+ V+  V/J      . . NSg/I/J/C
 > she  began again : “ Où est  ma     chatte ? ” which was the first   sentence in      her     French
-# ISg+ V     P     . . ?  NPr+ NPr/J+ ?      . . I/C+  V   D   NSg/V/J NSg/V    NPr/J/P ISg/D$+ NPr/V/J+
+# ISg+ V     P     . . ?  NPr+ NPr/J+ ?      . . I/C+  V   D   NSg/V/J NSg/V    NPr/J/P ISg/D$+ NPr🅪/V/J+
 > lesson - book  . The Mouse  gave a   sudden leap    out         of the water   , and seemed to quiver
 # NSg/V+ . NSg/V . D+  NSg/V+ V    D/P NSg/J  NSg/V/J NSg/V/J/R/P P  D+  N🅪Sg/V+ . V/C V/J    P  NSg/V/J
 > all          over      with fright  . “ Oh    , I    beg   your pardon ! ” cried Alice hastily , afraid that
@@ -658,8 +658,8 @@
 # V/C NSg/V/C ISg+ NSg/V ISg+ NSg/VX NSg/V ISgPl+ D$+ NSg/V/J+ NPr   . ISg+ NSg/V W?    NSg/V D/P NSg/V/J P
 > cats  if    you    could  only  see   her     . She  is such  a   dear    quiet    thing  , ” Alice went  on  ,
 # NPl/V NSg/C ISgPl+ NSg/VX J/R/C NSg/V ISg/D$+ . ISg+ VL NSg/I D/P NSg/V/J NSg/V/J+ NSg/V+ . . NPr+  NSg/V J/P .
-> half      to herself , as    she  swam lazily about in      the pool  , “ and she  sits  purring so
-# NSg/V/J/P P  ISg+    . NSg/R ISg+ V    R      J/P   NPr/J/P D+  NSg/V . . V/C ISg+ NPl/V V       NSg/I/J/C
+> half       to herself , as    she  swam lazily about in      the pool  , “ and she  sits  purring so
+# N🅪Sg/V/J/P P  ISg+    . NSg/R ISg+ V    R      J/P   NPr/J/P D+  NSg/V . . V/C ISg+ NPl/V V       NSg/I/J/C
 > nicely by      the fire      , licking her     paws   and washing her     face   — and she  is such  a   nice
 # R      NSg/J/P D+  N🅪Sg/V/J+ . NSg/V   ISg/D$+ NPl/V+ V/C NSg/V   ISg/D$+ NSg/V+ . V/C ISg+ VL NSg/I D/P NPr/V/J
 > soft  thing to nurse — and she’s such  a   capital one       for catching mice   — oh    , I    beg
@@ -690,8 +690,8 @@
 # NSg/V/J/C/P P  NSg/V ISgPl+ . D/P NPr/I/J/Dq NPr/V/J . V/J+ NSg     . ISgPl+ NSg/V . P    NPr/V . NSg/I NPr/V/J
 > curly   brown   hair    ! And it’ll fetch things when    you    throw them     , and it’ll sit   up
 # NSg/J/R NPr/V/J N🅪Sg/V+ . V/C W?    NSg/V NPl/V+ NSg/I/C ISgPl+ NSg/V NSg/IPl+ . V/C W?    NSg/V NSg/V/J/P
-> and beg   for its     dinner , and all          sorts of things — I    can’t remember half      of
-# V/C NSg/V C/P ISg/D$+ NSg/V+ . V/C NSg/I/J/C/Dq NPl/V P  NPl/V+ . ISg+ VX    NSg/V    NSg/V/J/P P
+> and beg   for its     dinner , and all          sorts of things — I    can’t remember half       of
+# V/C NSg/V C/P ISg/D$+ NSg/V+ . V/C NSg/I/J/C/Dq NPl/V P  NPl/V+ . ISg+ VX    NSg/V    N🅪Sg/V/J/P P
 > them     — and it       belongs to a    farmer , you    know  , and he       says  it’s so        useful , it’s
 # NSg/IPl+ . V/C NPr/ISg+ V       P  D/P+ NPr+   . ISgPl+ NSg/V . V/C NPr/ISg+ NPl/V W?   NSg/I/J/C J      . W?
 > worth   a   hundred pounds ! He       says  it       kills all          the rats   and — oh    dear    ! ” cried Alice
@@ -772,8 +772,8 @@
 # . V    . . V/J  D+  NSg/V+ P    D/P+ J+        NSg/V+ . . V   ISgPl+ NSg/I/J/C/Dq NSg/V/J . I/Ddem+ VL D
 > driest thing I    know   . Silence all          round     , if    you    please ! ‘          William the Conqueror ,
 # JS     NSg/V ISg+ NSg/V+ . NSg/V+  NSg/I/J/C/Dq NSg/V/J/P . NSg/C ISgPl+ V      . Unlintable NPr+    D   NSg       .
-> whose cause    was favoured by      the pope   , was soon submitted to by      the English  , who
-# I+    NSg/V/C+ V   V/J/Comm NSg/J/P D+  NPr/V+ . V   J/R  V         P  NSg/J/P D+  NPr/V/J+ . NPr/I+
+> whose cause    was favoured by      the pope   , was soon submitted to by      the English   , who
+# I+    NSg/V/C+ V   V/J/Comm NSg/J/P D+  NPr/V+ . V   J/R  V         P  NSg/J/P D+  NPr🅪/V/J+ . NPr/I+
 > wanted leaders , and had been  of late  much       accustomed to usurpation and conquest .
 # V/J    +       . V/C V   NSg/V P  NSg/J NSg/I/J/Dq V/J        P  NSg        V/C NSg/V+   .
 > Edwin and Morcar , the earls of Mercia and Northumbria — ’ ”
@@ -840,8 +840,8 @@
 # NSg/V+  V       . C/P D   J         NSg      P  NPr/I/V/J/Dq NSg/J     NPl/V+   . .
 >
 #
-> “ Speak English  ! ” said the Eaglet . “ I    don’t know  the meaning  of half       those   long
-# . NSg/V NPr/V/J+ . . V/J  D+  NSg    . . ISg+ V     NSg/V D   N🅪Sg/V/J P  NSg/V/J/P+ I/Ddem+ NPr/V/J+
+> “ Speak English   ! ” said the Eaglet . “ I    don’t know  the meaning  of half        those   long
+# . NSg/V NPr🅪/V/J+ . . V/J  D+  NSg    . . ISg+ V     NSg/V D   N🅪Sg/V/J P  N🅪Sg/V/J/P+ I/Ddem+ NPr/V/J+
 > words  , and , what’s more         , I    don’t believe you    do     either ! ” And the Eaglet bent
 # NPl/V+ . V/C . NSg$   NPr/I/V/J/Dq . ISg+ V     V       ISgPl+ NSg/VX I/C    . . V/C D   NSg    NSg/V/J
 > down      its     head     to hide  a   smile  : some     of the other    birds  tittered audibly .
@@ -878,8 +878,8 @@
 # NSg/J/R+ V/C+ +     . +     V   NPr/P . NSg/I/V/J+ . NSg . NSg   . V/C V/J  . . NSg/C/P IPl+ V     NSg/V/J/P
 > when    they liked , and left    off       when    they liked , so        that         it       was not   easy    to know
 # NSg/I/C IPl+ V/J   . V/C NPr/V/J NSg/V/J/P NSg/I/C IPl+ V/J   . NSg/I/J/C NSg/I/C/Ddem NPr/ISg+ V   NSg/C NSg/V/J P  NSg/V
-> when    the race   was over      . However , when    they had been  running   half       an  hour or    so        ,
-# NSg/I/C D+  NSg/V+ V   NSg/V/J/P . C       . NSg/I/C IPl+ V   NSg/V NSg/V/J/P NSg/V/J/P+ D/P NSg  NPr/C NSg/I/J/C .
+> when    the race   was over      . However , when    they had been  running   half        an  hour or    so        ,
+# NSg/I/C D+  NSg/V+ V   NSg/V/J/P . C       . NSg/I/C IPl+ V   NSg/V NSg/V/J/P N🅪Sg/V/J/P+ D/P NSg  NPr/C NSg/I/J/C .
 > and were  quite dry      again , the Dodo suddenly called out         “ The race   is over      ! ” and
 # V/C NSg/V NSg   NSg/V/J+ P     . D   NSg  R        V/J    NSg/V/J/R/P . D+  NSg/V+ VL NSg/V/J/P . . V/C
 > they all          crowded round     it      , panting , and asking , “ But     who    has won     ? ”
@@ -964,8 +964,8 @@
 #
 > “ You    promised to tell  me       your history , you    know  , ” said Alice , “ and why   it       is you
 # . ISgPl+ V/J      P  NPr/V NPr/ISg+ D$+  N🅪Sg+   . ISgPl+ NSg/V . . V/J  NPr   . . V/C NSg/V NPr/ISg+ VL ISgPl
-> hate   — C       and D      , ” she  added in      a    whisper , half       afraid that         it       would be     offended
-# N🅪Sg/V . NPr/V/J V/C NPr/J+ . . ISg+ V/J   NPr/J/P D/P+ NSg/V+  . NSg/V/J/P+ J      NSg/I/C/Ddem NPr/ISg+ VX    NSg/VX V/J+
+> hate   — C       and D      , ” she  added in      a    whisper , half        afraid that         it       would be     offended
+# N🅪Sg/V . NPr/V/J V/C NPr/J+ . . ISg+ V/J   NPr/J/P D/P+ NSg/V+  . N🅪Sg/V/J/P+ J      NSg/I/C/Ddem NPr/ISg+ VX    NSg/VX V/J+
 > again .
 # P+    .
 >
@@ -1030,8 +1030,8 @@
 #
 > “ I    shall do     nothing of the sort   , ” said the Mouse  , getting up        and  walking  away .
 # . ISg+ VX    NSg/VX NSg/I/J P  D+  NSg/V+ . . V/J  D+  NSg/V+ . NSg/V   NSg/V/J/P V/C+ NSg/V/J+ V/J  .
-> “ You    insult me       by      talking such  nonsense ! ”
-# . ISgPl+ NSg/V+ NPr/ISg+ NSg/J/P V       NSg/I NSg/V/J+ . .
+> “ You    insult me       by      talking such  nonsense  ! ”
+# . ISgPl+ NSg/V+ NPr/ISg+ NSg/J/P V       NSg/I NᴹSg/V/J+ . .
 >
 #
 > “ I    didn’t mean    it       ! ” pleaded poor     Alice . “ But     you’re so        easily offended , you
@@ -1087,7 +1087,7 @@
 > This    speech caused a   remarkable sensation among the party    . Some     of the birds
 # I/Ddem+ N🅪Sg/V V/J    D/P W?         NSg       P     D+  NSg/V/J+ . I/J/R/Dq P  D   NPl/V+
 > hurried off       at    once  : one       old   Magpie began wrapping itself up        very carefully ,
-# V/J     NSg/V/J/P NSg/P NSg/C . NSg/I/V/J NSg/J NSg/V  V     NSg/V+   ISg    NSg/V/J/P J/R  R         .
+# V/J     NSg/V/J/P NSg/P NSg/C . NSg/I/V/J NSg/J NSg/V  V     N🅪Sg/V+  ISg    NSg/V/J/P J/R  R         .
 > remarking , “ I    really must  be     getting home     ; the night   - air   doesn’t suit   my
 # V         . . ISg+ R      NSg/V NSg/VX NSg/V   NSg/V/J+ . D   N🅪Sg/V+ . NSg/V V       NSg/V+ D$+
 > throat ! ” and a   Canary  called out         in      a   trembling voice to its     children , “ Come
@@ -1108,8 +1108,8 @@
 # NSg/V/J+ NPr+  V     P  NSg/V P     . C/P ISg+ NSg/V/J J/R  J/R    V/C NSg/V/J+ . V/J      . NPr/J/P D/P+
 > little      while     , however , she  again heard a   little     pattering of footsteps in      the
 # NPr/I/J/Dq+ NSg/V/C/P . C       . ISg+ P     V/J   D/P NPr/I/J/Dq V         P  NPl+      NPr/J/P D+
-> distance , and she  looked up        eagerly , half       hoping that         the Mouse  had changed his
-# NSg/V+   . V/C ISg+ V/J    NSg/V/J/P R       . NSg/V/J/P+ V      NSg/I/C/Ddem D+  NSg/V+ V   V/J     ISg/D$+
+> distance , and she  looked up        eagerly , half        hoping that         the Mouse  had changed his
+# NSg/V+   . V/C ISg+ V/J    NSg/V/J/P R       . N🅪Sg/V/J/P+ V      NSg/I/C/Ddem D+  NSg/V+ V   V/J     ISg/D$+
 > mind   , and was coming  back    to finish his     story  .
 # NSg/V+ . V/C V   NSg/V/J NSg/V/J P  NSg/V  ISg/D$+ NSg/V+ .
 >
@@ -1202,8 +1202,8 @@
 #
 > It       did so        indeed , and much       sooner than she  had expected : before she  had drunk
 # NPr/ISg+ V   NSg/I/J/C W?     . V/C NSg/I/J/Dq JC     C/P  ISg+ V   NSg/V/J  . C/P    ISg+ V   NSg/V/J
-> half       the bottle , she  found her     head     pressing against the ceiling , and had to
-# NSg/V/J/P+ D+  NSg/V+ . ISg+ NSg/V ISg/D$+ NPr/V/J+ NSg/V/J  C/P     D+  NSg/V+  . V/C V   P
+> half        the bottle , she  found her     head     pressing against the ceiling , and had to
+# N🅪Sg/V/J/P+ D+  NSg/V+ . ISg+ NSg/V ISg/D$+ NPr/V/J+ NSg/V/J  C/P     D+  NSg/V+  . V/C V   P
 > stoop to save      her     neck   from being    broken . She  hastily put   down      the bottle ,
 # NSg/V P  NSg/V/C/P ISg/D$+ NSg/V+ P+   NSg/V/C+ V/J+   . ISg+ R       NSg/V NSg/V/J/P D+  NSg/V+ .
 > saying to herself “ That’s quite enough — I    hope   I    shan’t grow any     more         — As    it       is , I
@@ -1376,8 +1376,8 @@
 # ISg+ V    NSg/V/J/R/P D+  NPl/V+ . . NSg$    D+  NSg/V/J+ NSg/V+ . . NSg/V . ISg+ V      P  V     NSg/C/P
 > one       ; Bill’s got the other   — Bill   ! fetch it       here    , lad ! — Here    , put   ’ em       up        at    this
 # NSg/I/V/J . NSg$   V   D   NSg/V/J . NPr/V+ . NSg/V NPr/ISg+ NSg/J/R . NSg . . NSg/J/R . NSg/V . NSg/I/J+ NSg/V/J/P NSg/P I/Ddem+
-> corner — No    , tie   ’ em       together first   — they don’t reach half       high    enough yet     — Oh    !
-# NSg/V+ . NPr/P . NSg/V . NSg/I/J+ J        NSg/V/J . IPl+ V     NSg/V NSg/V/J/P+ NSg/V/J NSg/I  NSg/V/C . NPr/V .
+> corner — No    , tie   ’ em       together first   — they don’t reach half        high    enough yet     — Oh    !
+# NSg/V+ . NPr/P . NSg/V . NSg/I/J+ J        NSg/V/J . IPl+ V     NSg/V N🅪Sg/V/J/P+ NSg/V/J NSg/I  NSg/V/C . NPr/V .
 > they’ll do     well    enough ; don’t be     particular — Here    , Bill   ! catch hold    of this
 # W?      NSg/VX NSg/V/J NSg/I  . V     NSg/VX NSg/J      . NSg/J/R . NPr/V+ . NSg/V NSg/V/J P  I/Ddem+
 > rope   — Will   the roof  bear     ? — Mind   that         loose   slate    — Oh    , it’s coming  down      ! Heads
@@ -1540,8 +1540,8 @@
 # J/R  NPr/I/J/Dq NSg/J NPl/V    Dq+  N🅪Sg/V/J V/C D/P NPr/V/J+ NSg/J+ NSg/V/J . V/C V+      R        NSg/I/J/C/Dq
 > the while     , till      at    last    it       sat     down      a   good    way   off       , panting , with its     tongue
 # D   NSg/V/C/P . NSg/V/C/P NSg/P NSg/V/J NPr/ISg+ NSg/V/J NSg/V/J/P D/P NPr/V/J NSg/J NSg/V/J/P . V       . P    ISg/D$+ NSg/V+
-> hanging out         of its     mouth  , and its     great eyes   half       shut     .
-# NSg/V/J NSg/V/J/R/P P  ISg/D$+ NSg/V+ . V/C ISg/D$+ NSg/J NPl/V+ NSg/V/J/P+ NSg/V/J+ .
+> hanging out         of its     mouth  , and its     great eyes   half        shut     .
+# NSg/V/J NSg/V/J/R/P P  ISg/D$+ NSg/V+ . V/C ISg/D$+ NSg/J NPl/V+ N🅪Sg/V/J/P+ NSg/V/J+ .
 >
 #
 > This    seemed to Alice a   good    opportunity for making her     escape ; so        she  set     off       at
@@ -1584,8 +1584,8 @@
 # ISg+ V/J       ISg     NSg/V/J/P J/P NSg/V/J+ . V/C V/J    NSg/V/J/P D   NSg/V P  D   NᴹSg/V/J .
 > and her     eyes   immediately met those  of a   large blue     caterpillar , that          was sitting
 # V/C ISg/D$+ NPl/V+ R           V   I/Ddem P  D/P NSg/J NSg/V/J+ NSg/V       . NSg/I/C/Ddem+ V   NSg/V/J
-> on  the top      with its     arms   folded , quietly smoking a    long     hookah , and taking  not
-# J/P D+  NSg/V/J+ P    ISg/D$+ NPl/V+ V/J    . R       NSg/V/J D/P+ NPr/V/J+ NSg    . V/C NSg/V/J NSg/C
+> on  the top      with its     arms   folded , quietly smoking  a    long     hookah , and taking  not
+# J/P D+  NSg/V/J+ P    ISg/D$+ NPl/V+ V/J    . R       NᴹSg/V/J D/P+ NPr/V/J+ NSg    . V/C NSg/V/J NSg/C
 > the smallest notice of her    or    of anything else     .
 # D   JS       NSg/V  P  ISg/D$ NPr/C P  NSg/I/V+ NSg/J/C+ .
 >
@@ -1870,8 +1870,8 @@
 #
 > “ You’ll get   used to it       in      time      , ” said the Caterpillar ; and it       put   the hookah
 # . W?     NSg/V V/J  P  NPr/ISg+ NPr/J/P N🅪Sg/V/J+ . . V/J  D   NSg/V       . V/C NPr/ISg+ NSg/V D   NSg
-> into its     mouth  and began smoking  again .
-# P    ISg/D$+ NSg/V+ V/C V     NSg/V/J+ P+    .
+> into its     mouth  and began smoking   again .
+# P    ISg/D$+ NSg/V+ V/C V     NᴹSg/V/J+ P+    .
 >
 #
 > This    time     Alice waited patiently until it       chose to speak  again . In      a   minute  or
@@ -2096,8 +2096,8 @@
 # NPr/ISg+ V   NSg/I/J/C NPr/V/J C/P   ISg+ V   NSg/V NSg/I/V  NSg/V/J/P D+  NPr/V/J+ NSg/V+ . NSg/I/C/Ddem NPr/ISg+ NSg/V/J
 > quite strange at    first   ; but     she  got used to it       in      a   few       minutes , and began
 # NSg   NSg/V/J NSg/P NSg/V/J . NSg/C/P ISg+ V   V/J  P  NPr/ISg+ NPr/J/P D/P NSg/I/Dq+ NPl/V+  . V/C V
-> talking to herself , as     usual  . “ Come    , there’s half       my  plan   done    now       ! How   puzzling
-# V       P  ISg+    . NSg/R+ NSg/J+ . . NSg/V/P . W?      NSg/V/J/P+ D$+ NSg/V+ NSg/V/J NPr/V/J/C . NSg/C V
+> talking to herself , as     usual  . “ Come    , there’s half        my  plan   done    now       ! How   puzzling
+# V       P  ISg+    . NSg/R+ NSg/J+ . . NSg/V/P . W?      N🅪Sg/V/J/P+ D$+ NSg/V+ NSg/V/J NPr/V/J/C . NSg/C V
 > all          these   changes are ! I’m never sure what   I’m going   to be     , from one       minute   to
 # NSg/I/J/C/Dq I/Ddem+ NPl/V+  V   . W?  R     J    NSg/I+ W?  NSg/V/J P  NSg/VX . P    NSg/I/V/J NSg/V/J+ P
 > another ! However , I’ve got back    to my  right    size   : the next     thing  is , to get   into
@@ -2549,7 +2549,7 @@
 >
 #
 > “ — so        long    as    I    get   somewhere , ” Alice added as    an   explanation .
-# . . NSg/I/J/C NPr/V/J NSg/R ISg+ NSg/V NSg       . . NPr+  V/J   NSg/R D/P+ NSg+        .
+# . . NSg/I/J/C NPr/V/J NSg/R ISg+ NSg/V NSg       . . NPr+  V/J   NSg/R D/P+ N🅪Sg+       .
 >
 #
 > “ Oh    , you’re sure to do     that          , ” said the Cat      , “ if    you    only  walk  long     enough . ”
@@ -2652,8 +2652,8 @@
 # . ISg+ NSg/V   NPr/ISg+ VX    . . V/J  D+  NSg/V/J+ . V/C V/J+     P     .
 >
 #
-> Alice waited a   little     , half       expecting to see   it       again , but     it       did not   appear ,
-# NPr+  V/J    D/P NPr/I/J/Dq . NSg/V/J/P+ V         P  NSg/V NPr/ISg+ P     . NSg/C/P NPr/ISg+ V   NSg/C V      .
+> Alice waited a   little     , half        expecting to see   it       again , but     it       did not   appear ,
+# NPr+  V/J    D/P NPr/I/J/Dq . N🅪Sg/V/J/P+ V         P  NSg/V NPr/ISg+ P     . NSg/C/P NPr/ISg+ V   NSg/C V      .
 > and after a   minute  or    two  she  walked on  in      the direction in      which the March  Hare
 # V/C JC/P  D/P NSg/V/J NPr/C NSg+ ISg+ V/J    J/P NPr/J/P D+  NSg+      NPr/J/P I/C+  D+  NPr/V+ NSg/V/J+
 > was said to live . “ I’ve seen  hatters before , ” she  said to herself ; “ the March
@@ -2898,8 +2898,8 @@
 #
 > Alice felt    dreadfully puzzled , The Hatter’s remark seemed to have   no    sort  of
 # NPr+  NSg/V/J R          V/J     . D+  NSg$+    NSg/V+ V/J    P  NSg/VX NPr/P NSg/V P
-> meaning   in      it       , and yet     it       was certainly English  . “ I    don’t quite understand you    , ”
-# N🅪Sg/V/J+ NPr/J/P NPr/ISg+ . V/C NSg/V/C NPr/ISg+ V   R         NPr/V/J+ . . ISg+ V     NSg   V          ISgPl+ . .
+> meaning   in      it       , and yet     it       was certainly English   . “ I    don’t quite understand you    , ”
+# N🅪Sg/V/J+ NPr/J/P NPr/ISg+ . V/C NSg/V/C NPr/ISg+ V   R         NPr🅪/V/J+ . . ISg+ V     NSg   V          ISgPl+ . .
 > she  said , as    politely as    she  could   .
 # ISg+ V/J  . NSg/R R        NSg/R ISg+ NSg/VX+ .
 >
@@ -2968,8 +2968,8 @@
 # NSg/V+ . C/P NSg/V+   . V       NPr/ISg+ NSg/V NSg  W?      NPr/J/P D+  N🅪Sg/V+ . V/J  N🅪Sg/V/J+ P
 > begin lessons : you’d only  have   to whisper a   hint  to Time     , and round     goes  the
 # NSg/V NPl/V+  . W?    J/R/C NSg/VX P  NSg/V   D/P NSg/V P  N🅪Sg/V/J . V/C NSg/V/J/P NPl/V D+
-> clock  in      a   twinkling ! Half       - past      one       , time     for dinner ! ”
-# NSg/V+ NPr/J/P D/P NSg/V/J   . NSg/V/J/P+ . NSg/V/J/P NSg/I/V/J . N🅪Sg/V/J C/P NSg/V  . .
+> clock  in      a   twinkling ! Half        - past      one       , time     for dinner ! ”
+# NSg/V+ NPr/J/P D/P NSg/V/J   . N🅪Sg/V/J/P+ . NSg/V/J/P NSg/I/V/J . N🅪Sg/V/J C/P NSg/V  . .
 >
 #
 > ( “ I    only  wish  it       was , ” the March  Hare     said to itself in      a   whisper . )
@@ -2982,8 +2982,8 @@
 # NSg/VX J      C/P NPr/ISg+ . ISgPl+ NSg/V+ . .
 >
 #
-> “ Not   at    first   , perhaps , ” said the Hatter : “ but     you    could  keep  it       to half      - past
-# . NSg/C NSg/P NSg/V/J . NSg     . . V/J  D   NSg/V  . . NSg/C/P ISgPl+ NSg/VX NSg/V NPr/ISg+ P  NSg/V/J/P . NSg/V/J/P
+> “ Not   at    first   , perhaps , ” said the Hatter : “ but     you    could  keep  it       to half       - past
+# . NSg/C NSg/P NSg/V/J . NSg     . . V/J  D   NSg/V  . . NSg/C/P ISgPl+ NSg/VX NSg/V NPr/ISg+ P  N🅪Sg/V/J/P . NSg/V/J/P
 > one       as    long    as    you    liked . ”
 # NSg/I/V/J NSg/R NPr/V/J NSg/R ISgPl+ V/J+  . .
 >
@@ -3298,8 +3298,8 @@
 # NSg/V+  . V/C V/J    NSg/V/J/P . D   NSg      NSg/V/J J+     R         . V/C I/C     P  D+
 > others took the least notice of her     going   , though she  looked back    once  or    twice ,
 # NPl/V+ V    D   NSg/J NSg/V  P  ISg/D$+ NSg/V/J . V/C    ISg+ V/J    NSg/V/J NSg/C NPr/C W?    .
-> half       hoping that         they would call  after her     : the last     time      she  saw   them     , they
-# NSg/V/J/P+ V      NSg/I/C/Ddem IPl+ VX    NSg/V JC/P  ISg/D$+ . D+  NSg/V/J+ N🅪Sg/V/J+ ISg+ NSg/V NSg/IPl+ . IPl+
+> half        hoping that         they would call  after her     : the last     time      she  saw   them     , they
+# N🅪Sg/V/J/P+ V      NSg/I/C/Ddem IPl+ VX    NSg/V JC/P  ISg/D$+ . D+  NSg/V/J+ N🅪Sg/V/J+ ISg+ NSg/V NSg/IPl+ . IPl+
 > were  trying  to put   the Dormouse into the teapot .
 # NSg/V NSg/V/J P  NSg/V D   NSg      P    D   NSg+   .
 >
@@ -3497,7 +3497,7 @@
 >
 #
 > “ Nonsense ! ” said Alice , very loudly and decidedly , and the Queen    was silent .
-# . NSg/V/J  . . V/J  NPr+  . J/R  R      V/C R         . V/C D+  NPr/V/J+ V+  NSg/J  .
+# . NᴹSg/V/J . . V/J  NPr+  . J/R  R      V/C R         . V/C D+  NPr/V/J+ V+  NSg/J  .
 >
 #
 > The King    laid his     hand   upon her     arm      , and timidly said “ Consider , my  dear     : she  is
@@ -3862,8 +3862,8 @@
 #
 > The King’s argument was , that         anything that          had a    head     could  be     beheaded , and
 # D+  NSg$+  NSg/V    V   . NSg/I/C/Ddem NSg/I/V+ NSg/I/C/Ddem+ V   D/P+ NPr/V/J+ NSg/VX NSg/VX V/J      . V/C
-> that         you    weren’t to talk  nonsense .
-# NSg/I/C/Ddem ISgPl+ V       P  NSg/V NSg/V/J+ .
+> that         you    weren’t to talk  nonsense  .
+# NSg/I/C/Ddem ISgPl+ V       P  NSg/V NᴹSg/V/J+ .
 >
 #
 > The Queen’s argument was , that         if    something wasn’t done    about it       in      less    than no
@@ -4110,8 +4110,8 @@
 #
 > “ Now       , I    give  you    fair     warning , ” shouted the Queen    , stamping on  the ground   as    she
 # . NPr/V/J/C . ISg+ NSg/V ISgPl+ NSg/V/J+ NSg/V+  . . V/J     D+  NPr/V/J+ . NSg      J/P D+  NSg/V/J+ NSg/R ISg+
-> spoke ; “ either you   or    your head     must  be     off       , and that          in      about half       no     time      !
-# NSg/V . . I/C    ISgPl NPr/C D$+  NPr/V/J+ NSg/V NSg/VX NSg/V/J/P . V/C NSg/I/C/Ddem+ NPr/J/P J/P   NSg/V/J/P+ NPr/P+ N🅪Sg/V/J+ .
+> spoke ; “ either you   or    your head     must  be     off       , and that          in      about half        no     time      !
+# NSg/V . . I/C    ISgPl NPr/C D$+  NPr/V/J+ NSg/V NSg/VX NSg/V/J/P . V/C NSg/I/C/Ddem+ NPr/J/P J/P   N🅪Sg/V/J/P+ NPr/P+ N🅪Sg/V/J+ .
 > Take  your choice ! ”
 # NSg/V D$+  NSg/J+ . .
 >
@@ -4140,8 +4140,8 @@
 # NSg/V/J+ NPl+    . V/C V+       . NSg/V/J/P P    ISg/D$+ NPr/V/J+ . . NPr/C . NSg/V/J/P P    ISg/D$+ NPr/V/J+ . . I/Ddem+
 > whom she  sentenced were  taken into custody by      the soldiers , who   of course had to
 # I+   ISg+ V/J       NSg/V V/J   P    NᴹSg+   NSg/J/P D+  NPl/V+   . NPr/I P  NSg/V+ V   P
-> leave off       being   arches to do     this    , so        that         by      the end   of half       an  hour or    so
-# NSg/V NSg/V/J/P NSg/V/C NPl/V  P  NSg/VX I/Ddem+ . NSg/I/J/C NSg/I/C/Ddem NSg/J/P D   NSg/V P  NSg/V/J/P+ D/P NSg  NPr/C NSg/I/J/C
+> leave off       being   arches to do     this    , so        that         by      the end   of half        an  hour or    so
+# NSg/V NSg/V/J/P NSg/V/C NPl/V  P  NSg/VX I/Ddem+ . NSg/I/J/C NSg/I/C/Ddem NSg/J/P D   NSg/V P  N🅪Sg/V/J/P+ D/P NSg  NPr/C NSg/I/J/C
 > there were  no     arches left    , and all          the players , except the King     , the Queen    , and
 # +     NSg/V NPr/P+ NPl/V  NPr/V/J . V/C NSg/I/J/C/Dq D+  NPl+    . V/C/P  D+  NPr/V/J+ . D+  NPr/V/J+ . V/C
 > Alice , were  in      custody and under   sentence of execution .
@@ -4198,10 +4198,10 @@
 #
 > The Gryphon sat     up        and rubbed its     eyes   : then    it       watched the Queen    till      she  was
 # D   ?       NSg/V/J NSg/V/J/P V/C V/J    ISg/D$+ NPl/V+ . NSg/J/C NPr/ISg+ V/J     D+  NPr/V/J+ NSg/V/C/P ISg+ V
-> out         of sight  : then    it       chuckled . “ What   fun      ! ” said the Gryphon , half      to itself ,
-# NSg/V/J/R/P P  NSg/V+ . NSg/J/C NPr/ISg+ V/J+     . . NSg/I+ NᴹSg/V/J . . V/J  D   ?       . NSg/V/J/P P  ISg+   .
-> half      to Alice .
-# NSg/V/J/P P  NPr+  .
+> out         of sight  : then    it       chuckled . “ What   fun      ! ” said the Gryphon , half       to itself ,
+# NSg/V/J/R/P P  NSg/V+ . NSg/J/C NPr/ISg+ V/J+     . . NSg/I+ NᴹSg/V/J . . V/J  D   ?       . N🅪Sg/V/J/P P  ISg+   .
+> half       to Alice .
+# N🅪Sg/V/J/P P  NPr+  .
 >
 #
 > “ What   is the fun      ? ” said Alice .
@@ -4338,8 +4338,8 @@
 # . P    NPl+   . . V/J   D   NSg/V/J NSg/V+ D/P+ NPr/I/J/Dq+ R         .
 >
 #
-> “ Yes   , ” said Alice , “ we   learned French   and music     . ”
-# . NPl/V . . V/J  NPr+  . . IPl+ V/J     NPr/V/J+ V/C N🅪Sg/V/J+ . .
+> “ Yes   , ” said Alice , “ we   learned French    and music     . ”
+# . NPl/V . . V/J  NPr+  . . IPl+ V/J     NPr🅪/V/J+ V/C N🅪Sg/V/J+ . .
 >
 #
 > “ And washing ? ” said the Mock     Turtle .
@@ -4352,8 +4352,8 @@
 #
 > “ Ah      ! then    yours wasn’t a   really good    school , ” said the Mock    Turtle in      a   tone    of
 # . NSg/I/V . NSg/J/C I+    V      D/P R      NPr/V/J NSg/V  . . V/J  D   NSg/V/J NSg/V  NPr/J/P D/P NSg/I/V P
-> great  relief . “ Now       at    ours they had at    the end   of the bill   , ‘          French  , music     , and
-# NSg/J+ NSg/J+ . . NPr/V/J/C NSg/P I+   IPl+ V   NSg/P D   NSg/V P  D+  NPr/V+ . Unlintable NPr/V/J . N🅪Sg/V/J+ . V/C
+> great  relief . “ Now       at    ours they had at    the end   of the bill   , ‘          French   , music     , and
+# NSg/J+ NSg/J+ . . NPr/V/J/C NSg/P I+   IPl+ V   NSg/P D   NSg/V P  D+  NPr/V+ . Unlintable NPr🅪/V/J . N🅪Sg/V/J+ . V/C
 > washing — extra . ’ ”
 # NSg/V   . NSg/J . . .
 >
@@ -4377,7 +4377,7 @@
 > “ Reeling and Writhing , of course , to begin with , ” the Mock     Turtle replied ; “ and
 # . V       V/C V+       . P  NSg/V+ . P  NSg/V P    . . D+  NSg/V/J+ NSg/V+ V/J     . . V/C
 > then    the different branches of Arithmetic — Ambition , Distraction , Uglification ,
-# NSg/J/C D   NSg/J     NPl/V    P  NSg/J      . NSg/V+   . NSg/V+      . ?            .
+# NSg/J/C D   NSg/J     NPl/V    P  NᴹSg/J     . NSg/V+   . NSg/V+      . ?            .
 > and  Derision . ”
 # V/C+ N🅪Sg+    . .
 >
@@ -4870,8 +4870,8 @@
 #
 > “ Well    , I    never heard it       before , ” said the Mock     Turtle ; “ but     it       sounds uncommon
 # . NSg/V/J . ISg+ R     V/J   NPr/ISg+ C/P    . . V/J  D+  NSg/V/J+ NSg/V+ . . NSg/C/P NPr/ISg+ NPl/V  NSg/V/J+
-> nonsense . ”
-# NSg/V/J+ . .
+> nonsense  . ”
+# NᴹSg/V/J+ . .
 >
 #
 > Alice said nothing  ; she  had sat     down      with her     face   in      her     hands  , wondering if
@@ -4914,14 +4914,14 @@
 #
 > “ I    passed by      his     garden   , and marked , with one        eye    , How   the Owl   and the Panther
 # . ISg+ V/J    NSg/J/P ISg/D$+ NSg/V/J+ . V/C V/J    . P    NSg/I/V/J+ NSg/V+ . NSg/C D   NSg/V V/C D   NSg
-> were  sharing a    pie    — ”
-# NSg/V V       D/P+ NSg/V+ . .
+> were  sharing a    pie     — ”
+# NSg/V V       D/P+ N🅪Sg/V+ . .
 >
 #
-> ( later editions continued as    follows The Panther took pie   - crust  , and gravy   ,
-# . JC    NPl      V/J       NSg/R NPl/V   D   NSg     V    NSg/V . N🅪Sg/V . V/C N🅪Sg/V+ .
+> ( later editions continued as    follows The Panther took pie    - crust  , and gravy   ,
+# . JC    NPl      V/J       NSg/R NPl/V   D   NSg     V    N🅪Sg/V . N🅪Sg/V . V/C N🅪Sg/V+ .
 > and meat  , While     the Owl    had the dish   as    its     share of the treat  . When    the pie
-# V/C N🅪Sg+ . NSg/V/C/P D+  NSg/V+ V   D+  NSg/V+ NSg/R ISg/D$+ NSg/V P  D   NSg/V+ . NSg/I/C D+  NSg/V+
+# V/C N🅪Sg+ . NSg/V/C/P D+  NSg/V+ V   D+  NSg/V+ NSg/R ISg/D$+ NSg/V P  D   NSg/V+ . NSg/I/C D+  N🅪Sg/V+
 > was all          finished , the Owl    , as    a    boon   , Was kindly permitted to pocket  the
 # V   NSg/I/J/C/Dq V/J      . D+  NSg/V+ . NSg/R D/P+ NSg/J+ . V   J/R    V/J       P  NSg/V/J D+
 > spoon  : While     the Panther received knife and fork   with a   growl , And concluded
@@ -5197,7 +5197,7 @@
 >
 #
 > “ I    keep  them     to sell  , ” the Hatter added as    an   explanation ; “ I’ve none  of my  own      .
-# . ISg+ NSg/V NSg/IPl+ P  NSg/V . . D   NSg/V  V/J   NSg/R D/P+ NSg+        . . W?   NSg/I P  D$+ NSg/V/J+ .
+# . ISg+ NSg/V NSg/IPl+ P  NSg/V . . D   NSg/V  V/J   NSg/R D/P+ N🅪Sg+       . . W?   NSg/I P  D$+ NSg/V/J+ .
 > I’m a    hatter . ”
 # W?  D/P+ NSg/V+ . .
 >
@@ -5248,8 +5248,8 @@
 # . W?     NPr/P NPr/V/J+ P  V    NSg/J/R . . V/J  D   NSg+     .
 >
 #
-> “ Don’t talk  nonsense , ” said Alice more         boldly : “ you    know  you’re growing too . ”
-# . V     NSg/V NSg/V/J+ . . V/J  NPr+  NPr/I/V/J/Dq R      . . ISgPl+ NSg/V W?     NSg/V+  W?  . .
+> “ Don’t talk  nonsense  , ” said Alice more         boldly : “ you    know  you’re growing too . ”
+# . V     NSg/V NᴹSg/V/J+ . . V/J  NPr+  NPr/I/V/J/Dq R      . . ISgPl+ NSg/V W?     NSg/V+  W?  . .
 >
 #
 > “ Yes   , but     I    grow at    a    reasonable pace       , ” said the Dormouse : “ not   in      that
@@ -5860,8 +5860,8 @@
 # . NPr/P+ . NPr/P+ . . V/J  D+  NPr/V/J+ . . NSg/V+   NSg/V/J . NSg+    R/Comm+    . .
 >
 #
-> “ Stuff  and nonsense ! ” said Alice loudly . “ The idea of having the sentence
-# . NᴹSg/V V/C NSg/V/J+ . . V/J  NPr+  R+     . . D   NSg  P  V      D+  NSg/V+
+> “ Stuff  and nonsense  ! ” said Alice loudly . “ The idea of having the sentence
+# . NᴹSg/V V/C NᴹSg/V/J+ . . V/J  NPr+  R+     . . D   NSg  P  V      D+  NSg/V+
 > first    ! ”
 # NSg/V/J+ . .
 >
@@ -5886,8 +5886,8 @@
 #
 > At    this   the whole  pack   rose    up        into the air    , and came    flying  down      upon her     : she
 # NSg/P I/Ddem D+  NSg/J+ NSg/V+ NPr/V/J NSg/V/J/P P    D+  NSg/V+ . V/C NSg/V/P NSg/V/J NSg/V/J/P P    ISg/D$+ . ISg+
-> gave a    little      scream , half      of fright  and half      of anger  , and tried to beat    them
-# V    D/P+ NPr/I/J/Dq+ NSg/V+ . NSg/V/J/P P  NSg/V/J V/C NSg/V/J/P P  NSg/V+ . V/C V/J   P  NSg/V/J NSg/IPl+
+> gave a    little      scream , half       of fright  and half       of anger  , and tried to beat    them
+# V    D/P+ NPr/I/J/Dq+ NSg/V+ . N🅪Sg/V/J/P P  NSg/V/J V/C N🅪Sg/V/J/P P  NSg/V+ . V/C V/J   P  NSg/V/J NSg/IPl+
 > off       , and found herself lying   on  the bank   , with her     head     in      the lap     of her
 # NSg/V/J/P . V/C NSg/V ISg+    NSg/V/J J/P D+  NSg/V+ . P    ISg/D$+ NPr/V/J+ NPr/J/P D   NSg/V/J P  ISg/D$+
 > sister , who    was gently brushing away some      dead     leaves that          had fluttered down
@@ -5958,8 +5958,8 @@
 # NSg/V/J+ NSg/V  .
 >
 #
-> So        she  sat     on  , with closed eyes   , and half       believed herself in      Wonderland , though
-# NSg/I/J/C ISg+ NSg/V/J J/P . P    V/J    NPl/V+ . V/C NSg/V/J/P+ V/J      ISg+    NPr/J/P NSg+       . V/C
+> So        she  sat     on  , with closed eyes   , and half        believed herself in      Wonderland , though
+# NSg/I/J/C ISg+ NSg/V/J J/P . P    V/J    NPl/V+ . V/C N🅪Sg/V/J/P+ V/J      ISg+    NPr/J/P NSg+       . V/C
 > she  knew she  had but     to open    them     again , and all          would change to dull
 # ISg+ V    ISg+ V   NSg/C/P P  NSg/V/J NSg/IPl+ P     . V/C NSg/I/J/C/Dq VX    N🅪Sg/V P  V/J
 > reality — the grass  would be     only  rustling in      the wind   , and the pool   rippling to

--- a/harper-core/tests/text/tagged/Computer science.md
+++ b/harper-core/tests/text/tagged/Computer science.md
@@ -7,31 +7,31 @@
 >            -->
 # Unlintable Unlintable
 >            Computer science
-# Unlintable NSg/V+   NSg/V
+# Unlintable NSg/V+   N🅪Sg/V
 >
 #
 > Computer science is the study of computation , information , and  automation .
-# NSg/V+   NSg/V   VL D   NSg/V P  NSg         . NᴹSg+       . V/C+ NSg+       .
+# NSg/V+   N🅪Sg/V  VL D   NSg/V P  NSg         . NᴹSg+       . V/C+ NSg+       .
 > Computer science spans theoretical disciplines ( such  as    algorithms , theory of
-# NSg/V+   NSg/V+  NPl/V J           NPl/V       . NSg/I NSg/R NPl+       . NSg    P
+# NSg/V+   N🅪Sg/V+ NPl/V J           NPl/V       . NSg/I NSg/R NPl+       . NSg    P
 > computation , and information theory ) to applied disciplines ( including the
 # NSg         . V/C NᴹSg+       NSg+   . P  V/J     NPl/V+      . V         D+
 > design and implementation of hardware and software ) .
-# NSg/V  V/C NSg            P  NᴹSg     V/C NᴹSg+    . .
+# N🅪Sg/V V/C NSg            P  NᴹSg     V/C NᴹSg+    . .
 >
 #
 > Algorithms and data  structures are central to computer science . The theory of
-# NPl+       V/C N🅪Pl+ NPl/V+     V   NPr/J   P  NSg/V    NSg/V+  . D   NSg    P
+# NPl+       V/C N🅪Pl+ NPl/V+     V   NPr/J   P  NSg/V    N🅪Sg/V+ . D   NSg    P
 > computation concerns abstract models of computation and general classes of
 # NSg         NSg/V+   NSg/V/J  NPl/V  P  NSg         V/C NSg/V/J NPl/V   P
 > problems that          can    be     solved using them     . The fields  of cryptography and computer
 # NPl+     NSg/I/C/Ddem+ NPr/VX NSg/VX V/J    V     NSg/IPl+ . D   NPrPl/V P  NSg          V/C NSg/V+
 > security involve studying the means for secure communication and preventing
-# NSg+     V       V        D   NPl/V C/P V/J    NSg+          V/C V
+# NSg+     V       V        D   NPl/V C/P V/J    N🅪Sg+         V/C V
 > security vulnerabilities . Computer graphics and computational geometry address
 # NSg+     NSg+            . NSg/V+   NPl+     V/C J             N🅪Sg+    NSg/V+
 > the generation of images . Programming language theory considers different ways
-# D   NSg        P  NPl/V+ . NSg/V+      N🅪Sg/V+  NSg+   V         NSg/J     NPl
+# D   NSg        P  NPl/V+ . NᴹSg/V+     N🅪Sg/V+  NSg+   V         NSg/J     NPl
 > to describe computational processes , and database theory concerns the management
 # P  V        J+            NPl/V+    . V/C NSg/V+   NSg+   NSg/V+   D   NSg
 > of repositories of data  . Human   – computer interaction investigates the interfaces
@@ -39,9 +39,9 @@
 > through which humans and computers interact , and software engineering focuses on
 # NSg/J/P I/C+  NPl/V  V/C NPl/V+    NSg/V    . V/C NᴹSg+    NSg/V+      NPl/V   J/P
 > the design and principles behind  developing software . Areas such  as    operating
-# D   NSg/V  V/C NPl/V+     NSg/J/P V          NᴹSg+    . NPl+  NSg/I NSg/R V
+# D   N🅪Sg/V V/C NPl/V+     NSg/J/P V          NᴹSg+    . NPl+  NSg/I NSg/R V
 > systems , networks and embedded systems investigate the principles and design
-# NPl     . NPl/V+   V/C V/J      NPl+    V           D   NPl/V      V/C NSg/V+
+# NPl     . NPl/V+   V/C V/J      NPl+    V           D   NPl/V      V/C N🅪Sg/V+
 > behind  complex  systems . Computer architecture describes the construction of
 # NSg/J/P NSg/V/J+ NPl+    . NSg/V+   NSg+         V         D   NSg          P
 > computer components and computer - operated equipment . Artificial intelligence and
@@ -59,11 +59,11 @@
 >
 #
 > The fundamental concern of computer science is determining what  can    and cannot
-# D   NSg/J       NSg/V   P  NSg/V+   NSg/V+  VL V           NSg/I NPr/VX V/C NSg/V+
+# D   NSg/J       NSg/V   P  NSg/V+   N🅪Sg/V+ VL V           NSg/I NPr/VX V/C NSg/V+
 > be      automated . The Turing Award  is generally recognized as    the highest
 # NSg/VX+ V/J+      . D+  NPr+   NSg/V+ VL R         V/J        NSg/R D   JS
 > distinction in      computer science .
-# NSg         NPr/J/P NSg/V+   NSg/V+  .
+# NSg         NPr/J/P NSg/V+   N🅪Sg/V+ .
 >
 #
 > History
@@ -71,7 +71,7 @@
 >
 #
 > The earliest foundations of what   would become computer science predate the
-# D   JS       NPl         P  NSg/I+ VX    V      NSg/V+   NSg/V+  NSg/V   D
+# D   JS       NPl         P  NSg/I+ VX    V      NSg/V+   N🅪Sg/V+ NSg/V   D
 > invention of the modern digital computer . Machines for calculating fixed
 # NSg       P  D+  NSg/J+ NSg/J+  NSg/V+   . NPl/V    C/P V/J         V/J
 > numerical tasks  such  as    the abacus have   existed since antiquity , aiding in
@@ -81,7 +81,7 @@
 > computations have   existed since antiquity , even    before the development of
 # NPl          NSg/VX V/J     C/P   NSg+      . NSg/V/J C/P    D   N🅪Sg        P
 > sophisticated computing equipment .
-# V/J+          NSg/V+    NᴹSg+     .
+# V/J+          NᴹSg/V+   NᴹSg+     .
 >
 #
 > Wilhelm Schickard designed and constructed the first   working mechanical
@@ -101,7 +101,7 @@
 > reliable enough to be     used daily   in      an   office environment . Charles Babbage
 # NSg/J    NSg/I  P  NSg/VX V/J  NSg/V/J NPr/J/P D/P+ NSg/V+ NSg+        . NPr+    NPr
 > started the design of the first   automatic mechanical calculator , his     Difference
-# V/J     D   NSg/V  P  D   NSg/V/J NSg/J     NSg/J+     NSg+       . ISg/D$+ N🅪Sg/V+
+# V/J     D   N🅪Sg/V P  D   NSg/V/J NSg/J     NSg/J+     NSg+       . ISg/D$+ N🅪Sg/V+
 > Engine , in      1822 , which eventually gave him  the idea of the first   programmable
 # NSg/V+ . NPr/J/P #    . I/C+  R          V    ISg+ D   NSg  P  D   NSg/V/J NSg/J
 > mechanical calculator , his     Analytical Engine . He       started developing this    machine
@@ -112,8 +112,8 @@
 # NPl/V    P  D+  NSg/J+ NSg/V+   . . . D/P+ J+      NSg/V+ V   D   NSg      P  D/P V/J
 > card    system derived from the Jacquard loom  " making it       infinitely
 # N🅪Sg/V+ NSg+   V/J     P    D   NPr      NSg/V . NSg/V  NPr/ISg+ R+
-> programmable . [ note  2 ] In      1843 , during the translation of a   French  article on  the
-# NSg/J        . . NSg/V # . NPr/J/P #    . V/P    D   NSg         P  D/P NPr/V/J NSg/V   J/P D+
+> programmable . [ note  2 ] In      1843 , during the translation of a   French   article on  the
+# NSg/J        . . NSg/V # . NPr/J/P #    . V/P    D   NSg         P  D/P NPr🅪/V/J NSg/V   J/P D+
 > Analytical Engine , Ada  Lovelace wrote , in      one       of the many        notes  she  included , an
 # J+         NSg/V+ . NPr+ NPr      V     . NPr/J/P NSg/I/V/J P  D+  NSg/I/J/Dq+ NPl/V+ ISg+ V/J      . D/P
 > algorithm to compute the Bernoulli numbers  , which is considered to be     the first
@@ -129,13 +129,13 @@
 > published the 2nd of the only  two designs for mechanical analytical engines in
 # V/J       D   #   P  D   J/R/C NSg NPl/V   C/P NSg/J      J          NPl/V   NPr/J/P
 > history . In      1914 , the Spanish engineer Leonardo Torres Quevedo published his
-# N🅪Sg+   . NPr/J/P #    . D+  NPr/J+  NSg/V+   NPr+     NPr    ?       V/J       ISg/D$+
+# N🅪Sg+   . NPr/J/P #    . D+  NPrᴹ/J+ NSg/V+   NPr+     NPr    ?       V/J       ISg/D$+
 > Essays on  Automatics , and designed , inspired by      Babbage , a   theoretical
 # NPl/V+ J/P NPl        . V/C V/J      . V/J      NSg/J/P NPr     . D/P J
 > electromechanical calculating machine which was to be     controlled by      a   read   - only
 # ?                 V/J         NSg/V+  I/C+  V   P  NSg/VX V/J        NSg/J/P D/P NSg/V+ . J/R/C
 > program . The paper     also introduced the idea of floating - point  arithmetic . In
-# NPr/V   . D+  N🅪Sg/V/J+ W?   V/J        D   NSg  P  V+       . NSg/V+ NSg/J+     . NPr/J/P
+# NPr/V   . D+  N🅪Sg/V/J+ W?   V/J        D   NSg  P  V+       . NSg/V+ NᴹSg/J+    . NPr/J/P
 > 1920 , to celebrate the 100th anniversary of the invention of the arithmometer ,
 # #    . P  V         D   #     NSg         P  D   NSg       P  D   ?            .
 > Torres presented in      Paris the Electromechanical Arithmometer , a    prototype that
@@ -153,13 +153,13 @@
 > ASCC / Harvard Mark   I    , based on  Babbage's Analytical Engine , which itself used
 # ?    . NPr+    NPr/V+ ISg+ . V/J   J/P NSg$      J+         NSg/V+ . I/C+  ISg+   V/J
 > cards and a   central computing unit . When    the machine was finished , some     hailed
-# NPl/V V/C D/P NPr/J+  NSg/V     NSg+ . NSg/I/C D+  NSg/V+  V   V/J      . I/J/R/Dq V/J
+# NPl/V V/C D/P NPr/J+  NᴹSg/V    NSg+ . NSg/I/C D+  NSg/V+  V   V/J      . I/J/R/Dq V/J
 > it       as    " Babbage's dream    come    true    " .
 # NPr/ISg+ NSg/R . NSg$      NSg/V/J+ NSg/V/P NSg/V/J . .
 >
 #
 > During the 1940s , with the development of new     and more         powerful computing
-# V/P    D+  #d    . P    D   N🅪Sg        P  NSg/V/J V/C NPr/I/V/J/Dq J        NSg/V+
+# V/P    D+  #d    . P    D   N🅪Sg        P  NSg/V/J V/C NPr/I/V/J/Dq J        NᴹSg/V+
 > machines such  as    the Atanasoff – Berry   computer and ENIAC , the term     computer came
 # NPl/V+   NSg/I NSg/R D   ?         . NPr🅪/V+ NSg/V+   V/C ?     . D+  NSg/V/J+ NSg/V+   NSg/V/P
 > to refer to the machines rather  than their human    predecessors . As    it       became
@@ -167,15 +167,15 @@
 > clear   that         computers could  be     used for more         than just mathematical calculations ,
 # NSg/V/J NSg/I/C/Ddem NPl/V+    NSg/VX NSg/VX V/J  C/P NPr/I/V/J/Dq C/P  V/J  J+           +            .
 > the field of computer science broadened to study computation in      general  . In
-# D   NSg/V P  NSg/V+   NSg/V+  V/J       P  NSg/V NSg         NPr/J/P NSg/V/J+ . NPr/J/P
+# D   NSg/V P  NSg/V+   N🅪Sg/V+ V/J       P  NSg/V NSg         NPr/J/P NSg/V/J+ . NPr/J/P
 > 1945 , IBM  founded the Watson Scientific Computing Laboratory at    Columbia
-# #    . NPr+ V/J     D+  NPr+   J          NSg/V+    NSg+       NSg/P NPr+
+# #    . NPr+ V/J     D+  NPr+   J          NᴹSg/V+   NSg+       NSg/P NPr+
 > University in      New      York City . The renovated fraternity house on  Manhattan's West
 # NSg+       NPr/J/P NSg/V/J+ NPr+ NSg+ . D+  V/J+      NSg+       NPr/V J/P NSg$        NPr/V/J+
 > Side     was IBM's first   laboratory devoted to pure     science . The lab  is the
-# NSg/V/J+ V   NSg$  NSg/V/J NSg        V/J     P  NSg/V/J+ NSg/V+  . D+  NPr+ VL D
+# NSg/V/J+ V   NSg$  NSg/V/J NSg        V/J     P  NSg/V/J+ N🅪Sg/V+ . D+  NPr+ VL D
 > forerunner of IBM's Research Division , which today  operates research facilities
-# NSg        P  NSg$+ NSg/V+   NSg+     . I/C+  NSg/J+ V        NSg/V+   NPl
+# NSg        P  NSg$+ NᴹSg/V+  NSg+     . I/C+  NSg/J+ V        NᴹSg/V+  NPl
 > around the world  . Ultimately , the close   relationship between IBM and Columbia
 # J/P    D   NSg/V+ . R          . D   NSg/V/J NSg          NSg/P   NPr V/C NPr+
 > University was instrumental in      the emergence of a   new      scientific discipline ,
@@ -183,17 +183,17 @@
 > with Columbia offering one       of the first   academic - credit courses in      computer
 # P    NPr      N🅪Sg/V   NSg/I/V/J P  D   NSg/V/J NSg/J    . NSg/V  NPl/V   NPr/J/P NSg/V+
 > science in      1946 . Computer science began to be     established as    a   distinct academic
-# NSg/V   NPr/J/P #    . NSg/V+   NSg/V+  V     P  NSg/VX V/J         NSg/R D/P V/J      NSg/J
+# N🅪Sg/V  NPr/J/P #    . NSg/V+   N🅪Sg/V+ V     P  NSg/VX V/J         NSg/R D/P V/J      NSg/J
 > discipline in      the 1950s and early    1960s . The world's first   computer science
-# NSg/V      NPr/J/P D   #d    V/C NSg/J/R+ #d    . D   NSg$    NSg/V/J NSg/V+   NSg/V+
+# NSg/V      NPr/J/P D   #d    V/C NSg/J/R+ #d    . D   NSg$    NSg/V/J NSg/V+   N🅪Sg/V+
 > degree program , the Cambridge Diploma in      Computer Science , began at    the
-# NSg+   NPr/V+  . D+  NPr+      NSg     NPr/J/P NSg/V+   NSg/V+  . V     NSg/P D
+# NSg+   NPr/V+  . D+  NPr+      NSg     NPr/J/P NSg/V+   N🅪Sg/V+ . V     NSg/P D
 > University of Cambridge Computer Laboratory in      1953 . The first    computer science
-# NSg        P  NPr+      NSg/V+   NSg+       NPr/J/P #    . D+  NSg/V/J+ NSg/V+   NSg/V+
+# NSg        P  NPr+      NSg/V+   NSg+       NPr/J/P #    . D+  NSg/V/J+ NSg/V+   N🅪Sg/V+
 > department in      the United States   was formed at    Purdue University in      1962 . Since
 # NSg        NPr/J/P D+  V/J+   NPrPl/V+ V   V/J    NSg/P NPr    NSg+       NPr/J/P #    . C/P
 > practical computers became available , many       applications of computing have   become
-# NSg/J     NPl/V+    V      J         . NSg/I/J/Dq W?           P  NSg/V+    NSg/VX V
+# NSg/J     NPl/V+    V      J         . NSg/I/J/Dq W?           P  NᴹSg/V+   NSg/VX V
 > distinct areas of study in      their own      rights .
 # V/J      NPl   P  NSg/V NPr/J/P D$+   NSg/V/J+ NPl/V+ .
 >
@@ -203,15 +203,15 @@
 >
 #
 > Although first   proposed in      1956 , the term     " computer science " appears in      a   1959
-# C        NSg/V/J V/J      NPr/J/P #    . D   NSg/V/J+ . NSg/V+   NSg/V+  . V       NPr/J/P D/P #
+# C        NSg/V/J V/J      NPr/J/P #    . D   NSg/V/J+ . NSg/V+   N🅪Sg/V+ . V       NPr/J/P D/P #
 > article in      Communications of the ACM , in      which Louis Fein argues for the
-# NSg/V   NPr/J/P W?             P  D   NSg . NPr/J/P I/C+  NPr+  ?    V      C/P D
+# NSg/V   NPr/J/P NPl            P  D   NSg . NPr/J/P I/C+  NPr+  ?    V      C/P D
 > creation of a   Graduate School in      Computer Sciences analogous to the creation of
 # NSg      P  D/P NSg/V/J+ NSg/V  NPr/J/P NSg/V+   NPl/V+   J         P  D   NSg      P
 > Harvard Business School in      1921 . Louis justifies the name   by      arguing that          , like
 # NPr+    N🅪Sg/J+  NSg/V  NPr/J/P #    . NPr+  V         D+  NSg/V+ NSg/J/P V       NSg/I/C/Ddem+ . NSg/V/J/C/P
 > management science , the subject  is applied and interdisciplinary in      nature ,
-# NSg+       NSg/V+  . D+  NSg/V/J+ VL V/J     V/C J                 NPr/J/P NSg/V+ .
+# NSg+       N🅪Sg/V+ . D+  NSg/V/J+ VL V/J     V/C J                 NPr/J/P NSg/V+ .
 > while     having the characteristics typical of an   academic discipline . His     efforts ,
 # NSg/V/C/P V      D   NPl+            NSg/J   P  D/P+ NSg/J+   NSg/V+     . ISg/D$+ NPl/V+  .
 > and those  of others such  as    numerical analyst George Forsythe , were  rewarded :
@@ -219,13 +219,13 @@
 > universities went  on  to create such   departments , starting with Purdue in      1962 .
 # NPl+         NSg/V J/P P  V/J    NSg/I+ NPl+        . V        P    NPr    NPr/J/P #    .
 > Despite its     name   , a   significant amount of computer science does  not   involve the
-# NSg/V/P ISg/D$+ NSg/V+ . D/P NSg/J       NSg/V  P  NSg/V+   NSg/V+  NPl/V NSg/C V       D
+# NSg/V/P ISg/D$+ NSg/V+ . D/P NSg/J       NSg/V  P  NSg/V+   N🅪Sg/V+ NPl/V NSg/C V       D
 > study of computers themselves . Because of this    , several alternative names  have
 # NSg/V P  NPl/V+    IPl+       . C/P     P  I/Ddem+ . J/Dq    NSg/J       NPl/V+ NSg/VX+
 > been   proposed . Certain departments of major   universities prefer the term
 # NSg/V+ V/J      . I/J     NPl         P  NPr/V/J NPl+         V      D+  NSg/V/J+
 > computing science , to emphasize precisely that          difference . Danish scientist
-# NSg/V+    NSg/V+  . P  V         R         NSg/I/C/Ddem+ N🅪Sg/V+    . NPr/J  NSg+
+# NᴹSg/V+   N🅪Sg/V+ . P  V         R         NSg/I/C/Ddem+ N🅪Sg/V+    . NPrᴹ/J NSg+
 > Peter     Naur suggested the term     datalogy , to reflect the fact that         the scientific
 # NPr/V/JC+ ?    V/J       D+  NSg/V/J+ ?        . P  V       D+  NSg  NSg/I/C/Ddem D+  J+
 > discipline revolves around data and data  treatment , while     not   necessarily
@@ -239,15 +239,15 @@
 > Scandinavian countries . An   alternative term     , also proposed by      Naur , is data
 # NSg/J+       NPl+      . D/P+ NSg/J+      NSg/V/J+ . W?   V/J      NSg/J/P ?    . VL N🅪Pl+
 > science ; this    is now       used for a   multi - disciplinary field of data  analysis ,
-# NSg/V+  . I/Ddem+ VL NPr/V/J/C V/J  C/P D/P NSg   . NSg/J        NSg/V P  N🅪Pl+ N🅪Sg+    .
+# N🅪Sg/V+ . I/Ddem+ VL NPr/V/J/C V/J  C/P D/P NSg   . NSg/J        NSg/V P  N🅪Pl+ N🅪Sg+    .
 > including statistics and databases .
 # V         NPl/V      V/C NPl/V+    .
 >
 #
 > In      the early   days of computing , a   number   of terms for the practitioners of the
-# NPr/J/P D   NSg/J/R NPl  P  NSg/V+    . D/P NSg/V/JC P  NPl/V C/P D   NPl           P  D
+# NPr/J/P D   NSg/J/R NPl  P  NᴹSg/V+   . D/P NSg/V/JC P  NPl/V C/P D   NPl           P  D
 > field of computing were  suggested ( albeit facetiously ) in      the Communications of
-# NSg/V P  NSg/V+    NSg/V V/J       . C      R           . NPr/J/P D   W?             P
+# NSg/V P  NᴹSg/V+   NSg/V V/J       . C      R           . NPr/J/P D   NPl            P
 > the ACM — turingineer , turologist , flow   - charts - man     , applied meta  - mathematician ,
 # D   NSg . ?           . ?          . NSg/V+ . NPl/V  . NPr/V/J . V/J     NSg/J . NSg           .
 > and applied epistemologist . Three months later in      the same journal  , comptologist
@@ -257,11 +257,11 @@
 > been   suggested . In      Europe , terms  derived from contracted translations of the
 # NSg/V+ V/J       . NPr/J/P NPr+   . NPl/V+ V/J     P    V/J        W?           P  D
 > expression " automatic information " ( e.g. " informazione automatica " in      Italian )
-# NSg+       . NSg/J     NᴹSg+       . . NSg  . ?            ?          . NPr/J/P NSg/J   .
-> or    " information and mathematics " are often used , e.g. informatique ( French   ) ,
-# NPr/C . NᴹSg        V/C NᴹSg+       . V   R     V/J  . NSg  ?            . NPr/V/J+ . .
-> Informatik ( German ) , informatica ( Italian , Dutch   ) , informática ( Spanish ,
-# ?          . NPr/J+ . . ?           . NSg/J   . NPr/V/J . . ?           . NPr/J   .
+# NSg+       . NSg/J     NᴹSg+       . . NSg  . ?            ?          . NPr/J/P N🅪Sg/J  .
+> or    " information and mathematics " are often used , e.g. informatique ( French    ) ,
+# NPr/C . NᴹSg        V/C NᴹSg+       . V   R     V/J  . NSg  ?            . NPr🅪/V/J+ . .
+> Informatik ( German  ) , informatica ( Italian , Dutch    ) , informática ( Spanish ,
+# ?          . NPr🅪/J+ . . ?           . N🅪Sg/J  . NPrᴹ/V/J . . ?           . NPrᴹ/J  .
 > Portuguese ) , informatika ( Slavic languages and Hungarian ) or    pliroforiki
 # NPr/J      . . ?           . NSg/J  NPl/V+    V/C NSg/J     . NPr/C ?
 > ( π          λ          η          ρ          ο          φ          ο          ρ          ι          κ          ή          , which means informatics ) in      Greek    . Similar words  have   also been
@@ -269,21 +269,21 @@
 > adopted in      the UK   ( as    in      the School of Informatics , University of Edinburgh ) .
 # V/J     NPr/J/P D+  NPr+ . NSg/R NPr/J/P D   NSg/V  P  NᴹSg        . NSg        P  NPr+      . .
 > " In      the U.S. , however , informatics is linked with applied computing , or
-# . NPr/J/P D+  ?    . C       . NᴹSg        VL V/J    P    V/J     NSg/V+    . NPr/C
+# . NPr/J/P D+  ?    . C       . NᴹSg        VL V/J    P    V/J     NᴹSg/V+   . NPr/C
 > computing in      the context of another domain . "
-# NSg/V+    NPr/J/P D   N🅪Sg/V  P  I/D+    NSg+   . .
+# NᴹSg/V+   NPr/J/P D   N🅪Sg/V  P  I/D+    NSg+   . .
 >
 #
 > A   folkloric quotation , often attributed to — but     almost certainly not   first
 # D/P J         NSg       . R     V/J        P  . NSg/C/P NSg    R         NSg/C NSg/V/J
 > formulated by      — Edsger Dijkstra , states   that          " computer science is no    more         about
-# V/J        NSg/J/P . ?      NSg      . NPrPl/V+ NSg/I/C/Ddem+ . NSg/V+   NSg/V+  VL NPr/P NPr/I/V/J/Dq J/P
+# V/J        NSg/J/P . ?      NSg      . NPrPl/V+ NSg/I/C/Ddem+ . NSg/V+   N🅪Sg/V+ VL NPr/P NPr/I/V/J/Dq J/P
 > computers than astronomy is about telescopes . " [ note   3 ] The design and deployment
-# NPl/V+    C/P  NSg+      VL J/P+  NPl/V      . . . NSg/V+ # . D+  NSg/V  V/C NSg
+# NPl/V+    C/P  NSg+      VL J/P+  NPl/V      . . . NSg/V+ # . D+  N🅪Sg/V V/C NSg
 > of computers and computer systems is generally considered the province of
 # P  NPl/V     V/C NSg/V+   NPl+    VL R         V/J        D   NSg      P
 > disciplines other   than computer science . For example , the study of computer
-# NPl/V       NSg/V/J C/P  NSg/V+   NSg/V+  . C/P NSg/V+  . D   NSg/V P  NSg/V+
+# NPl/V       NSg/V/J C/P  NSg/V+   N🅪Sg/V+ . C/P NSg/V+  . D   NSg/V P  NSg/V+
 > hardware is usually considered part    of computer engineering , while     the study of
 # NᴹSg+    VL R       V/J        NSg/V/J P  NSg/V+   NSg/V+      . NSg/V/C/P D   NSg/V P
 > commercial computer systems and their deployment is often called information
@@ -291,19 +291,19 @@
 > technology or    information systems . However , there has been  exchange of ideas
 # N🅪Sg       NPr/C NᴹSg        NPl+    . C       . +     V   NSg/V NSg/V    P  NPl+
 > between the various computer - related disciplines . Computer science research also
-# NSg/P   D   J+      NSg/V+   . J       NPl/V       . NSg/V+   NSg/V+  NSg/V+   W?
+# NSg/P   D   J+      NSg/V+   . J       NPl/V       . NSg/V+   N🅪Sg/V+ NᴹSg/V+  W?
 > often intersects other    disciplines , such  as    cognitive science , linguistics ,
-# R     V+         NSg/V/J+ NPl/V+      . NSg/I NSg/R NSg/J+    NSg/V+  . NSg+        .
+# R     V+         NSg/V/J+ NPl/V+      . NSg/I NSg/R NSg/J+    N🅪Sg/V+ . NᴹSg+       .
 > mathematics , physics , biology , Earth  science , statistics , philosophy , and logic    .
-# NᴹSg+       . NPl/V+  . NSg+    . NPr/V+ NSg/V+  . NPl/V+     . NSg/V+     . V/C NSg/V/J+ .
+# NᴹSg+       . NPl/V+  . NSg+    . NPr/V+ N🅪Sg/V+ . NPl/V+     . NSg/V+     . V/C NSg/V/J+ .
 >
 #
 > Computer science is considered by      some      to have   a   much       closer relationship with
-# NSg/V+   NSg/V   VL V/J        NSg/J/P I/J/R/Dq+ P  NSg/VX D/P NSg/I/J/Dq NSg/JC NSg          P
+# NSg/V+   N🅪Sg/V  VL V/J        NSg/J/P I/J/R/Dq+ P  NSg/VX D/P NSg/I/J/Dq NSg/JC NSg          P
 > mathematics than many        scientific disciplines , with some      observers saying that
 # NᴹSg+       C/P  NSg/I/J/Dq+ J+         NPl/V+      . P    I/J/R/Dq+ NPl+      NSg/V  NSg/I/C/Ddem
 > computing is a   mathematical science . Early   computer science was strongly
-# NSg/V+    VL D/P J+           NSg/V+  . NSg/J/R NSg/V+   NSg/V+  V   R
+# NᴹSg/V+   VL D/P J+           N🅪Sg/V+ . NSg/J/R NSg/V+   N🅪Sg/V+ V   R
 > influenced by      the work  of mathematicians such  as    Kurt Gödel , Alan Turing , John
 # V/J        NSg/J/P D   NSg/V P  NPl+           NSg/I NSg/R NPr  NPr   . NPr+ NPr    . NPr+
 > von Neumann , Rózsa Péter and Alonzo Church and there continues to be     a   useful
@@ -315,35 +315,35 @@
 >
 #
 > The relationship between computer science and software engineering is a
-# D+  NSg          NSg/P   NSg/V+   NSg/V   V/C NᴹSg+    NSg/V+      VL D/P
+# D+  NSg          NSg/P   NSg/V+   N🅪Sg/V  V/C NᴹSg+    NSg/V+      VL D/P
 > contentious issue  , which is further muddied by      disputes over      what   the term
 # J           NSg/V+ . I/C+  VL V/J     V/J     NSg/J/P NPl/V+   NSg/V/J/P NSg/I+ D   NSg/V/J+
 > " software engineering " means , and how   computer science is  defined . David Parnas ,
-# . NᴹSg+    NSg/V+      . NPl/V . V/C NSg/C NSg/V+   NSg/V+  VL+ V/J     . NPr+  ?      .
+# . NᴹSg+    NSg/V+      . NPl/V . V/C NSg/C NSg/V+   N🅪Sg/V+ VL+ V/J     . NPr+  ?      .
 > taking  a   cue   from the relationship between other   engineering and science
-# NSg/V/J D/P NSg/V P    D+  NSg+         NSg/P   NSg/V/J NSg/V       V/C NSg/V+
+# NSg/V/J D/P NSg/V P    D+  NSg+         NSg/P   NSg/V/J NSg/V       V/C N🅪Sg/V+
 > disciplines , has claimed that         the principal focus of computer science is
-# NPl/V+      . V   V/J     NSg/I/C/Ddem D   NSg/J     NSg/V P  NSg/V+   NSg/V+  VL
+# NPl/V+      . V   V/J     NSg/I/C/Ddem D   NSg/J     NSg/V P  NSg/V+   N🅪Sg/V+ VL
 > studying the properties of computation in      general , while     the principal focus of
 # V        D   NPl/V      P  NSg         NPr/J/P NSg/V/J . NSg/V/C/P D   NSg/J     NSg/V P
 > software engineering is the design of specific computations to achieve practical
-# NᴹSg+    NSg/V+      VL D   NSg/V  P  NSg/J    NPl          P  V       NSg/J+
+# NᴹSg+    NSg/V+      VL D   N🅪Sg/V P  NSg/J    NPl          P  V       NSg/J+
 > goals  , making the two separate but     complementary disciplines .
 # NPl/V+ . NSg/V  D   NSg NSg/V/J  NSg/C/P NSg/J+        NPl/V+      .
 >
 #
 > The academic , political , and funding aspects of computer science tend to depend
-# D   NSg/J    . NSg/J     . V/C NSg/V+  NPl/V   P  NSg/V+   NSg/V+  V    P  NSg/V
+# D   NSg/J    . NSg/J     . V/C NSg/V+  NPl/V   P  NSg/V+   N🅪Sg/V+ V    P  NSg/V
 > on  whether a    department is formed with a   mathematical emphasis or    with an
 # J/P I/C     D/P+ NSg+       VL V/J    P    D/P J            NSg      NPr/C P    D/P+
 > engineering emphasis . Computer science departments with a   mathematics emphasis
-# NSg/V+      NSg+     . NSg/V+   NSg/V+  NPl         P    D/P NᴹSg+       NSg
+# NSg/V+      NSg+     . NSg/V+   N🅪Sg/V+ NPl         P    D/P NᴹSg+       NSg
 > and with a   numerical orientation consider alignment with computational science .
-# V/C P    D/P J         N🅪Sg+       V        NSg+      P    J+            NSg/V+  .
+# V/C P    D/P J         N🅪Sg+       V        N🅪Sg+     P    J+            N🅪Sg/V+ .
 > Both   types of departments tend to make  efforts to bridge the field  educationally
 # I/C/Dq NPl/V P  NPl+        V    P  NSg/V NPl/V+  P  NSg/V  D+  NSg/V+ R
 > if    not   across all           research .
-# NSg/C NSg/C NSg/P  NSg/I/J/C/Dq+ NSg/V+   .
+# NSg/C NSg/C NSg/P  NSg/I/J/C/Dq+ NᴹSg/V+  .
 >
 #
 > Philosophy
@@ -351,21 +351,21 @@
 >
 #
 > Epistemology of computer science
-# NSg          P  NSg/V+   NSg/V
+# NSg          P  NSg/V+   N🅪Sg/V
 >
 #
 > Despite the word   science in      its     name   , there is debate over      whether or    not
-# NSg/V/P D+  NSg/V+ NSg/V   NPr/J/P ISg/D$+ NSg/V+ . +     VL NSg/V+ NSg/V/J/P I/C     NPr/C NSg/C
+# NSg/V/P D+  NSg/V+ N🅪Sg/V  NPr/J/P ISg/D$+ NSg/V+ . +     VL NSg/V+ NSg/V/J/P I/C     NPr/C NSg/C
 > computer science is a   discipline of science , mathematics , or    engineering . Allen
-# NSg/V    NSg/V+  VL D/P NSg/V      P  NSg/V   . NᴹSg+       . NPr/C NSg/V+      . NPr+
+# NSg/V    N🅪Sg/V+ VL D/P NSg/V      P  N🅪Sg/V  . NᴹSg+       . NPr/C NSg/V+      . NPr+
 > Newell and Herbert A. Simon argued in      1975 ,
 # ?      V/C NPr+    ?  NPr+  V/J    NPr/J/P #    .
 >
 #
 > Computer science is an  empirical discipline . We   would have   called it       an
-# NSg/V+   NSg/V   VL D/P NSg/J+    NSg/V+     . IPl+ VX    NSg/VX V/J    NPr/ISg+ D/P+
+# NSg/V+   N🅪Sg/V  VL D/P NSg/J+    NSg/V+     . IPl+ VX    NSg/VX V/J    NPr/ISg+ D/P+
 > experimental science , but     like        astronomy , economics , and geology , some     of its
-# NSg/J+       NSg/V+  . NSg/C/P NSg/V/J/C/P NSg       . NSg+      . V/C NSg     . I/J/R/Dq P  ISg/D$+
+# NSg/J+       N🅪Sg/V+ . NSg/C/P NSg/V/J/C/P NSg       . NSg+      . V/C NSg     . I/J/R/Dq P  ISg/D$+
 > unique forms of observation and experience do     not   fit     a   narrow  stereotype of
 # NSg/J  NPl/V P  NSg         V/C NSg/V+     NSg/VX NSg/C NSg/V/J D/P NSg/V/J NSg/V      P
 > the experimental method . Nonetheless , they are experiments . Each new      machine
@@ -379,15 +379,15 @@
 >
 #
 > It       has since been  argued that         computer science can    be     classified as    an  empirical
-# NPr/ISg+ V   C/P   NSg/V V/J    NSg/I/C/Ddem NSg/V+   NSg/V+  NPr/VX NSg/VX NSg/V/J    NSg/R D/P NSg/J
+# NPr/ISg+ V   C/P   NSg/V V/J    NSg/I/C/Ddem NSg/V+   N🅪Sg/V+ NPr/VX NSg/VX NSg/V/J    NSg/R D/P NSg/J
 > science since it       makes use   of empirical testing to evaluate the correctness of
-# NSg/V+  C/P   NPr/ISg+ NPl/V NSg/V P  NSg/J     V       P  V        D   NSg         P
+# N🅪Sg/V+ C/P   NPr/ISg+ NPl/V NSg/V P  NSg/J     V       P  V        D   NSg         P
 > programs , but     a   problem remains in      defining the laws  and theorems of computer
 # NPl/V+   . NSg/C/P D/P NSg/J+  NPl/V   NPr/J/P V        D+  NPl/V V/C NPl/V    P  NSg/V+
 > science ( if    any     exist ) and defining the nature of experiments in      computer
-# NSg/V+  . NSg/C I/R/Dq+ V+    . V/C V        D   NSg/V  P  NPl/V+      NPr/J/P NSg/V+
+# N🅪Sg/V+ . NSg/C I/R/Dq+ V+    . V/C V        D   NSg/V  P  NPl/V+      NPr/J/P NSg/V+
 > science . Proponents of classifying computer science as    an   engineering discipline
-# NSg/V+  . NPl        P  V           NSg/V+   NSg/V   NSg/R D/P+ NSg/V+      NSg/V+
+# N🅪Sg/V+ . NPl        P  V           NSg/V+   N🅪Sg/V  NSg/R D/P+ NSg/V+      NSg/V+
 > argue that         the reliability of computational systems is investigated in      the same
 # V     NSg/I/C/Ddem D   NSg         P  J+            NPl+    VL V/J          NPr/J/P D   I/J
 > way   as    bridges  in      civil engineering and airplanes in      aerospace engineering . They
@@ -395,15 +395,15 @@
 > also argue that         while     empirical sciences observe what   presently exists , computer
 # W?   V     NSg/I/C/Ddem NSg/V/C/P NSg/J     NPl/V+   NSg/V   NSg/I+ R         V      . NSg/V+
 > science observes what   is possible to exist and while     scientists discover laws
-# NSg/V+  NPl/V    NSg/I+ VL NSg/J    P  V     V/C NSg/V/C/P NPl+       NSg/V/J  NPl/V+
+# N🅪Sg/V+ NPl/V    NSg/I+ VL NSg/J    P  V     V/C NSg/V/C/P NPl+       NSg/V/J  NPl/V+
 > from observation , no     proper laws   have   been  found in      computer science and it       is
-# P    NSg+        . NPr/P+ NSg/J  NPl/V+ NSg/VX NSg/V NSg/V NPr/J/P NSg/V+   NSg/V   V/C NPr/ISg+ VL
+# P    NSg+        . NPr/P+ NSg/J  NPl/V+ NSg/VX NSg/V NSg/V NPr/J/P NSg/V+   N🅪Sg/V  V/C NPr/ISg+ VL
 > instead concerned with creating phenomena .
 # W?      V/J       P    V        NSg+      .
 >
 #
 > Proponents of classifying computer science as    a   mathematical discipline argue
-# NPl        P  V           NSg/V+   NSg/V   NSg/R D/P J            NSg/V+     V
+# NPl        P  V           NSg/V+   N🅪Sg/V  NSg/R D/P J            NSg/V+     V
 > that         computer programs are physical realizations of mathematical entities and
 # NSg/I/C/Ddem NSg/V+   NPl/V+   V   NSg/J    NPl/NoAm     P  J            NPl      V/C
 > programs that          can    be     deductively reasoned through mathematical formal methods .
@@ -413,25 +413,25 @@
 > computer programs as    mathematical sentences and interpret formal semantics for
 # NSg/V+   NPl/V    NSg/R J            NPl/V+    V/C V         NSg/J  NPl       C/P
 > programming languages as    mathematical axiomatic systems .
-# NSg/V+      NPl/V     NSg/R J+           J         NPl+    .
+# NᴹSg/V+     NPl/V     NSg/R J+           J         NPl+    .
 >
 #
 > Paradigms of computer science
-# NPl       P  NSg/V+   NSg/V+
+# NPl       P  NSg/V+   N🅪Sg/V+
 >
 #
 > A   number   of computer scientists have   argued for the distinction of three
 # D/P NSg/V/JC P  NSg/V+   NPl+       NSg/VX V/J    C/P D   NSg         P  NSg
 > separate paradigms in      computer science . Peter     Wegner argued that         those   paradigms
-# NSg/V/J  NPl       NPr/J/P NSg/V+   NSg/V+  . NPr/V/JC+ ?      V/J    NSg/I/C/Ddem I/Ddem+ NPl+
+# NSg/V/J  NPl       NPr/J/P NSg/V+   N🅪Sg/V+ . NPr/V/JC+ ?      V/J    NSg/I/C/Ddem I/Ddem+ NPl+
 > are science , technology , and mathematics . Peter     Denning's working group  argued
-# V   NSg/V   . N🅪Sg+      . V/C NᴹSg+       . NPr/V/JC+ ?         V       NSg/V+ V/J
-> that         they are theory , abstraction ( modeling ) , and design . Amnon H. Eden
-# NSg/I/C/Ddem IPl+ V   NSg    . NSg         . NSg/V+   . . V/C NSg/V+ . ?     ?  NPr+
+# V   N🅪Sg/V  . N🅪Sg+      . V/C NᴹSg+       . NPr/V/JC+ ?         V       NSg/V+ V/J
+> that         they are theory , abstraction ( modeling ) , and design  . Amnon H. Eden
+# NSg/I/C/Ddem IPl+ V   NSg    . NSg         . NSg/V+   . . V/C N🅪Sg/V+ . ?     ?  NPr+
 > described them     as    the " rationalist paradigm " ( which treats computer science as    a
-# V/J       NSg/IPl+ NSg/R D   . NSg+        NSg+     . . I/C+  NPl/V+ NSg/V+   NSg/V   NSg/R D/P
+# V/J       NSg/IPl+ NSg/R D   . NSg+        NSg+     . . I/C+  NPl/V+ NSg/V+   N🅪Sg/V  NSg/R D/P
 > branch of mathematics , which is prevalent in      theoretical computer science , and
-# NPr/V  P  NᴹSg+       . I/C+  VL J         NPr/J/P J+          NSg/V+   NSg/V+  . V/C
+# NPr/V  P  NᴹSg+       . I/C+  VL J         NPr/J/P J+          NSg/V+   N🅪Sg/V+ . V/C
 > mainly employs deductive reasoning ) , the " technocratic paradigm " ( which might     be
 # R      NPl/V   J         NSg/V     . . D   . J            NSg+     . . I/C+  NᴹSg/VX/J NSg/VX
 > found in      engineering approaches , most       prominently in      software engineering ) , and
@@ -441,11 +441,11 @@
 > empirical perspective of natural sciences , identifiable in      some     branches of
 # NSg/J     NSg/J       P  NSg/J+  NPl/V+   . J            NPr/J/P I/J/R/Dq NPl/V    P
 > artificial intelligence ) . Computer science focuses on  methods involved in
-# J+         N🅪Sg+        . . NSg/V+   NSg/V+  NPl/V   J/P NPl/V+  V/J      NPr/J/P
+# J+         N🅪Sg+        . . NSg/V+   N🅪Sg/V+ NPl/V   J/P NPl/V+  V/J      NPr/J/P
 > design , specification , programming , verification , implementation and testing of
-# NSg/V  . NSg+          . NSg/V+      . NSg          . NSg            V/C V       P
+# N🅪Sg/V . NSg+          . NᴹSg/V+     . NSg          . NSg            V/C V       P
 > human   - made computing systems .
-# NSg/V/J . V    NSg/V+    NPl+    .
+# NSg/V/J . V    NᴹSg/V+   NPl+    .
 >
 #
 > Fields
@@ -453,39 +453,39 @@
 >
 #
 > As    a    discipline , computer science spans a   range of topics from theoretical
-# NSg/R D/P+ NSg/V      . NSg/V+   NSg/V+  NPl/V D/P NSg/V P  NPl+   P    J
+# NSg/R D/P+ NSg/V      . NSg/V+   N🅪Sg/V+ NPl/V D/P NSg/V P  NPl+   P    J
 > studies of algorithms and the limits of computation to the practical issues of
 # NPl/V   P  NPl+       V/C D   NPl/V  P  NSg         P  D   NSg/J     NPl/V  P
 > implementing computing systems in      hardware and software . CSAB , formerly called
-# V            NSg/V+    NPl     NPr/J/P NᴹSg     V/C NᴹSg+    . ?    . R        V/J
+# V            NᴹSg/V+   NPl     NPr/J/P NᴹSg     V/C NᴹSg+    . ?    . R        V/J
 > Computing Sciences Accreditation Board  — which is made up        of representatives of
-# NSg/V+    NPl/V+   N🅪Sg          NSg/V+ . I/C+  VL V    NSg/V/J/P P  NPl             P
+# NᴹSg/V+   NPl/V+   N🅪Sg          NSg/V+ . I/C+  VL V    NSg/V/J/P P  NPl             P
 > the Association for Computing Machinery ( ACM ) , and the IEEE Computer Society
-# D+  NSg         C/P NSg/V+    NᴹSg+     . NSg . . V/C D+  NPr+ NSg/V+   NSg+
+# D+  NSg         C/P NᴹSg/V+   NᴹSg+     . NSg . . V/C D+  NPr+ NSg/V+   NSg+
 > ( IEEE CS    ) — identifies four areas that          it       considers crucial to the discipline of
 # . NPr  NPl/V . . V          NSg  NPl+  NSg/I/C/Ddem+ NPr/ISg+ V         J       P  D   NSg/V      P
 > computer science : theory of computation , algorithms and data  structures ,
-# NSg/V+   NSg/V+  . NSg    P  NSg         . NPl        V/C N🅪Pl+ NPl/V+     .
+# NSg/V+   N🅪Sg/V+ . NSg    P  NSg         . NPl        V/C N🅪Pl+ NPl/V+     .
 > programming methodology and languages , and computer elements and  architecture .
-# NSg/V+      NSg         V/C NPl/V+    . V/C NSg/V+   NPl/V    V/C+ NSg+         .
+# NᴹSg/V+     NSg         V/C NPl/V+    . V/C NSg/V+   NPl/V    V/C+ NSg+         .
 > In      addition to these   four areas , CSAB also identifies fields   such  as    software
 # NPr/J/P NSg      P  I/Ddem+ NSg  NPl+  . ?    W?   V          NPrPl/V+ NSg/I NSg/R NᴹSg+
 > engineering , artificial intelligence , computer networking and communication ,
-# NSg/V+      . J+         N🅪Sg+        . NSg/V+   NᴹSg/V     V/C NSg+          .
+# NSg/V+      . J+         N🅪Sg+        . NSg/V+   NᴹSg/V     V/C N🅪Sg+         .
 > database systems , parallel computation , distributed computation , human   – computer
 # NSg/V+   NPl+    . NSg/V/J+ NSg         . V/J         NSg         . NSg/V/J . NSg/V+
 > interaction , computer graphics , operating systems , and numerical and symbolic
 # NSg+        . NSg/V+   NPl+     . V         NPl+    . V/C J         V/C J
 > computation as    being   important areas of computer science .
-# NSg         NSg/R NSg/V/C J         NPl   P  NSg/V+   NSg/V+  .
+# NSg         NSg/R NSg/V/C J         NPl   P  NSg/V+   N🅪Sg/V+ .
 >
 #
 > Theoretical computer science
-# J+          NSg/V+   NSg/V
+# J+          NSg/V+   N🅪Sg/V
 >
 #
 > Theoretical computer science is mathematical and abstract in      spirit , but     it
-# J+          NSg/V+   NSg/V   VL J            V/C NSg/V/J  NPr/J/P NSg/V+ . NSg/C/P NPr/ISg+
+# J+          NSg/V+   N🅪Sg/V  VL J            V/C NSg/V/J  NPr/J/P NSg/V+ . NSg/C/P NPr/ISg+
 > derives its     motivation from practical and everyday computation . It       aims  to
 # NPl/V   ISg/D$+ NSg+       P    NSg/J     V/C NSg/J+   NSg+        . NPr/ISg+ NPl/V P
 > understand the nature of computation and , as    a   consequence of this
@@ -499,7 +499,7 @@
 >
 #
 > According to Peter     Denning , the fundamental question underlying computer science
-# V/J       P  NPr/V/JC+ ?       . D+  NSg/J+      NSg/V+   NSg/V/J    NSg/V+   NSg/V+
+# V/J       P  NPr/V/JC+ ?       . D+  NSg/J+      NSg/V+   NSg/V/J    NSg/V+   N🅪Sg/V+
 > is , " What   can    be     automated ? " Theory of computation is focused on  answering
 # VL . . NSg/I+ NPr/VX NSg/VX V/J       . . NSg    P  NSg         VL V/J     J/P V
 > fundamental questions about what   can    be     computed and what   amount of resources
@@ -559,19 +559,19 @@
 >
 #
 > Programming language theory and formal methods
-# NSg/V+      N🅪Sg/V   NSg    V/C NSg/J  NPl/V
+# NᴹSg/V+     N🅪Sg/V   NSg    V/C NSg/J  NPl/V
 >
 #
 > Programming language theory is a   branch of computer science that          deals with the
-# NSg/V+      N🅪Sg/V   NSg+   VL D/P NPr/V  P  NSg/V+   NSg/V+  NSg/I/C/Ddem+ NPl/V P    D+
-> design , implementation , analysis , characterization , and classification of
-# NSg/V+ . NSg+           . N🅪Sg+    . NSg              . V/C NSg            P
+# NᴹSg/V+     N🅪Sg/V   NSg+   VL D/P NPr/V  P  NSg/V+   N🅪Sg/V+ NSg/I/C/Ddem+ NPl/V P    D+
+> design  , implementation , analysis , characterization , and classification of
+# N🅪Sg/V+ . NSg+           . N🅪Sg+    . NSg              . V/C NSg            P
 > programming languages and their individual features . It       falls  within  the
-# NSg/V+      NPl/V     V/C D$+   NSg/J+     NPl/V+   . NPr/ISg+ NPl/V+ NSg/J/P D
+# NᴹSg/V+     NPl/V     V/C D$+   NSg/J+     NPl/V+   . NPr/ISg+ NPl/V+ NSg/J/P D
 > discipline of computer science , both   depending on  and affecting mathematics ,
-# NSg/V      P  NSg/V+   NSg/V+  . I/C/Dq V         J/P V/C V/J       NᴹSg+       .
+# NSg/V      P  NSg/V+   N🅪Sg/V+ . I/C/Dq V         J/P V/C V/J       NᴹSg+       .
 > software engineering , and linguistics . It       is an  active research area  , with
-# NᴹSg+    NSg/V+      . V/C NSg+        . NPr/ISg+ VL D/P NSg/J  NSg/V+   N🅪Sg+ . P
+# NᴹSg+    NSg/V+      . V/C NᴹSg+       . NPr/ISg+ VL D/P NSg/J  NᴹSg/V+  N🅪Sg+ . P
 > numerous dedicated academic journals .
 # J        V/J+      NSg/J+   NPl/V+   .
 >
@@ -580,20 +580,20 @@
 # NSg/J+ NPl/V   V   D/P NSg/J      NSg/J P  R              V/J   NSg       C/P D+
 > specification , development and verification of software and hardware systems .
 # NSg           . N🅪Sg        V/C NSg          P  NᴹSg     V/C NᴹSg+    NPl+    .
-> The use   of formal methods for software and hardware design is motivated by      the
-# D   NSg/V P  NSg/J  NPl/V   C/P NᴹSg     V/C NᴹSg+    NSg/V+ VL V/J       NSg/J/P D+
+> The use   of formal methods for software and hardware design  is motivated by      the
+# D   NSg/V P  NSg/J  NPl/V   C/P NᴹSg     V/C NᴹSg+    N🅪Sg/V+ VL V/J       NSg/J/P D+
 > expectation that          , as    in      other    engineering disciplines , performing appropriate
 # NSg+        NSg/I/C/Ddem+ . NSg/R NPr/J/P NSg/V/J+ NSg/V+      NPl/V+      . V          V/J
 > mathematical analysis can    contribute to the reliability and robustness of a
 # J            N🅪Sg+    NPr/VX NSg/V      P  D+  NSg         V/C NSg        P  D/P+
-> design . They form  an  important theoretical underpinning for software
-# NSg/V+ . IPl+ NSg/V D/P J         J           NSg/V        C/P NᴹSg+
+> design  . They form  an  important theoretical underpinning for software
+# N🅪Sg/V+ . IPl+ NSg/V D/P J         J           NSg/V        C/P NᴹSg+
 > engineering , especially where safety or    security is  involved . Formal methods are
 # NSg/V+      . R          NSg/C N🅪Sg/V NPr/C NSg+     VL+ V/J      . NSg/J  NPl/V+  V
 > a   useful adjunct to software testing since they help  avoid errors and can    also
 # D/P J      NSg/V/J P  NᴹSg     V+      C/P   IPl+ NSg/V V     NPl/V+ V/C NPr/VX W?
 > give  a   framework for testing . For industrial use    , tool   support is required .
-# NSg/V D/P NSg       C/P V+      . C/P NSg/J+     NSg/V+ . NSg/V+ NSg/V+  VL V/J      .
+# NSg/V D/P NSg       C/P V+      . C/P NSg/J+     NSg/V+ . NSg/V+ N🅪Sg/V+ VL V/J      .
 > However , the high    cost    of using formal methods means that         they are usually only
 # C       . D   NSg/V/J NSg/V/J P  V     NSg/J  NPl/V+  NPl/V NSg/I/C/Ddem IPl+ V   R       J/R/C
 > used in      the development of high    - integrity and life   - critical systems , where
@@ -601,7 +601,7 @@
 > safety or    security is of utmost importance . Formal methods are best      described as
 # N🅪Sg/V NPr/C NSg+     VL P  NSg/J  NᴹSg+      . NSg/J  NPl/V+  V   NPr/VX/JS V/J       NSg/R
 > the application of a   fairly broad variety of theoretical computer science
-# D   NSg         P  D/P R      NSg/J NSg     P  J           NSg/V+   NSg/V+
+# D   NSg         P  D/P R      NSg/J NSg     P  J           NSg/V+   N🅪Sg/V+
 > fundamentals , in      particular logic    calculi , formal languages , automata theory ,
 # NPl+         . NPr/J/P NSg/J+     NSg/V/J+ NSg     . NSg/J+ NPl/V+    . NSg      NSg+   .
 > and program semantics , but     also type   systems and algebraic data  types  to
@@ -611,7 +611,7 @@
 >
 #
 > Applied computer science
-# V/J     NSg/V+   NSg/V
+# V/J     NSg/V+   N🅪Sg/V
 >
 #
 > Computer graphics and visualization
@@ -623,7 +623,7 @@
 > synthesis and manipulation of image  data  . The study  is connected to many       other
 # NSg       V/C N🅪Sg         P  NSg/V+ N🅪Pl+ . D+  NSg/V+ VL V/J       P  NSg/I/J/Dq NSg/V/J
 > fields  in      computer science , including computer vision , image  processing , and
-# NPrPl/V NPr/J/P NSg/V+   NSg/V+  . V         NSg/V+   NSg/V+ . NSg/V+ V+         . V/C
+# NPrPl/V NPr/J/P NSg/V+   N🅪Sg/V+ . V         NSg/V+   NSg/V+ . NSg/V+ V+         . V/C
 > computational geometry , and is heavily applied in      the fields  of special effects
 # J+            N🅪Sg+    . V/C VL R       V/J     NPr/J/P D   NPrPl/V P  NSg/V/J NPl/V
 > and video   games  .
@@ -639,7 +639,7 @@
 > of information can    be     streamed via    signals . Its     processing is the central notion
 # P  NᴹSg+       NPr/VX NSg/VX V/J      NSg/P+ NPl/V   . ISg/D$+ V+         VL D   NPr/J   NSg
 > of informatics , the European view  on  computing , which studies information
-# P  NᴹSg        . D   NSg/J    NSg/V J/P NSg/V+    . I/C+  NPl/V+  NᴹSg+
+# P  NᴹSg        . D   NSg/J    NSg/V J/P NᴹSg/V+   . I/C+  NPl/V+  NᴹSg+
 > processing algorithms independently of the type  of information carrier – whether
 # V+         NPl+       R             P  D   NSg/V P  NᴹSg+       NPr+    . I/C
 > it       is electrical , mechanical or     biological . This    field  plays important role in
@@ -647,37 +647,37 @@
 > information theory , telecommunications , information engineering and has
 # NᴹSg+       NSg+   . NPl+               . NᴹSg+       NSg/V+      V/C V
 > applications in      medical image  computing and speech  synthesis , among others . What
-# W?           NPr/J/P NSg/J   NSg/V+ NSg/V     V/C N🅪Sg/V+ NSg+      . P     NPl/V+ . NSg/I+
+# W?           NPr/J/P NSg/J   NSg/V+ NᴹSg/V    V/C N🅪Sg/V+ NSg+      . P     NPl/V+ . NSg/I+
 > is the lower    bound   on  the complexity of fast    Fourier transform algorithms ? is
 # VL D   NSg/V/JC NSg/V/J J/P D   NSg        P  NSg/V/J NPr     NSg/V     NPl+       . VL+
 > one       of the unsolved problems in      theoretical computer science .
-# NSg/I/V/J P  D   V/J      NPl      NPr/J/P J+          NSg/V+   NSg/V+  .
+# NSg/I/V/J P  D   V/J      NPl      NPr/J/P J+          NSg/V+   N🅪Sg/V+ .
 >
 #
 > Computational science , finance and engineering
-# J+            NSg/V   . N🅪Sg/V+ V/C NSg/V
+# J+            N🅪Sg/V  . N🅪Sg/V+ V/C NSg/V
 >
 #
 > Scientific computing ( or    computational science ) is the field of study  concerned
-# J+         NSg/V     . NPr/C J             NSg/V+  . VL D   NSg/V P  NSg/V+ V/J
+# J+         NᴹSg/V    . NPr/C J             N🅪Sg/V+ . VL D   NSg/V P  NSg/V+ V/J
 > with constructing mathematical models and quantitative analysis techniques and
 # P    V            J            NPl/V+ V/C J            N🅪Sg+    NPl+       V/C
 > using computers to analyze and solve scientific problems . A   major   usage of
 # V     NPl/V+    P  V       V/C NSg/V J+         NPl+     . D/P NPr/V/J N🅪Sg  P
 > scientific computing is simulation of various processes , including computational
-# J+         NSg/V+    VL NSg        P  J+      NPl/V+    . V         J
+# J+         NᴹSg/V+   VL NSg        P  J+      NPl/V+    . V         J
 > fluid   dynamics , physical , electrical , and electronic systems and circuits , as
 # N🅪Sg/J+ NSgPl+   . NSg/J    . NSg/J      . V/C J          NPl+    V/C NPl/V    . NSg/R
-> well    as    societies and social situations ( notably war    games  ) along with their
-# NSg/V/J NSg/R NPl+      V/C NSg/J  W?         . R       NSg/V+ NPl/V+ . P     P    D$+
+> well    as    societies and social situations ( notably war     games  ) along with their
+# NSg/V/J NSg/R NPl+      V/C NSg/J  W?         . R       N🅪Sg/V+ NPl/V+ . P     P    D$+
 > habitats , among many        others . Modern computers enable optimization of such
 # NPl      . P     NSg/I/J/Dq+ NPl/V+ . NSg/J  NPl/V+    V      N🅪Sg         P  NSg/I
 > designs as    complete aircraft . Notable in      electrical and electronic circuit
 # NPl/V   NSg/R NSg/V/J+ NSgPl+   . NSg/J   NPr/J/P NSg/J      V/C J          NSg/V+
-> design are SPICE  , as    well    as    software for physical realization of new     ( or
-# NSg/V+ V   N🅪Sg/V . NSg/R NSg/V/J NSg/R NᴹSg     C/P NSg/J    NSg/NoAm    P  NSg/V/J . NPr/C
-> modified ) designs . The latter includes essential design software for integrated
-# NSg/V/J  . NPl/V+  . D   NSg/J  NPl/V    NSg/J     NSg/V+ NᴹSg     C/P V/J+
+> design  are SPICE  , as    well    as    software for physical realization of new     ( or
+# N🅪Sg/V+ V   N🅪Sg/V . NSg/R NSg/V/J NSg/R NᴹSg     C/P NSg/J    NSg/NoAm    P  NSg/V/J . NPr/C
+> modified ) designs . The latter includes essential design  software for integrated
+# NSg/V/J  . NPl/V+  . D   NSg/J  NPl/V    NSg/J     N🅪Sg/V+ NᴹSg     C/P V/J+
 > circuits .
 # NPl/V+   .
 >
@@ -687,9 +687,9 @@
 >
 #
 > Human    – computer interaction ( HCI ) is the field of study and research concerned
-# NSg/V/J+ . NSg/V+   NSg+        . ?   . VL D   NSg/V P  NSg/V V/C NSg/V+   V/J
+# NSg/V/J+ . NSg/V+   NSg+        . ?   . VL D   NSg/V P  NSg/V V/C NᴹSg/V+  V/J
 > with the design and use   of computer systems , mainly based on  the analysis of the
-# P    D+  NSg/V  V/C NSg/V P  NSg/V+   NPl+    . R      V/J   J/P D   N🅪Sg     P  D
+# P    D+  N🅪Sg/V V/C NSg/V P  NSg/V+   NPl+    . R      V/J   J/P D   N🅪Sg     P  D
 > interaction between humans and computer interfaces . HCI has several subfields
 # NSg         NSg/P   NPl/V  V/C NSg/V+   NPl/V+     . ?   V   J/Dq    NPl
 > that          focus on  the relationship between emotions , social behavior and brain
@@ -706,8 +706,8 @@
 # NᴹSg+    NSg/V       VL D   NSg/V P  V         . V            . V/C V         D+
 > software in      order  to ensure it       is of high    quality , affordable , maintainable , and
 # NᴹSg+    NPr/J/P NSg/V+ P  V      NPr/ISg+ VL P  NSg/V/J NSg/J+  . W?         . J            . V/C
-> fast     to build . It       is a   systematic approach to software design , involving the
-# NSg/V/J+ P+ NSg/V . NPr/ISg+ VL D/P J          NSg/V    P  NᴹSg     NSg/V+ . V         D
+> fast     to build . It       is a   systematic approach to software design  , involving the
+# NSg/V/J+ P+ NSg/V . NPr/ISg+ VL D/P J          NSg/V    P  NᴹSg     N🅪Sg/V+ . V         D
 > application of engineering practices to software . Software engineering deals
 # NSg         P  NSg/V+      NPl/V+    P+ NᴹSg     . NᴹSg+    NSg/V+      NPl/V
 > with the organizing and analyzing of software — it       does  not   just deal    with the
@@ -729,11 +729,11 @@
 > goal   - orientated processes such  as    problem - solving , decision - making ,
 # NSg/V+ . V/J        NPl/V     NSg/I NSg/R NSg/J   . V       . NSg/V+   . NSg/V  .
 > environmental adaptation , learning , and communication found in      humans and
-# NSg/J+        NSg+       . V+       . V/C NSg+          NSg/V NPr/J/P NPl/V  V/C+
+# NSg/J+        NSg+       . V+       . V/C N🅪Sg+         NSg/V NPr/J/P NPl/V  V/C+
 > animals . From its     origins in      cybernetics and in      the Dartmouth Conference ( 1956 ) ,
 # NPl+    . P    ISg/D$+ NPl+    NPr/J/P NSg         V/C NPr/J/P D+  NPr+      NSg/V+     . #    . .
 > artificial intelligence research has been  necessarily cross      - disciplinary ,
-# J          N🅪Sg+        NSg/V+   V   NSg/V R           NPr/V/J/P+ . NSg/J        .
+# J          N🅪Sg+        NᴹSg/V+  V   NSg/V R           NPr/V/J/P+ . NSg/J        .
 > drawing on  areas of expertise such  as    applied mathematics , symbolic logic    ,
 # NSg/V   J/P NPl   P  NSg/V+    NSg/I NSg/R V/J     NᴹSg+       . J+       NSg/V/J+ .
 > semiotics , electrical engineering , philosophy of mind  , neurophysiology , and
@@ -770,14 +770,14 @@
 #
 > Computer architecture , or    digital computer organization , is the conceptual
 # NSg/V+   NSg          . NPr/C NSg/J   NSg/V+   NSg+         . VL D   J
-> design and fundamental operational structure of a    computer system . It       focuses
-# NSg/V+ V/C NSg/J       J           NSg/V     P  D/P+ NSg/V+   NSg+   . NPr/ISg+ NPl/V
+> design  and fundamental operational structure of a    computer system . It       focuses
+# N🅪Sg/V+ V/C NSg/J       J           NSg/V     P  D/P+ NSg/V+   NSg+   . NPr/ISg+ NPl/V
 > largely on  the way    by      which the central processing unit performs internally and
 # R       J/P D+  NSg/J+ NSg/J/P I/C+  D+  NPr/J+  V+         NSg+ V        R          V/C
 > accesses addresses in      memory . Computer engineers study  computational logic   and
 # NPl/V    NPl/V+    NPr/J/P N🅪Sg+  . NSg/V+   NPl/V+    NSg/V+ J             NSg/V/J V/C
 > design of computer hardware , from individual processor components ,
-# NSg/V  P  NSg/V+   NᴹSg+    . P    NSg/J+     NSg+      NPl+       .
+# N🅪Sg/V P  NSg/V+   NᴹSg+    . P    NSg/J+     NSg+      NPl+       .
 > microcontrollers , personal computers to supercomputers and embedded systems . The
 # NPl              . NSg/J    NPl/V     P  NPl            V/C V/J      NPl+    . D
 > term     " architecture " in      computer literature can    be     traced to the work  of Lyle R.
@@ -785,11 +785,11 @@
 > Johnson and Frederick P. Brooks  Jr     . , members of the Machine Organization
 # NPr     V/C NPr+      ?  NPrPl/V NSg/J+ . . NPl/V   P  D+  NSg/V+  NSg+
 > department in      IBM's main    research center  in      1959 .
-# NSg        NPr/J/P NSg$  NSg/V/J NSg/V    NSg/V/J NPr/J/P #    .
+# NSg        NPr/J/P NSg$  NSg/V/J NᴹSg/V   NSg/V/J NPr/J/P #    .
 >
 #
 > Concurrent , parallel and distributed computing
-# NSg/J      . NSg/V/J  V/C V/J+        NSg/V+
+# NSg/J      . NSg/V/J  V/C V/J+        NᴹSg/V+
 >
 #
 > Concurrency is a   property of systems in      which several computations are executing
@@ -815,7 +815,7 @@
 >
 #
 > This   branch of computer science aims  to manage networks between computers
-# I/Ddem NPr/V  P  NSg/V+   NSg/V+  NPl/V P  NSg/V  NPl/V+   NSg/P   NPl/V+
+# I/Ddem NPr/V  P  NSg/V+   N🅪Sg/V+ NPl/V P  NSg/V  NPl/V+   NSg/P   NPl/V+
 > worldwide .
 # J+        .
 >
@@ -867,9 +867,9 @@
 >
 #
 > The philosopher of computing Bill   Rapaport noted three Great Insights of
-# D   NSg         P  NSg/V+    NPr/V+ ?        V/J   NSg   NSg/J NPl      P
+# D   NSg         P  NᴹSg/V+   NPr/V+ ?        V/J   NSg   NSg/J NPl      P
 > Computer Science :
-# NSg/V+   NSg/V+  .
+# NSg/V+   N🅪Sg/V+ .
 >
 #
 >
@@ -969,7 +969,7 @@
 > Boehm's and Jacopini's insight can    be     further simplified with the use   of
 # ?       V/C ?          NSg+    NPr/VX NSg/VX V/J     V/J        P    D   NSg/V P
 > goto ( which means it       is more         elementary than structured programming ) .
-# ?    . I/C+  NPl/V NPr/ISg+ VL NPr/I/V/J/Dq NSg/J      C/P  V/J        NSg/V       . .
+# ?    . I/C+  NPl/V NPr/ISg+ VL NPr/I/V/J/Dq NSg/J      C/P  V/J        NᴹSg/V      . .
 >
 #
 >
@@ -977,13 +977,13 @@
 >
 #
 > Programming paradigms
-# NSg/V       NPl
+# NᴹSg/V      NPl
 >
 #
 > Programming languages can    be     used to accomplish different tasks in      different
-# NSg/V+      NPl/V     NPr/VX NSg/VX V/J  P  V          NSg/J     NPl/V NPr/J/P NSg/J+
+# NᴹSg/V+     NPl/V     NPr/VX NSg/VX V/J  P  V          NSg/J     NPl/V NPr/J/P NSg/J+
 > ways . Common  programming paradigms include :
-# NPl+ . NSg/V/J NSg/V+      NPl+      NSg/V+  .
+# NPl+ . NSg/V/J NᴹSg/V+     NPl+      NSg/V+  .
 >
 #
 >
@@ -991,31 +991,31 @@
 >
 #
 > Functional programming , a   style of building the structure and elements of
-# NSg/J      NSg/V       . D/P NSg/V P  NSg/V+   D+  NSg/V     V/C NPl/V    P
+# NSg/J      NᴹSg/V      . D/P NSg/V P  NSg/V+   D+  NSg/V     V/C NPl/V    P
 > computer programs that          treats computation as    the evaluation of mathematical
 # NSg/V+   NPl/V+   NSg/I/C/Ddem+ NPl/V+ NSg         NSg/R D   NSg        P  J
 > functions and avoids state  and mutable data  . It       is a   declarative programming
-# NPl/V+    V/C V      NSg/V+ V/C W?      N🅪Pl+ . NPr/ISg+ VL D/P NSg/J+      NSg/V+
+# NPl/V+    V/C V      NSg/V+ V/C W?      N🅪Pl+ . NPr/ISg+ VL D/P NSg/J+      NᴹSg/V+
 > paradigm , which means programming is done    with expressions or    declarations
-# NSg+     . I/C+  NPl/V NSg/V+      VL NSg/V/J P    NPl         NPr/C NPl+
+# NSg+     . I/C+  NPl/V NᴹSg/V+     VL NSg/V/J P    NPl         NPr/C NPl+
 > instead of statements .
 # W?      P  NPl/V+     .
 >
 #
 > Imperative programming , a    programming paradigm that          uses  statements that
-# NSg/J+     NSg/V       . D/P+ NSg/V+      NSg+     NSg/I/C/Ddem+ NPl/V NPl/V+     NSg/I/C/Ddem+
+# NSg/J+     NᴹSg/V      . D/P+ NᴹSg/V+     NSg+     NSg/I/C/Ddem+ NPl/V NPl/V+     NSg/I/C/Ddem+
 > change a   program's state  . In      much       the same way    that         the imperative mood in
 # N🅪Sg/V D/P NSg$+     NSg/V+ . NPr/J/P NSg/I/J/Dq D+  I/J+ NSg/J+ NSg/I/C/Ddem D   NSg/J      NSg  NPr/J/P
 > natural languages expresses commands , an  imperative program consists of
 # NSg/J   NPl/V+    NPl/V     NPl/V+   . D/P NSg/J      NPr/V+  NPl/V    P
 > commands for the computer to perform . Imperative programming focuses on
-# NPl/V    C/P D+  NSg/V+   P+ V       . NSg/J      NSg/V+      NPl/V   J/P
+# NPl/V    C/P D+  NSg/V+   P+ V       . NSg/J      NᴹSg/V+     NPl/V   J/P
 > describing how   a    program operates .
 # V          NSg/C D/P+ NPr/V+  V+       .
 >
 #
 > Object - oriented programming , a   programming paradigm based on  the concept of
-# NSg/V+ . V/J      NSg/V       . D/P NSg/V+      NSg+     V/J   J/P D   NSg/V   P
+# NSg/V+ . V/J      NᴹSg/V      . D/P NᴹSg/V+     NSg+     V/J   J/P D   NSg/V   P
 > " objects " , which may    contain data , in      the form  of fields   , often known as
 # . NPl/V+  . . I/C+  NPr/VX V       N🅪Pl . NPr/J/P D   NSg/V P  NPrPl/V+ . R     V/J   NSg/R
 > attributes ; and code    , in      the form  of procedures , often known as    methods . A
@@ -1031,33 +1031,33 @@
 >
 #
 > Service - oriented programming , a    programming paradigm that          uses  " services " as
-# NSg/V+  . V/J      NSg/V       . D/P+ NSg/V+      NSg+     NSg/I/C/Ddem+ NPl/V . NPl/V    . NSg/R
+# NSg/V+  . V/J      NᴹSg/V      . D/P+ NᴹSg/V+     NSg+     NSg/I/C/Ddem+ NPl/V . NPl/V    . NSg/R
 > the unit of computer work   , to design and implement integrated business
-# D   NSg  P  NSg/V+   NSg/V+ . P  NSg/V  V/C NSg/V     V/J        N🅪Sg/J+
+# D   NSg  P  NSg/V+   NSg/V+ . P  N🅪Sg/V V/C NSg/V     V/J        N🅪Sg/J+
 > applications and mission critical software programs .
 # W?           V/C NSg/V+  NSg/J+   NᴹSg+    NPl/V+   .
 >
 #
 > Many        languages offer    support for multiple  paradigms , making the distinction more
-# NSg/I/J/Dq+ NPl/V     NSg/V/JC NSg/V   C/P NSg/J/Dq+ NPl+      . NSg/V  D+  NSg+        NPr/I/V/J/Dq
+# NSg/I/J/Dq+ NPl/V     NSg/V/JC N🅪Sg/V  C/P NSg/J/Dq+ NPl+      . NSg/V  D+  NSg+        NPr/I/V/J/Dq
 > a   matter    of style  than of technical capabilities .
 # D/P N🅪Sg/V/JC P  NSg/V+ C/P  P  NSg/J+    NSg+         .
 >
 #
 > Research
-# NSg/V
+# NᴹSg/V
 >
 #
 > Conferences are important events for computer science research . During these
-# NPl/V+      V   J         NPl/V  C/P NSg/V+   NSg/V+  NSg/V+   . V/P    I/Ddem+
+# NPl/V+      V   J         NPl/V  C/P NSg/V+   N🅪Sg/V+ NᴹSg/V+  . V/P    I/Ddem+
 > conferences , researchers from the public  and private sectors present their
-# NPl/V+      . W?          P    D   NSg/V/J V/C NSg/V/J NPl+    NSg/V/J D$+
+# NPl/V+      . NPl         P    D   NSg/V/J V/C NSg/V/J NPl+    NSg/V/J D$+
 > recent work   and  meet     . Unlike    in      most       other    academic fields   , in      computer science ,
-# NSg/J  NSg/V+ V/C+ NSg/V/J+ . NSg/V/J/P NPr/J/P NSg/I/J/Dq NSg/V/J+ NSg/J+   NPrPl/V+ . NPr/J/P NSg/V+   NSg/V+  .
+# NSg/J  NSg/V+ V/C+ NSg/V/J+ . NSg/V/J/P NPr/J/P NSg/I/J/Dq NSg/V/J+ NSg/J+   NPrPl/V+ . NPr/J/P NSg/V+   N🅪Sg/V+ .
 > the prestige of conference papers is greater than that         of journal  publications .
 # D   NSg/V/J  P  NSg/V+     NPl/V+ VL JC      C/P  NSg/I/C/Ddem P  NSg/V/J+ NPl+         .
 > One       proposed explanation for this    is the quick   development of this    relatively
-# NSg/I/V/J V/J      NSg         C/P I/Ddem+ VL D   NSg/V/J N🅪Sg        P  I/Ddem+ R
+# NSg/I/V/J V/J      N🅪Sg        C/P I/Ddem+ VL D   NSg/V/J N🅪Sg        P  I/Ddem+ R
 > new      field  requires rapid review and distribution of results , a   task   better
 # NSg/V/J+ NSg/V+ NPl/V    NSg/J NSg/V  V/C NSg          P  NPl/V+  . D/P NSg/V+ NSg/VX/JC
 > handled by      conferences than by      journals .

--- a/harper-core/tests/text/tagged/Computer science.md
+++ b/harper-core/tests/text/tagged/Computer science.md
@@ -621,7 +621,7 @@
 > Computer graphics is the study of digital visual contents and involves the
 # NSg/V+   NPl      VL D   NSg/V P  NSg/J   NSg/J  NPl/V+   V/C V        D+
 > synthesis and manipulation of image  data  . The study  is connected to many       other
-# NSg       V/C N🅪Sg         P  NSg/V+ N🅪Pl+ . D+  NSg/V+ VL V/J       P  NSg/I/J/Dq NSg/V/J
+# NᴹSg      V/C N🅪Sg         P  NSg/V+ N🅪Pl+ . D+  NSg/V+ VL V/J       P  NSg/I/J/Dq NSg/V/J
 > fields  in      computer science , including computer vision , image  processing , and
 # NPrPl/V NPr/J/P NSg/V+   N🅪Sg/V+ . V         NSg/V+   NSg/V+ . NSg/V+ V+         . V/C
 > computational geometry , and is heavily applied in      the fields  of special effects
@@ -647,7 +647,7 @@
 > information theory , telecommunications , information engineering and has
 # NᴹSg+       NSg+   . NPl+               . NᴹSg+       NSg/V+      V/C V
 > applications in      medical image  computing and speech  synthesis , among others . What
-# W?           NPr/J/P NSg/J   NSg/V+ NᴹSg/V    V/C N🅪Sg/V+ NSg+      . P     NPl/V+ . NSg/I+
+# W?           NPr/J/P NSg/J   NSg/V+ NᴹSg/V    V/C N🅪Sg/V+ NᴹSg+     . P     NPl/V+ . NSg/I+
 > is the lower    bound   on  the complexity of fast    Fourier transform algorithms ? is
 # VL D   NSg/V/JC NSg/V/J J/P D   NSg        P  NSg/V/J NPr     NSg/V     NPl+       . VL+
 > one       of the unsolved problems in      theoretical computer science .

--- a/harper-core/tests/text/tagged/Difficult sentences.md
+++ b/harper-core/tests/text/tagged/Difficult sentences.md
@@ -62,8 +62,8 @@
 # ISg+ V   NSg/V/J NSg/P D$+   NPl/V+   .
 > men at    work   ; children at    play
 # NSg NSg/P NSg/V+ . NPl+     NSg/P NSg/V
-> The two  countries are at    war    .
-# D+  NSg+ NPl+      V   NSg/P NSg/V+ .
+> The two  countries are at    war     .
+# D+  NSg+ NPl+      V   NSg/P N🅪Sg/V+ .
 > She  is at    sixes and sevens with him  .
 # ISg+ VL NSg/P NPl   V/C NPl    P    ISg+ .
 >
@@ -236,14 +236,14 @@
 # NSg/C V      P  NSg/V D+  NPl/V+    R         VL NPr/I/V/J/Dq C/P  ISgPl+ NPr/VX NSg/V  . NSg/J/C I/Ddem+ NSg/V D   NPr/V C/P ISgPl+ .
 > This    is a   new     bell  for my  bicycle .
 # I/Ddem+ VL D/P NSg/V/J NPr/V C/P D$+ NSg/V+  .
-> The cake   is for Tom    and Helen's anniversary .
-# D+  NSg/V+ VL C/P NPr/V+ V/C NSg$    NSg+        .
+> The cake    is for Tom    and Helen's anniversary .
+# D+  N🅪Sg/V+ VL C/P NPr/V+ V/C NSg$    NSg+        .
 > This    medicine is for your cough  .
 # I/Ddem+ NSg/V+   VL C/P D$+  NSg/V+ .
 > He       wouldn't apologize ; and just for that          , she  refused to help  him  .
 # NPr/ISg+ VX       V         . V/C V/J  C/P NSg/I/C/Ddem+ . ISg+ V/J     P  NSg/V ISg+ .
-> He       looks better    for having lost weight . ( UK   usage )
-# NPr/ISg+ NPl/V NSg/VX/JC C/P V      V/J  NSg/V+ . . NPr+ N🅪Sg+ .
+> He       looks better    for having lost weight  . ( UK   usage )
+# NPr/ISg+ NPl/V NSg/VX/JC C/P V      V/J  N🅪Sg/V+ . . NPr+ N🅪Sg+ .
 > She  was the worse    for drink  .
 # ISg+ V   D   NSg/V/JC C/P NSg/V+ .
 > All          those  for the motion , raise your hands  .
@@ -434,16 +434,16 @@
 # NSg$ V   ISg/D$+ NSg/V+ NPr/J/P ISg/D$+ .
 > There has been  no    change in      his     condition .
 # +     V   NSg/V NPr/P N🅪Sg/V NPr/J/P ISg/D$+ NSg/V+    .
-> What   grade  did he       get   in      English  ?
-# NSg/I+ NSg/V+ V   NPr/ISg+ NSg/V NPr/J/P NPr/V/J+ .
+> What   grade  did he       get   in      English   ?
+# NSg/I+ NSg/V+ V   NPr/ISg+ NSg/V NPr/J/P NPr🅪/V/J+ .
 > Please pay     me       in      cash     — preferably in      tens and twenties .
 # V      NSg/V/J NPr/ISg+ NPr/J/P NPr/V/J+ . R          NPr/J/P W?   V/C NPl+     .
 > The deposit can    be     in      any    legal  tender  , even    in      gold      .
 # D+  NSg/V+  NPr/VX NSg/VX NPr/J/P I/R/Dq NSg/J+ NSg/V/J . NSg/V/J NPr/J/P NᴹSg/V/J+ .
 > Beethoven's " Symphony No     . 5 " in      C        minor   is among his     most        popular .
 # NSg$        . NSg+     NPr/P+ . # . NPr/J/P NPr/V/J+ NSg/V/J VL P     ISg/D$+ NSg/I/J/Dq+ NSg/J+  .
-> His     speech  was in      French  , but     was simultaneously translated into eight languages .
-# ISg/D$+ N🅪Sg/V+ V   NPr/J/P NPr/V/J . NSg/C/P V   R              V/J        P    NSg/J NPl/V+    .
+> His     speech  was in      French   , but     was simultaneously translated into eight languages .
+# ISg/D$+ N🅪Sg/V+ V   NPr/J/P NPr🅪/V/J . NSg/C/P V   R              V/J        P    NSg/J NPl/V+    .
 > When    you    write in      cursive , it's illegible .
 # NSg/I/C ISgPl+ NSg/V NPr/J/P NSg/J   . +    J+        .
 > Military letters should be     formal in      tone     , but     not   stilted .
@@ -545,15 +545,15 @@
 > He       seemed devoid of human    feelings .
 # NPr/ISg+ V/J    V/J    P  NSg/V/J+ +        .
 > The word   is believed to be     of Japanese origin .
-# D+  NSg/V+ VL V/J      P  NSg/VX P  NPr/J+   NSg+   .
+# D+  NSg/V+ VL V/J      P  NSg/VX P  NPr🅪/J+  NSg+   .
 > Jesus of Nazareth
 # NPr/V P  NPr+
 > The invention was born    of necessity .
 # D+  NSg+      V   NPr/V/J P  NSg+      .
 > It       is said that         she  died of a    broken heart   .
 # NPr/ISg+ VL V/J  NSg/I/C/Ddem ISg+ V/J  P  D/P+ V/J+   N🅪Sg/V+ .
-> What   a   lot   of nonsense !
-# NSg/I+ D/P NPr/V P  NSg/V/J+ .
+> What   a   lot   of nonsense  !
+# NSg/I+ D/P NPr/V P  NᴹSg/V/J+ .
 > I'll have   a   dozen of those   apples , please .
 # W?   NSg/VX D/P NSg   P  I/Ddem+ NPl    . V      .
 > Welcome to the historic town of Harwich .
@@ -568,8 +568,8 @@
 # I/Ddem+ N🅪Sg/Comm+ VL NSg/J   P  +         .
 > He       is a   friend  of mine     .
 # NPr/ISg+ VL D/P NPr/V/J P  NSg/I/V+ .
-> We   want  a   larger slice   of the cake   .
-# IPl+ NSg/V D/P JC     NSg/V/J P  D+  NSg/V+ .
+> We   want  a   larger slice   of the cake    .
+# IPl+ NSg/V D/P JC     NSg/V/J P  D+  N🅪Sg/V+ .
 > The owner of the nightclub was arrested .
 # D   NSg   P  D+  NSg/V+    V+  V/J      .
 > My  companion seemed affable and easy    of manner .
@@ -592,8 +592,8 @@
 #
 > All          the lights are on  , so        they must   be     home     .
 # NSg/I/J/C/Dq D+  NPl/V  V   J/P . NSg/I/J/C IPl+ NSg/V+ NSg/VX NSg/V/J+ .
-> We   had to ration our food because there was a   war    on  .
-# IPl+ V   P  NSg/V  D$+ NSg+ C/P     +     V   D/P NSg/V+ J/P .
+> We   had to ration our food because there was a   war     on  .
+# IPl+ V   P  NSg/V  D$+ NSg+ C/P     +     V   D/P N🅪Sg/V+ J/P .
 > Some     of the cast    went  down      with flu  , but     the show's still    on  .
 # I/J/R/Dq P  D   NSg/V/J NSg/V NSg/V/J/P P    NSg+ . NSg/C/P D   NSg$   NSg/V/J+ J/P .
 > That          TV   programme    that          you    wanted to watch is on  now       .

--- a/harper-core/tests/text/tagged/Part-of-speech tagging.md
+++ b/harper-core/tests/text/tagged/Part-of-speech tagging.md
@@ -11,9 +11,9 @@
 >
 #
 > In      corpus linguistics , part    - of - speech tagging ( POS  tagging or    PoS  tagging or
-# NPr/J/P NSg+   NSg         . NSg/V/J . P  . N🅪Sg/V NSg/V   . NSg+ NSg/V   NPr/C NSg+ NSg/V   NPr/C
-> POST     ) , also called grammatical tagging is the process of marking up        a   word  in      a
-# NPr/V/P+ . . W?   V/J    J           NSg/V   VL D   NSg/V   P  NSg/V   NSg/V/J/P D/P NSg/V NPr/J/P D/P
+# NPr/J/P NSg+   NᴹSg        . NSg/V/J . P  . N🅪Sg/V NSg/V   . NSg+ NSg/V   NPr/C NSg+ NSg/V   NPr/C
+> POST      ) , also called grammatical tagging is the process of marking up        a   word  in      a
+# NPr🅪/V/P+ . . W?   V/J    J           NSg/V   VL D   NSg/V   P  NSg/V   NSg/V/J/P D/P NSg/V NPr/J/P D/P
 > text  ( corpus ) as    corresponding to a   particular part    of speech  , based on  both   its
 # NSg/V . NSg+   . NSg/R NSg/V/J       P  D/P NSg/J      NSg/V/J P  N🅪Sg/V+ . V/J   J/P I/C/Dq ISg/D$+
 > definition and its     context . A   simplified form  of this    is commonly taught to
@@ -27,13 +27,13 @@
 > Once  performed by      hand   , POS  tagging is now       done    in      the context of computational
 # NSg/C V/J       NSg/J/P NSg/V+ . NSg+ NSg/V   VL NPr/V/J/C NSg/V/J NPr/J/P D   N🅪Sg/V  P  J+
 > linguistics , using algorithms which associate discrete terms  , as    well    as    hidden
-# NSg+        . V     NPl+       I/C+  NSg/V/J+  J        NPl/V+ . NSg/R NSg/V/J NSg/R V/J
+# NᴹSg+       . V     NPl+       I/C+  NSg/V/J+  J        NPl/V+ . NSg/R NSg/V/J NSg/R V/J
 > parts of speech  , by      a   set     of descriptive tags   . POS  - tagging algorithms fall  into
 # NPl/V P  N🅪Sg/V+ . NSg/J/P D/P NPr/V/J P  NSg/J+      NPl/V+ . NSg+ . NSg/V   NPl        NSg/V P
 > two distinctive groups : rule   - based and  stochastic . E. Brill's tagger , one       of the
 # NSg NSg/J       NPl/V+ . NSg/V+ . V/J+  V/C+ J+         . ?  ?       NSg    . NSg/I/V/J P  D
-> first   and most       widely used English  POS  - taggers , employs rule   - based algorithms .
-# NSg/V/J V/C NSg/I/J/Dq R      V/J  NPr/V/J+ NSg+ . NPl     . NPl/V   NSg/V+ . V/J   NPl+       .
+> first   and most       widely used English   POS  - taggers , employs rule   - based algorithms .
+# NSg/V/J V/C NSg/I/J/Dq R      V/J  NPr🅪/V/J+ NSg+ . NPl     . NPl/V   NSg/V+ . V/J   NPl+       .
 >
 #
 > Principle
@@ -76,8 +76,8 @@
 # NSg/V+ NPl/V
 >
 #
-> Schools commonly teach that         there are 9 parts of speech  in      English : noun   , verb   ,
-# NPl/V+  R        NSg/V NSg/I/C/Ddem +     V   # NPl/V P  N🅪Sg/V+ NPr/J/P NPr/V/J . NSg/V+ . NSg/V+ .
+> Schools commonly teach that         there are 9 parts of speech  in      English  : noun   , verb   ,
+# NPl/V+  R        NSg/V NSg/I/C/Ddem +     V   # NPl/V P  N🅪Sg/V+ NPr/J/P NPr🅪/V/J . NSg/V+ . NSg/V+ .
 > article , adjective , preposition , pronoun , adverb , conjunction , and interjection .
 # NSg/V+  . NSg/V/J+  . NSg/V       . NSg/V+  . NSg/V+ . NSg/V+      . V/C NSg+         .
 > However , there are clearly many       more         categories and sub     - categories . For nouns ,
@@ -104,12 +104,12 @@
 #
 > In      part    - of - speech tagging by      computer , it       is typical to distinguish from 50 to
 # NPr/J/P NSg/V/J . P  . N🅪Sg/V NSg/V   NSg/J/P NSg/V+   . NPr/ISg+ VL NSg/J   P  V           P    #  P
-> 150 separate parts of speech for English  . Work  on  stochastic methods for tagging
-# #   NSg/V/J  NPl/V P  N🅪Sg/V C/P NPr/V/J+ . NSg/V J/P J          NPl/V   C/P NSg/V
+> 150 separate parts of speech for English   . Work  on  stochastic methods for tagging
+# #   NSg/V/J  NPl/V P  N🅪Sg/V C/P NPr🅪/V/J+ . NSg/V J/P J          NPl/V   C/P NSg/V
 > Koine Greek   ( DeRose 1990 ) has used over      1 , 000 parts of speech  and found that
 # ?     NPr/V/J . ?      #    . V   V/J  NSg/V/J/P # . #   NPl/V P  N🅪Sg/V+ V/C NSg/V NSg/I/C/Ddem
-> about as    many        words  were  ambiguous in      that          language as    in      English  . A
-# J/P   NSg/R NSg/I/J/Dq+ NPl/V+ NSg/V J         NPr/J/P NSg/I/C/Ddem+ N🅪Sg/V+  NSg/R NPr/J/P NPr/V/J+ . D/P
+> about as    many        words  were  ambiguous in      that          language as    in      English   . A
+# J/P   NSg/R NSg/I/J/Dq+ NPl/V+ NSg/V J         NPr/J/P NSg/I/C/Ddem+ N🅪Sg/V+  NSg/R NPr/J/P NPr🅪/V/J+ . D/P
 > morphosyntactic descriptor in      the case  of morphologically rich    languages is
 # ?               NSg        NPr/J/P D   NPr/V P  ?               NPr/V/J NPl/V+    VL
 > commonly expressed using very short      mnemonics , such  as    Ncmsan for Category = Noun   ,
@@ -120,8 +120,8 @@
 # . NPr/P .
 >
 #
-> The most       popular " tag    set     " for POS  tagging for American English  is probably the
-# D   NSg/I/J/Dq NSg/J   . NSg/V+ NPr/V/J . C/P NSg+ NSg/V   C/P NPr/J    NPr/V/J+ VL R        D+
+> The most       popular " tag    set     " for POS  tagging for American English   is probably the
+# D   NSg/I/J/Dq NSg/J   . NSg/V+ NPr/V/J . C/P NSg+ NSg/V   C/P NPr/J    NPr🅪/V/J+ VL R        D+
 > Penn tag    set     , developed in      the Penn Treebank project . It       is largely similar to
 # NPr+ NSg/V+ NPr/V/J . V/J       NPr/J/P D+  NPr+ ?        NSg/V+  . NPr/ISg+ VL R       NSg/J   P
 > the earlier Brown   Corpus and LOB   Corpus tag    sets  , though much        smaller . In
@@ -138,8 +138,8 @@
 # NPl/V+ V/J  NPl/V  R       P    N🅪Sg/V+  . NPl/V+ R       V   V/J      P  NSg/V
 > overt morphological distinctions , although this    leads to inconsistencies such  as
 # NSg/J J+            NPl+         . C        I/Ddem+ NPl/V P  NPl             NSg/I NSg/R
-> case   - marking for pronouns but     not   nouns in      English  , and much       larger
-# NPr/V+ . NSg/V   C/P NPl/V    NSg/C/P NSg/C NPl/V NPr/J/P NPr/V/J+ . V/C NSg/I/J/Dq JC
+> case   - marking for pronouns but     not   nouns in      English   , and much       larger
+# NPr/V+ . NSg/V   C/P NPl/V    NSg/C/P NSg/C NPl/V NPr/J/P NPr🅪/V/J+ . V/C NSg/I/J/Dq JC
 > cross      - language differences . The tag    sets  for heavily inflected languages such  as
 # NPr/V/J/P+ . N🅪Sg/V+  NSg/V       . D+  NSg/V+ NPl/V C/P R       V/J       NPl/V+    NSg/I NSg/R
 > Greek   and Latin can    be     very large ; tagging words  in      agglutinative languages such
@@ -165,13 +165,13 @@
 >
 #
 > Research on  part    - of - speech tagging has been  closely tied to corpus linguistics .
-# NSg/V    J/P NSg/V/J . P  . N🅪Sg/V NSg/V   V   NSg/V R       V/J  P  NSg    NSg+        .
-> The first   major   corpus of English  for computer analysis was the Brown   Corpus
-# D   NSg/V/J NPr/V/J NSg    P  NPr/V/J+ C/P NSg/V+   N🅪Sg+    V   D   NPr/V/J NSg
+# NᴹSg/V   J/P NSg/V/J . P  . N🅪Sg/V NSg/V   V   NSg/V R       V/J  P  NSg    NᴹSg+       .
+> The first   major   corpus of English   for computer analysis was the Brown   Corpus
+# D   NSg/V/J NPr/V/J NSg    P  NPr🅪/V/J+ C/P NSg/V+   N🅪Sg+    V   D   NPr/V/J NSg
 > developed at    Brown   University by      Henry Kučera and W. Nelson Francis , in      the
 # V/J       NSg/P NPr/V/J NSg        NSg/J/P NPr+  ?      V/C ?  NPr+   NPr+    . NPr/J/P D
-> mid      - 1960s . It       consists of about 1 , 000 , 000 words of running   English  prose text   ,
-# NSg/J/P+ . #d    . NPr/ISg+ NPl/V    P  J/P   # . #   . #   NPl/V P  NSg/V/J/P NPr/V/J+ NSg/V NSg/V+ .
+> mid      - 1960s . It       consists of about 1 , 000 , 000 words of running   English   prose text   ,
+# NSg/J/P+ . #d    . NPr/ISg+ NPl/V    P  J/P   # . #   . #   NPl/V P  NSg/V/J/P NPr🅪/V/J+ NSg/V NSg/V+ .
 > made up        of 500 samples from randomly chosen   publications . Each sample is 2 , 000
 # V    NSg/V/J/P P  #   NPl/V+  P    R+       NᴹSg/V/J NPl+         . Dq+  NSg/V+ VL # . #
 > or    more         words  ( ending at    the first    sentence - end   after 2 , 000 words  , so        that         the
@@ -233,11 +233,11 @@
 >
 #
 > In      the mid     - 1980s , researchers in      Europe began to use   hidden Markov models ( HMMs )
-# NPr/J/P D   NSg/J/P . #d    . W?          NPr/J/P NPr+   V     P  NSg/V V/J    NPr    NPl/V+ . ?    .
+# NPr/J/P D   NSg/J/P . #d    . NPl         NPr/J/P NPr+   V     P  NSg/V V/J    NPr    NPl/V+ . ?    .
 > to disambiguate parts of speech  , when    working to tag   the Lancaster - Oslo - Bergen
 # P  V            NPl/V P  N🅪Sg/V+ . NSg/I/C V       P  NSg/V D   NPr       . NPr+ . NPr
-> Corpus of British English  . HMMs involve counting cases ( such  as    from the Brown
-# NSg    P  NPr/J+  NPr/V/J+ . ?    V       V        NPl/V . NSg/I NSg/R P    D+  NPr/V/J+
+> Corpus of British English   . HMMs involve counting cases ( such  as    from the Brown
+# NSg    P  NPr/J+  NPr🅪/V/J+ . ?    V       V        NPl/V . NSg/I NSg/R P    D+  NPr/V/J+
 > Corpus ) and making a   table of the probabilities of certain sequences . For
 # NSg+   . V/C NSg/V  D/P NSg/V P  D   NPl           P  I/J+    NPl/V+    . C/P
 > example , once  you've seen  an  article such  as    ' the ' , perhaps the next     word   is a
@@ -273,7 +273,7 @@
 > European group  developed CLAWS  , a   tagging program that          did exactly this    and
 # NSg/J+   NSg/V+ V/J       NPl/V+ . D/P NSg/V+  NPr/V+  NSg/I/C/Ddem+ V   R       I/Ddem+ V/C
 > achieved accuracy in      the 93 – 95 % range  .
-# V/J      NSg+     NPr/J/P D   #  . #  . NSg/V+ .
+# V/J      N🅪Sg+    NPr/J/P D   #  . #  . NSg/V+ .
 >
 #
 > Eugene Charniak points out         in      Statistical techniques for natural language
@@ -281,7 +281,7 @@
 > parsing ( 1997 ) that          merely assigning the most       common  tag   to each known word  and
 # V       . #    . NSg/I/C/Ddem+ R      V         D   NSg/I/J/Dq NSg/V/J NSg/V P  Dq+  V/J   NSg/V V/C
 > the tag    " proper noun  " to all           unknowns will   approach 90 % accuracy because many
-# D   NSg/V+ . NSg/J  NSg/V . P  NSg/I/J/C/Dq+ NPl/V+   NPr/VX NSg/V    #  . NSg+     C/P     NSg/I/J/Dq+
+# D   NSg/V+ . NSg/J  NSg/V . P  NSg/I/J/C/Dq+ NPl/V+   NPr/VX NSg/V    #  . N🅪Sg+    C/P     NSg/I/J/Dq+
 > words  are unambiguous , and many        others only  rarely represent their less    - common
 # NPl/V+ V   J           . V/C NSg/I/J/Dq+ NPl/V+ J/R/C R      V         D$+   V/J/C/P . NSg/V/J
 > parts of speech  .
@@ -309,13 +309,13 @@
 >
 #
 > Dynamic programming methods
-# NSg/J+  NSg/V+      NPl/V
+# NSg/J+  NᴹSg/V+     NPl/V
 >
 #
 > In      1987 , Steven DeRose and Kenneth W. Church independently developed dynamic
 # NPr/J/P #    . NPr+   ?      V/C NPr+    ?  NPr/V+ R             V/J       NSg/J
 > programming algorithms to solve the same problem in      vastly less    time      . Their
-# NSg/V+      NPl+       P  NSg/V D   I/J  NSg/J   NPr/J/P R      V/J/C/P N🅪Sg/V/J+ . D$+
+# NᴹSg/V+     NPl+       P  NSg/V D   I/J  NSg/J   NPr/J/P R      V/J/C/P N🅪Sg/V/J+ . D$+
 > methods were  similar to the Viterbi algorithm known for some     time      in      other
 # NPl/V+  NSg/V NSg/J   P  D   ?       NSg       V/J   C/P I/J/R/Dq N🅪Sg/V/J+ NPr/J/P NSg/V/J+
 > fields   . DeRose used a   table of pairs  , while     Church used a   table of triples and a
@@ -325,7 +325,7 @@
 > Brown    Corpus ( an  actual measurement of triple  probabilities would require a   much
 # NPr/V/J+ NSg    . D/P NSg/J  NSg         P  NSg/V/J NPl+          VX    NSg/V   D/P NSg/I/J/Dq
 > larger corpus ) . Both   methods achieved an  accuracy of over      95 % . DeRose's 1990
-# JC     NSg+   . . I/C/Dq NPl/V+  V/J      D/P NSg      P  NSg/V/J/P #  . . ?        #
+# JC     NSg+   . . I/C/Dq NPl/V+  V/J      D/P N🅪Sg     P  NSg/V/J/P #  . . ?        #
 > dissertation at    Brown   University included analyses    of the specific error  types  ,
 # NSg+         NSg/P NPr/V/J NSg+       V/J      NPl/V/Au/Br P  D+  NSg/J+   NSg/V+ NPl/V+ .
 > probabilities , and other    related data  , and replicated his     work  for Greek   , where
@@ -337,7 +337,7 @@
 > These   findings were  surprisingly disruptive to the field of natural language
 # I/Ddem+ NSg      NSg/V R            J          P  D   NSg/V P  NSg/J+  N🅪Sg/V+
 > processing . The accuracy reported was higher than the typical accuracy of very
-# V+         . D+  NSg+     V/J      V   NSg/JC C/P  D   NSg/J   NSg      P  J/R
+# V+         . D+  N🅪Sg+    V/J      V   NSg/JC C/P  D   NSg/J   N🅪Sg     P  J/R
 > sophisticated algorithms that          integrated part    of speech  choice with many       higher
 # V/J           NPl+       NSg/I/C/Ddem+ V/J        NSg/V/J P  N🅪Sg/V+ NSg/J  P    NSg/I/J/Dq NSg/JC
 > levels of linguistic analysis : syntax , morphology , semantics , and so         on  . CLAWS ,
@@ -351,7 +351,7 @@
 > levels of processing ; this    , in      turn  , simplified the theory and practice of
 # NPl/V  P  V          . I/Ddem+ . NPr/J/P NSg/V . V/J        D+  NSg    V/C NSg/V    P
 > computerized language analysis and encouraged researchers to find  ways to
-# V/J          N🅪Sg/V+  N🅪Sg+    V/C V/J        +           P  NSg/V NPl+ P
+# V/J          N🅪Sg/V+  N🅪Sg+    V/C V/J        NPl+        P  NSg/V NPl+ P
 > separate other    pieces as     well    . Markov Models became the standard method for the
 # NSg/V/J  NSg/V/J+ NPl/V+ NSg/R+ NSg/V/J . NPr    NPl/V+ V      D   NSg/J    NSg/V  C/P D
 > part    - of - speech  assignment .
@@ -413,7 +413,7 @@
 > tagging . Methods such  as    SVM , maximum entropy classifier , perceptron , and
 # NSg/V+  . NPl/V+  NSg/I NSg/R ?   . NSg/J   NSg     NSg        . NSg        . V/C
 > nearest - neighbor   have   all          been  tried , and most       can    achieve accuracy above
-# JS      . NSg/V/J/Am NSg/VX NSg/I/J/C/Dq NSg/V V/J   . V/C NSg/I/J/Dq NPr/VX V       NSg+     NSg/J/P
+# JS      . NSg/V/J/Am NSg/VX NSg/I/J/C/Dq NSg/V V/J   . V/C NSg/I/J/Dq NPr/VX V       N🅪Sg+    NSg/J/P
 > 95 % . [ citation needed ]
 # #  . . . NSg+     V/J+   .
 >

--- a/harper-core/tests/text/tagged/Spell.US.md
+++ b/harper-core/tests/text/tagged/Spell.US.md
@@ -2,8 +2,8 @@
 # NSg/V
 >
 #
-> This    document contains a   list  of words  spelled correctly in      some     dialects of English  , but     not   American English  . This    is designed to test  the spelling suggestions we   give  for such   mistakes .
-# I/Ddem+ NSg/V    V        D/P NSg/V P  NPl/V+ V/J     R         NPr/J/P I/J/R/Dq NPl      P  NPr/V/J+ . NSg/C/P NSg/C NPr/J+   NPr/V/J+ . I/Ddem+ VL V/J      P  NSg/V D+  NSg/V+   NPl+        IPl+ NSg/V C/P NSg/I+ NPl/V+   .
+> This    document contains a   list  of words  spelled correctly in      some     dialects of English   , but     not   American English   . This    is designed to test  the spelling suggestions we   give  for such   mistakes .
+# I/Ddem+ NSg/V    V        D/P NSg/V P  NPl/V+ V/J     R         NPr/J/P I/J/R/Dq NPl      P  NPr🅪/V/J+ . NSg/C/P NSg/C NPr/J+   NPr🅪/V/J+ . I/Ddem+ VL V/J      P  NSg/V D+  NSg/V+   NPl+        IPl+ NSg/V C/P NSg/I+ NPl/V+   .
 >
 #
 > To achieve this   , the filename of this    file   contains `.US       , which will   tell  the snapshot generator to use   the American dialect , rather  than trying  to use   an  automatically detected dialect .
@@ -30,8 +30,8 @@
 # V/J/Comm+ .
 >
 #
-> Flavour     .
-# NSg/V/Comm+ .
+> Flavour      .
+# N🅪Sg/V/Comm+ .
 >
 #
 > Favoured  .

--- a/harper-core/tests/text/tagged/The Constitution of the United States.md
+++ b/harper-core/tests/text/tagged/The Constitution of the United States.md
@@ -49,9 +49,9 @@
 > any     State  legislature , or    as    an  executive or    judicial officer of any     State  , to
 # I/R/Dq+ NSg/V+ NSg+        . NPr/C NSg/R D/P NSg/J     NPr/C NSg/J    NSg/V   P  I/R/Dq+ NSg/V+ . P
 > support the Constitution of the United States   , shall have   engaged in
-# NSg/V   D   NPr          P  D+  V/J+   NPrPl/V+ . VX    NSg/VX V/J     NPr/J/P
-> insurrection or    rebellion against the same , or    given     aid   or    comfort to the
-# NSg          NPr/C NSg       C/P     D   I/J  . NPr/C NSg/V/J/P NSg/V NPr/C NSg/V+  P  D+
+# N🅪Sg/V  D   NPr          P  D+  V/J+   NPrPl/V+ . VX    NSg/VX V/J     NPr/J/P
+> insurrection or    rebellion against the same , or    given     aid    or    comfort to the
+# NSg          NPr/C NSg       C/P     D   I/J  . NPr/C NSg/V/J/P N🅪Sg/V NPr/C NSg/V+  P  D+
 > enemies thereof . But     Congress may    , by      a   vote  of two - thirds of each House  ,
 # NPl/V+  +       . NSg/C/P NPr/V+   NPr/VX . NSg/J/P D/P NSg/V P  NSg . NPl/V  P  Dq+  NPr/V+ .
 > remove such   disability .
@@ -298,8 +298,8 @@
 # C/P D$+   NPl/V+   . P  NSg/VX V/J         NSg/J/P NSg/V+ . V/C V/J  NSg/V/J/R/P P  D   NPr      P
 > the United States   . They shall in      all          Cases  , except Treason , Felony and Breach
 # D+  V/J+   NPrPl/V+ . IPl+ VX    NPr/J/P NSg/I/J/C/Dq NPl/V+ . V/C/P  NSg     . NSg    V/C NSg/V
-> of the Peace  , be     privileged from Arrest during their Attendance at    the Session
-# P  D+  NPr/V+ . NSg/VX V/J        P    NSg/V+ V/P    D$+   NSg+       NSg/P D   NSg/V
+> of the Peace   , be     privileged from Arrest during their Attendance at    the Session
+# P  D+  NPr🅪/V+ . NSg/VX V/J        P    NSg/V+ V/P    D$+   NSg+       NSg/P D   NSg/V
 > of their respective Houses , and in      going   to and returning from the same ; and
 # P  D$+   J+         NPl/V+ . V/C NPr/J/P NSg/V/J P  V/C V         P    D   I/J  . V/C
 > for any    Speech or    Debate in      either House  , they shall not   be     questioned in      any
@@ -450,8 +450,8 @@
 #
 >
 #
-> To establish Post     Offices and post     Roads ;
-# P  V         NPr/V/P+ NPl/V   V/C NPr/V/P+ NPl+  .
+> To establish Post      Offices and post      Roads ;
+# P  V         NPr🅪/V/P+ NPl/V   V/C NPr🅪/V/P+ NPl+  .
 >
 #
 >
@@ -459,7 +459,7 @@
 >
 #
 > To promote the Progress of Science and useful Arts   , by      securing for limited
-# P  NSg/V   D   NSg/V    P  NSg/V+  V/C J+     NPl/V+ . NSg/J/P V        C/P NSg/V/J
+# P  NSg/V   D   NSg/V    P  N🅪Sg/V+ V/C J+     NPl/V+ . NSg/J/P V        C/P NSg/V/J
 > Times to Authors and Inventors the exclusive Right   to their respective Writings
 # NPl/V P  NPl/V   V/C NPl       D   NSg/J     NPr/V/J P  D$+   J          W?
 > and Discoveries ;
@@ -488,8 +488,8 @@
 #
 >
 #
-> To declare War   , grant  Letters of Marque and Reprisal , and make  Rules  concerning
-# P  V       NSg/V . NPr/V+ NPl/V   P  NSg    V/C NSg+     . V/C NSg/V NPl/V+ NSg/V/J/P
+> To declare War    , grant  Letters of Marque and Reprisal , and make  Rules  concerning
+# P  V       N🅪Sg/V . NPr/V+ NPl/V   P  NSg    V/C NSg+     . V/C NSg/V NPl/V+ NSg/V/J/P
 > Captures on  Land   and Water   ;
 # NPl/V    J/P NPr🅪/V V/C N🅪Sg/V+ .
 >
@@ -499,7 +499,7 @@
 >
 #
 > To raise and support Armies , but     no    Appropriation of Money  to that          Use   shall be
-# P  NSg/V V/C NSg/V+  NPl+   . NSg/C/P NPr/P NSg           P  N🅪Sg/J P  NSg/I/C/Ddem+ NSg/V VX    NSg/VX
+# P  NSg/V V/C N🅪Sg/V+ NPl+   . NSg/C/P NPr/P NSg           P  N🅪Sg/J P  NSg/I/C/Ddem+ NSg/V VX    NSg/VX
 > for a   longer Term    than two  Years ;
 # C/P D/P NSg/J  NSg/V/J C/P  NSg+ NPl+  .
 >
@@ -604,8 +604,8 @@
 # NPr/J/P NPl/V P  NSg       NPr/C NSg      D+  NSg/V/J+ N🅪Sg/V+ NPr/VX NSg/V   NPr/ISg+ .
 >
 #
-> No    Bill  of Attainder or    ex       post     facto Law    shall be      passed .
-# NPr/P NPr/V P  NSg       NPr/C NSg/V/J+ NPr/V/P+ ?     NSg/V+ VX+   NSg/VX+ V/J    .
+> No    Bill  of Attainder or    ex       post      facto Law    shall be      passed .
+# NPr/P NPr/V P  NSg       NPr/C NSg/V/J+ NPr🅪/V/P+ ?     NSg/V+ VX+   NSg/VX+ V/J    .
 >
 #
 > No     Capitation , or    other    direct , Tax     shall be     laid , unless in      Proportion to the
@@ -672,8 +672,8 @@
 # NSg/J         . NPr/V+ NPl/V   P  NSg    V/C NSg+     . NSg/V+ N🅪Sg/J+ . V    NPl/V P
 > Credit ; make  any     Thing  but     gold     and silver    Coin   a   Tender  in      Payment of Debts ;
 # NSg/V+ . NSg/V I/R/Dq+ NSg/V+ NSg/C/P NᴹSg/V/J V/C NᴹSg/V/J+ NSg/V+ D/P NSg/V/J NPr/J/P N🅪Sg    P  NPl+  .
-> pass  any    Bill  of Attainder , ex       post     facto Law    , or    Law    impairing the Obligation
-# NSg/V I/R/Dq NPr/V P  NSg       . NSg/V/J+ NPr/V/P+ ?     NSg/V+ . NPr/C NSg/V+ V         D   NSg
+> pass  any    Bill  of Attainder , ex       post      facto Law    , or    Law    impairing the Obligation
+# NSg/V I/R/Dq NPr/V P  NSg       . NSg/V/J+ NPr🅪/V/P+ ?     NSg/V+ . NPr/C NSg/V+ V         D   NSg
 > of Contracts , or    grant any    Title of Nobility .
 # P  NPl/V+    . NPr/C NPr/V I/R/Dq NSg/V P  NSg+     .
 >
@@ -694,10 +694,10 @@
 #
 > No    State shall , without the Consent of Congress , lay     any    Duty of Tonnage , keep
 # NPr/P NSg/V VX    . C/P     D   NSg/V   P  NPr/V+   . NSg/V/J I/R/Dq NSg  P  NSg+    . NSg/V
-> Troops , or    Ships of War    in      time     of Peace  , enter into any    Agreement or    Compact
-# NPl/V+ . NPr/C NPl/V P  NSg/V+ NPr/J/P N🅪Sg/V/J P  NPr/V+ . NSg/V P    I/R/Dq NSg       NPr/C NSg/V/J
-> with another State  , or    with a    foreign Power    , or    engage in      War    , unless actually
-# P    I/D+    NSg/V+ . NPr/C P    D/P+ NSg/J+  NSg/V/J+ . NPr/C V      NPr/J/P NSg/V+ . C      R
+> Troops , or    Ships of War     in      time     of Peace   , enter into any    Agreement or    Compact
+# NPl/V+ . NPr/C NPl/V P  N🅪Sg/V+ NPr/J/P N🅪Sg/V/J P  NPr🅪/V+ . NSg/V P    I/R/Dq NSg       NPr/C NSg/V/J
+> with another State  , or    with a    foreign Power    , or    engage in      War     , unless actually
+# P    I/D+    NSg/V+ . NPr/C P    D/P+ NSg/J+  NSg/V/J+ . NPr/C V      NPr/J/P N🅪Sg/V+ . C      R
 > invaded , or    in      such  imminent Danger     as    will   not   admit of delay    .
 # V/J     . NPr/C NPr/J/P NSg/I J        N🅪Sg/V/JC+ NSg/R NPr/VX NSg/C V     P  NSg/V/J+ .
 >
@@ -1046,10 +1046,10 @@
 # P  D$+   NSg/J/P+ NSg/V+  .
 >
 #
-> No    soldier shall , in      time     of peace  be     quartered in      any     house  , without the
-# NPr/P NSg/V/J VX    . NPr/J/P N🅪Sg/V/J P  NPr/V+ NSg/VX V/J       NPr/J/P I/R/Dq+ NPr/V+ . C/P     D
-> consent of the owner , nor   in      time     of war    , but     in      a   manner to be     prescribed by
-# NSg/V   P  D+  NSg+  . NSg/C NPr/J/P N🅪Sg/V/J P  NSg/V+ . NSg/C/P NPr/J/P D/P NSg    P  NSg/VX V/J        NSg/J/P
+> No    soldier shall , in      time     of peace   be     quartered in      any     house  , without the
+# NPr/P NSg/V/J VX    . NPr/J/P N🅪Sg/V/J P  NPr🅪/V+ NSg/VX V/J       NPr/J/P I/R/Dq+ NPr/V+ . C/P     D
+> consent of the owner , nor   in      time     of war     , but     in      a   manner to be     prescribed by
+# NSg/V   P  D+  NSg+  . NSg/C NPr/J/P N🅪Sg/V/J P  N🅪Sg/V+ . NSg/C/P NPr/J/P D/P NSg    P  NSg/VX V/J        NSg/J/P
 > law    .
 # NSg/V+ .
 >
@@ -1160,8 +1160,8 @@
 #
 > Treason against the United States   , shall consist only  in
 # NSg     C/P     D+  V/J+   NPrPl/V+ . VX    NSg/V   J/R/C NPr/J/P
-> levying War    against them     , or    in      adhering to their Enemies , giving them     Aid   and
-# V       NSg/V+ C/P     NSg/IPl+ . NPr/C NPr/J/P V        P  D$+   NPl/V+  . V      NSg/IPl+ NSg/V V/C
+> levying War     against them     , or    in      adhering to their Enemies , giving them     Aid    and
+# V       N🅪Sg/V+ C/P     NSg/IPl+ . NPr/C NPr/J/P V        P  D$+   NPl/V+  . V      NSg/IPl+ N🅪Sg/V V/C
 > Comfort . No     Person shall be     convicted of Treason unless on  the Testimony of two
 # NSg/V+  . NPr/P+ NSg/V+ VX    NSg/VX V/J       P  NSg     C      J/P D   NSg       P  NSg+
 > Witnesses to the same overt  Act    , or    on  Confession in      open     Court    .
@@ -1198,8 +1198,8 @@
 # C      J/P D/P NSg         NPr/C NSg        P  D/P NSg/J+ NSg/V/J+ . V/C/P  NPr/J/P NPl/V+ V
 > in      the land   or    naval forces , or    in      the militia , when    in      actual service in      time
 # NPr/J/P D+  NPr🅪/V NPr/C J+    NPl/V+ . NPr/C NPr/J/P D   NSg     . NSg/I/C NPr/J/P NSg/J  NSg/V   NPr/J/P N🅪Sg/V/J
-> of war   or    public  danger     ; nor   shall any     person be     subject for the same offense
-# P  NSg/V NPr/C NSg/V/J N🅪Sg/V/JC+ . NSg/C VX    I/R/Dq+ NSg/V  NSg/VX NSg/V/J C/P D+  I/J+ NSg
+> of war    or    public  danger     ; nor   shall any     person be     subject for the same offense
+# P  N🅪Sg/V NPr/C NSg/V/J N🅪Sg/V/JC+ . NSg/C VX    I/R/Dq+ NSg/V  NSg/VX NSg/V/J C/P D+  I/J+ NSg
 > to be     twice put   in      jeopardy of life  or    limb   ; nor   shall be     compelled in      any
 # P  NSg/VX W?    NSg/V NPr/J/P NSg/V    P  NSg/V NPr/C NSg/V+ . NSg/C VX    NSg/VX V/J       NPr/J/P I/R/Dq+
 > criminal case  to be     a   witness against himself , nor   be     deprived of life  ,
@@ -1366,8 +1366,8 @@
 # NPl/V    C/P NPl/V+   NPr/J/P V           NSg          NPr/C NSg+      . VX    NSg/C NSg/VX
 > questioned . But     neither the United States   nor   any     State  shall assume or    pay     any
 # V/J        . NSg/C/P I/C     D+  V/J+   NPrPl/V+ NSg/C I/R/Dq+ NSg/V+ VX    V      NPr/C NSg/V/J I/R/Dq
-> debt or    obligation incurred in      aid   of insurrection or    rebellion against the
-# N🅪Sg NPr/C NSg+       V        NPr/J/P NSg/V P  NSg          NPr/C NSg+      C/P     D+
+> debt or    obligation incurred in      aid    of insurrection or    rebellion against the
+# N🅪Sg NPr/C NSg+       V        NPr/J/P N🅪Sg/V P  NSg          NPr/C NSg+      C/P     D+
 > United States   , or    any    claim for the loss  or    emancipation of any     slave  ; but     all
 # V/J+   NPrPl/V+ . NPr/C I/R/Dq NSg/V C/P D+  NSg/V NPr/C NSg          P  I/R/Dq+ NSg/V+ . NSg/C/P NSg/I/J/C/Dq+
 > such   debts , obligations and claims shall be     held illegal and void     .
@@ -1433,7 +1433,7 @@
 > the United States  and of the several States   , shall be     bound   by      Oath  or
 # D+  V/J+   NPrPl/V V/C P  D+  J/Dq+   NPrPl/V+ . VX    NSg/VX NSg/V/J NSg/J/P NSg/V NPr/C
 > Affirmation , to support this    Constitution ; but     no     religious Test   shall ever be
-# NSg         . P  NSg/V   I/Ddem+ NPr+         . NSg/C/P NPr/P+ NSg/J     NSg/V+ VX    J    NSg/VX
+# NSg         . P  N🅪Sg/V  I/Ddem+ NPr+         . NSg/C/P NPr/P+ NSg/J     NSg/V+ VX    J    NSg/VX
 > required as    a   Qualification to any    Office or    public  Trust    under   the United
 # V/J      NSg/R D/P NSg           P  I/R/Dq NSg/V  NPr/C NSg/V/J N🅪Sg/V/J NSg/J/P D+  V/J+
 > States   .

--- a/harper-core/tests/text/tagged/The Great Gatsby.md
+++ b/harper-core/tests/text/tagged/The Great Gatsby.md
@@ -102,8 +102,8 @@
 # NSg/V+    NSg/I/C/Ddem+ W?    V/J       P    D   NPl/V P  ?         . NSg/C/P D   NSg/J
 > founder of my  line   was my  grandfather’s brother  , who    came    here    in      fifty - one       ,
 # NSg/V   P  D$+ NSg/V+ V   D$+ NSg$          NSg/V/J+ . NPr/I+ NSg/V/P NSg/J/R NPr/J/P NSg   . NSg/I/V/J .
-> sent  a   substitute to the Civil War    , and started the wholesale hardware business
-# NSg/V D/P NSg/V      P  D+  J+    NSg/V+ . V/C V/J     D+  NSg/V/J+  NᴹSg+    N🅪Sg/J+
+> sent  a   substitute to the Civil War     , and started the wholesale hardware business
+# NSg/V D/P NSg/V      P  D+  J+    N🅪Sg/V+ . V/C V/J     D+  NSg/V/J+  NᴹSg+    N🅪Sg/J+
 > that          my  father carries on  to - day   .
 # NSg/I/C/Ddem+ D$+ NPr/V+ NPl/V   J/P P  . NPr🅪+ .
 >
@@ -116,8 +116,8 @@
 # V/J       P    NSg/V/J NSg/V NPr/J/P #    . V/J  D/P NSg/V/J P  D/P NSg     JC/P  D$+ NPr/V+ .
 > and a   little     later I    participated in      that          delayed Teutonic migration known as
 # V/C D/P NPr/I/J/Dq JC    ISg+ V/J          NPr/J/P NSg/I/C/Ddem+ V/J     NSg/J    NSg+      V/J   NSg/R
-> the Great  War    . I    enjoyed the counter  - raid  so        thoroughly that         I    came    back
-# D+  NSg/J+ NSg/V+ . ISg+ V/J     D   NSg/V/J+ . NSg/V NSg/I/J/C R          NSg/I/C/Ddem ISg+ NSg/V/P NSg/V/J
+> the Great  War     . I    enjoyed the counter  - raid  so        thoroughly that         I    came    back
+# D+  NSg/J+ N🅪Sg/V+ . ISg+ V/J     D   NSg/V/J+ . NSg/V NSg/I/J/C R          NSg/I/C/Ddem ISg+ NSg/V/P NSg/V/J
 > restless . Instead of being   the warm    centre     of the world  , the Middle   West     now
 # J+       . W?      P  NSg/V/C D   NSg/V/J NSg/V/Comm P  D+  NSg/V+ . D+  NSg/V/J+ NPr/V/J+ NPr/V/J/C
 > seemed like        the ragged edge  of the universe — so        I    decided to go      East   and learn
@@ -125,7 +125,7 @@
 > the bond     business . Everybody I    knew was in      the bond     business , so        I    supposed it
 # D+  NPr/V/J+ N🅪Sg/J+  . NSg/I+    ISg+ V    V   NPr/J/P D+  NPr/V/J+ N🅪Sg/J+  . NSg/I/J/C ISg+ V/J      NPr/ISg+
 > could  support one       more         single   man      . All          my  aunts and uncles talked it       over      as    if
-# NSg/VX NSg/V+  NSg/I/V/J NPr/I/V/J/Dq NSg/V/J+ NPr/V/J+ . NSg/I/J/C/Dq D$+ NPl   V/C NPl/V  V/J    NPr/ISg+ NSg/V/J/P NSg/R NSg/C
+# NSg/VX N🅪Sg/V+ NSg/I/V/J NPr/I/V/J/Dq NSg/V/J+ NPr/V/J+ . NSg/I/J/C/Dq D$+ NPl   V/C NPl/V  V/J    NPr/ISg+ NSg/V/J/P NSg/R NSg/C
 > they were  choosing a   prep   school for me       , and finally said , “ Why   — ye       - es  , ” with
 # IPl+ NSg/V V        D/P NSg/V+ NSg/V  C/P NPr/ISg+ . V/C R       V/J  . . NSg/V . NSg/I/D+ . NPl . . P
 > very grave    , hesitant faces  . Father agreed to finance me       for a    year , and after
@@ -260,8 +260,8 @@
 # P     D+  N🅪Sg/V+ . V/C D   N🅪Sg    P  D+  NPr/V+ R      NPl/V  J/P D+  N🅪Sg/V+ ISg+
 > drove over      there to have   dinner with the Tom    Buchanans . Daisy was my  second
 # NSg/V NSg/V/J/P +     P  NSg/VX NSg/V+ P    D+  NPr/V+ ?         . NPr+  V   D$+ NSg/V/J
-> cousin once  removed , and I’d known Tom    in      college . And just after the war    I
-# NSg/V  NSg/C V/J     . V/C W?  V/J   NPr/V+ NPr/J/P NSg+    . V/C V/J  JC/P  D+  NSg/V+ ISg+
+> cousin once  removed , and I’d known Tom    in      college . And just after the war     I
+# NSg/V  NSg/C V/J     . V/C W?  V/J   NPr/V+ NPr/J/P NSg+    . V/C V/J  JC/P  D+  N🅪Sg/V+ ISg+
 > spent two  days with them     in      Chicago .
 # V/J   NSg+ NPl+ P    NSg/IPl+ NPr/J/P NPr+    .
 >
@@ -311,7 +311,7 @@
 > gardens — finally when    it       reached the house  drifting up        the side     in      bright  vines
 # NPl/V+  . R       NSg/I/C NPr/ISg+ V/J     D+  NPr/V+ V        NSg/V/J/P D+  NSg/V/J+ NPr/J/P NPr/V/J NPl
 > as    though from the momentum of its     run    . The front    was broken by      a   line  of French
-# NSg/R V/C    P    D   NSg      P  ISg/D$+ NSg/V+ . D+  NSg/V/J+ V   V/J    NSg/J/P D/P NSg/V P  NPr/V/J+
+# NSg/R V/C    P    D   NSg      P  ISg/D$+ NSg/V+ . D+  NSg/V/J+ V   V/J    NSg/J/P D/P NSg/V P  NPr🅪/V/J+
 > windows  , glowing now       with reflected gold      and wide  open    to the warm    windy
 # NPrPl/V+ . NSg/V/J NPr/V/J/C P    V/J       NᴹSg/V/J+ V/C NSg/J NSg/V/J P  D   NSg/V/J NSg/J+
 > afternoon , and Tom    Buchanan in      riding clothes was standing with his     legs   apart
@@ -368,8 +368,8 @@
 #
 > Turning me       around by      one       arm      , he       moved a   broad flat    hand  along the front    vista  ,
 # NSg/V+  NPr/ISg+ J/P    NSg/J/P NSg/I/V/J NSg/V/J+ . NPr/ISg+ V/J   D/P NSg/J NSg/V/J NSg/V P     D+  NSg/V/J+ NSg/V+ .
-> including in      its     sweep a   sunken Italian garden   , a   half       acre of deep  , pungent
-# V         NPr/J/P ISg/D$+ NSg/V D/P W?     NSg/J+  NSg/V/J+ . D/P NSg/V/J/P+ NSg  P  NSg/J . J
+> including in      its     sweep a   sunken Italian garden   , a   half        acre of deep  , pungent
+# V         NPr/J/P ISg/D$+ NSg/V D/P W?     N🅪Sg/J+ NSg/V/J+ . D/P N🅪Sg/V/J/P+ NSg  P  NSg/J . J
 > roses  , and a   snub     - nosed motor   - boat  that          bumped the tide   offshore .
 # NPl/V+ . V/C D/P NSg/V/J+ . V/J   NSg/V/J . NSg/V NSg/I/C/Ddem+ V/J    D+  NSg/V+ NSg/V/J  .
 >
@@ -382,14 +382,14 @@
 #
 > We   walked through a   high    hallway into a   bright  rosy    - colored    space  , fragilely
 # IPl+ V/J    NSg/J/P D/P NSg/V/J NSg     P    D/P NPr/V/J NSg/V/J . NSg/V/J/Am N🅪Sg/V . ?
-> bound   into the house  by      French  windows at    either end    . The windows  were  ajar and
-# NSg/V/J P    D+  NPr/V+ NSg/J/P NPr/V/J NPrPl/V NSg/P I/C    NSg/V+ . D+  NPrPl/V+ NSg/V V/J  V/C
+> bound   into the house  by      French   windows at    either end    . The windows  were  ajar and
+# NSg/V/J P    D+  NPr/V+ NSg/J/P NPr🅪/V/J NPrPl/V NSg/P I/C    NSg/V+ . D+  NPrPl/V+ NSg/V V/J  V/C
 > gleaming white   against the fresh    grass  outside   that          seemed to grow a   little     way
 # V        NPr/V/J C/P     D+  NSg/V/J+ NPr/V+ NSg/V/J/P NSg/I/C/Ddem+ V/J    P  V    D/P NPr/I/J/Dq NSg/J
 > into the house  . A   breeze blew    through the room     , blew    curtains in      at    one       end   and
 # P    D+  NPr/V+ . D/P NSg/V+ NSg/V/J NSg/J/P D+  NSg/V/J+ . NSg/V/J NPl/V+   NPr/J/P NSg/P NSg/I/V/J NSg/V V/C
 > out         the other   like        pale     flags  , twisting them     up        toward the frosted wedding - cake
-# NSg/V/J/R/P D   NSg/V/J NSg/V/J/C/P NSg/V/J+ NPl/V+ . V        NSg/IPl+ NSg/V/J/P J/P    D   V/J+    NSg/V+  . NSg/V
+# NSg/V/J/R/P D   NSg/V/J NSg/V/J/C/P NSg/V/J+ NPl/V+ . V        NSg/IPl+ NSg/V/J/P J/P    D   V/J+    NSg/V+  . N🅪Sg/V
 > of the ceiling , and then    rippled over      the wine    - colored    rug     , making a   shadow  on
 # P  D+  NSg/V+  . V/C NSg/J/C V/J     NSg/V/J/P D   N🅪Sg/V+ . NSg/V/J/Am NSg/V/J . NSg/V  D/P NSg/V/J J/P
 > it       as    wind   does  on  the sea  .
@@ -787,7 +787,7 @@
 > me       again . ‘          ‘          — And we’ve produced all          the things that          go      to make  civilization — oh    ,
 # NPr/ISg+ P+    . Unlintable Unlintable . V/C W?    V/J      NSg/I/J/C/Dq D+  NPl/V+ NSg/I/C/Ddem+ NSg/V/J P  NSg/V NPr          . NPr/V .
 > science and art    , and all          that          . Do     you    see   ? ”
-# NSg/V   V/C NPr/V+ . V/C NSg/I/J/C/Dq NSg/I/C/Ddem+ . NSg/VX ISgPl+ NSg/V . .
+# N🅪Sg/V  V/C NPr/V+ . V/C NSg/I/J/C/Dq NSg/I/C/Ddem+ . NSg/VX ISgPl+ NSg/V . .
 >
 #
 > There was something pathetic in      his     concentration , as    if    his     complacency , more
@@ -994,8 +994,8 @@
 # NPl/V+  . ISgPl+ V      NSg/V/P P  D$+ NSg/V+  . .
 >
 #
-> “ I    wasn’t back    from the war    . ”
-# . ISg+ V      NSg/V/J P    D+  NSg/V+ . .
+> “ I    wasn’t back    from the war     . ”
+# . ISg+ V      NSg/V/J P    D+  N🅪Sg/V+ . .
 >
 #
 > “ That’s true     . ” She  hesitated . “ Well    , I’ve had a   very bad     time     , Nick   , and I’m
@@ -1068,8 +1068,8 @@
 # NSg/J/P . D   NSg/V/J+ NSg/V/J+ V/J     P    NSg/V/J+ . NPr/V+ V/C NSg/V NPr+  NSg/V/J NSg/P I/C
 > end   of the long    couch and she  read  aloud to him  from the Saturday Evening
 # NSg/V P  D   NPr/V/J NSg/V V/C ISg+ NSg/V J     P  ISg+ P    D+  NSg/V+   N🅪Sg/V+
-> Post     — the words , murmurous and uninflected , running   together in      a    soothing tune   .
-# NPr/V/P+ . D+  NPl/V . J         V/C ?           . NSg/V/J/P J        NPr/J/P D/P+ NSg/V/J+ NSg/V+ .
+> Post      — the words , murmurous and uninflected , running   together in      a    soothing tune   .
+# NPr🅪/V/P+ . D+  NPl/V . J         V/C ?           . NSg/V/J/P J        NPr/J/P D/P+ NSg/V/J+ NSg/V+ .
 > The lamp   - light   , bright  on  his     boots  and dull on  the autumn - leaf  yellow  of her
 # D   NSg/V+ . NSg/V/J . NPr/V/J J/P ISg/D$+ NPl/V+ V/C V/J  J/P D   NPr/V+ . NSg/V NSg/V/J P  ISg/D$+
 > hair    , glinted along the paper     as    she  turned a   page  with a   flutter of slender
@@ -1300,8 +1300,8 @@
 # NSg/V+  W?
 >
 #
-> About half      way   between West     Egg     and New      York the motor    road   hastily joins the
-# J/P   NSg/V/J/P NSg/J NSg/P   NPr/V/J+ N🅪Sg/V+ V/C NSg/V/J+ NPr+ D+  NSg/V/J+ NSg/J+ R       NPl/V D+
+> About half       way   between West     Egg     and New      York the motor    road   hastily joins the
+# J/P   N🅪Sg/V/J/P NSg/J NSg/P   NPr/V/J+ N🅪Sg/V+ V/C NSg/V/J+ NPr+ D+  NSg/V/J+ NSg/J+ R       NPl/V D+
 > railroad and runs  beside it       for a   quarter of a    mile , so        as    to shrink away from a
 # NSg/V+   V/C NPl/V P      NPr/ISg+ C/P D/P NSg/V/J P  D/P+ NSg+ . NSg/I/J/C NSg/R P  NSg/V  V/J  P    D/P
 > certain desolate area of land    . This    is a   valley of ashes  — a   fantastic farm   where
@@ -1346,8 +1346,8 @@
 # D   NSg/V  P  NPl/V+ VL V/J     J/P NSg/I/V/J NSg/V/J+ NSg/J/P D/P NPr/V/J NSg/V/J+ NSg/V+ . V/C . NSg/I/C D
 > drawbridge is up        to let   barges through , the passengers on  waiting trains can
 # NSg        VL NSg/V/J/P P  NSg/V NPl/V+ NSg/J/P . D+  NPl/V      J/P NSg/V   NPl/V+ NPr/VX
-> stare at    the dismal scene for as    long    as    half       an   hour . There is always a   halt
-# NSg/V NSg/P D   NSg/J  NSg/V C/P NSg/R NPr/V/J NSg/R NSg/V/J/P+ D/P+ NSg+ . +     VL R      D/P NSg/V/J+
+> stare at    the dismal scene for as    long    as    half        an   hour . There is always a   halt
+# NSg/V NSg/P D   NSg/J  NSg/V C/P NSg/R NPr/V/J NSg/R N🅪Sg/V/J/P+ D/P+ NSg+ . +     VL R      D/P NSg/V/J+
 > there of at    least a    minute   , and it       was because of this    that         I    first   met Tom
 # W?    P  NSg/P NSg/J D/P+ NSg/V/J+ . V/C NPr/ISg+ V   C/P     P  I/Ddem+ NSg/I/C/Ddem ISg+ NSg/V/J V   NPr/V+
 > Buchanan’s mistress .
@@ -1503,7 +1503,7 @@
 > We   waited for her     down      the road  and out         of sight  . It       was a   few      days before the
 # IPl+ V/J    C/P ISg/D$+ NSg/V/J/P D   NSg/J V/C NSg/V/J/R/P P  NSg/V+ . NPr/ISg+ V   D/P NSg/I/Dq NPl  C/P    D
 > Fourth  of July , and a   gray       , scrawny Italian child  was setting  torpedoes in      a   row
-# NPr/V/J P  NPr+ . V/C D/P NPr/V/J/Am . J       NSg/J   NSg/V+ V   NSg/V/J+ NPl/V     NPr/J/P D/P NSg/V
+# NPr/V/J P  NPr+ . V/C D/P NPr/V/J/Am . J       N🅪Sg/J  NSg/V+ V   NSg/V/J+ NPl/V     NPr/J/P D/P NSg/V
 > along the railroad track  .
 # P     D+  NSg/V+   NSg/V+ .
 >
@@ -1664,8 +1664,8 @@
 #
 > We  went  on  , cutting back    again over      the Park  toward the West     Hundreds . At    158th
 # IPl NSg/V J/P . NSg/V/J NSg/V/J P     NSg/V/J/P D   NPr/V J/P    D+  NPr/V/J+ NPl+     . NSg/P #
-> Street   the cab    stopped at    one       slice    in      a   long    white   cake  of apartment - houses .
-# NSg/V/J+ D+  NSg/V+ V/J     NSg/P NSg/I/V/J NSg/V/J+ NPr/J/P D/P NPr/V/J NPr/V/J NSg/V P  NSg+      . NPl/V  .
+> Street   the cab    stopped at    one       slice    in      a   long    white   cake   of apartment - houses .
+# NSg/V/J+ D+  NSg/V+ V/J     NSg/P NSg/I/V/J NSg/V/J+ NPr/J/P D/P NPr/V/J NPr/V/J N🅪Sg/V P  NSg+      . NPl/V  .
 > Throwing a   regal homecoming glance around the neighborhood , Mrs  . Wilson gathered
 # V        D/P NSg/J NSg        NSg/V+ J/P    D+  NSg/Am+      . NPl+ . NPr+   V/J
 > up        her     dog     and her     other    purchases , and went  haughtily in      .
@@ -1741,7 +1741,7 @@
 > eyebrows had been  plucked and then    drawn on  again at    a   more         rakish angle , but
 # NPl/V+   V   NSg/V V/J     V/C NSg/J/C V/J   J/P P     NSg/P D/P NPr/I/V/J/Dq J      NSg/V . NSg/C/P
 > the efforts of nature toward the restoration of the old    alignment gave a   blurred
-# D   NPl/V   P  NSg/V  J/P    D   NPr🅪        P  D+  NSg/J+ NSg+      V    D/P V/J
+# D   NPl/V   P  NSg/V  J/P    D   NPr🅪        P  D+  NSg/J+ N🅪Sg+     V    D/P V/J
 > air   to her    face   . When    she  moved about there was an  incessant clicking as
 # NSg/V P  ISg/D$ NSg/V+ . NSg/I/C ISg+ V/J   J/P   +     V   D/P J         V        NSg/R
 > innumerable pottery bracelets jingled up        and down      upon her     arms   . She  came    in
@@ -2253,13 +2253,13 @@
 > scolding , and high    over      the confusion a   long    broken wail  of pain    . Mr   . McKee
 # NSg/V    . V/C NSg/V/J NSg/V/J/P D+  NSg/V+    D/P NPr/V/J V/J+   NSg/V P  N🅪Sg/V+ . NSg+ . NPr
 > awoke from his     doze  and started in      a   daze  toward the door   . When    he       had gone  half
-# V     P    ISg/D$+ NSg/V V/C V/J     NPr/J/P D/P NSg/V J/P    D   NSg/V+ . NSg/I/C NPr/ISg+ V   V/J/P NSg/V/J/P+
+# V     P    ISg/D$+ NSg/V V/C V/J     NPr/J/P D/P NSg/V J/P    D   NSg/V+ . NSg/I/C NPr/ISg+ V   V/J/P N🅪Sg/V/J/P+
 > way    he       turned around and stared at    the scene  — his     wife    and Catherine scolding and
 # NSg/J+ NPr/ISg+ V/J    J/P    V/C V/J    NSg/P D+  NSg/V+ . ISg/D$+ NSg/V/J V/C NPr+      NSg/V    V/C
 > consoling as    they stumbled here    and there among the crowded furniture with
 # NSg/V/J   NSg/R IPl+ V/J      NSg/J/R V/C W?    P     D   V/J     NᴹSg      P
-> articles of aid    , and the despairing figure on  the couch  , bleeding fluently , and
-# NPl/V    P  NSg/V+ . V/C D+  NSg/V/J+   NSg/V+ J/P D+  NSg/V+ . NSg/V/J  R        . V/C
+> articles of aid     , and the despairing figure on  the couch  , bleeding fluently , and
+# NPl/V    P  N🅪Sg/V+ . V/C D+  NSg/V/J+   NSg/V+ J/P D+  NSg/V+ . NSg/V/J  R        . V/C
 > trying  to spread a   copy  of Town Tattle over      the tapestry scenes of Versailles .
 # NSg/V/J P  N🅪Sg/V D/P NSg/V P  NSg+ NSg/V  NSg/V/J/P D   NSg/V    NPl/V  P  NPr+       .
 > Then    Mr   . McKee turned and continued on  out         the door   . Taking  my  hat    from the
@@ -2302,8 +2302,8 @@
 #
 > “ Beauty   and the Beast    . . . Loneliness . . . Old    Grocery Horse  . . . Brook’n
 # . N🅪Sg/V/J V/C D+  NSg/V/J+ . . . NSg+       . . . NSg/J+ NSg/V+  NSg/V+ . . . ?
-> Bridge . . . ” Then    I    was lying   half       asleep in      the cold  lower    level   of the
-# NSg/V+ . . . . NSg/J/C ISg+ V   NSg/V/J NSg/V/J/P+ J      NPr/J/P D   NSg/J NSg/V/JC NSg/V/J P  D+
+> Bridge . . . ” Then    I    was lying   half        asleep in      the cold  lower    level   of the
+# NSg/V+ . . . . NSg/J/C ISg+ V   NSg/V/J N🅪Sg/V/J/P+ J      NPr/J/P D   NSg/J NSg/V/JC NSg/V/J P  D+
 > Pennsylvania Station , staring at    the morning Tribune , and waiting for the four
 # NPr+         NSg/V+  . V       NSg/P D+  N🅪Sg/V+ NSg     . V/C NSg/V   C/P D   NSg+
 > o’clock train  .
@@ -2344,8 +2344,8 @@
 # NPr+ . Dq+   NSg+   I/Ddem+ I/J  NPl/V   V/C NPl/V+ NPr/V/J ISg/D$+ NSg/V/J NSg/V NPr/J/P D/P NSg/V
 > of pulpless halves . There was a   machine in      the kitchen which could  extract the
 # P  ?        V+     . +     V   D/P NSg/V   NPr/J/P D+  NSg/V+  I/C+  NSg/VX NSg/V   D
-> juice    of two hundred oranges in      half       an   hour if    a    little      button was pressed two
-# N🅪Sg/V/J P  NSg NSg     NPl/V   NPr/J/P NSg/V/J/P+ D/P+ NSg+ NSg/C D/P+ NPr/I/J/Dq+ NSg/V+ V   V/J     NSg
+> juice    of two hundred oranges in      half        an   hour if    a    little      button was pressed two
+# N🅪Sg/V/J P  NSg NSg     NPl/V   NPr/J/P N🅪Sg/V/J/P+ D/P+ NSg+ NSg/C D/P+ NPr/I/J/Dq+ NSg/V+ V   V/J     NSg
 > hundred times  by      a   butler’s thumb  .
 # NSg     NPl/V+ NSg/J/P D/P NSg$+    NSg/V+ .
 >
@@ -2618,8 +2618,8 @@
 #
 > “ I    don’t think it’s so        much       that          , ” argued Lucille sceptically ; “ it’s more         that
 # . ISg+ V     NSg/V W?   NSg/I/J/C NSg/I/J/Dq NSg/I/C/Ddem+ . . V/J    NPr+    R/Au/Br     . . W?   NPr/I/V/J/Dq NSg/I/C/Ddem
-> he       was a   German spy   during the war    . ”
-# NPr/ISg+ V   D/P NPr/J  NSg/V V/P    D+  NSg/V+ . .
+> he       was a   German spy   during the war     . ”
+# NPr/ISg+ V   D/P NPr🅪/J NSg/V V/P    D+  N🅪Sg/V+ . .
 >
 #
 > One       of the men  nodded in      confirmation .
@@ -2634,8 +2634,8 @@
 #
 > “ Oh    , no     , ” said the first    girl   , “ it       couldn’t be     that         , because he       was in      the
 # . NPr/V . NPr/P+ . . V/J  D+  NSg/V/J+ NSg/V+ . . NPr/ISg+ V        NSg/VX NSg/I/C/Ddem . C/P     NPr/ISg+ V   NPr/J/P D
-> American army during the war    . ” As    our credulity switched back    to her     she  leaned
-# NPr/J    NSg  V/P    D+  NSg/V+ . . NSg/R D$+ NSg       V/J      NSg/V/J P  ISg/D$+ ISg+ V/J
+> American army during the war     . ” As    our credulity switched back    to her     she  leaned
+# NPr/J    NSg  V/P    D+  N🅪Sg/V+ . . NSg/R D$+ NSg       V/J      NSg/V/J P  ISg/D$+ ISg+ V/J
 > forward with enthusiasm . “ You    look  at    him  sometimes when    he       thinks nobody’s
 # NSg/V/J P    NSg+       . . ISgPl+ NSg/V NSg/P ISg+ R         NSg/I/C NPr/ISg+ NPl/V  NSg$
 > looking at    him  . I’ll bet      he       killed a    man      . ”
@@ -2674,8 +2674,8 @@
 #
 > “ Let’s get   out         , ” whispered Jordan , after a   somehow wasteful and inappropriate
 # . NSg$  NSg/V NSg/V/J/R/P . . V/J       NPr+   . JC/P  D/P W?      J        V/C J
-> half      - hour ; “ this    is much       too polite for me      . ”
-# NSg/V/J/P . NSg  . . I/Ddem+ VL NSg/I/J/Dq W?  V/J    C/P NPr/ISg . .
+> half       - hour ; “ this    is much       too polite for me      . ”
+# N🅪Sg/V/J/P . NSg  . . I/Ddem+ VL NSg/I/J/Dq W?  V/J    C/P NPr/ISg . .
 >
 #
 > We  got up        , and she  explained that         we   were  going   to find  the host   : I    had never
@@ -2692,8 +2692,8 @@
 # V        NSg/V ISg+ P    D   NSg/V/J P  D+  NPl/V+ . V/C NPr/ISg+ V      J/P D+  NSg/NoAm/Br+ . J/P D/P+
 > chance   we   tried an  important - looking door  , and walked into a   high    Gothic
 # NPr/V/J+ IPl+ V/J   D/P J         . V       NSg/V . V/C V/J    P    D/P NSg/V/J NPr/J+
-> library , panelled with carved English  oak      , and probably transported complete
-# NSg+    . V/J/Comm P    V/J    NPr/V/J+ NSg/V/J+ . V/C R        V/J         NSg/V/J
+> library , panelled with carved English   oak      , and probably transported complete
+# NSg+    . V/J/Comm P    V/J    NPr🅪/V/J+ NSg/V/J+ . V/C R        V/J         NSg/V/J
 > from some      ruin   overseas .
 # P    I/J/R/Dq+ NSg/V+ W?       .
 >
@@ -2811,7 +2811,7 @@
 > burden of the banjo or    the traps . By      midnight the hilarity had increased . A
 # NSg/V  P  D   NSg/V NPr/C D+  NPl/V . NSg/J/P NSg/J+   D   NSg+     V+  V/J       . D/P+
 > celebrated tenor had sung  in      Italian , and a    notorious contralto had sung  in
-# V/J+       NSg/J V   NPr/V NPr/J/P NSg/J   . V/C D/P+ J+        NSg       V   NPr/V NPr/J/P
+# V/J+       NSg/J V   NPr/V NPr/J/P N🅪Sg/J  . V/C D/P+ J+        NSg       V   NPr/V NPr/J/P
 > jazz   , and between the numbers  people were  doing ‘          ‘          stunts ” all          over      the garden   ,
 # NSg/V+ . V/C NSg/P   D+  NPrPl/V+ NSg/V+ NSg/V NSg/V Unlintable Unlintable NPl/V  . NSg/I/J/C/Dq NSg/V/J/P D+  NSg/V/J+ .
 > while     happy   , vacuous bursts of laughter rose    toward the summer sky    . A   pair  of
@@ -2844,8 +2844,8 @@
 #
 > “ Your face   is familiar , ” he       said , politely . “ Weren’t you    in      the First   Division
 # . D$+  NSg/V+ VL NSg/J    . . NPr/ISg+ V/J  . R        . . V       ISgPl+ NPr/J/P D   NSg/V/J NSg
-> during the war    ? ”
-# V/P    D+  NSg/V+ . .
+> during the war     ? ”
+# V/P    D+  N🅪Sg/V+ . .
 >
 #
 > “ Why   , yes   . I    was in      the Twenty - eighth  Infantry . ”
@@ -3062,8 +3062,8 @@
 # ?        . J         NSg/J+ . NPl/V+ NSg/V V        NSg/J    R         P    NSg$+ NPl/V+ .
 > even    into groups , knowing   that         some      one        would arrest their falls  — but     no     one
 # NSg/V/J P    NPl/V+ . NSg/V/J/P NSg/I/C/Ddem I/J/R/Dq+ NSg/I/V/J+ VX    NSg/V  D$+   NPl/V+ . NSg/C/P NPr/P+ NSg/I/V/J+
-> swooned backward on  Gatsby , and no     French  bob    touched Gatsby’s shoulder , and no
-# V/J     NSg/J    J/P NPr    . V/C NPr/P+ NPr/V/J NPr/V+ V/J     NSg$     NSg/V+   . V/C NPr/P+
+> swooned backward on  Gatsby , and no     French   bob    touched Gatsby’s shoulder , and no
+# V/J     NSg/J    J/P NPr    . V/C NPr/P+ NPr🅪/V/J NPr/V+ V/J     NSg$     NSg/V+   . V/C NPr/P+
 > singing quartets were  formed for Gatsby’s head    for one        link   .
 # NSg/V/J NPl      NSg/V V/J    C/P NSg$     NPr/V/J C/P NSg/I/V/J+ NSg/V+ .
 >
@@ -3182,8 +3182,8 @@
 #
 > “ Well    , we’re almost the last     to - night  , ” said one       of the men  sheepishly . “ The
 # . NSg/V/J . W?    NSg    D   NSg/V/J+ P  . N🅪Sg/V . . V/J  NSg/I/V/J P  D+  NSg+ R+         . . D+
-> orchestra left    half       an   hour ago  . ”
-# NSg+      NPr/V/J NSg/V/J/P+ D/P+ NSg+ J/P+ . .
+> orchestra left    half        an   hour ago  . ”
+# NSg+      NPr/V/J N🅪Sg/V/J/P+ D/P+ NSg+ J/P+ . .
 >
 #
 > In      spite   of the wives ’ agreement that         such  malevolence was beyond credibility ,
@@ -3286,8 +3286,8 @@
 # NSg/V+ . V/J    D/P NSg/V/J ?     I/C+  V   NPr/V/J NSg$     NSg/V NSg/C NSg+ NPl/V+  C/P+   .
 > The sharp   jut   of a   wall   accounted for the detachment of the wheel  , which was now
 # D   NPr/V/J NSg/V P  D/P NPr/V+ V/J       C/P D   N🅪Sg       P  D+  NSg/V+ . I/C+  V   NPr/V/J/C
-> getting considerable attention from half       a   dozen curious chauffeurs . However , as
-# NSg/V   NSg/J        NSg       P    NSg/V/J/P+ D/P NSg+  J       NPl/V+     . C       . NSg/R
+> getting considerable attention from half        a   dozen curious chauffeurs . However , as
+# NSg/V   NSg/J        NSg       P    N🅪Sg/V/J/P+ D/P NSg+  J       NPl/V+     . C       . NSg/R
 > they had left    their cars blocking the road   , a   harsh , discordant din    from those
 # IPl+ V   NPr/V/J D$+   NPl+ V        D+  NSg/J+ . D/P V/J   . J          NSg/V+ P    I/Ddem
 > in      the rear    had been  audible for some      time      , and added to the already violent
@@ -3390,8 +3390,8 @@
 # . NSg/V . .
 >
 #
-> Half       a   dozen fingers pointed at    the amputated wheel  — he       stared at    it       for a
-# NSg/V/J/P+ D/P NSg   NPl/V+  V/J     NSg/P D+  V/J+      NSg/V+ . NPr/ISg+ V/J    NSg/P NPr/ISg+ C/P D/P+
+> Half        a   dozen fingers pointed at    the amputated wheel  — he       stared at    it       for a
+# N🅪Sg/V/J/P+ D/P NSg   NPl/V+  V/J     NSg/P D+  V/J+      NSg/V+ . NPr/ISg+ V/J    NSg/P NPr/ISg+ C/P D/P+
 > moment , and then    looked upward as    though he       suspected that         it       had dropped from
 # NSg+   . V/C NSg/J/C V/J    NSg/J  NSg/R V/C    NPr/ISg+ V/J       NSg/I/C/Ddem NPr/ISg+ V   V/J     P
 > the sky    .
@@ -3786,8 +3786,8 @@
 # NPr/J/P NSg      P  NSg/I/J/C/Dq I/Ddem+ ISg+ NPr/VX NSg/V    NSg/I/C/Ddem ?        NPr     NSg/V/P W?    NSg/P
 > least once  and the Baedeker girls  and young    Brewer , who    had his     nose  shot    off       in
 # NSg/J NSg/C V/C D+  NPr+     NPl/V+ V/C NPr/V/J+ NPr    . NPr/I+ V   ISg/D$+ NSg/V NSg/V/J NSg/V/J/P NPr/J/P
-> the war    , and Mr   . Albrucksburger and Miss  Haag , his     fiancée , and Ardita
-# D+  NSg/V+ . V/C NSg+ . ?              V/C NSg/V ?    . ISg/D$+ ?       . V/C ?
+> the war     , and Mr   . Albrucksburger and Miss  Haag , his     fiancée , and Ardita
+# D+  N🅪Sg/V+ . V/C NSg+ . ?              V/C NSg/V ?    . ISg/D$+ ?       . V/C ?
 > Fitz - Peters and Mr   . P. Jewett , once  head    of the American Legion   , and Miss
 # ?    . NPr+   V/C NSg+ . ?  ?      . NSg/C NPr/V/J P  D+  NPr/J+   NSg/V/J+ . V/C NSg/V
 > Claudia Hip      , with a    man      reputed to be     her    chauffeur , and a   prince  of something  ,
@@ -3856,8 +3856,8 @@
 # P  NPr/V/J+ NSg/V/J+ NSg/J+       . IPl+ V/J     P+ NSg  .
 >
 #
-> I    had talked with him  perhaps half      a   dozen times in      the past       month  and found , to
-# ISg+ V   V/J    P    ISg+ NSg     NSg/V/J/P D/P NSg   NPl/V NPr/J/P D+  NSg/V/J/P+ NSg/J+ V/C NSg/V . P
+> I    had talked with him  perhaps half       a   dozen times in      the past       month  and found , to
+# ISg+ V   V/J    P    ISg+ NSg     N🅪Sg/V/J/P D/P NSg   NPl/V NPr/J/P D+  NSg/V/J/P+ NSg/J+ V/C NSg/V . P
 > my  disappointment , that         he       had little      to say   . So        my  first    impression , that         he
 # D$+ NSg+           . NSg/I/C/Ddem NPr/ISg+ V   NPr/I/J/Dq+ P  NSg/V . NSg/I/J/C D$+ NSg/V/J+ NSg/V+     . NSg/I/C/Ddem NPr/ISg+
 > was a   person of some      undefined consequence , had gradually faded and he       had
@@ -3964,20 +3964,20 @@
 # NPr+ ?        .
 >
 #
-> “ Then    came    the war    , old    sport  . It       was a   great relief , and I    tried very hard   to
-# . NSg/J/C NSg/V/P D+  NSg/V+ . NSg/J+ NSg/V+ . NPr/ISg+ V   D/P NSg/J NSg/J  . V/C ISg+ V/J   J/R  N🅪Sg/J P
+> “ Then    came    the war     , old    sport  . It       was a   great relief , and I    tried very hard   to
+# . NSg/J/C NSg/V/P D+  N🅪Sg/V+ . NSg/J+ NSg/V+ . NPr/ISg+ V   D/P NSg/J NSg/J  . V/C ISg+ V/J   J/R  N🅪Sg/J P
 > die   , but     I    seemed to bear    an  enchanted life   . I    accepted a   commission as    first
 # NSg/V . NSg/C/P ISg+ V/J    P  NSg/V/J D/P V/J+      NSg/V+ . ISg+ V/J      D/P NSg/V      NSg/R NSg/V/J
 > lieutenant when    it       began . In      the Argonne Forest I    took the remains of my
 # NSg/J+     NSg/I/C NPr/ISg+ V+    . NPr/J/P D+  NPr+    NPr/V+ ISg+ V    D   NPl/V   P  D$+
-> machine - gun   battalion so        far     forward that         there was a   half       mile gap   on  either
-# NSg/V+  . NSg/V NSg/V     NSg/I/J/C NSg/V/J NSg/V/J NSg/I/C/Ddem +     V   D/P NSg/V/J/P+ NSg+ NPr/V J/P I/C
+> machine - gun   battalion so        far     forward that         there was a   half        mile gap   on  either
+# NSg/V+  . NSg/V NSg/V     NSg/I/J/C NSg/V/J NSg/V/J NSg/I/C/Ddem +     V   D/P N🅪Sg/V/J/P+ NSg+ NPr/V J/P I/C
 > side    of us       where the infantry couldn’t advance  . We   stayed there two  days and two
 # NSg/V/J P  NPr/IPl+ NSg/C D+  NSg+     V        NSg/V/J+ . IPl+ V/J    +     NSg+ NPl+ V/C NSg+
 > nights , a   hundred and thirty men  with sixteen Lewis guns   , and when    the infantry
 # NPl/V+ . D/P NSg     V/C NSg    NSg+ P    NSg     NPr+  NPl/V+ . V/C NSg/I/C D+  NSg+
 > came    up        at    last    they found the insignia of three German divisions among the
-# NSg/V/P NSg/V/J/P NSg/P NSg/V/J IPl+ NSg/V D   NSg      P  NSg   NPr/J  NPl       P     D+
+# NSg/V/P NSg/V/J/P NSg/P NSg/V/J IPl+ NSg/V D   NSg      P  NSg   NPr🅪/J NPl       P     D+
 > piles of dead     . I    was promoted to be     a   major   , and every Allied government gave me
 # NPl/V P+ NSg/V/J+ . ISg+ V   V/J      P  NSg/VX D/P NPr/V/J . V/C Dq    V/J    NSg+       V    NPr/ISg+
 > a    decoration — even    Montenegro , little     Montenegro down      on  the Adriatic Sea  ! ”
@@ -4028,8 +4028,8 @@
 # NPr+    NSg/V/J+ . D+  NPr/V/J+ J/P D$+ NPr/V/J VL NPr/V/J/C D   NPr  P+ ?         . .
 >
 #
-> It       was a   photograph of half       a   dozen young   men in      blazers loafing in      an  archway
-# NPr/ISg+ V   D/P NSg/V      P  NSg/V/J/P+ D/P NSg   NPr/V/J NSg NPr/J/P W?      V       NPr/J/P D/P NSg
+> It       was a   photograph of half        a   dozen young   men in      blazers loafing in      an  archway
+# NPr/ISg+ V   D/P NSg/V      P  N🅪Sg/V/J/P+ D/P NSg   NPr/V/J NSg NPr/J/P W?      V       NPr/J/P D/P NSg
 > through which were  visible a   host  of spires . There was Gatsby , looking a   little     ,
 # NSg/J/P I/C+  NSg/V J       D/P NSg/V P  NPl/V+ . +     V   NPr    . V       D/P NPr/I/J/Dq .
 > not   much       , younger — with a   cricket bat   in      his     hand  .
@@ -4100,10 +4100,10 @@
 # P    V       NSg+     NSg/R IPl+ NSg/V NSg/J/P .
 >
 #
-> With fenders spread like        wings  we   scattered light    through half       Astoria — only
-# P    W?      N🅪Sg/V NSg/V/J/C/P NPl/V+ IPl+ V/J       NSg/V/J+ NSg/J/P NSg/V/J/P+ NPr     . J/R/C
-> half       , for as    we   twisted among the pillars of the elevated I    heard the familiar
-# NSg/V/J/P+ . C/P NSg/R IPl+ V/J     P     D   NPl/V   P  D+  V/J+     ISg+ V/J   D   NSg/J
+> With fenders spread like        wings  we   scattered light    through half        Astoria — only
+# P    W?      N🅪Sg/V NSg/V/J/C/P NPl/V+ IPl+ V/J       NSg/V/J+ NSg/J/P N🅪Sg/V/J/P+ NPr     . J/R/C
+> half        , for as    we   twisted among the pillars of the elevated I    heard the familiar
+# N🅪Sg/V/J/P+ . C/P NSg/R IPl+ V/J     P     D   NPl/V   P  D+  V/J+     ISg+ V/J   D   NSg/J
 > “ jug    - jug   - spat  ! ” of a    motorcycle , and a   frantic policeman rode  alongside .
 # . NSg/V+ . NSg/V . NSg/V . . P  D/P+ NSg/V+     . V/C D/P NSg/J   NSg+      NSg/V P         .
 >
@@ -4186,8 +4186,8 @@
 # D/P NPr/V/J . NSg/V/J . V/J   NPr/V/J V/J    ISg/D$+ NSg/J+ NPr/V/J+ V/C V/J      NPr/ISg+ P    NSg NSg/V/J
 > growths of hair    which luxuriated in      either nostril . After a    moment I    discovered
 # NSg     P  N🅪Sg/V+ I/C+  V/J        NPr/J/P I/C+   NSg+    . JC/P  D/P+ NSg+   ISg+ V/J
-> his     tiny   eyes  in      the half       - darkness .
-# ISg/D$+ NSg/J+ NPl/V NPr/J/P D   NSg/V/J/P+ . NSg+     .
+> his     tiny   eyes  in      the half        - darkness .
+# ISg/D$+ NSg/J+ NPl/V NPr/J/P D   N🅪Sg/V/J/P+ . NSg+     .
 >
 #
 > “ So        I    took one       look  at    him  , ” said Mr  . Wolfshiem , shaking my  hand   earnestly , “ and
@@ -4400,8 +4400,8 @@
 # . J/Dq    NPl   . . NPr/ISg+ V/J      NPr/J/P D/P+ V/J+      NSg/J+ .
 >
 #
-> “ I    made the pleasure of his     acquaintance just after the war    . But     I    knew I    had
-# . ISg+ V    D   NSg/V    P  ISg/D$+ NSg+         V/J  JC/P  D+  NSg/V+ . NSg/C/P ISg+ V    ISg+ V
+> “ I    made the pleasure of his     acquaintance just after the war     . But     I    knew I    had
+# . ISg+ V    D   NSg/V    P  ISg/D$+ NSg+         V/J  JC/P  D+  N🅪Sg/V+ . NSg/C/P ISg+ V    ISg+ V
 > discovered a   man     of fine    breeding after I    talked with him  an   hour . I    said to
 # V/J        D/P NPr/V/J P  NSg/V/J NSg/V/J+ JC/P  ISg+ V/J    P    ISg+ D/P+ NSg+ . ISg+ V/J  P
 > myself : ‘          There’s the kind  of man      you’d like        to take  home     and introduce to your
@@ -4530,8 +4530,8 @@
 # . NSg/V/P P     P    NPr/ISg+ C/P D/P+ NSg/V/J+ . . ISg+ V/J  . . W?   V   P  NSg/V NSg/V P  I/J/R/Dq+ NSg/I/V/J+ . .
 >
 #
-> When    he       saw   us       Tom    jumped up        and took half       a   dozen steps in      our direction .
-# NSg/I/C NPr/ISg+ NSg/V NPr/IPl+ NPr/V+ V/J    NSg/V/J/P V/C V    NSg/V/J/P+ D/P NSg   NPl/V NPr/J/P D$+ NSg+      .
+> When    he       saw   us       Tom    jumped up        and took half        a   dozen steps in      our direction .
+# NSg/I/C NPr/ISg+ NSg/V NPr/IPl+ NPr/V+ V/J    NSg/V/J/P V/C V    N🅪Sg/V/J/P+ D/P NSg   NPl/V NPr/J/P D$+ NSg+      .
 >
 #
 > “ Where’ve you    been  ? ” he       demanded eagerly . “ Daisy’s furious because you    haven’t
@@ -4574,8 +4574,8 @@
 # NPr/J/P D   N🅪Sg/V+ . NSg/V/J NSg/P D+  NSg+  NSg+  .
 >
 #
-> — I    was walking along from one       place  to another , half      on  the sidewalks and half
-# . ISg+ V   NSg/V/J P     P    NSg/I/V/J NSg/V+ P  I/D+    . NSg/V/J/P J/P D   NPl       V/C NSg/V/J/P+
+> — I    was walking along from one       place  to another , half       on  the sidewalks and half
+# . ISg+ V   NSg/V/J P     P    NSg/I/V/J NSg/V+ P  I/D+    . N🅪Sg/V/J/P J/P D   NPl       V/C N🅪Sg/V/J/P+
 > on  the lawns  . I    was happier on  the lawns because I    had on  shoes  from England
 # J/P D+  NPl/V+ . ISg+ V   NSg/JC  J/P D   NPl/V C/P     ISg+ V   J/P NPl/V+ P    NPr+
 > with rubber   nobs  on  the soles  that          bit   into the soft   ground   . I    had on  a   new
@@ -4670,8 +4670,8 @@
 # NSg+     NPl+    .
 >
 #
-> I    was a   bridesmaid . I    came    into her     room     half       an   hour before the bridal dinner ,
-# ISg+ V   D/P NSg/V+     . ISg+ NSg/V/P P    ISg/D$+ NSg/V/J+ NSg/V/J/P+ D/P+ NSg+ C/P    D+  NSg/J+ NSg/V+ .
+> I    was a   bridesmaid . I    came    into her     room     half        an   hour before the bridal dinner ,
+# ISg+ V   D/P NSg/V+     . ISg+ NSg/V/P P    ISg/D$+ NSg/V/J+ N🅪Sg/V/J/P+ D/P+ NSg+ C/P    D+  NSg/J+ NSg/V+ .
 > and found her     lying   on  her     bed      as    lovely as    the June night   in      her     flowered
 # V/C NSg/V ISg/D$+ NSg/V/J J/P ISg/D$+ NSg/V/J+ NSg/R NSg/J  NSg/R D+  NPr+ N🅪Sg/V+ NPr/J/P ISg/D$+ V/J+
 > dress  — and as    drunk   as    a    monkey . She  had a   bottle of Sauterne in      one       hand   and a
@@ -4718,8 +4718,8 @@
 #
 > But      she  didn’t say   another word   . We   gave her     spirits of ammonia and put   ice     on
 # NSg/C/P+ ISg+ V      NSg/V I/D+    NSg/V+ . IPl+ V    ISg/D$+ NPl/V   P  NSg+    V/C NSg/V NPr🅪/V+ J/P
-> her     forehead and hooked her     back    into her     dress  , and half      an   hour later , when    we
-# ISg/D$+ NSg+     V/C V/J    ISg/D$+ NSg/V/J P    ISg/D$+ NSg/V+ . V/C NSg/V/J/P D/P+ NSg+ JC    . NSg/I/C IPl+
+> her     forehead and hooked her     back    into her     dress  , and half       an   hour later , when    we
+# ISg/D$+ NSg+     V/C V/J    ISg/D$+ NSg/V/J P    ISg/D$+ NSg/V+ . V/C N🅪Sg/V/J/P D/P+ NSg+ JC    . NSg/I/C IPl+
 > walked out         of the room     , the pearls were  around her     neck  and the incident was
 # V/J    NSg/V/J/R/P P  D+  NSg/V/J+ . D+  NPl/V+ NSg/V J/P    ISg/D$+ NSg/V V/C D+  NSg/J+   V+
 > over      . Next    day  at    five o’clock she  married Tom    Buchanan without so        much       as    a
@@ -4778,8 +4778,8 @@
 # NPl+  . NPr/ISg+ V   NSg/I/C ISg+ V/J   ISgPl+ . NSg/VX ISgPl+ NSg/V    . . NSg/C ISgPl+ V    NPr    NPr/J/P NPr/V/J+ N🅪Sg/V+ .
 > After you    had gone  home     she  came    into my  room     and woke    me       up        , and said : “ What
 # JC/P  ISgPl+ V   V/J/P NSg/V/J+ ISg+ NSg/V/P P    D$+ NSg/V/J+ V/C NSg/V/J NPr/ISg+ NSg/V/J/P . V/C V/J  . . NSg/I+
-> Gatsby ? ” and when    I    described him  — I    was half       asleep — she  said in      the strangest
-# NPr    . . V/C NSg/I/C ISg+ V/J       ISg+ . ISg+ V   NSg/V/J/P+ J      . ISg+ V/J  NPr/J/P D+  JS+
+> Gatsby ? ” and when    I    described him  — I    was half        asleep — she  said in      the strangest
+# NPr    . . V/C NSg/I/C ISg+ V/J       ISg+ . ISg+ V   N🅪Sg/V/J/P+ J      . ISg+ V/J  NPr/J/P D+  JS+
 > voice  that          it       must  be     the man     she  used to know  . It       wasn’t until then    that         I
 # NSg/V+ NSg/I/C/Ddem+ NPr/ISg+ NSg/V NSg/VX D   NPr/V/J ISg+ V/J  P+ NSg/V . NPr/ISg+ V      C/P   NSg/J/C NSg/I/C/Ddem ISg+
 > connected this    Gatsby with the officer in      her     white    car .
@@ -4787,7 +4787,7 @@
 >
 #
 > When    Jordan Baker had finished telling all          this    we   had left    the Plaza for half
-# NSg/I/C NPr    NPr   V   V/J      NSg/V/J NSg/I/J/C/Dq I/Ddem+ IPl+ V   NPr/V/J D+  NSg   C/P NSg/V/J/P+
+# NSg/I/C NPr    NPr   V   V/J      NSg/V/J NSg/I/J/C/Dq I/Ddem+ IPl+ V   NPr/V/J D+  NSg   C/P N🅪Sg/V/J/P+
 > an   hour and were  driving in      a   victoria through Central Park   . The sun    had gone
 # D/P+ NSg+ V/C NSg/V V       NPr/J/P D/P NPr      NSg/J/P NPr/J+  NPr/V+ . D+  NPr/V+ V   V/J/P
 > down      behind  the tall  apartments of the movie stars in      the West     Fifties , and the
@@ -4870,8 +4870,8 @@
 # . NPr/V . .
 >
 #
-> “ I    think he       half       expected her     to wander into one       of his     parties , some      night   , ”
-# . ISg+ NSg/V NPr/ISg+ NSg/V/J/P+ NSg/V/J  ISg/D$+ P  NSg/V  P    NSg/I/V/J P  ISg/D$+ NPl/V+  . I/J/R/Dq+ N🅪Sg/V+ . .
+> “ I    think he       half        expected her     to wander into one       of his     parties , some      night   , ”
+# . ISg+ NSg/V NPr/ISg+ N🅪Sg/V/J/P+ NSg/V/J  ISg/D$+ P  NSg/V  P    NSg/I/V/J P  ISg/D$+ NPl/V+  . I/J/R/Dq+ N🅪Sg/V+ . .
 > went  on  Jordan , “ but     she  never did . Then    he       began asking people casually if    they
 # NSg/V J/P NPr    . . NSg/C/P ISg+ R     V   . NSg/J/C NPr/ISg+ V     V      NSg/V+ R        NSg/C IPl+
 > knew her     , and I    was the first   one       he       found  . It       was that          night   he       sent  for me       at
@@ -5206,8 +5206,8 @@
 # . P  NSg/V  . P  NSg/V+ . W?      NSg/V/J . . V/C NPr/ISg+ V/J   R        . . . . . NSg/J+ NSg/V+ . .
 >
 #
-> The rain  cooled about half       - past      three to a   damp      mist    , through which occasional
-# D+  NSg/V V/J    J/P   NSg/V/J/P+ . NSg/V/J/P NSg   P  D/P NᴹSg/V/J+ N🅪Sg/V+ . NSg/J/P I/C+  NSg/J
+> The rain  cooled about half        - past      three to a   damp      mist    , through which occasional
+# D+  NSg/V V/J    J/P   N🅪Sg/V/J/P+ . NSg/V/J/P NSg   P  D/P NᴹSg/V/J+ N🅪Sg/V+ . NSg/J/P I/C+  NSg/J
 > thin    drops  swam like        dew     . Gatsby looked with vacant eyes  through a   copy  of
 # NSg/V/J NPl/V+ V    NSg/V/J/C/P N🅪Sg/V+ . NPr    V/J    P    J      NPl/V NSg/J/P D/P NSg/V P
 > Clay’s “ Economics , ” starting at    the Finnish tread that          shook   the kitchen floor  ,
@@ -5322,8 +5322,8 @@
 # C/P     D+  NSg/V/J+   NSg/V+ .
 >
 #
-> For half       a    minute   there wasn’t a   sound    . Then    from the living   - room    I    heard a   sort
-# C/P NSg/V/J/P+ D/P+ NSg/V/J+ +     V      D/P NSg/V/J+ . NSg/J/C P    D   NSg/V/J+ . NSg/V/J ISg+ V/J   D/P NSg/V
+> For half        a    minute   there wasn’t a   sound    . Then    from the living   - room    I    heard a   sort
+# C/P N🅪Sg/V/J/P+ D/P+ NSg/V/J+ +     V      D/P NSg/V/J+ . NSg/J/C P    D   NSg/V/J+ . NSg/V/J ISg+ V/J   D/P NSg/V
 > of choking murmur and part    of a    laugh  , followed by      Daisy’s voice  on  a   clear
 # P  V       NSg/V  V/C NSg/V/J P  D/P+ NSg/V+ . V/J      NSg/J/P NSg$    NSg/V+ J/P D/P NSg/V/J
 > artificial note   :
@@ -5472,8 +5472,8 @@
 #
 > I    walked out         the back     way    — just as    Gatsby had when    he       had made his     nervous
 # ISg+ V/J    NSg/V/J/R/P D+  NSg/V/J+ NSg/J+ . V/J  NSg/R NPr    V   NSg/I/C NPr/ISg+ V   V    ISg/D$+ J
-> circuit of the house  half       an   hour before — and ran   for a   huge black   knotted tree   ,
-# NSg/V   P  D+  NPr/V+ NSg/V/J/P+ D/P+ NSg+ C/P    . V/C NSg/V C/P D/P J    NSg/V/J V/J     NSg/V+ .
+> circuit of the house  half        an   hour before — and ran   for a   huge black   knotted tree   ,
+# NSg/V   P  D+  NPr/V+ N🅪Sg/V/J/P+ D/P+ NSg+ C/P    . V/C NSg/V C/P D/P J    NSg/V/J V/J     NSg/V+ .
 > whose massed leaves made a   fabric against the rain   . Once  more         it       was pouring ,
 # I+    V/J    NPl/V+ V    D/P NSg/V  C/P     D   NSg/V+ . NSg/C NPr/I/V/J/Dq NPr/ISg+ V   V       .
 > and my  irregular lawn   , well    - shaved by      Gatsby’s gardener , abounded in      small   muddy
@@ -5482,8 +5482,8 @@
 # NPl/V  V/C J+          NPl+    . +     V   NSg/I/J P  NSg/V NSg/P P    NSg/J/P D+  NSg/V+
 > except Gatsby’s enormous house  , so        I    stared at    it       , like        Kant at    his     church
 # V/C/P  NSg$     J+       NPr/V+ . NSg/I/J/C ISg+ V/J    NSg/P NPr/ISg+ . NSg/V/J/C/P NPr+ NSg/P ISg/D$+ NPr/V+
-> steeple , for half       an   hour . A    brewer had built   it       early   in      the “ period   ” craze , a
-# NSg/V   . C/P NSg/V/J/P+ D/P+ NSg+ . D/P+ NPr+   V   NSg/V/J NPr/ISg+ NSg/J/R NPr/J/P D   . NSg/V/J+ . NSg/V . D/P+
+> steeple , for half        an   hour . A    brewer had built   it       early   in      the “ period   ” craze , a
+# NSg/V   . C/P N🅪Sg/V/J/P+ D/P+ NSg+ . D/P+ NPr+   V   NSg/V/J NPr/ISg+ NSg/J/R NPr/J/P D   . NSg/V/J+ . NSg/V . D/P+
 > decade before , and there was a    story  that          he’d agreed to pay     five years ’ taxes
 # NSg+   C/P    . V/C +     V   D/P+ NSg/V+ NSg/I/C/Ddem+ W?   V/J    P  NSg/V/J NSg  NPl+  . NPl/V+
 > on  all          the neighboring cottages if    the owners would have   their roofs  thatched
@@ -5498,8 +5498,8 @@
 # NPl   . NSg/VX R      NSg/V J         J/P+  NSg/V/C+ N🅪Sg      .
 >
 #
-> After half       an   hour , the sun    shone again , and the grocer’s automobile rounded
-# JC/P  NSg/V/J/P+ D/P+ NSg+ . D+  NPr/V+ V     P     . V/C D   NSg$     NSg/V/J    V/J
+> After half        an   hour , the sun    shone again , and the grocer’s automobile rounded
+# JC/P  N🅪Sg/V/J/P+ D/P+ NSg+ . D+  NPr/V+ V     P     . V/C D   NSg$     NSg/V/J    V/J
 > Gatsby’s drive with the raw     material for his     servants ’ dinner — I    felt    sure he
 # NSg$     NSg/V P    D   NSg/V/J NSg/V/J  C/P ISg/D$+ NPl/V+   . NSg/V+ . ISg+ NSg/V/J J    NPr/ISg+
 > wouldn’t eat a    spoonful . A    maid began opening the upper windows of his     house  ,
@@ -5602,8 +5602,8 @@
 #
 > “ I    did , old    sport  , ” he       said automatically , “ but     I    lost most       of it       in      the big
 # . ISg+ V   . NSg/J+ NSg/V+ . . NPr/ISg+ V/J  W?            . . NSg/C/P ISg+ V/J  NSg/I/J/Dq P  NPr/ISg+ NPr/J/P D+  NSg/V/J
-> panic    — the panic   of the war    . ”
-# NSg/V/J+ . D   NSg/V/J P  D+  NSg/V+ . .
+> panic    — the panic   of the war     . ”
+# NSg/V/J+ . D   NSg/V/J P  D+  N🅪Sg/V+ . .
 >
 #
 > I    think he      hardly knew what   he       was saying , for when    I    asked him  what   business he
@@ -5799,7 +5799,7 @@
 >
 #
 > I    began to walk  about the room     , examining various indefinite objects in      the half
-# ISg+ V     P  NSg/V J/P   D+  NSg/V/J+ . V         J       NSg/J      NPl/V   NPr/J/P D+  NSg/V/J/P+
+# ISg+ V     P  NSg/V J/P   D+  NSg/V/J+ . V         J       NSg/J      NPl/V   NPr/J/P D+  N🅪Sg/V/J/P+
 > darkness . A   large photograph of an  elderly man     in      yachting costume attracted me       ,
 # NSg+     . D/P NSg/J NSg/V      P  D/P R       NPr/V/J NPr/J/P NSg/V    NSg/V   V/J       NPr/ISg+ .
 > hung    on  the wall   over      his     desk   .
@@ -6060,8 +6060,8 @@
 # N🅪Sg      NPr/J/P D/P V/J  NPr/V/J NPr+   V/C D/P NSg/V P  NSg/V+ NPl/V+ . NSg/C/P NPr/ISg+ V   W?
 > Jay  Gatsby who    borrowed a   rowboat , pulled out         to the Tuolomee , and informed Cody
 # NPr+ NPr    NPr/I+ V/J      D/P NSg/V   . V/J    NSg/V/J/R/P P  D   ?        . V/C V/J      NPr
-> that         a    wind   might     catch him  and break  him  up        in      half       an  hour .
-# NSg/I/C/Ddem D/P+ NSg/V+ NᴹSg/VX/J NSg/V ISg+ V/C NSg/V+ ISg+ NSg/V/J/P NPr/J/P NSg/V/J/P+ D/P NSg+ .
+> that         a    wind   might     catch him  and break  him  up        in      half        an  hour .
+# NSg/I/C/Ddem D/P+ NSg/V+ NᴹSg/VX/J NSg/V ISg+ V/C NSg/V+ ISg+ NSg/V/J/P NPr/J/P N🅪Sg/V/J/P+ D/P NSg+ .
 >
 #
 > I    suppose he’d had the name   ready   for a    long     time      , even     then    . His     parents were
@@ -6088,8 +6088,8 @@
 # NPr/J    NSg/R D/P NSg/V/J . NSg    V/C D/P NSgPl/V/J+ . NPr    NPr/C NPr/J/P I/R/Dq+ NSg/V/J+ NSg/J+   NSg/I/C/Ddem+
 > brought him  food and bed      . His     brown   , hardening body   lived naturally through the
 # V       ISg+ NSg  V/C NSg/V/J+ . ISg/D$+ NPr/V/J . V         NSg/V+ V/J   R         NSg/J/P D
-> half       - fierce , half       - lazy    work  of the bracing days . He       knew women early   , and since
-# NSg/V/J/P+ . J      . NSg/V/J/P+ . NSg/V/J NSg/V P  D+  V+      NPl+ . NPr/ISg+ V    NPl+  NSg/J/R . V/C C/P
+> half        - fierce , half        - lazy    work  of the bracing days . He       knew women early   , and since
+# N🅪Sg/V/J/P+ . J      . N🅪Sg/V/J/P+ . NSg/V/J NSg/V P  D+  V+      NPl+ . NPr/ISg+ V    NPl+  NSg/J/R . V/C C/P
 > they spoiled him  he       became contemptuous of them     , of young   virgins because they
 # IPl+ V/J     ISg+ NPr/ISg+ V      J            P  NSg/IPl+ . P  NPr/V/J NPl     C/P     IPl+
 > were  ignorant , of the others because they were  hysterical about things which in
@@ -6584,8 +6584,8 @@
 # NPr+  V/C NPr+   V/J    . ISg+ NSg/V    NSg/V/C V/J       NSg/J/P ISg/D$+ J        .
 > conservative fox    - trot  — I    had never seen  him  dance before . Then    they sauntered
 # NSg/J        NPr/V+ . NSg/V . ISg+ V   R     NSg/V ISg+ NSg/V C/P+   . NSg/J/C IPl+ V/J
-> over      to my  house  and sat     on  the steps for half       an  hour , while     at    her     request I
-# NSg/V/J/P P  D$+ NPr/V+ V/C NSg/V/J J/P D   NPl/V C/P NSg/V/J/P+ D/P NSg+ . NSg/V/C/P NSg/P ISg/D$+ NSg/V+  ISg+
+> over      to my  house  and sat     on  the steps for half        an  hour , while     at    her     request I
+# NSg/V/J/P P  D$+ NPr/V+ V/C NSg/V/J J/P D   NPl/V C/P N🅪Sg/V/J/P+ D/P NSg+ . NSg/V/C/P NSg/P ISg/D$+ NSg/V+  ISg+
 > remained watchfully in      the garden   . “ In      case   there’s a   fire     or    a    flood  , ” she
 # V/J      R          NPr/J/P D+  NSg/V/J+ . . NPr/J/P NPr/V+ W?      D/P N🅪Sg/V/J NPr/C D/P+ NSg/V+ . . ISg+
 > explained , ‘          ‘          or    any    act   of God   . ”
@@ -6604,8 +6604,8 @@
 # . NSg/V/J W?    . . V/J      NPr+  R        . . V/C NSg/C ISgPl+ NSg/V P  NSg/V NSg/V/J/P I/R/Dq+ NPl/V+
 > here’s my  little      gold      pencil . ” . . . She  looked around after a    moment and told
 # W?     D$+ NPr/I/J/Dq+ NᴹSg/V/J+ NSg/V+ . . . . . ISg+ V/J    J/P    JC/P  D/P+ NSg+   V/C V
-> me       the girl   was “ common  but     pretty  , ” and I    knew that         except for the half       - hour
-# NPr/ISg+ D+  NSg/V+ V   . NSg/V/J NSg/C/P NSg/V/J . . V/C ISg+ V    NSg/I/C/Ddem V/C/P  C/P D   NSg/V/J/P+ . NSg
+> me       the girl   was “ common  but     pretty  , ” and I    knew that         except for the half        - hour
+# NPr/ISg+ D+  NSg/V+ V   . NSg/V/J NSg/C/P NSg/V/J . . V/C ISg+ V    NSg/I/C/Ddem V/C/P  C/P D   N🅪Sg/V/J/P+ . NSg
 > she’d been  alone with Gatsby she  wasn’t having a    good     time      .
 # W?    NSg/V J     P    NPr    ISg+ V      V      D/P+ NPr/V/J+ N🅪Sg/V/J+ .
 >
@@ -7034,8 +7034,8 @@
 #
 > My  Finn informed me       that         Gatsby had dismissed every servant in      his     house a    week
 # D$+ NPr+ V/J      NPr/ISg+ NSg/I/C/Ddem NPr    V   V/J       Dq+   NSg/V+  NPr/J/P ISg/D$+ NPr/V D/P+ NSg/J+
-> ago and replaced them     with half       a   dozen others , who    never went  into West     Egg
-# J/P V/C V/J      NSg/IPl+ P+   NSg/V/J/P+ D/P NSg   NPl/V+ . NPr/I+ R     NSg/V P    NPr/V/J+ N🅪Sg/V+
+> ago and replaced them     with half        a   dozen others , who    never went  into West     Egg
+# J/P V/C V/J      NSg/IPl+ P+   N🅪Sg/V/J/P+ D/P NSg   NPl/V+ . NPr/I+ R     NSg/V P    NPr/V/J+ N🅪Sg/V+
 > Village to be     bribed by      the tradesmen , but     ordered moderate supplies over      the
 # NSg+    P  NSg/VX V/J    NSg/J/P D   NPl       . NSg/C/P V/J     NSg/V/J  NPl/V    NSg/V/J/P D+
 > telephone . The grocery boy    reported that         the kitchen looked like        a    pigsty , and
@@ -7086,8 +7086,8 @@
 #
 > He       was calling up        at    Daisy’s request — would I    come    to lunch at    her    house
 # NPr/ISg+ V   NSg/V   NSg/V/J/P NSg/P NSg$    NSg/V+  . VX    ISg+ NSg/V/P P  NSg/V NSg/P ISg/D$ NPr/V+
-> to - morrow ? Miss  Baker would be      there . Half       an   hour later Daisy herself
-# P  . NPr/V  . NSg/V NPr+  VX+   NSg/VX+ W?    . NSg/V/J/P+ D/P+ NSg+ JC    NPr   ISg+
+> to - morrow ? Miss  Baker would be      there . Half        an   hour later Daisy herself
+# P  . NPr/V  . NSg/V NPr+  VX+   NSg/VX+ W?    . N🅪Sg/V/J/P+ D/P+ NSg+ JC    NPr   ISg+
 > telephoned and seemed relieved to find  that         I    was coming  . Something  was up        . And
 # V/J        V/C V/J    V/J      P  NSg/V NSg/I/C/Ddem ISg+ V+  NSg/V/J . NSg/I/V/J+ V+  NSg/V/J/P . V/C
 > yet     I    couldn’t believe that         they would choose  this    occasion for a
@@ -7593,7 +7593,7 @@
 >
 #
 > Tom    came    out         of the house  wrapping a   quart    bottle in      a    towel  , followed by      Daisy
-# NPr/V+ NSg/V/P NSg/V/J/R/P P  D+  NPr/V+ NSg/V+   D/P NSg/V/J+ NSg/V  NPr/J/P D/P+ NSg/V+ . V/J      NSg/J/P NPr
+# NPr/V+ NSg/V/P NSg/V/J/R/P P  D+  NPr/V+ N🅪Sg/V+  D/P NSg/V/J+ NSg/V  NPr/J/P D/P+ NSg/V+ . V/J      NSg/J/P NPr
 > and Jordan wearing small   tight hats  of metallic cloth and carrying light    capes
 # V/C NPr+   V       NPr/V/J V/J   NPl/V P  NSg/J    NSg+  V/C V        NSg/V/J+ NPl/V
 > over      their arms   .
@@ -7683,7 +7683,7 @@
 > a   — almost a    second   sight  , sometimes , that          tells me       what   to do     . Maybe   you    don’t
 # D/P . NSg    D/P+ NSg/V/J+ NSg/V+ . R         . NSg/I/C/Ddem+ NPl/V NPr/ISg+ NSg/I+ P  NSg/VX . NSg/J/R ISgPl+ V
 > believe that          , but     science — — — ”
-# V       NSg/I/C/Ddem+ . NSg/C/P NSg/V+  . . . .
+# V       NSg/I/C/Ddem+ . NSg/C/P N🅪Sg/V+ . . . .
 >
 #
 > He       paused . The immediate contingency overtook him  , pulled him  back    from the edge
@@ -7793,7 +7793,7 @@
 >
 #
 > With an   effort Wilson left    the shade  and support of the doorway and , breathing
-# P    D/P+ NSg/V+ NPr+   NPr/V/J D+  N🅪Sg/V V/C NSg/V   P  D+  NSg+    V/C . NSg/V
+# P    D/P+ NSg/V+ NPr+   NPr/V/J D+  N🅪Sg/V V/C N🅪Sg/V  P  D+  NSg+    V/C . NSg/V
 > hard   , unscrewed the cap   of the tank   . In      the sunlight his     face   was green   .
 # N🅪Sg/J . V/J       D   NPr/V P  D+  NSg/V+ . NPr/J/P D+  NSg/V+   ISg/D$+ NSg/V+ V+  NPr/V/J .
 >
@@ -7964,8 +7964,8 @@
 # . W?   NSg/I/J/C NSg/V/J . . ISg+ V/J+       . . ISgPl+ NSg/V/J+ . W?    NSg/V+ J/P    V/C NSg/V/J ISgPl+ JC/P+ . .
 > With an   effort her     wit      rose    faintly , “ We’ll meet    you    on  some      corner . I'll be     the
 # P    D/P+ NSg/V+ ISg/D$+ NSg/V/P+ NPr/V/J R       . . W?    NSg/V/J ISgPl+ J/P I/J/R/Dq+ NSg/V+ . W?   NSg/VX D
-> man     smoking  two  cigarettes . ”
-# NPr/V/J NSg/V/J+ NSg+ NPl/V+     . .
+> man     smoking   two  cigarettes . ”
+# NPr/V/J NᴹSg/V/J+ NSg+ NPl/V+     . .
 >
 #
 > “ We   can’t argue about it       here    , ” Tom    said impatiently , as    a   truck  gave out         a
@@ -8579,7 +8579,7 @@
 >
 #
 > “ Nonsense . ”
-# . NSg/V/J  . .
+# . NᴹSg/V/J . .
 >
 #
 > “ I    am      , though , ” she  said with a    visible effort .
@@ -8717,7 +8717,7 @@
 >
 #
 > After a   moment Tom    got up        and began wrapping the unopened bottle of whiskey in
-# JC/P  D/P NSg+   NPr/V+ V   NSg/V/J/P V/C V     NSg/V+   D   V/J      NSg/V  P  NSg     NPr/J/P
+# JC/P  D/P NSg+   NPr/V+ V   NSg/V/J/P V/C V     N🅪Sg/V+  D   V/J      NSg/V  P  NSg     NPr/J/P
 > the towel  .
 # D+  NSg/V+ .
 >
@@ -9016,8 +9016,8 @@
 #
 > “ One       goin ’ each way    . Well    , she  ” — his     hand   rose    toward the blankets but     stopped
 # . NSg/I/V/J ?    . Dq   NSg/J+ . NSg/V/J . ISg+ . . ISg/D$+ NSg/V+ NPr/V/J J/P    D+  NPl/V+   NSg/C/P V/J
-> half       way    and fell    to his     side     — “ she  ran   out         there an  ’ the one       comin ’ from N’York
-# NSg/V/J/P+ NSg/J+ V/C NSg/V/J P  ISg/D$+ NSg/V/J+ . . ISg+ NSg/V NSg/V/J/R/P +     D/P . D   NSg/I/V/J ?     . P    ?
+> half        way    and fell    to his     side     — “ she  ran   out         there an  ’ the one       comin ’ from N’York
+# N🅪Sg/V/J/P+ NSg/J+ V/C NSg/V/J P  ISg/D$+ NSg/V/J+ . . ISg+ NSg/V NSg/V/J/R/P +     D/P . D   NSg/I/V/J ?     . P    ?
 > knock right   into her     , goin ’ thirty or    forty miles  an   hour . ”
 # NSg/V NPr/V/J P    ISg/D$+ . ?    . NSg    NPr/C NSg/J NPrPl+ D/P+ NSg+ . .
 >
@@ -9156,8 +9156,8 @@
 # NSg/I/V/J . R           . P    ISg/D$+ J+            NPl/V+ V        D+  NSg/J+ . IPl+ V/J
 > through the still   gathering crowd , passing a   hurried doctor , case  in      hand   , who
 # NSg/J/P D   NSg/V/J NSg/V/J   NSg/V . NSg/V/J D/P V/J     NSg/V+ . NPr/V NPr/J/P NSg/V+ . NPr/I+
-> had been  sent  for in      wild    hope   half       an   hour ago  .
-# V   NSg/V NSg/V C/P NPr/J/P NSg/V/J NPr🅪/V NSg/V/J/P+ D/P+ NSg+ J/P+ .
+> had been  sent  for in      wild    hope   half        an   hour ago  .
+# V   NSg/V NSg/V C/P NPr/J/P NSg/V/J NPr🅪/V N🅪Sg/V/J/P+ D/P+ NSg+ J/P+ .
 >
 #
 > Tom    drove slowly until we   were  beyond the bend   — then    his     foot   came    down      hard   , and
@@ -9230,8 +9230,8 @@
 # NSg+   NPr/I/V/J/Dq+ .
 >
 #
-> “ It’s only  half       - past       nine , ” she  said .
-# . W?   J/R/C NSg/V/J/P+ . NSg/V/J/P+ NSg  . . ISg+ V/J+ .
+> “ It’s only  half        - past       nine , ” she  said .
+# . W?   J/R/C N🅪Sg/V/J/P+ . NSg/V/J/P+ NSg  . . ISg+ V/J+ .
 >
 #
 > I’d be     damned if    I’d go      in      ; I’d had enough of all          of them     for one        day   , and
@@ -9472,8 +9472,8 @@
 #
 > I    couldn’t sleep  all           night   ; a   fog    - horn  was groaning incessantly on  the Sound    ,
 # ISg+ V        N🅪Sg/V NSg/I/J/C/Dq+ N🅪Sg/V+ . D/P NSg/V+ . NPr/V V   V        R           J/P D+  NSg/V/J+ .
-> and I    tossed half       - sick    between grotesque reality and savage   , frightening dreams .
-# V/C ISg+ V/J    NSg/V/J/P+ . NSg/V/J NSg/P   NSg/J     NSg     V/C NPr/V/J+ . V/J+        NPl/V+ .
+> and I    tossed half        - sick    between grotesque reality and savage   , frightening dreams .
+# V/C ISg+ V/J    N🅪Sg/V/J/P+ . NSg/V/J NSg/P   NSg/J     NSg     V/C NPr/V/J+ . V/J+        NPl/V+ .
 > Toward dawn   I    heard a   taxi   go      up        Gatsby’s drive , and immediately I    jumped out         of
 # J/P    NPr/V+ ISg+ V/J   D/P NSg/V+ NSg/V/J NSg/V/J/P NSg$     NSg/V . V/C R           ISg+ V/J    NSg/V/J/R/P P
 > bed      and began to dress — I    felt    that         I    had something  to tell  him  , something  to
@@ -9508,8 +9508,8 @@
 # NSg/R V/C    IPl+ V      NSg/V V/J   C/P NSg/I/J/Dq+ NPl+ . ISg+ NSg/V D   NSg     J/P D/P
 > unfamiliar table  , with two stale   , dry      cigarettes inside   . Throwing open    the
 # NSg/J+     NSg/V+ . P    NSg NSg/V/J . NSg/V/J+ NPl/V+     NSg/J/P+ . V        NSg/V/J D
-> French  windows of the drawing - room    , we   sat     smoking  out         into the darkness .
-# NPr/V/J NPrPl/V P  D   NSg/V+  . NSg/V/J . IPl+ NSg/V/J NSg/V/J+ NSg/V/J/R/P P    D+  NSg+     .
+> French   windows of the drawing - room    , we   sat     smoking   out         into the darkness .
+# NPr🅪/V/J NPrPl/V P  D   NSg/V+  . NSg/V/J . IPl+ NSg/V/J NᴹSg/V/J+ NSg/V/J/R/P P    D+  NSg+     .
 >
 #
 > “ You    ought    to go      away , ” I    said . “ It’s pretty  certain they'll trace  your car  . ”
@@ -9672,8 +9672,8 @@
 # NSg/V+ J      .
 >
 #
-> He       did extraordinarily well    in      the war    . He       was a   captain before he       went  to the
-# NPr/ISg+ V   R               NSg/V/J NPr/J/P D+  NSg/V+ . NPr/ISg+ V   D/P NSg/V   C/P    NPr/ISg+ NSg/V P  D+
+> He       did extraordinarily well    in      the war     . He       was a   captain before he       went  to the
+# NPr/ISg+ V   R               NSg/V/J NPr/J/P D+  N🅪Sg/V+ . NPr/ISg+ V   D/P NSg/V   C/P    NPr/ISg+ NSg/V P  D+
 > front    , and following the Argonne battles he       got his     majority and the command of
 # NSg/V/J+ . V/C NSg/V/J/P D+  NPr+    NPl/V+  NPr/ISg+ V   ISg/D$+ NSg+     V/C D   NSg/V   P
 > the divisional machine - guns  . After the armistice he       tried frantically to get
@@ -9710,8 +9710,8 @@
 #
 > Through this    twilight universe Daisy began to move  again with the season ;
 # NSg/J/P I/Ddem+ NSg/V/J+ NPr+     NPr+  V     P  NSg/V P     P    D+  NSg/V+ .
-> suddenly she  was again keeping half       a   dozen dates  a   day  with half       a   dozen men  ,
-# R        ISg+ V   P     NSg/V   NSg/V/J/P+ D/P NSg   NPl/V+ D/P NPr🅪 P    NSg/V/J/P+ D/P NSg   NSg+ .
+> suddenly she  was again keeping half        a   dozen dates  a   day  with half        a   dozen men  ,
+# R        ISg+ V   P     NSg/V   N🅪Sg/V/J/P+ D/P NSg   NPl/V+ D/P NPr🅪 P    N🅪Sg/V/J/P+ D/P NSg   NSg+ .
 > and drowsing asleep at    dawn  with the beads and chiffon of an   evening dress
 # V/C V        J      NSg/P NPr/V P    D+  NPl/V V/C NSg     P  D/P+ N🅪Sg/V+ NSg/V+
 > tangled among dying   orchids on  the floor  beside her     bed      . And all          the time
@@ -9831,7 +9831,7 @@
 > It       was nine o’clock when    we   finished breakfast and went  out         on  the porch . The
 # NPr/ISg+ V   NSg  W?      NSg/I/C IPl+ V/J      NSg/V+    V/C NSg/V NSg/V/J/R/P J/P D+  NSg+  . D+
 > night   had made a   sharp   difference in      the weather  and there was an  autumn flavor
-# N🅪Sg/V+ V   V    D/P NPr/V/J N🅪Sg/V     NPr/J/P D   NᴹSg/V/J V/C +     V   D/P NPr/V+ NSg/V/Am
+# N🅪Sg/V+ V   V    D/P NPr/V/J N🅪Sg/V     NPr/J/P D   NᴹSg/V/J V/C +     V   D/P NPr/V+ N🅪Sg/V/Am
 > in      the air    . The gardener , the last    one       of Gatsby’s former servants , came    to the
 # NPr/J/P D+  NSg/V+ . D   NSg/JC   . D   NSg/V/J NSg/I/V/J P  NSg$     NSg/J+ NPl/V+   . NSg/V/P P  D
 > foot  of the steps  .
@@ -10152,8 +10152,8 @@
 #
 > The effort of answering broke   the rhythm of his     rocking — for a    moment he       was
 # D   NSg/V  P  V         NSg/V/J D   NSg/V  P  ISg/D$+ V       . C/P D/P+ NSg+   NPr/ISg+ V
-> silent . Then    the same half      - knowing   , half       - bewildered look  came    back    into his
-# NSg/J+ . NSg/J/C D   I/J+ NSg/V/J/P . NSg/V/J/P . NSg/V/J/P+ . V/J        NSg/V NSg/V/P NSg/V/J P    ISg/D$+
+> silent . Then    the same half       - knowing   , half        - bewildered look  came    back    into his
+# NSg/J+ . NSg/J/C D   I/J+ N🅪Sg/V/J/P . NSg/V/J/P . N🅪Sg/V/J/P+ . V/J        NSg/V NSg/V/P NSg/V/J P    ISg/D$+
 > faded eyes   .
 # J     NPl/V+ .
 >
@@ -10358,8 +10358,8 @@
 # NSg/V/J P    NSg/V+ P  NSg/V  W?         . NSg/V/J   C/P D/P NSg/V/J+ NSg+ . J/P D+  NSg/V/J+
 > hand   , no     garage man      who    had seen  him  ever came    forward , and perhaps he       had an
 # NSg/V+ . NPr/P+ NSg/V+ NPr/V/J+ NPr/I+ V   NSg/V ISg+ J    NSg/V/P NSg/V/J . V/C NSg     NPr/ISg+ V   D/P
-> easier , surer way   of finding out         what   he       wanted to know  . By      half       - past      two  he       was
-# NSg/JC . JC    NSg/J P  NSg/V   NSg/V/J/R/P NSg/I+ NPr/ISg+ V/J    P+ NSg/V . NSg/J/P NSg/V/J/P+ . NSg/V/J/P NSg+ NPr/ISg+ V
+> easier , surer way   of finding out         what   he       wanted to know  . By      half        - past      two  he       was
+# NSg/JC . JC    NSg/J P  NSg/V   NSg/V/J/R/P NSg/I+ NPr/ISg+ V/J    P+ NSg/V . NSg/J/P N🅪Sg/V/J/P+ . NSg/V/J/P NSg+ NPr/ISg+ V
 > in      West    Egg     , where he       asked some      one        the way    to Gatsby’s house  . So        by      that          time
 # NPr/J/P NPr/V/J N🅪Sg/V+ . NSg/C NPr/ISg+ V/J   I/J/R/Dq+ NSg/I/V/J+ D+  NSg/J+ P  NSg$     NPr/V+ . NSg/I/J/C NSg/J/P NSg/I/C/Ddem+ N🅪Sg/V/J+
 > he       knew Gatsby’s name   .
@@ -10514,8 +10514,8 @@
 # NSg/V+ .
 >
 #
-> I    called up        Daisy half       an  hour after we   found him  , called her     instinctively and
-# ISg+ V/J    NSg/V/J/P NPr+  NSg/V/J/P+ D/P NSg  JC/P  IPl+ NSg/V ISg+ . V/J    ISg/D$+ R             V/C
+> I    called up        Daisy half        an  hour after we   found him  , called her     instinctively and
+# ISg+ V/J    NSg/V/J/P NPr+  N🅪Sg/V/J/P+ D/P NSg  JC/P  IPl+ NSg/V ISg+ . V/J    ISg/D$+ R             V/C
 > without hesitation . But     she  and Tom    had gone  away early   that         afternoon , and
 # C/P     NSg+       . NSg/C/P ISg+ V/C NPr/V+ V   V/J/P V/J  NSg/J/R NSg/I/C/Ddem N🅪Sg+     . V/C
 > taken baggage with them     .
@@ -11006,8 +11006,8 @@
 #
 > “ My  memory goes  back    to when    first   I    met him  , ” he       said . “ A   young   major   just out
 # . D$+ N🅪Sg+  NPl/V NSg/V/J P  NSg/I/C NSg/V/J ISg+ V   ISg+ . . NPr/ISg+ V/J+ . . D/P NPr/V/J NPr/V/J V/J  NSg/V/J/R/P
-> of the army and covered over      with medals he       got in      the war    . He       was so        hard   up        he
-# P  D+  NSg+ V/C V/J     NSg/V/J/P P    NPl/V+ NPr/ISg+ V   NPr/J/P D+  NSg/V+ . NPr/ISg+ V   NSg/I/J/C N🅪Sg/J NSg/V/J/P NPr/ISg+
+> of the army and covered over      with medals he       got in      the war     . He       was so        hard   up        he
+# P  D+  NSg+ V/C V/J     NSg/V/J/P P    NPl/V+ NPr/ISg+ V   NPr/J/P D+  N🅪Sg/V+ . NPr/ISg+ V   NSg/I/J/C N🅪Sg/J NSg/V/J/P NPr/ISg+
 > had to keep  on  wearing his     uniform  because he       couldn’t buy   some      regular clothes .
 # V   P  NSg/V J/P V       ISg/D$+ NSg/V/J+ C/P     NPr/ISg+ V        NSg/V I/J/R/Dq+ NSg/J+  NPl/V+  .
 > First   time      I    saw   him  was when    he       come    into Winebrenner’s poolroom at    Forty - third
@@ -11016,8 +11016,8 @@
 # NSg/V/J V/C V/J   C/P D/P+ NPr/V+ . NPr/ISg+ V      V   NSg/I/V  C/P D/P NSg/V/J P  NPl+ . Unlintable NSg/V/P
 > on  have   some     lunch  with me       , ’ I    sid  . He       ate   more         than four dollars ’ worth   of food
 # J/P NSg/VX I/J/R/Dq NSg/V+ P    NPr/ISg+ . . ISg+ NPr+ . NPr/ISg+ NSg/V NPr/I/V/J/Dq C/P  NSg  NPl+    . NSg/V/J P  NSg+
-> in      half       an   hour . ”
-# NPr/J/P NSg/V/J/P+ D/P+ NSg+ . .
+> in      half        an   hour . ”
+# NPr/J/P N🅪Sg/V/J/P+ D/P+ NSg+ . .
 >
 #
 > “ Did you    start him  in      business ? ” I    inquired .
@@ -11242,8 +11242,8 @@
 # ISg/D$+ NPl/V+ V     P  NSg/V R         . V/C NPr/ISg+ NSg/V P  D+  NSg/V+ NPr/J/P D/P V/J     .
 > uncertain way    . The minister glanced several times at    his     watch , so        I    took him
 # I/J+      NSg/J+ . D+  NSg/V+   V/J     J/Dq    NPl/V NSg/P ISg/D$+ NSg/V . NSg/I/J/C ISg+ V    ISg+
-> aside and asked him  to wait  for half       an   hour . But     it       wasn’t any     use    . Nobody
-# NSg/J V/C V/J   ISg+ P  NSg/V C/P NSg/V/J/P+ D/P+ NSg+ . NSg/C/P NPr/ISg+ V      I/R/Dq+ NSg/V+ . NSg/I+
+> aside and asked him  to wait  for half        an   hour . But     it       wasn’t any     use    . Nobody
+# NSg/J V/C V/J   ISg+ P  NSg/V C/P N🅪Sg/V/J/P+ D/P+ NSg+ . NSg/C/P NPr/ISg+ V      I/R/Dq+ NSg/V+ . NSg/I+
 > came    .
 # NSg/V/P .
 >
@@ -11474,8 +11474,8 @@
 # N🅪Sg/V/Am+ . .
 >
 #
-> She  didn’t answer . Angry , and half       in      love   with her     , and tremendously sorry   , I
-# ISg+ V      NSg/V  . V/J   . V/C NSg/V/J/P+ NPr/J/P NPr🅪/V P    ISg/D$+ . V/C R            NSg/V/J . ISg+
+> She  didn’t answer . Angry , and half        in      love   with her     , and tremendously sorry   , I
+# ISg+ V      NSg/V  . V/J   . V/C N🅪Sg/V/J/P+ NPr/J/P NPr🅪/V P    ISg/D$+ . V/C R            NSg/V/J . ISg+
 > turned away .
 # V/J+   V/J+ .
 >
@@ -11620,8 +11620,8 @@
 # V/C/P  D   J       . NSg/V/J NSg/V P  D/P NSg       NSg/P  D+  NSg/V/J+ . V/C NSg/R D+  NPr/V+
 > rose    higher the inessential houses began to melt  away until gradually I    became
 # NPr/V/J NSg/JC D+  NSg/J+      NPl/V+ V     P  NSg/V V/J  C/P   R         ISg+ V
-> aware of the old    island here    that          flowered once  for Dutch   sailors ’ eyes   — a   fresh   ,
-# V/J   P  D+  NSg/J+ NSg/V+ NSg/J/R NSg/I/C/Ddem+ V/J      NSg/C C/P NPr/V/J NPl+    . NPl/V+ . D/P NSg/V/J .
+> aware of the old    island here    that          flowered once  for Dutch    sailors ’ eyes   — a   fresh   ,
+# V/J   P  D+  NSg/J+ NSg/V+ NSg/J/R NSg/I/C/Ddem+ V/J      NSg/C C/P NPrᴹ/V/J NPl+    . NPl/V+ . D/P NSg/V/J .
 > green   breast of the new      world  . Its     vanished trees  , the trees  that          had made way
 # NPr/V/J NSg/V  P  D+  NSg/V/J+ NSg/V+ . ISg/D$+ V/J      NPl/V+ . D+  NPl/V+ NSg/I/C/Ddem+ V   V    NSg/J
 > for Gatsby’s house  , had once  pandered in      whispers to the last    and greatest of

--- a/harper-core/tests/text/tagged/this and that.md
+++ b/harper-core/tests/text/tagged/this and that.md
@@ -1,5 +1,5 @@
-> " This    " and " that          " are common  and fulfill multiple purposes in      everyday English  .
-# . I/Ddem+ . V/C . NSg/I/C/Ddem+ . V   NSg/V/J V/C V/NoAm  NSg/J/Dq NPl/V    NPr/J/P NSg/J+   NPr/V/J+ .
+> " This    " and " that          " are common  and fulfill multiple purposes in      everyday English   .
+# . I/Ddem+ . V/C . NSg/I/C/Ddem+ . V   NSg/V/J V/C V/NoAm  NSg/J/Dq NPl/V    NPr/J/P NSg/J+   NPr🅪/V/J+ .
 > As    such  , disambiguating them     is  necessary .
 # NSg/R NSg/I . V              NSg/IPl+ VL+ NSg/J     .
 >


### PR DESCRIPTION
# Issues 
N/A

# Description

Marked mass nouns that came up in a PR review.

Updated the noun countability test to treat OOV similar to noun so as not to flag "Chinese lorem ipsum" after marking "Chinese" as a mass noun.


# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?

All tests now pass again.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
