### PR TITLE
fix: correct a/an before MP3

### DIFF
--- a/harper-core/src/linting/an_a.rs
+++ b/harper-core/src/linting/an_a.rs
@@ -96,7 +96,7 @@ fn to_lower_word(word: &[char]) -> Cow<'_, [char]> {
 /// Matches with 99.71% and 99.77% of vowels and non-vowels in the
 /// Carnegie-Mellon University word -> pronunciation dataset.
 fn starts_with_vowel(word: &[char]) -> bool {
-    let is_likely_initialism = word.iter().all(|c| c.is_uppercase());
+    let is_likely_initialism = word.iter().all(|c| !c.is_alphabetic() || c.is_uppercase());
 
     if is_likely_initialism && !word.is_empty() {
         return matches!(
@@ -278,5 +278,15 @@ mod tests {
     #[test]
     fn allow_issue_751() {
         assert_lint_count("He got a 52% approval rating.", AnA, 0);
+    }
+
+    #[test]
+    fn allow_an_mp_and_an_mp3() {
+        assert_lint_count("an MP and an MP3?", AnA, 0);
+    }
+
+    #[test]
+    fn disallow_a_mp_and_a_mp3() {
+        assert_lint_count("a MP and a MP3?", AnA, 2);
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

Harper was incorrectly marking "an MP3" to be changed to "a MP3".

It turns out its way of checking if a word in an initialism was to check if every character is uppercase.
I've changed it to check if every *letter* is uppercase.

(Note that the first character being a number is not affected by this since that would prevent the tokenizer from seeing it as a word.)

# Demo
Before:
<img width="413" height="70" alt="Screenshot 2025-07-22 at 3 01 35 pm" src="https://github.com/user-attachments/assets/ae59b60a-35a0-42e3-a75f-3d9fbafa12af" />

After:
<img width="413" height="74" alt="Screenshot 2025-07-22 at 3 21 09 pm" src="https://github.com/user-attachments/assets/868aec5f-eaf6-4483-be57-bfada5732f52" />

# How Has This Been Tested?

I added two new unit tests to enforce this. All existing tests still pass.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
