### PR TITLE
chore: add "investment into" to the "invest into" linter

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -197,10 +197,14 @@ pub fn lint_group() -> LintGroup {
         ),
         "InvestIn" => (
             &[
+                // Verb
                 ("invest into", "invest in"),
                 ("invested into", "invested in"),
                 ("investing into", "investing in"),
                 ("invests into", "invests in"),
+                // Noun
+                ("investment into", "investment in"),
+                // Note "investments into" can be correct in some contexts
             ],
             "Traditionally `invest` uses the preposition `in`.",
             "`Invest` is traditionally followed by 'in,' not `into.`",

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -391,6 +391,15 @@ fn corrects_invests_into() {
     );
 }
 
+#[test]
+fn corrects_investment_into() {
+    assert_suggestion_result(
+        "A $10,000 investment into the fund made on February 28, 1997 would have grown to a value of $42,650 at the end of the 20-year period.",
+        lint_group(),
+        "A $10,000 investment in the fund made on February 28, 1997 would have grown to a value of $42,650 at the end of the 20-year period.",
+    );
+}
+
 // MakeDoWith
 
 #[test]


### PR DESCRIPTION
# Issues 
N/A

# Description

Add "investment into" to the "invest into" linter.
But not "investments into" since that results in too many false positives.

# How Has This Been Tested?

I added a unit test using a sentence found on GitHub.com

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
