### PR TITLE
feat: correct "dose" as typo for "does"

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -115,6 +115,22 @@ pub fn lint_group() -> LintGroup {
             // or maybe Redundancy?
             LintKind::Usage
         ),
+        "DoesOrDose" => (
+            &[
+                // Negatives
+                ("dose not", "does not"),
+                // Pronouns, statement
+                ("he dose", "he does"),
+                ("it dose", "it does"),
+                ("she dose", "she does"),
+                ("someone dose", "someone does"),
+                // Pronouns, question
+                ("dose it", "does it"),
+            ],
+            "It looks like you meant `does`.",
+            "Corrects the typo `dose` to `does`.",
+            LintKind::Typo
+        ),
         "ExpandArgument" => (
             &[
                 ("arg", "argument"),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -166,6 +166,61 @@ fn corrects_definite_articles_lowercase() {
 // Discuss
 // -none-
 
+// DoesOrDose
+#[test]
+fn corrects_dose_not() {
+    assert_suggestion_result(
+        "It dose not run windows ?",
+        lint_group(),
+        "It does not run windows ?",
+    );
+}
+
+#[test]
+fn corrects_dose_it() {
+    assert_suggestion_result(
+        "dose it support zh_cn ？",
+        lint_group(),
+        "does it support zh_cn ？",
+    );
+}
+
+#[test]
+fn corrects_it_dose() {
+    assert_suggestion_result(
+        "it dose work without WEBP enabled",
+        lint_group(),
+        "it does work without WEBP enabled",
+    );
+}
+
+#[test]
+fn corrects_someone_dose() {
+    assert_suggestion_result(
+        "Hopefully someone dose, I'm not good at C programing....",
+        lint_group(),
+        "Hopefully someone does, I'm not good at C programing....",
+    );
+}
+
+#[test]
+fn corrects_she_does() {
+    assert_suggestion_result(
+        "we wont agree on everything she dose thats what a real person would feel like",
+        lint_group(),
+        "we wont agree on everything she does thats what a real person would feel like",
+    );
+}
+
+#[test]
+fn corrects_he_does() {
+    assert_suggestion_result(
+        "This validate each and every field of your from with nice dotted red color warring for the user, incase he dose some mistakes.",
+        lint_group(),
+        "This validate each and every field of your from with nice dotted red color warring for the user, incase he does some mistakes.",
+    );
+}
+
 // ExpandDependency
 // -none-
 


### PR DESCRIPTION
# Issues 

Fixes #484

# Description

Detects the most common(?) contexts when "dose" is a typo for "does".
Before or after certain pronouns and before "not".

# How Has This Been Tested?

I added a unit test for each variant I could find an instance of on GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
