### PR TITLE
refactor(core): span refactorings

### DIFF
--- a/harper-core/src/span.rs
+++ b/harper-core/src/span.rs
@@ -82,7 +82,7 @@ impl<T> Span<T> {
         (self.start < other.end) && (other.start < self.end)
     }
 
-    /// Get the associated content. Will return [`None`] if any aspect is
+    /// Get the associated content. Will return [`None`] if the span is non-empty and any aspect is
     /// invalid.
     pub fn try_get_content<'a>(&self, source: &'a [T]) -> Option<&'a [T]> {
         if self.is_empty() {

--- a/harper-core/src/span.rs
+++ b/harper-core/src/span.rs
@@ -155,13 +155,6 @@ impl<T> Span<T> {
         clone.end -= by;
         Some(clone)
     }
-
-    /// Add an amount to a copy of both [`Self::start`] and [`Self::end`]
-    pub fn with_offset(&self, by: usize) -> Self {
-        let mut clone = *self;
-        clone.push_by(by);
-        clone
-    }
 }
 
 /// Additional functions for types that implement [`std::fmt::Debug`] and [`Display`].

--- a/harper-core/src/span.rs
+++ b/harper-core/src/span.rs
@@ -85,14 +85,11 @@ impl<T> Span<T> {
     /// Get the associated content. Will return [`None`] if any aspect is
     /// invalid.
     pub fn try_get_content<'a>(&self, source: &'a [T]) -> Option<&'a [T]> {
-        if (self.start > self.end) || (self.start >= source.len()) || (self.end > source.len()) {
-            if self.is_empty() {
-                return Some(&source[0..0]);
-            }
-            return None;
+        if self.is_empty() {
+            Some(&source[0..0])
+        } else {
+            source.get(self.start..self.end)
         }
-
-        Some(&source[self.start..self.end])
     }
 
     /// Expand the span by either modifying [`Self::start`] or [`Self::end`] to include the target

--- a/harper-core/src/span.rs
+++ b/harper-core/src/span.rs
@@ -74,8 +74,6 @@ impl<T> Span<T> {
 
     /// Checks whether `idx` is within the range of the span.
     pub fn contains(&self, idx: usize) -> bool {
-        assert!(self.start <= self.end);
-
         self.start <= idx && idx < self.end
     }
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
Some minor code-quality changes in `harper-core/src/span.rs`.
<!-- Any details that you think are important to review this PR? -->
Though not the intended purpose of this PR, the changes in `Span::try_get_content()` also seem to improve performance on the benchmarks by about 1-2% on my machine.

I'm not 100% on removing the assert in `Span::contains()`. I removed it because other similar methods did not have such asserts, and placing such range checks in other methods of `Span` would likely have a noticeable impact on performance. In lieu of removing it, maybe it would be better to instead do the range check as a `debug_assert!`, and place similar debug asserts in other relevant `Span` functions? Or alternatively, make all the `Span` fields private, and do such checks in the constructor and mutator functions only?
<!-- Are there other PRs related to this one? -->

# How Has This Been Tested?
- `cargo test`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
