### PR TITLE
fix(chrome-ext): filter out erroneous double-clicking

### DIFF
--- a/packages/chrome-plugin/src/Highlights.ts
+++ b/packages/chrome-plugin/src/Highlights.ts
@@ -1,7 +1,6 @@
-import { render } from 'svelte/server';
 import type { VNode } from 'virtual-dom';
 import h from 'virtual-dom/h';
-import { isBoxInScreen, type LintBox } from './Box';
+import type { LintBox } from './Box';
 import {
 	getCMRoot,
 	getDraftRoot,

--- a/packages/chrome-plugin/src/PopupHandler.ts
+++ b/packages/chrome-plugin/src/PopupHandler.ts
@@ -11,7 +11,8 @@ function monitorDoubleShift(onDoubleShift: DoubleShiftHandler, interval = 300): 
 	const handler = (e: KeyboardEvent) => {
 		if (e.key !== 'Shift') return;
 		const now = performance.now();
-		if (now - lastTime <= interval) onDoubleShift();
+		const diff = now - lastTime;
+		if (diff <= interval && diff > 10) onDoubleShift();
 		lastTime = now;
 	};
 	window.addEventListener('keydown', handler);

--- a/packages/obsidian-plugin/.gitignore
+++ b/packages/obsidian-plugin/.gitignore
@@ -3,3 +3,4 @@ main.js
 node_modules
 harper-obsidian-plugin.zip
 manifest.json
+data.json


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->

#1643

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

It looks like #1643 was caused by the Warframe page itself: upon receiving an input event, it would create a new one without stopping propagation of the old. To solve this, I just filtered out any input calls that happen within 10 milliseconds of the original.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
