### PR TITLE
fix: solve that/than false positive

### DIFF
--- a/harper-core/src/linting/that_than.rs
+++ b/harper-core/src/linting/that_than.rs
@@ -16,7 +16,9 @@ impl Default for ThatThan {
                     return false;
                 }
                 let adj = tok.span.get_content(src);
-                !adj.eq_ignore_ascii_case_str("better") && !adj.eq_ignore_ascii_case_str("later")
+                !&["better", "later", "number"]
+                    .iter()
+                    .any(|&s| adj.eq_ignore_ascii_case_str(s))
             })
             .t_ws()
             .t_aco("that")
@@ -226,6 +228,15 @@ mod tests {
     fn dont_flag_its_better_that() {
         assert_lint_count(
             "It’s better that the shock should all come at once.",
+            ThatThan::default(),
+            0,
+        )
+    }
+
+    #[test]
+    fn dont_flag_number_that_1663() {
+        assert_lint_count(
+            " 455 │ `MAJOR.MINOR.PATCH` version number that increments with:",
             ThatThan::default(),
             0,
         )


### PR DESCRIPTION
# Issues 
Fixes #1663

# Description

"number that" is no longer considered be "more numb than" and is not flagged.

Does not attempt to detect the rare cases when "number" does actually mean "more numb".

# How Has This Been Tested?

I added the sentence from the issue as a new unit test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
