### PR TITLE
ci: update PR template to encourage linking issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,6 @@
 # Issues 
 <!-- Link any relevant GitHub issues here. -->
+<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->
 
 # Description
 <!-- Please include a summary of the change. -->


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
Updates the PR template to encourage the linking of issues where appropriate.
<!-- Any details that you think are important to review this PR? -->
This linking should make it easier to see which issues are being worked on and what still needs to be done. It will also (generally) automatically close the linked issues when the PR is merged, preventing issues from remaining open despite being resolved.

Relevant GitHub docs:
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
