### PR TITLE
fix(core): typo in phrase correction message

### DIFF
--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -47,7 +47,7 @@ pub fn lint_group() -> LintGroup {
         "AfterAWhile" => (
             ["after while"],
             ["after a while"],
-            "When describafterg a timeframe, use `a while`.",
+            "When describing a timeframe, use `a while`.",
             "Corrects the missing article in `after while`, forming `after a while`.",
             LintKind::Grammar
         ),


### PR DESCRIPTION
# Description
I recently came across Harper, and while source-diving, found a small typo in the message for the `AfterAWhile` phrase correction. I'm actually not familiar with Rust, but it's only some text, so I hope I did everything correctly 😅.

# How Has This Been Tested?
It hasn't — but it doesn't seem like this message is asserted against anywhere.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
