### PR TITLE
fix: don't flag repeated words if either is hyphenated

### DIFF
--- a/harper-core/src/linting/repeated_words.rs
+++ b/harper-core/src/linting/repeated_words.rs
@@ -42,6 +42,15 @@ impl Linter for RepeatedWords {
                 let word_a = document.get_span_content(&tok_a.span);
                 let word_b = document.get_span_content(&tok_b.span);
 
+                let prev_tok = document.get_token_offset(idx_a, -1);
+                let next_tok = document.get_token_offset(*idx_b, 1);
+
+                if prev_tok.is_some_and(|t| t.kind.is_hyphen())
+                    || next_tok.is_some_and(|t| t.kind.is_hyphen())
+                {
+                    continue;
+                }
+
                 if (tok_a.kind.is_preposition()
                     || tok_a.kind.is_conjunction()
                     || !tok_a.kind.is_likely_homograph()
@@ -151,5 +160,19 @@ mod tests {
             RepeatedWords::default(),
             "he is as hard as nails",
         );
+    }
+
+    #[test]
+    fn dont_flag_first_hyphenated() {
+        assert_lint_count(
+            "The driver-facing camera and microphone are only logged if you explicitly opt-in in settings.",
+            RepeatedWords::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_hyphenated_either_side() {
+        assert_lint_count("foo-foo foo bar bar-bar", RepeatedWords::default(), 0);
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

I noticed that the repeated word linter was flagging words where one was actually part of a hyphenated term rather than a true repeated word: 
<img width="805" height="71" alt="image" src="https://github.com/user-attachments/assets/f30da851-6f96-4b90-a039-9a68311ea06e" />
"In" is not a repeat of "opt-in".

So I modified the linter to check for a hyphen immediately before the first word or immediately after the second.

# How Has This Been Tested?

I added a unit test based on the sentence that alerted me to this problem plus a second unit test where there are hyphenated words on either side of the normal word.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
