### PR TITLE
fix(chrome-ext): properly position highlights in Ghost editor DOM

### DIFF
--- a/packages/chrome-plugin/src/Highlights.ts
+++ b/packages/chrome-plugin/src/Highlights.ts
@@ -4,6 +4,7 @@ import type { LintBox } from './Box';
 import {
 	getCMRoot,
 	getDraftRoot,
+	getGhostRoot,
 	getGutenbergRoot,
 	getLexicalRoot,
 	getMediumRoot,
@@ -141,6 +142,7 @@ export default class Highlights {
 		}
 
 		const queries = [
+			getGhostRoot,
 			getDraftRoot,
 			getPMRoot,
 			getCMRoot,

--- a/packages/chrome-plugin/src/editorUtils.ts
+++ b/packages/chrome-plugin/src/editorUtils.ts
@@ -70,6 +70,12 @@ export function getLexicalEditable(el: HTMLElement): HTMLElement | null {
 	return findChild(lexical, (node: HTMLElement) => node.getAttribute('contenteditable') == 'true');
 }
 
+/** Determines if a given node is a child of a Ghost editor instance.
+ * If so, returns the root node of that instance. */
+export function getGhostRoot(el: HTMLElement): HTMLElement | null {
+	return findAncestor(el, (node: HTMLElement) => node.classList.contains('gh-editor'));
+}
+
 /** Determines if a given node is a child of a Slate.js editor instance.
  * If so, returns the root node of that instance. */
 export function getSlateRoot(el: HTMLElement): HTMLElement | null {


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Should address #1690

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

In my manual testing, problems in the Ghost editor appeared only due to improper positioning of the Harper highlight elements in the DOM. This PR represents a simple fix for that.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
