### PR TITLE
feat: condense TL;DR

### DIFF
--- a/harper-core/src/document.rs
+++ b/harper-core/src/document.rs
@@ -11,7 +11,7 @@ use crate::patterns::WordSet;
 use crate::punctuation::Punctuation;
 use crate::spell::{Dictionary, FstDictionary};
 use crate::vec_ext::VecExt;
-use crate::{FatStringToken, FatToken, Lrc, Token, TokenKind, TokenStringExt};
+use crate::{CharStringExt, FatStringToken, FatToken, Lrc, Token, TokenKind, TokenStringExt};
 use crate::{OrdinalSuffix, Span};
 
 /// A document containing some amount of lexed and parsed English text.
@@ -138,6 +138,7 @@ impl Document {
         self.condense_ellipsis();
         self.condense_latin();
         self.condense_filename_extensions();
+        self.condense_tldr();
         self.match_quotes();
 
         let chunker = burn_chunker();
@@ -628,6 +629,58 @@ impl Document {
         self.tokens.remove_indices(to_remove);
     }
 
+    /// Condenses "tl;dr" down to a single word token.
+    fn condense_tldr(&mut self) {
+        if self.tokens.len() < 3 {
+            return;
+        }
+
+        let mut to_remove = VecDeque::new();
+        let mut cursor = 2;
+
+        loop {
+            let tl = &self.tokens[cursor - 2];
+            let simicolon = &self.tokens[cursor - 1];
+            let dr = &self.tokens[cursor];
+
+            let is_tldr_chunk = tl.kind.is_word()
+                && tl.span.len() == 2
+                && tl
+                    .span
+                    .get_content(&self.source)
+                    .eq_ignore_ascii_case_chars(&['t', 'l'])
+                && simicolon.kind.is_semicolon()
+                && dr.kind.is_word()
+                && dr.span.len() == 2
+                && dr
+                    .span
+                    .get_content(&self.source)
+                    .eq_ignore_ascii_case_chars(&['d', 'r']);
+
+            if is_tldr_chunk {
+                // Update the first token to be the full "tl;dr" as a word
+                self.tokens[cursor - 2].span = Span::new(
+                    self.tokens[cursor - 2].span.start,
+                    self.tokens[cursor].span.end,
+                );
+
+                // Mark the semicolon and "dr" tokens for removal
+                to_remove.push_back(cursor - 1);
+                to_remove.push_back(cursor);
+            }
+
+            // Skip ahead since we've processed these tokens
+            cursor += 1;
+
+            if cursor >= self.tokens.len() {
+                break;
+            }
+        }
+
+        // Remove the marked tokens in reverse order to maintain correct indices
+        self.tokens.remove_indices(to_remove);
+    }
+
     fn uncached_ellipsis_pattern() -> Lrc<Repeating> {
         let period = SequenceExpr::default().then_period();
         Lrc::new(Repeating::new(Box::new(period), 2))
@@ -993,5 +1046,34 @@ mod tests {
         assert!(doc.tokens[21].kind.is_open_round());
         assert!(doc.tokens[22].kind.is_unlintable());
         assert!(doc.tokens[23].kind.is_close_round());
+    }
+
+    #[test]
+    fn condesne_tldr_uppercase() {
+        let doc = Document::new_plain_english_curated("TL;DR");
+        assert!(doc.tokens.len() == 1);
+        assert!(doc.tokens[0].kind.is_word());
+        assert!(doc.tokens[0].span.len() == 5);
+    }
+
+    #[test]
+    fn condense_tldr_lowercase() {
+        let doc = Document::new_plain_english_curated("tl;dr");
+        assert!(doc.tokens.len() == 1);
+        assert!(doc.tokens[0].kind.is_word());
+    }
+
+    #[test]
+    fn condense_tldr_mixed_case_1() {
+        let doc = Document::new_plain_english_curated("tl;DR");
+        assert!(doc.tokens.len() == 1);
+        assert!(doc.tokens[0].kind.is_word());
+    }
+
+    #[test]
+    fn condense_tldr_mixed_case_2() {
+        let doc = Document::new_plain_english_curated("TL;Dr");
+        assert!(doc.tokens.len() == 1);
+        assert!(doc.tokens[0].kind.is_word());
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

Previously the common internet abbreviation `TL;DR` (or `tl;dr`) was flagged as one or two spelling errors.

There has been an entry in `dictionary.dict` for at least a couple of weeks, but spellcheck is word-by-word and `;` is not treated as a character that can be part of a word.

This PR condenses the abbreviation into a single word token that will then behave with the spellchecker so the letter cases can be corrected etc.

# How Has This Been Tested?

I added several unit tests for different letter case variants.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
