### PR TITLE
feat(chrome-ext): close the SuggestionBox with the Escape key

### DIFF
--- a/packages/chrome-plugin/src/SuggestionBox.ts
+++ b/packages/chrome-plugin/src/SuggestionBox.ts
@@ -260,19 +260,27 @@ export default function SuggestionBox(box: IgnorableLintBox, close: () => void) 
 		left: `${left}px`,
 	};
 
-	return h('div', { className: 'harper-container fade-in', style: positionStyle, 'harper-close-on-escape': new CloseOnEscapeHook(close) }, [
-		styleTag(),
-		header(box.lint.lint_kind_pretty, lintKindColor(box.lint.lint_kind), close),
-		body(box.lint.message_html),
-		footer(
-			suggestions(box.lint.suggestions, (v) => {
-				box.applySuggestion(v);
-				close();
-			}),
-			[
-				box.lint.lint_kind === 'Spelling' ? addToDictionary(box) : undefined,
-				ignoreLint(box.ignoreLint),
-			],
-		),
-	]);
+	return h(
+		'div',
+		{
+			className: 'harper-container fade-in',
+			style: positionStyle,
+			'harper-close-on-escape': new CloseOnEscapeHook(close),
+		},
+		[
+			styleTag(),
+			header(box.lint.lint_kind_pretty, lintKindColor(box.lint.lint_kind), close),
+			body(box.lint.message_html),
+			footer(
+				suggestions(box.lint.suggestions, (v) => {
+					box.applySuggestion(v);
+					close();
+				}),
+				[
+					box.lint.lint_kind === 'Spelling' ? addToDictionary(box) : undefined,
+					ignoreLint(box.ignoreLint),
+				],
+			),
+		],
+	);
 }

--- a/packages/chrome-plugin/tests/simple_textarea.spec.ts
+++ b/packages/chrome-plugin/tests/simple_textarea.spec.ts
@@ -51,7 +51,6 @@ test('Scrolls correctly', async ({ page }) => {
 	await page.waitForTimeout(6000);
 
 	await assertHarperHighlightBoxes(page, [{ height: 19, width: 56, x: 97.953125, y: 63 }]);
-	
 });
 
 test('Can dismiss with escape key', async ({ page }) => {


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

#1698 

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

This PR adds a listener for the escape key, closing the Chrome extension's suggestion popup when it fires.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Additional integration test + manual testing.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
