### PR TITLE
fix(core): PiqueInterest now works with possessive determiners

### DIFF
--- a/harper-core/src/linting/pique_interest.rs
+++ b/harper-core/src/linting/pique_interest.rs
@@ -15,7 +15,9 @@ impl Default for PiqueInterest {
                 "peak", "peaked", "peek", "peeked", "peeking", "peaking",
             ]))
             .then_whitespace()
-            .then_non_plural_nominal()
+            .then(|tok: &Token, _: &[char]| {
+                tok.kind.is_non_plural_nominal() || tok.kind.is_possessive_determiner()
+            })
             .then_whitespace()
             .t_aco("interest");
 
@@ -126,6 +128,15 @@ mod tests {
             "She was peaking his interest with her stories.",
             PiqueInterest::default(),
             "She was piquing his interest with her stories.",
+        );
+    }
+
+    #[test]
+    fn corrects_peaked_my_interest() {
+        assert_suggestion_result(
+            "you've peaked my interest.",
+            PiqueInterest::default(),
+            "you've piqued my interest.",
         );
     }
 }


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Found in Discord.

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

The PiqueInterest rule previously refused to acknowledge possessive determiners, leading the examples phrase "you've peaked my interest" to slip through. 


# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Additional unit tests

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
