### PR TITLE
fix: canonicalize workspace_root in configuration

### DIFF
--- a/harper-cli/src/input.rs
+++ b/harper-cli/src/input.rs
@@ -32,7 +32,7 @@ impl Input {
     /// Gets a human-readable identifier for the input. For example, this can be a filename, or
     /// simply the string `"<input>"`.
     #[must_use]
-    pub(super) fn get_identifier(&self) -> Cow<str> {
+    pub(super) fn get_identifier(&self) -> Cow<'_, str> {
         match self {
             Input::File(file) => file
                 .file_name()

--- a/harper-core/src/char_string.rs
+++ b/harper-core/src/char_string.rs
@@ -9,10 +9,10 @@ pub type CharString = SmallVec<[char; 16]>;
 /// Extensions to character sequences that make them easier to wrangle.
 pub trait CharStringExt {
     /// Convert all characters to lowercase, returning a new owned vector if any changes were made.
-    fn to_lower(&self) -> Cow<[char]>;
+    fn to_lower(&self) -> Cow<'_, [char]>;
 
     /// Normalize the character sequence according to the dictionary's standard character set.
-    fn normalized(&self) -> Cow<[char]>;
+    fn normalized(&self) -> Cow<'_, [char]>;
 
     /// Convert the character sequence to a String.
     fn to_string(&self) -> String;
@@ -35,7 +35,7 @@ pub trait CharStringExt {
 }
 
 impl CharStringExt for [char] {
-    fn to_lower(&self) -> Cow<[char]> {
+    fn to_lower(&self) -> Cow<'_, [char]> {
         if self.iter().all(|c| c.is_lowercase()) {
             return Cow::Borrowed(self);
         }
@@ -53,7 +53,7 @@ impl CharStringExt for [char] {
 
     /// Convert a given character sequence to the standard character set
     /// the dictionary is in.
-    fn normalized(&self) -> Cow<[char]> {
+    fn normalized(&self) -> Cow<'_, [char]> {
         if self.as_ref().iter().any(|c| char_to_normalized(*c) != *c) {
             Cow::Owned(
                 self.as_ref()

--- a/harper-core/src/document.rs
+++ b/harper-core/src/document.rs
@@ -178,10 +178,10 @@ impl Document {
     /// Convert all sets of newlines greater than 2 to paragraph breaks.
     fn newlines_to_breaks(&mut self) {
         for token in &mut self.tokens {
-            if let TokenKind::Newline(n) = token.kind {
-                if n >= 2 {
-                    token.kind = TokenKind::ParagraphBreak;
-                }
+            if let TokenKind::Newline(n) = token.kind
+                && n >= 2
+            {
+                token.kind = TokenKind::ParagraphBreak;
             }
         }
     }
@@ -380,13 +380,12 @@ impl Document {
 
             // TODO: Allow spaces between `a` and `b`
 
-            if let (TokenKind::Number(..), TokenKind::Word(..)) = (&a.kind, &b.kind) {
-                if let Some(found_suffix) =
+            if let (TokenKind::Number(..), TokenKind::Word(..)) = (&a.kind, &b.kind)
+                && let Some(found_suffix) =
                     OrdinalSuffix::from_chars(self.get_span_content(&b.span))
-                {
-                    self.tokens[idx].kind.as_mut_number().unwrap().suffix = Some(found_suffix);
-                    replace_starts.push(idx);
-                }
+            {
+                self.tokens[idx].kind.as_mut_number().unwrap().suffix = Some(found_suffix);
+                replace_starts.push(idx);
             }
         }
 

--- a/harper-core/src/lexing/url.rs
+++ b/harper-core/src/lexing/url.rs
@@ -56,10 +56,10 @@ fn lex_ip_schemepart(source: &[char]) -> Option<usize> {
 
 fn lex_login(source: &[char]) -> Option<usize> {
     let hostport_start = if let Some(cred_end) = source.iter().position(|c| *c == '@') {
-        if let Some(pass_beg) = source[0..cred_end].iter().position(|c| *c == ':') {
-            if !is_uchar_plus_string(&source[pass_beg + 1..cred_end]) {
-                return None;
-            }
+        if let Some(pass_beg) = source[0..cred_end].iter().position(|c| *c == ':')
+            && !is_uchar_plus_string(&source[pass_beg + 1..cred_end])
+        {
+            return None;
         }
 
         // Check username

--- a/harper-core/src/linting/back_in_the_day.rs
+++ b/harper-core/src/linting/back_in_the_day.rs
@@ -39,10 +39,10 @@ impl ExprLinter for BackInTheDay {
     }
 
     fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
-        if let Some(tail) = matched_tokens.get(8..) {
-            if self.exceptions.matches(tail, source).is_some() {
-                return None;
-            }
+        if let Some(tail) = matched_tokens.get(8..)
+            && self.exceptions.matches(tail, source).is_some()
+        {
+            return None;
         }
 
         let span = matched_tokens.span()?;

--- a/harper-core/src/linting/correct_number_suffix.rs
+++ b/harper-core/src/linting/correct_number_suffix.rs
@@ -20,19 +20,16 @@ impl Linter for CorrectNumberSuffix {
                 suffix: Some(suffix),
                 ..
             }) = number_tok.kind
+                && let Some(correct_suffix) = OrdinalSuffix::correct_suffix_for(value)
+                && suffix != correct_suffix
             {
-                if let Some(correct_suffix) = OrdinalSuffix::correct_suffix_for(value) {
-                    if suffix != correct_suffix {
-                        output.push(Lint {
-                            span: suffix_span,
-                            lint_kind: LintKind::Miscellaneous,
-                            message: "This number needs a different suffix to sound right."
-                                .to_string(),
-                            suggestions: vec![Suggestion::ReplaceWith(correct_suffix.to_chars())],
-                            ..Default::default()
-                        })
-                    }
-                }
+                output.push(Lint {
+                    span: suffix_span,
+                    lint_kind: LintKind::Miscellaneous,
+                    message: "This number needs a different suffix to sound right.".to_string(),
+                    suggestions: vec![Suggestion::ReplaceWith(correct_suffix.to_chars())],
+                    ..Default::default()
+                })
             }
         }
 

--- a/harper-core/src/linting/inflected_verb_after_to.rs
+++ b/harper-core/src/linting/inflected_verb_after_to.rs
@@ -41,10 +41,11 @@ impl<T: Dictionary> Linter for InflectedVerbAfterTo<T> {
             }
 
             let check_stem = |stem: &[char]| {
-                if let Some(metadata) = self.dictionary.get_word_metadata(stem) {
-                    if metadata.is_verb() && !metadata.is_noun() {
-                        return true;
-                    }
+                if let Some(metadata) = self.dictionary.get_word_metadata(stem)
+                    && metadata.is_verb()
+                    && !metadata.is_noun()
+                {
+                    return true;
                 }
                 false
             };

--- a/harper-core/src/linting/of_course.rs
+++ b/harper-core/src/linting/of_course.rs
@@ -36,8 +36,8 @@ impl ExprLinter for OfCourse {
 
     fn match_to_lint(&self, matched: &[Token], source: &[char]) -> Option<Lint> {
         // Skip if the word before “of” is “kind” or “sort” → “kind of curse” is valid.
-        if let Some(of_idx) = matched.first().map(|t| t.span.start) {
-            if let Some(prev) = source.get(..of_idx).map(|src| {
+        if let Some(of_idx) = matched.first().map(|t| t.span.start)
+            && let Some(prev) = source.get(..of_idx).map(|src| {
                 // Walk backwards over whitespace to find the preceding word token.
                 let mut i = of_idx.saturating_sub(1);
                 while i > 0 && src[i].is_whitespace() {
@@ -50,11 +50,11 @@ impl ExprLinter for OfCourse {
                     .map(|p| p + 1)
                     .unwrap_or(0);
                 src[start..=i].iter().collect::<String>()
-            }) {
-                let lower = prev.to_ascii_lowercase();
-                if lower == "kind" || lower == "sort" {
-                    return None;
-                }
+            })
+        {
+            let lower = prev.to_ascii_lowercase();
+            if lower == "kind" || lower == "sort" {
+                return None;
             }
         }
 

--- a/harper-core/src/linting/oxford_comma.rs
+++ b/harper-core/src/linting/oxford_comma.rs
@@ -65,13 +65,14 @@ impl Linter for OxfordComma {
                 .filter_map(|v| v.kind.as_word())
                 .flatten();
 
-            if let (Some(first), Some(second)) = (words.next(), words.next()) {
-                if first.preposition && second.is_likely_homograph() {
-                    skip = sentence
-                        .iter()
-                        .position(|t| t.kind.is_comma())
-                        .unwrap_or(sentence.iter().len())
-                }
+            if let (Some(first), Some(second)) = (words.next(), words.next())
+                && first.preposition
+                && second.is_likely_homograph()
+            {
+                skip = sentence
+                    .iter()
+                    .position(|t| t.kind.is_comma())
+                    .unwrap_or(sentence.iter().len())
             }
 
             let sentence = &sentence[skip..];

--- a/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
+++ b/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
@@ -153,10 +153,10 @@ impl Linter for PhrasalVerbAsCompoundNoun {
                 // If the compound is part of a list of nouns, it's probably not a verb.
                 if prev_tok.kind.is_conjunction() {
                     let maybe_prev_tok_2 = document.get_next_word_from_offset(i, -3);
-                    if let Some(prev_tok_2) = maybe_prev_tok_2 {
-                        if prev_tok_2.kind.is_noun() {
-                            continue;
-                        }
+                    if let Some(prev_tok_2) = maybe_prev_tok_2
+                        && prev_tok_2.kind.is_noun()
+                    {
+                        continue;
                     }
                 }
 

--- a/harper-core/src/linting/sentence_capitalization.rs
+++ b/harper-core/src/linting/sentence_capitalization.rs
@@ -49,41 +49,42 @@ impl<T: Dictionary> Linter for SentenceCapitalization<T> {
 
                     let word_chars = document.get_span_content(&first_word.span);
 
-                    if let Some(first_char) = word_chars.first() {
-                        if first_char.is_alphabetic() && !first_char.is_uppercase() {
-                            if let Some(canonical_spelling) =
-                                self.dictionary.get_correct_capitalization_of(word_chars)
-                            {
-                                // Skip if it's a proper noun or contains uppercase letters before a separator
-                                if first_word.kind.is_proper_noun() {
-                                    continue;
-                                }
-
-                                // Check for uppercase letters in the rest of the word before any separators
-                                if canonical_spelling
-                                    .iter()
-                                    .skip(1)
-                                    .take_while(|&c| !c.is_whitespace() && *c != '-' && *c != '\'')
-                                    .any(|&c| c.is_uppercase())
-                                {
-                                    continue;
-                                }
+                    if let Some(first_char) = word_chars.first()
+                        && first_char.is_alphabetic()
+                        && !first_char.is_uppercase()
+                    {
+                        if let Some(canonical_spelling) =
+                            self.dictionary.get_correct_capitalization_of(word_chars)
+                        {
+                            // Skip if it's a proper noun or contains uppercase letters before a separator
+                            if first_word.kind.is_proper_noun() {
+                                continue;
                             }
 
-                            let target_span = first_word.span;
-                            let mut replacement_chars =
-                                document.get_span_content(&target_span).to_vec();
-                            replacement_chars[0] = replacement_chars[0].to_ascii_uppercase();
-
-                            lints.push(Lint {
-                                span: target_span,
-                                lint_kind: LintKind::Capitalization,
-                                suggestions: vec![Suggestion::ReplaceWith(replacement_chars)],
-                                priority: 31,
-                                message: "This sentence does not start with a capital letter"
-                                    .to_string(),
-                            });
+                            // Check for uppercase letters in the rest of the word before any separators
+                            if canonical_spelling
+                                .iter()
+                                .skip(1)
+                                .take_while(|&c| !c.is_whitespace() && *c != '-' && *c != '\'')
+                                .any(|&c| c.is_uppercase())
+                            {
+                                continue;
+                            }
                         }
+
+                        let target_span = first_word.span;
+                        let mut replacement_chars =
+                            document.get_span_content(&target_span).to_vec();
+                        replacement_chars[0] = replacement_chars[0].to_ascii_uppercase();
+
+                        lints.push(Lint {
+                            span: target_span,
+                            lint_kind: LintKind::Capitalization,
+                            suggestions: vec![Suggestion::ReplaceWith(replacement_chars)],
+                            priority: 31,
+                            message: "This sentence does not start with a capital letter"
+                                .to_string(),
+                        });
                     }
                 }
             }

--- a/harper-core/src/linting/spell_check.rs
+++ b/harper-core/src/linting/spell_check.rs
@@ -73,23 +73,22 @@ impl<T: Dictionary> Linter for SpellCheck<T> {
         for word in document.iter_words() {
             let word_chars = document.get_span_content(&word.span);
 
-            if let Some(metadata) = word.kind.as_word().unwrap() {
-                if metadata.dialects.is_dialect_enabled(self.dialect)
-                    && (self.dictionary.contains_exact_word(word_chars)
-                        || self.dictionary.contains_exact_word(&word_chars.to_lower()))
-                {
-                    continue;
-                }
+            if let Some(metadata) = word.kind.as_word().unwrap()
+                && metadata.dialects.is_dialect_enabled(self.dialect)
+                && (self.dictionary.contains_exact_word(word_chars)
+                    || self.dictionary.contains_exact_word(&word_chars.to_lower()))
+            {
+                continue;
             };
 
             let mut possibilities = self.suggest_correct_spelling(word_chars);
 
             // If the misspelled word is capitalized, capitalize the results too.
-            if let Some(mis_f) = word_chars.first() {
-                if mis_f.is_uppercase() {
-                    for sug_f in possibilities.iter_mut().filter_map(|w| w.first_mut()) {
-                        *sug_f = sug_f.to_uppercase().next().unwrap();
-                    }
+            if let Some(mis_f) = word_chars.first()
+                && mis_f.is_uppercase()
+            {
+                for sug_f in possibilities.iter_mut().filter_map(|w| w.first_mut()) {
+                    *sug_f = sug_f.to_uppercase().next().unwrap();
                 }
             }
 

--- a/harper-core/src/linting/throw_rubbish.rs
+++ b/harper-core/src/linting/throw_rubbish.rs
@@ -64,12 +64,11 @@ impl Linter for ThrowRubbish {
                     if JUNK.contains(token_str.as_str()) {
                         // Check if this is being used as a qualifier for another noun
                         // by looking at the next token after any whitespace
-                        if let Some(next_token) = document.get_next_word_from_offset(chunk_i, 1) {
-                            if next_token.kind.is_noun()
-                                && !is_progressive_verb_form(document, next_token)
-                            {
-                                continue; // Skip if it's being used as an adjective
-                            }
+                        if let Some(next_token) = document.get_next_word_from_offset(chunk_i, 1)
+                            && next_token.kind.is_noun()
+                            && !is_progressive_verb_form(document, next_token)
+                        {
+                            continue; // Skip if it's being used as an adjective
                         }
                         junk_seen = true;
                         last_i = Some(chunk_i);

--- a/harper-core/src/parsers/markdown.rs
+++ b/harper-core/src/parsers/markdown.rs
@@ -94,12 +94,12 @@ impl Markdown {
                 }
             }
 
-            if let Some(open_bracket_idx) = open_bracket {
-                if let Some(close_bracket_idx) = close_bracket {
-                    to_remove.extend(open_bracket_idx..=pipe_idx);
-                    to_remove.push_back(close_bracket_idx);
-                    to_remove.push_back(close_bracket_idx + 1);
-                }
+            if let Some(open_bracket_idx) = open_bracket
+                && let Some(close_bracket_idx) = close_bracket
+            {
+                to_remove.extend(open_bracket_idx..=pipe_idx);
+                to_remove.push_back(close_bracket_idx);
+                to_remove.push_back(close_bracket_idx + 1);
             }
         }
 

--- a/harper-core/src/patterns/nominal_phrase.rs
+++ b/harper-core/src/patterns/nominal_phrase.rs
@@ -12,16 +12,14 @@ impl Pattern for NominalPhrase {
         loop {
             let tok = tokens.get(cursor)?;
 
-            if tok.kind.is_adjective()
+            if (tok.kind.is_adjective()
                 || tok.kind.is_determiner()
-                || tok.kind.is_verb_progressive_form()
+                || tok.kind.is_verb_progressive_form())
+                && let Some(next) = tokens.get(cursor + 1)
+                && next.kind.is_whitespace()
             {
-                if let Some(next) = tokens.get(cursor + 1) {
-                    if next.kind.is_whitespace() {
-                        cursor += 2;
-                        continue;
-                    }
-                }
+                cursor += 2;
+                continue;
             }
 
             if tok.kind.is_nominal() {

--- a/harper-core/src/spell/dictionary.rs
+++ b/harper-core/src/spell/dictionary.rs
@@ -23,14 +23,14 @@ pub trait Dictionary: Send + Sync {
         word: &[char],
         max_distance: u8,
         max_results: usize,
-    ) -> Vec<FuzzyMatchResult>;
+    ) -> Vec<FuzzyMatchResult<'_>>;
     /// Gets best fuzzy match from dictionary
     fn fuzzy_match_str(
         &self,
         word: &str,
         max_distance: u8,
         max_results: usize,
-    ) -> Vec<FuzzyMatchResult>;
+    ) -> Vec<FuzzyMatchResult<'_>>;
     fn get_correct_capitalization_of(&self, word: &[char]) -> Option<&'_ [char]>;
     /// Get the associated [`WordMetadata`] for any capitalization of a given word.
     fn get_word_metadata(&self, word: &[char]) -> Option<&WordMetadata>;

--- a/harper-core/src/spell/fst_dictionary.rs
+++ b/harper-core/src/spell/fst_dictionary.rs
@@ -133,7 +133,7 @@ impl Dictionary for FstDictionary {
         word: &[char],
         max_distance: u8,
         max_results: usize,
-    ) -> Vec<FuzzyMatchResult> {
+    ) -> Vec<FuzzyMatchResult<'_>> {
         let misspelled_word_charslice = word.normalized();
         let misspelled_word_string = misspelled_word_charslice.to_string();
 
@@ -181,7 +181,7 @@ impl Dictionary for FstDictionary {
         word: &str,
         max_distance: u8,
         max_results: usize,
-    ) -> Vec<FuzzyMatchResult> {
+    ) -> Vec<FuzzyMatchResult<'_>> {
         self.fuzzy_match(
             word.chars().collect::<Vec<_>>().as_slice(),
             max_distance,

--- a/harper-core/src/spell/merged_dictionary.rs
+++ b/harper-core/src/spell/merged_dictionary.rs
@@ -127,7 +127,7 @@ impl Dictionary for MergedDictionary {
         word: &[char],
         max_distance: u8,
         max_results: usize,
-    ) -> Vec<FuzzyMatchResult> {
+    ) -> Vec<FuzzyMatchResult<'_>> {
         self.children
             .iter()
             .flat_map(|d| d.fuzzy_match(word, max_distance, max_results))
@@ -141,7 +141,7 @@ impl Dictionary for MergedDictionary {
         word: &str,
         max_distance: u8,
         max_results: usize,
-    ) -> Vec<FuzzyMatchResult> {
+    ) -> Vec<FuzzyMatchResult<'_>> {
         self.children
             .iter()
             .flat_map(|d| d.fuzzy_match_str(word, max_distance, max_results))

--- a/harper-core/src/spell/mod.rs
+++ b/harper-core/src/spell/mod.rs
@@ -209,14 +209,15 @@ pub(crate) fn is_ay_ey_misspelling(a: &[char], b: &[char]) -> bool {
             || (a_char.eq_ignore_ascii_case(&'e') && b_char.eq_ignore_ascii_case(&'a'))
         {
             // Check if next character is 'y' for both
-            if let (Some(&a_next), Some(&b_next)) = (a_iter.next(), b_iter.next()) {
-                if a_next.eq_ignore_ascii_case(&'y') && b_next.eq_ignore_ascii_case(&'y') {
-                    if found_ay_ey {
-                        return false; // More than one ay/ey difference
-                    }
-                    found_ay_ey = true;
-                    continue;
+            if let (Some(&a_next), Some(&b_next)) = (a_iter.next(), b_iter.next())
+                && a_next.eq_ignore_ascii_case(&'y')
+                && b_next.eq_ignore_ascii_case(&'y')
+            {
+                if found_ay_ey {
+                    return false; // More than one ay/ey difference
                 }
+                found_ay_ey = true;
+                continue;
             }
         }
         return false; // Non-ay/ey difference found
@@ -259,16 +260,17 @@ pub(crate) fn is_ei_ie_misspelling(a: &[char], b: &[char]) -> bool {
             }
         }
         // Check for 'i' vs 'e' in first position
-        else if a_char.eq_ignore_ascii_case(&'i') && b_char.eq_ignore_ascii_case(&'e') {
-            if let (Some(&a_next), Some(&b_next)) = (a_iter.next(), b_iter.next()) {
-                // Next chars must be 'e' and 'i' respectively
-                if a_next.eq_ignore_ascii_case(&'e') && b_next.eq_ignore_ascii_case(&'i') {
-                    if found_ei_ie {
-                        return false; // More than one ei/ie difference
-                    }
-                    found_ei_ie = true;
-                    continue;
+        else if a_char.eq_ignore_ascii_case(&'i')
+            && b_char.eq_ignore_ascii_case(&'e')
+            && let (Some(&a_next), Some(&b_next)) = (a_iter.next(), b_iter.next())
+        {
+            // Next chars must be 'e' and 'i' respectively
+            if a_next.eq_ignore_ascii_case(&'e') && b_next.eq_ignore_ascii_case(&'i') {
+                if found_ei_ie {
+                    return false; // More than one ei/ie difference
                 }
+                found_ei_ie = true;
+                continue;
             }
         }
         return false;

--- a/harper-core/src/spell/mutable_dictionary.rs
+++ b/harper-core/src/spell/mutable_dictionary.rs
@@ -141,7 +141,7 @@ impl Dictionary for MutableDictionary {
         word: &[char],
         max_distance: u8,
         max_results: usize,
-    ) -> Vec<FuzzyMatchResult> {
+    ) -> Vec<FuzzyMatchResult<'_>> {
         let misspelled_charslice = word.normalized();
         let misspelled_charslice_lower = misspelled_charslice.to_lower();
 
@@ -196,7 +196,7 @@ impl Dictionary for MutableDictionary {
         word: &str,
         max_distance: u8,
         max_results: usize,
-    ) -> Vec<FuzzyMatchResult> {
+    ) -> Vec<FuzzyMatchResult<'_>> {
         let word: Vec<_> = word.chars().collect();
         self.fuzzy_match(&word, max_distance, max_results)
     }

--- a/harper-core/src/spell/mutable_dictionary.rs
+++ b/harper-core/src/spell/mutable_dictionary.rs
@@ -216,10 +216,10 @@ impl Dictionary for MutableDictionary {
     fn contains_exact_word(&self, word: &[char]) -> bool {
         let normalized = word.normalized();
 
-        if let Some(found) = self.word_map.get_with_chars(normalized.as_ref()) {
-            if found.canonical_spelling.as_ref() == normalized.as_ref() {
-                return true;
-            }
+        if let Some(found) = self.word_map.get_with_chars(normalized.as_ref())
+            && found.canonical_spelling.as_ref() == normalized.as_ref()
+        {
+            return true;
         }
 
         false

--- a/harper-core/src/title_case.rs
+++ b/harper-core/src/title_case.rs
@@ -38,18 +38,18 @@ pub fn make_title_case(toks: &[Token], source: &[char], dict: &impl Dictionary) 
     let mut output = toks.span().unwrap().get_content(source).to_vec();
 
     while let Some((index, word)) = word_likes.next() {
-        if let Some(Some(metadata)) = word.kind.as_word() {
-            if metadata.is_proper_noun() {
-                // Replace it with the dictionary entry verbatim.
-                let orig_text = word.span.get_content(source);
+        if let Some(Some(metadata)) = word.kind.as_word()
+            && metadata.is_proper_noun()
+        {
+            // Replace it with the dictionary entry verbatim.
+            let orig_text = word.span.get_content(source);
 
-                if let Some(correct_caps) = dict.get_correct_capitalization_of(orig_text) {
-                    // It should match the dictionary verbatim
-                    output[word.span.start - start_index..word.span.end - start_index]
-                        .iter_mut()
-                        .enumerate()
-                        .for_each(|(idx, c)| *c = correct_caps[idx]);
-                }
+            if let Some(correct_caps) = dict.get_correct_capitalization_of(orig_text) {
+                // It should match the dictionary verbatim
+                output[word.span.start - start_index..word.span.end - start_index]
+                    .iter_mut()
+                    .enumerate()
+                    .for_each(|(idx, c)| *c = correct_caps[idx]);
             }
         };
 

--- a/harper-core/tests/linters.rs
+++ b/harper-core/tests/linters.rs
@@ -29,7 +29,7 @@ struct Lines<'a> {
     offsets: Vec<usize>,
 }
 impl Lines<'_> {
-    fn new(source: &str) -> Lines {
+    fn new(source: &str) -> Lines<'_> {
         let lines: Vec<&str> = source.split('\n').collect();
         let offsets: Vec<usize> = lines
             .iter()

--- a/harper-ls/src/config.rs
+++ b/harper-ls/src/config.rs
@@ -83,6 +83,9 @@ impl Config {
     pub fn from_lsp_config(workspace_root: &Path, value: Value) -> Result<Self> {
         let mut base = Config::default();
 
+        let workspace_root = workspace_root.canonicalize()?;
+        let workspace_root = workspace_root.as_path();
+
         let Value::Object(value) = value else {
             bail!("Settings must be an object.");
         };

--- a/harper-ls/src/config.rs
+++ b/harper-ls/src/config.rs
@@ -179,10 +179,10 @@ impl Config {
             base.max_file_length = serde_json::from_value(v.clone())?;
         }
 
-        if let Some(v) = value.get("markdown") {
-            if let Some(v) = v.get("IgnoreLinkTitle") {
-                base.markdown_options.ignore_link_title = serde_json::from_value(v.clone())?;
-            }
+        if let Some(v) = value.get("markdown")
+            && let Some(v) = v.get("IgnoreLinkTitle")
+        {
+            base.markdown_options.ignore_link_title = serde_json::from_value(v.clone())?;
         }
 
         Ok(base)

--- a/harper-pos-utils/src/chunker/cached_chunker.rs
+++ b/harper-pos-utils/src/chunker/cached_chunker.rs
@@ -28,10 +28,10 @@ impl<C: Chunker> Chunker for CachedChunker<C> {
 
         // Attempt a cache hit.
         // We put this in the block so `read` gets dropped as early as possible.
-        if let Ok(mut read) = self.cache.try_lock() {
-            if let Some(result) = read.get(&key) {
-                return result.clone();
-            }
+        if let Ok(mut read) = self.cache.try_lock()
+            && let Some(result) = read.get(&key)
+        {
+            return result.clone();
         };
 
         // We don't want to hold the lock since it may take a while to run the chunker.

--- a/harper-pos-utils/src/tagger/brill_tagger/mod.rs
+++ b/harper-pos-utils/src/tagger/brill_tagger/mod.rs
@@ -77,18 +77,17 @@ impl BrillTagger<FreqDict> {
         self.apply_patches(sentence, &mut base_tags);
 
         for ((tag, correct_tag), word) in base_tags.iter().zip(correct_tags.iter()).zip(sentence) {
-            if let Some(tag) = tag {
-                if let Some(correct_tag) = correct_tag {
-                    if tag != correct_tag {
-                        errors.inc(
-                            ErrorKind {
-                                was_tagged: *tag,
-                                correct_tag: *correct_tag,
-                            },
-                            word.as_str(),
-                        )
-                    }
-                }
+            if let Some(tag) = tag
+                && let Some(correct_tag) = correct_tag
+                && tag != correct_tag
+            {
+                errors.inc(
+                    ErrorKind {
+                        was_tagged: *tag,
+                        correct_tag: *correct_tag,
+                    },
+                    word.as_str(),
+                )
             }
         }
     }
@@ -105,18 +104,17 @@ impl BrillTagger<FreqDict> {
         let mut errors = ErrorCounter::new();
 
         for ((tag, correct_tag), word) in tags.iter().zip(correct_tags.iter()).zip(sentence) {
-            if let Some(tag) = tag {
-                if let Some(correct_tag) = correct_tag {
-                    if tag != correct_tag {
-                        errors.inc(
-                            ErrorKind {
-                                was_tagged: *tag,
-                                correct_tag: *correct_tag,
-                            },
-                            word.as_str(),
-                        )
-                    }
-                }
+            if let Some(tag) = tag
+                && let Some(correct_tag) = correct_tag
+                && tag != correct_tag
+            {
+                errors.inc(
+                    ErrorKind {
+                        was_tagged: *tag,
+                        correct_tag: *correct_tag,
+                    },
+                    word.as_str(),
+                )
             }
         }
 

--- a/harper-typst/src/lib.rs
+++ b/harper-typst/src/lib.rs
@@ -62,12 +62,12 @@ fn convert_parbreaks<'a>(buf: &'a mut Vec<SyntaxNode>, exprs: &'a [Expr]) -> Vec
     let mut last_element: Option<Expr> = None;
     for ((i, expr), (_, next_expr)) in exprs.iter().enumerate().tuple_windows() {
         let mut current_expr = *expr;
-        if let Some(last_element) = last_element {
-            if should_parbreak(last_element, *expr, *next_expr) {
-                let pbreak = typst_syntax::ast::Parbreak::from_untyped(&buf[i])
-                    .expect("Unable to convert expression to Parbreak");
-                current_expr = Expr::Parbreak(pbreak);
-            }
+        if let Some(last_element) = last_element
+            && should_parbreak(last_element, *expr, *next_expr)
+        {
+            let pbreak = typst_syntax::ast::Parbreak::from_untyped(&buf[i])
+                .expect("Unable to convert expression to Parbreak");
+            current_expr = Expr::Parbreak(pbreak);
         }
         res.push(current_expr);
         last_element = Some(*expr)


### PR DESCRIPTION
# Issues 

Fixes #1707

# Description

If the LSP client does not provide any mechanism to determine the root of the workspace, we need to resolve things relative to the current directory, but previously we tried that as `.` which it turns out `.try_resolve_in()` does not like.

This changes the behaviour to always `.canonicalize()` the root of the workspace so that subsequent path resolution starts from an absolute path.

# Demo

N/A ?

# How Has This Been Tested?

The original poster of #1707 confirmed that this fixed their issue.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
