### PR TITLE
fix: false positives in phrasal verb to compound noun

### DIFF
--- a/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
+++ b/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
@@ -167,19 +167,22 @@ impl Linter for PhrasalVerbAsCompoundNoun {
             }
 
             // If the compound noun is followed by another noun, check for larger compound nouns.
-            if let Some(next_tok) = maybe_next_tok.filter(|tok| tok.kind.is_noun()) {
-                if match nountok_lower {
-                    ['b', 'a', 'c', 'k', 'u', 'p'] => &["file", "images", "location", "snapshots"],
-                    _ => &[] as &[&str],
+            if let Some(next_tok) = maybe_next_tok.filter(|tok| tok.kind.is_noun())
+                && match nountok_lower {
+                    ['b', 'a', 'c', 'k', 'u', 'p'] => {
+                        &["file", "images", "location", "snapshots"][..]
+                    }
+                    ['c', 'a', 'l', 'l', 'b', 'a', 'c', 'k'] => &["function"][..],
+                    _ => &[],
                 }
                 .contains(
                     &next_tok
                         .span
                         .get_content_string(document.get_source())
                         .as_ref(),
-                ) {
-                    continue;
-                }
+                )
+            {
+                continue;
             }
 
             let message = match confidence {
@@ -520,6 +523,16 @@ mod tests {
     fn dont_flag_helm_backup_plugin() {
         assert_lint_count(
             "Helm Backup Plugin.",
+            PhrasalVerbAsCompoundNoun::default(),
+            0,
+        );
+    }
+
+    // By the time the `setTimeout` callback function was invoked
+    #[test]
+    fn dont_flag_callback_function() {
+        assert_lint_count(
+            "By the time the `setTimeout` callback function was invoked",
             PhrasalVerbAsCompoundNoun::default(),
             0,
         );

--- a/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
+++ b/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
@@ -169,7 +169,7 @@ impl Linter for PhrasalVerbAsCompoundNoun {
             // If the compound noun is followed by another noun, check for larger compound nouns.
             if let Some(next_tok) = maybe_next_tok.filter(|tok| tok.kind.is_noun()) {
                 if match nountok_lower {
-                    ['b', 'a', 'c', 'k', 'u', 'p'] => &["file", "location"],
+                    ['b', 'a', 'c', 'k', 'u', 'p'] => &["file", "images", "location", "snapshots"],
                     _ => &[] as &[&str],
                 }
                 .contains(
@@ -447,6 +447,79 @@ mod tests {
     fn dont_flag_backup_location() {
         assert_lint_count(
             "Backup location: `%APPDATA%\\Cursor\\User\\globalStorage\\backups`",
+            PhrasalVerbAsCompoundNoun::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_backup_plan() {
+        assert_lint_count(
+            "Every backup plan is unique, based on your risk assessment.",
+            PhrasalVerbAsCompoundNoun::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_backup_program() {
+        assert_lint_count(
+            "restic is a backup program that is fast, efficient and secure",
+            PhrasalVerbAsCompoundNoun::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_backup_solution_or_backup_problems() {
+        assert_lint_count(
+            "NPBackup is a multiparadigm backup solution which tries to solve two major backup problems",
+            PhrasalVerbAsCompoundNoun::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_backup_utilities_backup_system_or_backup_snapshots() {
+        assert_lint_count(
+            "GitHub Enterprise Server Backup Utilities is a backup system you install on a separate host, which takes backup snapshots",
+            PhrasalVerbAsCompoundNoun::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_backup_images() {
+        assert_lint_count(
+            "This App creates and stores backup images of your Nextcloud.",
+            PhrasalVerbAsCompoundNoun::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn fix_backup_individual_apps() {
+        assert_suggestion_result(
+            "It requires root and allows you to backup individual apps and their data.",
+            PhrasalVerbAsCompoundNoun::default(),
+            "It requires root and allows you to back up individual apps and their data.",
+        );
+    }
+
+    #[test]
+    fn dont_flag_backup_strategy() {
+        assert_lint_count(
+            "This is for you if you want to quickly set up a backup strategy without much fuss.",
+            PhrasalVerbAsCompoundNoun::default(),
+            0,
+        );
+    }
+
+    // Helm Backup Plugin.
+    #[test]
+    fn dont_flag_helm_backup_plugin() {
+        assert_lint_count(
+            "Helm Backup Plugin.",
             PhrasalVerbAsCompoundNoun::default(),
             0,
         );

--- a/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
+++ b/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
@@ -166,6 +166,22 @@ impl Linter for PhrasalVerbAsCompoundNoun {
                 }
             }
 
+            // If the compound noun is followed by another noun, check for larger compound nouns.
+            if let Some(next_tok) = maybe_next_tok.filter(|tok| tok.kind.is_noun()) {
+                if match nountok_lower {
+                    ['b', 'a', 'c', 'k', 'u', 'p'] => &["file", "location"],
+                    _ => &[] as &[&str],
+                }
+                .contains(
+                    &next_tok
+                        .span
+                        .get_content_string(document.get_source())
+                        .as_ref(),
+                ) {
+                    continue;
+                }
+            }
+
             let message = match confidence {
                 Confidence::DefinitelyVerb => {
                     "This word should be a phrasal verb, not a compound noun."
@@ -422,6 +438,15 @@ mod tests {
     fn false_positive_issue_1495() {
         assert_lint_count(
             "Color schemes are available by using the Style Settings plugin.",
+            PhrasalVerbAsCompoundNoun::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_backup_location() {
+        assert_lint_count(
+            "Backup location: `%APPDATA%\\Cursor\\User\\globalStorage\\backups`",
             PhrasalVerbAsCompoundNoun::default(),
             0,
         );


### PR DESCRIPTION
# Issues 
N/A

# Description

Now checks if the compound noun is part of a larger compound.

For instance: "backup file".

# How Has This Been Tested?

New unit tests added based on text from GitHub repos.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
