### PR TITLE
fix: don't make compounds with conjunctions

### DIFF
--- a/harper-core/src/linting/compound_nouns/mod.rs
+++ b/harper-core/src/linting/compound_nouns/mod.rs
@@ -13,8 +13,8 @@ pub(crate) fn is_content_word(tok: &Token, src: &[char]) -> bool {
 
     tok.span.len() > 1
         && (meta.is_noun() || meta.is_adjective() || meta.is_verb() || meta.is_adverb())
-        && !meta.is_determiner()
-        && (!meta.preposition || *tok.span.get_content(src).to_lower() == ['b', 'a', 'r'])
+        && !(meta.is_determiner() || meta.is_conjunction())
+        && (!meta.preposition || tok.span.get_content(src).eq_ignore_ascii_case_str("bar"))
 }
 
 pub(crate) fn predicate(closed: Option<&WordMetadata>, open: Option<&WordMetadata>) -> bool {
@@ -382,6 +382,14 @@ mod tests {
     fn allow_issue_1298() {
         assert_no_lints(
             "A series of tests that cover all possible cases.",
+            CompoundNouns::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_project_or() {
+        assert_no_lints(
+            "You can star or watch this project or follow author to get release notifications in time.",
             CompoundNouns::default(),
         );
     }

--- a/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
+++ b/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
@@ -1593,16 +1593,6 @@ Message: |
 
 
 
-Lint:    WordChoice (63 priority)
-Message: |
-     658 | questioned. But neither the United States nor any State shall assume or pay any
-     659 | debt or obligation incurred in aid of insurrection or rebellion against the
-         | ^~~~~~~ Did you mean the closed compound noun “debtor”?
-Suggest:
-  - Replace with: “debtor”
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
      663 | ## Article. V.


### PR DESCRIPTION
# Issues 
N/A

# Description

Harper was flagging the phrase "project or" in the middle of a sentence to be changed to "projector":

> You can star or watch this project or follow author to get release notifications in time.

<img width="1228" height="67" alt="image" src="https://github.com/user-attachments/assets/f7d996e3-8688-452b-a364-3f2c081872de" />

As a bonus it fixes a false positive in the US constitution too where it wanted to join "debt" and "or" in the phrase "pay any debt or obligation" into "debtor".

# How Has This Been Tested?

I added a unit test using the sentence from a trending GitHub repo's readme where I spotted this problem.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
