### PR TITLE
feat(harper-ls): add `excludePatterns` config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,6 +2188,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "glow"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2398,6 +2421,7 @@ dependencies = [
  "clap",
  "dirs 6.0.0",
  "futures",
+ "globset",
  "harper-comments",
  "harper-core",
  "harper-html",

--- a/harper-ls/Cargo.toml
+++ b/harper-ls/Cargo.toml
@@ -30,6 +30,7 @@ futures = "0.3.31"
 serde = { version = "1.0.219", features = ["derive"] }
 indexmap = { version = "2.10.0", features = ["serde"] }
 reqwest = { version = "0.12.22", features = ["rustls-tls"], default-features = false }
+globset = "0.4.16"
 
 [features]
 default = []

--- a/harper-ls/src/config.rs
+++ b/harper-ls/src/config.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Result, bail};
 use dirs::{config_dir, data_local_dir};
+use globset::{Glob, GlobSet};
 use harper_core::{Dialect, linting::LintGroupConfig, parsers::MarkdownOptions};
 use resolve_path::PathResolveExt;
 use serde::{Deserialize, Serialize};
@@ -77,6 +78,7 @@ pub struct Config {
     /// Maximum length (in bytes) a file can have before it's skipped.
     /// Above this limit, the file will not be linted.
     pub max_file_length: usize,
+    pub exclude_patterns: GlobSet,
 }
 
 impl Config {
@@ -185,6 +187,23 @@ impl Config {
             base.markdown_options.ignore_link_title = serde_json::from_value(v.clone())?;
         }
 
+        if let Some(v) = value.get("excludePatterns") {
+            let Some(a) = v.as_array() else {
+                bail!("excludePatterns must be an array.");
+            };
+
+            let patterns: Vec<Value> = a.to_vec();
+            if !patterns.is_empty() {
+                let mut builder = GlobSet::builder();
+
+                for pattern in patterns {
+                    builder.add(Glob::new(pattern.as_str().unwrap())?);
+                }
+
+                base.exclude_patterns = builder.build()?;
+            }
+        }
+
         Ok(base)
     }
 }
@@ -206,6 +225,7 @@ impl Default for Config {
             markdown_options: MarkdownOptions::default(),
             dialect: Dialect::American,
             max_file_length: 120_000,
+            exclude_patterns: GlobSet::empty(),
         }
     }
 }

--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -119,6 +119,11 @@
 					"default": "information",
 					"description": "How severe do you want diagnostics to appear in the editor?"
 				},
+				"harper.excludePatterns": {
+					"scope": "resource",
+					"type": "array",
+					"description": "A set of globs to ignore. If a file matches any of the globs, it will not be linted."
+				},
 				"harper.fileDictPath": {
 					"scope": "resource",
 					"type": "string",

--- a/packages/vscode-plugin/src/tests/fixtures/.vscode/settings.json
+++ b/packages/vscode-plugin/src/tests/fixtures/.vscode/settings.json
@@ -4,5 +4,6 @@
 	},
 	"harper.linters.SpellCheck": true,
 	"harper.linters.RepeatedWords": true,
-	"harper.dialect": "American"
+	"harper.dialect": "American",
+	"harper.excludePatterns": []
 }

--- a/packages/vscode-plugin/src/tests/suite/integration.test.ts
+++ b/packages/vscode-plugin/src/tests/suite/integration.test.ts
@@ -148,6 +148,32 @@ describe('Integration >', () => {
 		);
 	});
 
+	it('excludes Markdown files when excludePatterns include *.md', async () => {
+		const config = workspace.getConfiguration('harper');
+
+		compareActualVsExpectedDiagnostics(
+			await waitForDiagnosticsChange(markdownUri, async () => {
+				await config.update('excludePatterns', ['*.md'], ConfigurationTarget.Workspace);
+			}),
+			createExpectedDiagnostics(),
+		);
+
+		await waitForDiagnosticsChange(markdownUri, async () => {
+			// Set config back to default value
+			await config.update('excludePatterns', [], ConfigurationTarget.Workspace);
+
+			// Ideally, we can just execute `workbench.action.closeActiveEditor` then
+			// `workbench.action.reopenClosedEditor` here and the diagnostics should reset since that
+			// works when done manually as that triggers `textDocument/didOpen`, but when done automated,
+			// it won't work. So, we delete, restore, then reopen the file instead.
+			const markdownContent = await workspace.fs.readFile(markdownUri);
+			await commands.executeCommand('workbench.files.action.showActiveFileInExplorer');
+			await commands.executeCommand('deleteFile');
+			await workspace.fs.writeFile(markdownUri, markdownContent);
+			await openUri(markdownUri);
+		});
+	});
+
 	it('updates diagnostics when files are deleted', async () => {
 		const markdownContent = await workspace.fs.readFile(markdownUri);
 

--- a/packages/web/src/routes/docs/integrations/emacs/+page.md
+++ b/packages/web/src/routes/docs/integrations/emacs/+page.md
@@ -61,7 +61,8 @@ Additionally, you can also configure things like which linters to use or how you
                             :diagnosticSeverity "hint"
                             :isolateEnglish :json-false
                             :dialect "American"
-                            :maxFileLength 120000)))
+                            :maxFileLength 120000
+                            :ignoredLintsPath [])))
 ```
 
 :::note

--- a/packages/web/src/routes/docs/integrations/helix/+page.md
+++ b/packages/web/src/routes/docs/integrations/helix/+page.md
@@ -47,6 +47,7 @@ diagnosticSeverity = "hint"
 isolateEnglish = false
 dialect = "American"
 maxFileLength = 120000
+ignoredLintsPath = []
 
 [language-server.harper-ls.config.harper-ls.linters]
 SpellCheck = true

--- a/packages/web/src/routes/docs/integrations/language-server/+page.md
+++ b/packages/web/src/routes/docs/integrations/language-server/+page.md
@@ -261,6 +261,7 @@ These configs are under the `markdown` key:
 | `isolateEnglish`     | `boolean`                                               | `false`       | In documents that are a mixture of English and another language, only lint English text. This feature is incredibly new and unstable. Do not expect it to work perfectly. |
 | `dialect`            | `"American"`, `"British"`, `"Australian"`, `"Canadian"` | `"American"`  | Set the dialect of English Harper should expect.                                                                                                                          |
 | `maxFileLength`      | `number`                                                | `120000`      | Maximum length of file to be linted (in bytes). If a file is larger/longer than this, it will not be linted.                                                              |
+| `excludePatterns`    | `array`                                                 | `[]`          | A set of globs to ignore. If a file matches any of the globs, it will not be linted.                                                                                      |
 
 ## Supported Languages
 

--- a/packages/web/src/routes/docs/integrations/neovim/+page.md
+++ b/packages/web/src/routes/docs/integrations/neovim/+page.md
@@ -49,7 +49,8 @@ require('lspconfig').harper_ls.setup {
       diagnosticSeverity = "hint",
       isolateEnglish = false,
       dialect = "American",
-      maxFileLength = 120000
+      maxFileLength = 120000,
+      ignoredLintsPath = {}
     }
   }
 }

--- a/packages/web/src/routes/docs/integrations/sublime-text/+page.md
+++ b/packages/web/src/routes/docs/integrations/sublime-text/+page.md
@@ -50,7 +50,9 @@ Open `Preferences > Package Settings > LSP > Settings` and add the `harper-ls` c
           },
           "diagnosticSeverity": "hint",
           "isolateEnglish": false,
-          "dialect": "American"
+          "dialect": "American",
+          "maxFileLength": 120000,
+          "ignoredLintsPath": []
         }
       }
     }


### PR DESCRIPTION
# Issues 

Closes #1651
Closes #1364
#1170 is only partially addressed since I think it wants more fine-grained control over what gets ignored than what globs can provide.

# Description

Adds the `excludePatterns` config, which is an array of globs, to `harper-ls` to:

- Allow ignoring files by type (e.g., `*.sol`) (#1651)
- Allow ignoring specific files (e.g., `*/tasks.txt`) (#1364)
- Allow ignoring some files of a type (e.g., `**/ignored/*.md`) (#1170)

## Limitations

- Only applies changes instantly when adding globs to the array if the client sends a `workspace/didChangeConfiguration` notification to `harper-ls` (i.e., like how our VS Code extension does it), otherwise, the user needs to close and reopen the file to trigger `textDocument/didOpen`
- Does not automatically apply changes when the user removes globs from the array since the file has been ignored and is not in `doc_state`, they would need to close and reopen the file to trigger `textDocument/didOpen`

## Notes

- I used `UriExt::to_file_path` in `update_document` which would've been a no-no due to #1365, but since https://github.com/tower-lsp-community/tower-lsp-server/issues/51 has been closed, it shouldn't be a problem anymore

# How Has This Been Tested?

- Manually in VS Code
- Added test to `packages/vscode-plugin/src/tests/suite/integration.test.ts` to test the new config

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
