### PR TITLE
Add a "disabled" version of the logo for the Obsidian plugin.

### DIFF
--- a/packages/obsidian-plugin/logo-disabled.svg
+++ b/packages/obsidian-plugin/logo-disabled.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 695 411"   fill="#ffffff" stroke="currentColor">
+	<path fill="none" d="M0 .5h695v410H0z"/>
+	<path fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="1.5" d="M0 0h694.643v410.022H0z"/>
+	<path fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="1.5" stroke-width="22.92" d="M103.261 128.26s43.73-41.02 110.41-27.65c45.27 9.08 81.49 51.3 81.49 51.3M397.674 124.923s11.5-41.52 61.29-60.05c50.03-18.61 110.83 4.08 110.83 4.08"/>
+	<path fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="1.5" stroke-width="20.82" d="M276.072 255.735c0 53.43-43.077 96.744-96.215 96.744s-96.215-43.314-96.215-96.744 43.077-96.744 96.215-96.744 96.215 43.314 96.215 96.744q0 0 0 0M276.072 238.643h73.429v17.086h-73.429zM65.69 213.962h17.95v33.226H65.69zM418.554 255.735c0 53.43 43.077 96.744 96.215 96.744s96.215-43.314 96.215-96.744-43.077-96.744-96.215-96.744-96.215 43.314-96.215 96.744q0 0 0 0"/>
+	<path fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="1.5" stroke-width="20.82" d="M418.554 238.643h-73.428v17.086h73.428zM628.937 213.962h-17.95v33.226h17.95z"/>
+	<path fill="none" stroke-linecap="round" stroke-width="40" d="m-325.9-159 632.8 317.022" transform="matrix(.9636 0 0 .93034 354.28 205.466)"/>
+</svg>

--- a/packages/obsidian-plugin/src/index.ts
+++ b/packages/obsidian-plugin/src/index.ts
@@ -1,6 +1,7 @@
 import { Dialect } from 'harper.js';
 import { type App, editorViewField, Menu, Notice, Plugin, type PluginManifest } from 'obsidian';
 import logoSvg from '../logo.svg?raw';
+import logoSvgDisabled from '../logo-disabled.svg?raw';
 import packageJson from '../package.json';
 import { HarperSettingTab } from './HarperSettingTab';
 import State from './State';
@@ -39,6 +40,7 @@ export async function logVersionInfo(showNotification: boolean): Promise<void> {
 export default class HarperPlugin extends Plugin {
 	private state: State;
 	private dialectSpan: HTMLSpanElement | null = null;
+	private logo: HTMLSpanElement | null = null;
 
 	constructor(app: App, manifest: PluginManifest) {
 		super(app, manifest);
@@ -94,6 +96,7 @@ export default class HarperPlugin extends Plugin {
 		const logo = document.createElement('span');
 		logo.style.width = '24px';
 		logo.innerHTML = logoSvg;
+		this.logo = logo;
 		button.appendChild(logo);
 
 		const dialect = document.createElement('span');
@@ -114,6 +117,7 @@ export default class HarperPlugin extends Plugin {
 					.setIcon('documents')
 					.onClick(() => {
 						this.state.toggleAutoLint();
+						this.updateStatusBar();
 					}),
 			);
 
@@ -127,13 +131,21 @@ export default class HarperPlugin extends Plugin {
 		this.addCommand({
 			id: 'harper-toggle-auto-lint',
 			name: 'Toggle automatic grammar checking',
-			callback: () => this.state.toggleAutoLint(),
+			callback: () => {
+				this.state.toggleAutoLint();
+				this.updateStatusBar();
+			},
 		});
 	}
 
-	public updateStatusBar(dialect: Dialect) {
-		if (this.dialectSpan != null) {
-			this.dialectSpan.innerHTML = this.getDialectStatus(dialect);
+	public updateStatusBar(dialect?: Dialect) {
+		if (this.logo != null) {
+			this.logo.innerHTML = this.state.hasEditorLinter() ? logoSvg : logoSvgDisabled;
+		}
+		if (typeof dialect !== 'undefined') {
+			if (this.dialectSpan != null) {
+				this.dialectSpan.innerHTML = this.getDialectStatus(dialect);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Add a "disabled" version of the logo for the Obsidian plugin.  Display either the normal enabled or the disabled version of the logo in the status bar depending on if Harper's editor linter is enabled or not.

# Issues 

# Description
Add a "disabled" version of the logo for the Obsidian plugin.  Display either the normal enabled or the disabled version of the logo in the status bar depending on if Harper's editor linter is enabled or not.

# Demo


# How Has This Been Tested?
Validated image changes correctly when toggling either from the status bar or from the command palette command.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ x ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
