### PR TITLE
fix(cli): disable training feature by default to fix OOM

### DIFF
--- a/harper-cli/Cargo.toml
+++ b/harper-cli/Cargo.toml
@@ -13,7 +13,7 @@ harper-stats = { path = "../harper-stats", version = "0.56.0" }
 dirs = "6.0.0"
 harper-literate-haskell = { path = "../harper-literate-haskell", version = "0.56.0" }
 harper-core = { path = "../harper-core", version = "0.56.0" }
-harper-pos-utils = { path = "../harper-pos-utils", version = "0.56.0", features = ["training", "threaded"] }
+harper-pos-utils = { path = "../harper-pos-utils", version = "0.56.0", features = ["threaded"] }
 harper-comments = { path = "../harper-comments", version = "0.56.0" }
 harper-typst = { path = "../harper-typst", version = "0.56.0" }
 hashbrown = "0.15.5"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

The `training` feature of `harper-cli` was accidentally enabled by default. This led to excessively long build times, which made iteration much slower. After some discussion on the Discord server, we've isolated the problem and solved it.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
