### PR TITLE
feat: separate joined "afew" and "infact"

### DIFF
--- a/harper-core/src/linting/open_compounds.rs
+++ b/harper-core/src/linting/open_compounds.rs
@@ -1,6 +1,4 @@
-use crate::expr::Expr;
-use crate::expr::LongestMatchOf;
-use crate::expr::SequenceExpr;
+use crate::expr::{Expr, LongestMatchOf, SequenceExpr};
 use crate::{Lrc, Token, patterns::WordSet};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
@@ -14,12 +12,14 @@ pub struct OpenCompounds {
 impl Default for OpenCompounds {
     fn default() -> Self {
         let phrases = [
+            "a few",
             "a lot",
             "a while",
             "as well",
             "at least",
             "each other",
             "in case",
+            "in fact",
             "in front",
         ];
         let mut compound_to_phrase = HashMap::new();
@@ -239,6 +239,17 @@ mod tests {
         );
     }
 
+    // A few
+
+    #[test]
+    fn correct_afew_atomic() {
+        assert_suggestion_result(
+            "ITK code to generate anisotropic metrics, mostly Riemannian metrics and afew particular cases of Finslerian metrics.",
+            OpenCompounds::default(),
+            "ITK code to generate anisotropic metrics, mostly Riemannian metrics and a few particular cases of Finslerian metrics.",
+        );
+    }
+
     // A lot
 
     #[test]
@@ -404,6 +415,17 @@ mod tests {
             "InCase save your secrets for a friend, so they can use in case it in case you went \"missing\".",
             OpenCompounds::default(),
             0,
+        );
+    }
+
+    // In fact
+
+    #[test]
+    fn correct_infact_atomic() {
+        assert_suggestion_result(
+            "Yes I do infact exist :O",
+            OpenCompounds::default(),
+            "Yes I do in fact exist :O",
         );
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

I saw somebody use "afew" without a space in overlay text in a YouTube video. It turned out to be reasonably common.

I thought we already supported "infact" in the same way but discovered we haven't so far. So I've added it as well.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
