### PR TITLE
feat: condense R&D to a single word token

### DIFF
--- a/harper-core/src/token_kind.rs
+++ b/harper-core/src/token_kind.rs
@@ -207,6 +207,10 @@ impl TokenKind {
         matches!(self, TokenKind::Punctuation(Punctuation::Semicolon))
     }
 
+    pub fn is_ampersand(&self) -> bool {
+        matches!(self, TokenKind::Punctuation(Punctuation::Ampersand))
+    }
+
     // Miscellaneous is-methods
 
     /// Checks whether a token is word-like--meaning it is more complex than punctuation and can


### PR DESCRIPTION
# Issues 

I thought I filed a feature request for this some time ago, but I can't find it. Maybe I mentioned it in Discord or elsewhere?

# Description

Condenses the 3 tokens in `R` `&` `D` into a single word token.
Doesn't care about the case of the letters.
Doesn't allow spaces between the characters.

Before: 
<img width="637" height="126" alt="image" src="https://github.com/user-attachments/assets/be3a62d9-6570-4442-86cf-226f45afbe38" />

# How Has This Been Tested?

I added unit tests for uppercase, lowercase, mixed case, and a negative test to make sure spaces aren't allowed.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
