### PR TITLE
Fix 1734

### DIFF
--- a/harper-ls/src/backend.rs
+++ b/harper-ls/src/backend.rs
@@ -209,7 +209,7 @@ impl Backend {
         );
 
         let mut global_dictionary =
-            global_dictionary.context("Unable to load the global dictionary.")?;
+            global_dictionary.context("Unable to load the user dictionary.")?;
         global_dictionary.add_dictionary(Arc::new(
             file_dictionary.context("Unable to load the file dictionary.")?,
         ));

--- a/harper-ls/src/diagnostics.rs
+++ b/harper-ls/src/diagnostics.rs
@@ -91,7 +91,7 @@ pub fn lint_to_code_actions<'a>(
         let orig = lint.span.get_content_string(source);
 
         results.push(CodeActionOrCommand::Command(Command::new(
-            format!("Add \"{orig}\" to the global dictionary."),
+            format!("Add \"{orig}\" to the user dictionary."),
             "HarperAddToUserDict".to_string(),
             Some(vec![orig.clone().into(), uri.to_string().into()]),
         )));

--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -145,7 +145,7 @@
 				"harper.userDictPath": {
 					"scope": "resource",
 					"type": "string",
-					"description": "Optional path to a global dictionary file to use."
+					"description": "Optional path to a user dictionary file to use."
 				},
 				"harper.workspaceDictPath": {
 					"scope": "resource",

--- a/packages/web/src/routes/docs/integrations/language-server/+page.md
+++ b/packages/web/src/routes/docs/integrations/language-server/+page.md
@@ -124,7 +124,7 @@ We _do_ take pull requests or issues for adding words to the static dictionary. 
 | ---------------------- | ---------------------------------------------------------- | ---------------------------------------------- |
 | Quick Fixes            | Suggests fixes for the selected error                      | `Replace with: "contained"`                    |
 | `HarperIgnoreLint`     | Ignores the selected error for the duration of the session | `Ignore Harper error.`                         |
-| `HarperAddToUserDict`  | Adds the selected word to the user dictionary              | `Add "containes" to the global dictionary.`    |
+| `HarperAddToUserDict`  | Adds the selected word to the user dictionary              | `Add "containes" to the user dictionary.`      |
 | `HarperAddToWSDict`    | Adds the selected word to the workspace dictionary         | `Add "containes" to the workspace dictionary.` |
 | `HarperAddToFileDict`  | Adds the selected word to a file-local dictionary          | `Add "containes" to the file dictionary.`      |
 


### PR DESCRIPTION
# Issues 

This PR closes #1734 

# Description

In order to deal with the items raised in #1734, we change user-visible strings from 'global dictionary' to 'user dictionary' to match the LSP server config, verbs, and documentation.   We also clarify in the documentation that the user dictionary will only be created when words are added to it.

# Demo

N/A (unless you really want)

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I fired up an editor using the harper-ls built from this tree and confirmed that the action text read `Add "fooble" to the user dictionary.`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
