### PR TITLE
chore: simplify / minimalize github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Platform**
-What platform has the issue? Is it in Obsidian, Neovim, or Visual Studio Code? Something else?
+What platform has the issue? Is it in Obsidian, Neovim, Visual Studio Code, Chrome, or Firefox? Something else?
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/report-false-positive.md
+++ b/.github/ISSUE_TEMPLATE/report-false-positive.md
@@ -1,22 +1,14 @@
 ---
 name: Report False Positive
-about: If Harper flags an error that is not actually wrong, let us know
+about: Harper flagged something that's actually correct
 title: ''
-labels: bug, harper-core, linting, false-positive
-assignees: ''
+labels: bug, false-positive
 
----
+**What got flagged?**
+The text that was incorrectly flagged.
 
-## Description
+**Why is this incorrect?**
+Brief explanation.
 
-Provide a detailed description of the false positive flagged by Harper.
-
-Is it only flagging a non-error or is a spurious fix also suggested?
-
-## Resources
-
-If the problem is not obvious, some online resources clarifying the relevant grammar point can be useful.
-
-## Screenshots
-
-If applicable, add screenshots to help explain the false positive.
+**Example of correct usage:**
+[Your example here]

--- a/.github/ISSUE_TEMPLATE/report-grammatical-error.md
+++ b/.github/ISSUE_TEMPLATE/report-grammatical-error.md
@@ -1,24 +1,18 @@
 ---
 name: Report Grammatical Error
-about: If a grammatical error is not found by Harper, let us know
+about: Harper missed a grammatical error
 title: ''
-labels: enhancement, harper-core, linting
-assignees: ''
+labels: enhancement, linting
 
----
+**The Error**
+Description of the error.
 
-## Description
+**Examples (2-3):**
+1. 
+2. 
 
-Give a detailed description of the grammatical error Harper should be able to find.
+**References**
+Any grammar rules or resources that support this.
 
-## Resources
-
-If there are any resources online we can reference that described grammatical rules, let us know.
-
-## Examples
-
-Please provide at least three examples of the grammatical error in real text.
-
-## Potential False Positives
-
-If there is any grammatical context in which the error may lie (for example, a word may always be invalid if preceded by a preposition), let us know. Provide a few examples, if possible.
+**Potential Edge Cases**
+When might this not apply?

--- a/.github/ISSUE_TEMPLATE/suggest-a-feature.md
+++ b/.github/ISSUE_TEMPLATE/suggest-a-feature.md
@@ -1,50 +1,22 @@
 ---
 name: Suggest a Feature
-about: Suggest a new feature for Harper to improve its functionality
+about: Propose a new feature
 title: ''
 labels: enhancement
-assignees: ''
 
----
+**What problem does this solve?**
+Brief description.
 
-## Note
+**Proposed Solution**
+How should it work?
 
-This template is for suggesting new features for Harper. If you want to report a grammatical error that Harper doesn't detect, please use the [Report Grammatical Error](https://github.com/Automattic/harper/issues/new?template=report-grammatical-error.md) 
-template instead.
+**Examples**
+Show, don't tell.
 
-## Description
+**Component**
+[ ] Core engine
+[ ] Plugin/Extension
+[ ] Other: _____
 
-Provide a detailed description of the feature you would like to see in Harper. Explain what problem it would solve or what benefit it would bring to users.
-
-## Component
-
-Which component of Harper would this feature affect? For example:
-- Core grammar checking engine
-- Obsidian plugin
-- VS Code extension
-- The `harper-ls` language server
-- `harper.js`
-- Another component
-
-## Use Cases
-
-Describe specific scenarios where this feature would be useful. Include examples of text or situations where this feature would be particularly beneficial.
-
-## Implementation Ideas
-
-If you have any ideas about how this feature could be implemented, please share them. Consider:
-- What kind of rules or patterns would need to be detected?
-- Would it require new data structures or algorithms?
-- Are there any existing tools or libraries that could be leveraged?
-
-## Existing Solutions
-
-If similar functionality exists in other grammar checkers or tools, mention them and explain how your proposed feature would differ or improve upon them.
-
-## Screenshots/Examples
-
-If applicable, add screenshots or examples to help illustrate the feature you're suggesting.
-
-## Additional Context
-
-Add any other context or considerations that would be helpful for implementing this feature.
+**Additional Context**
+Any other relevant info.


### PR DESCRIPTION
# Issues 
N/A

# Description

I've noticed that many of the GitHub templates are unnecessarily wordy.
The PR one and the regular Bug report one were OK but I chopped the others down.

If you feel I've cut out something essential or just gone too far, please give feedback!

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
