### PR TITLE
chore: new words, annotation fixes

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -388,7 +388,7 @@ American/NJOgS
 Americana/Ng
 Americanisation/NgS!_
 Americanise/VGdS!_
-Americanism/NgS
+Americanism/NwgS
 Americanization/NgS
 Americanize/VGdS
 Amerind/NJSg
@@ -617,7 +617,7 @@ Argonne/Og
 Argos/Og
 Argus/ONg
 Ariadne/Og
-Arianism/Ng
+Arianism/Nmg
 Ariel/Og
 Aries/ONgS
 Ariosto/g
@@ -1413,7 +1413,7 @@ Brahma/ONgS
 Brahmagupta/Og
 Brahman/NOgS
 Brahmani/N
-Brahmanism/OSg
+Brahmanism/OwSg
 Brahmaputra/ONg
 Brahms/Jg
 Braille/ONJgS
@@ -1733,7 +1733,7 @@ Caloocan/Og
 Calvary/Og
 Calvert/Og
 Calvin/Og
-Calvinism/NgS
+Calvinism/NwgS
 Calvinist/NJgS
 Calvinistic/J
 Camacho/Og
@@ -1767,7 +1767,7 @@ Canaanite/ONJgS
 Canad
 Canada/ONg
 Canadian/JNOSg
-Canadianism/N
+Canadianism/Nmg
 Canaletto/g
 Canaries/Og
 Canaveral/Og
@@ -2289,7 +2289,7 @@ Commodore/OgS
 Commons/Og
 Commonwealth/O
 Communion/OSg
-Communism/N
+Communism/Nmg
 Communist/NJSg
 Como/Og             # laku
 Comoran/JN
@@ -2310,7 +2310,7 @@ Conestoga/ONg
 Confederacy/Og
 Confederate/JNgS
 Confucian/JNSg
-Confucianism/Ng
+Confucianism/Nmg
 Confucianist/NgS
 Confucius/Og
 Cong/Og
@@ -2655,7 +2655,7 @@ Dartmouth/Og
 Darvon/g
 Darwin/Og
 Darwinian/JNg
-Darwinism/NSg
+Darwinism/NwSg
 Darwinist/N
 Daryl/Og
 Datamation
@@ -3352,7 +3352,7 @@ Eurodollar/NSg
 Europa/Og
 Europe/Og
 European/JNgS
-Europeanism/Ng
+Europeanism/Nmg
 Eurotrash/Ng
 Eurozone/Og
 Eurydice/Og
@@ -4435,7 +4435,7 @@ Hellene/NSg
 Hellenic/JOg
 Hellenisation/Ng!_
 Hellenise/V!_
-Hellenism/NgS
+Hellenism/NwgS
 Hellenist/N
 Hellenistic/Jg
 Hellenization/Ng
@@ -5015,7 +5015,7 @@ Jaguar/ONg
 Jahangir/g
 Jaime/Og
 Jain/JNOg
-Jainism/Og
+Jainism/Omg
 Jaipur/Og
 Jakarta/Og
 Jake/Og
@@ -5448,7 +5448,7 @@ Kewpie/g
 Key/Og
 Keynes/Og
 Keynesian/JNg
-Keynesianism/Ng
+Keynesianism/Nmg
 Khabarovsk/Og
 Khachaturian/Og
 Khalid/Og
@@ -5848,7 +5848,7 @@ Lena/Og
 Lenard/Og
 Lenin/Og
 Leningrad/Og
-Leninism/Ng
+Leninism/Nmg
 Leninist/JNg
 Lennon/Og
 Lenny/Og
@@ -6141,7 +6141,7 @@ Lusaka/Og
 Lusitania/Og
 Luther/Og
 Lutheran/JNSg
-Lutheranism/NgS
+Lutheranism/NwgS
 Luvs/g
 Luxembourg/OZg>
 Luxembourger/Ng
@@ -6947,7 +6947,7 @@ Mohacs/g
 Mohamed/Og
 Mohammad/Og
 Mohammedan/NJSg
-Mohammedanism/OSg
+Mohammedanism/OwSg
 Mohave/NOSg
 Mohawk/NOSg
 Mohegan/NO
@@ -7047,7 +7047,7 @@ Morison/Og
 Morita/Og
 Morley/Og
 Mormon/ONJSg
-Mormonism/OSg
+Mormonism/OwSg
 Moro/ONg
 Moroccan/NJSg
 Morocco/Og
@@ -7097,7 +7097,7 @@ Muenster/gS
 Mugabe/Og           # president
 Muhammad/Og
 Muhammadan/NJgS
-Muhammadanism/OSg
+Muhammadanism/OwSg
 Muir/Og
 Mujib/Og
 Mulder/Og
@@ -7735,7 +7735,7 @@ Otis/Og
 Ottawa/ONSg
 Otto/Og
 Ottoman/NJg
-Ottomanism/Ng
+Ottomanism/Nmg
 Ouagadougou/Og
 Ouija/NgS
 Ouranos/g
@@ -7884,7 +7884,7 @@ Park/OSg>
 Parker/ONg
 Parkersburg/Og
 Parkinson/Og
-Parkinsonism/N
+Parkinsonism/Nmg
 Parkman/Og
 Parks/Og
 Parliament/Og
@@ -8003,7 +8003,7 @@ Permalloy/g
 Permian/NJOg
 Pernod/Ng
 Peron/Og
-Peronism/Ng
+Peronism/Nmg
 Peronist/JNgS
 Perot/Og
 Perrier/Og
@@ -8127,7 +8127,7 @@ Plataea/Og
 Plath/Og
 Plato/Og
 Platonic/JN
-Platonism/Og
+Platonism/Omg
 Platonist/Ng
 Platte/Og
 Plautus/Og
@@ -8252,7 +8252,7 @@ Prensa/g
 Prentice/Og
 Pres/JN
 Presbyterian/JNSg
-Presbyterianism/NgS
+Presbyterianism/NwgS
 Prescott/Og
 Presley/Og
 Preston/Og
@@ -8502,7 +8502,7 @@ Rasputin/Og
 Rasta/ON
 Rastaban/Og
 Rastafarian/NJgS
-Rastafarianism/O
+Rastafarianism/Omg
 Rather/Og
 Ratliff/Og
 Raul/Og
@@ -8568,7 +8568,7 @@ Renoir/NOg
 Rep/N
 Representative
 Republican/JNSg
-Republicanism/N
+Republicanism/Nmg
 Requiem/gS
 Resistance
 Restoration/Og
@@ -9053,7 +9053,7 @@ Sassanian/JNg
 Sassoon/Og
 Sat/Ng
 Satan/ONg
-Satanism/Ng
+Satanism/Nmg
 Satanist/Ng
 Saturday/NVgS
 Saturn/ONg
@@ -9581,7 +9581,7 @@ Stafford/ONg
 StairMaster/g
 Stalin/Og
 Stalingrad/Og
-Stalinism/Ng
+Stalinism/Nmg
 Stalinist/JNg
 Stallone/Og
 Stamford/Og
@@ -10251,7 +10251,7 @@ Tunney/Og
 Tupi/NOg
 Tupperware/Nwg      # company
 Tupungato/Og
-Turanism/Ng
+Turanism/Nmg
 Turgenev/g
 Turin/Og            # city
 Turing/Og
@@ -10368,7 +10368,7 @@ Unionist
 Uniontown/Og
 Uniroyal/g
 Unitarian/NJgS
-Unitarianism/NOgS
+Unitarianism/NwOgS
 Unitas/g
 Unix/ONS
 Unukalhai/g
@@ -10548,7 +10548,7 @@ Vicky/Og
 Victor/NOg
 Victoria/ONg
 Victorian/JNgS
-Victorianism/N
+Victorianism/Nmg
 Victorville/Og
 Victrola/Ng
 Vidal/Og
@@ -11101,7 +11101,7 @@ Zimbabwean/NJSg
 Zimmerman/Og
 Zinfandel/g
 Zion/OSg
-Zionism/NSg
+Zionism/NwSg
 Zionist/NJSg
 Ziploc/Ng           # trademark
 Žižek/Og            # slavoj -
@@ -11115,7 +11115,7 @@ Zomba/g
 Zorn/Og
 Zoroaster/Og
 Zoroastrian/NJgS
-Zoroastrianism/OSg
+Zoroastrianism/OwSg
 Zorro/ONg
 Zosma/Og
 Zr/g                # zirconium
@@ -11211,7 +11211,7 @@ aboard/~P
 abode/~NVgS
 abolish/~VGdS
 abolition/~Ng
-abolitionism/Ng
+abolitionism/Nmg
 abolitionist/~JNSg
 abominable/J
 abominably/R
@@ -11317,7 +11317,7 @@ acanthus/NgS
 accede/~VGdS
 accelerate/~VJGnXdS
 acceleration/~Ng
-accelerationism/Ng
+accelerationism/Nmg
 accelerationist/NSg
 accelerator/~NSg
 accelerometer/NSg
@@ -11883,7 +11883,7 @@ agony/~NSg
 agoraphobia/Ng
 agoraphobic/NJgS
 agrarian/~JNgS
-agrarianism/Ng
+agrarianism/Nmg
 agree/~VEBLdS
 agreeableness/NEg
 agreeably/ER
@@ -11983,22 +11983,22 @@ ajar/JV
 aka/~NP
 akimbo/J
 akin/~J
-alabaster/~NJg
+alabaster/~NmJg
 alack/
-alacrity/Ng
+alacrity/Nmg
 alarm/~NVGgdS
 alarming/~VJY
-alarmism/Ng
+alarmism/Nmg
 alarmist/NJSg
 alas/~N
 alb/~NSg
 albacore/NSg
 albatross/~NgS
 albeit/~C
-albinism/Ng
+albinism/Nmg
 albino/~JNgS
 album/~NgnS
-albumen/Ng
+albumen/Nmg
 albumin/~Ng
 albuminous/J
 alchemist/~NSg
@@ -12327,7 +12327,7 @@ amylase/Ng
 amyloid/NJ
 an/~DPeS            # removed `7` conjunction: archaic
 anabolism/Ng
-anachronism/NSg
+anachronism/NwSg
 anachronistic/JQ
 anaconda/NOSg
 anaemia/Ng!_
@@ -12656,7 +12656,7 @@ antipollution/NJ
 antipoverty/J
 antiproton/NgS
 antiquarian/~JNSg
-antiquarianism/Ng
+antiquarianism/Nmg
 antiquary/~NJSg
 antiquate/VGdS
 antique/~JNVdSgG
@@ -15127,7 +15127,7 @@ bogus/~JN
 bogyman/Ng
 bogymen/9
 bohemian/~NJSg
-bohemianism/Ng
+bohemianism/Nmg
 boil/~NVSzZGgd>
 boiler/~Ng
 boilermaker/NSg
@@ -17048,7 +17048,7 @@ charitably/UR
 charity/~NSg
 charlady/NS
 charlatan/NSg
-charlatanism/Ng
+charlatanism/Nmg
 charlatanry/Ng
 charlie/~NS
 charm/~NVZGgd>S
@@ -17096,7 +17096,7 @@ chattiness/Ng
 chatting/VN
 chatty/JN^p>
 chauffeur/~NVGgdS
-chauvinism/Ng
+chauvinism/Nmg
 chauvinist/JNSg
 chauvinistic/JQ
 cheap/~NJVpX^n>Y
@@ -18769,7 +18769,7 @@ consequent/~JNY
 consequential/JiY
 conservancy/~NSg
 conservation/~Ng
-conservationism/Ng
+conservationism/Nmg
 conservationist/~NSg
 conservatism/~Ng
 conservative/~NJgYS
@@ -18960,7 +18960,7 @@ contrapositive/NSg
 contraption/NSg
 contrapuntal/JY
 contrarian/NJSg
-contrarianism/N
+contrarianism/Nmg
 contrariety/Ng
 contrarily/R
 contrariness/Ng
@@ -19271,7 +19271,7 @@ cosmologist/NSg
 cosmology/~NSg
 cosmonaut/~NSg
 cosmopolitan/~JNgS
-cosmopolitanism/Ng
+cosmopolitanism/Nmg
 cosmos/~NgS
 cosplay/NVdGgS>
 cosponsor/NVGSgd
@@ -19605,7 +19605,7 @@ create/~VJKrdSGnv
 creatine/Ng
 creation/~NrSg
 creation's/K
-creationism/~NSg
+creationism/~NwSg
 creationist/NJSg
 creative/~JNSgYp
 creativeness/Ng
@@ -19661,7 +19661,7 @@ crestfallen/J
 crestless/J
 cretaceous/~J
 cretin/NSg
-cretinism/Ng
+cretinism/Nmg
 cretinous/J
 cretonne/Ng
 crevasse/NVSg
@@ -22473,7 +22473,7 @@ ectoplasm/Ng
 ecu/NS
 ecumenical/~JY
 ecumenicism/Ng
-ecumenism/Ng
+ecumenism/Nmg
 eczema/Nwg
 ed/~NreSg
 edamame/N
@@ -22566,7 +22566,7 @@ effusive/JYp
 effusiveness/Ng
 egad/
 egalitarian/~JNSg
-egalitarianism/Ng
+egalitarianism/Nmg
 egg/~NwVGSgd
 eggbeater/NgS
 eggcorn/NgS
@@ -23300,7 +23300,7 @@ equator/~NSg
 equatorial/~JN
 equerry/NSg
 equestrian/~JNSg
-equestrianism/Ng
+equestrianism/Nmg
 equestrienne/NSg
 equidistant/JY
 equilateral/~JNSg
@@ -23422,7 +23422,7 @@ espionage/~Ng
 esplanade/~NgS
 espousal/Ng
 espouse/VGdS
-espresso/NgS
+espresso/NwgS
 esprit/~Ng
 espy/~VNdSG
 esquire/~NVSg
@@ -23434,20 +23434,20 @@ essential/~JNigS
 essentially/~R
 establish/~VrESdGL
 establishment/~NrEg
-establishmentarianism/Ng
+establishmentarianism/Nmg
 establishments/~N
 estate/~NJVSg
-esteem/~NVESgdG
+esteem/~NmVESgdG
 ester/~NSg
 estimable/Ji
 estimate/~NVgGndSX
-estimation/~Ng
+estimation/~Nmg
 estimator/~NSg
 estoppel/N
 estradiol/N
 estrange/VLdSG
 estrangement/NgS
-estrogen/~NgS
+estrogen/~NwgS
 estrous/J
 estrus/NgS
 estuary/~NSg
@@ -23457,11 +23457,11 @@ etch/VNd>SZGz
 etcher/Ng
 etching/~NVg
 eternal/~JNYp
-eternalness/Ng
-eternity/~NSg
+eternalness/Nmg
+eternity/~NwSg
 ethane/Ng
 ethanol/~Nmg
-ether/~NVg
+ether/~NmVg
 ethereal/~JNY
 ethic/~JNSg
 ethical/~JNUY
@@ -23734,7 +23734,7 @@ exhaustive/~JYp
 exhaustiveness/Ng
 exhibit/~VNGgdS
 exhibition/~NgS
-exhibitionism/Ng
+exhibitionism/Nmg
 exhibitionist/NJgS
 exhibitor/NSg
 exhilarate/VdSGn
@@ -23783,7 +23783,7 @@ expanse/~NXgnvS
 expansible/J
 expansion/~Ng
 expansionary/J
-expansionism/Ng
+expansionism/Nmg
 expansionist/~JNgS
 expansive/~JYp
 expansiveness/Ng
@@ -23890,7 +23890,7 @@ express/~JNVGvgdSY
 expressed/~VJU
 expressible/Ji
 expression/~NwSg
-expressionism/~Ng
+expressionism/~Nmg
 expressionist/~JNSg
 expressionistic/J
 expressionless/JY
@@ -24355,10 +24355,10 @@ federation/~NJWg
 fedora/NSg
 fee/~NVSg
 feeble/~JV>^p
-feebleness/Ng
+feebleness/Nmg
 feebly/R
 feed/~VNg>ZGSz
-feedback/~NVg
+feedback/~Nm^Vg
 feedbag/NSg
 feeder/~Ng
 feeding/~VNg
@@ -24385,18 +24385,18 @@ fellatio/Ng
 fellow/~NVSg
 fellowman/Ng
 fellowmen/9
-fellowship/~NVgS
+fellowship/~NwVgS
 felon/JNSg
 felonious/J
 felony/~NSg
-felt/~NVJgdGS
+felt/~NwVJgdGS
 fem/~NJ
 female/~JNpSg
 femaleness/Ng
 feminine/~JNSgY
-femininity/~Ng
+femininity/~Nmg
 feminise/VdSG!_
-feminism/~Ng
+feminism/~Nmg
 feminist/~JNSg
 feminize/VdSG
 femme/NgS
@@ -24405,7 +24405,7 @@ femur/~NSg
 fen/~NSg
 fence/~NVd>SgZG
 fencer/~Ng
-fencing/~VNg
+fencing/~VNmg
 fend/~VNed>ZGS
 fender/~NVeg
 fenestration/Ng
@@ -24421,8 +24421,8 @@ fermium/Ng
 fern/~NgS
 ferny/J>^
 ferocious/~JpY
-ferociousness/Ng
-ferocity/Ng
+ferociousness/Nmg
+ferocity/Nmg
 ferret/~NVGSgd
 ferric/J
 ferromagnetic/J
@@ -25951,7 +25951,7 @@ galumphs/V
 galvanic/JQ
 galvanisation/Ng!_
 galvanise/VdSG!_
-galvanism/Ng
+galvanism/Nmg
 galvanization/Ng
 galvanize/VdSG
 galvanometer/NgS
@@ -27809,7 +27809,7 @@ heath/~Ngn>X
 heathen/~JNg
 heathendom/Ng
 heathenish/J
-heathenism/Ng
+heathenism/Nmg
 heather/~NJg
 heaths/N
 heating/~NmJVg
@@ -30168,7 +30168,7 @@ interurban/~JN
 interval/~NSg
 intervene/~VGdS
 intervention/~NSg
-interventionism/Ng
+interventionism/Nmg
 interventionist/JNSg
 interview/~NVZGgd>S
 interviewee/NgS
@@ -30421,7 +30421,7 @@ isobaric/J
 isochronous/J
 isolate/~VNJdSgGn
 isolation/~Nmg
-isolationism/Ng
+isolationism/Nmg
 isolationist/JNSg
 isolator/NgS
 isoline/NgS
@@ -31167,23 +31167,23 @@ kookaburra/NSg
 kookiness/Nmg
 kooky/JN^p>
 kopeck/NgS
-korma/N
+korma/Nmg
 kosher/~JVdSG
 kowtow/VNGgdS
 kph/N
 kraal/NVSg
 kraut/NVSg!_
-krill/Ng
+krill/Nmg
 krona/Ng
 krone/N>g
 kronor/N
 kronur/N
-krypton/~Ng
-kryptonite/Ng
+krypton/~Nmg
+kryptonite/Nmg
 kt/~N
 kuchen/NSg
 kudos/NVg
-kudzu/NSg
+kudzu/NwSg
 kumquat/NgS
 kvetch/VNZGgd>S
 kvetcher/Ng
@@ -31193,20 +31193,20 @@ la/~NJg
 lab/~NSg
 label/~NVrSdG>
 label's
-labeled/~JVU
+labeled/~JVUr<
 labelled/JVUr!@_
 labelless/J
 labelling/VNr!@_
-labia/N
+labia/N9
 labial/~JNSg
 labile/J
 lability/Ng
-labium/Ng
+labium/N0g
 labor/~NVSgd>ZG<
 laboratory/~NSg
 laborer/~Ng<
 laborious/JpY
-laboriousness/Ng
+laboriousness/Nmg
 laborsaving/J<
 labour/NVZGSgd>!@_
 labourer/Ng!@_
@@ -31698,7 +31698,7 @@ leprous/J
 lepta/N
 lepton/~NgS
 lesbian/~JNVSg
-lesbianism/Ng
+lesbianism/Nmg
 lesion/~NVgS
 less/~PVJCn>X
 lessee/NVgS
@@ -31789,7 +31789,7 @@ liberate/~VedSGn
 liberation/~Neg
 liberator/~NgS
 libertarian/~NJSg
-libertarianism/Ng
+libertarianism/Nmg
 libertine/~NJgS
 liberty/~NSg
 libidinal/J
@@ -34145,7 +34145,7 @@ modern/~JNgYpS
 modernisation/Ng!_
 modernise/Vd>SZG!_
 moderniser/Ng!_
-modernism/~Ng
+modernism/~Nmg
 modernist/~JNSg
 modernistic/J
 modernity/~Ng
@@ -34269,7 +34269,7 @@ mongoose/NgS
 mongrel/NJSg
 monies/~N
 moniker/~NSg
-monism/Ng
+monism/Nmg
 monist/NgS
 monition/NSg
 monitor/~NVSgdG
@@ -35554,7 +35554,7 @@ nondepreciating/J
 nondescript/JN
 nondestructive/J
 nondetachable/J
-nondeterminism/N
+nondeterminism/Nmg
 nondeterministic/J
 nondisciplinary/J
 nondisclosure/Ng
@@ -36126,7 +36126,7 @@ obstreperousness/Ng
 obstruct/~VdGvS
 obstructed/~VU
 obstruction/~NSg
-obstructionism/Ng
+obstructionism/Nmg
 obstructionist/NJgS
 obstructive/JNYp
 obstructiveness/Nmg
@@ -36439,7 +36439,7 @@ opossum/NgS
 opp/~PN
 opponent/~NJSg
 opportune/JiY
-opportunism/Ng
+opportunism/Nmg
 opportunist/NSg
 opportunistic/~JQ
 opportunity/~NSg
@@ -36526,7 +36526,7 @@ ordination/~Nwg
 ordnance/~Ng
 ordure/Ng
 ore/~NPSg
-oregano/Ng
+oregano/Nmg
 org/~NSg
 organ/~NVgS
 organdie/Ng!_
@@ -36541,7 +36541,7 @@ organiser/NgS!_
 organism/~NgS
 organismic/J
 organist/~NgS
-organization/~NrSg
+organization/~NwrSg
 organizational/~JY
 organize/~VrESdG
 organized/~JVU
@@ -37042,7 +37042,7 @@ oversimple/J
 oversimplification/Ng
 oversimplify/VdSnGX
 oversize/JVNdSG
-oversized/J!@_
+oversized/J
 oversleep/VGS
 overslept/V
 oversold/J
@@ -37202,7 +37202,7 @@ paedophile/NS!_
 paedophilia/Nm!@_
 paella/NwgS
 pagan/~JNSg
-paganism/~Ng
+paganism/~Nmg
 page/~NVgZGd>S
 pageant/~NVgS
 pageantry/Ng
@@ -38050,7 +38050,7 @@ perfecta/NgS
 perfectibility/Ng
 perfectible/J
 perfection/~NVSg
-perfectionism/Ng
+perfectionism/Nmg
 perfectionist/NJSg
 perfectness/Ng
 perfidious/JY
@@ -38357,7 +38357,7 @@ philately/Ng
 philharmonic/~JNSg
 philippic/~NgS
 philistine/~NJgS
-philistinism/Ng
+philistinism/Nmg
 philodendron/NSg
 philological/~J
 philologist/~NgS
@@ -40169,7 +40169,7 @@ protect/~VGvSd
 protectant/NSg
 protected/~JVU
 protection/~NwSg
-protectionism/~Ng
+protectionism/~Nmg
 protectionist/JNgS
 protective/~JNpY
 protectiveness/Ng
@@ -40462,16 +40462,16 @@ purgatorial/J
 purgatory/~NJSg
 purge/~VNgZGd>S
 purger/Ng
-purification/~Ng
+purification/~Nmg
 purifier/Ng
 purify/~Vnd>SZG
 purine/NgS
-purism/Ng
+purism/Nmg
 purist/JNgS
 puristic/J
 puritan/~NJSg
 puritanical/JNY
-puritanism/Ng
+puritanism/Nmg
 purity/~Ng
 purl/NVGgdS
 purlieu/NSg
@@ -40480,7 +40480,7 @@ purple/~NwJVg^>S
 purplish/~J
 purport/VNSgdG
 purported/~JVY
-purpose/~NVdSgG
+purpose/~NwVdSgG
 purposed/JVr
 purposeful/JYp
 purposefulness/Ng
@@ -40617,6 +40617,7 @@ qualm/NVgS
 qualmish/J
 quandary/NSg
 quango/NS
+quant/NgS           # quantitative analyst
 quanta/~N
 quantifiable/JN
 quantification/~Ng
@@ -41762,7 +41763,7 @@ reproving/VJNY
 reptile/~NJSg
 reptilian/~JNgS
 republic/~NS
-republicanism/~Ng
+republicanism/~Nmg
 repudiate/VXGndS
 repudiation/~Ng
 repudiator/NgS
@@ -42043,7 +42044,7 @@ revilement/Ng
 reviler/Ng
 reviser/NgS
 revision/~NVSg
-revisionism/Ng
+revisionism/Nmg
 revisionist/~JNSg
 revival/~NgS
 revivalism/Ng
@@ -42887,7 +42888,7 @@ sassy/~J>^
 sat/~JVN
 satanic/~J
 satanical/JY
-satanism/~Ng
+satanism/~Nmg
 satanist/~NgS
 satay/~N
 satchel/NgS
@@ -43461,7 +43462,7 @@ secretiveness/Ng
 secretory/JN
 sect/~NigS
 sectarian/~JNgS
-sectarianism/Ng
+sectarianism/Nmg
 sectary/NSg
 section/~NVrESg
 sectional/~JNgS
@@ -43905,7 +43906,7 @@ shalt/V
 sham/~JNVGgdS
 shaman/~NSg
 shamanic/~J
-shamanism/~N
+shamanism/~Nmg
 shamanistic/J
 shamble/VNgGdS
 shambles/NVg
@@ -48638,7 +48639,7 @@ toilette/Ng
 toilsome/J
 toke/NVgGdS
 token/~NJVSg
-tokenism/Ng
+tokenism/Nmg
 tokenization/Nmg
 tokenize/VdSG
 tokenizer/NgS
@@ -48801,7 +48802,7 @@ tot/~NVSGgd
 total/~NJVGSgdY
 totalisator/NgS!@_
 totalitarian/~JNSg
-totalitarianism/~Ng
+totalitarianism/~Nmg
 totality/~NSg
 totalizator/NSg
 totalize/VSdG
@@ -49035,7 +49036,7 @@ transgress/VGdS
 transgression/~NSg
 transgressive/~NSg
 transgressor/NSg
-transhumanism/Ng
+transhumanism/Nmg
 transience/Ng
 transiency/Ng
 transient/~JNSgY
@@ -50112,7 +50113,7 @@ unintuitive/~JNpY
 uninvested/J
 uninviting/J
 union/~NVJrSg
-unionism/Ng
+unionism/Nmg
 unionist/~JNgS
 unique/~JNY^>p
 uniqueness/~Ng
@@ -50407,7 +50408,7 @@ urban/~J
 urbane/J>Y^
 urbanisation/Ng!_
 urbanise/VdSG!_
-urbanism/~Ng
+urbanism/~Nmg
 urbanite/NgS
 urbanity/Ng
 urbanization/~Nwg
@@ -50474,7 +50475,7 @@ util/NgS
 utilisation/Ng!_
 utilise/VGBdS!_
 utilitarian/~JNgS
-utilitarianism/~Ng
+utilitarianism/~Nmg
 utility/~NwJSg
 utilization/~Ng
 utilize/~VGBdS
@@ -50533,7 +50534,7 @@ valency/NSg
 valentine/~NSg
 valet/~NVSgdG
 valetudinarian/JNgS
-valetudinarianism/Ng
+valetudinarianism/Nmg
 valiance/Ng
 valiant/~JNY
 valid/~JY
@@ -50642,23 +50643,23 @@ vaulter/Ng
 vaulting/NVJg
 vaunt/VNSgdG
 vb/~N
-veal/NVg
+veal/NmVg
 vector/~NVSGgd
 vectorization/Nmg
 vectorize/VdSG>
 veejay/NVSg
 veep/NgS
 veer/~VNgdGS
-veg/JNVg
+veg/JNmVg
 vegan/~JNSg
-veganism/N
+veganism/Nmg
 vegeburger/NS
 veges/NV
 vegetable/~NJSg
 vegetarian/~NJSg
-vegetarianism/~Ng
+vegetarianism/~Nmg
 vegetate/VGnvdS
-vegetation/~Ng
+vegetation/~Nmg
 vegged/V
 vegges/V
 veggie/NJSg
@@ -51099,7 +51100,7 @@ volatilise/VdSG!_
 volatility/~Ng
 volatilize/VdSG
 volcanic/~JN
-volcanism/~N
+volcanism/~Nmg
 volcano/~N0Vg
 volcanoes/~N9
 vole/~NVgS
@@ -51614,7 +51615,7 @@ western/~JNSZg>
 westerner/Ng
 westernisation/Ng!_
 westernise/VGdS!_
-westernism/Ng
+westernism/Nmg
 westernization/Ng
 westernize/VGdS
 westernmost/~J
@@ -52687,6 +52688,7 @@ Codeberg/Og         # GitHub alternative
 Colemak/NJg
 CommonMark/g
 CompUSA             # retailer
+Conda/Og            # package manager for Python and R
 Corretto/Sg
 Coursera/Og
 Crowdsignal/Og
@@ -53162,6 +53164,7 @@ scatterplot/NVSgG   # dictionaries prefer: scatter plot
 screencast/VdSG
 scrollbar/NSg       # dictionaries prefer: scroll bar
 sed/Og              # *nix tool / language
+sigil/NgS
 singleplayer/J
 sioyek/Sg           # !! please check and comment !!
 stacktrace/SgN      # dictionaries prefer: stack trace
@@ -53501,6 +53504,7 @@ opt-in/J
 opt out/V
 opt-out/J
 OR gate/NgS
+order book/NgS
 OS X/Og             # before macOS
 out-and-out/J
 out of date

--- a/harper-core/proper_noun_rules.json
+++ b/harper-core/proper_noun_rules.json
@@ -516,6 +516,7 @@
 		"canonical": [
 			"Big Sur",
 			"Bretton Woods",
+			"Coney Island",
 			"Darien Gap",
 			"Des Moines",
 			"El Paso",

--- a/harper-core/src/linting/very_unique.rs
+++ b/harper-core/src/linting/very_unique.rs
@@ -55,7 +55,7 @@ impl ExprLinter for VeryUnique {
             span: very_unique_span,
             lint_kind: LintKind::WordChoice,
             suggestions,
-            message: "`Unique` is an absolute, so consider using `unique` alone or a more precise adjective such as `special`, `rare`, or `unusual`.".to_string(),
+            message: "`Unique` is absolute, so consider using `unique` alone or a more precise adjective such as `special`, `rare`, or `unusual`.".to_string(),
             priority: 57,
         })
     }

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -3736,9 +3736,9 @@ Message: |
     2492 | some of the rooms. Let’s go to Coney Island, old sport. In my car.”
          |                                ^~~~~ Did you mean to spell `Coney` this way?
 Suggest:
-  - Replace with: “Cone”
   - Replace with: “Conley”
   - Replace with: “Corey”
+  - Replace with: “Coley”
 
 
 
@@ -3767,9 +3767,9 @@ Message: |
     2562 | Coney Island, or for how many hours he “glanced into rooms” while his house
          | ^~~~~ Did you mean to spell `Coney` this way?
 Suggest:
-  - Replace with: “Cone”
   - Replace with: “Conley”
   - Replace with: “Corey”
+  - Replace with: “Coley”
 
 
 

--- a/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
+++ b/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
@@ -158,8 +158,8 @@
 # P  ISg+    . NPr/J/P D/P J      NSg/V P  NSg/J+ . . NSg/VX NPl/V+ V   NPl/V . NSg/VX NPl/V+ V   NPl/V . . V/C
 > sometimes , “ Do     bats  eat cats   ? ” for , you    see   , as    she  couldn’t answer either
 # R         . . NSg/VX NPl/V V   NPl/V+ . . C/P . ISgPl+ NSg/V . NSg/R ISg+ V        NSg/V+ I/C
-> question , it       didn’t much       matter    which way    she  put   it       . She  felt    that         she  was
-# NSg/V+   . NPr/ISg+ V      NSg/I/J/Dq N🅪Sg/V/JC I/C+  NSg/J+ ISg+ NSg/V NPr/ISg+ . ISg+ NSg/V/J NSg/I/C/Ddem ISg+ V
+> question , it       didn’t much       matter    which way    she  put   it       . She  felt     that         she  was
+# NSg/V+   . NPr/ISg+ V      NSg/I/J/Dq N🅪Sg/V/JC I/C+  NSg/J+ ISg+ NSg/V NPr/ISg+ . ISg+ N🅪Sg/V/J NSg/I/C/Ddem ISg+ V
 > dozing off       , and had just begun to dream   that         she  was walking hand   in      hand   with
 # V      NSg/V/J/P . V/C V   V/J  V     P  NSg/V/J NSg/I/C/Ddem ISg+ V   NSg/V/J NSg/V+ NPr/J/P NSg/V+ P
 > Dinah , and saying to her     very earnestly , “ Now       , Dinah , tell  me       the truth   : did you
@@ -290,8 +290,8 @@
 # NSg/V/J/P NSg/P D   NSg/V   NSg/I/C/Ddem ISg+ V   NPr/V/J/C D   NPr/V/J N🅪Sg/V+ C/P NSg/V/J NSg/J/P D   NPr/I/J/Dq
 > door   into that         lovely garden   . First   , however , she  waited for a    few       minutes to
 # NSg/V+ P    NSg/I/C/Ddem NSg/J  NSg/V/J+ . NSg/V/J . C       . ISg+ V/J    C/P D/P+ NSg/I/Dq+ NPl/V+  P
-> see   if    she  was going   to shrink any    further : she  felt    a   little     nervous about
-# NSg/V NSg/C ISg+ V   NSg/V/J P  NSg/V  I/R/Dq V/J     . ISg+ NSg/V/J D/P NPr/I/J/Dq J       J/P
+> see   if    she  was going   to shrink any    further : she  felt     a   little     nervous about
+# NSg/V NSg/C ISg+ V   NSg/V/J P  NSg/V  I/R/Dq V/J     . ISg+ N🅪Sg/V/J D/P NPr/I/J/Dq J       J/P
 > this    ; “ for it       might     end    , you    know  , ” said Alice to herself , “ in      my  going   out
 # I/Ddem+ . . C/P NPr/ISg+ NᴹSg/VX/J NSg/V+ . ISgPl+ NSg/V . . V/J  NPr+  P  ISg+    . . NPr/J/P D$+ NSg/V/J NSg/V/J/R/P
 > altogether , like        a    candle . I    wonder what   I    should be     like        then    ? ” And she  tried
@@ -450,8 +450,8 @@
 # NSg/J+ NSg/V+ NPr/J/P D   NSg/V/J . NPr/ISg+ NSg/V/P NSg/V/J  P     NPr/J/P D/P+ NSg/J+ NSg/V+ . NSg/V     P
 > himself as    he       came    , “ Oh    ! the Duchess , the Duchess ! Oh    ! won’t she  be     savage   if
 # ISg+    NSg/R NPr/ISg+ NSg/V/P . . NPr/V . D   NSg/V   . D   NSg/V   . NPr/V . V     ISg+ NSg/VX NPr/V/J+ NSg/C
-> I’ve kept her     waiting ! ” Alice felt    so        desperate that         she  was ready   to ask   help
-# W?   V    ISg/D$+ NSg/V   . . NPr+  NSg/V/J NSg/I/J/C NSg/J     NSg/I/C/Ddem ISg+ V   NSg/V/J P  NSg/V NSg/V
+> I’ve kept her     waiting ! ” Alice felt     so        desperate that         she  was ready   to ask   help
+# W?   V    ISg/D$+ NSg/V   . . NPr+  N🅪Sg/V/J NSg/I/J/C NSg/J     NSg/I/C/Ddem ISg+ V   NSg/V/J P  NSg/V NSg/V
 > of any     one        ; so        , when    the Rabbit came    near      her     , she  began , in      a   low     , timid voice  ,
 # P  I/R/Dq+ NSg/I/V/J+ . NSg/I/J/C . NSg/I/C D+  NSg/V+ NSg/V/P NSg/V/J/P ISg/D$+ . ISg+ V     . NPr/J/P D/P NSg/V/J . J+    NSg/V+ .
 > “ If    you    please , sir    — ” The Rabbit started violently , dropped the white     kid    gloves
@@ -666,8 +666,8 @@
 # NSg/J NSg/V+ P  NSg/V . V/C W?    NSg/I D/P NSg/J+  NSg/I/V/J+ C/P V        NSg/V+ . NPr/V . ISg+ NSg/V
 > your pardon ! ” cried Alice again , for this    time      the Mouse  was bristling all          over    ,
 # D$+  NSg/V  . . V/J   NPr+  P     . C/P I/Ddem+ N🅪Sg/V/J+ D+  NSg/V+ V   V         NSg/I/J/C/Dq NSg/J/P .
-> and she  felt    certain it       must  be     really offended . “ We   won’t talk   about her     any
-# V/C ISg+ NSg/V/J I/J     NPr/ISg+ NSg/V NSg/VX R      V/J      . . IPl+ V     N🅪Sg/V J/P   ISg/D$+ I/R/Dq
+> and she  felt     certain it       must  be     really offended . “ We   won’t talk   about her     any
+# V/C ISg+ N🅪Sg/V/J I/J     NPr/ISg+ NSg/V NSg/VX R      V/J      . . IPl+ V     N🅪Sg/V J/P   ISg/D$+ I/R/Dq
 > more         if    you’d rather  not   . ”
 # NPr/I/V/J/Dq NSg/C W?    NPr/V/J NSg/C . .
 >
@@ -762,8 +762,8 @@
 # NSg/V/J/R/P . . NSg/V N🅪Sg/V/J/P . NSg/I/J/C/Dq P  ISgPl+ . V/C NSg/V  P  NPr/ISg+ . W?   J/R  NSg/V ISgPl+ NSg/V/J NSg/I  . .
 > They all          sat     down       at    once  , in      a    large  ring   , with the Mouse  in      the middle  . Alice
 # IPl+ NSg/I/J/C/Dq NSg/V/J N🅪Sg/V/J/P NSg/P NSg/C . NPr/J/P D/P+ NSg/J+ NSg/V+ . P    D+  NSg/V+ NPr/J/P D   NSg/V/J . NPr+
-> kept her     eyes   anxiously fixed on  it       , for she  felt    sure she  would catch a   bad
-# V    ISg/D$+ NPl/V+ R         V/J   J/P NPr/ISg+ . C/P ISg+ NSg/V/J J    ISg+ VX    NSg/V D/P NSg/V/J
+> kept her     eyes   anxiously fixed on  it       , for she  felt     sure she  would catch a   bad
+# V    ISg/D$+ NPl/V+ R         V/J   J/P NPr/ISg+ . C/P ISg+ N🅪Sg/V/J J    ISg+ VX    NSg/V D/P NSg/V/J
 > cold  if    she  did not   get   dry     very soon .
 # NSg/J NSg/C ISg+ V   NSg/C NSg/V NSg/V/J J/R  J/R  .
 >
@@ -1104,8 +1104,8 @@
 # . NSg/I+ V     P  NSg/V/J/C/P ISg/D$+ . N🅪Sg/V/J/P NSg/J/R . V/C W?  J    W?    D   NPr/VX/JS NSg/V/J+ NPr/J/P D
 > world  ! Oh    , my  dear    Dinah ! I    wonder if    I    shall ever see   you    any    more         ! ” And here
 # NSg/V+ . NPr/V . D$+ NSg/V/J NPr   . ISg+ N🅪Sg/V NSg/C ISg+ VX    J    NSg/V ISgPl+ I/R/Dq NPr/I/V/J/Dq . . V/C NSg/J/R
-> poor     Alice began to cry   again , for she  felt    very lonely and low     - spirited . In      a
-# NSg/V/J+ NPr+  V     P  NSg/V P     . C/P ISg+ NSg/V/J J/R  J/R    V/C NSg/V/J . V/J      . NPr/J/P D/P
+> poor     Alice began to cry   again , for she  felt     very lonely and low     - spirited . In      a
+# NSg/V/J+ NPr+  V     P  NSg/V P     . C/P ISg+ N🅪Sg/V/J J/R  J/R    V/C NSg/V/J . V/J      . NPr/J/P D/P
 > little     while     , however , she  again heard a   little     pattering of footsteps in      the
 # NPr/I/J/Dq NSg/V/C/P . C       . ISg+ P     V/J   D/P NPr/I/J/Dq V         P  NPl+      NPr/J/P D
 > distance , and she  looked up        eagerly , half        hoping that         the Mouse  had changed his
@@ -1233,7 +1233,7 @@
 > grew no    larger : still   it       was very uncomfortable , and , as    there seemed to be     no
 # V    NPr/P JC     . NSg/V/J NPr/ISg+ V   J/R  J             . V/C . NSg/R +     V/J    P  NSg/VX NPr/P
 > sort  of chance  of her     ever getting out         of the room     again , no    wonder she  felt
-# NSg/V P  NPr/V/J P  ISg/D$+ J    NSg/V   NSg/V/J/R/P P  D+  NSg/V/J+ P     . NPr/P N🅪Sg/V ISg+ NSg/V/J
+# NSg/V P  NPr/V/J P  ISg/D$+ J    NSg/V   NSg/V/J/R/P P  D+  NSg/V/J+ P     . NPr/P N🅪Sg/V ISg+ N🅪Sg/V/J
 > unhappy .
 # NSg/V/J .
 >
@@ -1664,8 +1664,8 @@
 # . ISgPl+ . . V/J  D   NSg/V       R              . . NPr/I+ V   ISgPl+ . .
 >
 #
-> Which brought them     back    again to the beginning of the conversation . Alice felt    a
-# I/C+  V       NSg/IPl+ NSg/V/J P     P  D   NSg/V/J   P  D+  N🅪Sg/V+      . NPr+  NSg/V/J D/P+
+> Which brought them     back    again to the beginning of the conversation . Alice felt     a
+# I/C+  V       NSg/IPl+ NSg/V/J P     P  D   NSg/V/J   P  D+  N🅪Sg/V+      . NPr+  N🅪Sg/V/J D/P+
 > little      irritated at    the Caterpillar’s making such  very short     remarks , and she
 # NPr/I/J/Dq+ V/J+      NSg/P D   NSg$          NSg/V  NSg/I J/R  NPr/V/J/P NPl/V+  . V/C ISg+
 > drew  herself up        and said , very gravely , “ I    think , you    ought    to tell  me       who    you
@@ -1842,8 +1842,8 @@
 #
 > Alice said nothing  : she  had never been  so        much       contradicted in      her     life    before ,
 # NPr+  V/J  NSg/I/J+ . ISg+ V   R     NSg/V NSg/I/J/C NSg/I/J/Dq V/J          NPr/J/P ISg/D$+ N🅪Sg/V+ C/P    .
-> and she  felt    that         she  was losing  her     temper    .
-# V/C ISg+ NSg/V/J NSg/I/C/Ddem ISg+ V   NSg/V/J ISg/D$+ NSg/V/JC+ .
+> and she  felt     that         she  was losing  her     temper    .
+# V/C ISg+ N🅪Sg/V/J NSg/I/C/Ddem ISg+ V   NSg/V/J ISg/D$+ NSg/V/JC+ .
 >
 #
 > “ Are you    content   now       ? ” said the Caterpillar .
@@ -1908,14 +1908,14 @@
 #
 > “ And now       which is which ? ” she  said to herself , and nibbled a   little     of the
 # . V/C NPr/V/J/C I/C+  VL I/C+  . . ISg+ V/J  P  ISg+    . V/C V/J     D/P NPr/I/J/Dq P  D
-> right   - hand   bit    to try     the effect : the next    moment she  felt    a   violent blow
-# NPr/V/J . NSg/V+ NSg/V+ P  NSg/V/J D   NSg/V+ . D   NSg/J/P NSg+   ISg+ NSg/V/J D/P NSg/V/J NSg/V/J+
+> right   - hand   bit    to try     the effect : the next    moment she  felt     a   violent blow
+# NPr/V/J . NSg/V+ NSg/V+ P  NSg/V/J D   NSg/V+ . D   NSg/J/P NSg+   ISg+ N🅪Sg/V/J D/P NSg/V/J NSg/V/J+
 > underneath her     chin   : it       had struck her     foot   !
 # NSg/J/P    ISg/D$+ NPr/V+ . NPr/ISg+ V   V      ISg/D$+ NSg/V+ .
 >
 #
-> She  was a   good    deal    frightened by      this   very sudden change , but     she  felt    that
-# ISg+ V   D/P NPr/V/J NSg/V/J V/J        NSg/J/P I/Ddem J/R  NSg/J  N🅪Sg/V . NSg/C/P ISg+ NSg/V/J NSg/I/C/Ddem
+> She  was a   good    deal    frightened by      this   very sudden change , but     she  felt     that
+# ISg+ V   D/P NPr/V/J NSg/V/J V/J        NSg/J/P I/Ddem J/R  NSg/J  N🅪Sg/V . NSg/C/P ISg+ N🅪Sg/V/J NSg/I/C/Ddem
 > there was no    time      to be     lost , as    she  was shrinking rapidly ; so        she  set     to work
 # +     V   NPr/P N🅪Sg/V/J+ P  NSg/VX V/J  . NSg/R ISg+ V   V         R       . NSg/I/J/C ISg+ NPr/V/J P  N🅪Sg/V
 > at    once  to eat some     of the other    bit    . Her     chin   was pressed so        closely against
@@ -2093,7 +2093,7 @@
 >
 #
 > It       was so        long    since she  had been  anything near      the right    size    , that         it       felt
-# NPr/ISg+ V   NSg/I/J/C NPr/V/J C/P   ISg+ V   NSg/V NSg/I/V+ NSg/V/J/P D+  NPr/V/J+ N🅪Sg/V+ . NSg/I/C/Ddem NPr/ISg+ NSg/V/J
+# NPr/ISg+ V   NSg/I/J/C NPr/V/J C/P   ISg+ V   NSg/V NSg/I/V+ NSg/V/J/P D+  NPr/V/J+ N🅪Sg/V+ . NSg/I/C/Ddem NPr/ISg+ N🅪Sg/V/J
 > quite strange at    first   ; but     she  got used to it       in      a    few       minutes , and began
 # NSg   NSg/V/J NSg/P NSg/V/J . NSg/C/P ISg+ V   V/J  P  NPr/ISg+ NPr/J/P D/P+ NSg/I/Dq+ NPl/V+  . V/C V
 > talking to herself , as    usual . “ Come    , there’s half        my  plan   done    now       ! How   puzzling
@@ -2132,8 +2132,8 @@
 # P    ISg/D$+ NPl/V    . NPr/ISg+ V   V/J    NSg/J/P I/D     NSg     NPr/J/P NSg/V/J . P    D/P NSg/V/J/P
 > face   , and large eyes   like        a   frog  ; and both   footmen , Alice noticed , had powdered
 # NSg/V+ . V/C NSg/J NPl/V+ NSg/V/J/C/P D/P NSg/V . V/C I/C/Dq NPl     . NPr+  V/J     . V   V/J
-> hair    that          curled all          over    their heads  . She  felt    very curious to know  what   it       was
-# N🅪Sg/V+ NSg/I/C/Ddem+ V/J    NSg/I/J/C/Dq NSg/J/P D$+   NPl/V+ . ISg+ NSg/V/J J/R  J       P  NSg/V NSg/I+ NPr/ISg+ V
+> hair    that          curled all          over    their heads  . She  felt     very curious to know  what   it       was
+# N🅪Sg/V+ NSg/I/C/Ddem+ V/J    NSg/I/J/C/Dq NSg/J/P D$+   NPl/V+ . ISg+ N🅪Sg/V/J J/R  J       P  NSg/V NSg/I+ NPr/ISg+ V
 > all          about , and crept a   little      way    out         of the wood     to listen .
 # NSg/I/J/C/Dq J/P   . V/C V     D/P NPr/I/J/Dq+ NSg/J+ NSg/V/J/R/P P  D+  NPr/V/J+ P  NSg/V  .
 >
@@ -2358,8 +2358,8 @@
 # . D   NSg/V+ VX    NSg/V/J NSg/V/J/P D/P NSg/V/J+ NSg/JC C/P  NPr/ISg+ NPl/V . .
 >
 #
-> “ Which would not   be     an   advantage , ” said Alice , who    felt    very glad    to get   an
-# . I/C+  VX    NSg/C NSg/VX D/P+ N🅪Sg/V+   . . V/J  NPr+  . NPr/I+ NSg/V/J J/R  NSg/V/J P  NSg/V D/P
+> “ Which would not   be     an   advantage , ” said Alice , who    felt     very glad    to get   an
+# . I/C+  VX    NSg/C NSg/VX D/P+ N🅪Sg/V+   . . V/J  NPr+  . NPr/I+ N🅪Sg/V/J J/R  NSg/V/J P  NSg/V D/P
 > opportunity of showing off       a   little     of her     knowledge . “ Just think of what   work
 # NSg         P  NSg/V   NSg/V/J/P D/P NPr/I/J/Dq P  ISg/D$+ NᴹSg+     . . V/J  NSg/V P  NSg/I+ N🅪Sg/V+
 > it       would make  with the day  and night   ! You    see   the earth   takes twenty - four hours
@@ -2496,14 +2496,14 @@
 # NSg+     NSg/I/C ISg+ NSg/V NPr/ISg+ NSg/V/J+ . . NSg/I/C NPr/ISg+ V/J     P     . NSg/I/J/C R         . NSg/I/C/Ddem ISg+
 > looked down       into its     face   in      some     alarm  . This    time      there could  be     no    mistake
 # V/J    N🅪Sg/V/J/P P    ISg/D$+ NSg/V+ NPr/J/P I/J/R/Dq NSg/V+ . I/Ddem+ N🅪Sg/V/J+ +     NSg/VX NSg/VX NPr/P NSg/V
-> about it       : it       was neither more         nor   less    than a    pig    , and she  felt    that         it       would be
-# J/P   NPr/ISg+ . NPr/ISg+ V   I/C     NPr/I/V/J/Dq NSg/C V/J/C/P C/P  D/P+ NSg/V+ . V/C ISg+ NSg/V/J NSg/I/C/Ddem NPr/ISg+ VX    NSg/VX
+> about it       : it       was neither more         nor   less    than a    pig    , and she  felt     that         it       would be
+# J/P   NPr/ISg+ . NPr/ISg+ V   I/C     NPr/I/V/J/Dq NSg/C V/J/C/P C/P  D/P+ NSg/V+ . V/C ISg+ N🅪Sg/V/J NSg/I/C/Ddem NPr/ISg+ VX    NSg/VX
 > quite absurd for her     to carry it       further .
 # NSg   NSg/J  C/P ISg/D$+ P  NSg/V NPr/ISg+ V/J     .
 >
 #
-> So        she  set     the little      creature down       , and felt    quite relieved to see   it       trot   away
-# NSg/I/J/C ISg+ NPr/V/J D+  NPr/I/J/Dq+ NSg+     N🅪Sg/V/J/P . V/C NSg/V/J NSg   V/J      P  NSg/V NPr/ISg+ NSg/V+ V/J
+> So        she  set     the little      creature down       , and felt     quite relieved to see   it       trot   away
+# NSg/I/J/C ISg+ NPr/V/J D+  NPr/I/J/Dq+ NSg+     N🅪Sg/V/J/P . V/C N🅪Sg/V/J NSg   V/J      P  NSg/V NPr/ISg+ NSg/V+ V/J
 > quietly into the wood     . “ If    it       had grown up        , ” she  said to herself , “ it       would have
 # R       P    D+  NPr/V/J+ . . NSg/C NPr/ISg+ V   V/J   NSg/V/J/P . . ISg+ V/J  P  ISg+    . . NPr/ISg+ VX    NSg/VX
 > made a   dreadfully ugly     child  : but     it       makes rather  a   handsome pig    , I    think . ” And
@@ -2520,8 +2520,8 @@
 #
 > The Cat      only  grinned when    it       saw   Alice . It       looked good    - natured , she  thought :
 # D+  NSg/V/J+ J/R/C V       NSg/I/C NPr/ISg+ NSg/V NPr+  . NPr/ISg+ V/J    NPr/V/J . ?       . ISg+ NSg/V   .
-> still   it       had very long    claws and a   great many       teeth , so        she  felt    that         it       ought
-# NSg/V/J NPr/ISg+ V   J/R  NPr/V/J NPl/V V/C D/P NSg/J NSg/I/J/Dq NPl+  . NSg/I/J/C ISg+ NSg/V/J NSg/I/C/Ddem NPr/ISg+ NSg/I/VX
+> still   it       had very long    claws and a   great many       teeth , so        she  felt     that         it       ought
+# NSg/V/J NPr/ISg+ V   J/R  NPr/V/J NPl/V V/C D/P NSg/J NSg/I/J/Dq NPl+  . NSg/I/J/C ISg+ N🅪Sg/V/J NSg/I/C/Ddem NPr/ISg+ NSg/I/VX
 > to be     treated with respect .
 # P  NSg/VX V/J     P    NᴹSg/V+ .
 >
@@ -2556,8 +2556,8 @@
 # . NPr/V . W?     J    P  NSg/VX NSg/I/C/Ddem+ . . V/J  D   NSg/V/J+ . . NSg/C ISgPl+ J/R/C NSg/V NPr/V/J NSg/I  . .
 >
 #
-> Alice felt    that         this    could  not   be     denied , so        she  tried another question . “ What
-# NPr+  NSg/V/J NSg/I/C/Ddem I/Ddem+ NSg/VX NSg/C NSg/VX V/J    . NSg/I/J/C ISg+ V/J   I/D+    NSg/V+   . . NSg/I+
+> Alice felt     that         this    could  not   be     denied , so        she  tried another question . “ What
+# NPr+  N🅪Sg/V/J NSg/I/C/Ddem I/Ddem+ NSg/VX NSg/C NSg/VX V/J    . NSg/I/J/C ISg+ V/J   I/D+    NSg/V+   . . NSg/I+
 > sort  of people live about here    ? ”
 # NSg/V P  NPl/V+ V/J  J/P   NSg/J/R . .
 >
@@ -2896,8 +2896,8 @@
 # . I/C+  VL V/J  D   NPr/V P    NSg/I/V+ . . V/J  D   NSg/V  .
 >
 #
-> Alice felt    dreadfully puzzled , The Hatter’s remark seemed to have   no    sort  of
-# NPr+  NSg/V/J R          V/J     . D   NSg$     NSg/V+ V/J    P  NSg/VX NPr/P NSg/V P
+> Alice felt     dreadfully puzzled , The Hatter’s remark seemed to have   no    sort  of
+# NPr+  N🅪Sg/V/J R          V/J     . D   NSg$     NSg/V+ V/J    P  NSg/VX NPr/P NSg/V P
 > meaning   in      it       , and yet     it       was certainly English   . “ I    don’t quite understand you    , ”
 # N🅪Sg/V/J+ NPr/J/P NPr/ISg+ . V/C NSg/V/C NPr/ISg+ V   R         NPr🅪/V/J+ . . ISg+ V     NSg   V          ISgPl+ . .
 > she  said , as    politely as    she  could  .
@@ -4174,8 +4174,8 @@
 # NSg/R IPl+ V/J    NSg/V/J/P J        . NPr+  V/J   D+  NPr/V/J+ NSg/V NPr/J/P D/P+ NSg/V/J+ NSg/V+ . P  D+
 > company generally , “ You    are all          pardoned . ” “ Come    , that’s a    good    thing  ! ” she  said
 # NSg/V+  R         . . ISgPl+ V   NSg/I/J/C/Dq V/J      . . . NSg/V/P . NSg$   D/P+ NPr/V/J NSg/V+ . . ISg+ V/J
-> to herself , for she  had felt    quite unhappy at    the number   of executions the Queen
-# P  ISg+    . C/P ISg+ V   NSg/V/J NSg   NSg/V/J NSg/P D   NSg/V/JC P  +          D+  NPr/V/J+
+> to herself , for she  had felt     quite unhappy at    the number   of executions the Queen
+# P  ISg+    . C/P ISg+ V   N🅪Sg/V/J NSg   NSg/V/J NSg/P D   NSg/V/JC P  +          D+  NPr/V/J+
 > had ordered .
 # V   V/J     .
 >
@@ -4297,7 +4297,7 @@
 > “ You    ought    to be     ashamed of yourself for asking such   a    simple   question , ” added
 # . ISgPl+ NSg/I/VX P  NSg/VX V/J     P  ISg+     C/P V      NSg/I+ D/P+ NSg/V/J+ NSg/V+   . . V/J
 > the Gryphon ; and then    they both   sat     silent and looked at    poor    Alice , who    felt
-# D   ?       . V/C NSg/J/C IPl+ I/C/Dq NSg/V/J NSg/J  V/C V/J    NSg/P NSg/V/J NPr+  . NPr/I+ NSg/V/J
+# D   ?       . V/C NSg/J/C IPl+ I/C/Dq NSg/V/J NSg/J  V/C V/J    NSg/P NSg/V/J NPr+  . NPr/I+ N🅪Sg/V/J
 > ready   to sink  into the earth   . At    last    the Gryphon said to the Mock    Turtle ,
 # NSg/V/J P  NSg/V P    D   NPrᴹ/V+ . NSg/P NSg/V/J D   ?       V/J  P  D   NSg/V/J NSg/V+ .
 > “ Drive on  , old   fellow ! Don’t be     all          day   about it       ! ” and he       went  on  in      these
@@ -4779,7 +4779,7 @@
 >
 #
 > “ Don’t you    mean    ‘          purpose ’ ? ” said Alice .
-# . V     ISgPl+ NSg/V/J Unlintable NSg/V+  . . . V/J  NPr+  .
+# . V     ISgPl+ NSg/V/J Unlintable N🅪Sg/V+ . . . V/J  NPr+  .
 >
 #
 > “ I    mean    what   I    say   , ” the Mock     Turtle replied in      an   offended tone      . And the
@@ -4906,8 +4906,8 @@
 # V/J    NSg/J/P ISg/D$+ NSg/V/J+ . . .
 >
 #
-> Alice did not   dare   to disobey , though she  felt    sure it       would all          come    wrong   , and
-# NPr+  V   NSg/C NPr/VX P  V       . V/C    ISg+ NSg/V/J J    NPr/ISg+ VX    NSg/I/J/C/Dq NSg/V/P NSg/V/J . V/C
+> Alice did not   dare   to disobey , though she  felt     sure it       would all          come    wrong   , and
+# NPr+  V   NSg/C NPr/VX P  V       . V/C    ISg+ N🅪Sg/V/J J    NPr/ISg+ VX    NSg/I/J/C/Dq NSg/V/P NSg/V/J . V/C
 > she  went  on  in      a   trembling voice  : —
 # ISg+ NSg/V J/P NPr/J/P D/P V         NSg/V+ . .
 >
@@ -5222,8 +5222,8 @@
 # NSg/J NSg/V+ NSg/V/J/R/P P  ISg/D$+ NSg/J  W?      P  D   N🅪Sg/V+ . V/C . NSg/V+ .
 >
 #
-> Just at    this    moment Alice felt    a   very curious sensation , which puzzled her     a
-# V/J  NSg/P I/Ddem+ NSg+   NPr+  NSg/V/J D/P J/R  J+      NSg+      . I/C+  V/J     ISg/D$+ D/P+
+> Just at    this    moment Alice felt     a   very curious sensation , which puzzled her     a
+# V/J  NSg/P I/Ddem+ NSg+   NPr+  N🅪Sg/V/J D/P J/R  J+      NSg+      . I/C+  V/J     ISg/D$+ D/P+
 > good     deal     until she  made out         what   it       was : she  was beginning to grow larger
 # NPr/V/J+ NSg/V/J+ C/P   ISg+ V    NSg/V/J/R/P NSg/I+ NPr/ISg+ V   . ISg+ V   NSg/V/J   P  V    JC
 > again , and she  thought at    first   she  would get   up        and leave the court    ; but     on

--- a/harper-core/tests/text/tagged/Computer science.md
+++ b/harper-core/tests/text/tagged/Computer science.md
@@ -543,7 +543,7 @@
 > compression , cryptography , error  detection and correction , and more         recently
 # NSg+        . NSg          . NSg/V+ N🅪Sg      V/C NSg+       . V/C NPr/I/V/J/Dq R
 > also for network coding . Codes  are studied for the purpose of designing
-# W?   C/P NSg/V+  V+     . NPl/V+ V   V/J     C/P D   NSg/V   P  V
+# W?   C/P NSg/V+  V+     . NPl/V+ V   V/J     C/P D   N🅪Sg/V  P  V
 > efficient and reliable data  transmission methods .
 # NSg/J     V/C NSg/J+   N🅪Pl+ NSg+         NPl/V+  .
 >
@@ -769,7 +769,7 @@
 >
 #
 > Computer architecture , or    digital computer organization , is the conceptual
-# NSg/V+   NᴹSg+        . NPr/C NSg/J+  NSg/V+   NSg+         . VL D   J
+# NSg/V+   NᴹSg+        . NPr/C NSg/J+  NSg/V+   N🅪Sg+        . VL D   J
 > design  and fundamental operational structure of a    computer system . It       focuses
 # N🅪Sg/V+ V/C NSg/J       J           N🅪Sg/V    P  D/P+ NSg/V+   NSg+   . NPr/ISg+ NPl/V
 > largely on  the way    by      which the central processing unit performs internally and
@@ -783,7 +783,7 @@
 > term    " architecture " in      computer literature can    be     traced to the work   of Lyle R.
 # NSg/V/J . NᴹSg+        . NPr/J/P NSg/V+   NᴹSg+      NPr/VX NSg/VX V/J    P  D   N🅪Sg/V P  NPr  ?
 > Johnson and Frederick P. Brooks  Jr     . , members of the Machine Organization
-# NPr     V/C NPr+      ?  NPrPl/V NSg/J+ . . NPl/V   P  D+  NSg/V+  NSg+
+# NPr     V/C NPr+      ?  NPrPl/V NSg/J+ . . NPl/V   P  D+  NSg/V+  N🅪Sg+
 > department in      IBM's main     research center   in      1959 .
 # NSg+       NPr/J/P NSg$  NSg/V/J+ NᴹSg/V+  NSg/V/J+ NPr/J/P #    .
 >

--- a/harper-core/tests/text/tagged/Difficult sentences.md
+++ b/harper-core/tests/text/tagged/Difficult sentences.md
@@ -408,8 +408,8 @@
 # V/J/C/P N🅪Sg/V+ NPl/V NPr/J/P D$+  NPl/V I/Ddem+ NSg/J+ .
 > She  stood there looking in      the window longingly .
 # ISg+ V     W?    V       NPr/J/P D+  NSg/V+ R         .
-> In      replacing the faucet washers , he       felt    he       was making his     contribution to the environment .
-# NPr/J/P V         D   NSg    W?      . NPr/ISg+ NSg/V/J NPr/ISg+ V   NSg/V  ISg/D$+ NSg+         P  D   NSg+        .
+> In      replacing the faucet washers , he       felt     he       was making his     contribution to the environment .
+# NPr/J/P V         D   NSg    W?      . NPr/ISg+ N🅪Sg/V/J NPr/ISg+ V   NSg/V  ISg/D$+ NSg+         P  D   NSg+        .
 > In      trying  to make  amends , she  actually made matters worse    .
 # NPr/J/P NSg/V/J P  NSg/V NPl/V  . ISg+ R        V    NPl/V+  NSg/V/JC .
 > My  aim    in      travelling   there was to find  my  missing friend   .

--- a/harper-core/tests/text/tagged/Part-of-speech tagging.md
+++ b/harper-core/tests/text/tagged/Part-of-speech tagging.md
@@ -153,7 +153,7 @@
 > very broad tags   or    a   much       larger set     of more         precise ones   is preferable , depends
 # J/R  NSg/J NPl/V+ NPr/C D/P NSg/I/J/Dq JC     NPr/V/J P  NPr/I/V/J/Dq V/J+    NPl/V+ VL W?         . NPl/V
 > on  the purpose at    hand   . Automatic tagging is easier on  smaller tag    - sets  .
-# J/P D   NSg/V+  NSg/P NSg/V+ . NSg/J     NSg/V   VL NSg/JC J/P NSg/JC  NSg/V+ . NPl/V .
+# J/P D   N🅪Sg/V+ NSg/P NSg/V+ . NSg/J     NSg/V   VL NSg/JC J/P NSg/JC  NSg/V+ . NPl/V .
 >
 #
 > History

--- a/harper-core/tests/text/tagged/The Constitution of the United States.md
+++ b/harper-core/tests/text/tagged/The Constitution of the United States.md
@@ -207,7 +207,7 @@
 > The Senate shall have   the sole     Power    to try     all          Impeachments . When    sitting for
 # D+  NPr+   VX    NSg/VX D+  NSg/V/J+ NSg/V/J+ P  NSg/V/J NSg/I/J/C/Dq NPl          . NSg/I/C NSg/V/J C/P
 > that          Purpose , they shall be     on  Oath   or    Affirmation . When    the President of the
-# NSg/I/C/Ddem+ NSg/V+  . IPl+ VX    NSg/VX J/P NSg/V+ NPr/C NSg         . NSg/I/C D   NSg/V     P  D+
+# NSg/I/C/Ddem+ N🅪Sg/V+ . IPl+ VX    NSg/VX J/P NSg/V+ NPr/C NSg         . NSg/I/C D   NSg/V     P  D+
 > United States   is tried , the Chief    Justice shall preside : And no     Person shall be
 # V/J    NPrPl/V+ VL V/J   . D+  NSg/V/J+ NPr🅪+   VX    V       . V/C NPr/P+ NSg/V+ VX    NSg/VX
 > convicted without the Concurrence of two thirds of the Members present .
@@ -771,7 +771,7 @@
 > taken by      states   , the representation from each state  having one        vote   ; a   quorum
 # V/J   NSg/J/P NPrPl/V+ . D   NSg            P    Dq+  NSg/V+ V      NSg/I/V/J+ NSg/V+ . D/P NSg
 > for this   purpose shall consist of a   member or    members from two - thirds of the
-# C/P I/Ddem NSg/V+  VX    NSg/V   P  D/P NSg/V  NPr/C NPl/V+  P    NSg . NPl/V  P  D
+# C/P I/Ddem N🅪Sg/V+ VX    NSg/V   P  D/P NSg/V  NPr/C NPl/V+  P    NSg . NPl/V  P  D
 > states   , and a   majority of all          the states   shall be     necessary to a   choice . [ If    ,
 # NPrPl/V+ . V/C D/P NSg      P  NSg/I/J/C/Dq D   NPrPl/V+ VX    NSg/VX NSg/J     P  D/P NSg/J+ . . NSg/C .
 > at    the time      fixed for the beginning of the term    of the President , the President
@@ -811,7 +811,7 @@
 > on  the list   , the Senate shall choose  the Vice       - President ; a   quorum for the
 # J/P D   NSg/V+ . D   NPr+   VX    NSg/V/C D   NSg/V/J/P+ . NSg/V+    . D/P NSg    C/P D
 > purpose shall consist of two - thirds of the whole number   of Senators , and a
-# NSg/V+  VX    NSg/V   P  NSg . NPl/V  P  D   NSg/J NSg/V/JC P  NPl+     . V/C D/P
+# N🅪Sg/V+ VX    NSg/V   P  NSg . NPl/V  P  D   NSg/J NSg/V/JC P  NPl+     . V/C D/P
 > majority of the whole number    shall be     necessary to a   choice . But     no     person
 # NSg      P  D   NSg/J NSg/V/JC+ VX    NSg/VX NSg/J     P  D/P NSg/J+ . NSg/C/P NPr/P+ NSg/V+
 > constitutionally ineligible to the office of President shall be     eligible to
@@ -927,7 +927,7 @@
 > Congress shall decide the issue  , assembling within  forty - eight hours for that
 # NPr/V+   VX    V      D   NSg/V+ . V          NSg/J/P NSg/J . NSg/J NPl+  C/P NSg/I/C/Ddem
 > purpose if    not   in      session . If    the Congress , within  twenty - one       days after
-# NSg/V+  NSg/C NSg/C NPr/J/P NSg/V+  . NSg/C D+  NPr/V+   . NSg/J/P NSg    . NSg/I/V/J NPl  P
+# N🅪Sg/V+ NSg/C NSg/C NPr/J/P NSg/V+  . NSg/C D+  NPr/V+   . NSg/J/P NSg    . NSg/I/V/J NPl  P
 > receipt of the latter written declaration , or    , if    Congress is not   in      session ,
 # NSg/V   P  D+  NSg/J+ V/J     NSg+        . NPr/C . NSg/C NPr/V+   VL NSg/C NPr/J/P NSg/V+  .
 > within  twenty - one       days after Congress is required to assemble , determines by

--- a/harper-core/tests/text/tagged/The Great Gatsby.md
+++ b/harper-core/tests/text/tagged/The Great Gatsby.md
@@ -62,8 +62,8 @@
 # V   D/P+ NSg/V/J+ . NSg/V   NPr/VX NSg/VX V/J     J/P D   N🅪Sg/J NPr🅪/V NPr/C D+  NSg/V/J+ NPl+    . NSg/C/P
 > after a    certain point  I    don’t care    what   it’s founded on  . When    I    came    back    from
 # P     D/P+ I/J+    NSg/V+ ISg+ V     N🅪Sg/V+ NSg/I+ W?   V/J     J/P . NSg/I/C ISg+ NSg/V/P NSg/V/J P
-> the East   last     autumn I    felt    that         I    wanted the world  to be     in      uniform and at    a
-# D+  NPr/J+ NSg/V/J+ NPr/V+ ISg+ NSg/V/J NSg/I/C/Ddem ISg+ V/J    D+  NSg/V+ P  NSg/VX NPr/J/P NSg/V/J V/C NSg/P D/P
+> the East   last     autumn I    felt     that         I    wanted the world  to be     in      uniform and at    a
+# D+  NPr/J+ NSg/V/J+ NPr/V+ ISg+ N🅪Sg/V/J NSg/I/C/Ddem ISg+ V/J    D+  NSg/V+ P  NSg/VX NPr/J/P NSg/V/J V/C NSg/P D/P
 > sort  of moral    attention forever ; I    wanted no    more         riotous excursions with
 # NSg/V P  NSg/V/J+ NSg+      NSg/J   . ISg+ V/J    NPr/P NPr/I/V/J/Dq J       NPl/V      P
 > privileged glimpses into the human   heart   . Only  Gatsby , the man      who    gives his
@@ -292,8 +292,8 @@
 # V/J    NPrᴹ+ V/C NSg/V NPr/V/J J        . I/Ddem+ V   D/P NSg/V/J   NSg/V . V/J  NPr+  NSg/J/P
 > the telephone , but     I    didn’t believe it       — I    had no    sight   into Daisy’s heart   , but     I
 # D+  NSg/V+    . NSg/C/P ISg+ V      V       NPr/ISg+ . ISg+ V   NPr/P N🅪Sg/V+ P    NSg$    N🅪Sg/V+ . NSg/C/P ISg+
-> felt    that         Tom    would drift on  forever seeking , a   little     wistfully , for the
-# NSg/V/J NSg/I/C/Ddem NPr/V+ VX    NSg/V J/P NSg/J   V       . D/P NPr/I/J/Dq R         . C/P D
+> felt     that         Tom    would drift on  forever seeking , a   little     wistfully , for the
+# N🅪Sg/V/J NSg/I/C/Ddem NPr/V+ VX    NSg/V J/P NSg/J   V       . D/P NPr/I/J/Dq R         . C/P D
 > dramatic turbulence of some     irrecoverable football game     .
 # J        NSg        P  I/J/R/Dq J             NSg/V+   NSg/V/J+ .
 >
@@ -1026,8 +1026,8 @@
 #
 > “ I’ll show  you    how   I’ve gotten to feel    about — things . Well    , she  was less    than an
 # . W?   NSg/V ISgPl+ NSg/C W?   V/J    P  NSg/I/V J/P   . NPl/V+ . NSg/V/J . ISg+ V   V/J/C/P C/P  D/P
-> hour old   and Tom    was God    knows where . I    woke    up        out         of the ether with an  utterly
-# NSg  NSg/J V/C NPr/V+ V   NPr/V+ NPl/V NSg/C . ISg+ NSg/V/J NSg/V/J/P NSg/V/J/R/P P  D   NSg/V P    D/P R
+> hour old   and Tom    was God    knows where . I    woke    up        out         of the ether  with an  utterly
+# NSg  NSg/J V/C NPr/V+ V   NPr/V+ NPl/V NSg/C . ISg+ NSg/V/J NSg/V/J/P NSg/V/J/R/P P  D   NᴹSg/V P    D/P R
 > abandoned feeling , and asked the nurse  right   away if    it       was a   boy   or    a   girl   . She
 # V/J       NSg/V/J . V/C V/J   D   NSg/V+ NPr/V/J V/J  NSg/C NPr/ISg+ V   D/P NSg/V NPr/C D/P NSg/V+ . ISg+
 > told me       it       was a   girl  , and so        I    turned my  head     away and wept . ‘          All          right   , ’ I
@@ -1052,8 +1052,8 @@
 #
 > The instant  her     voice  broke   off       , ceasing to compel my  attention , my  belief , I
 # D+  NSg/V/J+ ISg/D$+ NSg/V+ NSg/V/J NSg/V/J/P . V       P  V      D$+ NSg+      . D$+ N🅪Sg+  . ISg+
-> felt    the basic insincerity of what   she  had said . It       made me       uneasy  , as    though
-# NSg/V/J D   NPr/J NᴹSg        P  NSg/I+ ISg+ V   V/J  . NPr/ISg+ V    NPr/ISg+ NSg/V/J . NSg/R V/C
+> felt     the basic insincerity of what   she  had said . It       made me       uneasy  , as    though
+# N🅪Sg/V/J D   NPr/J NᴹSg        P  NSg/I+ ISg+ V   V/J  . NPr/ISg+ V    NPr/ISg+ NSg/V/J . NSg/R V/C
 > the whole  evening had been  a   trick   of some      sort   to exact a   contributary emotion
 # D+  NSg/J+ N🅪Sg/V+ V   NSg/V D/P NSg/V/J P  I/J/R/Dq+ NSg/V+ P  V/J   D/P ?            N🅪Sg+
 > from me       . I    waited , and sure enough , in      a    moment she  looked at    me       with an
@@ -2148,8 +2148,8 @@
 #
 > The bottle of whiskey — a   second  one        — was now       in      constant demand by      all          present ,
 # D   NSg/V  P  NSg     . D/P NSg/V/J NSg/I/V/J+ . V   NPr/V/J/C NPr/J/P NSg/J    NSg/V+ NSg/J/P NSg/I/J/C/Dq NSg/V/J .
-> excepting Catherine , who    “ felt    just as    good    on  nothing  at    all          . ” Tom    rang for the
-# V         NPr+      . NPr/I+ . NSg/V/J V/J  NSg/R NPr/V/J J/P NSg/I/J+ NSg/P NSg/I/J/C/Dq . . NPr/V+ V    C/P D
+> excepting Catherine , who    “ felt     just as    good    on  nothing  at    all          . ” Tom    rang for the
+# V         NPr+      . NPr/I+ . N🅪Sg/V/J V/J  NSg/R NPr/V/J J/P NSg/I/J+ NSg/P NSg/I/J/C/Dq . . NPr/V+ V    C/P D
 > janitor and sent  him  for some     celebrated sandwiches , which were  a   complete
 # NSg     V/C NSg/V ISg+ C/P I/J/R/Dq V/J        NPl/V+     . I/C+  NSg/V D/P NSg/V/J
 > supper in      themselves . I    wanted to get   out         and walk  eastward toward the park
@@ -3514,10 +3514,10 @@
 # V/J      NSg/IPl+ P  D$+   NPl+       J/P D   W?      P  V/J    NPl/V+  . V/C IPl+
 > turned and smiled back    at    me       before they faded through a    door   into warm
 # V/J    V/C V/J    NSg/V/J NSg/P NPr/ISg+ C/P    IPl+ J     NSg/J/P D/P+ NSg/V+ P    NSg/V/J+
-> darkness . At    the enchanted metropolitan twilight I    felt    a   haunting loneliness
-# NᴹSg+    . NSg/P D   V/J       NSg/J+       NSg/V/J+ ISg+ NSg/V/J D/P NSg/V/J  NSg
-> sometimes , and felt    it       in      others — poor    young   clerks who    loitered in      front   of
-# R         . V/C NSg/V/J NPr/ISg+ NPr/J/P NPl/V+ . NSg/V/J NPr/V/J NPl/V+ NPr/I+ V/J      NPr/J/P NSg/V/J P
+> darkness . At    the enchanted metropolitan twilight I    felt     a   haunting loneliness
+# NᴹSg+    . NSg/P D   V/J       NSg/J+       NSg/V/J+ ISg+ N🅪Sg/V/J D/P NSg/V/J  NSg
+> sometimes , and felt     it       in      others — poor    young   clerks who    loitered in      front   of
+# R         . V/C N🅪Sg/V/J NPr/ISg+ NPr/J/P NPl/V+ . NSg/V/J NPr/V/J NPl/V+ NPr/I+ V/J      NPr/J/P NSg/V/J P
 > windows  waiting until it       was time     for a   solitary restaurant dinner  — young   clerks
 # NPrPl/V+ NSg/V   C/P   NPr/ISg+ V   N🅪Sg/V/J C/P D/P NSg/J    NSg+       N🅪Sg/V+ . NPr/V/J NPl/V+
 > in      the dusk     , wasting the most       poignant moments of night  and life    .
@@ -3526,8 +3526,8 @@
 #
 > Again at    eight o’clock , when    the dark    lanes of the Forties were  lined five deep
 # P     NSg/P NSg/J W?      . NSg/I/C D   NSg/V/J NPl   P  D+  NPl+    NSg/V V/J   NSg  NSg/J
-> with throbbing taxicabs , bound   for the theatre    district , I    felt    a   sinking in      my
-# P    NSg/V/J   NPl/V    . NSg/V/J C/P D   N🅪Sg/Comm+ NSg/V/J+ . ISg+ NSg/V/J D/P V+      NPr/J/P D$+
+> with throbbing taxicabs , bound   for the theatre    district , I    felt     a   sinking in      my
+# P    NSg/V/J   NPl/V    . NSg/V/J C/P D   N🅪Sg/Comm+ NSg/V/J+ . ISg+ N🅪Sg/V/J D/P V+      NPr/J/P D$+
 > heart   . Forms  leaned together in      the taxis  as    they waited , and voices sang  , and
 # N🅪Sg/V+ . NPl/V+ V/J    J        NPr/J/P D+  NPl/V+ NSg/R IPl+ V/J    . V/C NPl/V+ NPr/V . V/C
 > there was laughter from unheard jokes  , and lighted cigarettes made
@@ -3544,8 +3544,8 @@
 # P     . NSg/P NSg/V/J ISg+ V   V/J       P  NSg/V/J NPl/V+ P    ISg/D$+ . C/P     ISg+ V   D/P NSg/V
 > champion , and every one        knew her     name   . Then    it       was something  more         . I    wasn’t
 # NSg/V/J  . V/C Dq+   NSg/I/V/J+ V    ISg/D$+ NSg/V+ . NSg/J/C NPr/ISg+ V   NSg/I/V/J+ NPr/I/V/J/Dq . ISg+ V
-> actually in      love   , but     I    felt    a   sort  of tender  curiosity . The bored haughty face
-# R        NPr/J/P NPr🅪/V . NSg/C/P ISg+ NSg/V/J D/P NSg/V P  NSg/V/J NSg+      . D   V/J   J       NSg/V+
+> actually in      love   , but     I    felt     a   sort  of tender  curiosity . The bored haughty face
+# R        NPr/J/P NPr🅪/V . NSg/C/P ISg+ N🅪Sg/V/J D/P NSg/V P  NSg/V/J NSg+      . D   V/J   J       NSg/V+
 > that          she  turned to the world  concealed something  — most       affectations conceal
 # NSg/I/C/Ddem+ ISg+ V/J    P  D   NSg/V+ V/J       NSg/I/V/J+ . NSg/I/J/Dq NPl          V
 > something  eventually , even    though they don’t in      the beginning — and one       day   I
@@ -3572,8 +3572,8 @@
 #
 > Jordan Baker instinctively avoided clever , shrewd men  , and now       I    saw   that         this
 # NPr+   NPr+  R             V/J     J      . J+     NSg+ . V/C NPr/V/J/C ISg+ NSg/V NSg/I/C/Ddem I/Ddem+
-> was because she  felt    safer  on  a   plane    where any    divergence from a   code    would be
-# V   C/P     ISg+ NSg/V/J NSg/JC J/P D/P NSg/V/J+ NSg/C I/R/Dq NSg        P    D/P N🅪Sg/V+ VX    NSg/VX
+> was because she  felt     safer  on  a   plane    where any    divergence from a   code    would be
+# V   C/P     ISg+ N🅪Sg/V/J NSg/JC J/P D/P NSg/V/J+ NSg/C I/R/Dq NSg        P    D/P N🅪Sg/V+ VX    NSg/VX
 > thought impossible . She  was incurably dishonest . She  wasn’t able    to endure being
 # NSg/V   NSg/J      . ISg+ V   R         V/J       . ISg+ V      NSg/V/J P  V      N🅪Sg/V/C
 > at    a   disadvantage and , given     this   unwillingness , I    suppose she  had begun dealing
@@ -5500,8 +5500,8 @@
 #
 > After half        an   hour , the sun    shone again , and the grocer’s automobile rounded
 # P     N🅪Sg/V/J/P+ D/P+ NSg+ . D+  NPr/V+ V     P     . V/C D   NSg$     NSg/V/J    V/J
-> Gatsby’s drive with the raw     material  for his     servants ’ dinner  — I    felt    sure he
-# NSg$     NSg/V P    D   NSg/V/J N🅪Sg/V/J+ C/P ISg/D$+ NPl/V+   . N🅪Sg/V+ . ISg+ NSg/V/J J    NPr/ISg+
+> Gatsby’s drive with the raw     material  for his     servants ’ dinner  — I    felt     sure he
+# NSg$     NSg/V P    D   NSg/V/J N🅪Sg/V/J+ C/P ISg/D$+ NPl/V+   . N🅪Sg/V+ . ISg+ N🅪Sg/V/J J    NPr/ISg+
 > wouldn’t eat a   spoonful . A    maid began opening the upper windows of his     house  ,
 # VX       V   D/P NSg      . D/P+ NSg+ V     NSg/V/J D   NSg/J NPrPl/V P  ISg/D$+ NPr/V+ .
 > appeared momentarily in      each , and , leaning from the large central bay      , spat
@@ -5510,8 +5510,8 @@
 # R            P    D   NSg/V/J+ . NPr/ISg+ V   N🅪Sg/V/J ISg+ NSg/V NSg/V/J . NSg/V/C/P D+  N🅪Sg/V+ V/J
 > it       had seemed like        the murmur of their voices , rising    and swelling a   little     now
 # NPr/ISg+ V   V/J    NSg/V/J/C/P D   NSg/V  P  D$+   NPl/V+ . NSg/V/J/P V/C NSg/V    D/P NPr/I/J/Dq NPr/V/J/C
-> and then    with gusts of emotion . But     in      the new      silence I    felt    that         silence had
-# V/C NSg/J/C P    NPl/V P  N🅪Sg+   . NSg/C/P NPr/J/P D+  NSg/V/J+ NSg/V+  ISg+ NSg/V/J NSg/I/C/Ddem NSg/V+  V
+> and then    with gusts of emotion . But     in      the new      silence I    felt     that         silence had
+# V/C NSg/J/C P    NPl/V P  N🅪Sg+   . NSg/C/P NPr/J/P D+  NSg/V/J+ NSg/V+  ISg+ N🅪Sg/V/J NSg/I/C/Ddem NSg/V+  V
 > fallen within  the house  too .
 # W?     NSg/J/P D+  NPr/V+ W?  .
 >
@@ -5666,8 +5666,8 @@
 #
 > And inside  , as    we   wandered through Marie Antoinette music     - rooms and Restoration
 # V/C NSg/J/P . NSg/R IPl+ V/J      NSg/J/P NPr+  NPr        N🅪Sg/V/J+ . NPl/V V/C NPr🅪+
-> Salons , I    felt    that         there were  guests concealed behind  every couch and table  ,
-# NPl+   . ISg+ NSg/V/J NSg/I/C/Ddem +     NSg/V NPl/V+ V/J       NSg/J/P Dq    NSg/V V/C NSg/V+ .
+> Salons , I    felt     that         there were  guests concealed behind  every couch and table  ,
+# NPl+   . ISg+ N🅪Sg/V/J NSg/I/C/Ddem +     NSg/V NPl/V+ V/J       NSg/J/P Dq    NSg/V V/C NSg/V+ .
 > under   orders to be     breathlessly silent until we   had passed through . As    Gatsby
 # NSg/J/P NPl/V+ P  NSg/VX R            NSg/J  C/P   IPl+ V   V/J    NSg/J/P . NSg/R NPr
 > closed the door  of ‘          ‘          the Merton College Library ” I    could  have   sworn I    heard the
@@ -6470,8 +6470,8 @@
 # NPr/J/P D$+ N🅪Sg   P    NSg$     NSg/V/J+ NPl/V+  NSg/I/C/Ddem+ NPr/V+ . +     NSg/V D+  I/J+
 > people , or    at    least the same sort  of people , the same profusion of champagne ,
 # NPl/V+ . NPr/C NSg/P NSg/J D   I/J  NSg/V P  NPl/V+ . D   I/J  N🅪Sg/V    P  N🅪Sg/V/J+ .
-> the same many       - colored    , many       - keyed commotion , but     I    felt    an  unpleasantness in      the
-# D   I/J  NSg/I/J/Dq . NSg/V/J/Am . NSg/I/J/Dq . V/J   NSg       . NSg/C/P ISg+ NSg/V/J D/P NSg            NPr/J/P D
+> the same many       - colored    , many       - keyed commotion , but     I    felt     an  unpleasantness in      the
+# D   I/J  NSg/I/J/Dq . NSg/V/J/Am . NSg/I/J/Dq . V/J   NSg       . NSg/C/P ISg+ N🅪Sg/V/J D/P NSg            NPr/J/P D
 > air     , a   pervading harshness that          hadn’t been  there before . Or    perhaps I    had
 # N🅪Sg/V+ . D/P V         NSg       NSg/I/C/Ddem+ V      NSg/V +     C/P    . NPr/C NSg     ISg+ V
 > merely grown used to it       , grown to accept  West     Egg     as    a    world  complete in      itself ,
@@ -7600,8 +7600,8 @@
 # NSg/J/P D$+   NPl/V+ .
 >
 #
-> “ Shall we   all          go       in      my  car  ? ” suggested Gatsby . He       felt    the hot     , green    leather  of
-# . VX    IPl+ NSg/I/J/C/Dq NSg/V/J+ NPr/J/P D$+ NSg+ . . V/J       NPr    . NPr/ISg+ NSg/V/J D   NSg/V/J . NPr🅪/V/J N🅪Sg/V/J P
+> “ Shall we   all          go       in      my  car  ? ” suggested Gatsby . He       felt     the hot     , green    leather  of
+# . VX    IPl+ NSg/I/J/C/Dq NSg/V/J+ NPr/J/P D$+ NSg+ . . V/J       NPr    . NPr/ISg+ N🅪Sg/V/J D   NSg/V/J . NPr🅪/V/J N🅪Sg/V/J P
 > the seat   . “ I    ought    to have   left    it       in      the shade   . ”
 # D+  NSg/V+ . . ISg+ NSg/I/VX P  NSg/VX NPr/V/J NPr/ISg+ NPr/J/P D+  N🅪Sg/V+ . .
 >
@@ -7925,7 +7925,7 @@
 > ago secure and inviolate , were  slipping precipitately from his     control . Instinct
 # J/P V/J    V/C J         . NSg/V NSg/V    R             P    ISg/D$+ N🅪Sg/V+ . NSg/J+
 > made him  step   on  the accelerator with the double  purpose of overtaking Daisy and
-# V    ISg+ NSg/V+ J/P D   NSg+        P    D   NSg/V/J NSg/V   P  V          NPr+  V/C
+# V    ISg+ NSg/V+ J/P D   NSg+        P    D   NSg/V/J N🅪Sg/V  P  V          NPr+  V/C
 > leaving Wilson behind  , and we   sped  along toward Astoria at    fifty miles  an  hour ,
 # V       NPr+   NSg/J/P . V/C IPl+ NSg/V P     J/P    NPr     NSg/P NSg   NPrPl+ D/P NSg+ .
 > until , among the spidery girders of the elevated , we   came    in      sight  of the
@@ -9250,8 +9250,8 @@
 #
 > I    hadn’t gone  twenty yards  when    I    heard my  name   and Gatsby stepped from between
 # ISg+ V      V/J/P NSg    NPl/V+ NSg/I/C ISg+ V/J   D$+ NSg/V+ V/C NPr    J       P    NSg/P
-> two bushes into the path   . I    must  have   felt    pretty  weird   by      that          time      , because I
-# NSg NPl/V+ P    D   NSg/V+ . ISg+ NSg/V NSg/VX NSg/V/J NSg/V/J NSg/V/J NSg/J/P NSg/I/C/Ddem+ N🅪Sg/V/J+ . C/P     ISg+
+> two bushes into the path   . I    must  have   felt     pretty  weird   by      that          time      , because I
+# NSg NPl/V+ P    D   NSg/V+ . ISg+ NSg/V NSg/VX N🅪Sg/V/J NSg/V/J NSg/V/J NSg/J/P NSg/I/C/Ddem+ N🅪Sg/V/J+ . C/P     ISg+
 > could  think of nothing  except the luminosity of his     pink     suit   under   the moon   .
 # NSg/VX NSg/V P  NSg/I/J+ V/C/P  D   NᴹSg       P  ISg/D$+ N🅪Sg/V/J NSg/V+ NSg/J/P D   NPr/V+ .
 >
@@ -9344,8 +9344,8 @@
 # NSg/V P  NPr/IPl+ . NSg/V   IPl+ NSg/V NSg/I+   ISg+ V    . NSg/V/J . NSg/V/J+ NPr+  V/J    V/J
 > from the woman  toward the other    car  , and then    she  lost her     nerve  and turned
 # P    D+  NSg/V+ J/P    D+  NSg/V/J+ NSg+ . V/C NSg/J/C ISg+ V/J  ISg/D$+ NSg/V+ V/C V/J
-> back    . The second   my  hand   reached the wheel  I    felt    the shock    — it       must  have   killed
-# NSg/V/J . D+  NSg/V/J+ D$+ NSg/V+ V/J     D+  NSg/V+ ISg+ NSg/V/J D+  NSg/V/J+ . NPr/ISg+ NSg/V NSg/VX V/J
+> back    . The second   my  hand   reached the wheel  I    felt     the shock    — it       must  have   killed
+# NSg/V/J . D+  NSg/V/J+ D$+ NSg/V+ V/J     D+  NSg/V+ ISg+ N🅪Sg/V/J D+  NSg/V/J+ . NPr/ISg+ NSg/V NSg/VX V/J
 > her     instantly . ”
 # ISg/D$+ R         . .
 >
@@ -9476,8 +9476,8 @@
 # V/C ISg+ V/J    N🅪Sg/V/J/P+ . NSg/V/J NSg/P   NSg/J     N🅪Sg    V/C NPr/V/J+ . V/J         NPl/V+ .
 > Toward dawn   I    heard a    taxi   go      up        Gatsby’s drive , and immediately I    jumped out         of
 # J/P    NPr/V+ ISg+ V/J   D/P+ NSg/V+ NSg/V/J NSg/V/J/P NSg$     NSg/V . V/C R           ISg+ V/J    NSg/V/J/R/P P
-> bed      and began to dress — I    felt    that         I    had something  to tell  him  , something  to
-# NSg/V/J+ V/C V     P  NSg/V . ISg+ NSg/V/J NSg/I/C/Ddem ISg+ V   NSg/I/V/J+ P  NPr/V ISg+ . NSg/I/V/J+ P
+> bed      and began to dress — I    felt     that         I    had something  to tell  him  , something  to
+# NSg/V/J+ V/C V     P  NSg/V . ISg+ N🅪Sg/V/J NSg/I/C/Ddem ISg+ V   NSg/I/V/J+ P  NPr/V ISg+ . NSg/I/V/J+ P
 > warn him  about , and morning would be     too late  .
 # V    ISg+ J/P   . V/C N🅪Sg/V+ VX    NSg/VX W?  NSg/J .
 >
@@ -9498,8 +9498,8 @@
 # ISg/D$+ NPr/V+ V   R     V/J    NSg/I/J/C J        P  NPr/ISg+ NSg/R NPr/ISg+ V   NSg/I/C/Ddem+ N🅪Sg/V+ NSg/I/C IPl+ V/J
 > through the great rooms for cigarettes . We   pushed aside curtains that          were  like
 # NSg/J/P D   NSg/J NPl/V C/P NPl/V+     . IPl+ V/J    NSg/J NPl/V    NSg/I/C/Ddem+ NSg/V NSg/V/J/C/P
-> pavilions , and felt    over    innumerable feet of dark    wall   for electric light
-# NPl/V     . V/C NSg/V/J NSg/J/P J           NPl  P  NSg/V/J NPr/V+ C/P NSg/J    N🅪Sg/V/J+
+> pavilions , and felt     over    innumerable feet of dark    wall   for electric light
+# NPl/V     . V/C N🅪Sg/V/J NSg/J/P J           NPl  P  NSg/V/J NPr/V+ C/P NSg/J    N🅪Sg/V/J+
 > switches — once  I    tumbled with a   sort  of splash upon the keys  of a   ghostly piano    .
 # NPl/V+   . NSg/C ISg+ V/J     P    D/P NSg/V P  NSg/V+ P    D   NPl/V P  D/P J/R     NSg/V/J+ .
 > There was an  inexplicable amount of dust    everywhere , and the rooms  were  musty   ,
@@ -9568,8 +9568,8 @@
 # J        P  I/Ddem NSg$   V       NSg/V/J+ . NPl  V/C P  NPl/V+ I+    NPrPl/V+ NSg/V
 > scarcely withered . It       excited him  , too , that         many        men  had already loved Daisy — it
 # R        V/J      . NPr/ISg+ V/J     ISg+ . W?  . NSg/I/C/Ddem NSg/I/J/Dq+ NSg+ V   W?      V/J   NPr+  . NPr/ISg+
-> increased her     value   in      his     eyes   . He       felt    their presence all          about the house  ,
-# V/J       ISg/D$+ N🅪Sg/V+ NPr/J/P ISg/D$+ NPl/V+ . NPr/ISg+ NSg/V/J D$+   NSg/V    NSg/I/J/C/Dq J/P   D+  NPr/V+ .
+> increased her     value   in      his     eyes   . He       felt     their presence all          about the house  ,
+# V/J       ISg/D$+ N🅪Sg/V+ NPr/J/P ISg/D$+ NPl/V+ . NPr/ISg+ N🅪Sg/V/J D$+   NSg/V    NSg/I/J/C/Dq J/P   D+  NPr/V+ .
 > pervading the air     with the shades and echoes of still   vibrant emotions .
 # V         D   N🅪Sg/V+ P    D   NPl/V+ V/C NPl/V  P  NSg/V/J NSg/J   NPl+     .
 >
@@ -9614,8 +9614,8 @@
 # NSg/J         . NSg/C/P NPr/ISg+ V      V/NoAm  V/J  NSg/C NSg/J         D/P . NPr/V/J . NSg/V+ NSg/VX
 > be     . She  vanished into her     rich     house  , into her     rich    , full     life    , leaving
 # NSg/VX . ISg+ V/J      P    ISg/D$+ NPr/V/J+ NPr/V+ . P    ISg/D$+ NPr/V/J . NSg/V/J+ N🅪Sg/V+ . V
-> Gatsby — nothing  . He       felt    married to her     , that          was all          .
-# NPr    . NSg/I/J+ . NPr/ISg+ NSg/V/J NSg/V/J P  ISg/D$+ . NSg/I/C/Ddem+ V   NSg/I/J/C/Dq .
+> Gatsby — nothing  . He       felt     married to her     , that          was all          .
+# NPr    . NSg/I/J+ . NPr/ISg+ N🅪Sg/V/J NSg/V/J P  ISg/D$+ . NSg/I/C/Ddem+ V   NSg/I/J/C/Dq .
 >
 #
 > When    they met again , two  days later , it       was Gatsby who    was breathless , who    was ,
@@ -10394,8 +10394,8 @@
 # C/P NPr/ISg+ C/P   NSg  W?      . C/P   NPr/V/J P     +     V   I/R/Dq NSg/I/V/J+ P  NSg/V NPr/ISg+ P  NSg/C NPr/ISg+
 > came    . I    have   an   idea that          Gatsby himself didn’t believe it       would come    , and
 # NSg/V/P . ISg+ NSg/VX D/P+ NSg+ NSg/I/C/Ddem+ NPr    ISg+    V      V       NPr/ISg+ VX    NSg/V/P . V/C
-> perhaps he       no    longer cared . If    that          was true    he       must  have   felt    that         he       had lost
-# NSg     NPr/ISg+ NPr/P NSg/JC J     . NSg/C NSg/I/C/Ddem+ V   NSg/V/J NPr/ISg+ NSg/V NSg/VX NSg/V/J NSg/I/C/Ddem NPr/ISg+ V   V/J
+> perhaps he       no    longer cared . If    that          was true    he       must  have   felt     that         he       had lost
+# NSg     NPr/ISg+ NPr/P NSg/JC J     . NSg/C NSg/I/C/Ddem+ V   NSg/V/J NPr/ISg+ NSg/V NSg/VX N🅪Sg/V/J NSg/I/C/Ddem NPr/ISg+ V   V/J
 > the old    warm     world  , paid a    high     price  for living  too long    with a    single   dream    .
 # D+  NSg/J+ NSg/V/J+ NSg/V+ . V/J  D/P+ NSg/V/J+ NPr/V+ C/P NSg/V/J W?  NPr/V/J P    D/P+ NSg/V/J+ NSg/V/J+ .
 > He       must  have   looked up        at    an   unfamiliar sky     through frightening leaves and
@@ -10914,8 +10914,8 @@
 # ISg+ V      V    D   NSg/V/JS P  D   NSg/V+ . C/P     ISg+ NPr/V/J NSg/V/J/P D   NSg+     .
 >
 #
-> After that         I    felt    a    certain shame     for Gatsby — one       gentleman to whom I    telephoned
-# P     NSg/I/C/Ddem ISg+ NSg/V/J D/P+ I/J+    N🅪Sg/V/J+ C/P NPr    . NSg/I/V/J NSg/J+    P  I+   ISg+ V/J
+> After that         I    felt     a    certain shame     for Gatsby — one       gentleman to whom I    telephoned
+# P     NSg/I/C/Ddem ISg+ N🅪Sg/V/J D/P+ I/J+    N🅪Sg/V/J+ C/P NPr    . NSg/I/V/J NSg/J+    P  I+   ISg+ V/J
 > implied that         he       had got what   he       deserved . However , that          was my  fault  , for he       was
 # V/J     NSg/I/C/Ddem NPr/ISg+ V   V   NSg/I+ NPr/ISg+ V/J      . C       . NSg/I/C/Ddem+ V   D$+ NSg/V+ . C/P NPr/ISg+ V
 > one       of those  who    used to sneer most       bitterly at    Gatsby on  the courage of
@@ -11440,8 +11440,8 @@
 # . W?           ISgPl+ V   NSg/V NPr/ISg+ NSg/J/P . . V/J  NPr+   R        . Unlintable Unlintable ISgPl+ V     NPr/ISg+ NSg/J/P
 > on  the telephone . I    don’t give  a   damn    about you    now       , but     it       was a   new     experience
 # J/P D+  NSg/V+    . ISg+ V     NSg/V D/P NSg/V/J J/P   ISgPl+ NPr/V/J/C . NSg/C/P NPr/ISg+ V   D/P NSg/V/J NSg/V
-> for me       , and I    felt    a   little     dizzy   for a   while      . ”
-# C/P NPr/ISg+ . V/C ISg+ NSg/V/J D/P NPr/I/J/Dq NSg/V/J C/P D/P NSg/V/C/P+ . .
+> for me       , and I    felt     a   little     dizzy   for a   while      . ”
+# C/P NPr/ISg+ . V/C ISg+ N🅪Sg/V/J D/P NPr/I/J/Dq NSg/V/J C/P D/P NSg/V/C/P+ . .
 >
 #
 > We   shook   hands  .
@@ -11564,8 +11564,8 @@
 # NSg/IPl+ J        . V/C NSg/V NSg/V/J NPl/V+ NSg/V/J NSg/V/J/P D   NSg/V+ IPl+ V   V    . . . .
 >
 #
-> I    shook   hands  with him  ; it       seemed silly not   to , for I    felt    suddenly as    though I
-# ISg+ NSg/V/J NPl/V+ P    ISg+ . NPr/ISg+ V/J    NSg/J NSg/C P  . C/P ISg+ NSg/V/J R        NSg/R V/C    ISg+
+> I    shook   hands  with him  ; it       seemed silly not   to , for I    felt     suddenly as    though I
+# ISg+ NSg/V/J NPl/V+ P    ISg+ . NPr/ISg+ V/J    NSg/J NSg/C P  . C/P ISg+ N🅪Sg/V/J R        NSg/R V/C    ISg+
 > were  talking to a    child  . Then    he       went  into the jewelry store  to buy   a    pearl
 # NSg/V V       P  D/P+ NSg/V+ . NSg/J/C NPr/ISg+ NSg/V P    D+  NᴹSg/V+ NSg/V+ P  NSg/V D/P+ NPr/V+
 > necklace — or    perhaps only  a   pair  of cuff  buttons — rid of my  provincial


### PR DESCRIPTION
# Issues 
Fixes #798

# Description

Adds new words mostly from the READMEs of trending GitHub repos.
Corrects annotations of many entries, especially marking mass nouns.

Fixes #798 by adding "sigil" and removing commonwealth dialect flags from "oversized"

Also adds "Coney Island" to the list of place names to capitalize.

Also fixes the wording of the message in the `very_unique` linter.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
