### PR TITLE
feat: split out `DurationExpr` from `since_duration` linter

### DIFF
--- a/harper-core/src/expr/duration_expr.rs
+++ b/harper-core/src/expr/duration_expr.rs
@@ -1,0 +1,52 @@
+use crate::patterns::WordSet;
+use crate::{Span, Token};
+
+use super::{Expr, SequenceExpr, SpelledNumberExpr};
+
+#[derive(Default)]
+pub struct DurationExpr;
+
+impl Expr for DurationExpr {
+    fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span<Token>> {
+        if tokens.is_empty() {
+            return None;
+        }
+
+        let units = WordSet::new(&[
+            "minute", "minutes", "hour", "hours", "day", "days", "week", "weeks", "month",
+            "months", "year", "years",
+        ]);
+
+        let expr = SequenceExpr::default()
+            .then_longest_of(vec![
+                Box::new(SpelledNumberExpr),
+                Box::new(SequenceExpr::default().then_number()),
+            ])
+            .then_whitespace()
+            .then(units);
+
+        expr.run(cursor, tokens, source)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::DurationExpr;
+    use crate::Document;
+    use crate::expr::ExprExt;
+    use crate::linting::tests::SpanVecExt;
+
+    #[test]
+    fn detect_10_days() {
+        let doc = Document::new_markdown_default_curated("Is 10 days a long time?");
+        let matches = DurationExpr.iter_matches_in_doc(&doc).collect::<Vec<_>>();
+        assert_eq!(matches.to_strings(&doc), vec!["10 days"]);
+    }
+
+    #[test]
+    fn detect_ten_days() {
+        let doc = Document::new_markdown_default_curated("I think ten days is a long time.");
+        let matches = DurationExpr.iter_matches_in_doc(&doc).collect::<Vec<_>>();
+        assert_eq!(matches.to_strings(&doc), vec!["ten days"]);
+    }
+}

--- a/harper-core/src/expr/mod.rs
+++ b/harper-core/src/expr/mod.rs
@@ -16,6 +16,7 @@
 mod all;
 mod anchor_end;
 mod anchor_start;
+mod duration_expr;
 mod expr_map;
 mod first_match_of;
 mod fixed_phrase;
@@ -40,6 +41,7 @@ use std::sync::Arc;
 pub use all::All;
 pub use anchor_end::AnchorEnd;
 pub use anchor_start::AnchorStart;
+pub use duration_expr::DurationExpr;
 pub use expr_map::ExprMap;
 pub use first_match_of::FirstMatchOf;
 pub use fixed_phrase::FixedPhrase;

--- a/harper-core/src/linting/since_duration.rs
+++ b/harper-core/src/linting/since_duration.rs
@@ -1,8 +1,5 @@
-use crate::expr::Expr;
-use crate::expr::LongestMatchOf;
-use crate::expr::SequenceExpr;
-use crate::expr::SpelledNumberExpr;
-use crate::{Lrc, Token, TokenStringExt, patterns::WordSet};
+use crate::expr::{DurationExpr, Expr, LongestMatchOf, SequenceExpr};
+use crate::{Lrc, Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -27,21 +24,11 @@ pub struct SinceDuration {
 
 impl Default for SinceDuration {
     fn default() -> Self {
-        let units = WordSet::new(&[
-            "minute", "minutes", "hour", "hours", "day", "days", "week", "weeks", "month",
-            "months", "year", "years",
-        ]);
-
         let pattern_without_ago = Lrc::new(
             SequenceExpr::default()
                 .then_any_capitalization_of("since")
                 .then_whitespace()
-                .then_longest_of(vec![
-                    Box::new(SpelledNumberExpr),
-                    Box::new(SequenceExpr::default().then_number()),
-                ])
-                .then_whitespace()
-                .then(units),
+                .then(DurationExpr),
         );
 
         let pattern_with_ago = SequenceExpr::default()


### PR DESCRIPTION
# Issues 

#413 will be able to make use of this.

# Description

Splits out a `DurationExpr` expression from the `since_duration` linter.

# How Has This Been Tested?

I added a couple of unit tests to make sure both numeric and spelled-out numbers work.
Of course all the existing `since_duration` tests, now built upon this `Expr` too, still all pass.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
