### PR TITLE
fix: dont flag "playback latency"

### DIFF
--- a/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
+++ b/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
@@ -174,6 +174,7 @@ impl Linter for PhrasalVerbAsCompoundNoun {
                     }
                     ['c', 'a', 'l', 'l', 'b', 'a', 'c', 'k'] => &["function"][..],
                     ['p', 'l', 'a', 'y', 'b', 'a', 'c', 'k'] => &["latency"][..],
+                    ['r', 'o', 'l', 'l', 'o', 'u', 't'] => &["status"][..],
                     ['w', 'o', 'r', 'k', 'o', 'u', 't'] => &["constraints", "preference"][..],
                     _ => &[],
                 }
@@ -181,6 +182,7 @@ impl Linter for PhrasalVerbAsCompoundNoun {
                     &next_tok
                         .span
                         .get_content_string(document.get_source())
+                        .to_lowercase()
                         .as_ref(),
                 )
             {
@@ -560,6 +562,15 @@ mod tests {
     fn dont_flag_workout_preference() {
         assert_lint_count(
             "Workout preference",
+            PhrasalVerbAsCompoundNoun::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_rollout_status() {
+        assert_lint_count(
+            "Rollout Status of Latest Image Release",
             PhrasalVerbAsCompoundNoun::default(),
             0,
         );


### PR DESCRIPTION
# Issues 
N/A

# Description

Adds another exception to the `phrasal_verb_as_compound_noun` linter.
When "playback" is part of the known compound "playback latency", don't flag to change it to "play back".

# How Has This Been Tested?

I added a unit test using the sentence that brought this to my attention.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
