### PR TITLE
docs(harper-ls): document version check

### DIFF
--- a/packages/web/src/routes/docs/integrations/language-server/+page.md
+++ b/packages/web/src/routes/docs/integrations/language-server/+page.md
@@ -304,3 +304,7 @@ These configs are under the `markdown` key:
 
 Want your language added?
 Let us know by [commenting on this issue](https://github.com/Automattic/harper/issues/79).
+
+## Skipping the Version Check
+
+By default, on startup, `harper-ls` briefly connects to <https://writewithharper.com> to get the latest Harper version, printing it alongside the current Harper version. This happens to make debugging via logs easier when we don't have access to the full system. This action does not log or store anything about the user. However, if this makes you feel uncomfortable or if you simply want to forgo the version check, you can pass `--skip-version-check` when starting `harper-ls` to skip it, like so: `harper-ls --skip-version-check`.


### PR DESCRIPTION
# Issues 

None in particular

# Description

The version check was introduced in #1204, and since then has created some friction (#1211, #1725, #1774) . It's recently been removed in the Obsidian plugin (#1775), but still remains in `harper-ls`. Personally, I don't mind it since I understand that it doesn't log anything. However, unless it really helps with debugging, it might also be worth considering removing it from `harper-ls` in the future. Especially if it creates further friction with more privacy-focused users. That said, I think documenting it first would be good (I took some direct quotes from #1334's description) so users are aware of it and don't get surprised by it, hence, this PR.

# How Has This Been Tested?

Viewed the change locally

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
