### PR TITLE
Neovim code action does not hide Harper diagnostic #1785 fix

### DIFF
--- a/harper-core/src/span.rs
+++ b/harper-core/src/span.rs
@@ -24,6 +24,7 @@ pub struct Span<T> {
     /// Note that [`Span`] represents an exclusive range. This means that a `Span::new(0, 5)` will
     /// cover the values `0, 1, 2, 3, 4`; it will not cover the `5`.
     pub end: usize,
+    #[serde(skip)]
     span_type: PhantomData<T>,
 }
 


### PR DESCRIPTION
# Issues 
fixes #1785

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->
Told serde to ignore the span_type in span when de-serializing data.
This seems like the approach to me, unless Harper uses the span struct in a way I am not aware of this should not cause any issues. The reason I believe the issue is on Harper's side is due to the [lsp specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_executeCommand) mentioning that the lsp server needs to communicate CodeAction.command.arguments to the client. This is being done but one of the arguments (the span_type) is not a type that can be returned (as far as I know) by most lsp clients.
Therefore, it will not be returned which causes harper to reject the response.
# How Has This Been Tested?
I ran it locally and connected to the lsp and no longer got the lsp log errors and was able to hide diagnostics from within Neovim.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
