### PR TITLE
feat(obsidian): change how default values are displayed

### DIFF
--- a/packages/obsidian-plugin/src/HarperSettingTab.ts
+++ b/packages/obsidian-plugin/src/HarperSettingTab.ts
@@ -203,7 +203,7 @@ export class HarperSettingTab extends PluginSettingTab {
 		// Ensure default config is loaded before initial render so values reflect defaults.
 		this.state.getDefaultLintConfig().then((v) => {
 			this.defaultLintConfig = v as unknown as Record<string, boolean>;
-			this.renderLintSettings(this.currentRuleSearchQuery, lintSettings);
+			this.renderLintSettingsToId(this.currentRuleSearchQuery, lintSettings.id);
 		});
 	}
 
@@ -213,12 +213,18 @@ export class HarperSettingTab extends PluginSettingTab {
 		this.toggleAllButton.setButtonText(anyEnabled ? 'Disable All Rules' : 'Enable All Rules');
 	}
 
-	renderLintSettingsToId(searchQuery: string, id: string) {
+	async renderLintSettingsToId(searchQuery: string, id: string) {
 		const el = document.getElementById(id);
-		this.renderLintSettings(searchQuery, el!);
+		if (!el) return;
+		const effective = await this.state.getEffectiveLintConfig();
+		this.renderLintSettings(searchQuery, el, effective);
 	}
 
-	renderLintSettings(searchQuery: string, containerEl: HTMLElement) {
+	private renderLintSettings(
+		searchQuery: string,
+		containerEl: HTMLElement,
+		effectiveConfig: Record<string, boolean>,
+	) {
 		containerEl.innerHTML = '';
 
 		const queryLower = searchQuery.toLowerCase();
@@ -249,7 +255,7 @@ export class HarperSettingTab extends PluginSettingTab {
 				.setName(startCase(setting))
 				.setDesc(fragment)
 				.addDropdown((dropdown) => {
-					const effective: boolean | undefined = value === null ? defaultVal : (value ?? undefined);
+					const effective: boolean | undefined = effectiveConfig[setting];
 					const usingDefault = value === null;
 					const onLabel = usingDefault && defaultVal === true ? 'On (default)' : 'On';
 					const offLabel = usingDefault && defaultVal === false ? 'Off (default)' : 'Off';

--- a/packages/obsidian-plugin/src/State.test.ts
+++ b/packages/obsidian-plugin/src/State.test.ts
@@ -100,3 +100,36 @@ test('Can be initialized with incomplete lint settings and retain default state.
 
 	expect(await state.getSettings()).toStrictEqual(defaultSettings);
 });
+
+test('resetAllRulesToDefaults sets all overrides to null', async () => {
+	const state = createEphemeralState();
+
+	// Start with all enabled, then reset
+	let settings = await state.getSettings();
+	for (const key of Object.keys(settings.lintSettings)) {
+		settings.lintSettings[key] = true;
+	}
+	await state.initializeFromSettings(settings);
+
+	await state.resetAllRulesToDefaults();
+	settings = await state.getSettings();
+	for (const key of Object.keys(settings.lintSettings)) {
+		expect(settings.lintSettings[key]).toBeNull();
+	}
+});
+
+test('setAllRulesEnabled toggles all rules on and off', async () => {
+	const state = createEphemeralState();
+
+	await state.setAllRulesEnabled(true);
+	let settings = await state.getSettings();
+	for (const key of Object.keys(settings.lintSettings)) {
+		expect(settings.lintSettings[key]).toBe(true);
+	}
+
+	await state.setAllRulesEnabled(false);
+	settings = await state.getSettings();
+	for (const key of Object.keys(settings.lintSettings)) {
+		expect(settings.lintSettings[key]).toBe(false);
+	}
+});

--- a/packages/obsidian-plugin/src/State.test.ts
+++ b/packages/obsidian-plugin/src/State.test.ts
@@ -133,3 +133,27 @@ test('setAllRulesEnabled toggles all rules on and off', async () => {
 		expect(settings.lintSettings[key]).toBe(false);
 	}
 });
+
+test('getEffectiveLintConfig matches defaults after reset', async () => {
+	const state = createEphemeralState();
+	await state.resetAllRulesToDefaults();
+	const effective = await state.getEffectiveLintConfig();
+	const defaults = (await state.getDefaultLintConfig()) as Record<string, boolean>;
+	expect(Object.keys(effective).sort()).toStrictEqual(Object.keys(defaults).sort());
+	for (const k of Object.keys(defaults)) {
+		expect(effective[k]).toBe(defaults[k]);
+	}
+});
+
+test('getEffectiveLintConfig reflects explicit overrides', async () => {
+	const state = createEphemeralState();
+	const settings = await state.getSettings();
+	for (const key of Object.keys(settings.lintSettings)) {
+		settings.lintSettings[key] = true;
+	}
+	await state.initializeFromSettings(settings);
+	const effective = await state.getEffectiveLintConfig();
+	for (const k of Object.keys(effective)) {
+		expect(effective[k]).toBe(true);
+	}
+});

--- a/packages/obsidian-plugin/src/State.ts
+++ b/packages/obsidian-plugin/src/State.ts
@@ -225,6 +225,11 @@ export default class State {
 		return await this.harper.getLintDescriptionsHTML();
 	}
 
+	/** Expose the default lint configuration for UI rendering. */
+	public async getDefaultLintConfig(): Promise<LintConfig> {
+		return await this.harper.getDefaultLintConfig();
+	}
+
 	/** Get a reference to the CM editor extensions.
 	 * Do not mutate the returned value, except via methods on this class. */
 	public getCMEditorExtensions(): Extension[] {

--- a/packages/obsidian-plugin/src/State.ts
+++ b/packages/obsidian-plugin/src/State.ts
@@ -254,6 +254,21 @@ export default class State {
 		return await this.harper.getDefaultLintConfig();
 	}
 
+	/** Effective config: merges defaults with overrides (null/undefined uses default). */
+	public async getEffectiveLintConfig(): Promise<Record<string, boolean>> {
+		const defaults = (await this.getDefaultLintConfig()) as Record<string, boolean>;
+		const overrides = (await this.getSettings()).lintSettings as Record<
+			string,
+			boolean | null | undefined
+		>;
+		const effective: Record<string, boolean> = {};
+		for (const key of Object.keys(defaults)) {
+			const v = overrides[key];
+			effective[key] = v === null || v === undefined ? defaults[key] : Boolean(v);
+		}
+		return effective;
+	}
+
 	/** Determine if any rules are effectively enabled, considering defaults. */
 	public async areAnyRulesEnabled(): Promise<boolean> {
 		const settings = await this.getSettings();

--- a/packages/obsidian-plugin/src/State.ts
+++ b/packages/obsidian-plugin/src/State.ts
@@ -221,6 +221,30 @@ export default class State {
 		};
 	}
 
+	/**
+	 * Reset all lint rule overrides back to their defaults (null).
+	 * Persists and reinitializes state to apply changes.
+	 */
+	public async resetAllRulesToDefaults(): Promise<void> {
+		const settings = await this.getSettings();
+		for (const key of Object.keys(settings.lintSettings)) {
+			settings.lintSettings[key] = null;
+		}
+		await this.initializeFromSettings(settings);
+	}
+
+	/**
+	 * Enable or disable all lint rules in bulk by setting explicit values.
+	 * This overrides individual rule settings until changed again.
+	 */
+	public async setAllRulesEnabled(enabled: boolean): Promise<void> {
+		const settings = await this.getSettings();
+		for (const key of Object.keys(settings.lintSettings)) {
+			settings.lintSettings[key] = enabled;
+		}
+		await this.initializeFromSettings(settings);
+	}
+
 	public async getDescriptionHTML(): Promise<Record<string, string>> {
 		return await this.harper.getLintDescriptionsHTML();
 	}
@@ -228,6 +252,19 @@ export default class State {
 	/** Expose the default lint configuration for UI rendering. */
 	public async getDefaultLintConfig(): Promise<LintConfig> {
 		return await this.harper.getDefaultLintConfig();
+	}
+
+	/** Determine if any rules are effectively enabled, considering defaults. */
+	public async areAnyRulesEnabled(): Promise<boolean> {
+		const settings = await this.getSettings();
+		const defaults = await this.getDefaultLintConfig();
+		for (const key of Object.keys(settings.lintSettings)) {
+			const v = settings.lintSettings[key] as boolean | null | undefined;
+			const def = (defaults as Record<string, boolean | undefined>)[key];
+			const effective = v === null || v === undefined ? def : v;
+			if (effective) return true;
+		}
+		return false;
 	}
 
 	/** Get a reference to the CM editor extensions.

--- a/packages/obsidian-plugin/src/State.ts
+++ b/packages/obsidian-plugin/src/State.ts
@@ -53,7 +53,7 @@ export default class State {
 		}
 
 		const defaultConfig = await this.harper.getDefaultLintConfig();
-		for (const [key, value] of Object.entries(defaultConfig)) {
+		for (const key of Object.keys(defaultConfig)) {
 			if (settings.lintSettings[key] == undefined) {
 				settings.lintSettings[key] = null;
 			}


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

#1580 and #1786

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

I've added two buttons to the settings page of the Obsidian plugin. 

1. Allows you to toggle all rules (as described in #1786)
2. Allows you to reset all rules to their default value.

I've also updated the UI to reflect that described in #1580, which is hopefully more intuitive.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->
<img width="771" height="953" alt="image" src="https://github.com/user-attachments/assets/e64877ad-fdfb-488c-a615-63b26a480eef" />


# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
