### PR TITLE
fix: YAML headers of template markdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-false-positive.md
+++ b/.github/ISSUE_TEMPLATE/report-false-positive.md
@@ -2,8 +2,8 @@
 name: Report False Positive
 about: Harper flagged something that's actually correct
 title: ''
-labels: bug, false-positive
-
+labels: bug, harper-core, linting, false-positive
+---
 **What got flagged?**
 The text that was incorrectly flagged.
 

--- a/.github/ISSUE_TEMPLATE/report-grammatical-error.md
+++ b/.github/ISSUE_TEMPLATE/report-grammatical-error.md
@@ -2,8 +2,8 @@
 name: Report Grammatical Error
 about: Harper missed a grammatical error
 title: ''
-labels: enhancement, linting
-
+labels: enhancement, harper-core, linting
+---
 **The Error**
 Description of the error.
 

--- a/.github/ISSUE_TEMPLATE/suggest-a-feature.md
+++ b/.github/ISSUE_TEMPLATE/suggest-a-feature.md
@@ -3,7 +3,7 @@ name: Suggest a Feature
 about: Propose a new feature
 title: ''
 labels: enhancement
-
+---
 **What problem does this solve?**
 Brief description.
 


### PR DESCRIPTION
# Issues 

No issue but I mentioned it in the Discord here: https://discord.com/channels/1335035237213671495/1335035237213671498/1408302735715074209

# Description

The LLM I used to simplify the templates removed the second `---` from the YAML header of 3 out of 4 of the markdown files. I didn't spot it and neither did Copilot on GitHub when I was trying to figure out why we were seeing the GitHub default templates instead of our custom ones.

I also reverted the changes to the `labels` sections.

# How Has This Been Tested?

Not sure there's a way to test this? If there is, please let me know!

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
