### PR TITLE
feat(harper-ls): Replace all in document with...

### DIFF
--- a/harper-ls/src/document_state.rs
+++ b/harper-ls/src/document_state.rs
@@ -61,10 +61,15 @@ impl DocumentState {
         let span = range_to_span(source_chars, range).with_len(1);
 
         let mut actions: Vec<CodeActionOrCommand> = lints
-            .into_iter()
+            .iter()
             .filter(|lint| lint.span.overlaps_with(span))
             .flat_map(|lint| {
-                lint_to_code_actions(&lint, &self.uri, &self.document, code_action_config)
+                let others = lints
+                    .iter()
+                    .filter(|other| other.spanless_hash() == lint.spanless_hash())
+                    .filter(|other| *other != lint)
+                    .collect::<Vec<_>>();
+                lint_to_code_actions(lint, &others, &self.uri, &self.document, code_action_config)
             })
             .collect();
 


### PR DESCRIPTION
Find all similar lints and allow applying them all across the document in one code action. This should fix #998.

# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #998 

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

This adds additional quickfix actions which perform a particular lint suggestion document-wide.  The intent being to resolve #998 in a reasonable fashion.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

![replace-all](https://github.com/user-attachments/assets/c67dfb46-d222-4f38-90f7-d1cfb72e576e)

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I added the locally built `harper-ls` to my `helix` configuration and tested across a variety of markdown documents doing global replacements of the same and differing lengths, including situations where the action was similar but the lint different (eg. replacing a double-space in the middle of a sentence vs. after a full-stop).  All seemed good.

Also, `cargo test --all` didn't complain.

Right now I'm not particularly pleased with *how* this is implemented, so I'm interested in the views of @elijah-potter in particular.  I feel there must be a neater way to do this.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
