### PR TITLE
feat:at worse→at worst

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -381,6 +381,7 @@ pub fn lint_group() -> LintGroup {
                 (&["worst and worst", "worse and worst", "worst and worse"], &["worse and worse"]),
                 (&["worst than"], &["worse than"]),
                 // worse -> worst
+                (&["at worse"], &["at worst"]),
                 (&["worse case scenario", "worse-case scenario", "worse-case-scenario"], &["worst-case scenario"]),
                 (&["worse ever"], &["worst ever"]),
             ],

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -1365,6 +1365,16 @@ fn detect_worse_and_worst_real_world() {
     );
 }
 
+// -at worst-
+#[test]
+fn detect_at_worst_atomic() {
+    assert_suggestion_result(
+        "Partial moving of core objects to interpreter state is incorrect at best, unsafe at worse.",
+        lint_group(),
+        "Partial moving of core objects to interpreter state is incorrect at best, unsafe at worst.",
+    );
+}
+
 // -worst case scenario-
 #[test]
 fn correct_worse_case_space() {


### PR DESCRIPTION
# Issues 
#525 

# Description

I found another case where "worse" is often used mistakenly instead of "worst".
I added "at worse" to `phrase_set_corrections`

# How Has This Been Tested?

I included a unit test with a sentence found on GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
