### PR TITLE
Added a new togglable "Restore Active Status" setting

### DIFF
--- a/packages/obsidian-plugin/src/HarperSettingTab.ts
+++ b/packages/obsidian-plugin/src/HarperSettingTab.ts
@@ -87,12 +87,12 @@ export class HarperSettingTab extends PluginSettingTab {
 		});
 
 		new Setting(containerEl)
-			.setName('Restore Active Status')
-			.setDesc('Whether to restore the Harper active/inactive status between sessions.')
+			.setName('Activate Harper')
+			.setDesc('Enable or disable harper with this option.')
 			.addToggle((toggle) =>
-				toggle.setValue(this.settings.lintEnabledRestore).onChange(async (value) => {
-					this.settings.lintEnabledRestore = value;
-					await this.state.initializeFromSettings(this.settings);
+				toggle.setValue(this.settings.lintEnabled).onChange(async (value) => {
+					this.state.toggleAutoLint();
+					this.plugin.updateStatusBar();
 				}),
 			);
 

--- a/packages/obsidian-plugin/src/State.ts
+++ b/packages/obsidian-plugin/src/State.ts
@@ -15,7 +15,6 @@ export type Settings = {
 	delay?: number;
 	ignoredGlobs?: string[];
 	lintEnabled: boolean;
-	lintEnabledRestore: boolean;
 };
 
 const DEFAULT_DELAY = -1;
@@ -31,7 +30,6 @@ export default class State {
 	private ignoredGlobs?: string[];
 	private editorViewField?: StateField<MarkdownFileInfo>;
 	private lintEnabled: boolean;
-	private lintEnabledRestore: boolean;
 
 	/** The CodeMirror extension objects that should be inserted by the host. */
 	private editorExtensions: Extension[];
@@ -56,7 +54,6 @@ export default class State {
 			settings = {
 				useWebWorker: true,
 				lintEnabled: true,
-				lintEnabledRestore: false,
 				lintSettings: {},
 			};
 		}
@@ -97,7 +94,6 @@ export default class State {
 		this.delay = settings.delay ?? DEFAULT_DELAY;
 		this.ignoredGlobs = settings.ignoredGlobs;
 		this.lintEnabled = settings.lintEnabled;
-		this.lintEnabledRestore = settings.lintEnabledRestore;
 
 		// Reinitialize it.
 		if (this.hasEditorLinter()) {
@@ -230,7 +226,6 @@ export default class State {
 			delay: this.delay,
 			ignoredGlobs: this.ignoredGlobs,
 			lintEnabled: this.lintEnabled,
-			lintEnabledRestore: this.lintEnabledRestore,
 		};
 	}
 

--- a/packages/obsidian-plugin/src/index.ts
+++ b/packages/obsidian-plugin/src/index.ts
@@ -31,7 +31,7 @@ export default class HarperPlugin extends Plugin {
 		this.registerEditorExtension(this.state.getCMEditorExtensions());
 		this.setupCommands();
 		this.setupStatusBar();
-		if (data.lintEnabledRestore && !data.lintEnabled) {
+		if (!data.lintEnabled) {
 			this.state.disableEditorLinter();
 		} else this.state.enableEditorLinter();
 


### PR DESCRIPTION
Added a new togglable "Restore Active Status" setting to set whether to restore the Harper linter active/inactive status between sessions.

# Issues 


# Description
Added a new togglable "Restore Active Status" setting to set whether to restore the Harper linter active/inactive status between sessions.

# Demo


# How Has This Been Tested?
Tested closing and opening Obsidian vault with and without the new "Restore Active Status" enabled, and with and without the current Harper state being enabled. The new toggle is defaulted to off and the plugin behaves as it did previously where Harper is always enabled when Obsidian is opened. But if the new toggle is set to on and Harper is in an inactive state when Obsidian is closed, that inactive state will be preserved when the vault is next opened.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ x ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
