### PR TITLE
fix: no longer flag `with plugin` or `, layout`

### DIFF
--- a/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
+++ b/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
@@ -177,6 +177,7 @@ impl Linter for PhrasalVerbAsCompoundNoun {
                         &["file", "images", "location", "snapshots"][..]
                     }
                     ['c', 'a', 'l', 'l', 'b', 'a', 'c', 'k'] => &["function"][..],
+                    ['l', 'a', 'y', 'o', 'u', 't'] => &["estimation"][..],
                     ['p', 'l', 'a', 'y', 'b', 'a', 'c', 'k'] => &["latency"][..],
                     ['r', 'o', 'l', 'l', 'o', 'u', 't'] => &["status"][..],
                     ['w', 'o', 'r', 'k', 'o', 'u', 't'] => &["constraints", "preference"][..],
@@ -629,6 +630,15 @@ mod tests {
     fn dont_flag_in_noun_list_without_space_after_comma() {
         assert_lint_count(
             "shape, memory space,and layout of data",
+            PhrasalVerbAsCompoundNoun::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_layout_estimation() {
+        assert_lint_count(
+            "Layout estimation focuses on predicting architectural elements, i.e., walls, doors, and windows, within an indoor scene.",
             PhrasalVerbAsCompoundNoun::default(),
             0,
         );


### PR DESCRIPTION
# Issues 
N/A

# Description

The compound noun to phrasal verb linter was wrongly flagging "with plugin" to change to "with plug in".
This is now fixed by checking for preposition other than "to" as the previous word.

Later I found it was also wrongly flagging "memory space, and layout of data" to change to "memory space, and lay out of data".
This is fixed by updating the noun list detection logic to check for a comma as well as a conjunction.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

A unit test is added using the text from each GitHub repo README where I first noticed these.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
