### PR TITLE
feat:upto→up to

### DIFF
--- a/harper-core/src/linting/open_compounds.rs
+++ b/harper-core/src/linting/open_compounds.rs
@@ -21,6 +21,7 @@ impl Default for OpenCompounds {
             "in case",
             "in fact",
             "in front",
+            "up to",
         ];
         let mut compound_to_phrase = HashMap::new();
         for phrase in phrases {
@@ -426,6 +427,17 @@ mod tests {
             "Yes I do infact exist :O",
             OpenCompounds::default(),
             "Yes I do in fact exist :O",
+        );
+    }
+
+    // up to
+
+    #[test]
+    fn correct_upto() {
+        assert_suggestion_result(
+            "Free for upto 10k subscribers, unlimited push notifications, in-browser messaging",
+            OpenCompounds::default(),
+            "Free for up to 10k subscribers, unlimited push notifications, in-browser messaging",
         );
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

Yet another often wrongly compounded pair of words: `upto` should be `up to`.

# How Has This Been Tested?

I include a unit test using the sentence from GitHub that brought this to my attention.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
