### PR TITLE
feat:through great lengths→to great lengths

### DIFF
--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -1055,6 +1055,12 @@ pub fn lint_group() -> LintGroup {
             "Hyphenate `to-do`.",
             "Ensures `to-do` is correctly hyphenated."
         ),
+        "ToGreatLengths" => (
+            ["through great lengths"],
+            ["to great lengths"],
+            "Did you mean `to great lengths`?",
+            "Corrects `through great lengths` to `to great lengths`."
+        ),
         "ToTheMannerBorn" => (
             ["to the manor born"],
             ["to the manner born"],

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -1269,6 +1269,16 @@ fn suggests_ticking_clock() {
 // ToDoHyphen
 // -none-
 
+// ToGreatLengths
+#[test]
+fn correct_to_great_lengths() {
+    assert_suggestion_result(
+        "Bloomberg's sponsored paid for content goes through great lengths to market Nvidia's products and in particular its AI products that we've frequently criticized.",
+        lint_group(),
+        "Bloomberg's sponsored paid for content goes to great lengths to market Nvidia's products and in particular its AI products that we've frequently criticized.",
+    );
+}
+
 // ToTheMannerBorn
 // -none-
 


### PR DESCRIPTION
# Issues 
N/A

# Description

"Go through great lengths" seems to be a millennial variant of "go to great lengths": 
<img width="1279" height="435" alt="image" src="https://github.com/user-attachments/assets/a8dd39eb-c422-469f-9b53-aac5e8f27457" />

But it's still used only an infinitesimal amount compared to "go to great lengths": 
<img width="1271" height="439" alt="image" src="https://github.com/user-attachments/assets/4b0d2170-5f02-4eaf-8f3a-3fe050db4755" />

It's probably influenced by "go through the trouble/effort" seemingly being accepted as a variant of "go to the trouble/effort".

# How Has This Been Tested?

I added a unit test using the sentence from the Gamer's Nexus video that reminded me of this figure of speech.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
