### PR TITLE
feat: add idioms to then/than linter

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -31738,7 +31738,7 @@ lepton/~NgS
 lesbian/~JNVSg
 lesbianism/Nmg
 lesion/~NVgS
-less/~PVJCn>X
+less/~RPVJCn>X
 lessee/NVgS
 lessen/~VCGd
 lesson/~VNgS
@@ -34459,7 +34459,7 @@ morbidity/Ng
 morbidness/Ng
 mordancy/Ng
 mordant/JNVSgY
-more/~IJNVSDq
+more/~RIJNVSDq
 moreish/J
 morel/~NSg
 moreover/~

--- a/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
+++ b/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
@@ -302,8 +302,8 @@
 # ISg+ NSg/VX NSg/C NSg/V    J    V      NSg/V NSg/I+ D/P+ NSg/V+ .
 >
 #
-> After a    while      , finding that         nothing  more         happened , she  decided on  going   into the
-# P     D/P+ NSg/V/C/P+ . NSg/V   NSg/I/C/Ddem NSg/I/J+ NPr/I/V/J/Dq V/J      . ISg+ NSg/V/J J/P NSg/V/J P    D+
+> After a    while      , finding that         nothing  more           happened , she  decided on  going   into the
+# P     D/P+ NSg/V/C/P+ . NSg/V   NSg/I/C/Ddem NSg/I/J+ NPr/I/V/J/R/Dq V/J      . ISg+ NSg/V/J J/P NSg/V/J P    D+
 > garden   at    once  ; but     , alas for poor     Alice ! when    she  got to the door   , she  found
 # NSg/V/J+ NSg/P NSg/C . NSg/C/P . NPl  C/P NSg/V/J+ NPr+  . NSg/I/C ISg+ V   P  D+  NSg/V+ . ISg+ NSg/V
 > she  had forgotten the little     golden  key     , and when    she  went  back    to the table  for
@@ -413,7 +413,7 @@
 >
 #
 > Just then    her     head     struck against the roof  of the hall : in      fact she  was now       more
-# V/J  NSg/J/C ISg/D$+ NPr/V/J+ V      C/P     D   NSg/V P  D+  NPr+ . NPr/J/P NSg+ ISg+ V   NPr/V/J/C NPr/I/V/J/Dq
+# V/J  NSg/J/C ISg/D$+ NPr/V/J+ V      C/P     D   NSg/V P  D+  NPr+ . NPr/J/P NSg+ ISg+ V   NPr/V/J/C NPr/I/V/J/R/Dq
 > than nine feet high    , and she  at    once  took up        the little     golden  key     and hurried
 # C/P  NSg+ NPl+ NSg/V/J . V/C ISg+ NSg/P NSg/C V    NSg/V/J/P D   NPr/I/J/Dq NPr/V/J NPr/V/J V/C V/J
 > off       to the garden   door   .
@@ -422,8 +422,8 @@
 #
 > Poor     Alice ! It       was as    much         as    she  could  do     , lying   down       on  one        side     , to look
 # NSg/V/J+ NPr+  . NPr/ISg+ V   NSg/R NSg/I/J/R/Dq NSg/R ISg+ NSg/VX NSg/VX . NSg/V/J N🅪Sg/V/J/P J/P NSg/I/V/J+ NSg/V/J+ . P  NSg/V
-> through into the garden   with one        eye    ; but     to get   through was more         hopeless than
-# NSg/J/P P    D   NSg/V/J+ P    NSg/I/V/J+ NSg/V+ . NSg/C/P P  NSg/V NSg/J/P V   NPr/I/V/J/Dq J        C/P
+> through into the garden   with one        eye    ; but     to get   through was more           hopeless than
+# NSg/J/P P    D   NSg/V/J+ P    NSg/I/V/J+ NSg/V+ . NSg/C/P P  NSg/V NSg/J/P V   NPr/I/V/J/R/Dq J        C/P
 > ever : she  sat     down       and began to cry   again .
 # J    . ISg+ NSg/V/J N🅪Sg/V/J/P V/C V     P  NSg/V P     .
 >
@@ -668,8 +668,8 @@
 # D$+  NSg/V  . . V/J   NPr+  P     . C/P I/Ddem+ N🅪Sg/V/J+ D+  NSg/V+ V   V         NSg/I/J/C/Dq NSg/J/P .
 > and she  felt     certain it       must  be     really offended . “ We   won’t talk   about her     any
 # V/C ISg+ N🅪Sg/V/J I/J     NPr/ISg+ NSg/V NSg/VX R      V/J      . . IPl+ V     N🅪Sg/V J/P   ISg/D$+ I/R/Dq
-> more         if    you’d rather    not   . ”
-# NPr/I/V/J/Dq NSg/C W?    NPr/V/J/R NSg/C . .
+> more           if    you’d rather    not   . ”
+# NPr/I/V/J/R/Dq NSg/C W?    NPr/V/J/R NSg/C . .
 >
 #
 > “ We   indeed ! ” cried the Mouse  , who    was trembling down       to the end   of his     tail     . “ As
@@ -752,8 +752,8 @@
 # V/C VX    J/R/C NSg/V . . ISg+ NPr/V/J JC    C/P  ISgPl+ . V/C NSg/V NSg/V NSg/VX/JC . . V/C I/Ddem NPr+
 > would not   allow without knowing   how   old   it       was , and , as    the Lory positively
 # VX    NSg/C V     C/P     NSg/V/J/P NSg/C NSg/J NPr/ISg+ V   . V/C . NSg/R D   ?    R
-> refused to tell  its     age     , there was no    more         to be     said .
-# V/J     P  NPr/V ISg/D$+ N🅪Sg/V+ . +     V   NPr/P NPr/I/V/J/Dq P  NSg/VX V/J  .
+> refused to tell  its     age     , there was no    more           to be     said .
+# V/J     P  NPr/V ISg/D$+ N🅪Sg/V+ . +     V   NPr/P NPr/I/V/J/R/Dq P  NSg/VX V/J  .
 >
 #
 > At    last    the Mouse  , who    seemed to be     a   person of authority among them     , called
@@ -836,14 +836,14 @@
 #
 > “ In      that          case    , ” said the Dodo solemnly , rising    to its     feet , “ I    move  that         the
 # . NPr/J/P NSg/I/C/Ddem+ NPr🅪/V+ . . V/J  D   NSg  R        . NSg/V/J/P P  ISg/D$+ NPl+ . . ISg+ NSg/V NSg/I/C/Ddem D
-> meeting adjourn , for the immediate adoption of more         energetic remedies — ”
-# NSg/V+  V       . C/P D   J         NSg      P  NPr/I/V/J/Dq NSg/J     NPl/V+   . .
+> meeting adjourn , for the immediate adoption of more           energetic remedies — ”
+# NSg/V+  V       . C/P D   J         NSg      P  NPr/I/V/J/R/Dq NSg/J     NPl/V+   . .
 >
 #
 > “ Speak English   ! ” said the Eaglet . “ I    don’t know  the meaning  of half        those  long
 # . NSg/V NPr🅪/V/J+ . . V/J  D   NSg    . . ISg+ V     NSg/V D   N🅪Sg/V/J P  N🅪Sg/V/J/P+ I/Ddem NPr/V/J
-> words  , and , what’s more         , I    don’t believe you    do     either ! ” And the Eaglet bent
-# NPl/V+ . V/C . NSg$   NPr/I/V/J/Dq . ISg+ V     V       ISgPl+ NSg/VX I/C    . . V/C D   NSg    NSg/V/J
+> words  , and , what’s more           , I    don’t believe you    do     either ! ” And the Eaglet bent
+# NPl/V+ . V/C . NSg$   NPr/I/V/J/R/Dq . ISg+ V     V       ISgPl+ NSg/VX I/C    . . V/C D   NSg    NSg/V/J
 > down       its     head     to hide  a   smile  : some     of the other   birds  tittered audibly .
 # N🅪Sg/V/J/P ISg/D$+ NPr/V/J+ P  NSg/V D/P NSg/V+ . I/J/R/Dq P  D   NSg/V/J NPl/V+ V/J      R       .
 >
@@ -936,8 +936,8 @@
 # . NSg/V+ NPr/ISg+ NSg/J/P NSg/J/R . . V/J  D   NSg  .
 >
 #
-> Then    they all          crowded round     her     once  more         , while     the Dodo solemnly presented the
-# NSg/J/C IPl+ NSg/I/J/C/Dq V/J     NSg/V/J/P ISg/D$+ NSg/C NPr/I/V/J/Dq . NSg/V/C/P D   NSg  R        V/J       D
+> Then    they all          crowded round     her     once  more           , while     the Dodo solemnly presented the
+# NSg/J/C IPl+ NSg/I/J/C/Dq V/J     NSg/V/J/P ISg/D$+ NSg/C NPr/I/V/J/R/Dq . NSg/V/C/P D   NSg  R        V/J       D
 > thimble , saying “ We   beg   your acceptance of this   elegant thimble ; ” and , when    it
 # NSg/V   . NSg/V  . IPl+ NSg/V D$+  NSg        P  I/Ddem NSg/J   NSg/V   . . V/C . NSg/I/C NPr/ISg+
 > had finished this   short     speech  , they all          cheered .
@@ -958,8 +958,8 @@
 # D   NSg/J NPl/V+ V/J        NSg/I/C/Ddem IPl+ NSg/VX NSg/C NSg/V/J I+     . V/C D   NPr/V/J NPl/V+
 > choked and had to be     patted on  the back    . However , it       was over    at    last    , and they
 # V/J    V/C V   P  NSg/VX V      J/P D   NSg/V/J . C       . NPr/ISg+ V   NSg/J/P NSg/P NSg/V/J . V/C IPl+
-> sat     down       again in      a    ring   , and begged the Mouse  to tell  them     something  more         .
-# NSg/V/J N🅪Sg/V/J/P P     NPr/J/P D/P+ NSg/V+ . V/C V      D+  NSg/V+ P  NPr/V NSg/IPl+ NSg/I/V/J+ NPr/I/V/J/Dq .
+> sat     down       again in      a    ring   , and begged the Mouse  to tell  them     something  more           .
+# NSg/V/J N🅪Sg/V/J/P P     NPr/J/P D/P+ NSg/V+ . V/C V      D+  NSg/V+ P  NPr/V NSg/IPl+ NSg/I/V/J+ NPr/I/V/J/R/Dq .
 >
 #
 > “ You    promised to tell  me       your history , you    know  , ” said Alice , “ and why   it       is you
@@ -1102,8 +1102,8 @@
 # . ISg+ NSg/V ISg+ V      V/J       NPr   . . ISg+ V/J  P  ISg+    NPr/J/P D/P NSg/J      N🅪Sg/I/V+ .
 > “ Nobody seems to like        her     , down       here    , and I’m sure she’s the best      cat      in      the
 # . NSg/I+ V     P  NSg/V/J/C/P ISg/D$+ . N🅪Sg/V/J/P NSg/J/R . V/C W?  J    W?    D   NPr/VX/JS NSg/V/J+ NPr/J/P D
-> world  ! Oh    , my  dear    Dinah ! I    wonder if    I    shall ever see   you    any    more         ! ” And here
-# NSg/V+ . NPr/V . D$+ NSg/V/J NPr   . ISg+ N🅪Sg/V NSg/C ISg+ VX    J    NSg/V ISgPl+ I/R/Dq NPr/I/V/J/Dq . . V/C NSg/J/R
+> world  ! Oh    , my  dear    Dinah ! I    wonder if    I    shall ever see   you    any    more           ! ” And here
+# NSg/V+ . NPr/V . D$+ NSg/V/J NPr   . ISg+ N🅪Sg/V NSg/C ISg+ VX    J    NSg/V ISgPl+ I/R/Dq NPr/I/V/J/R/Dq . . V/C NSg/J/R
 > poor     Alice began to cry   again , for she  felt     very lonely and low     - spirited . In      a
 # NSg/V/J+ NPr+  V     P  NSg/V P     . C/P ISg+ N🅪Sg/V/J J/R  J/R    V/C NSg/V/J . V/J      . NPr/J/P D/P
 > little     while     , however , she  again heard a   little     pattering of footsteps in      the
@@ -1206,8 +1206,8 @@
 # N🅪Sg/V/J/P+ D+  NSg/V+ . ISg+ NSg/V ISg/D$+ NPr/V/J+ NSg/V/J  C/P     D+  NSg/V+  . V/C V   P
 > stoop to save      her     neck   from being    broken . She  hastily put   down       the bottle ,
 # NSg/V P  NSg/V/C/P ISg/D$+ NSg/V+ P    N🅪Sg/V/C V/J    . ISg+ R       NSg/V N🅪Sg/V/J/P D+  NSg/V+ .
-> saying to herself “ That’s quite enough — I    hope   I    shan’t grow any    more         — As    it       is , I
-# NSg/V  P  ISg+    . NSg$   R     NSg/I  . ISg+ NPr🅪/V ISg+ V      V    I/R/Dq NPr/I/V/J/Dq . NSg/R NPr/ISg+ VL . ISg+
+> saying to herself “ That’s quite enough — I    hope   I    shan’t grow any    more           — As    it       is , I
+# NSg/V  P  ISg+    . NSg$   R     NSg/I  . ISg+ NPr🅪/V ISg+ V      V    I/R/Dq NPr/I/V/J/R/Dq . NSg/R NPr/ISg+ VL . ISg+
 > can’t get   out         at    the door   — I    do     wish  I    hadn’t drunk   quite so        much         ! ”
 # VX    NSg/V NSg/V/J/R/P NSg/P D   NSg/V+ . ISg+ NSg/VX NSg/V ISg+ V      NSg/V/J R     NSg/I/J/C NSg/I/J/R/Dq . .
 >
@@ -1222,8 +1222,8 @@
 # NSg/V+ . V/C D   NSg/V/J NSg/V/J+ V/J    NSg/V/J/P ISg/D$+ NPr/V/J+ . NSg/V/J ISg+ NSg/V J/P NSg/V   . V/C .
 > as    a    last     resource , she  put   one       arm      out         of the window , and one        foot   up        the
 # NSg/R D/P+ NSg/V/J+ N🅪Sg/V+  . ISg+ NSg/V NSg/I/V/J NSg/V/J+ NSg/V/J/R/P P  D+  NSg/V+ . V/C NSg/I/V/J+ NSg/V+ NSg/V/J/P D+
-> chimney , and said to herself “ Now       I    can    do     no    more         , whatever happens . What   will
-# NSg/V+  . V/C V/J  P  ISg+    . NPr/V/J/C ISg+ NPr/VX NSg/VX NPr/P NPr/I/V/J/Dq . NSg/I/J+ V       . NSg/I+ NPr/VX
+> chimney , and said to herself “ Now       I    can    do     no    more           , whatever happens . What   will
+# NSg/V+  . V/C V/J  P  ISg+    . NPr/V/J/C ISg+ NPr/VX NSg/VX NPr/P NPr/I/V/J/R/Dq . NSg/I/J+ V       . NSg/I+ NPr/VX
 > become of me       ? ”
 # V      P  NPr/ISg+ . .
 >
@@ -1253,7 +1253,7 @@
 > me       , that         there ought    ! And when    I    grow up        , I’ll write one       — but     I’m grown up        now       , ”
 # NPr/ISg+ . NSg/I/C/Ddem +     NSg/I/VX . V/C NSg/I/C ISg+ V    NSg/V/J/P . W?   NSg/V NSg/I/V/J . NSg/C/P W?  V/J   NSg/V/J/P NPr/V/J/C . .
 > she  added in      a   sorrowful tone      ; “ at    least there’s no    room     to grow up        any    more
-# ISg+ V/J   NPr/J/P D/P J         N🅪Sg/I/V+ . . NSg/P NSg/J W?      NPr/P NSg/V/J+ P  V    NSg/V/J/P I/R/Dq NPr/I/V/J/Dq
+# ISg+ V/J   NPr/J/P D/P J         N🅪Sg/I/V+ . . NSg/P NSg/J W?      NPr/P NSg/V/J+ P  V    NSg/V/J/P I/R/Dq NPr/I/V/J/R/Dq
 > here    . ”
 # NSg/J/R . .
 >
@@ -1326,8 +1326,8 @@
 #
 > “ Digging for apples , indeed ! ” said the Rabbit angrily . “ Here    ! Come    and help  me
 # . NSg/V   C/P NPl    . W?     . . V/J  D+  NSg/V+ R       . . NSg/J/R . NSg/V/P V/C NSg/V NPr/ISg+
-> out         of this    ! ” ( Sounds of more         broken glass   . )
-# NSg/V/J/R/P P  I/Ddem+ . . . NPl/V  P  NPr/I/V/J/Dq V/J    NPr🅪/V+ . .
+> out         of this    ! ” ( Sounds of more           broken glass   . )
+# NSg/V/J/R/P P  I/Ddem+ . . . NPl/V  P  NPr/I/V/J/R/Dq V/J    NPr🅪/V+ . .
 >
 #
 > “ Now       tell  me       , Pat      , what’s that          in      the window ? ”
@@ -1357,7 +1357,7 @@
 > tell  you    , you    coward  ! ” and at    last    she  spread out         her     hand   again , and made
 # NPr/V ISgPl+ . ISgPl+ NPr/V/J . . V/C NSg/P NSg/V/J ISg+ N🅪Sg/V NSg/V/J/R/P ISg/D$+ NSg/V+ P     . V/C V
 > another snatch in      the air     . This    time      there were  two  little      shrieks , and more
-# I/D     NSg/V  NPr/J/P D   N🅪Sg/V+ . I/Ddem+ N🅪Sg/V/J+ +     NSg/V NSg+ NPr/I/J/Dq+ NPl/V+  . V/C NPr/I/V/J/Dq
+# I/D     NSg/V  NPr/J/P D   N🅪Sg/V+ . I/Ddem+ N🅪Sg/V/J+ +     NSg/V NSg+ NPr/I/J/Dq+ NPl/V+  . V/C NPr/I/V/J/R/Dq
 > sounds of broken glass   . “ What   a   number    of cucumber - frames there must  be     ! ”
 # NPl/V  P  V/J    NPr🅪/V+ . . NSg/I+ D/P N🅪Sg/V/JC P  N🅪Sg+    . NPl/V+ +     NSg/V NSg/VX . .
 > thought Alice . “ I    wonder what   they’ll do     next    ! As    for  pulling me       out         of the
@@ -1368,8 +1368,8 @@
 # NSg/JC . .
 >
 #
-> She  waited for some     time      without hearing  anything more         : at    last    came    a   rumbling
-# ISg+ V/J    C/P I/J/R/Dq N🅪Sg/V/J+ C/P     NSg/V/J+ NSg/I/V+ NPr/I/V/J/Dq . NSg/P NSg/V/J NSg/V/P D/P N🅪Sg/V/J
+> She  waited for some     time      without hearing  anything more           : at    last    came    a   rumbling
+# ISg+ V/J    C/P I/J/R/Dq N🅪Sg/V/J+ C/P     NSg/V/J+ NSg/I/V+ NPr/I/V/J/R/Dq . NSg/P NSg/V/J NSg/V/P D/P N🅪Sg/V/J
 > of little     cartwheels , and the sound    of a   good    many       voices all          talking together :
 # P  NPr/I/J/Dq NPl/V      . V/C D   N🅪Sg/V/J P  D/P NPr/V/J NSg/I/J/Dq NPl/V+ NSg/I/J/C/Dq V       J        .
 > she  made out         the words  : “ Where’s the other   ladder ? — Why   , I    hadn’t to bring but
@@ -1422,8 +1422,8 @@
 #
 > Last    came    a   little     feeble , squeaking voice  , ( “ That’s Bill   , ” thought Alice , )
 # NSg/V/J NSg/V/P D/P NPr/I/J/Dq V/J    . V         NSg/V+ . . . NSg$   NPr/V+ . . NSg/V   NPr+  . .
-> “ Well    , I    hardly know  — No    more         , thank ye       ; I’m better    now       — but     I’m a   deal     too
-# . NSg/V/J . ISg+ R      NSg/V . NPr/P NPr/I/V/J/Dq . NSg/V NSg/I/D+ . W?  NSg/VX/JC NPr/V/J/C . NSg/C/P W?  D/P NSg/V/J+ W?
+> “ Well    , I    hardly know  — No    more           , thank ye       ; I’m better    now       — but     I’m a   deal     too
+# . NSg/V/J . ISg+ R      NSg/V . NPr/P NPr/I/V/J/R/Dq . NSg/V NSg/I/D+ . W?  NSg/VX/JC NPr/V/J/C . NSg/C/P W?  D/P NSg/V/J+ W?
 > flustered to tell  you    — all          I    know  is , something  comes at    me       like        a
 # V/J       P  NPr/V ISgPl+ . NSg/I/J/C/Dq ISg+ NSg/V VL . NSg/I/V/J+ NPl/V NSg/P NPr/ISg+ NSg/V/J/C/P D/P
 > Jack     - in      - the - box    , and up        I    goes  like        a   sky     - rocket ! ”
@@ -1630,8 +1630,8 @@
 # . ISg+ V     NSg/V . . V/J  D   NSg/V       .
 >
 #
-> “ I’m afraid I    can’t put   it       more         clearly , ” Alice replied very politely , “ for I
-# . W?  J      ISg+ VX    NSg/V NPr/ISg+ NPr/I/V/J/Dq R       . . NPr+  V/J     J/R  R        . . C/P ISg+
+> “ I’m afraid I    can’t put   it       more           clearly , ” Alice replied very politely , “ for I
+# . W?  J      ISg+ VX    NSg/V NPr/ISg+ NPr/I/V/J/R/Dq R       . . NPr+  V/J     J/R  R        . . C/P ISg+
 > can’t understand it       myself to begin with ; and being    so        many       different sizes  in      a
 # VX    V          NPr/ISg+ ISg+   P  NSg/V P    . V/C N🅪Sg/V/C NSg/I/J/C NSg/I/J/Dq NSg/J     NPl/V+ NPr/J/P D/P
 > day   is very confusing . ”
@@ -1972,8 +1972,8 @@
 # . W?  NSg/C D/P NSg/V+  . . V/J  NPr+  R           . . NSg/V NPr/ISg+ J     . .
 >
 #
-> “ Serpent , I    say   again ! ” repeated the Pigeon , but     in      a   more         subdued tone     , and
-# . NSg/V+  . ISg+ NSg/V P     . . V/J      D+  NSg/V+ . NSg/C/P NPr/J/P D/P NPr/I/V/J/Dq V/J+    N🅪Sg/I/V . V/C
+> “ Serpent , I    say   again ! ” repeated the Pigeon , but     in      a   more           subdued tone     , and
+# . NSg/V+  . ISg+ NSg/V P     . . V/J      D+  NSg/V+ . NSg/C/P NPr/J/P D/P NPr/I/V/J/R/Dq V/J+    N🅪Sg/I/V . V/C
 > added with a   kind   of sob   , “ I’ve tried every way    , and nothing  seems to suit
 # V/J   P    D/P NSg/J+ P  NSg/V . . W?   V/J   Dq    NSg/J+ . V/C NSg/I/J+ V     P  NSg/V
 > them     ! ”
@@ -1992,10 +1992,10 @@
 # NSg/V/J  NSg/IPl+ . .
 >
 #
-> Alice was more         and more         puzzled , but     she  thought there was no    use   in      saying
-# NPr+  V   NPr/I/V/J/Dq V/C NPr/I/V/J/Dq V/J     . NSg/C/P ISg+ NSg/V   +     V   NPr/P NSg/V NPr/J/P NSg/V
-> anything more         till      the Pigeon had finished .
-# NSg/I/V+ NPr/I/V/J/Dq NSg/V/C/P D+  NSg/V+ V   V/J      .
+> Alice was more           and more           puzzled , but     she  thought there was no    use   in      saying
+# NPr+  V   NPr/I/V/J/R/Dq V/C NPr/I/V/J/R/Dq V/J     . NSg/C/P ISg+ NSg/V   +     V   NPr/P NSg/V NPr/J/P NSg/V
+> anything more           till      the Pigeon had finished .
+# NSg/I/V+ NPr/I/V/J/R/Dq NSg/V/C/P D+  NSg/V+ V   V/J      .
 >
 #
 > “ As    if    it       wasn’t trouble enough hatching the eggs   , ” said the Pigeon ; “ but     I    must
@@ -2470,8 +2470,8 @@
 # D+  NSg/V/J+ V/J     P     . V/C NPr+  V/J    J/R  R         P    ISg/D$+ NSg/V+ P  NSg/V
 > what   was the matter  with it       . There could  be     no     doubt   that          it       had a   very turn  - up
 # NSg/I+ V   D   N🅪Sg/V+ P    NPr/ISg+ . +     NSg/VX NSg/VX NPr/P+ N🅪Sg/V+ NSg/I/C/Ddem+ NPr/ISg+ V   D/P J/R  NSg/V . NSg/V/J/P
-> nose   , much         more         like        a   snout than a   real  nose   ; also its     eyes   were  getting
-# NSg/V+ . NSg/I/J/R/Dq NPr/I/V/J/Dq NSg/V/J/C/P D/P NSg/V C/P  D/P NSg/J NSg/V+ . W?   ISg/D$+ NPl/V+ NSg/V NSg/V
+> nose   , much         more           like        a   snout than a   real  nose   ; also its     eyes   were  getting
+# NSg/V+ . NSg/I/J/R/Dq NPr/I/V/J/R/Dq NSg/V/J/C/P D/P NSg/V C/P  D/P NSg/J NSg/V+ . W?   ISg/D$+ NPl/V+ NSg/V NSg/V
 > extremely small   for a   baby     : altogether Alice did not   like        the look  of the thing
 # R         NPr/V/J C/P D/P NSg/V/J+ . NSg        NPr+  V   NSg/C NSg/V/J/C/P D   NSg/V P  D   NSg/V+
 > at    all          . “ But     perhaps it       was only  sobbing , ” she  thought , and looked into its     eyes
@@ -2482,8 +2482,8 @@
 #
 > No    , there were  no     tears  . “ If    you’re going   to turn  into a   pig    , my  dear    , ” said
 # NPr/P . +     NSg/V NPr/P+ NPl/V+ . . NSg/C W?     NSg/V/J P  NSg/V P    D/P NSg/V+ . D$+ NSg/V/J . . V/J
-> Alice , seriously , “ I’ll have   nothing  more         to do     with you    . Mind   now       ! ” The poor
-# NPr+  . R         . . W?   NSg/VX NSg/I/J+ NPr/I/V/J/Dq P  NSg/VX P    ISgPl+ . NSg/V+ NPr/V/J/C . . D+  NSg/V/J+
+> Alice , seriously , “ I’ll have   nothing  more           to do     with you    . Mind   now       ! ” The poor
+# NPr+  . R         . . W?   NSg/VX NSg/I/J+ NPr/I/V/J/R/Dq P  NSg/VX P    ISgPl+ . NSg/V+ NPr/V/J/C . . D+  NSg/V/J+
 > little      thing  sobbed again ( or    grunted , it       was impossible to say   which ) , and they
 # NPr/I/J/Dq+ NSg/V+ V      P     . NPr/C V/J     . NPr/ISg+ V   NSg/J      P  NSg/V I/C+  . . V/C IPl+
 > went  on  for some     while     in      silence .
@@ -2496,8 +2496,8 @@
 # NSg+     NSg/I/C ISg+ NSg/V NPr/ISg+ NSg/V/J+ . . NSg/I/C NPr/ISg+ V/J     P     . NSg/I/J/C R         . NSg/I/C/Ddem ISg+
 > looked down       into its     face   in      some     alarm  . This    time      there could  be     no    mistake
 # V/J    N🅪Sg/V/J/P P    ISg/D$+ NSg/V+ NPr/J/P I/J/R/Dq NSg/V+ . I/Ddem+ N🅪Sg/V/J+ +     NSg/VX NSg/VX NPr/P NSg/V
-> about it       : it       was neither more         nor   less    than a    pig    , and she  felt     that         it       would be
-# J/P   NPr/ISg+ . NPr/ISg+ V   I/C     NPr/I/V/J/Dq NSg/C V/J/C/P C/P  D/P+ NSg/V+ . V/C ISg+ N🅪Sg/V/J NSg/I/C/Ddem NPr/ISg+ VX    NSg/VX
+> about it       : it       was neither more           nor   less      than a    pig    , and she  felt     that         it       would be
+# J/P   NPr/ISg+ . NPr/ISg+ V   I/C     NPr/I/V/J/R/Dq NSg/C V/J/R/C/P C/P  D/P+ NSg/V+ . V/C ISg+ N🅪Sg/V/J NSg/I/C/Ddem NPr/ISg+ VX    NSg/VX
 > quite absurd for her     to carry it       further .
 # R     NSg/J  C/P ISg/D$+ P  NSg/V NPr/ISg+ V/J     .
 >
@@ -2696,8 +2696,8 @@
 # NSg/V/J+ . ISg+ NSg/V   NPr/ISg+ NSg/V NSg/VX D+  NPr/V/J+ NPr/V+ . C/P     D+  NPl/V+   NSg/V V/J
 > like        ears  and the roof   was thatched with fur         . It       was so        large a   house  , that         she
 # NSg/V/J/C/P NPl/V V/C D+  NSg/V+ V   V/J      P    N🅪Sg/V/C/P+ . NPr/ISg+ V   NSg/I/J/C NSg/J D/P NPr/V+ . NSg/I/C/Ddem ISg+
-> did not   like        to go      nearer till      she  had nibbled some     more         of the lefthand bit    of
-# V   NSg/C NSg/V/J/C/P P  NSg/V/J NSg/JC NSg/V/C/P ISg+ V   V/J     I/J/R/Dq NPr/I/V/J/Dq P  D   ?        NSg/V+ P
+> did not   like        to go      nearer till      she  had nibbled some     more           of the lefthand bit    of
+# V   NSg/C NSg/V/J/C/P P  NSg/V/J NSg/JC NSg/V/C/P ISg+ V   V/J     I/J/R/Dq NPr/I/V/J/R/Dq P  D   ?        NSg/V+ P
 > mushroom , and raised herself to about two feet high    : even    then    she  walked up
 # N🅪Sg/V/J . V/C V/J    ISg+    P  J/P   NSg NPl+ NSg/V/J . NSg/V/J NSg/J/C ISg+ V/J    NSg/V/J/P
 > towards it       rather    timidly , saying to herself “ Suppose it       should be     raving  mad
@@ -2757,7 +2757,7 @@
 >
 #
 > “ I    didn’t know  it       was your table  , ” said Alice ; “ it’s laid for a   great many       more
-# . ISg+ V      NSg/V NPr/ISg+ V   D$+  NSg/V+ . . V/J  NPr+  . . W?   V/J  C/P D/P NSg/J NSg/I/J/Dq NPr/I/V/J/Dq
+# . ISg+ V      NSg/V NPr/ISg+ V   D$+  NSg/V+ . . V/J  NPr+  . . W?   V/J  C/P D/P NSg/J NSg/I/J/Dq NPr/I/V/J/R/Dq
 > than three . ”
 # C/P  NSg   . .
 >
@@ -3142,18 +3142,18 @@
 # D   NSg/V/J P  D/P+ NSg/V/J+ . .
 >
 #
-> “ Take  some      more          tea     , ” the March  Hare     said to Alice , very earnestly .
-# . NSg/V I/J/R/Dq+ NPr/I/V/J/Dq+ N🅪Sg/V+ . . D+  NPr/V+ NSg/V/J+ V/J  P  NPr+  . J/R  R         .
+> “ Take  some      more            tea     , ” the March  Hare     said to Alice , very earnestly .
+# . NSg/V I/J/R/Dq+ NPr/I/V/J/R/Dq+ N🅪Sg/V+ . . D+  NPr/V+ NSg/V/J+ V/J  P  NPr+  . J/R  R         .
 >
 #
 > “ I’ve had nothing  yet     , ” Alice replied in      an  offended tone      , “ so        I    can’t take
 # . W?   V   NSg/I/J+ NSg/V/C . . NPr+  V/J     NPr/J/P D/P V/J      N🅪Sg/I/V+ . . NSg/I/J/C ISg+ VX    NSg/V
-> more         . ”
-# NPr/I/V/J/Dq . .
+> more           . ”
+# NPr/I/V/J/R/Dq . .
 >
 #
-> “ You    mean    you    can’t take  less    , ” said the Hatter : “ it’s very easy    to take  more
-# . ISgPl+ NSg/V/J ISgPl+ VX    NSg/V V/J/C/P . . V/J  D   NSg/V  . . W?   J/R  NSg/V/J P  NSg/V NPr/I/V/J/Dq
+> “ You    mean    you    can’t take  less      , ” said the Hatter : “ it’s very easy    to take  more
+# . ISgPl+ NSg/V/J ISgPl+ VX    NSg/V V/J/R/C/P . . V/J  D   NSg/V  . . W?   J/R  NSg/V/J P  NSg/V NPr/I/V/J/R/Dq
 > than nothing  . ”
 # C/P  NSg/I/J+ . .
 >
@@ -3292,8 +3292,8 @@
 # . NSg/J/C ISgPl+ V         N🅪Sg/V . . V/J  D   NSg/V  .
 >
 #
-> This   piece of rudeness was more         than Alice could  bear     : she  got up        in      great
-# I/Ddem NSg/V P  NSg+     V   NPr/I/V/J/Dq C/P  NPr+  NSg/VX NSg/V/J+ . ISg+ V   NSg/V/J/P NPr/J/P NSg/J+
+> This   piece of rudeness was more           than Alice could  bear     : she  got up        in      great
+# I/Ddem NSg/V P  NSg+     V   NPr/I/V/J/R/Dq C/P  NPr+  NSg/VX NSg/V/J+ . ISg+ V   NSg/V/J/P NPr/J/P NSg/J+
 > disgust , and walked off       ; the Dormouse fell    asleep instantly , and neither of the
 # Nᴹ/V+   . V/C V/J    NSg/V/J/P . D   NSg      NSg/V/J J      R         . V/C I/C     P  D
 > others took the least notice of her     going   , though she  looked back    once  or    twice ,
@@ -3318,8 +3318,8 @@
 # NSg/J+ . ISg+ NSg/V ISg+ NPr/VX NSg/R NSg/V/J NSg/V/J NPr/J/P NSg/P NSg/C . . V/C NPr/J/P ISg+ NSg/V .
 >
 #
-> Once  more         she  found herself in      the long     hall , and close   to the little      glass
-# NSg/C NPr/I/V/J/Dq ISg+ NSg/V ISg+    NPr/J/P D+  NPr/V/J+ NPr+ . V/C NSg/V/J P  D+  NPr/I/J/Dq+ NPr🅪/V+
+> Once  more           she  found herself in      the long     hall , and close   to the little      glass
+# NSg/C NPr/I/V/J/R/Dq ISg+ NSg/V ISg+    NPr/J/P D+  NPr/V/J+ NPr+ . V/C NSg/V/J P  D+  NPr/I/J/Dq+ NPr🅪/V+
 > table  . “ Now       , I’ll manage better    this   time      , ” she  said to herself , and began by
 # NSg/V+ . . NPr/V/J/C . W?   NSg/V  NSg/VX/JC I/Ddem N🅪Sg/V/J+ . . ISg+ V/J  P  ISg+    . V/C V     NSg/J/P
 > taking  the little     golden  key     , and unlocking the door   that          led     into the garden   .
@@ -3708,8 +3708,8 @@
 # NSg/V/J+ D+  NSg/J+ NPr/V/J+ V/J      . V/C NSg/J/C NPr+  NSg/V N🅪Sg/V/J/P ISg/D$+ NSg/J    . V/C V
 > an  account of the game     , feeling very glad    she  had someone to listen to her     . The
 # D/P NSg/V   P  D   NSg/V/J+ . NSg/V/J J/R  NSg/V/J ISg+ V   NSg/I+  P  NSg/V  P  ISg/D$+ . D+
-> Cat      seemed to think that         there was enough of it       now       in      sight   , and no    more         of it
-# NSg/V/J+ V/J    P  NSg/V NSg/I/C/Ddem +     V   NSg/I  P  NPr/ISg+ NPr/V/J/C NPr/J/P N🅪Sg/V+ . V/C NPr/P NPr/I/V/J/Dq P  NPr/ISg+
+> Cat      seemed to think that         there was enough of it       now       in      sight   , and no    more           of it
+# NSg/V/J+ V/J    P  NSg/V NSg/I/C/Ddem +     V   NSg/I  P  NPr/ISg+ NPr/V/J/C NPr/J/P N🅪Sg/V+ . V/C NPr/P NPr/I/V/J/R/Dq P  NPr/ISg+
 > appeared .
 # V/J      .
 >
@@ -3830,8 +3830,8 @@
 # NPr+  . . NSg/R NSg/I/J/C/Dq D   NPl/V  V   V/J/P P    I/Ddem NSg/V/J P  D   N🅪Sg/V/J+ . . NSg/I/J/C ISg+ V/J
 > it       away under   her     arm      , that         it       might   not   escape again , and went  back    for a
 # NPr/ISg+ V/J  NSg/J/P ISg/D$+ NSg/V/J+ . NSg/I/C/Ddem NPr/ISg+ Nᴹ/VX/J NSg/C NSg/V  P     . V/C NSg/V NSg/V/J C/P D/P
-> little     more         conversation with her     friend   .
-# NPr/I/J/Dq NPr/I/V/J/Dq N🅪Sg/V       P    ISg/D$+ NPr/V/J+ .
+> little     more           conversation with her     friend   .
+# NPr/I/J/Dq NPr/I/V/J/R/Dq N🅪Sg/V       P    ISg/D$+ NPr/V/J+ .
 >
 #
 > When    she  got back    to the Cheshire Cat      , she  was surprised to find  quite a   large
@@ -3866,8 +3866,8 @@
 # NSg/I/C/Ddem ISgPl+ V       P  N🅪Sg/V Nᴹ/V/J+  .
 >
 #
-> The Queen’s argument was , that         if    something  wasn’t done    about it       in      less    than no
-# D   NSg$    N🅪Sg/V+  V   . NSg/I/C/Ddem NSg/C NSg/I/V/J+ V      NSg/V/J J/P   NPr/ISg+ NPr/J/P V/J/C/P C/P  NPr/P
+> The Queen’s argument was , that         if    something  wasn’t done    about it       in      less      than no
+# D   NSg$    N🅪Sg/V+  V   . NSg/I/C/Ddem NSg/C NSg/I/V/J+ V      NSg/V/J J/P   NPr/ISg+ NPr/J/P V/J/R/C/P C/P  NPr/P
 > time      she’d have   everybody executed , all          round     . ( It       was this   last    remark that          had
 # N🅪Sg/V/J+ W?    NSg/VX NSg/I+    V/J      . NSg/I/J/C/Dq NSg/V/J/P . . NPr/ISg+ V   I/Ddem NSg/V/J NSg/V  NSg/I/C/Ddem+ V
 > made the whole  party    look  so        grave    and anxious . )
@@ -4030,8 +4030,8 @@
 # . P  NSg/V+ NPr/ISg+ VL . . V/J  D   NSg/V   . NPr/I+ V/J    NSg/V/J P  V     P  NSg/I/V+
 > that         Alice said ; “ there’s a   large mustard - mine     near      here    . And the moral   of that
 # NSg/I/C/Ddem NPr+  V/J  . . W?      D/P NSg/J Nᴹ/J    . NSg/I/V+ NSg/V/J/P NSg/J/R . V/C D   NSg/V/J P  NSg/I/C/Ddem+
-> is — ‘          The more         there is of mine     , the less    there is of yours . ’ ”
-# VL . Unlintable D   NPr/I/V/J/Dq W?    VL P  NSg/I/V+ . D   V/J/C/P W?    VL P  I+    . . .
+> is — ‘          The more           there is of mine     , the less      there is of yours . ’ ”
+# VL . Unlintable D   NPr/I/V/J/R/Dq W?    VL P  NSg/I/V+ . D   V/J/R/C/P W?    VL P  I+    . . .
 >
 #
 > “ Oh    , I    know  ! ” exclaimed Alice , who    had not   attended to this    last     remark , “ it’s a
@@ -4042,8 +4042,8 @@
 #
 > “ I    quite agree with you    , ” said the Duchess ; “ and the moral   of that          is — ‘          Be     what
 # . ISg+ R     V     P    ISgPl+ . . V/J  D   NSg/V   . . V/C D   NSg/V/J P  NSg/I/C/Ddem+ VL . Unlintable NSg/VX NSg/I+
-> you    would seem to be     ’ — or    if    you’d like        it       put   more         simply — ‘          Never imagine
-# ISgPl+ VX    V    P  NSg/VX . . NPr/C NSg/C W?    NSg/V/J/C/P NPr/ISg+ NSg/V NPr/I/V/J/Dq R      . Unlintable R     NSg/V
+> you    would seem to be     ’ — or    if    you’d like        it       put   more           simply — ‘          Never imagine
+# ISgPl+ VX    V    P  NSg/VX . . NPr/C NSg/C W?    NSg/V/J/C/P NPr/ISg+ NSg/V NPr/I/V/J/R/Dq R      . Unlintable R     NSg/V
 > yourself not   to be     otherwise than what   it       might   appear to others that         what   you
 # ISg+     NSg/C P  NSg/VX J         C/P  NSg/I+ NPr/ISg+ Nᴹ/VX/J V      P  NPl/V  NSg/I/C/Ddem NSg/I+ ISgPl+
 > were  or    might   have   been  was not   otherwise than what   you    had been  would have
@@ -4271,13 +4271,13 @@
 > the Mock    Turtle . Alice was very nearly getting up        and saying , “ Thank you    , sir    ,
 # D   NSg/V/J NSg/V+ . NPr+  V   J/R  R      NSg/V   NSg/V/J/P V/C NSg/V  . . NSg/V ISgPl+ . NPr/V+ .
 > for your interesting story  , ” but     she  could  not   help  thinking there must  be     more
-# C/P D$+  V/J+        NSg/V+ . . NSg/C/P ISg+ NSg/VX NSg/C NSg/V V        +     NSg/V NSg/VX NPr/I/V/J/Dq
+# C/P D$+  V/J+        NSg/V+ . . NSg/C/P ISg+ NSg/VX NSg/C NSg/V V        +     NSg/V NSg/VX NPr/I/V/J/R/Dq
 > to come    , so        she  sat     still   and said nothing  .
 # P  NSg/V/P . NSg/I/J/C ISg+ NSg/V/J NSg/V/J V/C V/J  NSg/I/J+ .
 >
 #
-> “ When    we   were  little     , ” the Mock     Turtle went  on  at    last    , more         calmly , though
-# . NSg/I/C IPl+ NSg/V NPr/I/J/Dq . . D+  NSg/V/J+ NSg/V+ NSg/V J/P NSg/P NSg/V/J . NPr/I/V/J/Dq R      . V/C
+> “ When    we   were  little     , ” the Mock     Turtle went  on  at    last    , more           calmly , though
+# . NSg/I/C IPl+ NSg/V NPr/I/J/Dq . . D+  NSg/V/J+ NSg/V+ NSg/V J/P NSg/P NSg/V/J . NPr/I/V/J/R/Dq R      . V/C
 > still   sobbing a   little     now       and then    , “ we   went  to school in      the sea  . The master
 # NSg/V/J NSg/V/J D/P NPr/I/J/Dq NPr/V/J/C V/C NSg/J/C . . IPl+ NSg/V P  NSg/V  NPr/J/P D   NSg+ . D+  NPr/V/J+
 > was an  old   Turtle — we   used to call  him  Tortoise — ”
@@ -4402,8 +4402,8 @@
 # D/P NSg       . .
 >
 #
-> Alice did not   feel    encouraged to ask   any     more          questions about it       , so        she  turned
-# NPr+  V   NSg/C NSg/I/V V/J        P  NSg/V I/R/Dq+ NPr/I/V/J/Dq+ NPl/V+    J/P   NPr/ISg+ . NSg/I/J/C ISg+ V/J
+> Alice did not   feel    encouraged to ask   any     more            questions about it       , so        she  turned
+# NPr+  V   NSg/C NSg/I/V V/J        P  NSg/V I/R/Dq+ NPr/I/V/J/R/Dq+ NPl/V+    J/P   NPr/ISg+ . NSg/I/J/C ISg+ V/J
 > to the Mock     Turtle , and said “ What   else    had you    to learn ? ”
 # P  D+  NSg/V/J+ NSg/V+ . V/C V/J  . NSg/I+ NSg/J/C V   ISgPl+ P  NSg/V . .
 >
@@ -4706,8 +4706,8 @@
 # NSg/V+  C/P    . .
 >
 #
-> “ I    can    tell  you    more         than that          , if    you    like        , ” said the Gryphon . “ Do     you    know  why
-# . ISg+ NPr/VX NPr/V ISgPl+ NPr/I/V/J/Dq C/P  NSg/I/C/Ddem+ . NSg/C ISgPl+ NSg/V/J/C/P . . V/J  D   ?       . . NSg/VX ISgPl+ NSg/V NSg/V
+> “ I    can    tell  you    more           than that          , if    you    like        , ” said the Gryphon . “ Do     you    know  why
+# . ISg+ NPr/VX NPr/V ISgPl+ NPr/I/V/J/R/Dq C/P  NSg/I/C/Ddem+ . NSg/C ISgPl+ NSg/V/J/C/P . . V/J  D   ?       . . NSg/VX ISgPl+ NSg/V NSg/V
 > it’s called a    whiting ? ”
 # W?   V/J    D/P+ NSg/V+  . .
 >
@@ -4998,8 +4998,8 @@
 #
 > “ What   trial    is it       ? ” Alice panted as    she  ran   ; but     the Gryphon only  answered “ Come
 # . NSg/I+ NSg/V/J+ VL NPr/ISg+ . . NPr+  V/J    NSg/R ISg+ NSg/V . NSg/C/P D   ?       J/R/C V/J      . NSg/V/P
-> on  ! ” and ran   the faster , while     more         and more         faintly came    , carried on  the breeze
-# J/P . . V/C NSg/V D   NSg/JC . NSg/V/C/P NPr/I/V/J/Dq V/C NPr/I/V/J/Dq R       NSg/V/P . V/J     J/P D+  NSg/V+
+> on  ! ” and ran   the faster , while     more           and more           faintly came    , carried on  the breeze
+# J/P . . V/C NSg/V D   NSg/JC . NSg/V/C/P NPr/I/V/J/R/Dq V/C NPr/I/V/J/R/Dq R       NSg/V/P . V/J     J/P D+  NSg/V+
 > that          followed them     , the melancholy words  : —
 # NSg/I/C/Ddem+ V/J      NSg/IPl+ . D   NSg/J      NPl/V+ . .
 >
@@ -5248,8 +5248,8 @@
 # . W?     NPr/P NPr/V/J+ P  V    NSg/J/R . . V/J  D   NSg      .
 >
 #
-> “ Don’t talk   nonsense , ” said Alice more         boldly : “ you    know  you’re growing too . ”
-# . V     N🅪Sg/V Nᴹ/V/J+  . . V/J  NPr+  NPr/I/V/J/Dq R      . . ISgPl+ NSg/V W?     NSg/V   W?  . .
+> “ Don’t talk   nonsense , ” said Alice more           boldly : “ you    know  you’re growing too . ”
+# . V     N🅪Sg/V Nᴹ/V/J+  . . V/J  NPr+  NPr/I/V/J/R/Dq R      . . ISgPl+ NSg/V W?     NSg/V   W?  . .
 >
 #
 > “ Yes   , but     I    grow at    a    reasonable pace       , ” said the Dormouse : “ not   in      that
@@ -5328,8 +5328,8 @@
 # NSg/V/J J      .
 >
 #
-> “ After that          , ” continued the Hatter , “ I    cut     some     more         bread   - and - butter — ”
-# . P     NSg/I/C/Ddem+ . . V/J       D   NSg/V  . . ISg+ NSg/V/J I/J/R/Dq NPr/I/V/J/Dq N🅪Sg/V+ . V/C . NSg/V+ . .
+> “ After that          , ” continued the Hatter , “ I    cut     some     more           bread   - and - butter — ”
+# . P     NSg/I/C/Ddem+ . . V/J       D   NSg/V  . . ISg+ NSg/V/J I/J/R/Dq NPr/I/V/J/R/Dq N🅪Sg/V+ . V/C . NSg/V+ . .
 >
 #
 > “ But     what   did the Dormouse say   ? ” one       of the jury     asked .
@@ -5598,8 +5598,8 @@
 # NSg/P I/Ddem+ NSg+   D+  NPr/V/J+ . NPr/I+ V   NSg/V C/P I/J/R/Dq+ N🅪Sg/V/J+ R      NSg/V   NPr/J/P ISg/D$+
 > note   - book   , cackled out         “ Silence ! ” and read  out         from his     book   , “ Rule   Forty - two .
 # NSg/V+ . NSg/V+ . V/J     NSg/V/J/R/P . NSg/V+  . . V/C NSg/V NSg/V/J/R/P P    ISg/D$+ NSg/V+ . . NSg/V+ NSg/J . NSg .
-> All           persons more         than a    mile high    to leave the court    . ”
-# NSg/I/J/C/Dq+ NPl/V+  NPr/I/V/J/Dq C/P  D/P+ NSg+ NSg/V/J P  NSg/V D+  NSg/V/J+ . .
+> All           persons more           than a    mile high    to leave the court    . ”
+# NSg/I/J/C/Dq+ NPl/V+  NPr/I/V/J/R/Dq C/P  D/P+ NSg+ NSg/V/J P  NSg/V D+  NSg/V/J+ . .
 >
 #
 > Everybody looked at    Alice .
@@ -5638,8 +5638,8 @@
 # NPr/ISg+ V/J  P  D+  NSg/V/J+ . NPr/J/P D/P NSg/V/J . V         NSg/V+ .
 >
 #
-> “ There’s more         evidence to come    yet     , please your Majesty , ” said the White    Rabbit ,
-# . W?      NPr/I/V/J/Dq Nᴹ/V+    P  NSg/V/P NSg/V/C . V      D$+  NSg/I+  . . V/J  D   NPr🅪/V/J NSg/V+ .
+> “ There’s more           evidence to come    yet     , please your Majesty , ” said the White    Rabbit ,
+# . W?      NPr/I/V/J/R/Dq Nᴹ/V+    P  NSg/V/P NSg/V/C . V      D$+  NSg/I+  . . V/J  D   NPr🅪/V/J NSg/V+ .
 > jumping up        in      a   great hurry  ; “ this   paper     has just been  picked up        . ”
 # V       NSg/V/J/P NPr/J/P D/P NSg/J NSg/V+ . . I/Ddem N🅪Sg/V/J+ V   V/J  NSg/V V/J    NSg/V/J/P . .
 >
@@ -5750,8 +5750,8 @@
 # D+  N🅪Sg/V+ J/P . NSg/I+ VX    V      P  ISgPl+ .
 >
 #
-> I    gave her     one       , they gave him  two , You    gave us       three or    more         ; They all
-# ISg+ V    ISg/D$+ NSg/I/V/J . IPl+ V    ISg+ NSg . ISgPl+ V    NPr/IPl+ NSg   NPr/C NPr/I/V/J/Dq . IPl+ NSg/I/J/C/Dq
+> I    gave her     one       , they gave him  two , You    gave us       three or    more           ; They all
+# ISg+ V    ISg/D$+ NSg/I/V/J . IPl+ V    ISg+ NSg . ISgPl+ V    NPr/IPl+ NSg   NPr/C NPr/I/V/J/R/Dq . IPl+ NSg/I/J/C/Dq
 > returned from him  to you    , Though they were  mine     before .
 # V/J+     P    ISg+ P  ISgPl+ . V/C    IPl+ NSg/V NSg/I/V+ C/P    .
 >
@@ -5946,10 +5946,10 @@
 # P  D   NPl     NSg/R D   NPr/V+ NSg/V/J+ V/C ISg/D$+ NPl/V+  V/J    D$+   R     . NSg/V  NSg/V+ .
 > and the shrill  voice of the Queen    ordering off       her     unfortunate guests to
 # V/C D   NSg/V/J NSg/V P  D   NPr/V/J+ V+       NSg/V/J/P ISg/D$+ NSg/J       NPl/V+ P
-> execution — once  more         the pig    - baby     was sneezing on  the Duchess’s knee   , while
-# NSg       . NSg/C NPr/I/V/J/Dq D   NSg/V+ . NSg/V/J+ V   V        J/P D   NSg$      NSg/V+ . NSg/V/C/P
-> plates and dishes crashed around it       — once  more         the shriek of the Gryphon , the
-# NPl/V  V/C NPl/V+ V/J     J/P    NPr/ISg+ . NSg/C NPr/I/V/J/Dq D   NSg/V  P  D   ?       . D
+> execution — once  more           the pig    - baby     was sneezing on  the Duchess’s knee   , while
+# NSg       . NSg/C NPr/I/V/J/R/Dq D   NSg/V+ . NSg/V/J+ V   V        J/P D   NSg$      NSg/V+ . NSg/V/C/P
+> plates and dishes crashed around it       — once  more           the shriek of the Gryphon , the
+# NPl/V  V/C NPl/V+ V/J     J/P    NPr/ISg+ . NSg/C NPr/I/V/J/R/Dq D   NSg/V  P  D   ?       . D
 > squeaking of the Lizard’s slate    - pencil , and the choking of the suppressed
 # V         P  D   NSg$     NSg/V/J+ . NSg/V+ . V/C D   V       P  D   V/J
 > guinea - pigs   , filled the air     , mixed up        with the distant sobs  of the miserable

--- a/harper-core/tests/text/tagged/Computer science.md
+++ b/harper-core/tests/text/tagged/Computer science.md
@@ -106,8 +106,8 @@
 # NSg/V+ . NPr/J/P #    . I/C+  R          V    ISg+ D   NSg  P  D   NSg/V/J NSg/J
 > mechanical calculator , his     Analytical Engine . He       started developing this    machine
 # NSg/J      NSg+       . ISg/D$+ J          NSg/V+ . NPr/ISg+ V/J     V          I/Ddem+ NSg/V+
-> in      1834 , and " in      less    than two  years , he       had sketched out         many       of the salient
-# NPr/J/P #    . V/C . NPr/J/P V/J/C/P C/P  NSg+ NPl+  . NPr/ISg+ V   V/J      NSg/V/J/R/P NSg/I/J/Dq P  D   NSg/J
+> in      1834 , and " in      less      than two  years , he       had sketched out         many       of the salient
+# NPr/J/P #    . V/C . NPr/J/P V/J/R/C/P C/P  NSg+ NPl+  . NPr/ISg+ V   V/J      NSg/V/J/R/P NSg/I/J/Dq P  D   NSg/J
 > features of the modern computer " . " A    crucial step   was the adoption of a   punched
 # NPl/V    P  D   NSg/J  NSg/V+   . . . D/P+ J+      NSg/V+ V   D   NSg      P  D/P V/J
 > card    system derived from the Jacquard loom  " making it       infinitely
@@ -158,14 +158,14 @@
 # NPr/ISg+ NSg/R . NSg$      NSg/V/J+ NSg/V/P NSg/V/J . .
 >
 #
-> During the 1940s , with the development of new     and more         powerful computing
-# V/P    D+  #d    . P    D   N🅪Sg        P  NSg/V/J V/C NPr/I/V/J/Dq J        Nᴹ/V+
+> During the 1940s , with the development of new     and more           powerful computing
+# V/P    D+  #d    . P    D   N🅪Sg        P  NSg/V/J V/C NPr/I/V/J/R/Dq J        Nᴹ/V+
 > machines such  as    the Atanasoff – Berry   computer and ENIAC , the term     computer came
 # NPl/V    NSg/I NSg/R D   ?         . NPr🅪/V+ NSg/V+   V/C ?     . D   NSg/V/J+ NSg/V+   NSg/V/P
 > to refer to the machines rather    than their human   predecessors . As    it       became
 # P  NSg/V P  D   NPl/V+   NPr/V/J/R C/P  D$+   NSg/V/J NPl+         . NSg/R NPr/ISg+ V
-> clear   that         computers could  be     used for more         than just mathematical calculations ,
-# NSg/V/J NSg/I/C/Ddem NPl/V+    NSg/VX NSg/VX V/J  C/P NPr/I/V/J/Dq C/P  V/J  J+           +            .
+> clear   that         computers could  be     used for more           than just mathematical calculations ,
+# NSg/V/J NSg/I/C/Ddem NPl/V+    NSg/VX NSg/VX V/J  C/P NPr/I/V/J/R/Dq C/P  V/J  J+           +            .
 > the field of computer science broadened to study computation in      general . In
 # D   NSg/V P  NSg/V+   N🅪Sg/V+ V/J       P  NSg/V NSg         NPr/J/P NSg/V/J . NPr/J/P
 > 1945 , IBM  founded the Watson Scientific Computing Laboratory at    Columbia
@@ -276,8 +276,8 @@
 #
 > A   folkloric quotation , often attributed to — but     almost certainly not   first
 # D/P J         NSg       . R     V/J        P  . NSg/C/P R      R         NSg/C NSg/V/J
-> formulated by      — Edsger Dijkstra , states   that          " computer science is no    more         about
-# V/J        NSg/J/P . ?      NSg      . NPrPl/V+ NSg/I/C/Ddem+ . NSg/V+   N🅪Sg/V+ VL NPr/P NPr/I/V/J/Dq J/P
+> formulated by      — Edsger Dijkstra , states   that          " computer science is no    more           about
+# V/J        NSg/J/P . ?      NSg      . NPrPl/V+ NSg/I/C/Ddem+ . NSg/V+   N🅪Sg/V+ VL NPr/P NPr/I/V/J/R/Dq J/P
 > computers than astronomy is about telescopes . " [ note   3 ] The design and deployment
 # NPl/V+    C/P  Nᴹ+       VL J/P   NPl/V      . . . NSg/V+ # . D   N🅪Sg/V V/C NSg
 > of computers and computer systems is generally considered the province of
@@ -490,8 +490,8 @@
 # NPl/V   ISg/D$+ N🅪Sg+      P    NSg/J     V/C NSg/J    NSg         . NPr/ISg+ NPl/V P
 > understand the nature of computation and , as    a   consequence of this
 # V          D   NSg/V  P  NSg         V/C . NSg/R D/P NSg/V       P  I/Ddem
-> understanding , provide more         efficient methodologies .
-# N🅪Sg/V/J+     . V       NPr/I/V/J/Dq NSg/J     NPl           .
+> understanding , provide more           efficient methodologies .
+# N🅪Sg/V/J+     . V       NPr/I/V/J/R/Dq NSg/J     NPl           .
 >
 #
 > Theory of computation
@@ -540,8 +540,8 @@
 # NPl/V      P  NPl/V+ . NPl+    C/P V          Nᴹ+         P    NSg/I/V/J NSg/V+ P
 > another ) and their fitness for a    specific application . Codes  are used for data
 # I/D     . V/C D$+   NSg     C/P D/P+ NSg/J+   NSg+        . NPl/V+ V   V/J  C/P N🅪Pl+
-> compression , cryptography , error  detection and correction , and more         recently
-# NSg+        . NSg          . NSg/V+ N🅪Sg      V/C NSg+       . V/C NPr/I/V/J/Dq R
+> compression , cryptography , error  detection and correction , and more           recently
+# NSg+        . NSg          . NSg/V+ N🅪Sg      V/C NSg+       . V/C NPr/I/V/J/R/Dq R
 > also for network coding . Codes  are studied for the purpose of designing
 # W?   C/P NSg/V+  V+     . NPl/V+ V   V/J     C/P D   N🅪Sg/V  P  V
 > efficient and reliable data  transmission methods .
@@ -940,14 +940,14 @@
 #
 > Corrado Böhm and Giuseppe Jacopini's insight : there are only  three ways of
 # ?       ?    V/C NSg      ?          NSg+    . +     V   J/R/C NSg   NPl  P
-> combining these  actions ( into more         complex ones   ) that          are needed in      order  for
-# V         I/Ddem NPl/V+  . P    NPr/I/V/J/Dq NSg/V/J NPl/V+ . NSg/I/C/Ddem+ V   V/J    NPr/J/P NSg/V+ C/P
+> combining these  actions ( into more           complex ones   ) that          are needed in      order  for
+# V         I/Ddem NPl/V+  . P    NPr/I/V/J/R/Dq NSg/V/J NPl/V+ . NSg/I/C/Ddem+ V   V/J    NPr/J/P NSg/V+ C/P
 > a   computer to do     " anything " .
 # D/P NSg/V+   P  NSg/VX . NSg/I/V+ . .
 >
 #
 > Only  three rules  are needed to combine any    set     of basic  instructions into more
-# J/R/C NSg+  NPl/V+ V   V/J    P  NSg/V   I/R/Dq NPr/V/J P  NPr/J+ NPl+         P    NPr/I/V/J/Dq
+# J/R/C NSg+  NPl/V+ V   V/J    P  NSg/V   I/R/Dq NPr/V/J P  NPr/J+ NPl+         P    NPr/I/V/J/R/Dq
 > complex  ones   :
 # NSg/V/J+ NPl/V+ .
 >
@@ -968,8 +968,8 @@
 # NSg/V+     . NSg/V/C/P NSg/I . V/C . NSg/I VL D   NPr🅪/V . NSg/VX I/Ddem+ . D   NSg   NPl/V P
 > Boehm's and Jacopini's insight can    be     further simplified with the use    of
 # ?       V/C ?          NSg+    NPr/VX NSg/VX V/J     V/J        P    D   NSg/V+ P
-> goto ( which means it       is more         elementary than structured programming ) .
-# ?    . I/C+  NPl/V NPr/ISg+ VL NPr/I/V/J/Dq NSg/J      C/P  V/J        Nᴹ/V+       . .
+> goto ( which means it       is more           elementary than structured programming ) .
+# ?    . I/C+  NPl/V NPr/ISg+ VL NPr/I/V/J/R/Dq NSg/J      C/P  V/J        Nᴹ/V+       . .
 >
 #
 >
@@ -1039,7 +1039,7 @@
 >
 #
 > Many        languages offer    support for multiple  paradigms , making the distinction more
-# NSg/I/J/Dq+ NPl/V+    NSg/V/JC N🅪Sg/V  C/P NSg/J/Dq+ NPl+      . NSg/V  D+  NSg+        NPr/I/V/J/Dq
+# NSg/I/J/Dq+ NPl/V+    NSg/V/JC N🅪Sg/V  C/P NSg/J/Dq+ NPl+      . NSg/V  D+  NSg+        NPr/I/V/J/R/Dq
 > a   matter of style  than of technical capabilities .
 # D/P N🅪Sg/V P  NSg/V+ C/P  P  NSg/J+    NPl+         .
 >

--- a/harper-core/tests/text/tagged/Difficult sentences.md
+++ b/harper-core/tests/text/tagged/Difficult sentences.md
@@ -232,8 +232,8 @@
 # W?    V      D/P NSg/V+   NSg/V/J C/P NPr+  .
 > The mayor gave a   speech for the charity gala   .
 # D+  NSg+  V    D/P N🅪Sg/V C/P D+  NPr+    NSg/J+ .
-> If    having to bag   the groceries correctly is more         than you    can    handle , then    this   isn't the job    for you    .
-# NSg/C V      P  NSg/V D+  NPl/V+    R         VL NPr/I/V/J/Dq C/P  ISgPl+ NPr/VX NSg/V  . NSg/J/C I/Ddem NSg/V D   NPr/V+ C/P ISgPl+ .
+> If    having to bag   the groceries correctly is more           than you    can    handle , then    this   isn't the job    for you    .
+# NSg/C V      P  NSg/V D+  NPl/V+    R         VL NPr/I/V/J/R/Dq C/P  ISgPl+ NPr/VX NSg/V  . NSg/J/C I/Ddem NSg/V D   NPr/V+ C/P ISgPl+ .
 > This    is a   new     bell  for my  bicycle .
 # I/Ddem+ VL D/P NSg/V/J NPr/V C/P D$+ NSg/V+  .
 > The cake    is for Tom   and Helen's anniversary .
@@ -314,8 +314,8 @@
 # NPr/J/P NSg/V/J P  NSg/V/J+ NPl/V . NPr/V+ V   NSg   C/P NSg  J/P D+  NPr🅪+
 > At    close   of play  , England were  305 for 3 .
 # NSg/P NSg/V/J P  NSg/V . NPr+    NSg/V #   C/P # .
-> He       took the swing  shift  for he       could  get   more         overtime .
-# NPr/ISg+ V    D+  NSg/V+ NSg/V+ C/P NPr/ISg+ NSg/VX NSg/V NPr/I/V/J/Dq NSg/V    .
+> He       took the swing  shift  for he       could  get   more           overtime .
+# NPr/ISg+ V    D+  NSg/V+ NSg/V+ C/P NPr/ISg+ NSg/VX NSg/V NPr/I/V/J/R/Dq NSg/V    .
 > to account for one's whereabouts .
 # P  NSg/V   C/P NSg$+ NSg+        .
 >
@@ -404,8 +404,8 @@
 # NPr/VX ISgPl+ NSg/VX NSg/V/J P  NSg/V  I/Ddem+ NPr/J/P D/P+ NSg/J+ .
 > They said they would call  us       in      a    week   .
 # IPl+ V/J  IPl+ VX    NSg/V NPr/IPl+ NPr/J/P D/P+ NSg/J+ .
-> Less    water   gets  in      your boots this    way    .
-# V/J/C/P N🅪Sg/V+ NPl/V NPr/J/P D$+  NPl/V I/Ddem+ NSg/J+ .
+> Less      water   gets  in      your boots this    way    .
+# V/J/R/C/P N🅪Sg/V+ NPl/V NPr/J/P D$+  NPl/V I/Ddem+ NSg/J+ .
 > She  stood there looking in      the window longingly .
 # ISg+ V     W?    V       NPr/J/P D+  NSg/V+ R         .
 > In      replacing the faucet washers , he       felt     he       was making his     contribution to the environment .
@@ -796,8 +796,8 @@
 # NPr/I+ NPr/V/J ISg+ P  V/Au/Br   . W?   NSg/V/J NSg/V/JC+ NPl/V+ ISg+   .
 > Precisely to get   away from you    was why   I    did what   I    did .
 # R         P  NSg/V V/J  P    ISgPl+ V   NSg/V ISg+ V   NSg/I+ ISg+ V   .
-> I    need    some     more         books  to read  and friends to go      partying with .
-# ISg+ N🅪Sg/VX I/J/R/Dq NPr/I/V/J/Dq NPl/V+ P  NSg/V V/C NPl/V+  P  NSg/V/J V        P    .
+> I    need    some     more           books  to read  and friends to go      partying with .
+# ISg+ N🅪Sg/VX I/J/R/Dq NPr/I/V/J/R/Dq NPl/V+ P  NSg/V V/C NPl/V+  P  NSg/V/J V        P    .
 > If    he       hasn't read  it       yet     , he       ought    to .
 # NSg/C NPr/ISg+ V      NSg/V NPr/ISg+ NSg/V/C . NPr/ISg+ NSg/I/VX P  .
 > I    went  to the shops  to buy   some      bread   .

--- a/harper-core/tests/text/tagged/Part-of-speech tagging.md
+++ b/harper-core/tests/text/tagged/Part-of-speech tagging.md
@@ -42,8 +42,8 @@
 #
 > Part     - of - speech  tagging is harder than just having a   list  of words  and their
 # NSg/V/J+ . P  . N🅪Sg/V+ NSg/V   VL JC     C/P  V/J  V      D/P NSg/V P  NPl/V+ V/C D$+
-> parts of speech  , because some     words  can    represent more         than one       part    of speech
-# NPl/V P  N🅪Sg/V+ . C/P     I/J/R/Dq NPl/V+ NPr/VX V         NPr/I/V/J/Dq C/P  NSg/I/V/J NSg/V/J P  N🅪Sg/V+
+> parts of speech  , because some     words  can    represent more           than one       part    of speech
+# NPl/V P  N🅪Sg/V+ . C/P     I/J/R/Dq NPl/V+ NPr/VX V         NPr/I/V/J/R/Dq C/P  NSg/I/V/J NSg/V/J P  N🅪Sg/V+
 > at    different times  , and because some     parts of speech  are complex . This    is not
 # NSg/P NSg/J     NPl/V+ . V/C C/P     I/J/R/Dq NPl/V P  N🅪Sg/V+ V   NSg/V/J . I/Ddem+ VL NSg/C
 > rare    — in      natural languages ( as    opposed to many        artificial languages ) , a   large
@@ -60,8 +60,8 @@
 #
 > Correct grammatical tagging will   reflect that          " dogs   " is here    used as    a   verb   , not
 # NSg/V/J J           NSg/V   NPr/VX V       NSg/I/C/Ddem+ . NPl/V+ . VL NSg/J/R V/J  NSg/R D/P NSg/V+ . NSg/C
-> as    the more         common  plural noun   . Grammatical context is one       way   to determine
-# NSg/R D   NPr/I/V/J/Dq NSg/V/J NSg/J  NSg/V+ . J+          N🅪Sg/V+ VL NSg/I/V/J NSg/J P  V
+> as    the more           common  plural noun   . Grammatical context is one       way   to determine
+# NSg/R D   NPr/I/V/J/R/Dq NSg/V/J NSg/J  NSg/V+ . J+          N🅪Sg/V+ VL NSg/I/V/J NSg/J P  V
 > this    ; semantic analysis can    also be     used to infer that          " sailor " and " hatch "
 # I/Ddem+ . NSg/J+   N🅪Sg+    NPr/VX W?   NSg/VX V/J  P  V     NSg/I/C/Ddem+ . NSg+   . V/C . NSg/V .
 > implicate " dogs   " as    1 ) in      the nautical context and 2 ) an  action    applied to the
@@ -80,8 +80,8 @@
 # NPl/V+  R        NSg/V NSg/I/C/Ddem +     V   # NPl/V P  N🅪Sg/V NPr/J/P NPr🅪/V/J . NSg/V+ . NSg/V+ .
 > article , adjective , preposition , pronoun , adverb , conjunction , and interjection .
 # NSg/V+  . NSg/V/J+  . NSg/V       . NSg/V+  . NSg/V+ . NSg/V+      . V/C NSg+         .
-> However , there are clearly many        more          categories and sub     - categories . For nouns ,
-# C       . +     V   R       NSg/I/J/Dq+ NPr/I/V/J/Dq+ NPl+       V/C NSg/V/P . NPl+       . C/P NPl/V .
+> However , there are clearly many        more            categories and sub     - categories . For nouns ,
+# C       . +     V   R       NSg/I/J/Dq+ NPr/I/V/J/R/Dq+ NPl+       V/C NSg/V/P . NPl+       . C/P NPl/V .
 > the plural , possessive , and singular forms  can    be     distinguished . In      many
 # D   NSg/J  . NSg/J      . V/C NSg/J    NPl/V+ NPr/VX NSg/VX V/J           . NPr/J/P NSg/I/J/Dq+
 > languages words  are also marked for their " case    " ( role as    subject  , object ,
@@ -150,8 +150,8 @@
 # ?   NSg/VX V/J      D/P . NSg/J     . NSg/V+ NPr/V/J . P    #  NPl+       . C/P NSg/V+  . NPr/P
 > subtypes of nouns , verbs  , punctuation , and so        on  ) . Whether a   very small   set     of
 # NPl      P  NPl/V . NPl/V+ . Nᴹ+         . V/C NSg/I/J/C J/P . . I/C     D/P J/R  NPr/V/J NPr/V/J P
-> very broad tags   or    a   much         larger set     of more         precise ones   is preferable , depends
-# J/R  NSg/J NPl/V+ NPr/C D/P NSg/I/J/R/Dq JC     NPr/V/J P  NPr/I/V/J/Dq V/J+    NPl/V+ VL W?         . NPl/V
+> very broad tags   or    a   much         larger set     of more           precise ones   is preferable , depends
+# J/R  NSg/J NPl/V+ NPr/C D/P NSg/I/J/R/Dq JC     NPr/V/J P  NPr/I/V/J/R/Dq V/J+    NPl/V+ VL W?         . NPl/V
 > on  the purpose at    hand   . Automatic tagging is easier on  smaller tag    - sets  .
 # J/P D   N🅪Sg/V+ NSg/P NSg/V+ . NSg/J     NSg/V   VL NSg/JC J/P NSg/JC  NSg/V+ . NPl/V .
 >
@@ -174,8 +174,8 @@
 # NSg/J/P+ . #d    . NPr/ISg+ NPl/V    P  J/P   # . #   . #   NPl/V P  Nᴹ/V/J/P NPr🅪/V/J+ Nᴹ/V  N🅪Sg/V+ .
 > made up        of 500 samples from randomly chosen publications . Each sample is 2 , 000
 # V    NSg/V/J/P P  #   NPl/V+  P    R        Nᴹ/V/J NPl+         . Dq+  NSg/V+ VL # . #
-> or    more         words  ( ending at    the first   sentence - end    after 2 , 000 words  , so        that         the
-# NPr/C NPr/I/V/J/Dq NPl/V+ . NSg/V  NSg/P D   NSg/V/J NSg/V+   . NSg/V+ P     # . #   NPl/V+ . NSg/I/J/C NSg/I/C/Ddem D
+> or    more           words  ( ending at    the first   sentence - end    after 2 , 000 words  , so        that         the
+# NPr/C NPr/I/V/J/R/Dq NPl/V+ . NSg/V  NSg/P D   NSg/V/J NSg/V+   . NSg/V+ P     # . #   NPl/V+ . NSg/I/J/C NSg/I/C/Ddem D
 > corpus contains only  complete sentences ) .
 # NSg+   V        J/R/C NSg/V/J  NPl/V+    . .
 >
@@ -244,22 +244,22 @@
 # NSg/V+  . NSg/C W?     NSg/V D/P NSg/V+  NSg/I NSg/R . D   . . NSg/R   D   NSg/J/P NSg/V+ VL D/P
 > noun   40 % of the time      , an  adjective 40 % , and a   number     20 % . Knowing   this    , a
 # NSg/V+ #  . P  D   N🅪Sg/V/J+ . D/P NSg/V/J+  #  . . V/C D/P N🅪Sg/V/JC+ #  . . NSg/V/J/P I/Ddem+ . D/P+
-> program can    decide that          " can    " in      " the can    " is far     more         likely to be     a   noun  than
-# NPr/V+  NPr/VX V      NSg/I/C/Ddem+ . NPr/VX . NPr/J/P . D+  NPr/VX . VL NSg/V/J NPr/I/V/J/Dq NSg/J  P  NSg/VX D/P NSg/V C/P
+> program can    decide that          " can    " in      " the can    " is far     more           likely to be     a   noun  than
+# NPr/V+  NPr/VX V      NSg/I/C/Ddem+ . NPr/VX . NPr/J/P . D+  NPr/VX . VL NSg/V/J NPr/I/V/J/R/Dq NSg/J  P  NSg/VX D/P NSg/V C/P
 > a    verb   or    a   modal . The same method can    , of course , be     used to benefit from
 # D/P+ NSg/V+ NPr/C D/P NSg/J . D+  I/J+ NSg/V+ NPr/VX . P  NSg/V+ . NSg/VX V/J  P  NSg/V   P
 > knowledge about the following words  .
 # Nᴹ+       J/P   D+  NSg/V/J/P NPl/V+ .
 >
 #
-> More         advanced ( " higher - order " ) HMMs learn the probabilities not   only  of pairs
-# NPr/I/V/J/Dq V/J      . . NSg/JC . NSg/V . . ?    NSg/V D   NPl+          NSg/C J/R/C P  NPl/V+
+> More           advanced ( " higher - order " ) HMMs learn the probabilities not   only  of pairs
+# NPr/I/V/J/R/Dq V/J      . . NSg/JC . NSg/V . . ?    NSg/V D   NPl+          NSg/C J/R/C P  NPl/V+
 > but     triples or    even    larger sequences . So        , for example , if    you've just seen  a
 # NSg/C/P NPl/V   NPr/C NSg/V/J JC     NPl/V+    . NSg/I/J/C . C/P NSg/V+  . NSg/C W?     V/J  NSg/V D/P
 > noun   followed by      a   verb   , the next    item   may    be     very likely a   preposition ,
 # NSg/V+ V/J      NSg/J/P D/P NSg/V+ . D   NSg/J/P NSg/V+ NPr/VX NSg/VX J/R  NSg/J  D/P NSg/V       .
-> article , or    noun   , but     much         less    likely another verb   .
-# NSg/V+  . NPr/C NSg/V+ . NSg/C/P NSg/I/J/R/Dq V/J/C/P NSg/J  I/D     NSg/V+ .
+> article , or    noun   , but     much         less      likely another verb   .
+# NSg/V+  . NPr/C NSg/V+ . NSg/C/P NSg/I/J/R/Dq V/J/R/C/P NSg/J  I/D     NSg/V+ .
 >
 #
 > When    several ambiguous words  occur together , the possibilities multiply .
@@ -282,8 +282,8 @@
 # V       . #    . NSg/I/C/Ddem+ R      V         D   NSg/I/J/R/Dq NSg/V/J NSg/V+ P  Dq   V/J   NSg/V+ V/C
 > the tag    " proper noun   " to all          unknowns will   approach 90 % accuracy because many
 # D   NSg/V+ . NSg/J  NSg/V+ . P  NSg/I/J/C/Dq NPl/V+   NPr/VX NSg/V+   #  . N🅪Sg+    C/P     NSg/I/J/Dq
-> words  are unambiguous , and many       others only  rarely represent their less    - common
-# NPl/V+ V   J           . V/C NSg/I/J/Dq NPl/V+ J/R/C R      V         D$+   V/J/C/P . NSg/V/J
+> words  are unambiguous , and many       others only  rarely represent their less      - common
+# NPl/V+ V   J           . V/C NSg/I/J/Dq NPl/V+ J/R/C R      V         D$+   V/J/R/C/P . NSg/V/J
 > parts of speech  .
 # NPl/V P  N🅪Sg/V+ .
 >
@@ -314,8 +314,8 @@
 #
 > In      1987 , Steven DeRose and Kenneth W. Church  independently developed dynamic
 # NPr/J/P #    . NPr+   ?      V/C NPr+    ?  NPr🅪/V+ R             V/J       NSg/J
-> programming algorithms to solve the same problem in      vastly less    time      . Their
-# Nᴹ/V+       NPl+       P  NSg/V D   I/J  NSg/J+  NPr/J/P R      V/J/C/P N🅪Sg/V/J+ . D$+
+> programming algorithms to solve the same problem in      vastly less      time      . Their
+# Nᴹ/V+       NPl+       P  NSg/V D   I/J  NSg/J+  NPr/J/P R      V/J/R/C/P N🅪Sg/V/J+ . D$+
 > methods were  similar to the Viterbi algorithm known for some     time      in      other
 # NPl/V+  NSg/V NSg/J   P  D   ?       NSg       V/J   C/P I/J/R/Dq N🅪Sg/V/J+ NPr/J/P NSg/V/J
 > fields   . DeRose used a   table of pairs  , while     Church  used a   table of triples and a

--- a/harper-core/tests/text/tagged/The Constitution of the United States.md
+++ b/harper-core/tests/text/tagged/The Constitution of the United States.md
@@ -4,8 +4,8 @@
 # Unlintable D   NPr+         P  D   V/J    NPrPl/V+ P  NPr+
 >
 #
-> We   the People of the United States   , in      Order  to form  a   more         perfect  Union    ,
-# IPl+ D   NPl/V  P  D+  V/J    NPrPl/V+ . NPr/J/P NSg/V+ P  NSg/V D/P NPr/I/V/J/Dq NSg/V/J+ NPr/V/J+ .
+> We   the People of the United States   , in      Order  to form  a   more           perfect  Union    ,
+# IPl+ D   NPl/V  P  D+  V/J    NPrPl/V+ . NPr/J/P NSg/V+ P  NSg/V D/P NPr/I/V/J/R/Dq NSg/V/J+ NPr/V/J+ .
 > establish Justice , insure domestic Tranquility , provide for the common  defence    ,
 # V         NPr🅪+   . V      NSg/J    NSg         . V       C/P D   NSg/V/J N🅪Sg/Comm+ .
 > promote the general Welfare , and secure the Blessings of Liberty to ourselves
@@ -282,8 +282,8 @@
 #
 > Neither House  , during the Session of Congress , shall , without the Consent of
 # I/C     NPr/V+ . V/P    D   NSg/V   P  NPr/V+   . VX    . C/P     D   NSg/V   P
-> the other   , adjourn for more         than three days , nor   to any    other   Place   than that
-# D   NSg/V/J . V       C/P NPr/I/V/J/Dq C/P  NSg   NPl+ . NSg/C P  I/R/Dq NSg/V/J N🅪Sg/V+ C/P  NSg/I/C/Ddem+
+> the other   , adjourn for more           than three days , nor   to any    other   Place   than that
+# D   NSg/V/J . V       C/P NPr/I/V/J/R/Dq C/P  NSg   NPl+ . NSg/C P  I/R/Dq NSg/V/J N🅪Sg/V+ C/P  NSg/I/C/Ddem+
 > in      which the two Houses shall be     sitting .
 # NPr/J/P I/C+  D   NSg NPl/V+ VX    NSg/VX NSg/V/J .
 >
@@ -844,14 +844,14 @@
 # NSg/V NSg      NPl+  D/P NSg/J+   NSg/J/P D   V/J    NPrPl/V+ .
 >
 #
-> No     person shall be     elected to the office of the President more         than twice , and
-# NPr/P+ NSg/V+ VX    NSg/VX NSg/V/J P  D   NSg/V  P  D+  NSg/V+    NPr/I/V/J/Dq C/P  W?    . V/C
+> No     person shall be     elected to the office of the President more           than twice , and
+# NPr/P+ NSg/V+ VX    NSg/VX NSg/V/J P  D   NSg/V  P  D+  NSg/V+    NPr/I/V/J/R/Dq C/P  W?    . V/C
 > no     person who    has held the office of President , or    acted as    President , for more
-# NPr/P+ NSg/V+ NPr/I+ V   V    D   NSg/V  P  NSg/V+    . NPr/C V/J   NSg/R NSg/V+    . C/P NPr/I/V/J/Dq
+# NPr/P+ NSg/V+ NPr/I+ V   V    D   NSg/V  P  NSg/V+    . NPr/C V/J   NSg/R NSg/V+    . C/P NPr/I/V/J/R/Dq
 > than two years of a    term     to which some      other    person was elected President shall
 # C/P  NSg NPl   P  D/P+ NSg/V/J+ P  I/C+  I/J/R/Dq+ NSg/V/J+ NSg/V+ V   NSg/V/J NSg/V+    VX
-> be     elected to the office of the President more         than once  . But     this    article
-# NSg/VX NSg/V/J P  D   NSg/V  P  D+  NSg/V+    NPr/I/V/J/Dq C/P  NSg/C . NSg/C/P I/Ddem+ NSg/V+
+> be     elected to the office of the President more           than once  . But     this    article
+# NSg/VX NSg/V/J P  D   NSg/V  P  D+  NSg/V+    NPr/I/V/J/R/Dq C/P  NSg/C . NSg/C/P I/Ddem+ NSg/V+
 > shall not   apply to any     person holding the office of President when    this    article
 # VX    NSg/C V/J   P  I/R/Dq+ NSg/V+ NSg/V   D   NSg/V  P  NSg/V+    NSg/I/C I/Ddem+ NSg/V+
 > was proposed by      the Congress , and shall not   prevent any     person who    may    be
@@ -984,8 +984,8 @@
 # D/P N🅪Sg/V/JC P  NPl      P  NSg/V     V/C NSg/V/J/P+ NSg/V+    NSg/V/J P  D   NSg/J N🅪Sg/V/JC
 > of Senators and Representatives in      Congress to which the District would be
 # P  NPl+     V/C NPl+            NPr/J/P NPr/V+   P  I/C+  D   NSg/V/J+ VX    NSg/VX
-> entitled if    it       were  a   State   , but     in      no    event  more         than the least populous
-# V/J      NSg/C NPr/ISg+ NSg/V D/P N🅪Sg/V+ . NSg/C/P NPr/J/P NPr/P NSg/V+ NPr/I/V/J/Dq C/P  D   NSg/J J
+> entitled if    it       were  a   State   , but     in      no    event  more           than the least populous
+# V/J      NSg/C NPr/ISg+ NSg/V D/P N🅪Sg/V+ . NSg/C/P NPr/J/P NPr/P NSg/V+ NPr/I/V/J/R/Dq C/P  D   NSg/J J
 > State   ; they shall be     in      addition to those  appointed by      the States   , but     they
 # N🅪Sg/V+ . IPl+ VX    NSg/VX NPr/J/P NSg+     P  I/Ddem V/J+      NSg/J/P D   NPrPl/V+ . NSg/C/P IPl+
 > shall be     considered , for the purposes of the election of President and Vice
@@ -1124,8 +1124,8 @@
 # V/J       NPl+        . NSg/V/J+ Nᴹ/V/J+ NPl/V+    V/C NPl     . . P  NSg/I/J/C/Dq NPl/V P
 > admiralty and maritime Jurisdiction ; — to Controversies to which the United
 # NPr       V/C J        NSg+         . . P  NPl           P  I/C+  D   V/J
-> States   shall be     a   Party    ; — to Controversies between two or    more         States   ; — between
-# NPrPl/V+ VX    NSg/VX D/P NSg/V/J+ . . P  NPl           NSg/P   NSg NPr/C NPr/I/V/J/Dq NPrPl/V+ . . NSg/P
+> States   shall be     a   Party    ; — to Controversies between two or    more           States   ; — between
+# NPrPl/V+ VX    NSg/VX D/P NSg/V/J+ . . P  NPl           NSg/P   NSg NPr/C NPr/I/V/J/R/Dq NPrPl/V+ . . NSg/P
 > Citizens of different States   , — between Citizens of the same State   claiming
 # NPl      P  NSg/J     NPrPl/V+ . . NSg/P   NPl      P  D   I/J  N🅪Sg/V+ V
 > Lands  under   Grants of different States   .
@@ -1322,8 +1322,8 @@
 # NSg/V/J+ NPrPl/V+ NPr/VX NSg/VX V/J      NSg/J/P D+  NPr/V+   P    I/Ddem+ NPr/V/J+ . NSg/C/P
 > no     new      State   shall be     formed or    erected within  the Jurisdiction of any     other
 # NPr/P+ NSg/V/J+ N🅪Sg/V+ VX    NSg/VX V/J    NPr/C V/J     NSg/J/P D   NSg          P  I/R/Dq+ NSg/V/J+
-> State   ; nor   any     State   be     formed by      the Junction of two or    more         States   , or    Parts
-# N🅪Sg/V+ . NSg/C I/R/Dq+ N🅪Sg/V+ NSg/VX V/J    NSg/J/P D   NSg/V    P  NSg NPr/C NPr/I/V/J/Dq NPrPl/V+ . NPr/C NPl/V
+> State   ; nor   any     State   be     formed by      the Junction of two or    more           States   , or    Parts
+# N🅪Sg/V+ . NSg/C I/R/Dq+ N🅪Sg/V+ NSg/VX V/J    NSg/J/P D   NSg/V    P  NSg NPr/C NPr/I/V/J/R/Dq NPrPl/V+ . NPr/C NPl/V
 > of States   , without the Consent of the Legislatures of the States   concerned as
 # P  NPrPl/V+ . C/P     D   NSg/V   P  D   NPl          P  D   NPrPl/V+ V/J       NSg/R
 > well    as    of the Congress .

--- a/harper-core/tests/text/tagged/The Great Gatsby.md
+++ b/harper-core/tests/text/tagged/The Great Gatsby.md
@@ -10,8 +10,8 @@
 # NSg/V+  ISg+
 >
 #
-> In      my  younger and more         vulnerable years my  father gave me       some      advice that          I’ve
-# NPr/J/P D$+ NSg/JC  V/C NPr/I/V/J/Dq J+         NPl+  D$+ NPr/V+ V    NPr/ISg+ I/J/R/Dq+ Nᴹ+    NSg/I/C/Ddem+ W?
+> In      my  younger and more           vulnerable years my  father gave me       some      advice that          I’ve
+# NPr/J/P D$+ NSg/JC  V/C NPr/I/V/J/R/Dq J+         NPl+  D$+ NPr/V+ V    NPr/ISg+ I/J/R/Dq+ Nᴹ+    NSg/I/C/Ddem+ W?
 > been  turning over    in      my  mind   ever since .
 # NSg/V NSg/V   NSg/J/P NPr/J/P D$+ NSg/V+ J    C/P   .
 >
@@ -22,10 +22,10 @@
 # NSg/I/J/C/Dq D   NPl/V  NPr/J/P I/Ddem+ NSg/V+ V       V   D+  NPl/V+     NSg/I/C/Ddem+ W?     V   . .
 >
 #
-> He       didn’t say   any    more         , but     we’ve always been  unusually communicative in      a
-# NPr/ISg+ V      NSg/V I/R/Dq NPr/I/V/J/Dq . NSg/C/P W?    R      NSg/V R         J             NPr/J/P D/P
-> reserved way    , and I    understood that         he       meant a   great deal     more         than that          . In
-# V/J      NSg/J+ . V/C ISg+ V/J        NSg/I/C/Ddem NPr/ISg+ V     D/P NSg/J NSg/V/J+ NPr/I/V/J/Dq C/P  NSg/I/C/Ddem+ . NPr/J/P
+> He       didn’t say   any    more           , but     we’ve always been  unusually communicative in      a
+# NPr/ISg+ V      NSg/V I/R/Dq NPr/I/V/J/R/Dq . NSg/C/P W?    R      NSg/V R         J             NPr/J/P D/P
+> reserved way    , and I    understood that         he       meant a   great deal     more           than that          . In
+# V/J      NSg/J+ . V/C ISg+ V/J        NSg/I/C/Ddem NPr/ISg+ V     D/P NSg/J NSg/V/J+ NPr/I/V/J/R/Dq C/P  NSg/I/C/Ddem+ . NPr/J/P
 > consequence , I’m inclined to reserve all          judgments , a   habit  that          has opened up
 # NSg/V+      . W?  V/J      P  NSg/V   NSg/I/J/C/Dq NPl+      . D/P NSg/V+ NSg/I/C/Ddem+ V   V/J    NSg/V/J/P
 > many       curious natures to me       and also made me       the victim of not   a   few      veteran
@@ -64,8 +64,8 @@
 # P     D/P+ I/J+    NSg/V+ ISg+ V     N🅪Sg/V+ NSg/I+ W?   V/J     J/P . NSg/I/C ISg+ NSg/V/P NSg/V/J P
 > the East   last     autumn I    felt     that         I    wanted the world  to be     in      uniform and at    a
 # D+  NPr/J+ NSg/V/J+ NPr/V+ ISg+ N🅪Sg/V/J NSg/I/C/Ddem ISg+ V/J    D+  NSg/V+ P  NSg/VX NPr/J/P NSg/V/J V/C NSg/P D/P
-> sort  of moral    attention forever ; I    wanted no    more         riotous excursions with
-# NSg/V P  NSg/V/J+ NSg+      NSg/J   . ISg+ V/J    NPr/P NPr/I/V/J/Dq J       NPl/V      P
+> sort  of moral    attention forever ; I    wanted no    more           riotous excursions with
+# NSg/V P  NSg/V/J+ NSg+      NSg/J   . ISg+ V/J    NPr/P NPr/I/V/J/R/Dq J       NPl/V      P
 > privileged glimpses into the human   heart   . Only  Gatsby , the man      who    gives his
 # V/J        NPl/V+   P    D   NSg/V/J N🅪Sg/V+ . J/R/C NPr    . D   NPr/V/J+ NPr/I+ NPl/V ISg/D$+
 > name   to this   book   , was exempt  from my  reaction  — Gatsby , who    represented
@@ -124,8 +124,8 @@
 # V/J    NSg/V/J/C/P D   V/J    NSg/V P  D   NPr+     . NSg/I/J/C ISg+ NSg/V/J P  NSg/V/J NPr/J+ V/C NSg/V
 > the bond     business . Everybody I    knew was in      the bond     business , so        I    supposed it
 # D   NPr/V/J+ N🅪Sg/J+  . NSg/I+    ISg+ V    V   NPr/J/P D+  NPr/V/J+ N🅪Sg/J+  . NSg/I/J/C ISg+ V/J      NPr/ISg+
-> could  support one       more         single   man      . All          my  aunts and uncles talked it       over    as    if
-# NSg/VX N🅪Sg/V+ NSg/I/V/J NPr/I/V/J/Dq NSg/V/J+ NPr/V/J+ . NSg/I/J/C/Dq D$+ NPl   V/C NPl/V  V/J    NPr/ISg+ NSg/J/P NSg/R NSg/C
+> could  support one       more           single   man      . All          my  aunts and uncles talked it       over    as    if
+# NSg/VX N🅪Sg/V+ NSg/I/V/J NPr/I/V/J/R/Dq NSg/V/J+ NPr/V/J+ . NSg/I/J/C/Dq D$+ NPl   V/C NPl/V  V/J    NPr/ISg+ NSg/J/P NSg/R NSg/C
 > they were  choosing a   prep  school for me       , and finally said , “ Why   — ye       - es  , ” with
 # IPl+ NSg/V V        D/P Nᴹ/V+ NSg/V+ C/P NPr/ISg+ . V/C R       V/J  . . NSg/V . NSg/I/D+ . NPl . . P
 > very grave    , hesitant faces  . Father agreed to finance me       for a    year , and after
@@ -154,8 +154,8 @@
 # NSg/J+   NSg/V+ .
 >
 #
-> It       was lonely for a    day   or    so        until one        morning some      man      , more         recently arrived
-# NPr/ISg+ V   J/R    C/P D/P+ NPr🅪+ NPr/C NSg/I/J/C C/P   NSg/I/V/J+ N🅪Sg/V+ I/J/R/Dq+ NPr/V/J+ . NPr/I/V/J/Dq R        V/J
+> It       was lonely for a    day   or    so        until one        morning some      man      , more           recently arrived
+# NPr/ISg+ V   J/R    C/P D/P+ NPr🅪+ NPr/C NSg/I/J/C C/P   NSg/I/V/J+ N🅪Sg/V+ I/J/R/Dq+ NPr/V/J+ . NPr/I/V/J/R/Dq R        V/J
 > than I    , stopped me       on  the road    .
 # C/P  ISg+ . V/J     NPr/ISg+ J/P D+  N🅪Sg/J+ .
 >
@@ -198,8 +198,8 @@
 # V     NSg/V/J NSg/I/J/C/Dq NSg/I NPl/V+ P    D$+ N🅪Sg/V+ V/C V      P     NSg/I/C/Ddem NSg/I/J/R/Dq NSg/V/J P
 > all          specialists , the “ well    - rounded man      . ” This   isn’t just an  epigram — life    is much
 # NSg/I/J/C/Dq NPl+        . D   . NSg/V/J . V/J     NPr/V/J+ . . I/Ddem NSg/V V/J  D/P NSg     . N🅪Sg/V+ VL NSg/I/J/R/Dq
-> more         successfully looked at    from a   single  window , after all          .
-# NPr/I/V/J/Dq R            V/J    NSg/P P    D/P NSg/V/J NSg/V+ . P     NSg/I/J/C/Dq .
+> more           successfully looked at    from a   single  window , after all          .
+# NPr/I/V/J/R/Dq R            V/J    NSg/P P    D/P NSg/V/J NSg/V+ . P     NSg/I/J/C/Dq .
 >
 #
 > It       was a   matter of chance   that          I    should have   rented a    house  in      one       of the
@@ -220,14 +220,14 @@
 # NPl   . NSg/V/J/C/P D   N🅪Sg/V+ NPr/J/P D   NPr/V+   NSg/V+ . IPl+ V   I/C/Dq V/J     NSg/V/J NSg/P D
 > contact end    — but     their physical resemblance must  be     a   source of perpetual wonder
 # N🅪Sg/V+ NSg/V+ . NSg/C/P D$+   NSg/J+   NSg+        NSg/V NSg/VX D/P N🅪Sg/V P  NSg/J     N🅪Sg/V
-> to the gulls that          fly     overhead . To the wingless a   more         interesting phenomenon is
-# P  D   NPl/V NSg/I/C/Ddem+ NSg/V/J NSg/J/P+ . P  D   J        D/P NPr/I/V/J/Dq V/J         NSg+       VL
+> to the gulls that          fly     overhead . To the wingless a   more           interesting phenomenon is
+# P  D   NPl/V NSg/I/C/Ddem+ NSg/V/J NSg/J/P+ . P  D   J        D/P NPr/I/V/J/R/Dq V/J         NSg+       VL
 > their dissimilarity in      every particular except shape and size    .
 # D$+   NSg           NPr/J/P Dq    NSg/J      V/C/P  NSg/V V/C N🅪Sg/V+ .
 >
 #
-> I    lived at    West     Egg     , the — well    , the less    fashionable of the two , though this    is a
-# ISg+ V/J   NSg/P NPr/V/J+ N🅪Sg/V+ . D   . NSg/V/J . D   V/J/C/P NSg/J       P  D   NSg . V/C    I/Ddem+ VL D/P
+> I    lived at    West     Egg     , the — well    , the less      fashionable of the two , though this    is a
+# ISg+ V/J   NSg/P NPr/V/J+ N🅪Sg/V+ . D   . NSg/V/J . D   V/J/R/C/P NSg/J       P  D   NSg . V/C    I/Ddem+ VL D/P
 > most         superficial tag   to express the bizarre and not   a   little     sinister contrast
 # NSg/I/J/R/Dq NSg/J       NSg/V P  NSg/V/J D   J       V/C NSg/C D/P NPr/I/J/Dq J        NSg/V
 > between them     . My  house  was at    the very tip   of the egg     , only  fifty yards from the
@@ -240,8 +240,8 @@
 # V   D/P NSg/J   N🅪Sg      P  I/J/R/Dq ?     NPr+ ?     NPr/J/P NPr      . P    D/P NSg/V+ J/P NSg/I/V/J
 > side     , spanking new     under   a   thin    beard of raw     ivy  , and a   marble   swimming pool   ,
 # NSg/V/J+ . NSg/V/J  NSg/V/J NSg/J/P D/P NSg/V/J NPr/V P  NSg/V/J NPr+ . V/C D/P NSg/V/J+ NSg/V    NSg/V+ .
-> and more         than forty acres of lawn  and garden   . It       was Gatsby’s mansion . Or    ,
-# V/C NPr/I/V/J/Dq C/P  NSg/J NPl   P  NSg/V V/C NSg/V/J+ . NPr/ISg+ V   NSg$     NSg+    . NPr/C .
+> and more           than forty acres of lawn  and garden   . It       was Gatsby’s mansion . Or    ,
+# V/C NPr/I/V/J/R/Dq C/P  NSg/J NPl   P  NSg/V V/C NSg/V/J+ . NPr/ISg+ V   NSg$     NSg+    . NPr/C .
 > rather    , as    I    didn’t know  Mr   . Gatsby , it       was a   mansion inhabited by      a   gentleman
 # NPr/V/J/R . NSg/R ISg+ V      NSg/V NSg+ . NPr    . NPr/ISg+ V   D/P NSg+    V/J       NSg/J/P D/P NSg/J
 > of that         name   . My  own      house  was an  eyesore , but     it       was a   small   eyesore , and it
@@ -300,8 +300,8 @@
 #
 > And so        it       happened that         on  a    warm     windy  evening I    drove over    to East   Egg     to see
 # V/C NSg/I/J/C NPr/ISg+ V/J      NSg/I/C/Ddem J/P D/P+ NSg/V/J+ NSg/J+ N🅪Sg/V+ ISg+ NSg/V NSg/J/P P  NPr/J+ N🅪Sg/V+ P  NSg/V
-> two  old    friends whom I    scarcely knew at    all          . Their house  was even    more         elaborate
-# NSg+ NSg/J+ NPl/V+  I+   ISg+ R        V    NSg/P NSg/I/J/C/Dq . D$+   NPr/V+ V   NSg/V/J NPr/I/V/J/Dq V/J
+> two  old    friends whom I    scarcely knew at    all          . Their house  was even    more           elaborate
+# NSg+ NSg/J+ NPl/V+  I+   ISg+ R        V    NSg/P NSg/I/J/C/Dq . D$+   NPr/V+ V   NSg/V/J NPr/I/V/J/R/Dq V/J
 > than I    expected , a   cheerful red    - and - white    Georgian Colonial mansion , overlooking
 # C/P  ISg+ NSg/V/J  . D/P J        N🅪Sg/J . V/C . NPr🅪/V/J NSg/J    NSg/J+   NSg+    . V
 > the bay      . The lawn   started at    the beach  and ran   toward the front    door   for a
@@ -348,8 +348,8 @@
 #
 > “ Now       , don’t think my  opinion on  these  matters is final   , ” he       seemed to say   , “ just
 # . NPr/V/J/C . V     NSg/V D$+ NSg+    J/P I/Ddem NPl/V+  VL NSg/V/J . . NPr/ISg+ V/J    P  NSg/V . . V/J
-> because I’m stronger and more         of a   man      than you    are . ” We   were  in      the same senior
-# C/P     W?  JC       V/C NPr/I/V/J/Dq P  D/P NPr/V/J+ C/P  ISgPl+ V   . . IPl+ NSg/V NPr/J/P D+  I/J+ NPr/J+
+> because I’m stronger and more           of a   man      than you    are . ” We   were  in      the same senior
+# C/P     W?  JC       V/C NPr/I/V/J/R/Dq P  D/P NPr/V/J+ C/P  ISgPl+ V   . . IPl+ NSg/V NPr/J/P D+  I/J+ NPr/J+
 > society , and while     we   were  never intimate I    always had the impression that          he
 # N🅪Sg+   . V/C NSg/V/C/P IPl+ NSg/V R     NSg/V/J  ISg+ R      V   D+  NSg/V+     NSg/I/C/Ddem+ NPr/ISg+
 > approved of me       and wanted me       to like        him  with some     harsh , defiant wistfulness of
@@ -448,8 +448,8 @@
 # D   NSg/V   P  D   V+        NSg/V+ V   NPr+  . . W?   V/J   NPr/ISg+ V/J  NSg/I/C/Ddem NSg$
 > murmur was only  to make  people lean    toward her     ; an  irrelevant criticism that
 # NSg/V  V   J/R/C P  NSg/V NPl/V+ NPr/V/J J/P    ISg/D$+ . D/P J          N🅪Sg+     NSg/I/C/Ddem+
-> made it       no    less    charming . )
-# V    NPr/ISg+ NPr/P V/J/C/P NSg/V/J  . .
+> made it       no    less      charming . )
+# V    NPr/ISg+ NPr/P V/J/R/C/P NSg/V/J  . .
 >
 #
 > At    any     rate   , Miss  Baker’s lips   fluttered , she  nodded at    me       almost imperceptibly ,
@@ -558,8 +558,8 @@
 #
 > “ Oh    , I’ll stay    in      the East   , don’t you    worry , ” he       said , glancing at    Daisy and
 # . NPr/V . W?   NSg/V/J NPr/J/P D   NPr/J+ . V     ISgPl+ NSg/V . . NPr/ISg+ V/J  . V        NSg/P NPr+  V/C
-> then    back    at    me       , as    if    he       were  alert    for something  more         . “ I’d be     a   God    damned
-# NSg/J/C NSg/V/J NSg/P NPr/ISg+ . NSg/R NSg/C NPr/ISg+ NSg/V NSg/V/J+ C/P NSg/I/V/J+ NPr/I/V/J/Dq . . W?  NSg/VX D/P NPr/V+ V/J
+> then    back    at    me       , as    if    he       were  alert    for something  more           . “ I’d be     a   God    damned
+# NSg/J/C NSg/V/J NSg/P NPr/ISg+ . NSg/R NSg/C NPr/ISg+ NSg/V NSg/V/J+ C/P NSg/I/V/J+ NPr/I/V/J/R/Dq . . W?  NSg/VX D/P NPr/V+ V/J
 > fool    to live anywhere else    . ”
 # NSg/V/J P  V/J  NSg/I    NSg/J/C . .
 >
@@ -791,9 +791,9 @@
 >
 #
 > There was something  pathetic in      his     concentration , as    if    his     complacency , more
-# +     V   NSg/I/V/J+ J        NPr/J/P ISg/D$+ NSg+          . NSg/R NSg/C ISg/D$+ NSg         . NPr/I/V/J/Dq
-> acute   than of old   , was not   enough to him  any    more         . When    , almost immediately , the
-# NSg/V/J C/P  P  NSg/J . V   NSg/C NSg/I  P  ISg+ I/R/Dq NPr/I/V/J/Dq . NSg/I/C . R      R           . D+
+# +     V   NSg/I/V/J+ J        NPr/J/P ISg/D$+ NSg+          . NSg/R NSg/C ISg/D$+ NSg         . NPr/I/V/J/R/Dq
+> acute   than of old   , was not   enough to him  any    more           . When    , almost immediately , the
+# NSg/V/J C/P  P  NSg/J . V   NSg/C NSg/I  P  ISg+ I/R/Dq NPr/I/V/J/R/Dq . NSg/I/C . R      R           . D+
 > telephone rang inside  and the butler left    the porch Daisy seized upon the
 # NSg/V+    V    NSg/J/P V/C D   NPr/V  NPr/V/J D   NSg+  NPr+  V/J    P    D
 > momentary interruption and leaned toward me       .
@@ -1004,8 +1004,8 @@
 # NSg/V/J/R J       J/P   NSg/I/V+   . .
 >
 #
-> Evidently she  had reason  to be     . I    waited but     she  didn’t say   any    more         , and after
-# R         ISg+ V   N🅪Sg/V+ P  NSg/VX . ISg+ V/J    NSg/C/P ISg+ V      NSg/V I/R/Dq NPr/I/V/J/Dq . V/C P
+> Evidently she  had reason  to be     . I    waited but     she  didn’t say   any    more           , and after
+# R         ISg+ V   N🅪Sg/V+ P  NSg/VX . ISg+ V/J    NSg/C/P ISg+ V      NSg/V I/R/Dq NPr/I/V/J/R/Dq . V/C P
 > a   moment I    returned rather    feebly to the subject of her     daughter .
 # D/P NSg+   ISg+ V/J      NPr/V/J/R R      P  D   NSg/V/J P  ISg/D$+ NSg+     .
 >
@@ -1024,8 +1024,8 @@
 # . J/R  NSg/I/J/R/Dq . .
 >
 #
-> “ I’ll show  you    how   I’ve gotten to feel    about — things . Well    , she  was less    than an
-# . W?   NSg/V ISgPl+ NSg/C W?   V/J    P  NSg/I/V J/P   . NPl/V+ . NSg/V/J . ISg+ V   V/J/C/P C/P  D/P
+> “ I’ll show  you    how   I’ve gotten to feel    about — things . Well    , she  was less      than an
+# . W?   NSg/V ISgPl+ NSg/C W?   V/J    P  NSg/I/V J/P   . NPl/V+ . NSg/V/J . ISg+ V   V/J/R/C/P C/P  D/P
 > hour old   and Tom    was God    knows where . I    woke    up        out         of the ether with an  utterly
 # NSg  NSg/J V/C NPr/V+ V   NPr/V+ NPl/V NSg/C . ISg+ NSg/V/J NSg/V/J/P NSg/V/J/R/P P  D   Nᴹ/V  P    D/P R
 > abandoned feeling , and asked the nurse  right   away if    it       was a   boy   or    a   girl   . She
@@ -1236,16 +1236,16 @@
 # NSg/V/J NSg/V+ ISg+ V   NPr/P NSg/V     P  N🅪Sg/V/C V/J/Am  P    N🅪Sg+    .
 >
 #
-> Their interest rather    touched me       and made them     less    remotely rich    — nevertheless ,
-# D$+   NSg/V+   NPr/V/J/R V/J     NPr/ISg+ V/C V    NSg/IPl+ V/J/C/P R        NPr/V/J . W?           .
+> Their interest rather    touched me       and made them     less      remotely rich    — nevertheless ,
+# D$+   NSg/V+   NPr/V/J/R V/J     NPr/ISg+ V/C V    NSg/IPl+ V/J/R/C/P R        NPr/V/J . W?           .
 > I    was confused and a   little     disgusted as    I    drove away . It       seemed to me       that         the
 # ISg+ V   V/J      V/C D/P NPr/I/J/Dq V/J       NSg/R ISg+ NSg/V V/J  . NPr/ISg+ V/J    P  NPr/ISg+ NSg/I/C/Ddem D+
 > thing  for Daisy to do     was to rush    out         of the house  , child  in      arms   — but     apparently
 # NSg/V+ C/P NPr+  P  NSg/VX V   P  NPr/V/J NSg/V/J/R/P P  D+  NPr/V+ . NSg/V+ NPr/J/P NPl/V+ . NSg/C/P R
 > there were  no    such  intentions in      her     head     . As    for Tom    , the fact that          he       “ had
 # +     NSg/V NPr/P NSg/I NPl/V+     NPr/J/P ISg/D$+ NPr/V/J+ . NSg/R C/P NPr/V+ . D+  NSg+ NSg/I/C/Ddem+ NPr/ISg+ . V
-> some     woman in      New      York ” was really less    surprising than that         he       had been
-# I/J/R/Dq NSg/V NPr/J/P NSg/V/J+ NPr+ . V   R      V/J/C/P NSg/V/J    C/P  NSg/I/C/Ddem NPr/ISg+ V   NSg/V
+> some     woman in      New      York ” was really less      surprising than that         he       had been
+# I/J/R/Dq NSg/V NPr/J/P NSg/V/J+ NPr+ . V   R      V/J/R/C/P NSg/V/J    C/P  NSg/I/C/Ddem NPr/ISg+ V   NSg/V
 > depressed by      a    book   . Something  was making him  nibble at    the edge  of stale    ideas
 # V/J       NSg/J/P D/P+ NSg/V+ . NSg/I/V/J+ V   NSg/V  ISg+ NSg/V  NSg/P D   NSg/V P  NSg/V/J+ NPl+
 > as    if    his     sturdy physical egotism no    longer nourished his     peremptory heart   .
@@ -1290,8 +1290,8 @@
 # V   V         . R             ISg+ V/J     NSg/J   . V/C V/J           NSg/I/J+ V/C/P
 > a   single  green    light     , minute   and far     away , that          might   have   been  the end   of a
 # D/P NSg/V/J NPr🅪/V/J N🅪Sg/V/J+ . NSg/V/J+ V/C NSg/V/J V/J  . NSg/I/C/Ddem+ Nᴹ/VX/J NSg/VX NSg/V D   NSg/V P  D/P
-> dock   . When    I    looked once  more         for Gatsby he       had vanished , and I    was alone again
-# NSg/V+ . NSg/I/C ISg+ V/J    NSg/C NPr/I/V/J/Dq C/P NPr    NPr/ISg+ V   V/J      . V/C ISg+ V   J     P
+> dock   . When    I    looked once  more           for Gatsby he       had vanished , and I    was alone again
+# NSg/V+ . NSg/I/C ISg+ V/J    NSg/C NPr/I/V/J/R/Dq C/P NPr    NPr/ISg+ V   V/J      . V/C ISg+ V   J     P
 > in      the unquiet darkness .
 # NPr/J/P D   V/J     Nᴹ+      .
 >
@@ -1596,8 +1596,8 @@
 #
 > “ No    , it’s not   exactly a   police dog      , ” said the man      with disappointment in      his
 # . NPr/P . W?   NSg/C R       D/P Nᴹ/V+  NSg/V/J+ . . V/J  D   NPr/V/J+ P    NSg+           NPr/J/P ISg/D$+
-> voice  . “ It’s more         of an  Airedale . ” He       passed his     hand   over    the brown    washrag of
-# NSg/V+ . . W?   NPr/I/V/J/Dq P  D/P NPr      . . NPr/ISg+ V/J    ISg/D$+ NSg/V+ NSg/J/P D   NPr🅪/V/J NSg     P
+> voice  . “ It’s more           of an  Airedale . ” He       passed his     hand   over    the brown    washrag of
+# NSg/V+ . . W?   NPr/I/V/J/R/Dq P  D/P NPr      . . NPr/ISg+ V/J    ISg/D$+ NSg/V+ NSg/J/P D   NPr🅪/V/J NSg     P
 > a   back     . “ Look  at    that          coat   . Some      coat   . That’s a    dog      that’ll never bother you
 # D/P NSg/V/J+ . . NSg/V NSg/P NSg/I/C/Ddem+ NSg/V+ . I/J/R/Dq+ NSg/V+ . NSg$   D/P+ NSg/V/J+ W?      R     NSg/V  ISgPl+
 > with catching cold  . ”
@@ -1629,7 +1629,7 @@
 >
 #
 > “ It’s a    bitch  , ” said Tom    decisively . “ Here’s your money   . Go      and buy   ten more
-# . W?   D/P+ NSg/V+ . . V/J  NPr/V+ R          . . W?     D$+  N🅪Sg/J+ . NSg/V/J V/C NSg/V NSg NPr/I/V/J/Dq
+# . W?   D/P+ NSg/V+ . . V/J  NPr/V+ R          . . W?     D$+  N🅪Sg/J+ . NSg/V/J V/C NSg/V NSg NPr/I/V/J/R/Dq
 > dogs   with it       . ”
 # NPl/V+ P    NPr/ISg+ . .
 >
@@ -1738,8 +1738,8 @@
 # D+  NSg/V+ . NPr+      . V   D/P J       . J       NSg/V+ P  J/P   NSg    . P    D/P
 > solid , sticky  bob   of red    hair    , and a   complexion powdered milky white    . Her
 # NSg/J . NSg/V/J NPr/V P  N🅪Sg/J N🅪Sg/V+ . V/C D/P NSg/V+     V/J      J     NPr🅪/V/J . ISg/D$+
-> eyebrows had been  plucked and then    drawn on  again at    a   more         rakish angle  , but
-# NPl/V+   V   NSg/V V/J     V/C NSg/J/C V/J   J/P P     NSg/P D/P NPr/I/V/J/Dq J      NSg/V+ . NSg/C/P
+> eyebrows had been  plucked and then    drawn on  again at    a   more           rakish angle  , but
+# NPl/V+   V   NSg/V V/J     V/C NSg/J/C V/J   J/P P     NSg/P D/P NPr/I/V/J/R/Dq J      NSg/V+ . NSg/C/P
 > the efforts of nature toward the restoration of the old   alignment gave a   blurred
 # D   NPl/V   P  NSg/V+ J/P    D   NPr🅪        P  D   NSg/J N🅪Sg+     V    D/P V/J
 > air     to her     face   . When    she  moved about there was an  incessant clicking as
@@ -1784,8 +1784,8 @@
 # N🅪Sg+       V   W?   V         D/P+ N🅪Sg/V+ . D+  J+      NSg+     NSg/I/C/Ddem+ V   NSg/V NSg/I/J/C
 > remarkable in      the garage was converted into impressive hauteur . Her     laughter ,
 # W?         NPr/J/P D+  NSg/V+ V   V/J       P    J          NSg     . ISg/D$+ NSg+     .
-> her     gestures , her     assertions became more         violently affected moment by      moment ,
-# ISg/D$+ NPl/V+   . ISg/D$+ NSg+       V      NPr/I/V/J/Dq R         NSg/V/J  NSg+   NSg/J/P NSg+   .
+> her     gestures , her     assertions became more           violently affected moment by      moment ,
+# ISg/D$+ NPl/V+   . ISg/D$+ NSg+       V      NPr/I/V/J/R/Dq R         NSg/V/J  NSg+   NSg/J/P NSg+   .
 > and as    she  expanded the room     grew smaller around her     , until she  seemed to be
 # V/C NSg/R ISg+ V/J      D+  NSg/V/J+ V    NSg/JC  J/P    ISg/D$+ . C/P   ISg+ V/J    P  NSg/VX
 > revolving on  a   noisy , creaking pivot through the smoky air     .
@@ -1858,8 +1858,8 @@
 # NPr+     V/J    R       V/C V   P  ISg/D$+ NPl+ .
 >
 #
-> “ You    McKees have   something  to drink , ” he       said . “ Get   some     more         ice    and mineral
-# . ISgPl+ ?      NSg/VX NSg/I/V/J+ P  NSg/V . . NPr/ISg+ V/J  . . NSg/V I/J/R/Dq NPr/I/V/J/Dq NPr🅪/V V/C NSg/J+
+> “ You    McKees have   something  to drink , ” he       said . “ Get   some     more           ice    and mineral
+# . ISgPl+ ?      NSg/VX NSg/I/V/J+ P  NSg/V . . NPr/ISg+ V/J  . . NSg/V I/J/R/Dq NPr/I/V/J/R/Dq NPr🅪/V V/C NSg/J+
 > water   , Myrtle , before everybody goes  to sleep  . ”
 # N🅪Sg/V+ . NPr    . C/P    NSg/I+    NPl/V P  N🅪Sg/V . .
 >
@@ -1954,8 +1954,8 @@
 # J/R/C V      NPr/J/P D/P V/J   NSg/J+ . V/C V/J    ISg/D$+ NSg+      P  NPr/V+ .
 >
 #
-> “ I’d like        to do     more         work    on  Long    Island , if    I    could  get   the entry . All          I    ask   is
-# . W?  NSg/V/J/C/P P  NSg/VX NPr/I/V/J/Dq N🅪Sg/V+ J/P NPr/V/J NSg/V+ . NSg/C ISg+ NSg/VX NSg/V D   NSg+  . NSg/I/J/C/Dq ISg+ NSg/V VL
+> “ I’d like        to do     more           work    on  Long    Island , if    I    could  get   the entry . All          I    ask   is
+# . W?  NSg/V/J/C/P P  NSg/VX NPr/I/V/J/R/Dq N🅪Sg/V+ J/P NPr/V/J NSg/V+ . NSg/C ISg+ NSg/VX NSg/V D   NSg+  . NSg/I/J/C/Dq ISg+ NSg/V VL
 > that         they should give  me       a    start  . ”
 # NSg/I/C/Ddem IPl+ VX     NSg/V NPr/ISg+ D/P+ NSg/V+ . .
 >
@@ -2030,8 +2030,8 @@
 # D/P NSg/V/C/P+ C/P   NPr/ISg+ NPl/V NSg/J/P . .
 >
 #
-> “ It’d be     more         discreet to go      to Europe . ”
-# . W?   NSg/VX NPr/I/V/J/Dq J        P  NSg/V/J P  NPr+   . .
+> “ It’d be     more           discreet to go      to Europe . ”
+# . W?   NSg/VX NPr/I/V/J/R/Dq J        P  NSg/V/J P  NPr+   . .
 >
 #
 > “ Oh    , do     you    like        Europe ? ” she  exclaimed surprisingly . “ I    just got back    from
@@ -2116,8 +2116,8 @@
 #
 > “ Crazy about him  ! ” cried Myrtle incredulously . “ Who    said I    was crazy about him  ?
 # . NSg/J J/P   ISg+ . . V/J   NPr    R             . . NPr/I+ V/J  ISg+ V   NSg/J J/P   ISg+ .
-> I    never was any    more         crazy about him  than I    was about that          man      there . ”
-# ISg+ R     V   I/R/Dq NPr/I/V/J/Dq NSg/J J/P   ISg+ C/P  ISg+ V   J/P   NSg/I/C/Ddem+ NPr/V/J+ W?    . .
+> I    never was any    more           crazy about him  than I    was about that          man      there . ”
+# ISg+ R     V   I/R/Dq NPr/I/V/J/R/Dq NSg/J J/P   ISg+ C/P  ISg+ V   J/P   NSg/I/C/Ddem+ NPr/V/J+ W?    . .
 >
 #
 > She  pointed suddenly at    me       , and every one        looked at    me       accusingly . I    tried to
@@ -2396,12 +2396,12 @@
 # NSg+      VL V       NSg/V/J NSg/V/J+ N🅪Sg/V/J+ . V/C D   NSg   P  NPl/V+ NPl/V+  D/P
 > key     higher . Laughter is easier minute  by      minute   , spilled with prodigality ,
 # NPr/V/J NSg/JC . NSg+     VL NSg/JC NSg/V/J NSg/J/P NSg/V/J+ . V/J     P    NSg         .
-> tipped out         at    a   cheerful word   . The groups change  more         swiftly , swell    with new
-# V      NSg/V/J/R/P NSg/P D/P J        NSg/V+ . D+  NPl/V+ N🅪Sg/V+ NPr/I/V/J/Dq R       . NSg/V/J+ P    NSg/V/J
+> tipped out         at    a   cheerful word   . The groups change  more           swiftly , swell    with new
+# V      NSg/V/J/R/P NSg/P D/P J        NSg/V+ . D+  NPl/V+ N🅪Sg/V+ NPr/I/V/J/R/Dq R       . NSg/V/J+ P    NSg/V/J
 > arrivals , dissolve and form   in      the same breath    ; already there are wanderers ,
 # NPl      . NSg/V    V/C NSg/V+ NPr/J/P D   I/J  N🅪Sg/V/J+ . W?      +     V   W?        .
-> confident girls  who    weave here    and there among the stouter and more         stable  ,
-# NSg/J     NPl/V+ NPr/I+ NSg/V NSg/J/R V/C W?    P     D   NSg/JC  V/C NPr/I/V/J/Dq NSg/V/J .
+> confident girls  who    weave here    and there among the stouter and more           stable  ,
+# NSg/J     NPl/V+ NPr/I+ NSg/V NSg/J/R V/C W?    P     D   NSg/JC  V/C NPr/I/V/J/R/Dq NSg/V/J .
 > become for a   sharp   , joyous moment the centre     of a   group  , and then    , excited with
 # V      C/P D/P NPr/V/J . J      NSg+   D   NSg/V/Comm P  D/P NSg/V+ . V/C NSg/J/C . V/J     P
 > triumph , glide on  through the sea  - change of faces and voices and color        under   the
@@ -2616,8 +2616,8 @@
 # R       .
 >
 #
-> “ I    don’t think it’s so        much         that          , ” argued Lucille sceptically ; “ it’s more         that
-# . ISg+ V     NSg/V W?   NSg/I/J/C NSg/I/J/R/Dq NSg/I/C/Ddem+ . . V/J    NPr+    R/Au/Br     . . W?   NPr/I/V/J/Dq NSg/I/C/Ddem
+> “ I    don’t think it’s so        much         that          , ” argued Lucille sceptically ; “ it’s more           that
+# . ISg+ V     NSg/V W?   NSg/I/J/C NSg/I/J/R/Dq NSg/I/C/Ddem+ . . V/J    NPr+    R/Au/Br     . . W?   NPr/I/V/J/R/Dq NSg/I/C/Ddem
 > he       was a   German spy   during the war     . ”
 # NPr/ISg+ V   D/P NPr🅪/J NSg/V V/P    D   N🅪Sg/V+ . .
 >
@@ -2914,8 +2914,8 @@
 # . ISg+ NSg/V   ISgPl+ V    . NSg/J+ NSg/V+ . W?  J      W?  NSg/C D/P J/R  NPr/V/J NSg/V+ . .
 >
 #
-> He       smiled understandingly — much         more         than understandingly . It       was one       of those
-# NPr/ISg+ V/J    R               . NSg/I/J/R/Dq NPr/I/V/J/Dq C/P  R               . NPr/ISg+ V   NSg/I/V/J P  I/Ddem
+> He       smiled understandingly — much         more           than understandingly . It       was one       of those
+# NPr/ISg+ V/J    R               . NSg/I/J/R/Dq NPr/I/V/J/R/Dq C/P  R               . NPr/ISg+ V   NSg/I/V/J P  I/Ddem
 > rare    smiles with a   quality of eternal reassurance in      it       , that         you    may    come
 # NSg/V/J NPl/V  P    D/P NSg/J   P  NSg/J   N🅪Sg+       NPr/J/P NPr/ISg+ . NSg/I/C/Ddem ISgPl+ NPr/VX NSg/V/P
 > across four or    five times in      life    . It       faced — or    seemed to face  — the whole  eternal
@@ -3054,8 +3054,8 @@
 # ISg+ NSg/VX NSg/V NSg/I/J+ J        J/P   ISg+ . ISg+ V/J      NSg/C D+  NSg+ NSg/I/C/Ddem+ NPr/ISg+ V   NSg/C
 > drinking helped to set     him  off       from his     guests , for it       seemed to me       that         he       grew
 # V        V/J    P  NPr/V/J ISg+ NSg/V/J/P P    ISg/D$+ NPl/V+ . C/P NPr/ISg+ V/J    P  NPr/ISg+ NSg/I/C/Ddem NPr/ISg+ V
-> more         correct as    the fraternal hilarity increased . When    the “ Jazz  History of the
-# NPr/I/V/J/Dq NSg/V/J NSg/R D   NSg/J     NSg      V/J       . NSg/I/C D   . NSg/V N🅪Sg    P  D+
+> more           correct as    the fraternal hilarity increased . When    the “ Jazz  History of the
+# NPr/I/V/J/R/Dq NSg/V/J NSg/R D   NSg/J     NSg      V/J       . NSg/I/C D   . NSg/V N🅪Sg    P  D+
 > World  ” was over    , girls  were  putting their heads  on  men’s shoulders in      a
 # NSg/V+ . V   NSg/J/P . NPl/V+ NSg/V NSg/V   D$+   NPl/V+ J/P NSg$  NPl/V+    NPr/J/P D/P
 > puppyish , convivial way    , girls  were  swooning backward playfully into men’s arms   ,
@@ -3244,8 +3244,8 @@
 #
 > “ Don’t mention it       , ” he       enjoined me       eagerly . “ Don’t give  it       another thought , old
 # . V     NSg/V   NPr/ISg+ . . NPr/ISg+ V/J      NPr/ISg+ R       . . V     NSg/V NPr/ISg+ I/D     NSg/V+  . NSg/J
-> sport  . ” The familiar expression held no    more         familiarity than the hand   which
-# NSg/V+ . . D+  NSg/J+   N🅪Sg+      V    NPr/P NPr/I/V/J/Dq NSg+        C/P  D+  NSg/V+ I/C+
+> sport  . ” The familiar expression held no    more           familiarity than the hand   which
+# NSg/V+ . . D+  NSg/J+   N🅪Sg+      V    NPr/P NPr/I/V/J/R/Dq NSg+        C/P  D+  NSg/V+ I/C+
 > reassuringly brushed my  shoulder . “ And don’t forget we’re going   up        in      the
 # R            V/J     D$+ NSg/V+   . . V/C V     V      W?    NSg/V/J NSg/V/J/P NPr/J/P D
 > hydroplane to - morrow morning , at    nine o’clock . ”
@@ -3464,8 +3464,8 @@
 # D   NPl/V  P  NSg+  NPl/V+ J/Dq+   NPrPl+ J     NSg/V NSg/I/J/C/Dq NSg/I/C/Ddem+ V/J      NPr/ISg+ . J/P D+
 > contrary , they were  merely casual events in      a    crowded summer , and , until much
 # NSg/V/J+ . IPl+ NSg/V R      NSg/J  NPl/V  NPr/J/P D/P+ V/J+    NPr/V+ . V/C . C/P   NSg/I/J/R/Dq
-> later , they absorbed me       infinitely less    than my  personal affairs .
-# JC    . IPl+ V/J      NPr/ISg+ R          V/J/C/P C/P  D$+ NSg/J    NPl+    .
+> later , they absorbed me       infinitely less      than my  personal affairs .
+# JC    . IPl+ V/J      NPr/ISg+ R          V/J/R/C/P C/P  D$+ NSg/J    NPl+    .
 >
 #
 > Most         of the time      I    worked . In      the early    morning the sun    threw my  shadow   westward
@@ -3542,8 +3542,8 @@
 # C/P D/P+ NSg/V/C/P+ ISg+ V/J  N🅪Sg/V P  NPr+   NPr+  . V/C NSg/J/C NPr/J/P NSg/J     ISg+ NSg/V ISg/D$+
 > again . At    first   I    was flattered to go      places with her     , because she  was a   golf
 # P     . NSg/P NSg/V/J ISg+ V   V/J       P  NSg/V/J NPl/V+ P    ISg/D$+ . C/P     ISg+ V   D/P NSg/V
-> champion , and every one        knew her     name   . Then    it       was something  more         . I    wasn’t
-# NSg/V/J  . V/C Dq+   NSg/I/V/J+ V    ISg/D$+ NSg/V+ . NSg/J/C NPr/ISg+ V   NSg/I/V/J+ NPr/I/V/J/Dq . ISg+ V
+> champion , and every one        knew her     name   . Then    it       was something  more           . I    wasn’t
+# NSg/V/J  . V/C Dq+   NSg/I/V/J+ V    ISg/D$+ NSg/V+ . NSg/J/C NPr/ISg+ V   NSg/I/V/J+ NPr/I/V/J/R/Dq . ISg+ V
 > actually in      love   , but     I    felt     a   sort  of tender  curiosity . The bored haughty face
 # R        NPr/J/P NPr🅪/V . NSg/C/P ISg+ N🅪Sg/V/J D/P NSg/V P  NSg/V/J NSg+      . D   V/J   J       NSg/V+
 > that          she  turned to the world  concealed something  — most         affectations conceal
@@ -3596,8 +3596,8 @@
 # NSg/V+ .
 >
 #
-> “ You’re a    rotten driver , ” I    protested . “ Either you    ought    to be     more         careful , or
-# . W?     D/P+ J      NSg+   . . ISg+ V/J       . . I/C    ISgPl+ NSg/I/VX P  NSg/VX NPr/I/V/J/Dq J       . NPr/C
+> “ You’re a    rotten driver , ” I    protested . “ Either you    ought    to be     more           careful , or
+# . W?     D/P+ J      NSg+   . . ISg+ V/J       . . I/C    ISgPl+ NSg/I/VX P  NSg/VX NPr/I/V/J/R/Dq J       . NPr/C
 > you    oughtn’t to drive at    all          . ”
 # ISgPl+ VX       P  NSg/V NSg/P NSg/I/J/C/Dq . .
 >
@@ -3822,8 +3822,8 @@
 # NPr/ISg+ V   V         ISg+    J/P D   NSg/V     P  ISg/D$+ NSg+ P    NSg/I/C/Ddem+ NSg
 > of movement that          is so        peculiarly American — that          comes , I    suppose , with the
 # P  N🅪Sg+    NSg/I/C/Ddem+ VL NSg/I/J/C R          NPr/J    . NSg/I/C/Ddem+ NPl/V . ISg+ V       . P    D
-> absence of lifting work    in      youth and , even    more         , with the formless grace of our
-# NSg     P  V       N🅪Sg/V+ NPr/J/P NSg+  V/C . NSg/V/J NPr/I/V/J/Dq . P    D   J        NPr/V P  D$+
+> absence of lifting work    in      youth and , even    more           , with the formless grace of our
+# NSg     P  V       N🅪Sg/V+ NPr/J/P NSg+  V/C . NSg/V/J NPr/I/V/J/R/Dq . P    D   J        NPr/V P  D$+
 > nervous , sporadic games  . This    quality was continually breaking through his
 # J       . J        NPl/V+ . I/Ddem+ NSg/J+  V   R           V        NSg/J/P ISg/D$+
 > punctilious manner in      the shape  of restlessness . He       was never quite still   ; there
@@ -4076,8 +4076,8 @@
 # J/P   I/Ddem+ N🅪Sg/V+ . .
 >
 #
-> I    hadn’t the faintest idea what   “ this   matter  ” was , but     I    was more         annoyed than
-# ISg+ V      D   JS       NSg+ NSg/I+ . I/Ddem N🅪Sg/V+ . V   . NSg/C/P ISg+ V   NPr/I/V/J/Dq V/J     C/P
+> I    hadn’t the faintest idea what   “ this   matter  ” was , but     I    was more           annoyed than
+# ISg+ V      D   JS       NSg+ NSg/I+ . I/Ddem N🅪Sg/V+ . V   . NSg/C/P ISg+ V   NPr/I/V/J/R/Dq V/J     C/P
 > interested . I    hadn’t asked Jordan to tea    in      order  to discuss Mr   . Jay  Gatsby . I
 # V/J        . ISg+ V      V/J   NPr+   P  N🅪Sg/V NPr/J/P NSg/V+ P  NSg/V   NSg+ . NPr+ NPr    . ISg+
 > was sure the request would be     something  utterly fantastic , and for a    moment I
@@ -4144,8 +4144,8 @@
 #
 > A    dead     man      passed us       in      a   hearse heaped with blooms , followed by      two carriages
 # D/P+ NSg/V/J+ NPr/V/J+ V/J    NPr/IPl+ NPr/J/P D/P NSg/V  V/J    P    NPl/V  . V/J      NSg/J/P NSg NPl
-> with drawn blinds , and by      more         cheerful carriages for friends . The friends
-# P    V/J   NPl/V+ . V/C NSg/J/P NPr/I/V/J/Dq J        NPl       C/P NPl/V+  . D+  NPl/V+
+> with drawn blinds , and by      more           cheerful carriages for friends . The friends
+# P    V/J   NPl/V+ . V/C NSg/J/P NPr/I/V/J/R/Dq J        NPl       C/P NPl/V+  . D+  NPl/V+
 > looked out         at    us       with the tragic eyes   and short     upper lips  of southeastern
 # V/J    NSg/V/J/R/P NSg/P NPr/IPl+ P    D+  NSg/J+ NPl/V+ V/C NPr/V/J/P NSg/J NPl/V P  J+
 > Europe , and I    was glad    that         the sight  of Gatsby’s splendid car  was included in
@@ -4320,8 +4320,8 @@
 # . ISg+ NSg/V D$+  NSg/V  . . V/J  NSg+ . ?         . . ISg+ V   D/P NSg/V/J NPr/V/J+ . .
 >
 #
-> A    succulent hash   arrived , and Mr   . Wolfshiem , forgetting the more         sentimental
-# D/P+ NSg/J+    NSg/V+ V/J     . V/C NSg+ . ?         . NSg/V      D   NPr/I/V/J/Dq J
+> A    succulent hash   arrived , and Mr   . Wolfshiem , forgetting the more           sentimental
+# D/P+ NSg/J+    NSg/V+ V/J     . V/C NSg+ . ?         . NSg/V      D   NPr/I/V/J/R/Dq J
 > atmosphere of the old   Metropole , began to eat with ferocious delicacy . His     eyes   ,
 # N🅪Sg       P  D   NSg/J ?         . V     P  V   P    J         NSg+     . ISg/D$+ NPl/V+ .
 > meanwhile , roved very slowly all          around the room     — he       completed the arc      by      turning
@@ -4646,8 +4646,8 @@
 # N🅪Sg/V+ P  NSg/V/J P  NSg/V/J+ NPr+ V/C NSg/V NPr/V/J . NSg/J/P P  D/P+ NSg/V/J+ NPr/I+ V   NSg/V/J W?       . ISg+
 > was effectually prevented , but     she  wasn’t on  speaking terms  with her     family  for
 # V   R           V/J       . NSg/C/P ISg+ V      J/P V        NPl/V+ P    ISg/D$+ N🅪Sg/J+ C/P
-> several weeks  . After that         she  didn’t play  around with the soldiers any    more         , but
-# J/Dq+   NPrPl+ . P     NSg/I/C/Ddem ISg+ V      NSg/V J/P    P    D   NPl/V+   I/R/Dq NPr/I/V/J/Dq . NSg/C/P
+> several weeks  . After that         she  didn’t play  around with the soldiers any    more           , but
+# J/Dq+   NPrPl+ . P     NSg/I/C/Ddem ISg+ V      NSg/V J/P    P    D   NPl/V+   I/R/Dq NPr/I/V/J/R/Dq . NSg/C/P
 > only  with a   few      flat    - footed , shortsighted young   men  in      town , who    couldn’t get
 # J/R/C P    D/P NSg/I/Dq NSg/V/J . V/J    . J            NPr/V/J NSg+ NPr/J/P NSg+ . NPr/I+ V        NSg/V
 > into the army at    all          .
@@ -4658,8 +4658,8 @@
 # NSg/J/P D+  NSg/J/P+ NPr/V+ ISg+ V   NPr/V/J P     . NPr/V/J NSg/R J    . ISg+ V   D/P ?     P     D
 > armistice , and in      February she  was presumably engaged to a   man      from New     Orleans .
 # NPr🅪      . V/C NPr/J/P NPr+     ISg+ V   R          V/J     P  D/P NPr/V/J+ P    NSg/V/J NPr+    .
-> In      June she  married Tom    Buchanan of Chicago , with more         pomp  and circumstance
-# NPr/J/P NPr+ ISg+ NSg/V/J NPr/V+ NPr      P  NPr+    . P    NPr/I/V/J/Dq NSg/V V/C NSg/V
+> In      June she  married Tom    Buchanan of Chicago , with more           pomp  and circumstance
+# NPr/J/P NPr+ ISg+ NSg/V/J NPr/V+ NPr      P  NPr+    . P    NPr/I/V/J/R/Dq NSg/V V/C NSg/V
 > than Louisville ever knew before . He       came    down       with a   hundred people in      four
 # C/P  NPr        J    V    C/P    . NPr/ISg+ NSg/V/P N🅪Sg/V/J/P P    D/P NSg     NPl/V+ NPr/J/P NSg+
 > private  cars , and hired a   whole floor of the Muhlbach Hotel , and the day   before
@@ -4904,8 +4904,8 @@
 # NPr/ISg+ V   NSg/V/J NPr/V/J/C . V/C NSg/R IPl+ V/J    NSg/J/P D/P+ NPr/I/J/Dq+ N🅪Sg/V+ ISg+ NSg/V D$+ NSg/V/J+ J/P
 > Jordan’s golden   shoulder and drew  her     toward me       and asked her     to dinner .
 # NSg$     NPr/V/J+ NSg/V+   V/C NPr/V ISg/D$+ J/P    NPr/ISg+ V/C V/J   ISg/D$+ P  N🅪Sg/V .
-> Suddenly I    wasn’t thinking of Daisy and Gatsby any    more         , but     of this   clean   ,
-# R        ISg+ V      V        P  NPr+  V/C NPr    I/R/Dq NPr/I/V/J/Dq . NSg/C/P P  I/Ddem NSg/V/J .
+> Suddenly I    wasn’t thinking of Daisy and Gatsby any    more           , but     of this   clean   ,
+# R        ISg+ V      V        P  NPr+  V/C NPr    I/R/Dq NPr/I/V/J/R/Dq . NSg/C/P P  I/Ddem NSg/V/J .
 > hard   , limited person , who    dealt in      universal scepticism , and who    leaned back
 # N🅪Sg/J . NSg/V/J NSg/V+ . NPr/I+ V     NPr/J/P NSg/J     Nᴹ/Au/Br   . V/C NPr/I+ V/J    NSg/V/J
 > jauntily just within  the circle of my  arm      . A    phrase began to beat     in      my  ears
@@ -5066,8 +5066,8 @@
 # . NSg/C J/R  NSg/I/J/R/Dq . .
 >
 #
-> This   seemed to reassure him  and he       continued more         confidently .
-# I/Ddem V/J    P  V        ISg+ V/C NPr/ISg+ V/J       NPr/I/V/J/Dq R           .
+> This   seemed to reassure him  and he       continued more           confidently .
+# I/Ddem V/J    P  V        ISg+ V/C NPr/ISg+ V/J       NPr/I/V/J/R/Dq R           .
 >
 #
 > “ I    thought you    didn’t , if    you'll pardon my  — you    see   , I    carry on  a   little     business
@@ -5102,8 +5102,8 @@
 #
 > “ I’ve got my  hands  full    , ” I    said . “ I’m much         obliged but     I    couldn’t take  on  any
 # . W?   V   D$+ NPl/V+ NSg/V/J . . ISg+ V/J  . . W?  NSg/I/J/R/Dq V/J     NSg/C/P ISg+ V        NSg/V J/P I/R/Dq
-> more         work    . ”
-# NPr/I/V/J/Dq N🅪Sg/V+ . .
+> more           work    . ”
+# NPr/I/V/J/R/Dq N🅪Sg/V+ . .
 >
 #
 > “ You    wouldn’t have   to do     any    business with Wolfshiem . ” Evidently he       thought that
@@ -5474,8 +5474,8 @@
 # ISg+ V/J    NSg/V/J/R/P D+  NSg/V/J+ NSg/J+ . V/J  NSg/R NPr    V   NSg/I/C NPr/ISg+ V   V    ISg/D$+ J
 > circuit of the house  half        an  hour before — and ran   for a   huge black    knotted tree   ,
 # NSg/V   P  D   NPr/V+ N🅪Sg/V/J/P+ D/P NSg+ C/P    . V/C NSg/V C/P D/P J    N🅪Sg/V/J V/J     NSg/V+ .
-> whose massed leaves made a   fabric  against the rain    . Once  more         it       was pouring ,
-# I+    V/J    NPl/V+ V    D/P N🅪Sg/V+ C/P     D   N🅪Sg/V+ . NSg/C NPr/I/V/J/Dq NPr/ISg+ V   V       .
+> whose massed leaves made a   fabric  against the rain    . Once  more           it       was pouring ,
+# I+    V/J    NPl/V+ V    D/P N🅪Sg/V+ C/P     D   N🅪Sg/V+ . NSg/C NPr/I/V/J/R/Dq NPr/ISg+ V   V       .
 > and my  irregular lawn   , well    - shaved by      Gatsby’s gardener , abounded in      small   muddy
 # V/C D$+ NSg/J     NSg/V+ . NSg/V/J . V/J    NSg/J/P NSg$     NSg/JC   . V/J      NPr/J/P NPr/V/J NSg/V/J
 > swamps and prehistoric marshes . There was nothing  to look  at    from under   the tree
@@ -5618,8 +5618,8 @@
 # . NPr/V . W?   NSg/V NPr/J/P J/Dq    NPl/V+ . . NPr/ISg+ V/J       ISg+    . . ISg+ V   NPr/J/P D+  NSg/V+
 > business and then    I    was in      the oil     business . But     I’m not   in      either one       now       . ” He
 # N🅪Sg/J+  V/C NSg/J/C ISg+ V   NPr/J/P D+  N🅪Sg/V+ N🅪Sg/J+  . NSg/C/P W?  NSg/C NPr/J/P I/C    NSg/I/V/J NPr/V/J/C . . NPr/ISg+
-> looked at    me       with more          attention . “ Do     you    mean    you’ve been  thinking over    what   I
-# V/J    NSg/P NPr/ISg+ P    NPr/I/V/J/Dq+ NSg+      . . NSg/VX ISgPl+ NSg/V/J W?     NSg/V V        NSg/J/P NSg/I+ ISg+
+> looked at    me       with more            attention . “ Do     you    mean    you’ve been  thinking over    what   I
+# V/J    NSg/P NPr/ISg+ P    NPr/I/V/J/R/Dq+ NSg+      . . NSg/VX ISgPl+ NSg/V/J W?     NSg/V V        NSg/J/P NSg/I+ ISg+
 > proposed the other   night   ? ”
 # V/J      D   NSg/V/J N🅪Sg/V+ . .
 >
@@ -5752,8 +5752,8 @@
 # NPl/V  P  NSg/V/J NSg/J V/C NSg/V/J N🅪Sg/V V/C NSg/V/J+ NSg/V/J+ . I/C+  V/J  D$+   NPl/V+ NSg/R
 > they fell    and covered the table  in      many       colored    disarray . While     we   admired he
 # IPl+ NSg/V/J V/C V/J     D+  NSg/V+ NPr/J/P NSg/I/J/Dq NSg/V/J/Am NSg/V    . NSg/V/C/P IPl+ V/J     NPr/ISg+
-> brought more         and the soft  rich     heap   mounted higher — shirts with stripes and
-# V       NPr/I/V/J/Dq V/C D   NSg/J NPr/V/J+ NSg/V+ V/J     NSg/JC . NPl/V  P    NPl/V+  V/C
+> brought more           and the soft  rich     heap   mounted higher — shirts with stripes and
+# V       NPr/I/V/J/R/Dq V/C D   NSg/J NPr/V/J+ NSg/V+ V/J     NSg/JC . NPl/V  P    NPl/V+  V/C
 > scrolls and plaids in      coral  and applegreen and lavender and faint   orange   , with
 # NPl/V   V/C NPl/V  NPr/J/P N🅪Sg/J V/C ?          V/C Nᴹ/V/J   V/C NSg/V/J NPr🅪/V/J . P
 > monograms of Indian blue     . Suddenly , with a   strained sound     , Daisy bent    her     head
@@ -5872,8 +5872,8 @@
 #
 > I    tried to go      then    , but     they wouldn’t hear of it       ; perhaps my  presence made them
 # ISg+ V/J   P  NSg/V/J NSg/J/C . NSg/C/P IPl+ VX       V    P  NPr/ISg+ . NSg/R   D$+ NSg/V+   V    NSg/IPl+
-> feel    more         satisfactorily alone .
-# NSg/I/V NPr/I/V/J/Dq R              J     .
+> feel    more           satisfactorily alone .
+# NSg/I/V NPr/I/V/J/R/Dq R              J     .
 >
 #
 > “ I    know  what   we'll do     , ” said Gatsby , “ we'll have   Klipspringer play  the piano    . ”
@@ -5994,8 +5994,8 @@
 #
 > They had forgotten me       , but     Daisy glanced up        and held out         her     hand   ; Gatsby didn’t
 # IPl+ V   NSg/V/J   NPr/ISg+ . NSg/C/P NPr+  V/J     NSg/V/J/P V/C V    NSg/V/J/R/P ISg/D$+ NSg/V+ . NPr    V
-> know  me       now       at    all          . I    looked once  more         at    them     and they looked back    at    me       ,
-# NSg/V NPr/ISg+ NPr/V/J/C NSg/P NSg/I/J/C/Dq . ISg+ V/J    NSg/C NPr/I/V/J/Dq NSg/P NSg/IPl+ V/C IPl+ V/J    NSg/V/J NSg/P NPr/ISg+ .
+> know  me       now       at    all          . I    looked once  more           at    them     and they looked back    at    me       ,
+# NSg/V NPr/ISg+ NPr/V/J/C NSg/P NSg/I/J/C/Dq . ISg+ V/J    NSg/C NPr/I/V/J/R/Dq NSg/P NSg/IPl+ V/C IPl+ V/J    NSg/V/J NSg/P NPr/ISg+ .
 > remotely , possessed by      intense life    . Then    I    went  out         of the room     and down       the
 # R        . V/J       NSg/J/P J+      N🅪Sg/V+ . NSg/J/C ISg+ NSg/V NSg/V/J/R/P P  D+  NSg/V/J+ V/C N🅪Sg/V/J/P D+
 > marble   steps  into the rain    , leaving them     there together .
@@ -6178,8 +6178,8 @@
 # NPr/J/P NSg/V NSg/V+  . NSg/V . NSg/V+  . NPr/V+    . V/C NSg/V/J ?      . C/P NPr+ NPr  V/J
 > knew what   lavish  doings Dan  Cody drunk   might   soon be     about , and he       provided for
 # V    NSg/I+ NSg/V/J NPl/V  NPr+ NPr  NSg/V/J Nᴹ/VX/J J/R  NSg/VX J/P   . V/C NPr/ISg+ V/J/C    C/P
-> such  contingencies by      reposing more         and more         trust    in      Gatsby . The arrangement
-# NSg/I NPl+          NSg/J/P V        NPr/I/V/J/Dq V/C NPr/I/V/J/Dq N🅪Sg/V/J NPr/J/P NPr    . D+  NSg+
+> such  contingencies by      reposing more           and more           trust    in      Gatsby . The arrangement
+# NSg/I NPl+          NSg/J/P V        NPr/I/V/J/R/Dq V/C NPr/I/V/J/R/Dq N🅪Sg/V/J NPr/J/P NPr    . D+  NSg+
 > lasted five years , during which the boat   went  three times  around the Continent .
 # V/J    NSg+ NPl+  . V/P    I/C+  D+  NSg/V+ NSg/V NSg   NPl/V+ J/P    D+  NPr/J+    .
 > It       might   have   lasted indefinitely except for the fact that          Ella Kaye came    on
@@ -6364,8 +6364,8 @@
 #
 > “ Please don’t hurry  , ” Gatsby urged them     . He       had control of himself now       , and he
 # . V      V     NSg/V+ . . NPr    V/J   NSg/IPl+ . NPr/ISg+ V   N🅪Sg/V  P  ISg+    NPr/V/J/C . V/C NPr/ISg+
-> wanted to see   more         of Tom    . “ Why   don’t you    — why   don’t you    stay    for supper ? I
-# V/J    P  NSg/V NPr/I/V/J/Dq P  NPr/V+ . . NSg/V V     ISgPl+ . NSg/V V     ISgPl+ NSg/V/J C/P NSg/V+ . ISg+
+> wanted to see   more           of Tom    . “ Why   don’t you    — why   don’t you    stay    for supper ? I
+# V/J    P  NSg/V NPr/I/V/J/R/Dq P  NPr/V+ . . NSg/V V     ISgPl+ . NSg/V V     ISgPl+ NSg/V/J C/P NSg/V+ . ISg+
 > wouldn’t be     surprised if    some     other   people dropped in      from New     York . ”
 # VX       NSg/VX V/J       NSg/C I/J/R/Dq NSg/V/J NPl/V+ V/J     NPr/J/P P    NSg/V/J NPr+ . .
 >
@@ -6750,8 +6750,8 @@
 # D/P+ NSg/V+ V       D   NPr🅪/V/J/Am N🅪Sg/V P  NSg$    N🅪Sg/V/C/P+ NSg/V+ .
 >
 #
-> “ At    least they are more         interesting than the people we   know  , ” she  said with an
-# . NSg/P NSg/J IPl+ V   NPr/I/V/J/Dq V/J         C/P  D+  NPl/V+ IPl+ NSg/V . . ISg+ V/J  P    D/P+
+> “ At    least they are more           interesting than the people we   know  , ” she  said with an
+# . NSg/P NSg/J IPl+ V   NPr/I/V/J/R/Dq V/J         C/P  D+  NPl/V+ IPl+ NSg/V . . ISg+ V/J  P    D/P+
 > effort .
 # NSg/V+ .
 >
@@ -6876,12 +6876,12 @@
 # NPl/V+  . . NSg/J+ NSg/V+ . D+  NSg/V+ VL J           . .
 >
 #
-> He       wanted nothing  less    of Daisy than that         she  should go      to Tom    and say   : “ I    never
-# NPr/ISg+ V/J    NSg/I/J+ V/J/C/P P  NPr+  C/P  NSg/I/C/Ddem ISg+ VX     NSg/V/J P  NPr/V+ V/C NSg/V . . ISg+ R
+> He       wanted nothing  less      of Daisy than that         she  should go      to Tom    and say   : “ I    never
+# NPr/ISg+ V/J    NSg/I/J+ V/J/R/C/P P  NPr+  C/P  NSg/I/C/Ddem ISg+ VX     NSg/V/J P  NPr/V+ V/C NSg/V . . ISg+ R
 > loved you    . ” After she  had obliterated four years with that         sentence they could
 # V/J   ISgPl+ . . P     ISg+ V   V/J         NSg  NPl   P    NSg/I/C/Ddem NSg/V+   IPl+ NSg/VX
-> decide upon the more         practical measures to be     taken . One       of them     was that          , after
-# V      P    D   NPr/I/V/J/Dq NSg/J     NPl/V    P  NSg/VX V/J   . NSg/I/V/J P  NSg/IPl+ V   NSg/I/C/Ddem+ . P
+> decide upon the more           practical measures to be     taken . One       of them     was that          , after
+# V      P    D   NPr/I/V/J/R/Dq NSg/J     NPl/V    P  NSg/VX V/J   . NSg/I/V/J P  NSg/IPl+ V   NSg/I/C/Ddem+ . P
 > she  was free    , they were  to go      back    to Louisville and be     married from her
 # ISg+ V   NSg/V/J . IPl+ NSg/V P  NSg/V/J NSg/V/J P  NPr        V/C NSg/VX NSg/V/J P    ISg/D$+
 > house  — just as    if    it       were  five years ago .
@@ -6974,8 +6974,8 @@
 # P  NSg/I/V/J+ . D/P J       N🅪Sg/V+ . D/P NSg/V    P  V/J  NPl/V+ . NSg/I/C/Ddem ISg+ V   V/J
 > somewhere a   long    time      ago . For a    moment a    phrase tried to take  shape  in      my  mouth
 # NSg       D/P NPr/V/J N🅪Sg/V/J+ J/P . C/P D/P+ NSg+   D/P+ NSg/V+ V/J   P  NSg/V NSg/V+ NPr/J/P D$+ NSg/V+
-> and my  lips   parted like        a   dumb man’s      , as    though there was more         struggling upon
-# V/C D$+ NPl/V+ V/J    NSg/V/J/C/P D/P V/J  NPr$/I/V/J . NSg/R V/C    +     V   NPr/I/V/J/Dq V          P
+> and my  lips   parted like        a   dumb man’s      , as    though there was more           struggling upon
+# V/C D$+ NPl/V+ V/J    NSg/V/J/C/P D/P V/J  NPr$/I/V/J . NSg/R V/C    +     V   NPr/I/V/J/R/Dq V          P
 > them     than a   wisp  of startled air     . But     they made no     sound     , and what   I    had almost
 # NSg/IPl+ C/P  D/P NSg/V P  V/J      N🅪Sg/V+ . NSg/C/P IPl+ V    NPr/P+ N🅪Sg/V/J+ . V/C NSg/I+ ISg+ V   R
 > remembered was uncommunicable forever .
@@ -7872,8 +7872,8 @@
 # V   V/J        NSg/I/C/Ddem NPr    V   I/J/R/Dq NSg/V P  N🅪Sg/V+ J     P    ISg+ NPr/J/P I/D
 > world  , and the shock    had made him  physically sick    . I    stared at    him  and then    at
 # NSg/V+ . V/C D   NSg/V/J+ V   V    ISg+ R          NSg/V/J . ISg+ V/J    NSg/P ISg+ V/C NSg/J/C NSg/P
-> Tom    , who    had made a   parallel discovery less    than an   hour before — and it       occurred
-# NPr/V+ . NPr/I+ V   V    D/P NSg/V/J+ N🅪Sg+     V/J/C/P C/P  D/P+ NSg+ C/P    . V/C NPr/ISg+ V
+> Tom    , who    had made a   parallel discovery less      than an   hour before — and it       occurred
+# NPr/V+ . NPr/I+ V   V    D/P NSg/V/J+ N🅪Sg+     V/J/R/C/P C/P  D/P+ NSg+ C/P    . V/C NPr/ISg+ V
 > to me       that         there was no    difference between men  , in      intelligence or    race    , so
 # P  NPr/ISg+ NSg/I/C/Ddem +     V   NPr/P N🅪Sg/V     NSg/P   NSg+ . NPr/J/P N🅪Sg         NPr/C N🅪Sg/V+ . NSg/I/J/C
 > profound as    the difference between the sick    and the well    . Wilson was so        sick
@@ -7896,8 +7896,8 @@
 # NSg/J/P . NSg/J/P D   ?        D   NSg/J NPl/V P  NSg/V+ ?  ?  ?         V    D$+
 > vigil , but     I    perceived , after a   moment , that         other   eyes   were  regarding us       with
 # NSg/V . NSg/C/P ISg+ V/J       . P     D/P NSg+   . NSg/I/C/Ddem NSg/V/J NPl/V+ NSg/V V         NPr/IPl+ P
-> peculiar intensity from less    than twenty feet away .
-# NSg/J    NSg+      P    V/J/C/P C/P  NSg    NPl+ V/J  .
+> peculiar intensity from less      than twenty feet away .
+# NSg/J    NSg+      P    V/J/R/C/P C/P  NSg    NPl+ V/J  .
 >
 #
 > In      one       of the windows  over    the garage the curtains had been  moved aside a
@@ -7984,8 +7984,8 @@
 # J      IPl+ VX    NSg/V N🅪Sg/V/J/P D/P+ NSg/V/J+ NSg/V/J+ V/C NSg/V/J/R/P P  ISg/D$+ N🅪Sg/V+ NSg/J   .
 >
 #
-> But     they didn’t . And we   all          took the less    explicable step  of engaging the parlor
-# NSg/C/P IPl+ V      . V/C IPl+ NSg/I/J/C/Dq V    D   V/J/C/P J          NSg/V P  V        D   NSg
+> But     they didn’t . And we   all          took the less      explicable step  of engaging the parlor
+# NSg/C/P IPl+ V      . V/C IPl+ NSg/I/J/C/Dq V    D   V/J/R/C/P J          NSg/V P  V        D   NSg
 > of a   suite in      the Plaza Hotel .
 # P  D/P NSg+  NPr/J/P D   NSg+  NSg+  .
 >
@@ -8000,8 +8000,8 @@
 # P  N🅪Sg/V+ V/J   NSg/V/J NSg/P  D$+ NSg/V/J . D+  NSg+   V/J        P    NSg$
 > suggestion that          we   hire  five bathrooms and take  cold  baths  , and then    assumed
 # N🅪Sg+      NSg/I/C/Ddem+ IPl+ NSg/V NSg  NPl/V+    V/C NSg/V NSg/J NSg/V+ . V/C NSg/J/C V/J
-> more         tangible form   as    “ a   place   to have   a   mint    julep . ” Each of us       said over    and
-# NPr/I/V/J/Dq NSg/J    NSg/V+ NSg/R . D/P N🅪Sg/V+ P  NSg/VX D/P NSg/V/J NSg   . . Dq   P  NPr/IPl+ V/J  NSg/J/P V/C
+> more           tangible form   as    “ a   place   to have   a   mint    julep . ” Each of us       said over    and
+# NPr/I/V/J/R/Dq NSg/J    NSg/V+ NSg/R . D/P N🅪Sg/V+ P  NSg/VX D/P NSg/V/J NSg   . . Dq   P  NPr/IPl+ V/J  NSg/J/P V/C
 > over    that         it       was a   “ crazy idea ” — we   all           talked at    once  to a   baffled clerk  and
 # NSg/J/P NSg/I/C/Ddem NPr/ISg+ V   D/P . NSg/J NSg  . . IPl+ NSg/I/J/C/Dq+ V/J+   NSg/P NSg/C P  D/P V/J     NSg/V+ V/C
 > thought , or    pretended to think , that         we   were  being    very funny . . .
@@ -8024,8 +8024,8 @@
 # . NSg/V/J I/D+    NSg/V+ . . V/J       NPr+  . C/P     NSg/V   J/P    .
 >
 #
-> “ There aren’t any    more         . ”
-# . +     V      I/R/Dq NPr/I/V/J/Dq . .
+> “ There aren’t any    more           . ”
+# . +     V      I/R/Dq NPr/I/V/J/R/Dq . .
 >
 #
 > “ Well    , we’d better    telephone for an  axe       — — — ”
@@ -8268,8 +8268,8 @@
 # V     V    NSg/I/J/C NSg/J  P  ISg+     . . . . NSg/V NSg/P D   NSg/V/J . .
 >
 #
-> “ Wait  a    minute   , ” snapped Tom    , “ I    want  to ask   Mr   . Gatsby one        more         question . ”
-# . NSg/V D/P+ NSg/V/J+ . . V       NPr/V+ . . ISg+ NSg/V P  NSg/V NSg+ . NPr    NSg/I/V/J+ NPr/I/V/J/Dq NSg/V+   . .
+> “ Wait  a    minute   , ” snapped Tom    , “ I    want  to ask   Mr   . Gatsby one        more           question . ”
+# . NSg/V D/P+ NSg/V/J+ . . V       NPr/V+ . . ISg+ NSg/V P  NSg/V NSg+ . NPr    NSg/I/V/J+ NPr/I/V/J/R/Dq NSg/V+   . .
 >
 #
 > “ Go      on  , ” Gatsby said politely .
@@ -8428,8 +8428,8 @@
 #
 > “ She  does  , though . The trouble is that          sometimes she  gets  foolish ideas in      her
 # . ISg+ NPl/V . V/C    . D+  NSg/V+  VL NSg/I/C/Ddem+ R         ISg+ NPl/V J       NPl+  NPr/J/P ISg/D$+
-> head     and doesn’t know  what   she’s doing . ” He       nodded sagely . “ And what’s more         , I
-# NPr/V/J+ V/C V       NSg/V NSg/I+ W?    NSg/V . . NPr/ISg+ V      R      . . V/C NSg$   NPr/I/V/J/Dq . ISg+
+> head     and doesn’t know  what   she’s doing . ” He       nodded sagely . “ And what’s more           , I
+# NPr/V/J+ V/C V       NSg/V NSg/I+ W?    NSg/V . . NPr/ISg+ V      R      . . V/C NSg$   NPr/I/V/J/R/Dq . ISg+
 > love   Daisy too . Once  in      a    while      I    go      off       on  a    spree  and make  a   fool    of myself ,
 # NPr🅪/V NPr+  W?  . NSg/C NPr/J/P D/P+ NSg/V/C/P+ ISg+ NSg/V/J NSg/V/J/P J/P D/P+ NSg/V+ V/C NSg/V D/P NSg/V/J P  ISg+   .
 > but     I    always come    back    , and in      my  heart   I    love   her     all           the time      . ”
@@ -8450,8 +8450,8 @@
 # NPr    V/J    NSg/J/P V/C V     P      ISg/D$+ .
 >
 #
-> “ Daisy , that’s all          over    now       , ” he       said earnestly . “ It       doesn’t matter  any    more         .
-# . NPr+  . NSg$   NSg/I/J/C/Dq NSg/J/P NPr/V/J/C . . NPr/ISg+ V/J  R         . . NPr/ISg+ V       N🅪Sg/V+ I/R/Dq NPr/I/V/J/Dq .
+> “ Daisy , that’s all          over    now       , ” he       said earnestly . “ It       doesn’t matter  any    more           .
+# . NPr+  . NSg$   NSg/I/J/C/Dq NSg/J/P NPr/V/J/C . . NPr/ISg+ V/J  R         . . NPr/ISg+ V       N🅪Sg/V+ I/R/Dq NPr/I/V/J/R/Dq .
 > Just tell  him  the truth   — that         you    never loved him  — and it’s all           wiped out
 # V/J  NPr/V ISg+ D+  N🅪Sg/V+ . NSg/I/C/Ddem ISgPl+ R     V/J   ISg+ . V/C W?   NSg/I/J/C/Dq+ V/J+  NSg/V/J/R/P
 > forever . ”
@@ -8564,8 +8564,8 @@
 #
 > “ You    don’t understand , ” said Gatsby , with a   touch  of panic    . “ You’re not   going   to
 # . ISgPl+ V     V          . . V/J  NPr    . P    D/P N🅪Sg/V P  NSg/V/J+ . . W?     NSg/C NSg/V/J P
-> take  care   of her     any    more         . ”
-# NSg/V N🅪Sg/V P  ISg/D$+ I/R/Dq NPr/I/V/J/Dq . .
+> take  care   of her     any    more           . ”
+# NSg/V N🅪Sg/V P  ISg/D$+ I/R/Dq NPr/I/V/J/R/Dq . .
 >
 #
 > “ I’m not   ? ” Tom    opened his     eyes   wide  and laughed . He       could  afford to control
@@ -8686,8 +8686,8 @@
 # D+  NSg/V+ V      P     P  NSg/V/J .
 >
 #
-> “ Please , Tom    ! I    can’t stand this   any    more         . ”
-# . V      . NPr/V+ . ISg+ VX    NSg/V I/Ddem I/R/Dq NPr/I/V/J/Dq . .
+> “ Please , Tom    ! I    can’t stand this   any    more           . ”
+# . V      . NPr/V+ . ISg+ VX    NSg/V I/Ddem I/R/Dq NPr/I/V/J/R/Dq . .
 >
 #
 > Her     frightened eyes   told that         whatever intentions , whatever courage she  had had ,
@@ -9226,8 +9226,8 @@
 #
 > I    was feeling a   little     sick    and I    wanted to be     alone . But     Jordan lingered for a
 # ISg+ V   NSg/V/J D/P NPr/I/J/Dq NSg/V/J V/C ISg+ V/J    P  NSg/VX J     . NSg/C/P NPr+   V/J      C/P D/P
-> moment more         .
-# NSg+   NPr/I/V/J/Dq .
+> moment more           .
+# NSg+   NPr/I/V/J/R/Dq .
 >
 #
 > “ It’s only  half        - past      nine , ” she  said .
@@ -9558,8 +9558,8 @@
 # P  J+         NSg+      . V   NSg/I/C/Ddem+ NPr+  V/J   W?    . NPr/ISg+ V   NSg/R NSg/J  D/P NSg/V P
 > her     as    his     tent   out         at    camp     was to him  . There was a   ripe    mystery about it       , a
 # ISg/D$+ NSg/R ISg/D$+ NSg/V+ NSg/V/J/R/P NSg/P NSg/V/J+ V   P  ISg+ . +     V   D/P NSg/V/J NSg     J/P   NPr/ISg+ . D/P
-> hint  of bedrooms up        - stairs more         beautiful and cool    than other    bedrooms , of gay
-# NSg/V P  NPl+     NSg/V/J/P . NPl+   NPr/I/V/J/Dq NSg/J     V/C NSg/V/J C/P  NSg/V/J+ NPl+     . P  NPr/V/J
+> hint  of bedrooms up        - stairs more           beautiful and cool    than other    bedrooms , of gay
+# NSg/V P  NPl+     NSg/V/J/P . NPl+   NPr/I/V/J/R/Dq NSg/J     V/C NSg/V/J C/P  NSg/V/J+ NPl+     . P  NPr/V/J
 > and radiant activities taking  place   through its     corridors , and of romances that
 # V/C NSg/J+  NPl+       NSg/V/J N🅪Sg/V+ NSg/J/P ISg/D$+ NPl+      . V/C P  NPl/V    NSg/I/C/Ddem+
 > were  not   musty   and laid away already in      lavender but     fresh   and breathing and
@@ -9626,8 +9626,8 @@
 # D   NSg/JC P  D   NSg    V/J      R           NSg/R ISg+ V/J    J/P    ISg+ V/C NPr/ISg+
 > kissed her     curious and lovely mouth  . She  had caught a   cold  , and it       made her
 # V/J    ISg/D$+ J       V/C NSg/J  NSg/V+ . ISg+ V   V/J    D/P NSg/J . V/C NPr/ISg+ V    ISg/D$+
-> voice  huskier and more         charming than ever , and Gatsby was overwhelmingly aware
-# NSg/V+ JC      V/C NPr/I/V/J/Dq NSg/V/J  C/P  J    . V/C NPr    V   R              V/J
+> voice  huskier and more           charming than ever , and Gatsby was overwhelmingly aware
+# NSg/V+ JC      V/C NPr/I/V/J/R/Dq NSg/V/J  C/P  J    . V/C NPr    V   R              V/J
 > of the youth and mystery that          wealth imprisons and preserves , of the freshness
 # P  D   NSg   V/C NSg+    NSg/I/C/Ddem+ NSg+   V         V/C NPl/V     . P  D   NSg
 > of many       clothes , and of Daisy , gleaming like        silver  , safe    and proud above   the
@@ -9663,7 +9663,7 @@
 > as    if    to give  them     a   deep  memory for the long    parting the next    day   promised .
 # NSg/R NSg/C P  NSg/V NSg/IPl+ D/P NSg/J N🅪Sg+  C/P D   NPr/V/J N🅪Sg/V  D+  NSg/J/P NPr🅪+ V/J      .
 > They had never been  closer in      their month of love    , nor   communicated more
-# IPl+ V   R     NSg/V NSg/JC NPr/J/P D$+   NSg/J P  NPr🅪/V+ . NSg/C V/J          NPr/I/V/J/Dq
+# IPl+ V   R     NSg/V NSg/JC NPr/J/P D$+   NSg/J P  NPr🅪/V+ . NSg/C V/J          NPr/I/V/J/R/Dq
 > profoundly one       with another , than when    she  brushed silent lips   against his
 # R          NSg/I/V/J P    I/D     . C/P  NSg/I/C ISg+ V/J     NSg/J  NPl/V+ C/P     ISg/D$+
 > coat’s shoulder or    when    he       touched the end   of her     fingers , gently , as    though she
@@ -9764,8 +9764,8 @@
 #
 > “ Of course she  might   have   loved him  just for a    minute   , when    they were  first
 # . P  NSg/V+ ISg+ Nᴹ/VX/J NSg/VX V/J   ISg+ V/J  C/P D/P+ NSg/V/J+ . NSg/I/C IPl+ NSg/V NSg/V/J+
-> married — and loved me       more         even    then    , do     you    see   ? ”
-# NSg/V/J . V/C V/J   NPr/ISg+ NPr/I/V/J/Dq NSg/V/J NSg/J/C . NSg/VX ISgPl+ NSg/V . .
+> married — and loved me       more           even    then    , do     you    see   ? ”
+# NSg/V/J . V/C V/J   NPr/ISg+ NPr/I/V/J/R/Dq NSg/V/J NSg/J/C . NSg/VX ISgPl+ NSg/V . .
 >
 #
 > Suddenly he       came    out         with a    curious remark .
@@ -9792,8 +9792,8 @@
 # V/J     J        NSg/J/P D+  NPr+     N🅪Sg/V+ V/C V          D   NSg/V/J/R/P . P  . D   . NSg/J+
 > places to which they had driven in      her     white    car  . Just as    Daisy’s house  had
 # NPl/V+ P  I/C+  IPl+ V   V/J    NPr/J/P ISg/D$+ NPr🅪/V/J NSg+ . V/J  NSg/R NSg$    NPr/V+ V
-> always seemed to him  more         mysterious and gay     than other   houses , so        his     idea of
-# R      V/J    P  ISg+ NPr/I/V/J/Dq J          V/C NPr/V/J C/P  NSg/V/J NPl/V+ . NSg/I/J/C ISg/D$+ NSg  P
+> always seemed to him  more           mysterious and gay     than other   houses , so        his     idea of
+# R      V/J    P  ISg+ NPr/I/V/J/R/Dq J          V/C NPr/V/J C/P  NSg/V/J NPl/V+ . NSg/I/J/C ISg/D$+ NSg  P
 > the city itself , even    though she  was gone  from it       , was pervaded with a
 # D   NSg+ ISg+   . NSg/V/J V/C    ISg+ V   V/J/P P    NPr/ISg+ . V   V/J      P    D/P
 > melancholy beauty    .
@@ -9860,8 +9860,8 @@
 #
 > I    didn’t want  to go      to the city . I    wasn’t worth   a   decent stroke of work    , but     it
 # ISg+ V      NSg/V P  NSg/V/J P  D   NSg+ . ISg+ V      NSg/V/J D/P J      NSg/V  P  N🅪Sg/V+ . NSg/C/P NPr/ISg+
-> was more         than that          — I    didn’t want  to leave Gatsby . I    missed that          train  , and then
-# V   NPr/I/V/J/Dq C/P  NSg/I/C/Ddem+ . ISg+ V      NSg/V P  NSg/V NPr    . ISg+ V/J    NSg/I/C/Ddem+ NSg/V+ . V/C NSg/J/C
+> was more           than that          — I    didn’t want  to leave Gatsby . I    missed that          train  , and then
+# V   NPr/I/V/J/R/Dq C/P  NSg/I/C/Ddem+ . ISg+ V      NSg/V P  NSg/V NPr    . ISg+ V/J    NSg/I/C/Ddem+ NSg/V+ . V/C NSg/J/C
 > another , before I    could  get   myself away .
 # I/D     . C/P    ISg+ NSg/VX NSg/V ISg+   V/J  .
 >
@@ -10032,10 +10032,10 @@
 # P  D   NSg/V/J NSg/V/J P  D   NSg+ . ISg+ V/J      W?      NSg/VX D/P J       NSg/V+ J/P    +
 > all          day   with little     boys   searching for dark    spots  in      the dust  , and some
 # NSg/I/J/C/Dq NPr🅪+ P    NPr/I/J/Dq NPl/V+ Nᴹ/V/J    C/P NSg/V/J NPl/V+ NPr/J/P D   Nᴹ/V+ . V/C I/J/R/Dq
-> garrulous man      telling over    and over    what   had happened , until it       became less    and
-# J         NPr/V/J+ NSg/V/J NSg/J/P V/C NSg/J/P NSg/I+ V   V/J      . C/P   NPr/ISg+ V      V/J/C/P V/C
-> less    real  even    to him  and he       could  tell  it       no    longer , and Myrtle Wilson’s tragic
-# V/J/C/P NSg/J NSg/V/J P  ISg+ V/C NPr/ISg+ NSg/VX NPr/V NPr/ISg+ NPr/P NSg/JC . V/C NPr    NSg$     NSg/J
+> garrulous man      telling over    and over    what   had happened , until it       became less      and
+# J         NPr/V/J+ NSg/V/J NSg/J/P V/C NSg/J/P NSg/I+ V   V/J      . C/P   NPr/ISg+ V      V/J/R/C/P V/C
+> less      real  even    to him  and he       could  tell  it       no    longer , and Myrtle Wilson’s tragic
+# V/J/R/C/P NSg/J NSg/V/J P  ISg+ V/C NPr/ISg+ NSg/VX NPr/V NPr/ISg+ NPr/P NSg/JC . V/C NPr    NSg$     NSg/J
 > achievement was forgotten . Now       I    want  to go      back    a   little     and tell  what   happened
 # NSg+        V   NSg/V/J   . NPr/V/J/C ISg+ NSg/V P  NSg/V/J NSg/V/J D/P NPr/I/J/Dq V/C NPr/V NSg/I+ V/J
 > at    the garage after we   left    there the night   before .
@@ -10121,7 +10121,7 @@
 > moved uncomfortably around the office — he       knew every object in      it       before
 # V/J   R             J/P    D   NSg/V+ . NPr/ISg+ V    Dq    NSg/V+ NPr/J/P NPr/ISg+ C/P
 > morning — and from time      to time     sat     down       beside Wilson trying  to keep  him  more
-# N🅪Sg/V+ . V/C P    N🅪Sg/V/J+ P  N🅪Sg/V/J NSg/V/J N🅪Sg/V/J/P P      NPr+   NSg/V/J P  NSg/V ISg+ NPr/I/V/J/Dq
+# N🅪Sg/V+ . V/C P    N🅪Sg/V/J+ P  N🅪Sg/V/J NSg/V/J N🅪Sg/V/J/P P      NPr+   NSg/V/J P  NSg/V ISg+ NPr/I/V/J/R/Dq
 > quiet    .
 # N🅪Sg/V/J .
 >
@@ -10490,8 +10490,8 @@
 # NSg/V+  . NSg/I/C/Ddem ISg/D$+ NSg/V+ V   NSg/V P    NPr/P NSg/V+   NSg/I/J+ . ISg+ V/J
 > herself of it       , and cried into her     handkerchief , as    if    the very suggestion was
 # ISg+    P  NPr/ISg+ . V/C V/J   P    ISg/D$+ NSg+         . NSg/R NSg/C D+  J/R+ N🅪Sg+      V
-> more         than she  could  endure . So        Wilson was reduced to a    man      “ deranged by      grief  ”
-# NPr/I/V/J/Dq C/P  ISg+ NSg/VX V      . NSg/I/J/C NPr+   V   V/J     P  D/P+ NPr/V/J+ . V/J      NSg/J/P NSg/V+ .
+> more           than she  could  endure . So        Wilson was reduced to a    man      “ deranged by      grief  ”
+# NPr/I/V/J/R/Dq C/P  ISg+ NSg/VX V      . NSg/I/J/C NPr+   V   V/J     P  D/P+ NPr/V/J+ . V/J      NSg/J/P NSg/V+ .
 > in      order  that         the case    might   remain in      its     simplest form   . And it       rested there .
 # NPr/J/P NSg/V+ NSg/I/C/Ddem D   NPr🅪/V+ Nᴹ/VX/J NSg/V  NPr/J/P ISg/D$+ JS       NSg/V+ . V/C NPr/ISg+ V/J    W?    .
 >
@@ -10612,8 +10612,8 @@
 # V/J    J           NSg/I/C ISg+ V     NPr/ISg+ . ISg+ V   J    W?   NSg/V NSg/I/C NPr/ISg+ NSg/V D
 > newspapers , just as    I    was sure there’d be     a   wire    from Daisy before noon   — but
 # NPl/V+     . V/J  NSg/R ISg+ V   J    W?      NSg/VX D/P N🅪Sg/V+ P    NPr+  C/P    NSg/V+ . NSg/C/P
-> neither a   wire    nor   Mr   . Wolfshiem arrived ; no    one        arrived except more         police and
-# I/C     D/P N🅪Sg/V+ NSg/C NSg+ . ?         V/J     . NPr/P NSg/I/V/J+ V/J     V/C/P  NPr/I/V/J/Dq Nᴹ/V   V/C
+> neither a   wire    nor   Mr   . Wolfshiem arrived ; no    one        arrived except more           police and
+# I/C     D/P N🅪Sg/V+ NSg/C NSg+ . ?         V/J     . NPr/P NSg/I/V/J+ V/J     V/C/P  NPr/I/V/J/R/Dq Nᴹ/V   V/C
 > photographers and newspaper men  . When    the butler brought back    Wolfshiem’s answer
 # W?            V/C N🅪Sg/V+   NSg+ . NSg/I/C D   NPr/V  V       NSg/V/J ?           NSg/V+
 > I    began to have   a   feeling of defiance , of scornful solidarity between Gatsby and
@@ -11014,8 +11014,8 @@
 # NSg/V/J+ N🅪Sg/V/J+ ISg+ NSg/V ISg+ V   NSg/I/C NPr/ISg+ NSg/V/P P    ?             NSg      NSg/P NSg/J . NSg/V/J
 > Street   and asked for a   job    . He       hadn’t eat anything for a   couple  of days . ‘          Come
 # NSg/V/J+ V/C V/J   C/P D/P NPr/V+ . NPr/ISg+ V      V   NSg/I/V+ C/P D/P NSg/V/J P  NPl+ . Unlintable NSg/V/P
-> on  have   some      lunch   with me       , ’ I    sid . He       ate   more         than four dollars ’ worth   of food
-# J/P NSg/VX I/J/R/Dq+ N🅪Sg/V+ P    NPr/ISg+ . . ISg+ NPr . NPr/ISg+ NSg/V NPr/I/V/J/Dq C/P  NSg  NPl+    . NSg/V/J P  NSg
+> on  have   some      lunch   with me       , ’ I    sid . He       ate   more           than four dollars ’ worth   of food
+# J/P NSg/VX I/J/R/Dq+ N🅪Sg/V+ P    NPr/ISg+ . . ISg+ NPr . NPr/ISg+ NSg/V NPr/I/V/J/R/Dq C/P  NSg  NPl+    . NSg/V/J P  NSg
 > in      half        an   hour . ”
 # NPr/J/P N🅪Sg/V/J/P+ D/P+ NSg+ . .
 >
@@ -11132,8 +11132,8 @@
 # NPr/ISg+ V   D/P NSg/V      P  D+  NPr/V+ . V/J     NPr/J/P D+  +       V/C V/J   P    NSg/I/J/Dq+
 > hands  . He       pointed out         every detail   to me       eagerly . “ Look  there ! ” and then    sought
 # NPl/V+ . NPr/ISg+ V/J     NSg/V/J/R/P Dq+   NSg/V/J+ P  NPr/ISg+ R       . . NSg/V W?    . . V/C NSg/J/C V
-> admiration from my  eyes   . He       had shown it       so        often that         I    think it       was more         real
-# NSg+       P    D$+ NPl/V+ . NPr/ISg+ V   V     NPr/ISg+ NSg/I/J/C R     NSg/I/C/Ddem ISg+ NSg/V NPr/ISg+ V   NPr/I/V/J/Dq NSg/J
+> admiration from my  eyes   . He       had shown it       so        often that         I    think it       was more           real
+# NSg+       P    D$+ NPl/V+ . NPr/ISg+ V   V     NPr/ISg+ NSg/I/J/C R     NSg/I/C/Ddem ISg+ NSg/V NPr/ISg+ V   NPr/I/V/J/R/Dq NSg/J
 > to him  now       than the house  itself .
 # P  ISg+ NPr/V/J/C C/P  D+  NPr/V+ ISg+   .
 >
@@ -11198,8 +11198,8 @@
 # NSg/V/J NPl/V
 >
 #
-> No    wasting time      at    Shafters or    [ a   name   , indecipherable ] No    more         smokeing or
-# NPr/P V       N🅪Sg/V/J+ NSg/P ?        NPr/C . D/P NSg/V+ . J              . NPr/P NPr/I/V/J/Dq ?        NPr/C
+> No    wasting time      at    Shafters or    [ a   name   , indecipherable ] No    more           smokeing or
+# NPr/P V       N🅪Sg/V/J+ NSg/P ?        NPr/C . D/P NSg/V+ . J              . NPr/P NPr/I/V/J/R/Dq ?        NPr/C
 > chewing . Bath   every other    day   Read  one       improving book  or    magazine per    week
 # V       . NSg/V+ Dq+   NSg/V/J+ NPr🅪+ NSg/V NSg/I/V/J V         NSg/V NPr/C NSg      NSg/JC NSg/J+
 > Save      $ 5.00 [ crossed out         ] $ 3.00 per    week   Be     better    to parents
@@ -11378,8 +11378,8 @@
 # J            NPl/V        I/C+  V/J    J/R/C D   NPl+     V/C D   J/R  NSg/J . NSg/V/J
 > then    it       had always for me       a   quality of distortion . West     Egg     , especially , still
 # NSg/J/C NPr/ISg+ V   R      C/P NPr/ISg+ D/P NSg/J   P  NSg+       . NPr/V/J+ N🅪Sg/V+ . R          . NSg/V/J
-> figures in      my  more         fantastic dreams . I    see   it       as    a   night   scene by      El Greco : a
-# NPl/V+  NPr/J/P D$+ NPr/I/V/J/Dq NSg/J+    NPl/V+ . ISg+ NSg/V NPr/ISg+ NSg/R D/P N🅪Sg/V+ NSg/V NSg/J/P ?  ?     . D/P+
+> figures in      my  more           fantastic dreams . I    see   it       as    a   night   scene by      El Greco : a
+# NPl/V+  NPr/J/P D$+ NPr/I/V/J/R/Dq NSg/J+    NPl/V+ . ISg+ NSg/V NPr/ISg+ NSg/R D/P N🅪Sg/V+ NSg/V NSg/J/P ?  ?     . D/P+
 > hundred houses , at    once  conventional and grotesque , crouching under   a   sullen  ,
 # NSg+    NPl/V+ . NSg/P NSg/C NSg/J        V/C NSg/J     . V         NSg/J/P D/P NSg/V/J .
 > overhanging sky     and a   lustreless moon   . In      the foreground four solemn men in
@@ -11604,8 +11604,8 @@
 #
 > On  the last     night   , with my  trunk  packed and my  car  sold  to the grocer , I    went
 # J/P D+  NSg/V/J+ N🅪Sg/V+ . P    D$+ NSg/V+ V/J    V/C D$+ NSg+ NSg/V P  D   NSg/V  . ISg+ NSg/V
-> over    and looked at    that         huge incoherent failure of a   house  once  more         . On  the
-# NSg/J/P V/C V/J    NSg/P NSg/I/C/Ddem J    J          N🅪Sg    P  D/P NPr/V+ NSg/C NPr/I/V/J/Dq . J/P D+
+> over    and looked at    that         huge incoherent failure of a   house  once  more           . On  the
+# NSg/J/P V/C V/J    NSg/P NSg/I/C/Ddem J    J          N🅪Sg    P  D/P NPr/V+ NSg/C NPr/I/V/J/R/Dq . J/P D+
 > white     steps  an  obscene word   , scrawled by      some     boy    with a   piece of brick     , stood
 # NPr🅪/V/J+ NPl/V+ D/P V/J     NSg/V+ . V/J      NSg/J/P I/J/R/Dq NSg/V+ P    D/P NSg/V P  N🅪Sg/V/J+ . V
 > out         clearly in      the moonlight , and I    erased it       , drawing my  shoe   raspingly along


### PR DESCRIPTION
# Issues 
Fixes #380 to a greater degree at least

# Description

Adds a handful of idioms using the words "than" or "then".
Thus, we can now support mixing them up in either direction now.
Simplified a little using new word metadata methods.

# How Has This Been Tested?

I added new unit tests covering the added idioms.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
