### PR TITLE
Add LuaDoc Support

### DIFF
--- a/harper-comments/src/comment_parser.rs
+++ b/harper-comments/src/comment_parser.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use crate::comment_parsers;
-use comment_parsers::{Go, JavaDoc, JsDoc, Solidity, Unit};
+use comment_parsers::{Go, JavaDoc, JsDoc, Lua, Solidity, Unit};
 use harper_core::Token;
 use harper_core::parsers::{self, MarkdownOptions, Parser};
 use harper_core::spell::MutableDictionary;
@@ -53,6 +53,7 @@ impl CommentParser {
 
         let comment_parser: Box<dyn Parser> = match language_id {
             "go" => Box::new(Go::new_markdown(markdown_options)),
+            "lua" => Box::new(Lua::new_markdown(markdown_options)),
             "java" => Box::new(JavaDoc::default()),
             "javascriptreact" | "typescript" | "typescriptreact" | "javascript" => {
                 Box::new(JsDoc::new_markdown(markdown_options))

--- a/harper-comments/src/comment_parsers/lua.rs
+++ b/harper-comments/src/comment_parsers/lua.rs
@@ -1,0 +1,83 @@
+use harper_core::Lrc;
+use harper_core::Span;
+use harper_core::Token;
+use harper_core::parsers::{Markdown, MarkdownOptions, Parser};
+
+use super::without_initiators;
+
+#[derive(Clone)]
+pub struct Lua {
+    inner: Lrc<dyn Parser>,
+}
+
+impl Lua {
+    pub fn new(parser: Lrc<dyn Parser>) -> Self {
+        Self { inner: parser }
+    }
+
+    pub fn new_markdown(markdown_options: MarkdownOptions) -> Self {
+        Self::new(Lrc::new(Markdown::new(markdown_options)))
+    }
+}
+
+impl Parser for Lua {
+    fn parse(&self, source: &[char]) -> Vec<Token> {
+        let mut tokens = Vec::new();
+
+        let mut chars_traversed = 0;
+
+        for line in source.split(|c| *c == '\n') {
+            if starts_with_prefix(line) {
+                tokens.push(Token::new(
+                    Span::new_with_len(chars_traversed, 0),
+                    harper_core::TokenKind::Newline(2),
+                ));
+                chars_traversed += line.len() + 1;
+                continue;
+            }
+
+            let mut new_tokens = parse_line(line, self.inner.clone());
+
+            if chars_traversed + line.len() < source.len() {
+                new_tokens.push(Token::new(
+                    Span::new_with_len(line.len(), 1),
+                    harper_core::TokenKind::Newline(1),
+                ));
+            }
+
+            new_tokens
+                .iter_mut()
+                .for_each(|t| t.span.push_by(chars_traversed));
+
+            chars_traversed += line.len() + 1;
+            tokens.append(&mut new_tokens);
+        }
+
+        tokens
+    }
+}
+
+fn starts_with_prefix(source: &[char]) -> bool {
+    let actual = without_initiators(source);
+    let actual_chars = actual.get_content(source);
+
+    matches!(actual_chars, ['@', ..])
+}
+
+fn parse_line(source: &[char], parser: Lrc<dyn Parser>) -> Vec<Token> {
+    let actual = without_initiators(source);
+
+    if actual.is_empty() {
+        return Vec::new();
+    }
+
+    let source = actual.get_content(source);
+
+    let mut new_tokens = parser.parse(source);
+
+    new_tokens
+        .iter_mut()
+        .for_each(|t| t.span.push_by(actual.start));
+
+    new_tokens
+}

--- a/harper-comments/src/comment_parsers/mod.rs
+++ b/harper-comments/src/comment_parsers/mod.rs
@@ -1,6 +1,7 @@
 mod go;
 mod javadoc;
 mod jsdoc;
+mod lua;
 mod solidity;
 mod unit;
 
@@ -8,6 +9,7 @@ pub use go::Go;
 use harper_core::Span;
 pub use javadoc::JavaDoc;
 pub use jsdoc::JsDoc;
+pub use lua::Lua;
 pub use solidity::Solidity;
 pub use unit::Unit;
 


### PR DESCRIPTION
# Description
Improve the compatibility of parsing for lua files.  

# Demo
This code now properly ignores [annotated](https://luals.github.io/wiki/annotations/) lines and only parses the actual documentation lines. 
```lua
---@class NodeProps
---Spacing between child elements in [VStacks](lua://VStack) or [HStacks](lua://HStack)
---@field spacing? number
---Spacing inside the element
---Max 4 elements
---
---Example Usage:
---`padding = {1}` {Top|Bottom|Left|Right}
---`padding = {1, 2}` {Top|Bottom, Left|Right}
---`padding = {1, 2, 3, 4}` {Top, Right, Bottom, Right}
---@field padding? number[]
---Sets background color of the element
---@field backgroundColor? string
---Sets the font family to the specified font
---@field fontFamily? string
---Sets the font size to the specified pixel size
---@field fontSize? number
---Sets the fixed width of the element
---@field width? number
---Sets the fixed height of the element
---@field height? number

--- Slide is the base primitive of each slide of the slideshow.
--- Pass in other elements such as [Text](lua://Text) or
--- [VStack](lua://VStack) to present content to the slideshow. Each call to
--- Slide makes a new slideshow.
---@param children SlideNode[]
function Slide(children)
end
```

# How Has This Been Tested?
Tested on local lua codebases. 

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
