### PR TITLE
feat(chrome-ext): export enabled domains

### DIFF
--- a/packages/chrome-plugin/src/ProtocolClient.ts
+++ b/packages/chrome-plugin/src/ProtocolClient.ts
@@ -58,6 +58,10 @@ export default class ProtocolClient {
 		return (await chrome.runtime.sendMessage({ kind: 'getDefaultStatus' })).enabled;
 	}
 
+	public static async getEnabledDomains(): Promise<string[]> {
+		return (await chrome.runtime.sendMessage({ kind: 'getEnabledDomains' })).domains;
+	}
+
 	public static async setDefaultEnabled(enabled: boolean): Promise<void> {
 		await chrome.runtime.sendMessage({ kind: 'setDefaultStatus', enabled });
 	}

--- a/packages/chrome-plugin/src/background/index.ts
+++ b/packages/chrome-plugin/src/background/index.ts
@@ -12,6 +12,7 @@ import {
 	type GetDialectResponse,
 	type GetDomainStatusRequest,
 	type GetDomainStatusResponse,
+	type GetEnabledDomainsResponse,
 	type GetLintDescriptionsRequest,
 	type GetLintDescriptionsResponse,
 	type GetUserDictionaryResponse,
@@ -125,6 +126,8 @@ function handleRequest(message: Request): Promise<Response> {
 			return handleSetDefaultStatus(message);
 		case 'getDefaultStatus':
 			return handleGetDefaultStatus();
+		case 'getEnabledDomains':
+			return handleGetEnabledDomains();
 		case 'getUserDictionary':
 			return handleGetUserDictionary();
 		case 'setUserDictionary':
@@ -182,6 +185,17 @@ async function handleGetDefaultStatus(): Promise<GetDefaultStatusResponse> {
 		kind: 'getDefaultStatus',
 		enabled: await enabledByDefault(),
 	};
+}
+
+async function handleGetEnabledDomains(): Promise<GetEnabledDomainsResponse> {
+	const all = await chrome.storage.local.get(null as any);
+	const prefix = formatDomainKey(''); // yields 'domainStatus '
+	const domains = Object.entries(all)
+		.filter(([k, v]) => typeof v === 'boolean' && v === true && k.startsWith(prefix))
+		.map(([k]) => k.substring(prefix.length))
+		.sort((a, b) => a.localeCompare(b));
+
+	return { kind: 'getEnabledDomains', domains };
 }
 
 async function handleGetDomainStatus(

--- a/packages/chrome-plugin/src/options/Options.svelte
+++ b/packages/chrome-plugin/src/options/Options.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { Button, Checkbox, Input, Select, Toggle } from 'flowbite-svelte';
+import { Button, Input, Select } from 'flowbite-svelte';
 import { Dialect, type LintConfig } from 'harper.js';
 import logo from '/logo.png';
 import ProtocolClient from '../ProtocolClient';
@@ -96,6 +96,29 @@ export function stringToDict(s: string): string[] {
 export function dictToString(values: string[]): string {
 	return values.map((v) => v.trim()).join('\n');
 }
+
+async function exportEnabledDomainsCSV() {
+	try {
+		const enabledDomains = await ProtocolClient.getEnabledDomains();
+		const header = 'domain\n';
+		const rows = enabledDomains.map((d) => `${d}\n`).join('');
+		const csv = header + rows;
+
+		const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = 'enabled-domains.csv';
+		document.body.appendChild(a);
+		a.click();
+		a.remove();
+		URL.revokeObjectURL(url);
+	} catch (e) {
+		console.error('Failed to export enabled domains CSV:', e);
+	}
+}
+
+// Import removed
 </script>
 
 <!-- centered wrapper with side gutters -->
@@ -131,6 +154,18 @@ export function dictToString(values: string[]): string {
           <input type="checkbox" bind:checked={defaultEnabled}/>
         </div>
       </div>
+
+      <div class="space-y-5">
+        <div class="flex items-center justify-between">
+          <div class="flex flex-col">
+            <span class="font-medium">Export Enabled Domains</span>
+            <span class="font-light">Downloads a CSV of domains explicitly enabled.</span>
+          </div>
+          <Button size="sm" color="light" on:click={exportEnabledDomainsCSV}>Export CSV</Button>
+        </div>
+      </div>
+
+      
 
       <div class="space-y-5">
         <div class="flex items-center justify-between">

--- a/packages/chrome-plugin/src/options/Options.svelte
+++ b/packages/chrome-plugin/src/options/Options.svelte
@@ -100,21 +100,19 @@ export function dictToString(values: string[]): string {
 async function exportEnabledDomainsCSV() {
 	try {
 		const enabledDomains = await ProtocolClient.getEnabledDomains();
-		const header = 'domain\n';
-		const rows = enabledDomains.map((d) => `${d}\n`).join('');
-		const csv = header + rows;
+		const json = JSON.stringify(enabledDomains, null, 2);
 
-		const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+		const blob = new Blob([json], { type: 'application/json;charset=utf-8' });
 		const url = URL.createObjectURL(blob);
 		const a = document.createElement('a');
 		a.href = url;
-		a.download = 'enabled-domains.csv';
+		a.download = 'enabled-domains.json';
 		document.body.appendChild(a);
 		a.click();
 		a.remove();
 		URL.revokeObjectURL(url);
 	} catch (e) {
-		console.error('Failed to export enabled domains CSV:', e);
+		console.error('Failed to export enabled domains JSON:', e);
 	}
 }
 
@@ -159,9 +157,9 @@ async function exportEnabledDomainsCSV() {
         <div class="flex items-center justify-between">
           <div class="flex flex-col">
             <span class="font-medium">Export Enabled Domains</span>
-            <span class="font-light">Downloads a CSV of domains explicitly enabled.</span>
+            <span class="font-light">Downloads JSON of domains explicitly enabled.</span>
           </div>
-          <Button size="sm" color="light" on:click={exportEnabledDomainsCSV}>Export CSV</Button>
+          <Button size="sm" color="light" on:click={exportEnabledDomainsCSV}>Export JSON</Button>
         </div>
       </div>
 

--- a/packages/chrome-plugin/src/protocol.ts
+++ b/packages/chrome-plugin/src/protocol.ts
@@ -12,6 +12,7 @@ export type Request =
 	| SetDefaultStatusRequest
 	| GetDomainStatusRequest
 	| GetDefaultStatusRequest
+	| GetEnabledDomainsRequest
 	| AddToUserDictionaryRequest
 	| SetUserDictionaryRequest
 	| IgnoreLintRequest
@@ -28,6 +29,7 @@ export type Response =
 	| GetDialectResponse
 	| GetDomainStatusResponse
 	| GetDefaultStatusResponse
+	| GetEnabledDomainsResponse
 	| GetUserDictionaryResponse
 	| GetActivationKeyResponse;
 
@@ -97,6 +99,15 @@ export type GetDefaultStatusRequest = {
 export type GetDefaultStatusResponse = {
 	kind: 'getDefaultStatus';
 	enabled: boolean;
+};
+
+export type GetEnabledDomainsRequest = {
+	kind: 'getEnabledDomains';
+};
+
+export type GetEnabledDomainsResponse = {
+	kind: 'getEnabledDomains';
+	domains: string[];
 };
 
 export type SetDomainStatusRequest = {


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

@lukasmwerner suggested this while at WordCamp US

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

This PR adds a button to our options page to export the list of enabled domains. @lukasmwerner suggested we have this to more rapidly expand our "official" list of supported domains. Users can save and submit these lists to us, which we can commit to the code.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

<img width="720" height="456" alt="image" src="https://github.com/user-attachments/assets/9286c31b-7c1b-47d9-a1ee-d269f30d5aac" />

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
