### PR TITLE
feat: condense loan phrases from foreign languages into single tokens

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -53425,6 +53425,7 @@ each other/I
 easy peasy/J
 eco-friendly/J
 editor in chief/N
+en masse
 end user/NgS
 energy-efficient/J
 et al./~
@@ -53650,8 +53651,8 @@ out-and-out/J
 out of date
 Pan Am/Ng           # old airline
 pari passu/RJ
-part of speech/Ng
-parts speech/9
+part of speech/N0g
+parts of speech/N9
 Pascal case/Nmg
 Pax Americana/Og
 peer review/NgSdG
@@ -53682,7 +53683,7 @@ quid pro quo/Ng
 quote unquote/JR
 rack-mounted/J
 rate limit/NgS
-rate-ray casting/Nmg
+ray casting/Nmg
 ray marcher/NgS
 ray marching/Nmg
 ray tracer/NgS

--- a/harper-core/src/document.rs
+++ b/harper-core/src/document.rs
@@ -532,8 +532,6 @@ impl Document {
         self.condense_expr(&Self::LOAN_PHRASES_EXPR.with(|v| v.clone()), |_| {})
     }
 
-    //////
-
     /// Searches for multiple sequential newline tokens and condenses them down
     /// into one.
     fn condense_newlines(&mut self) {

--- a/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
+++ b/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
@@ -672,17 +672,6 @@ Message: |
 
 Lint:    Spelling (63 priority)
 Message: |
-     271 | The Privilege of the Writ of Habeas Corpus shall not be suspended, unless when
-         |                              ^~~~~~ Did you mean to spell `Habeas` this way?
-Suggest:
-  - Replace with: “Haber's”
-  - Replace with: “Hale's”
-  - Replace with: “Hebe's”
-
-
-
-Lint:    Spelling (63 priority)
-Message: |
      274 | No Bill of Attainder or ex post facto Law shall be passed.
          |                                 ^~~~~ Did you mean to spell `facto` this way?
 Suggest:

--- a/harper-core/tests/text/tagged/The Constitution of the United States.md
+++ b/harper-core/tests/text/tagged/The Constitution of the United States.md
@@ -599,7 +599,7 @@
 >
 #
 > The Privilege of the Writ  of Habeas Corpus shall not   be     suspended , unless when
-# D   NSg/V     P  D   NSg/V P  ?      NSg+   VX    NSg/C NSg/VX V/J       . C      NSg/I/C
+# D   NSg/V     P  D   NSg/V P  NSg           VX    NSg/C NSg/VX V/J       . C      NSg/I/C
 > in      Cases of Rebellion or    Invasion the public Safety  may    require it       .
 # NPr/J/P NPl/V P  NSg+      NPr/C NSg      D   Nᴹ/V/J N🅪Sg/V+ NPr/VX NSg/V   NPr/ISg+ .
 >


### PR DESCRIPTION
# Issues 
No issue as such but prompted by @elijah-potter 's question in Discord: https://discord.com/channels/1335035237213671495/1335036485765828668/1411099860807057418

Though I'd been thinking of implementing something like this in recent weeks as well.

# Description

Condenses all foreign loan phrases that are in our dictionary into single tokens, including `en masse`, `kung fu`, etc.

I renamed the `condense_latin` method since there's more Latin in the new method now.
I rearranged the order of the condensing functions with the helper for `SequenceExp` ones after all its uses. I put a comment before each of those to make it clearer that each consisted of a `fn_uncached_*_pattern()`, a `thread_local!` `*_EXPR`, and a `condense_*` function.

I experimented with building the list of multi-word terms to condense by checking all multi-word entries in the dictionary to see which of them included at least one word not in the dictionary in its own right. This revealed a few surprising English entries that fit that pattern too, but since we want to initialize the condensing pattern statically we can't use the `FstDictionary`.
I discovered two typos in the dictionary while working on this.
One false positive in the snapshots is resolved by this as a bonus.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I've added a unit test that checks that a two-word and a three-word loan phrase both get tokenized.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
