### PR TITLE
feat:digestive track→digestive tract

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -103,6 +103,15 @@ pub fn lint_group() -> LintGroup {
             "The name of the word `the` is `definite article`.",
             LintKind::Usage
         ),
+        "DigestiveTract" => (
+            &[
+                ("digestive track", "digestive tract"),
+                ("digestive tracks", "digestive tracts"),
+            ],
+            "The correct term is digestive `tract`.",
+            "Corrects `digestive track` to `digestive tract`.",
+            LintKind::WordChoice
+        ),
         "Discuss" => (
             &[
                 ("discuss about", "discuss"),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -163,6 +163,26 @@ fn corrects_definite_articles_lowercase() {
     );
 }
 
+// DigestiveTract
+
+#[test]
+fn dont_flag_digestive_track() {
+    assert_suggestion_result(
+        "In infants less than a year old, because their digestive track is not finished developing yet",
+        lint_group(),
+        "In infants less than a year old, because their digestive tract is not finished developing yet",
+    );
+}
+
+#[test]
+fn corrects_digestive_tracks() {
+    assert_suggestion_result(
+        "The digestive tracks of mammals are complex and diverse, with each species having its own unique digestive system.",
+        lint_group(),
+        "The digestive tracts of mammals are complex and diverse, with each species having its own unique digestive system.",
+    );
+}
+
 // Discuss
 // -none-
 


### PR DESCRIPTION
# Issues 
N/A

# Description

"Digestive track" seems to now be a very well-established variant of "digestive tract". Nonetheless here's a lint for it.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I added one unit test from a sentence in GitHub and another that the LLM dreamed up for the plural.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
