### PR TITLE
fix: false positive from #1492 and new one with proper noun

### DIFF
--- a/harper-core/src/expr/sequence_expr.rs
+++ b/harper-core/src/expr/sequence_expr.rs
@@ -231,6 +231,8 @@ impl SequenceExpr {
         })
     }
 
+    // Predicate matching methods
+
     /// Match a token of a given kind which is not in the list of words.
     pub fn then_kind_except<F>(self, pred: F, words: &'static [&'static str]) -> Self
     where
@@ -268,6 +270,23 @@ impl SequenceExpr {
         F: Fn(&TokenKind) -> bool + Send + Sync + 'static,
     {
         self.then(move |tok: &Token, _source: &[char]| preds.iter().any(|pred| pred(&tok.kind)))
+    }
+
+    pub fn then_kind_any_or_words<F>(
+        self,
+        preds: &'static [F],
+        words: &'static [&'static str],
+    ) -> Self
+    where
+        F: Fn(&TokenKind) -> bool + Send + Sync + 'static,
+    {
+        self.then(move |tok: &Token, src: &[char]| {
+            preds.iter().any(|pred| pred(&tok.kind))
+                // && !words
+                || words
+                    .iter()
+                    .any(|&word| tok.span.get_content(src).eq_ignore_ascii_case_str(word))
+        })
     }
 
     /// Adds a step matching a token where the first token kind predicate returns true and the second returns false.


### PR DESCRIPTION
# Issues 
Closes #1492

# Description

Harper was falsely flagging to add "to" between "how" and "Microsoft":
<img width="775" height="124" alt="Screenshot 2025-09-01 at 3 26 36 pm" src="https://github.com/user-attachments/assets/a163fc5b-d4dc-4d3d-9213-33798a7abae0" />

I fixed that by adding proper noun to the list of POS not to match.

I also cleaned up the logic with a new `SequenceExpr` QoL helper function.

I then found #1492 with other sentences this linter failed on. I cleaned up the logic further to do away with the verb progressive test. The only kind of verb form that can be used after "to" is the "lemma", (known simplistically as the "present tense").

The functionality for checking for the lemma form of verbs is currently broken until #1730 gets merged. Until then I've added a rough hack that just checks for the `-s`, `-ed`, and `-ing` endings that non-lemma forms of regular verbs end with.

# Demo

Linting the same position of the same file after the fix goes straight past and starts with the next problem: 
<img width="850" height="123" alt="Screenshot 2025-09-01 at 3 27 38 pm" src="https://github.com/user-attachments/assets/4dd03e31-775a-49d5-8b8e-0e8ae28920d8" />

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I added the sentence from Google's Rust course repo's readme that showed this false positive.

I also added the remaining sentences from #1492 as unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
