### PR TITLE
feat: `just getmetadata` and `harper-cli metadata` now accept multiple words

### DIFF
--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -88,8 +88,8 @@ enum Args {
         #[arg(short, long, value_enum, default_value_t = AnnotationType::Upos)]
         annotation_type: AnnotationType,
     },
-    /// Get the metadata associated with a particular word.
-    Metadata { word: String },
+    /// Get the metadata associated with one or more words.
+    Metadata { words: Vec<String> },
     /// Get all the forms of a word using the affixes.
     Forms { line: String },
     /// Emit a decompressed, line-separated list of the words in Harper's dictionary.
@@ -361,12 +361,14 @@ fn main() -> anyhow::Result<()> {
 
             Ok(())
         }
-        Args::Metadata { word } => {
-            let metadata = dictionary.get_word_metadata_str(&word);
-            let json = serde_json::to_string_pretty(&metadata).unwrap();
-
+        Args::Metadata { words } => {
+            let mut results = BTreeMap::new();
+            for word in words {
+                let metadata = dictionary.get_word_metadata_str(&word);
+                results.insert(word, metadata);
+            }
+            let json = serde_json::to_string_pretty(&results).unwrap();
             println!("{json}");
-
             Ok(())
         }
         Args::SummarizeLintRecord { file } => {

--- a/justfile
+++ b/justfile
@@ -352,9 +352,9 @@ userdictoverlap:
     just searchdictfor $line 2> /dev/null
   done < $USER_DICT_FILE
 
-# Get the metadata associated with a particular word in Harper's dictionary as JSON.
-getmetadata word:
-  cargo run --bin harper-cli -- metadata {{word}}
+# Get the metadata associated with one or more words in Harper's dictionary as JSON.
+getmetadata *words:
+  cargo run --bin harper-cli -- metadata {{words}}
 # Get all the forms of a word using the affixes.
 getforms word:
   cargo run --bin harper-cli -- forms {{word}}


### PR DESCRIPTION
# Issues 
N/A

# Description

While working on linters, especially false positive reports, I often want to look up the metadata of a couple of words. This makes that possible in a single command invocation.

# Demo
```
% just getmetadata foo bar
cargo run --bin harper-cli -- metadata foo bar
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.73s
     Running `target/debug/harper-cli metadata foo bar`
{
  "bar": {
    "noun": {
      "is_proper": null,
      "is_singular": null,
      "is_plural": null,
      "is_countable": null,
      "is_mass": null,
      "is_possessive": null
    },
    "pronoun": null,
    "verb": {
      "is_linking": null,
      "is_auxiliary": null,
      "verb_form": null
    },
    "adjective": null,
    "adverb": null,
    "conjunction": null,
    "swear": null,
    "dialects": "",
    "orth_info": "LOWERCASE",
    "determiner": null,
    "preposition": true,
    "common": true,
    "derived_from": null,
    "np_member": null,
    "pos_tag": null
  },
  "foo": {
    "noun": {
      "is_proper": null,
      "is_singular": null,
      "is_plural": null,
      "is_countable": null,
      "is_mass": null,
      "is_possessive": null
    },
    "pronoun": null,
    "verb": null,
    "adjective": null,
    "adverb": null,
    "conjunction": null,
    "swear": null,
    "dialects": "",
    "orth_info": "LOWERCASE",
    "determiner": null,
    "preposition": false,
    "common": false,
    "derived_from": null,
    "np_member": null,
    "pos_tag": null
  }
}
```

# How Has This Been Tested?
Manually

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
