### PR TITLE
fix: missing `LintKind`s from `LintKind::new_from_str`

### DIFF
--- a/harper-core/src/linting/lint_kind.rs
+++ b/harper-core/src/linting/lint_kind.rs
@@ -55,32 +55,6 @@ pub enum LintKind {
 }
 
 impl LintKind {
-    pub fn new_from_str(s: &str) -> Option<Self> {
-        Some(match s {
-            "Agreement" => LintKind::Agreement,
-            "BoundaryError" => LintKind::BoundaryError,
-            "Capitalization" => LintKind::Capitalization,
-            "Eggcorn" => LintKind::Eggcorn,
-            "Enhancement" => LintKind::Enhancement,
-            "Formatting" => LintKind::Formatting,
-            "Grammar" => LintKind::Grammar,
-            "Malapropism" => LintKind::Malapropism,
-            "Miscellaneous" => LintKind::Miscellaneous,
-            "Nonstandard" => LintKind::Nonstandard,
-            "Punctuation" => LintKind::Punctuation,
-            "Readability" => LintKind::Readability,
-            "Redundancy" => LintKind::Redundancy,
-            "Regionalism" => LintKind::Regionalism,
-            "Repetition" => LintKind::Repetition,
-            "Spelling" => LintKind::Spelling,
-            "Style" => LintKind::Style,
-            "Typo" => LintKind::Typo,
-            "Usage" => LintKind::Usage,
-            "Word Choice" => LintKind::WordChoice,
-            _ => return None,
-        })
-    }
-
     /// Produce a string representation, which can be used as keys in a map or CSS variables.
     pub fn to_string_key(&self) -> String {
         match self {

--- a/harper-core/src/linting/lint_kind.rs
+++ b/harper-core/src/linting/lint_kind.rs
@@ -64,7 +64,10 @@ impl LintKind {
             "Enhancement" => LintKind::Enhancement,
             "Formatting" => LintKind::Formatting,
             "Grammar" => LintKind::Grammar,
+            "Malapropism" => LintKind::Malapropism,
             "Miscellaneous" => LintKind::Miscellaneous,
+            "Nonstandard" => LintKind::Nonstandard,
+            "Punctuation" => LintKind::Punctuation,
             "Readability" => LintKind::Readability,
             "Redundancy" => LintKind::Redundancy,
             "Regionalism" => LintKind::Regionalism,
@@ -72,6 +75,7 @@ impl LintKind {
             "Spelling" => LintKind::Spelling,
             "Style" => LintKind::Style,
             "Typo" => LintKind::Typo,
+            "Usage" => LintKind::Usage,
             "Word Choice" => LintKind::WordChoice,
             _ => return None,
         })


### PR DESCRIPTION
# Issues 
N/A

# Description

<s>I noticed 4 `LintKind`s were missing from `LintKind::fn new_from_str()`
It seems the function is not used anywhere, so let me know if the better fix is to remove it.</s>

Unused `new_from_str` removed.

# How Has This Been Tested?

All tests still pass.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
