### PR TITLE
Restore Harper linter active/inactive status between sessions.

### DIFF
--- a/packages/obsidian-plugin/src/HarperSettingTab.ts
+++ b/packages/obsidian-plugin/src/HarperSettingTab.ts
@@ -87,12 +87,12 @@ export class HarperSettingTab extends PluginSettingTab {
 		});
 
 		new Setting(containerEl)
-			.setName('Restore Active Status')
-			.setDesc('Whether to restore the Harper active/inactive status between sessions.')
+			.setName('Activate Harper')
+			.setDesc('Enable or disable harper with this option.')
 			.addToggle((toggle) =>
-				toggle.setValue(this.settings.lintEnabledRestore).onChange(async (value) => {
-					this.settings.lintEnabledRestore = value;
-					await this.state.initializeFromSettings(this.settings);
+				toggle.setValue(this.settings.lintEnabled).onChange(async (value) => {
+					this.state.toggleAutoLint();
+					this.plugin.updateStatusBar();
 				}),
 			);
 

--- a/packages/obsidian-plugin/src/HarperSettingTab.ts
+++ b/packages/obsidian-plugin/src/HarperSettingTab.ts
@@ -138,9 +138,9 @@ export class HarperSettingTab extends PluginSettingTab {
 					.setValue(this.settings.delay ?? -1)
 					.onChange(async (value) => {
 						this.settings.delay = value;
-				await this.state.initializeFromSettings(this.settings);
+						await this.state.initializeFromSettings(this.settings);
+					});
 			});
-		});
 
 		new Setting(containerEl).setName('The Danger Zone').addButton((button) => {
 			button

--- a/packages/obsidian-plugin/src/HarperSettingTab.ts
+++ b/packages/obsidian-plugin/src/HarperSettingTab.ts
@@ -88,9 +88,7 @@ export class HarperSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName('Restore Active Status')
-			.setDesc(
-				'Whether to restore the Harper active/inactive status between sessions.',
-			)
+			.setDesc('Whether to restore the Harper active/inactive status between sessions.')
 			.addToggle((toggle) =>
 				toggle.setValue(this.settings.lintEnabledRestore).onChange(async (value) => {
 					this.settings.lintEnabledRestore = value;

--- a/packages/obsidian-plugin/src/HarperSettingTab.ts
+++ b/packages/obsidian-plugin/src/HarperSettingTab.ts
@@ -88,7 +88,7 @@ export class HarperSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName('Activate Harper')
-			.setDesc('Enable or disable harper with this option.')
+			.setDesc('Enable or disable Harper with this option.')
 			.addToggle((toggle) =>
 				toggle.setValue(this.settings.lintEnabled).onChange(async (value) => {
 					this.state.toggleAutoLint();

--- a/packages/obsidian-plugin/src/HarperSettingTab.ts
+++ b/packages/obsidian-plugin/src/HarperSettingTab.ts
@@ -87,6 +87,18 @@ export class HarperSettingTab extends PluginSettingTab {
 		});
 
 		new Setting(containerEl)
+			.setName('Restore Active Status')
+			.setDesc(
+				'Whether to restore the Harper active/inactive status between sessions.',
+			)
+			.addToggle((toggle) =>
+				toggle.setValue(this.settings.lintEnabledRestore).onChange(async (value) => {
+					this.settings.lintEnabledRestore = value;
+					await this.state.initializeFromSettings(this.settings);
+				}),
+			);
+
+		new Setting(containerEl)
 			.setName('Personal Dictionary')
 			.setDesc(
 				'Make edits to your personal dictionary. Add names, places, or terms you use often. Each line should contain its own word.',
@@ -126,9 +138,9 @@ export class HarperSettingTab extends PluginSettingTab {
 					.setValue(this.settings.delay ?? -1)
 					.onChange(async (value) => {
 						this.settings.delay = value;
-						await this.state.initializeFromSettings(this.settings);
-					});
+				await this.state.initializeFromSettings(this.settings);
 			});
+		});
 
 		new Setting(containerEl).setName('The Danger Zone').addButton((button) => {
 			button

--- a/packages/obsidian-plugin/src/State.ts
+++ b/packages/obsidian-plugin/src/State.ts
@@ -53,11 +53,11 @@ export default class State {
 
 	public async initializeFromSettings(settings: Settings | null) {
 		if (settings == null) {
-			settings = { 
-				useWebWorker: true
-				, lintEnabled: true
-				, lintEnabledRestore: false
-				, lintSettings: {} 
+			settings = {
+				useWebWorker: true,
+				lintEnabled: true,
+				lintEnabledRestore: false,
+				lintSettings: {},
 			};
 		}
 
@@ -307,7 +307,7 @@ export default class State {
 			this.editorExtensions.push(this.constructEditorLinter());
 			this.lintEnabled = true;
 			this.onExtensionChange();
-			if(reinit) this.reinitialize();
+			if (reinit) this.reinitialize();
 			console.log('Enabled');
 		}
 	}
@@ -319,7 +319,7 @@ export default class State {
 		}
 		this.lintEnabled = false;
 		this.onExtensionChange();
-		if(reinit) this.reinitialize();
+		if (reinit) this.reinitialize();
 		console.log('Disabled');
 	}
 

--- a/packages/obsidian-plugin/src/State.ts
+++ b/packages/obsidian-plugin/src/State.ts
@@ -15,7 +15,6 @@ export type Settings = {
 	delay?: number;
 	ignoredGlobs?: string[];
 	lintEnabled: boolean;
-	lintEnabledRestore: boolean;
 };
 
 const DEFAULT_DELAY = -1;
@@ -31,7 +30,6 @@ export default class State {
 	private ignoredGlobs?: string[];
 	private editorViewField?: StateField<MarkdownFileInfo>;
 	private lintEnabled: boolean;
-	private lintEnabledRestore: boolean;
 
 	/** The CodeMirror extension objects that should be inserted by the host. */
 	private editorExtensions: Extension[];
@@ -56,7 +54,6 @@ export default class State {
 			settings = {
 				useWebWorker: true,
 				lintEnabled: true,
-				lintEnabledRestore: false,
 				lintSettings: {},
 			};
 		}
@@ -97,7 +94,6 @@ export default class State {
 		this.delay = settings.delay ?? DEFAULT_DELAY;
 		this.ignoredGlobs = settings.ignoredGlobs;
 		this.lintEnabled = settings.lintEnabled;
-		this.lintEnabledRestore = settings.lintEnabledRestore;
 
 		// Reinitialize it.
 		if (this.hasEditorLinter()) {
@@ -230,7 +226,6 @@ export default class State {
 			delay: this.delay,
 			ignoredGlobs: this.ignoredGlobs,
 			lintEnabled: this.lintEnabled,
-			lintEnabledRestore: this.lintEnabledRestore,
 		};
 	}
 

--- a/packages/obsidian-plugin/src/State.ts
+++ b/packages/obsidian-plugin/src/State.ts
@@ -14,6 +14,8 @@ export type Settings = {
 	userDictionary?: string[];
 	delay?: number;
 	ignoredGlobs?: string[];
+	lintEnabled: boolean;
+	lintEnabledRestore: boolean;
 };
 
 const DEFAULT_DELAY = -1;
@@ -28,6 +30,8 @@ export default class State {
 	private onExtensionChange: () => void;
 	private ignoredGlobs?: string[];
 	private editorViewField?: StateField<MarkdownFileInfo>;
+	private lintEnabled: boolean;
+	private lintEnabledRestore: boolean;
 
 	/** The CodeMirror extension objects that should be inserted by the host. */
 	private editorExtensions: Extension[];
@@ -49,7 +53,12 @@ export default class State {
 
 	public async initializeFromSettings(settings: Settings | null) {
 		if (settings == null) {
-			settings = { useWebWorker: true, lintSettings: {} };
+			settings = { 
+				useWebWorker: true
+				, lintEnabled: true
+				, lintEnabledRestore: false
+				, lintSettings: {} 
+			};
 		}
 
 		const defaultConfig = await this.harper.getDefaultLintConfig();
@@ -87,11 +96,13 @@ export default class State {
 
 		this.delay = settings.delay ?? DEFAULT_DELAY;
 		this.ignoredGlobs = settings.ignoredGlobs;
+		this.lintEnabled = settings.lintEnabled;
+		this.lintEnabledRestore = settings.lintEnabledRestore;
 
 		// Reinitialize it.
 		if (this.hasEditorLinter()) {
-			this.disableEditorLinter();
-			this.enableEditorLinter();
+			this.disableEditorLinter(false);
+			this.enableEditorLinter(false);
 		}
 
 		await this.saveData(settings);
@@ -218,6 +229,8 @@ export default class State {
 			dialect: await this.harper.getDialect(),
 			delay: this.delay,
 			ignoredGlobs: this.ignoredGlobs,
+			lintEnabled: this.lintEnabled,
+			lintEnabledRestore: this.lintEnabledRestore,
 		};
 	}
 
@@ -289,20 +302,25 @@ export default class State {
 	}
 
 	/** Enables the editor linter by adding an extension to the editor extensions array. */
-	public enableEditorLinter() {
+	public enableEditorLinter(reinit = true) {
 		if (!this.hasEditorLinter()) {
 			this.editorExtensions.push(this.constructEditorLinter());
+			this.lintEnabled = true;
 			this.onExtensionChange();
+			if(reinit) this.reinitialize();
 			console.log('Enabled');
 		}
 	}
 
 	/** Disables the editor linter by removing the extension from the editor extensions array. */
-	public disableEditorLinter() {
+	public disableEditorLinter(reinit = true) {
 		while (this.hasEditorLinter()) {
 			this.editorExtensions.pop();
 		}
+		this.lintEnabled = false;
 		this.onExtensionChange();
+		if(reinit) this.reinitialize();
+		console.log('Disabled');
 	}
 
 	public hasEditorLinter(): boolean {

--- a/packages/obsidian-plugin/src/State.ts
+++ b/packages/obsidian-plugin/src/State.ts
@@ -14,7 +14,7 @@ export type Settings = {
 	userDictionary?: string[];
 	delay?: number;
 	ignoredGlobs?: string[];
-	lintEnabled: boolean;
+	lintEnabled?: boolean;
 };
 
 const DEFAULT_DELAY = -1;
@@ -29,7 +29,7 @@ export default class State {
 	private onExtensionChange: () => void;
 	private ignoredGlobs?: string[];
 	private editorViewField?: StateField<MarkdownFileInfo>;
-	private lintEnabled: boolean;
+	private lintEnabled?: boolean;
 
 	/** The CodeMirror extension objects that should be inserted by the host. */
 	private editorExtensions: Extension[];

--- a/packages/obsidian-plugin/src/index.ts
+++ b/packages/obsidian-plugin/src/index.ts
@@ -31,10 +31,9 @@ export default class HarperPlugin extends Plugin {
 		this.registerEditorExtension(this.state.getCMEditorExtensions());
 		this.setupCommands();
 		this.setupStatusBar();
-		if(data.lintEnabledRestore && !data.lintEnabled) {
+		if (data.lintEnabledRestore && !data.lintEnabled) {
 			this.state.disableEditorLinter();
-		} else 
-			this.state.enableEditorLinter();
+		} else this.state.enableEditorLinter();
 
 		this.addSettingTab(new HarperSettingTab(this.app, this, this.state));
 	}

--- a/packages/obsidian-plugin/src/index.ts
+++ b/packages/obsidian-plugin/src/index.ts
@@ -31,7 +31,10 @@ export default class HarperPlugin extends Plugin {
 		this.registerEditorExtension(this.state.getCMEditorExtensions());
 		this.setupCommands();
 		this.setupStatusBar();
-		this.state.enableEditorLinter();
+		if(data.lintEnabledRestore && !data.lintEnabled) {
+			this.state.disableEditorLinter();
+		} else 
+			this.state.enableEditorLinter();
 
 		this.addSettingTab(new HarperSettingTab(this.app, this, this.state));
 	}
@@ -62,7 +65,7 @@ export default class HarperPlugin extends Plugin {
 
 		const logo = document.createElement('span');
 		logo.style.width = '24px';
-		logo.innerHTML = logoSvg;
+		logo.innerHTML = this.state.hasEditorLinter() ? logoSvg : logoSvgDisabled;
 		this.logo = logo;
 		button.appendChild(logo);
 

--- a/packages/obsidian-plugin/src/index.ts
+++ b/packages/obsidian-plugin/src/index.ts
@@ -31,7 +31,7 @@ export default class HarperPlugin extends Plugin {
 		this.registerEditorExtension(this.state.getCMEditorExtensions());
 		this.setupCommands();
 		this.setupStatusBar();
-		if (data.lintEnabledRestore && !data.lintEnabled) {
+		if (!data.lintEnabled) {
 			this.state.disableEditorLinter();
 		} else this.state.enableEditorLinter();
 


### PR DESCRIPTION
# Issues 

# Description
Restore Harper linter active/inactive status between sessions.
Also added an 'Activate Harper' option in settings as one more way to enable or disable Harper's active state.

# Demo

# How Has This Been Tested?
Tested closing and opening Obsidian vault with and without the current Harper state being enabled to validate current state is restored between sessions.
Tested toggling the new 'Activate Harper' setting to validate it successfully changes the Harper active state and the status bar indicator.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
