### PR TITLE
Add core.trac.wordrpess.org support to Chrome extension

### DIFF
--- a/packages/chrome-plugin/src/Highlights.ts
+++ b/packages/chrome-plugin/src/Highlights.ts
@@ -80,6 +80,8 @@ export default class Highlights {
 				hostStyle.transform = `translate(${-cpa.x}px, ${-cpa.y}px)`;
 				hostStyle.inset = '0';
 				hostStyle.pointerEvents = 'none';
+				hostStyle.width = '0px';
+				hostStyle.height = '0px';
 			}
 
 			renderBox.render(this.renderTree(boxes));

--- a/packages/chrome-plugin/src/background/index.ts
+++ b/packages/chrome-plugin/src/background/index.ts
@@ -87,6 +87,7 @@ async function enableDefaultDomains() {
 		'prosemirror.net',
 		'draftjs.org',
 		'gitlab.com',
+		'core.trac.wordpress.org',
 	];
 
 	for (const item of defaultEnabledDomains) {


### PR DESCRIPTION

# Description

Add `core.trac.wordpress.org` to the list of allowed domains for the Harper Chrome plugin.

# Demo

It seems to work:

<img width="1892" height="1654" alt="Screenshot 2025-09-04 at 14 16 22" src="https://github.com/user-attachments/assets/f73c9eb0-f40f-4a2d-9ce5-f053313af8e7" />

[I edited a comment and it discovered a typo I was able to fix through the dialog.](https://core.trac.wordpress.org/ticket/50161?action=comment-diff&cnum=31&version=1)

# How Has This Been Tested?

Brief testing in the browser.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
