### PR TITLE
fix(chrome-ext): flaky tests

### DIFF
--- a/packages/chrome-plugin/tests/lexical.spec.ts
+++ b/packages/chrome-plugin/tests/lexical.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from './fixtures';
 import {
 	clickHarperHighlight,
+	getHarperHighlights,
 	getLexicalEditor,
 	randomString,
 	replaceEditorContent,
@@ -37,10 +38,11 @@ test('Can ignore suggestion.', async ({ page }) => {
 
 	await page.waitForTimeout(3000);
 
-	await clickHarperHighlight(page);
+	const opened = await clickHarperHighlight(page);
+	expect(opened).toBe(true);
 	await page.getByTitle('Ignore this lint').click();
 
-	await page.waitForTimeout(3000);
+	await expect(getHarperHighlights(page)).toHaveCount(0);
 
 	// Nothing should change.
 	expect(lexical).toContainText(cacheSalt);

--- a/packages/chrome-plugin/tests/prosemirror.spec.ts
+++ b/packages/chrome-plugin/tests/prosemirror.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from './fixtures';
 import {
 	clickHarperHighlight,
+	getHarperHighlights,
 	getProseMirrorEditor,
 	randomString,
 	replaceEditorContent,
@@ -37,10 +38,11 @@ test('Can ignore suggestion.', async ({ page }) => {
 
 	await page.waitForTimeout(3000);
 
-	await clickHarperHighlight(page);
+	const opened = await clickHarperHighlight(page);
+	expect(opened).toBe(true);
 	await page.getByTitle('Ignore this lint').click();
 
-	await page.waitForTimeout(3000);
+	await expect(getHarperHighlights(page)).toHaveCount(0);
 
 	// Nothing should change.
 	expect(pm).toContainText(cacheSalt);

--- a/packages/chrome-plugin/tests/slate.spec.ts
+++ b/packages/chrome-plugin/tests/slate.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from './fixtures';
 import {
 	clickHarperHighlight,
+	getHarperHighlights,
 	getSlateEditor,
 	randomString,
 	replaceEditorContent,
@@ -37,10 +38,11 @@ test('Can ignore suggestion.', async ({ page }) => {
 
 	await page.waitForTimeout(3000);
 
-	await clickHarperHighlight(page);
+	const opened = await clickHarperHighlight(page);
+	expect(opened).toBe(true);
 	await page.getByTitle('Ignore this lint').click();
 
-	await page.waitForTimeout(3000);
+	await expect(getHarperHighlights(page)).toHaveCount(0);
 
 	// Nothing should change.
 	expect(slate).toContainText(cacheSalt);


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

In the past few weeks, we've been seeing an elevation in the number of spurious test failures. This PR fixes that by properly waiting for Harper to modify the DOM before performing checks in the Chrome extension integration tests.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I've run the full test suite several times and no tests have failed. Before, they would occasionally pass.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
