### PR TITLE
feat: add colour to `harper-cli nominal-phrases` and `just getnps-colour`

### DIFF
--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -17,8 +17,8 @@ use harper_comments::CommentParser;
 use harper_core::linting::{LintGroup, Linter};
 use harper_core::parsers::{Markdown, MarkdownOptions, OrgMode, PlainEnglish};
 use harper_core::{
-    CharStringExt, Dialect, Document, TokenKind, TokenStringExt, WordMetadata, remove_overlaps,
-    word_metadata_orthography::OrthFlags,
+    CharStringExt, Dialect, Document, Span, TokenKind, TokenStringExt, WordMetadata,
+    remove_overlaps, word_metadata_orthography::OrthFlags,
 };
 use harper_literate_haskell::LiterateHaskellParser;
 #[cfg(feature = "training")]
@@ -165,8 +165,14 @@ enum Args {
     /// Emit a decompressed, line-separated list of the words in Harper's dictionary
     /// which occur in more than one lettercase variant.    
     CaseVariants,
-    /// Provided a sentence or phrase, emit a list of each noun phrase contained within.
-    NominalPhrases { input: String },
+    /// Emit a list of each noun phrase contained within the input
+    NominalPhrases {
+        /// The text or file to analyze. If not provided, it will be read from standard input.
+        input: Option<Input>,
+        /// Use colored output instead of detailed position information
+        #[arg(short, long)]
+        colour: bool,
+    },
 }
 
 fn main() -> anyhow::Result<()> {
@@ -746,14 +752,62 @@ fn main() -> anyhow::Result<()> {
             }
             Ok(())
         }
-        Args::NominalPhrases { input } => {
+        Args::NominalPhrases { input, colour } => {
+            // Get input from either file or direct text
+            let input = match input {
+                Some(Input::File(path)) => std::fs::read_to_string(path)?,
+                Some(Input::Text(text)) => text,
+                None => std::io::read_to_string(std::io::stdin())?,
+            };
+
             let doc = Document::new_markdown_default_curated(&input);
+            let phrases: Vec<_> = doc
+                .iter_nominal_phrases()
+                .map(|toks| {
+                    (
+                        toks.first().unwrap().span.start,
+                        toks.last().unwrap().span.end,
+                    )
+                })
+                .collect();
 
-            for phrase in doc.iter_nominal_phrases() {
-                let s =
-                    doc.get_span_content_str(&phrase.span().ok_or(anyhow!("Unable to get span"))?);
+            let mut last_end = 0;
 
-                println!("{s}");
+            for (start, end) in phrases {
+                // Plain text between nominal phrases
+                if start > last_end {
+                    let span = Span::new(last_end, start);
+                    let txt = doc.get_span_content_str(&span);
+                    if !txt.trim().is_empty() && colour {
+                        print!("{}", txt);
+                    }
+                }
+
+                // Highlighted nominal phrase
+                let span = Span::new(start, end);
+                let txt = doc.get_span_content_str(&span);
+
+                if colour {
+                    print!("\x1b[33m{}\x1b[0m", txt);
+                } else {
+                    println!("{}", txt);
+                }
+
+                last_end = end;
+            }
+
+            // Plain text after the last nominal phrase, if any
+            let doc_len = doc.get_full_content().len();
+            if last_end < doc_len {
+                let span = Span::new(last_end, doc_len);
+                let txt = doc.get_span_content_str(&span);
+                if !txt.trim().is_empty() && colour {
+                    print!("{}", txt);
+                }
+            }
+
+            if colour {
+                println!();
             }
 
             Ok(())

--- a/justfile
+++ b/justfile
@@ -591,8 +591,15 @@ newest-dict-changes *numCommits:
     });
   });
 
-getnps a:
-  cargo run --bin harper-cli -- nominal-phrases "{{a}}"
+# List the nominal phrases in the input string or file.
+getnps text:
+  cargo run --bin harper-cli -- nominal-phrases "{{text}}"
+
+# Print the input string or file with nominal phrases highlighted.
+getnps-color text:
+  cargo run --bin harper-cli -- nominal-phrases --colour "{{text}}"
+
+alias getnps-colour := getnps-color
 
 # Suggest annotations for a potential new property annotation
 suggestannotation input:


### PR DESCRIPTION
# Issues 
N/A

# Description

The new colour versions will print out the whole document with all nominal phrases highlighted.

It also now accepts either a text string or filename on the commandline.

The just command works with `-color` and `-colour`.

# Demo
<img width="638" height="357" alt="image" src="https://github.com/user-attachments/assets/b23bbcdb-bba3-466b-8a3b-237bba4ffce2" />

# How Has This Been Tested?
Manually

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
