### PR TITLE
feat: Added conditionals to spell check, allowing certain kinds of words to be ignored by spell check.

### DIFF
--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -106,7 +106,7 @@ use super::since_duration::SinceDuration;
 use super::somewhat_something::SomewhatSomething;
 use super::sought_after::SoughtAfter;
 use super::spaces::Spaces;
-use super::spell_check::SpellCheck;
+use super::spell_check::{SpellCheck, SpellCheckConfig};
 use super::spelled_numbers::SpelledNumbers;
 use super::that_than::ThatThan;
 use super::that_which::ThatWhich;
@@ -245,6 +245,7 @@ impl Hash for LintGroupConfig {
 /// Each child can be toggled via the public, mutable [Self::config] object.
 pub struct LintGroup {
     pub config: LintGroupConfig,
+    pub spell_check_config: SpellCheckConfig,
     /// We use a binary map here so the ordering is stable.
     linters: BTreeMap<String, Box<dyn Linter>>,
     /// We use a binary map here so the ordering is stable.
@@ -263,6 +264,7 @@ impl LintGroup {
     pub fn empty() -> Self {
         Self {
             config: LintGroupConfig::default(),
+            spell_check_config: SpellCheckConfig::default(),
             linters: BTreeMap::new(),
             expr_linters: BTreeMap::new(),
             chunk_expr_cache: LruCache::new(NonZero::new(10000).unwrap()),
@@ -310,6 +312,7 @@ impl LintGroup {
     /// The other lint group will be left empty after this operation.
     pub fn merge_from(&mut self, other: &mut LintGroup) {
         self.config.merge_from(&mut other.config);
+        // Note: spell_check_config is not merged, as each LintGroup should maintain its own
 
         let other_linters = std::mem::take(&mut other.linters);
         self.linters.extend(other_linters);
@@ -368,6 +371,28 @@ impl LintGroup {
     pub fn with_lint_config(mut self, config: LintGroupConfig) -> Self {
         self.config = config;
         self
+    }
+
+    /// Update the SpellCheck linter configuration. This will recreate the SpellCheck linter
+    pub fn update_spell_check_config(&mut self, spell_check_config: SpellCheckConfig, dictionary: Arc<impl Dictionary + 'static>, dialect: Dialect) {
+        self.spell_check_config = spell_check_config.clone();
+        
+        // If SpellCheck linter exists, recreate it with the new config
+        if self.linters.contains_key("SpellCheck") {
+            self.linters.insert("SpellCheck".to_string(), Box::new(SpellCheck::new(dictionary, dialect, spell_check_config)));
+        }
+    }
+
+    /// Enable or disable ignoring capitalized words in spell checking
+    pub fn set_spell_check_ignore_capitalized(&mut self, ignore: bool, dictionary: Arc<impl Dictionary + 'static>, dialect: Dialect) {
+        self.spell_check_config.ignore_capitalized = ignore;
+        self.update_spell_check_config(self.spell_check_config.clone(), dictionary, dialect);
+    }
+
+    /// Enable or disable ignoring abbreviations in spell checking
+    pub fn set_spell_check_ignore_abbreviations(&mut self, ignore: bool, dictionary: Arc<impl Dictionary + 'static>, dialect: Dialect) {
+        self.spell_check_config.ignore_abbreviations = ignore;
+        self.update_spell_check_config(self.spell_check_config.clone(), dictionary, dialect);
     }
 
     pub fn new_curated(dictionary: Arc<impl Dictionary + 'static>, dialect: Dialect) -> Self {
@@ -515,8 +540,12 @@ impl LintGroup {
         insert_expr_rule!(WinPrize, true);
         insert_struct_rule!(WordPressDotcom, true);
 
-        out.add("SpellCheck", SpellCheck::new(dictionary.clone(), dialect));
+        out.add("SpellCheck", SpellCheck::new(dictionary.clone(), dialect, out.spell_check_config.clone()));
         out.config.set_rule_enabled("SpellCheck", true);
+
+        // Add spell check configuration options as toggleable rules
+        out.config.set_rule_enabled("SpellCheckIgnoreCapitalized", false);
+        out.config.set_rule_enabled("SpellCheckIgnoreAbbreviations", true);
 
         out.add(
             "InflectedVerbAfterTo",
@@ -567,6 +596,24 @@ impl Default for LintGroup {
 
 impl Linter for LintGroup {
     fn lint(&mut self, document: &Document) -> Vec<Lint> {
+        // Sync spell check configuration with rule settings before linting
+        let ignore_capitalized = self.config.is_rule_enabled("SpellCheckIgnoreCapitalized");
+        let ignore_abbreviations = self.config.is_rule_enabled("SpellCheckIgnoreAbbreviations");
+        
+        if self.spell_check_config.ignore_capitalized != ignore_capitalized 
+            || self.spell_check_config.ignore_abbreviations != ignore_abbreviations {
+            
+            self.spell_check_config.ignore_capitalized = ignore_capitalized;
+            self.spell_check_config.ignore_abbreviations = ignore_abbreviations;
+            
+            // Update the SpellCheck linter's config
+            if let Some(spell_check_linter) = self.linters.get_mut("SpellCheck") {
+                if let Some(spell_check) = spell_check_linter.as_any_mut().downcast_mut::<SpellCheck<_>>() {
+                    spell_check.update_config(self.spell_check_config.clone());
+                }
+            }
+        }
+
         let mut results = Vec::new();
 
         // Normal linters

--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -545,7 +545,7 @@ impl LintGroup {
 
         // Add spell check configuration options as toggleable rules
         out.config.set_rule_enabled("SpellCheckIgnoreCapitalized", false);
-        out.config.set_rule_enabled("SpellCheckIgnoreAbbreviations", true);
+        out.config.set_rule_enabled("SpellCheckIgnoreAbbreviations", false);
 
         out.add(
             "InflectedVerbAfterTo",
@@ -596,6 +596,8 @@ impl Default for LintGroup {
 
 impl Linter for LintGroup {
     fn lint(&mut self, document: &Document) -> Vec<Lint> {
+    
+
         // Sync spell check configuration with rule settings before linting
         let ignore_capitalized = self.config.is_rule_enabled("SpellCheckIgnoreCapitalized");
         let ignore_abbreviations = self.config.is_rule_enabled("SpellCheckIgnoreAbbreviations");
@@ -606,11 +608,9 @@ impl Linter for LintGroup {
             self.spell_check_config.ignore_capitalized = ignore_capitalized;
             self.spell_check_config.ignore_abbreviations = ignore_abbreviations;
             
-            // Update the SpellCheck linter's config
+            // Update the existing SpellCheck linter's config safely through the trait
             if let Some(spell_check_linter) = self.linters.get_mut("SpellCheck") {
-                if let Some(spell_check) = spell_check_linter.as_any_mut().downcast_mut::<SpellCheck<_>>() {
-                    spell_check.update_config(self.spell_check_config.clone());
-                }
+                spell_check_linter.update_spell_check_config(self.spell_check_config.clone());
             }
         }
 

--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -374,23 +374,41 @@ impl LintGroup {
     }
 
     /// Update the SpellCheck linter configuration. This will recreate the SpellCheck linter
-    pub fn update_spell_check_config(&mut self, spell_check_config: SpellCheckConfig, dictionary: Arc<impl Dictionary + 'static>, dialect: Dialect) {
+    pub fn update_spell_check_config(
+        &mut self,
+        spell_check_config: SpellCheckConfig,
+        dictionary: Arc<impl Dictionary + 'static>,
+        dialect: Dialect,
+    ) {
         self.spell_check_config = spell_check_config.clone();
-        
+
         // If SpellCheck linter exists, recreate it with the new config
         if self.linters.contains_key("SpellCheck") {
-            self.linters.insert("SpellCheck".to_string(), Box::new(SpellCheck::new(dictionary, dialect, spell_check_config)));
+            self.linters.insert(
+                "SpellCheck".to_string(),
+                Box::new(SpellCheck::new(dictionary, dialect, spell_check_config)),
+            );
         }
     }
 
     /// Enable or disable ignoring capitalized words in spell checking
-    pub fn set_spell_check_ignore_capitalized(&mut self, ignore: bool, dictionary: Arc<impl Dictionary + 'static>, dialect: Dialect) {
+    pub fn set_spell_check_ignore_capitalized(
+        &mut self,
+        ignore: bool,
+        dictionary: Arc<impl Dictionary + 'static>,
+        dialect: Dialect,
+    ) {
         self.spell_check_config.ignore_capitalized = ignore;
         self.update_spell_check_config(self.spell_check_config.clone(), dictionary, dialect);
     }
 
     /// Enable or disable ignoring abbreviations in spell checking
-    pub fn set_spell_check_ignore_abbreviations(&mut self, ignore: bool, dictionary: Arc<impl Dictionary + 'static>, dialect: Dialect) {
+    pub fn set_spell_check_ignore_abbreviations(
+        &mut self,
+        ignore: bool,
+        dictionary: Arc<impl Dictionary + 'static>,
+        dialect: Dialect,
+    ) {
         self.spell_check_config.ignore_abbreviations = ignore;
         self.update_spell_check_config(self.spell_check_config.clone(), dictionary, dialect);
     }
@@ -540,12 +558,17 @@ impl LintGroup {
         insert_expr_rule!(WinPrize, true);
         insert_struct_rule!(WordPressDotcom, true);
 
-        out.add("SpellCheck", SpellCheck::new(dictionary.clone(), dialect, out.spell_check_config.clone()));
+        out.add(
+            "SpellCheck",
+            SpellCheck::new(dictionary.clone(), dialect, out.spell_check_config.clone()),
+        );
         out.config.set_rule_enabled("SpellCheck", true);
 
         // Add spell check configuration options as toggleable rules
-        out.config.set_rule_enabled("SpellCheckIgnoreCapitalized", false);
-        out.config.set_rule_enabled("SpellCheckIgnoreAbbreviations", false);
+        out.config
+            .set_rule_enabled("SpellCheckIgnoreCapitalized", false);
+        out.config
+            .set_rule_enabled("SpellCheckIgnoreAbbreviations", false);
 
         out.add(
             "InflectedVerbAfterTo",
@@ -596,18 +619,16 @@ impl Default for LintGroup {
 
 impl Linter for LintGroup {
     fn lint(&mut self, document: &Document) -> Vec<Lint> {
-    
-
         // Sync spell check configuration with rule settings before linting
         let ignore_capitalized = self.config.is_rule_enabled("SpellCheckIgnoreCapitalized");
         let ignore_abbreviations = self.config.is_rule_enabled("SpellCheckIgnoreAbbreviations");
-        
-        if self.spell_check_config.ignore_capitalized != ignore_capitalized 
-            || self.spell_check_config.ignore_abbreviations != ignore_abbreviations {
-            
+
+        if self.spell_check_config.ignore_capitalized != ignore_capitalized
+            || self.spell_check_config.ignore_abbreviations != ignore_abbreviations
+        {
             self.spell_check_config.ignore_capitalized = ignore_capitalized;
             self.spell_check_config.ignore_abbreviations = ignore_abbreviations;
-            
+
             // Update the existing SpellCheck linter's config safely through the trait
             if let Some(spell_check_linter) = self.linters.get_mut("SpellCheck") {
                 spell_check_linter.update_spell_check_config(self.spell_check_config.clone());

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -283,7 +283,6 @@ pub trait Linter: LSend {
     /// Default implementation does nothing.
     fn update_spell_check_config(&mut self, _config: SpellCheckConfig) {
         // Default: do nothing for linters that don't support spell check config
-        return ();
     }
 }
 

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -278,6 +278,13 @@ pub trait Linter: LSend {
     /// A user-facing description of what kinds of grammatical errors this rule looks for.
     /// It is usually shown in settings menus.
     fn description(&self) -> &str;
+    
+    /// Update spell check configuration if this linter supports it.
+    /// Default implementation does nothing.
+    fn update_spell_check_config(&mut self, _config: SpellCheckConfig) {
+        // Default: do nothing for linters that don't support spell check config
+        return ();
+    }
 }
 
 /// A blanket-implemented trait that renders the Markdown description field of a linter to HTML.

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -278,7 +278,7 @@ pub trait Linter: LSend {
     /// A user-facing description of what kinds of grammatical errors this rule looks for.
     /// It is usually shown in settings menus.
     fn description(&self) -> &str;
-    
+
     /// Update spell check configuration if this linter supports it.
     /// Default implementation does nothing.
     fn update_spell_check_config(&mut self, _config: SpellCheckConfig) {

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -242,7 +242,7 @@ pub use since_duration::SinceDuration;
 pub use somewhat_something::SomewhatSomething;
 pub use sought_after::SoughtAfter;
 pub use spaces::Spaces;
-pub use spell_check::SpellCheck;
+pub use spell_check::{SpellCheck, SpellCheckConfig};
 pub use spelled_numbers::SpelledNumbers;
 pub use suggestion::Suggestion;
 pub use take_serious::TakeSerious;

--- a/harper-core/src/linting/spell_check.rs
+++ b/harper-core/src/linting/spell_check.rs
@@ -1,13 +1,20 @@
 use std::num::NonZero;
 
 use lru::LruCache;
+use serde::{Deserialize, Serialize};
 use smallvec::ToSmallVec;
 
 use super::Suggestion;
 use super::{Lint, LintKind, Linter};
 use crate::document::Document;
-use crate::spell::{Dictionary, suggest_correct_spelling};
+use crate::spell::{suggest_correct_spelling, Dictionary};
 use crate::{CharString, CharStringExt, Dialect, TokenStringExt};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct SpellCheckConfig {
+    pub ignore_capitalized: bool,
+    pub ignore_abbreviations: bool,
+}
 
 pub struct SpellCheck<T>
 where
@@ -16,15 +23,22 @@ where
     dictionary: T,
     word_cache: LruCache<CharString, Vec<CharString>>,
     dialect: Dialect,
+    config: SpellCheckConfig,
 }
 
 impl<T: Dictionary> SpellCheck<T> {
-    pub fn new(dictionary: T, dialect: Dialect) -> Self {
+    pub fn new(dictionary: T, dialect: Dialect, config: SpellCheckConfig) -> Self {
         Self {
             dictionary,
             word_cache: LruCache::new(NonZero::new(10000).unwrap()),
             dialect,
+            config,
         }
+    }
+
+    /// Update the spell check configuration without rebuilding the entire linter
+    pub fn update_config(&mut self, config: SpellCheckConfig) {
+        self.config = config;
     }
 
     const MAX_SUGGESTIONS: usize = 3;
@@ -66,12 +80,61 @@ impl<T: Dictionary> SpellCheck<T> {
     }
 }
 
+fn check_abbrv(chars: &[char]) -> bool {
+    if chars.is_empty() {
+        return false;
+    }
+    
+    if chars.iter().all(|&c| c.is_uppercase() || c.is_numeric()) {
+        return true;
+    }
+    
+    // Find valid suffixes at the end
+    let mut found_lowercase = false;
+    let mut lowercase_start_idx = chars.len();
+    
+
+    for (i, &c) in chars.iter().enumerate().rev() {
+        if c.is_lowercase() {
+            lowercase_start_idx = i;
+            found_lowercase = true;
+        } else if found_lowercase {
+            break;
+        }
+    }
+    
+    if !found_lowercase {
+        return chars.iter().all(|&c| c.is_uppercase() || c.is_numeric());
+    }
+    
+    let lowercase_part: String = chars[lowercase_start_idx..].iter().collect();
+    
+    let allowed_suffixes = ["d", "s", "'s", "ed"];
+    let is_valid_suffix = allowed_suffixes.iter().any(|&suffix| lowercase_part == suffix);
+    
+    if !is_valid_suffix {
+        return false;
+    }
+    
+    chars[..lowercase_start_idx].iter().all(|&c| c.is_uppercase() || c.is_numeric())
+}
+
+
+
 impl<T: Dictionary> Linter for SpellCheck<T> {
     fn lint(&mut self, document: &Document) -> Vec<Lint> {
         let mut lints = Vec::new();
 
         for word in document.iter_words() {
             let word_chars = document.get_span_content(&word.span);
+
+            if self.config.ignore_capitalized && word_chars.first().is_some_and(|c| c.is_uppercase()) {
+                continue;
+            }
+
+            if self.config.ignore_abbreviations && check_abbrv(word_chars) {
+                continue;
+            }
 
             if let Some(metadata) = word.kind.as_word().unwrap()
                 && metadata.dialects.is_dialect_enabled(self.dialect)
@@ -128,7 +191,7 @@ impl<T: Dictionary> Linter for SpellCheck<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::SpellCheck;
+    use super::{SpellCheck, SpellCheckConfig};
     use crate::spell::FstDictionary;
     use crate::{
         Dialect,
@@ -143,7 +206,7 @@ mod tests {
     fn america_capitalized() {
         assert_suggestion_result(
             "The word america should be capitalized.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "The word America should be capitalized.",
         );
     }
@@ -154,7 +217,7 @@ mod tests {
     fn harper_automattic_capitalized() {
         assert_lint_count(
             "So should harper and automattic.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             2,
         );
     }
@@ -163,7 +226,7 @@ mod tests {
     fn american_color_in_british_dialect() {
         assert_lint_count(
             "Do you like the color?",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             1,
         );
     }
@@ -172,7 +235,7 @@ mod tests {
     fn canadian_words_in_australian_dialect() {
         assert_lint_count(
             "Does your mom like yogourt?",
-            SpellCheck::new(FstDictionary::curated(), Dialect::Australian),
+            SpellCheck::new(FstDictionary::curated(), Dialect::Australian, SpellCheckConfig::default()),
             2,
         );
     }
@@ -181,7 +244,7 @@ mod tests {
     fn australian_words_in_canadian_dialect() {
         assert_lint_count(
             "We mine bauxite to make aluminium.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::Canadian),
+            SpellCheck::new(FstDictionary::curated(), Dialect::Canadian, SpellCheckConfig::default()),
             1,
         );
     }
@@ -190,7 +253,7 @@ mod tests {
     fn mum_and_mummy_not_just_commonwealth() {
         assert_lint_count(
             "Mum's the word about that Egyptian mummy.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             0,
         );
     }
@@ -199,7 +262,7 @@ mod tests {
     fn australian_verandah() {
         assert_lint_count(
             "Our house has a verandah.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::Australian),
+            SpellCheck::new(FstDictionary::curated(), Dialect::Australian, SpellCheckConfig::default()),
             0,
         );
     }
@@ -208,7 +271,7 @@ mod tests {
     fn australian_verandah_in_american_dialect() {
         assert_lint_count(
             "Our house has a verandah.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             1,
         );
     }
@@ -217,7 +280,7 @@ mod tests {
     fn austrlaian_verandah_in_british_dialect() {
         assert_lint_count(
             "Our house has a verandah.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             1,
         );
     }
@@ -226,7 +289,7 @@ mod tests {
     fn australian_verandah_in_canadian_dialect() {
         assert_lint_count(
             "Our house has a verandah.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::Canadian),
+            SpellCheck::new(FstDictionary::curated(), Dialect::Canadian, SpellCheckConfig::default()),
             1,
         );
     }
@@ -235,7 +298,7 @@ mod tests {
     fn mixing_australian_and_canadian_dialects() {
         assert_lint_count(
             "In summer we sit on the verandah and eat yogourt.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::Australian),
+            SpellCheck::new(FstDictionary::curated(), Dialect::Australian, SpellCheckConfig::default()),
             1,
         );
     }
@@ -244,7 +307,7 @@ mod tests {
     fn mixing_canadian_and_australian_dialects() {
         assert_lint_count(
             "In summer we sit on the verandah and eat yogourt.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::Canadian),
+            SpellCheck::new(FstDictionary::curated(), Dialect::Canadian, SpellCheckConfig::default()),
             1,
         );
     }
@@ -253,7 +316,7 @@ mod tests {
     fn australian_and_canadian_spellings_that_are_not_american() {
         assert_lint_count(
             "In summer we sit on the verandah and eat yogourt.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             2,
         );
     }
@@ -262,7 +325,7 @@ mod tests {
     fn australian_and_canadian_spellings_that_are_not_british() {
         assert_lint_count(
             "In summer we sit on the verandah and eat yogourt.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             2,
         );
     }
@@ -271,7 +334,7 @@ mod tests {
     fn australian_labour_vs_labor() {
         assert_lint_count(
             "In Australia we write 'labour' but the political party is the 'Labor Party'.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::Australian),
+            SpellCheck::new(FstDictionary::curated(), Dialect::Australian, SpellCheckConfig::default()),
             0,
         )
     }
@@ -280,7 +343,7 @@ mod tests {
     fn australian_words_flagged_for_american_english() {
         assert_lint_count(
             "There's an esky full of beers in the back of the ute.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             2,
         );
     }
@@ -289,7 +352,7 @@ mod tests {
     fn american_words_not_flagged_for_australian_english() {
         assert_lint_count(
             "In general, utes have unibody construction while pickups have frames.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::Australian),
+            SpellCheck::new(FstDictionary::curated(), Dialect::Australian, SpellCheckConfig::default()),
             0,
         );
     }
@@ -298,7 +361,7 @@ mod tests {
     fn abandonware_correction() {
         assert_suggestion_result(
             "abanonedware",
-            SpellCheck::new(FstDictionary::curated(), Dialect::Australian),
+            SpellCheck::new(FstDictionary::curated(), Dialect::Australian, SpellCheckConfig::default()),
             "abandonware",
         );
     }
@@ -310,7 +373,7 @@ mod tests {
         // assert_suggestion_result(
         assert_top3_suggestion_result(
             "Abandonedware is abandoned. Do not bother submitting issues about the empty page bug. Author moved to greener pastures",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "Abandonware is abandoned. Do not bother submitting issues about the empty page bug. Author moved to greener pastures",
         );
     }
@@ -319,7 +382,7 @@ mod tests {
     fn afterwards_not_us() {
         assert_lint_count(
             "afterwards",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             1,
         );
     }
@@ -328,7 +391,7 @@ mod tests {
     fn afterward_is_us() {
         assert_lint_count(
             "afterward",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             0,
         );
     }
@@ -337,7 +400,7 @@ mod tests {
     fn afterward_not_au() {
         assert_lint_count(
             "afterward",
-            SpellCheck::new(FstDictionary::curated(), Dialect::Australian),
+            SpellCheck::new(FstDictionary::curated(), Dialect::Australian, SpellCheckConfig::default()),
             1,
         );
     }
@@ -346,7 +409,7 @@ mod tests {
     fn afterwards_is_au() {
         assert_lint_count(
             "afterwards",
-            SpellCheck::new(FstDictionary::curated(), Dialect::Australian),
+            SpellCheck::new(FstDictionary::curated(), Dialect::Australian, SpellCheckConfig::default()),
             0,
         );
     }
@@ -355,7 +418,7 @@ mod tests {
     fn afterward_not_ca() {
         assert_lint_count(
             "afterward",
-            SpellCheck::new(FstDictionary::curated(), Dialect::Canadian),
+            SpellCheck::new(FstDictionary::curated(), Dialect::Canadian, SpellCheckConfig::default()),
             1,
         );
     }
@@ -364,7 +427,7 @@ mod tests {
     fn afterwards_is_ca() {
         assert_lint_count(
             "afterwards",
-            SpellCheck::new(FstDictionary::curated(), Dialect::Canadian),
+            SpellCheck::new(FstDictionary::curated(), Dialect::Canadian, SpellCheckConfig::default()),
             0,
         );
     }
@@ -373,7 +436,7 @@ mod tests {
     fn afterward_not_uk() {
         assert_lint_count(
             "afterward",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             1,
         );
     }
@@ -382,7 +445,7 @@ mod tests {
     fn afterwards_is_uk() {
         assert_lint_count(
             "afterwards",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             0,
         );
     }
@@ -391,7 +454,7 @@ mod tests {
     fn corrects_hes() {
         assert_suggestion_result(
             "hes",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "he's",
         );
     }
@@ -400,8 +463,72 @@ mod tests {
     fn corrects_shes() {
         assert_suggestion_result(
             "shes",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "she's",
+        );
+    }
+}
+
+#[cfg(test)]
+mod conditional {
+    use super::{SpellCheck, SpellCheckConfig};
+    use crate::spell::FstDictionary;
+    use crate::{
+        Dialect,
+        linting::tests::{
+            assert_lint_count
+        },
+    };
+
+    #[test]
+    fn ignore_capitalized_word() {
+        let config = SpellCheckConfig {
+            ignore_capitalized: true,
+            ignore_abbreviations: false,
+        };
+        assert_lint_count(
+            "This is a Tst.",
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, config),
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_ignore_capitalized_word() {
+        let config = SpellCheckConfig {
+            ignore_capitalized: false,
+            ignore_abbreviations: false,
+        };
+        assert_lint_count(
+            "This is a Tst.",
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, config),
+            1,
+        );
+    }
+
+    #[test]
+    fn ignore_abbreviation() {
+        let config = SpellCheckConfig {
+            ignore_capitalized: false,
+            ignore_abbreviations: true,
+        };
+        assert_lint_count(
+            "This is an ABBRV.",
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, config),
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_ignore_abbreviation() {
+        let config = SpellCheckConfig {
+            ignore_capitalized: false,
+            ignore_abbreviations: false,
+        };
+        assert_lint_count(
+            "This is an ABBRV.",
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, config),
+            1,
         );
     }
 }

--- a/harper-core/src/linting/spell_check.rs
+++ b/harper-core/src/linting/spell_check.rs
@@ -122,6 +122,10 @@ fn check_abbrv(chars: &[char]) -> bool {
 
 
 impl<T: Dictionary> Linter for SpellCheck<T> {
+    fn update_spell_check_config(&mut self, config: SpellCheckConfig) {
+        self.config = config;
+    }
+
     fn lint(&mut self, document: &Document) -> Vec<Lint> {
         let mut lints = Vec::new();
 

--- a/harper-core/src/spell/mod.rs
+++ b/harper-core/src/spell/mod.rs
@@ -547,7 +547,11 @@ mod tests {
     fn suggest_color_for_colour_lowercase() {
         assert_suggestion_result(
             "colour",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::American,
+                SpellCheckConfig::default(),
+            ),
             "color",
         );
     }
@@ -556,7 +560,11 @@ mod tests {
     fn suggest_colour_for_color_lowercase() {
         assert_suggestion_result(
             "color",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "colour",
         );
     }
@@ -566,7 +574,11 @@ mod tests {
     fn suggest_color_for_colour_titlecase() {
         assert_suggestion_result(
             "Colour",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::American,
+                SpellCheckConfig::default(),
+            ),
             "Color",
         );
     }
@@ -576,7 +588,11 @@ mod tests {
     fn suggest_colour_for_color_titlecase() {
         assert_suggestion_result(
             "Color",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "Colour",
         );
     }
@@ -587,7 +603,11 @@ mod tests {
     fn suggest_color_for_colour_all_caps() {
         assert_suggestion_result(
             "COLOUR",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::American,
+                SpellCheckConfig::default(),
+            ),
             "COLOR",
         );
     }
@@ -597,7 +617,11 @@ mod tests {
     fn suggest_colour_for_color_all_caps() {
         assert_suggestion_result(
             "COLOR",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "COLOUR",
         );
     }
@@ -609,7 +633,11 @@ mod tests {
     fn suggest_realise_for_realize() {
         assert_suggestion_result(
             "realize",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "realise",
         );
     }
@@ -618,7 +646,11 @@ mod tests {
     fn suggest_realize_for_realise() {
         assert_suggestion_result(
             "realise",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::American,
+                SpellCheckConfig::default(),
+            ),
             "realize",
         );
     }
@@ -627,7 +659,11 @@ mod tests {
     fn suggest_realise_for_realize_titlecase() {
         assert_suggestion_result(
             "Realize",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "Realise",
         );
     }
@@ -637,7 +673,11 @@ mod tests {
     fn suggest_realize_for_realise_titlecase() {
         assert_suggestion_result(
             "Realise",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::American,
+                SpellCheckConfig::default(),
+            ),
             "Realize",
         );
     }
@@ -647,7 +687,11 @@ mod tests {
     fn suggest_realise_for_realize_all_caps() {
         assert_suggestion_result(
             "REALIZE",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "REALISE",
         );
     }
@@ -657,7 +701,11 @@ mod tests {
     fn suggest_realize_for_realise_all_caps() {
         assert_suggestion_result(
             "REALISE",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::American,
+                SpellCheckConfig::default(),
+            ),
             "REALIZE",
         );
     }
@@ -667,7 +715,11 @@ mod tests {
     fn suggest_defence_for_defense() {
         assert_suggestion_result(
             "defense",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "defence",
         );
     }
@@ -676,7 +728,11 @@ mod tests {
     fn suggest_defense_for_defence() {
         assert_suggestion_result(
             "defence",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::American,
+                SpellCheckConfig::default(),
+            ),
             "defense",
         );
     }
@@ -685,7 +741,11 @@ mod tests {
     fn suggest_defense_for_defence_titlecase() {
         assert_suggestion_result(
             "Defense",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "Defence",
         );
     }
@@ -694,7 +754,11 @@ mod tests {
     fn suggest_defence_for_defense_titlecase() {
         assert_suggestion_result(
             "Defence",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::American,
+                SpellCheckConfig::default(),
+            ),
             "Defense",
         );
     }
@@ -704,7 +768,11 @@ mod tests {
     fn suggest_defense_for_defence_all_caps() {
         assert_suggestion_result(
             "DEFENSE",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "DEFENCE",
         );
     }
@@ -714,7 +782,11 @@ mod tests {
     fn suggest_defence_for_defense_all_caps() {
         assert_suggestion_result(
             "DEFENCE",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::American,
+                SpellCheckConfig::default(),
+            ),
             "DEFENSE",
         );
     }
@@ -724,7 +796,11 @@ mod tests {
     fn suggest_sceptic_for_skeptic() {
         assert_suggestion_result(
             "skeptic",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "sceptic",
         );
     }
@@ -733,7 +809,11 @@ mod tests {
     fn suggest_skeptic_for_sceptic() {
         assert_suggestion_result(
             "sceptic",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::American,
+                SpellCheckConfig::default(),
+            ),
             "skeptic",
         );
     }
@@ -742,7 +822,11 @@ mod tests {
     fn suggest_sceptic_for_skeptic_titlecase() {
         assert_suggestion_result(
             "Skeptic",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "Sceptic",
         );
     }
@@ -752,7 +836,11 @@ mod tests {
     fn suggest_skeptic_for_sceptic_titlecase() {
         assert_suggestion_result(
             "Sceptic",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::American,
+                SpellCheckConfig::default(),
+            ),
             "Skeptic",
         );
     }
@@ -762,7 +850,11 @@ mod tests {
     fn suggest_skeptic_for_sceptic_all_caps() {
         assert_suggestion_result(
             "SKEPTIC",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "SCEPTIC",
         );
     }
@@ -772,7 +864,11 @@ mod tests {
     fn suggest_sceptic_for_skeptic_all_caps() {
         assert_suggestion_result(
             "SCEPTIC",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::American,
+                SpellCheckConfig::default(),
+            ),
             "SKEPTIC",
         );
     }
@@ -783,7 +879,11 @@ mod tests {
     fn suggest_centimeter_for_centimetre() {
         assert_suggestion_result(
             "centimetre",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::American,
+                SpellCheckConfig::default(),
+            ),
             "centimeter",
         );
     }
@@ -792,7 +892,11 @@ mod tests {
     fn suggest_centimetre_for_centimeter() {
         assert_suggestion_result(
             "centimeter",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "centimetre",
         );
     }
@@ -801,7 +905,11 @@ mod tests {
     fn suggest_centimeter_for_centimetre_titlecase() {
         assert_suggestion_result(
             "Centimetre",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::American,
+                SpellCheckConfig::default(),
+            ),
             "Centimeter",
         );
     }
@@ -811,7 +919,11 @@ mod tests {
     fn suggest_centimetre_for_centimeter_titlecase() {
         assert_suggestion_result(
             "Centimeter",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "Centimetre",
         );
     }
@@ -821,7 +933,11 @@ mod tests {
     fn suggest_centimeter_for_centimetre_all_caps() {
         assert_suggestion_result(
             "CENTIMETRE",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::American,
+                SpellCheckConfig::default(),
+            ),
             "CENTIMETER",
         );
     }
@@ -831,7 +947,11 @@ mod tests {
     fn suggest_centimetre_for_centimeter_all_caps() {
         assert_suggestion_result(
             "CENTIMETER",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "CENTIMETRE",
         );
     }
@@ -842,7 +962,11 @@ mod tests {
     fn suggest_traveler_for_traveller() {
         assert_suggestion_result(
             "traveller",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::American,
+                SpellCheckConfig::default(),
+            ),
             "traveler",
         );
     }
@@ -851,7 +975,11 @@ mod tests {
     fn suggest_traveller_for_traveler() {
         assert_suggestion_result(
             "traveler",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "traveller",
         );
     }
@@ -860,7 +988,11 @@ mod tests {
     fn suggest_traveler_for_traveller_titlecase() {
         assert_suggestion_result(
             "Traveller",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::American,
+                SpellCheckConfig::default(),
+            ),
             "Traveler",
         );
     }
@@ -870,7 +1002,11 @@ mod tests {
     fn suggest_traveller_for_traveler_titlecase() {
         assert_suggestion_result(
             "Traveler",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "Traveller",
         );
     }
@@ -880,7 +1016,11 @@ mod tests {
     fn suggest_traveler_for_traveller_all_caps() {
         assert_suggestion_result(
             "TRAVELLER",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::American,
+                SpellCheckConfig::default(),
+            ),
             "TRAVELER",
         );
     }
@@ -890,7 +1030,11 @@ mod tests {
     fn suggest_traveller_for_traveler_all_caps() {
         assert_suggestion_result(
             "TRAVELER",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "TRAVELLER",
         );
     }
@@ -902,7 +1046,11 @@ mod tests {
     fn suggest_grey_for_gray_in_non_american() {
         assert_suggestion_result(
             "I've got a gray cat.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "I've got a grey cat.",
         );
     }
@@ -911,7 +1059,11 @@ mod tests {
     fn suggest_gray_for_grey_in_american() {
         assert_suggestion_result(
             "It's a greyscale photo.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::American,
+                SpellCheckConfig::default(),
+            ),
             "It's a grayscale photo.",
         );
     }
@@ -921,7 +1073,11 @@ mod tests {
     fn suggest_grey_for_gray_in_non_american_titlecase() {
         assert_suggestion_result(
             "I've Got a Gray Cat.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "I've Got a Grey Cat.",
         );
     }
@@ -930,7 +1086,11 @@ mod tests {
     fn suggest_gray_for_grey_in_american_titlecase() {
         assert_suggestion_result(
             "It's a Greyscale Photo.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::American,
+                SpellCheckConfig::default(),
+            ),
             "It's a Grayscale Photo.",
         );
     }
@@ -940,7 +1100,11 @@ mod tests {
     fn suggest_grey_for_gray_in_non_american_all_caps() {
         assert_suggestion_result(
             "GRAY",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "GREY",
         );
     }
@@ -950,7 +1114,11 @@ mod tests {
     fn suggest_gray_for_grey_in_american_all_caps() {
         assert_suggestion_result(
             "GREY",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::American,
+                SpellCheckConfig::default(),
+            ),
             "GRAY",
         );
     }
@@ -962,7 +1130,11 @@ mod tests {
     fn fix_cheif_and_recieved() {
         assert_top3_suggestion_result(
             "The cheif recieved a letter.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "The chief received a letter.",
         );
     }
@@ -972,7 +1144,11 @@ mod tests {
     fn fix_cheif_and_recieved_titlecase() {
         assert_top3_suggestion_result(
             "The Cheif Recieved a Letter.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "The Chief Received a Letter.",
         );
     }
@@ -982,7 +1158,11 @@ mod tests {
     fn fix_cheif_and_recieved_all_caps() {
         assert_top3_suggestion_result(
             "THE CHEIF RECIEVED A LETTER.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
+            SpellCheck::new(
+                FstDictionary::curated(),
+                Dialect::British,
+                SpellCheckConfig::default(),
+            ),
             "THE CHEIF RECEIVED A LETTER.",
         );
     }

--- a/harper-core/src/spell/mod.rs
+++ b/harper-core/src/spell/mod.rs
@@ -381,7 +381,7 @@ mod tests {
     use crate::{
         CharStringExt, Dialect,
         linting::{
-            SpellCheck,
+            SpellCheck, SpellCheckConfig,
             tests::{assert_suggestion_result, assert_top3_suggestion_result},
         },
     };
@@ -547,7 +547,7 @@ mod tests {
     fn suggest_color_for_colour_lowercase() {
         assert_suggestion_result(
             "colour",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "color",
         );
     }
@@ -556,7 +556,7 @@ mod tests {
     fn suggest_colour_for_color_lowercase() {
         assert_suggestion_result(
             "color",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "colour",
         );
     }
@@ -566,7 +566,7 @@ mod tests {
     fn suggest_color_for_colour_titlecase() {
         assert_suggestion_result(
             "Colour",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "Color",
         );
     }
@@ -576,7 +576,7 @@ mod tests {
     fn suggest_colour_for_color_titlecase() {
         assert_suggestion_result(
             "Color",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "Colour",
         );
     }
@@ -587,7 +587,7 @@ mod tests {
     fn suggest_color_for_colour_all_caps() {
         assert_suggestion_result(
             "COLOUR",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "COLOR",
         );
     }
@@ -597,7 +597,7 @@ mod tests {
     fn suggest_colour_for_color_all_caps() {
         assert_suggestion_result(
             "COLOR",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "COLOUR",
         );
     }
@@ -609,7 +609,7 @@ mod tests {
     fn suggest_realise_for_realize() {
         assert_suggestion_result(
             "realize",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "realise",
         );
     }
@@ -618,7 +618,7 @@ mod tests {
     fn suggest_realize_for_realise() {
         assert_suggestion_result(
             "realise",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "realize",
         );
     }
@@ -627,7 +627,7 @@ mod tests {
     fn suggest_realise_for_realize_titlecase() {
         assert_suggestion_result(
             "Realize",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "Realise",
         );
     }
@@ -637,7 +637,7 @@ mod tests {
     fn suggest_realize_for_realise_titlecase() {
         assert_suggestion_result(
             "Realise",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "Realize",
         );
     }
@@ -647,7 +647,7 @@ mod tests {
     fn suggest_realise_for_realize_all_caps() {
         assert_suggestion_result(
             "REALIZE",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "REALISE",
         );
     }
@@ -657,7 +657,7 @@ mod tests {
     fn suggest_realize_for_realise_all_caps() {
         assert_suggestion_result(
             "REALISE",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "REALIZE",
         );
     }
@@ -667,7 +667,7 @@ mod tests {
     fn suggest_defence_for_defense() {
         assert_suggestion_result(
             "defense",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "defence",
         );
     }
@@ -676,7 +676,7 @@ mod tests {
     fn suggest_defense_for_defence() {
         assert_suggestion_result(
             "defence",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "defense",
         );
     }
@@ -685,7 +685,7 @@ mod tests {
     fn suggest_defense_for_defence_titlecase() {
         assert_suggestion_result(
             "Defense",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "Defence",
         );
     }
@@ -694,7 +694,7 @@ mod tests {
     fn suggest_defence_for_defense_titlecase() {
         assert_suggestion_result(
             "Defence",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "Defense",
         );
     }
@@ -704,7 +704,7 @@ mod tests {
     fn suggest_defense_for_defence_all_caps() {
         assert_suggestion_result(
             "DEFENSE",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "DEFENCE",
         );
     }
@@ -714,7 +714,7 @@ mod tests {
     fn suggest_defence_for_defense_all_caps() {
         assert_suggestion_result(
             "DEFENCE",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "DEFENSE",
         );
     }
@@ -724,7 +724,7 @@ mod tests {
     fn suggest_sceptic_for_skeptic() {
         assert_suggestion_result(
             "skeptic",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "sceptic",
         );
     }
@@ -733,7 +733,7 @@ mod tests {
     fn suggest_skeptic_for_sceptic() {
         assert_suggestion_result(
             "sceptic",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "skeptic",
         );
     }
@@ -742,7 +742,7 @@ mod tests {
     fn suggest_sceptic_for_skeptic_titlecase() {
         assert_suggestion_result(
             "Skeptic",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "Sceptic",
         );
     }
@@ -752,7 +752,7 @@ mod tests {
     fn suggest_skeptic_for_sceptic_titlecase() {
         assert_suggestion_result(
             "Sceptic",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "Skeptic",
         );
     }
@@ -762,7 +762,7 @@ mod tests {
     fn suggest_skeptic_for_sceptic_all_caps() {
         assert_suggestion_result(
             "SKEPTIC",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "SCEPTIC",
         );
     }
@@ -772,7 +772,7 @@ mod tests {
     fn suggest_sceptic_for_skeptic_all_caps() {
         assert_suggestion_result(
             "SCEPTIC",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "SKEPTIC",
         );
     }
@@ -783,7 +783,7 @@ mod tests {
     fn suggest_centimeter_for_centimetre() {
         assert_suggestion_result(
             "centimetre",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "centimeter",
         );
     }
@@ -792,7 +792,7 @@ mod tests {
     fn suggest_centimetre_for_centimeter() {
         assert_suggestion_result(
             "centimeter",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "centimetre",
         );
     }
@@ -801,7 +801,7 @@ mod tests {
     fn suggest_centimeter_for_centimetre_titlecase() {
         assert_suggestion_result(
             "Centimetre",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "Centimeter",
         );
     }
@@ -811,7 +811,7 @@ mod tests {
     fn suggest_centimetre_for_centimeter_titlecase() {
         assert_suggestion_result(
             "Centimeter",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "Centimetre",
         );
     }
@@ -821,7 +821,7 @@ mod tests {
     fn suggest_centimeter_for_centimetre_all_caps() {
         assert_suggestion_result(
             "CENTIMETRE",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "CENTIMETER",
         );
     }
@@ -831,7 +831,7 @@ mod tests {
     fn suggest_centimetre_for_centimeter_all_caps() {
         assert_suggestion_result(
             "CENTIMETER",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "CENTIMETRE",
         );
     }
@@ -842,7 +842,7 @@ mod tests {
     fn suggest_traveler_for_traveller() {
         assert_suggestion_result(
             "traveller",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "traveler",
         );
     }
@@ -851,7 +851,7 @@ mod tests {
     fn suggest_traveller_for_traveler() {
         assert_suggestion_result(
             "traveler",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "traveller",
         );
     }
@@ -860,7 +860,7 @@ mod tests {
     fn suggest_traveler_for_traveller_titlecase() {
         assert_suggestion_result(
             "Traveller",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "Traveler",
         );
     }
@@ -870,7 +870,7 @@ mod tests {
     fn suggest_traveller_for_traveler_titlecase() {
         assert_suggestion_result(
             "Traveler",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "Traveller",
         );
     }
@@ -880,7 +880,7 @@ mod tests {
     fn suggest_traveler_for_traveller_all_caps() {
         assert_suggestion_result(
             "TRAVELLER",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "TRAVELER",
         );
     }
@@ -890,7 +890,7 @@ mod tests {
     fn suggest_traveller_for_traveler_all_caps() {
         assert_suggestion_result(
             "TRAVELER",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "TRAVELLER",
         );
     }
@@ -902,7 +902,7 @@ mod tests {
     fn suggest_grey_for_gray_in_non_american() {
         assert_suggestion_result(
             "I've got a gray cat.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "I've got a grey cat.",
         );
     }
@@ -911,7 +911,7 @@ mod tests {
     fn suggest_gray_for_grey_in_american() {
         assert_suggestion_result(
             "It's a greyscale photo.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "It's a grayscale photo.",
         );
     }
@@ -921,7 +921,7 @@ mod tests {
     fn suggest_grey_for_gray_in_non_american_titlecase() {
         assert_suggestion_result(
             "I've Got a Gray Cat.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "I've Got a Grey Cat.",
         );
     }
@@ -930,7 +930,7 @@ mod tests {
     fn suggest_gray_for_grey_in_american_titlecase() {
         assert_suggestion_result(
             "It's a Greyscale Photo.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "It's a Grayscale Photo.",
         );
     }
@@ -940,7 +940,7 @@ mod tests {
     fn suggest_grey_for_gray_in_non_american_all_caps() {
         assert_suggestion_result(
             "GRAY",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "GREY",
         );
     }
@@ -950,7 +950,7 @@ mod tests {
     fn suggest_gray_for_grey_in_american_all_caps() {
         assert_suggestion_result(
             "GREY",
-            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            SpellCheck::new(FstDictionary::curated(), Dialect::American, SpellCheckConfig::default()),
             "GRAY",
         );
     }
@@ -962,7 +962,7 @@ mod tests {
     fn fix_cheif_and_recieved() {
         assert_top3_suggestion_result(
             "The cheif recieved a letter.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "The chief received a letter.",
         );
     }
@@ -972,7 +972,7 @@ mod tests {
     fn fix_cheif_and_recieved_titlecase() {
         assert_top3_suggestion_result(
             "The Cheif Recieved a Letter.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "The Chief Received a Letter.",
         );
     }
@@ -982,7 +982,7 @@ mod tests {
     fn fix_cheif_and_recieved_all_caps() {
         assert_top3_suggestion_result(
             "THE CHEIF RECIEVED A LETTER.",
-            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            SpellCheck::new(FstDictionary::curated(), Dialect::British, SpellCheckConfig::default()),
             "THE CHEIF RECEIVED A LETTER.",
         );
     }

--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -2101,6 +2101,18 @@
 					"default": true,
 					"description": "Looks and provides corrections for misspelled words."
 				},
+				"harper.linters.SpellCheckIgnoreCapitalized": {
+					"scope": "resource",
+					"type": "boolean",
+					"default": false,
+					"description": "Tells spell check to ignore capitalized words."
+				},
+				"harper.linters.SpellCheckIgnoreAbbreviations": {
+					"scope": "resource",
+					"type": "boolean",
+					"default": false,
+					"description": "Tells spell check to ignore abbreviations."
+				},
 				"harper.linters.SpelledNumbers": {
 					"scope": "resource",
 					"type": "boolean",


### PR DESCRIPTION
# Description
- Added spell check config struct to manage conditionals in spell check
- LintGroupConfig has a field for spell check config
- Spell check config is modified through fn lint
- Linter trait now has "update_spell_check_config" but returns () by default except for the spell check linter

# How Has This Been Tested?
Added tests to check new spell check rules. 

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
