### PR TITLE
feat: addicting→addictive

### DIFF
--- a/harper-core/src/expr/sequence_expr.rs
+++ b/harper-core/src/expr/sequence_expr.rs
@@ -84,6 +84,8 @@ impl Expr for SequenceExpr {
 impl SequenceExpr {
     // Constructor methods
 
+    // Single word token methods
+
     /// Construct a new sequence with a [`Word`] at the beginning of the operation list.
     pub fn any_capitalization_of(word: &'static str) -> Self {
         Self::default().then_any_capitalization_of(word)
@@ -94,17 +96,31 @@ impl SequenceExpr {
         Self::any_capitalization_of(word)
     }
 
-    /// Match the first of multiple expressions.
-    pub fn any_of(exprs: Vec<Box<dyn Expr>>) -> Self {
-        Self::default().then_any_of(exprs)
-    }
-
     /// Match any word from the given set of words, case-insensitive.
     pub fn word_set(words: &'static [&'static str]) -> Self {
         Self::default().then_word_set(words)
     }
 
-    // General builder methods
+    /// Match any word.
+    pub fn any_word() -> Self {
+        Self::default().then_any_word()
+    }
+
+    // Expressions of more than one token
+
+    // Multiple expressions
+
+    /// Match the first of multiple expressions.
+    pub fn any_of(exprs: Vec<Box<dyn Expr>>) -> Self {
+        Self::default().then_any_of(exprs)
+    }
+
+    /// Will be accepted unless the condition matches.
+    pub fn unless(condition: impl Expr + 'static) -> Self {
+        Self::default().then_unless(condition)
+    }
+
+    // Builder methods
 
     /// Push an [expression](Expr) to the operation list.
     pub fn then(mut self, expr: impl Expr + 'static) -> Self {

--- a/harper-core/src/linting/addicting.rs
+++ b/harper-core/src/linting/addicting.rs
@@ -1,0 +1,120 @@
+use crate::{
+    Token,
+    expr::{All, AnchorEnd, Expr, FirstMatchOf, LongestMatchOf, ReflexivePronoun, SequenceExpr},
+    linting::{ExprLinter, Lint, LintKind, Suggestion},
+};
+
+pub struct Addicting {
+    expr: Box<dyn Expr>,
+}
+
+impl Default for Addicting {
+    fn default() -> Self {
+        Self {
+            expr: Box::new(LongestMatchOf::new(vec![
+                // matches `addicting` without anything after
+                Box::new(SequenceExpr::aco("addicting").then(AnchorEnd)),
+                // matches `addicting` <ws> [ any word but not a reflexive pronoun or object pronoun ]
+                Box::new(
+                    SequenceExpr::aco("addicting")
+                        .then_whitespace()
+                        .then(All::new(vec![
+                            // positive - any word
+                            Box::new(SequenceExpr::any_word()),
+                            // negative - reflexive pronoun or object pronoun
+                            Box::new(SequenceExpr::unless(FirstMatchOf::new(vec![
+                                Box::new(ReflexivePronoun::with_common_errors()),
+                                Box::new(SequenceExpr::default().then_object_pronoun()),
+                            ]))),
+                        ])),
+                ),
+            ])),
+        }
+    }
+}
+
+impl ExprLinter for Addicting {
+    fn expr(&self) -> &dyn Expr {
+        self.expr.as_ref()
+    }
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        let tok = toks.first()?;
+
+        Some(Lint {
+            span: tok.span,
+            lint_kind: LintKind::Style,
+            suggestions: vec![Suggestion::replace_with_match_case(
+                "addictive".chars().collect(),
+                tok.span.get_content(src),
+            )],
+            message: "When used as an adjective, `addictive` is the traditional and more f form."
+                .to_owned(),
+            ..Default::default()
+        })
+    }
+
+    fn description(&self) -> &str {
+        "Replaces `addicting` with `addictive` when used as an adjective."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Addicting;
+    use crate::linting::tests::{assert_lint_count, assert_no_lints, assert_suggestion_result};
+
+    #[test]
+    fn fix_addicting() {
+        assert_suggestion_result(
+            "It is addicting like heroin.",
+            Addicting::default(),
+            "It is addictive like heroin.",
+        );
+    }
+
+    #[test]
+    fn dont_flag_addicting_object_pronoun() {
+        assert_lint_count("It is addicting me.", Addicting::default(), 0);
+    }
+
+    #[test]
+    fn dont_flag_addicting_reflexive_pronoun() {
+        assert_lint_count("He is addicting himself.", Addicting::default(), 0);
+    }
+
+    #[test]
+    fn fix_yet_highly_addicting() {
+        assert_suggestion_result(
+            "The objective of the game is simple yet highly addicting, you start out with the four basic elements.",
+            Addicting::default(),
+            "The objective of the game is simple yet highly addictive, you start out with the four basic elements.",
+        );
+    }
+
+    #[test]
+    fn dont_flag_addicting_them_on() {
+        assert_no_lints(
+            "Helping humans on their daily tasks instead of addicting them on social networks of all sorts.",
+            Addicting::default(),
+        );
+    }
+
+    #[test]
+    #[ignore = "False positive since `myself` is not an object pronoun in this construction"]
+    fn fix_find_things_addicting_myself() {
+        assert_suggestion_result(
+            "Yeah, I find taking the functional approach for these kinds of problems rather addicting myself :)",
+            Addicting::default(),
+            "Yeah, I find taking the functional approach for these kinds of problems rather addictive myself :)",
+        );
+    }
+
+    #[test]
+    fn dont_fix_coerced_into_addicting_themselves() {
+        assert_no_lints(
+            "The British, in another display of gunboat diplomacy, coerced countless innocent people into addicting themselves to opium.",
+            Addicting::default(),
+        );
+    }
+}

--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -12,6 +12,7 @@ use lru::LruCache;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::a_part::APart;
+use super::addicting::Addicting;
 use super::adjective_double_degree::AdjectiveDoubleDegree;
 use super::adjective_of_a::AdjectiveOfA;
 use super::am_in_the_morning::AmInTheMorning;
@@ -406,6 +407,7 @@ impl LintGroup {
         // Please maintain alphabetical order.
         // On *nix you can maintain sort order with `sort -t'(' -k2`
         insert_expr_rule!(APart, true);
+        insert_expr_rule!(Addicting, true);
         insert_expr_rule!(AdjectiveDoubleDegree, true);
         insert_struct_rule!(AdjectiveOfA, true);
         insert_struct_rule!(AmInTheMorning, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -3,6 +3,7 @@
 //! See the [`Linter`] trait and the [documentation for authoring a rule](https://writewithharper.com/docs/contributors/author-a-rule) for more information.
 
 mod a_part;
+mod addicting;
 mod adjective_double_degree;
 mod adjective_of_a;
 mod am_in_the_morning;
@@ -142,6 +143,7 @@ mod wordpress_dotcom;
 mod would_never_have;
 
 pub use a_part::APart;
+pub use addicting::Addicting;
 pub use adjective_double_degree::AdjectiveDoubleDegree;
 pub use adjective_of_a::AdjectiveOfA;
 pub use am_in_the_morning::AmInTheMorning;


### PR DESCRIPTION
# Issues 
N/A

# Description

Corrects `addicting` to `addictive` when used as an adjective.
Doesn't do so when `addicting` is used as a verb.

Got a linter with `AnchorEnd` working!

- Made `SequenceExpr` ctors for `any_word` and `unless`.
- Tidied the order of the methods a bit for consistency.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

There's unit tests for the various cases that should and shouldn't be flagged.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
