### PR TITLE
feat: windscreen vs windshield regionalism

### DIFF
--- a/harper-core/src/linting/regionalisms.rs
+++ b/harper-core/src/linting/regionalisms.rs
@@ -56,6 +56,7 @@ enum Concept {
     PramStroller,
     SpannerWrench,
     StationWagonEstate,
+    WindscreenWindshield,
 }
 
 use Concept::*;
@@ -449,6 +450,18 @@ const REGIONAL_TERMS: &[Term<'_>] = &[
         dialects: &[American],
         concept: SpannerWrench,
     },
+    Term {
+        term: "windscreen",
+        flag: Flag,
+        dialects: &[British, Australian],
+        concept: WindscreenWindshield,
+    },
+    Term {
+        term: "windshield",
+        flag: Flag,
+        dialects: &[American, Canadian],
+        concept: WindscreenWindshield,
+    },
 ];
 
 pub struct Regionalisms {
@@ -627,6 +640,15 @@ mod tests {
             "A caravan (from Persian کاروان kârvân) is a group of people traveling together, often on a trade expedition. Caravans were used mainly in desert areas.",
             Regionalisms::new(Dialect::British),
             0,
+        )
+    }
+
+    #[test]
+    fn uk_to_us_windscreen() {
+        assert_top3_suggestion_result(
+            "Detect raindrops on vehicle windscreen by combining various region proposal algorithm with Convolutional Neural Network.",
+            Regionalisms::new(Dialect::American),
+            "Detect raindrops on vehicle windshield by combining various region proposal algorithm with Convolutional Neural Network.",
         )
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

I thought of a regionalism we weren't handling. USA and Canada say "windshield" but UK and Australia say "windscreen".

# How Has This Been Tested?

I picked a test sentence from GitHub to use as a unit test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
