### PR TITLE
fix: verb lemma logic wasn't working for default case

### DIFF
--- a/harper-core/src/expr/sequence_expr.rs
+++ b/harper-core/src/expr/sequence_expr.rs
@@ -425,6 +425,7 @@ impl SequenceExpr {
     gen_then_from_is!(verb);
     gen_then_from_is!(auxiliary_verb);
     gen_then_from_is!(linking_verb);
+    gen_then_from_is!(verb_lemma);
 
     // Adjectives
 

--- a/harper-core/src/linting/cant.rs
+++ b/harper-core/src/linting/cant.rs
@@ -18,7 +18,7 @@ impl Default for Cant {
         let cant_pron = SequenceExpr::aco("cant").t_ws().then_personal_pronoun();
         let cant_verb = SequenceExpr::aco("cant")
             .t_ws()
-            .then_kind_is_but_is_not(|kind| kind.is_verb(), |kind| kind.is_noun());
+            .then_kind_is_but_is_not(|kind| kind.is_verb_lemma(), |kind| kind.is_noun());
 
         Self {
             expr: Box::new(LongestMatchOf::new(vec![
@@ -28,23 +28,6 @@ impl Default for Cant {
             ])),
         }
     }
-}
-
-// TODO: This can be removed once #1730 is merged
-fn is_verb_lemma(tok: &Token, src: &[char]) -> bool {
-    tok.kind.is_verb()
-        && !tok
-            .span
-            .get_content(src)
-            .ends_with_ignore_ascii_case_chars(&['s'])
-        && !tok
-            .span
-            .get_content(src)
-            .ends_with_ignore_ascii_case_chars(&['e', 'd'])
-        && !tok
-            .span
-            .get_content(src)
-            .ends_with_ignore_ascii_case_chars(&['i', 'n', 'g'])
 }
 
 impl ExprLinter for Cant {

--- a/harper-core/src/linting/how_to.rs
+++ b/harper-core/src/linting/how_to.rs
@@ -1,7 +1,7 @@
 use harper_brill::UPOS;
 
 use crate::{
-    CharStringExt, Token, TokenKind, TokenStringExt,
+    Token, TokenKind, TokenStringExt,
     expr::{All, Expr, OwnedExprExt, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
     patterns::{InflectionOfBe, UPOSSet},
@@ -20,11 +20,7 @@ impl Default for HowTo {
             .then_anything()
             .t_aco("how")
             .then_whitespace()
-            .then(|tok: &Token, src: &[char]| {
-                // TODO this is a temporary hack until PR #1730 is merged
-                // TODO we should use then_verb_lemma() instead
-                is_verb_lemma(tok, src)
-            });
+            .then_verb_lemma();
         pattern.add(pos_pattern);
 
         let exceptions = SequenceExpr::default()
@@ -49,16 +45,6 @@ impl Default for HowTo {
         Self {
             expr: Box::new(pattern),
         }
-    }
-}
-
-// TODO this is a temporary hack until PR #1730 is merged
-fn is_verb_lemma(tok: &Token, src: &[char]) -> bool {
-    tok.kind.is_verb() && {
-        let verb = tok.span.get_content(src);
-        !(verb.ends_with_ignore_ascii_case_str("s")
-            || verb.ends_with_ignore_ascii_case_str("ed")
-            || verb.ends_with_ignore_ascii_case_str("ing"))
     }
 }
 

--- a/harper-core/src/spell/mutable_dictionary.rs
+++ b/harper-core/src/spell/mutable_dictionary.rs
@@ -414,7 +414,7 @@ mod tests {
     }
 
     #[test]
-    fn is_is_verb_lemma() {
+    fn be_is_verb_lemma() {
         let dict = MutableDictionary::curated();
 
         let is = dict.get_word_metadata_str("be");

--- a/harper-core/src/word_metadata.rs
+++ b/harper-core/src/word_metadata.rs
@@ -459,11 +459,16 @@ impl WordMetadata {
         )
     }
 
+    // Lemma is default if no verb form is specified in the dictionary
     pub fn is_verb_lemma(&self) -> bool {
-        self.verb.is_some_and(|v| {
-            v.verb_forms
-                .is_some_and(|vf| vf.contains(VerbFormFlags::LEMMA))
-        })
+        if let Some(verb) = self.verb {
+            if let Some(forms) = verb.verb_forms {
+                return forms.is_empty() || forms.contains(VerbFormFlags::LEMMA);
+            } else {
+                return true;
+            }
+        }
+        false
     }
 
     pub fn is_verb_past_form(&self) -> bool {
@@ -1836,6 +1841,12 @@ pub mod tests {
         #[test]
         fn lemma_walk() {
             let md = md("walk");
+            assert!(md.is_verb_lemma())
+        }
+
+        #[test]
+        fn lemma_fix() {
+            let md = md("fix");
             assert!(md.is_verb_lemma())
         }
 


### PR DESCRIPTION
# Issues 
N/A

# Description

The logic for testing if a word is the lemma (base form) of a verb didn't take into account the lemma being the default form when no other form is marked in `dictionary.dict`

I discovered this while updating the logic in the `Cant` and `HowTo` linters that had some temporary ad-hoc tests for the lemma form of the verb. So those linters are also updated in this PR.

# How Has This Been Tested?

A test was added for the verb `fix` which is the one that brought the problem to my attention.
All tests that worked with the old logic work with the new logic.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
