### PR TITLE
fix(core): correct capitalization with contractions

### DIFF
--- a/harper-core/src/linting/semicolon_apostrophe.rs
+++ b/harper-core/src/linting/semicolon_apostrophe.rs
@@ -40,14 +40,15 @@ impl ExprLinter for SemicolonApostrophe {
             ending.span.get_content_string(src).to_lowercase()
         );
 
-        let lettercase_template_char_slice = base.span.get_content(src);
+        let mut lettercase_template = base.span.get_content(src).to_vec();
+        lettercase_template.extend_from_slice(ending.span.get_content(src));
 
         Some(Lint {
             span: whole_span,
             lint_kind: LintKind::Typo,
             suggestions: vec![Suggestion::replace_with_match_case(
                 replacement_str.chars().collect(),
-                lettercase_template_char_slice,
+                &lettercase_template,
             )],
             message: format!("Did you mean `{replacement_str}`?"),
             priority: 57,
@@ -115,5 +116,10 @@ mod tests {
             SemicolonApostrophe::default(),
             "Let's see if we've fixed patrakov's bug. Fun wasn't it?",
         )
+    }
+
+    #[test]
+    fn corrects_ive_with_correct_capitalization() {
+        assert_suggestion_result("I;ve", SemicolonApostrophe::default(), "I've");
     }
 }

--- a/harper-core/src/linting/suggestion.rs
+++ b/harper-core/src/linting/suggestion.rs
@@ -40,12 +40,10 @@ impl Suggestion {
                 .copied()
                 .chain(template_term),
         ) {
-            if v.is_ascii_uppercase() != t.is_ascii_uppercase() {
-                if t.is_uppercase() {
-                    *v = v.to_ascii_uppercase();
-                } else {
-                    *v = v.to_ascii_lowercase();
-                }
+            if t.is_uppercase() {
+                *v = v.to_ascii_uppercase();
+            } else {
+                *v = v.to_ascii_lowercase();
             }
         }
 


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

I noticed that sometimes, I would write a contraction like "I;ve", but Harper would try to correct it to "IVE".

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

This ended up being because the linter that produced the suggestion wouldn't include the ending of the contraction when generating the corrected capitalization. Since "I" is capitalized, it assumed the rest of the word should be capitalized as well. It was a simple fix to include the ending in the generation.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Additional unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
