### PR TITLE
feat(core): enable all rendering options for lint messages

### DIFF
--- a/harper-core/src/render_markdown.rs
+++ b/harper-core/src/render_markdown.rs
@@ -1,10 +1,10 @@
 use ammonia::clean;
-use pulldown_cmark::{Parser, html};
+use pulldown_cmark::{Options, Parser, html};
 
 /// The standard Markdown rendering function for the crate.
 /// Do not call `pulldown_cmark` directly. Use this.
 pub fn render_markdown(markdown: &str) -> String {
-    let parser = Parser::new(markdown);
+    let parser = Parser::new_ext(markdown, Options::all());
     let mut html = String::new();
     html::push_html(&mut html, parser);
     clean(&html)


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Closes #1877

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

Our lint messages did not have smart punctuation because I had neglected to enable the various options on `pulldown_cmark` which we use to render our lint messages to HTML. One of the missing options was indeed smart punctuation. This PR enabled that and all other "bonus" options from `pulldown_cmark`. 

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
