### PR TITLE
fix(#1926): isolate typst content blocks with parbreaks

### DIFF
--- a/harper-typst/src/typst_translator.rs
+++ b/harper-typst/src/typst_translator.rs
@@ -152,6 +152,17 @@ impl<'a> TypstTranslator<'a> {
             };
         }
 
+        fn parbreak() -> Option<Vec<Token>> {
+            Some(vec![Token {
+                span: harper_core::Span::EMPTY,
+                kind: TokenKind::ParagraphBreak,
+            }])
+        }
+
+        fn isolate(inner: Option<Vec<Token>>) -> Option<Vec<Token>> {
+            merge![parbreak(), inner, parbreak()]
+        }
+
         // Recurse on each element of an iterator
         let iter_recurse = |exprs: &mut dyn Iterator<Item = Expr>| {
             let mut buf = Vec::new();

--- a/harper-typst/src/typst_translator.rs
+++ b/harper-typst/src/typst_translator.rs
@@ -305,7 +305,9 @@ impl<'a> TypstTranslator<'a> {
                         .collect_vec(),
                 )
             }
-            Expr::Content(content_block) => iter_recurse(&mut content_block.body().exprs()),
+            Expr::Content(content_block) => {
+                isolate(iter_recurse(&mut content_block.body().exprs()))
+            }
             Expr::Parenthesized(parenthesized) => recurse!(parenthesized.expr()),
             Expr::Array(array) => Some(
                 array

--- a/harper-typst/tests/run_tests.rs
+++ b/harper-typst/tests/run_tests.rs
@@ -40,3 +40,4 @@ create_test!(simplified_document.typ, 0);
 create_test!(complex_document_with_spelling_mistakes.typ, 4);
 // create_test!(issue_399.typ, 3);
 create_test!(function_with_ignorable_args.typ, 9);
+create_test!(issue_1926.typ, 1);

--- a/harper-typst/tests/test_sources/issue_1926.typ
+++ b/harper-typst/tests/test_sources/issue_1926.typ
@@ -1,0 +1,5 @@
+No No
+#table(
+  columns: 2,
+  [No], [No]
+)


### PR DESCRIPTION
# Issues 
Closes #1926

# Description
- Adds an `parbreak()` function that returns a paragraph break token with an empty span
- Adds an `isolate(inner)` function that wraps the inner parse in paragraph breaks
- Uses `isolate` function to isolate the interior of a content block

# How Has This Been Tested?
Using `harper-cli` to verify the parse, and with the following test expecting 1 lint:
```typst
No No
#table(
  columns: 2,
  [No], [No],
)
```

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
