### PR TITLE
docs: improve message and description for `SomewhatSomething`

### DIFF
--- a/harper-core/src/linting/somewhat_something.rs
+++ b/harper-core/src/linting/somewhat_something.rs
@@ -1,6 +1,5 @@
 use crate::Token;
-use crate::expr::Expr;
-use crate::expr::SequenceExpr;
+use crate::expr::{Expr, SequenceExpr};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -35,13 +34,13 @@ impl ExprLinter for SomewhatSomething {
             span,
             lint_kind: LintKind::Style,
             suggestions: vec![Suggestion::replace_with_match_case_str("something", og)],
-            message: "Use the traditional form.".to_owned(),
+            message: "Consider using `something of a` in more formal writing.".to_owned(),
             priority: 63,
         })
     }
 
     fn description(&self) -> &'static str {
-        "When describing a single instance of a noun, use `something` rather than `somewhat`."
+        "Flags the phrase `somewhat of a` in favor of `something of a`, which can be considered more traditional."
     }
 }
 
@@ -57,6 +56,15 @@ mod tests {
             "This may be somewhat of a surprise.",
             SomewhatSomething::default(),
             "This may be something of a surprise.",
+        );
+    }
+
+    #[test]
+    fn flag_these() {
+        assert_suggestion_result(
+            "These are somewhat of a cult data structure.",
+            SomewhatSomething::default(),
+            "These are something of a cult data structure.",
         );
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

While dogfooding on the READMEs of trending GitHub repos the way it flagged `somewhat of a cult data structure` struck me as maybe a bit vague and maybe a bit opinionated?

<img width="548" height="67" alt="Screenshot 2025-09-13 at 3 13 08 am" src="https://github.com/user-attachments/assets/5cc82c79-5661-426b-be23-65475a4c0a9f" />

On checking the linter, the `description` didn't even seem to describe what the linter tries to do.

Current `message`: "Use the traditional form."
Proposed `message`: "Consider using `something of a` in more formal writing."

Current `description`: "When describing a single instance of a noun, use `something` rather than `somewhat`."
Proposed `description`: "Flags the phrase `somewhat of a` in favor of `something of a`, which can be considered more traditional."

Historically "somewhat of a" has been in use for a long time even though some dislike and avoid it. So I didn't want to call it "ungrammatical" or "unidiomatic" and tried to find a neutral wording that doesn't misrepresent the situation.

# How Has This Been Tested?

I added a second unit test using the sentence that brought this to my attention, just for good measure.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes


* By the way, this is such a simple and clear linter code-wise that I feel it would make an excellent example to point to in our documentation for people learning to write their first linter.