### PR TITLE
chore(dict): add Amdahl as proper noun

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -53983,3 +53983,4 @@ work out/V
 # If you're not confident in using the affix annotations, add missing words here
 # And they will be reviewed
 # Word added using the `just addnoun` command will be added here
+Amdahl/Og          # As in Amdahl's law


### PR DESCRIPTION
# Description
"Amdahl" is a proper noun and the person that first noted [Amdahl's law](https://en.wikipedia.org/wiki/Amdahl%27s_law).
This PR adds this missing entry to the dictionary


# How Has This Been Tested?
I've rebuild the harper-cli binary and confirmed that linting "Amdahl's law" now produces no errors.

# Checklist
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
