### PR TITLE
feat(core): add rule for unnecessary double-negatives

### DIFF
--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -759,13 +759,6 @@ pub fn lint_group() -> LintGroup {
             "Advises using `momentous` or `monumental` instead of `monumentous` for serious usage.",
             LintKind::Nonstandard
         ),
-        "MorePreferable" => (
-            ["more preferable"],
-            ["preferable"],
-            "Use just `preferable` instead of `more preferable`.",
-            "Corrects `more preferable` to `preferable`.",
-            LintKind::Redundancy
-        ),
         "MyHouse" => (
             ["mu house"],
             ["my house"],

--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -801,6 +801,13 @@ pub fn lint_group() -> LintGroup {
             "Corrects `no to` to `not to`, ensuring proper negation.",
             LintKind::Typo
         ),
+        "NotUncommon" => (
+            ["not uncommon"],
+            ["common"],
+            "Prefer the direct adjective `common` over the litotes `not uncommon`.",
+            "Rewrites the litotes `not uncommon` to the clearer `common`.",
+            LintKind::WordChoice
+        ),
         "OfCourse" => (
             // See also: `of_course.rs` for "of curse/corse" → "of course" corrections
             ["off course", "o course", "ofcourse"],

--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -801,13 +801,6 @@ pub fn lint_group() -> LintGroup {
             "Corrects `no to` to `not to`, ensuring proper negation.",
             LintKind::Typo
         ),
-        "NotUncommon" => (
-            ["not uncommon"],
-            ["common"],
-            "Prefer the direct adjective `common` over the litotes `not uncommon`.",
-            "Rewrites the litotes `not uncommon` to the clearer `common`.",
-            LintKind::WordChoice
-        ),
         "OfCourse" => (
             // See also: `of_course.rs` for "of curse/corse" → "of course" corrections
             ["off course", "o course", "ofcourse"],

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -900,16 +900,6 @@ fn detect_monumentous_real_world() {
     );
 }
 
-// MorePreferable
-#[test]
-fn correct_more_preferable() {
-    assert_suggestion_result(
-        "Is it more preferable to use process.env.variable or env.parsed.variable?",
-        lint_group(),
-        "Is it preferable to use process.env.variable or env.parsed.variable?",
-    );
-}
-
 // MyHouse
 // -none-
 

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -968,20 +968,8 @@ fn detect_nerve_racking_no_hyphen() {
 // NotTo
 // -none-
 
-// NotUncommon
-#[test]
-fn corrects_not_uncommon_atomic() {
-    assert_suggestion_result("not uncommon", lint_group(), "common");
-}
-
-#[test]
-fn corrects_not_uncommon_real_world() {
-    assert_suggestion_result(
-        "It is not uncommon to see outages during storms.",
-        lint_group(),
-        "It is common to see outages during storms.",
-    );
-}
+// NotUncommon moved to phrase_set_corrections as part of the
+// generalized double negative mapping.
 
 // OfCourse
 // See also: tests in `of_course.rs` for "of curse/corse" → "of course" corrections

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -968,6 +968,21 @@ fn detect_nerve_racking_no_hyphen() {
 // NotTo
 // -none-
 
+// NotUncommon
+#[test]
+fn corrects_not_uncommon_atomic() {
+    assert_suggestion_result("not uncommon", lint_group(), "common");
+}
+
+#[test]
+fn corrects_not_uncommon_real_world() {
+    assert_suggestion_result(
+        "It is not uncommon to see outages during storms.",
+        lint_group(),
+        "It is common to see outages during storms.",
+    );
+}
+
 // OfCourse
 // See also: tests in `of_course.rs` for "of curse/corse" → "of course" corrections
 #[test]

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -280,7 +280,7 @@ pub fn lint_group() -> LintGroup {
             LintKind::Eggcorn
         ),
 
-        // General litotes (double negatives) → direct positive
+        // General litotes (double negatives) → direct positive suggestions
         "LitotesDirectPositive" => (
             &[
                 ("not uncommon", "common"),
@@ -298,9 +298,9 @@ pub fn lint_group() -> LintGroup {
                 ("not unreasonable", "reasonable"),
                 ("not impossible", "possible"),
             ],
-            "Prefer a direct form over litotes like `not uncommon`.",
-            "Rewrites common double negatives (litotes) to a clearer direct positive.",
-            LintKind::WordChoice
+            "Consider a direct form instead of litotes like `not uncommon`.",
+            "Offers direct-positive alternatives when double negatives might feel heavy.",
+            LintKind::Style
         ),
 
         // Redundant degree modifiers on positives (double positives) → base form

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -279,6 +279,42 @@ pub fn lint_group() -> LintGroup {
             "Corrects the eggcorn `piggy bag` to `piggyback`, which is the proper term for riding on someone’s back or using an existing system.",
             LintKind::Eggcorn
         ),
+
+        // General litotes (double negatives) → direct positive
+        "LitotesDirectPositive" => (
+            &[
+                ("not uncommon", "common"),
+                ("not unusual", "common"),
+                ("not insignificant", "significant"),
+                ("not unimportant", "important"),
+                ("not unlikely", "likely"),
+                ("not infrequent", "frequent"),
+                ("not inaccurate", "accurate"),
+                ("not unclear", "clear"),
+                ("not irrelevant", "relevant"),
+                ("not unpredictable", "predictable"),
+                ("not inadequate", "adequate"),
+                ("not unpleasant", "pleasant"),
+                ("not unreasonable", "reasonable"),
+                ("not impossible", "possible"),
+            ],
+            "Prefer a direct form over litotes like `not uncommon`.",
+            "Rewrites common double negatives (litotes) to a clearer direct positive.",
+            LintKind::WordChoice
+        ),
+
+        // Redundant degree modifiers on positives (double positives) → base form
+        "RedundantSuperlatives" => (
+            &[
+                ("more optimal", "optimal"),
+                ("most optimal", "optimal"),
+                ("more ideal", "ideal"),
+                ("most ideal", "ideal"),
+            ],
+            "Avoid redundant degree modifiers; prefer the base adjective.",
+            "Simplifies redundant double positives like `most optimal` to the base form.",
+            LintKind::Redundancy
+        ),
     });
 
     add_many_to_many_mappings!(group, {

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -297,6 +297,7 @@ pub fn lint_group() -> LintGroup {
                 ("not unpleasant", "pleasant"),
                 ("not unreasonable", "reasonable"),
                 ("not impossible", "possible"),
+                ("more preferable", "preferable"),
             ],
             "Consider a direct form instead of litotes like `not uncommon`.",
             "Offers direct-positive alternatives when double negatives might feel heavy.",

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -198,6 +198,60 @@ fn corrects_dose_not() {
     );
 }
 
+// LitotesDirectPositive
+
+#[test]
+fn litotes_not_uncommon_atomic() {
+    assert_suggestion_result("not uncommon", lint_group(), "common");
+}
+
+#[test]
+fn litotes_not_uncommon_sentence() {
+    assert_suggestion_result(
+        "It is not uncommon to see outages during storms.",
+        lint_group(),
+        "It is common to see outages during storms.",
+    );
+}
+
+#[test]
+fn litotes_not_unlikely() {
+    assert_suggestion_result(
+        "This outcome is not unlikely given the data.",
+        lint_group(),
+        "This outcome is likely given the data.",
+    );
+}
+
+#[test]
+fn litotes_not_insignificant() {
+    assert_suggestion_result(
+        "That is not insignificant progress.",
+        lint_group(),
+        "That is significant progress.",
+    );
+}
+
+// RedundantSuperlatives
+
+#[test]
+fn redundant_more_optimal() {
+    assert_suggestion_result(
+        "Is this more optimal?",
+        lint_group(),
+        "Is this optimal?",
+    );
+}
+
+#[test]
+fn redundant_most_ideal() {
+    assert_suggestion_result(
+        "This is the most ideal scenario.",
+        lint_group(),
+        "This is the ideal scenario.",
+    );
+}
+
 // -dose it true positive-
 #[test]
 #[ignore = "due to false positives this can't be fixed yet"]

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -236,11 +236,7 @@ fn litotes_not_insignificant() {
 
 #[test]
 fn redundant_more_optimal() {
-    assert_suggestion_result(
-        "Is this more optimal?",
-        lint_group(),
-        "Is this optimal?",
-    );
+    assert_suggestion_result("Is this more optimal?", lint_group(), "Is this optimal?");
 }
 
 #[test]

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -232,6 +232,15 @@ fn litotes_not_insignificant() {
     );
 }
 
+#[test]
+fn litotes_more_preferable() {
+    assert_suggestion_result(
+        "Is it more preferable to use process.env.variable or env.parsed.variable?",
+        lint_group(),
+        "Is it preferable to use process.env.variable or env.parsed.variable?",
+    );
+}
+
 // RedundantSuperlatives
 
 #[test]

--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -1555,12 +1555,6 @@
 					"default": true,
 					"description": "Corrects `mute` to `moot` in the phrase `moot point`."
 				},
-				"harper.linters.MorePreferable": {
-					"scope": "resource",
-					"type": "boolean",
-					"default": true,
-					"description": "Corrects `more preferable` to `preferable`."
-				},
 				"harper.linters.MostNumber": {
 					"scope": "resource",
 					"type": "boolean",


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

I've added a rule that looks for common double-negatives and corrects them to encourage clarity. I'm mostly interested if this is reasonable from a philosophical perspective. _Should_ Harper include this?

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
