### PR TITLE
feat:rule of thumbs→rules of thumb/flip the bill→foot the bill

### DIFF
--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -924,6 +924,13 @@ pub fn lint_group() -> LintGroup {
             "Detects when `roadmap` is used instead of `road map`, prompting the correct spacing.",
             LintKind::WordChoice
         ),
+        "RulesOfThumb" => (
+            ["rule of thumbs", "rule-of-thumbs"],
+            ["rules of thumb"],
+            "The correct plural is `rules of thumb`.",
+            "Corrects pluralizing the wrong noun in `rule of thumb`.",
+            LintKind::Usage
+        ),
         "SameAs" => (
             ["same then"],
             ["same as"],

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -1142,6 +1142,26 @@ fn correct_iirc_correctly() {
 // RoadMap
 // -none-
 
+// RulesOfThumb
+
+#[test]
+fn correct_rules_of_thumbs() {
+    assert_suggestion_result(
+        "Thanks. 0.2 is just from my rule of thumbs.",
+        lint_group(),
+        "Thanks. 0.2 is just from my rules of thumb.",
+    );
+}
+
+#[test]
+fn correct_rules_of_thumbs_hyphenated() {
+    assert_suggestion_result(
+        "Add rule-of-thumbs for basic metrics, like \"Spill more than 1GB is a red flag\".",
+        lint_group(),
+        "Add rules of thumb for basic metrics, like \"Spill more than 1GB is a red flag\".",
+    );
+}
+
 // SameAs
 // -none-
 

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -194,6 +194,17 @@ pub fn lint_group() -> LintGroup {
             // ConfusedPair??
             LintKind::WordChoice
         ),
+        "FootTheBill" => (
+            &[
+                ("flip the bill", "foot the bill"),
+                ("flipped the bill", "footed the bill"),
+                ("flipping the bill", "footing the bill"),
+                ("flips the bill", "foots the bill"),
+            ],
+            "The standard expression is `foot the bill`.",
+            "Corrects `flip the bill` to `foot the bill`.",
+            LintKind::Nonstandard
+        ),
         "HavePassed" => (
             &[
                 ("had past", "had passed"),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -334,7 +334,6 @@ fn dont_flag_dont_dose_it_too_high() {
     );
 }
 
-// the only solution the other hopefully-dominant-reasonable-adult-human mind can find, is to dose it off, hoping the drowsiness can keep the fear at bay
 #[test]
 #[ignore = "would be a false positive in a naive implementation"]
 fn dont_flag_to_dose_it_off() {
@@ -549,6 +548,44 @@ fn correct_to_an_extend() {
         "It mimics (to an extend) the way in which Chrome requests SSO cookies with the Windows 10 accounts extension.",
         lint_group(),
         "It mimics (to an extent) the way in which Chrome requests SSO cookies with the Windows 10 accounts extension.",
+    );
+}
+
+// FootTheBill
+
+#[test]
+fn correct_flip_the_bill() {
+    assert_suggestion_result(
+        "- SQL Compare (If the company will flip the bill)",
+        lint_group(),
+        "- SQL Compare (If the company will foot the bill)",
+    );
+}
+
+#[test]
+fn correct_flipped_the_bill() {
+    assert_suggestion_result(
+        "As a meetup we were extremely lucky that NOVI flipped the bill for our in-person events.",
+        lint_group(),
+        "As a meetup we were extremely lucky that NOVI footed the bill for our in-person events.",
+    );
+}
+
+#[test]
+fn correct_flipping_the_bill() {
+    assert_suggestion_result(
+        "for the simple reason that there were no multimillion dollar company flipping the bill",
+        lint_group(),
+        "for the simple reason that there were no multimillion dollar company footing the bill",
+    );
+}
+
+#[test]
+fn correct_flips_the_bill() {
+    assert_suggestion_result(
+        "There seems to be a perennial debate in Illinois between urbanites and rural folk about who really flips the bill.",
+        lint_group(),
+        "There seems to be a perennial debate in Illinois between urbanites and rural folk about who really foots the bill.",
     );
 }
 


### PR DESCRIPTION
# Issues 
N/A

# Description

Noticed two new (to me) mistakes that could be fixed by phrase / phrase set corrections:

- **rule of thumbs** instead of "rules of thumb", exactly like "point of views" that I added recently.
- **flip the bill** instead of "foot the bill", which I asked about on Discord (https://discord.com/channels/1335035237213671495/1335035237213671498/1417771281293639751)

# How Has This Been Tested?

I added unit tests, preferring sentences in GitHub where possible.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
