### PR TITLE
fix: #1956

### DIFF
--- a/harper-core/src/linting/quite_quiet.rs
+++ b/harper-core/src/linting/quite_quiet.rs
@@ -18,7 +18,7 @@ impl Default for QuiteQuiet {
                     TokenKind::is_verb,
                 ] as &[_],
                 TokenKind::is_noun,
-                &["here", "not", "up"],
+                &["here", "up"],
             );
 
         let negative_contraction_quiet = SequenceExpr::default()
@@ -34,7 +34,7 @@ impl Default for QuiteQuiet {
             .t_aco("quiet");
 
         let adverb_quite = SequenceExpr::default()
-            .then_kind_except(TokenKind::is_adverb, &["never"])
+            .then_kind_except(TokenKind::is_adverb, &["never", "not"])
             .t_ws()
             .t_aco("quite");
 
@@ -116,7 +116,7 @@ impl ExprLinter for QuiteQuiet {
 #[cfg(test)]
 mod tests {
     use super::QuiteQuiet;
-    use crate::linting::tests::{assert_lint_count, assert_suggestion_result};
+    use crate::linting::tests::{assert_lint_count, assert_no_lints, assert_suggestion_result};
 
     #[test]
     fn fix_quiet_adverb() {
@@ -203,5 +203,10 @@ mod tests {
             QuiteQuiet::default(),
             "I couldn't quite understand everything",
         );
+    }
+
+    #[test]
+    fn fix_but_its_not_quite_clear_1956() {
+        assert_no_lints("But it's not quite clear", QuiteQuiet::default());
     }
 }


### PR DESCRIPTION
# Issues 
Fixes #1956

# Description

Despite there being an exception for the word `not` in the linter, `but it's not quite clear` was flagging the `quite` as a typo for `quiet` due to following the adverb `not`.

It seems the `not` exception was in the wrong part of the linter and there were no tests against it. I moved it to the other part of the linter and added the phrase from the bug report as a test.

# Demo
Before: 
<img width="812" height="196" alt="Screenshot 2025-09-17 at 5 30 38 pm" src="https://github.com/user-attachments/assets/ec7c35dd-5725-458a-a00f-32e5704be7f1" />
After: 
<img width="773" height="48" alt="image" src="https://github.com/user-attachments/assets/8ad9f4e8-cd98-4965-a017-5b714068ca7c" />

# How Has This Been Tested?

A unit test using the issue's phrase.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
