### PR TITLE
fix: adverbs that can come before "quite"

### DIFF
--- a/harper-core/src/linting/quite_quiet.rs
+++ b/harper-core/src/linting/quite_quiet.rs
@@ -34,7 +34,10 @@ impl Default for QuiteQuiet {
             .t_aco("quiet");
 
         let adverb_quite = SequenceExpr::default()
-            .then_kind_except(TokenKind::is_adverb, &["never", "not"])
+            .then_kind_except(
+                TokenKind::is_adverb,
+                &["actually", "never", "not", "really"],
+            )
             .t_ws()
             .t_aco("quite");
 
@@ -208,5 +211,13 @@ mod tests {
     #[test]
     fn fix_but_its_not_quite_clear_1956() {
         assert_no_lints("But it's not quite clear", QuiteQuiet::default());
+    }
+
+    #[test]
+    fn dont_flag_adv_quite_1971() {
+        assert_no_lints(
+            "It’s actually quite smart. It’s really quite smart. The proof is actually quite neat. Actually really quite simple. It’s actually quite strong. The Sneetches got really quite smart on that day.",
+            QuiteQuiet::default(),
+        );
     }
 }

--- a/harper-core/src/linting/quite_quiet.rs
+++ b/harper-core/src/linting/quite_quiet.rs
@@ -60,7 +60,6 @@ impl ExprLinter for QuiteQuiet {
         let text = toks.span()?.get_content_string(src).to_lowercase();
 
         if text.ends_with("quite") {
-            let first_token = toks.first()?;
             let quite_span = toks.last()?.span;
 
             return Some(Lint {
@@ -70,12 +69,10 @@ impl ExprLinter for QuiteQuiet {
                     "quiet".chars().collect(),
                     quite_span.get_content(src),
                 )],
-                message: "After an adverb like '{}', use 'quiet' not 'quite'"
-                    .replace("{}", &first_token.span.get_content_string(src)),
+                message: "‘Quite’ might be a typo here. It means ‘rather’ but you might be trying to say ‘quiet’ (not noisy).".to_string(),
                 priority: 63,
             });
         } else if text.starts_with("quiet") {
-            let last_token = toks.last()?;
             let quiet_span = toks.first()?.span;
 
             return Some(Lint {
@@ -85,14 +82,10 @@ impl ExprLinter for QuiteQuiet {
                     "quite".chars().collect(),
                     quiet_span.get_content(src),
                 )],
-                message: format!(
-                    "Before an adjective, adverb, or verb like '{}', use 'quite' not 'quiet'",
-                    last_token.span.get_content_string(src)
-                ),
+                message: "‘Quiet’ might be a typo here. It means ‘not noisy’ but you might be trying to say ‘quite’ (rather).".to_string(),
                 priority: 63,
             });
         } else if text.ends_with("quiet") {
-            let first_token = toks.first()?;
             let quiet_span = toks.last()?.span;
 
             return Some(Lint {
@@ -102,8 +95,7 @@ impl ExprLinter for QuiteQuiet {
                     "quite".chars().collect(),
                     quiet_span.get_content(src),
                 )],
-                message: "After a negative contraction like '{}', use 'quite' not 'quiet'"
-                    .replace("{}", &first_token.span.get_content_string(src)),
+                message: "‘Quiet’ might be a typo here. It means ‘not noisy’ but you might be trying to say ‘quite’ (rather).".to_string(),
                 priority: 63,
             });
         }
@@ -112,7 +104,7 @@ impl ExprLinter for QuiteQuiet {
     }
 
     fn description(&self) -> &str {
-        "Corrects when `quiet` is a typo for `quite` or the other way around."
+        "Helps distinguish between ‘quiet’ (making ‘little noise’) and ‘quite’ (meaning ‘rather’)."
     }
 }
 


### PR DESCRIPTION
# Issues 

Fixes #1971

# Description

I added "actually" and "really" to the list of exceptional adverbs that can be used correctly before "quite" as well as before "quiet".

# How Has This Been Tested?

A unit test has been added that has all of the bug report's sentences in it.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
