### PR TITLE
feat: aslong as→as long as

### DIFF
--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -141,6 +141,13 @@ pub fn lint_group() -> LintGroup {
             "Corrects `as it so happens` to `as it happens`.",
             LintKind::Usage
         ),
+        "AsLongAs" => (
+            ["aslong as"],
+            ["as long as"],
+            "`As long` should be written as two words.",
+            "Corrects `aslong as` to `as long as`.",
+            LintKind::BoundaryError
+        ),
         "AsOfLate" => (
             ["as of lately"],
             ["as of late"],

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -164,6 +164,16 @@ fn correct_as_it_happens() {
     );
 }
 
+// AsLongAs
+#[test]
+fn correct_as_long_as() {
+    assert_suggestion_result(
+        "server loads up fine but cant log on client side aslong as the plugin is installed",
+        lint_group(),
+        "server loads up fine but cant log on client side as long as the plugin is installed",
+    );
+}
+
 // AsOfLate
 #[test]
 fn corrects_as_of_lately() {


### PR DESCRIPTION
# Issues 
N/A

# Description

I just noticed that some people write `aslong` instead of `as long`. It turns out to be pretty common.
I didn't add it to the `OpenCompounds` linter though because `asLong()` is a pretty common function name.
Fortunately it's just about always part of the phrase `as long as`, which makes it a perfect candiate for the `phrase_corrections` module.

# How Has This Been Tested?

I added a unit test using the first sentence I found on GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
