### PR TITLE
fix: remove dupes and remnants of lints moved from `phrase_corrections`

### DIFF
--- a/harper-core/src/linting/open_compounds.rs
+++ b/harper-core/src/linting/open_compounds.rs
@@ -102,7 +102,7 @@ impl ExprLinter for OpenCompounds {
 
         Some(Lint {
             span,
-            lint_kind: LintKind::WordChoice,
+            lint_kind: LintKind::BoundaryError,
             suggestions: vec![Suggestion::replace_with_match_case(
                 phrase.chars().collect(),
                 span.get_content(source_chars),

--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -148,13 +148,6 @@ pub fn lint_group() -> LintGroup {
             "Corrects `as of lately` to `as of late`.",
             LintKind::WordChoice
         ),
-        "AsWell" => (
-            ["aswell"],
-            ["as well"],
-            "`as well` should be written as two words.",
-            "Corrects `aswell` to `as well`.",
-            LintKind::BoundaryError
-        ),
         "AtFaceValue" => (
             ["on face value"],
             ["at face value"],
@@ -599,13 +592,6 @@ pub fn lint_group() -> LintGroup {
             "Corrects the missing article in `in while`, forming `in a while`.",
             LintKind::Grammar
         ),
-        "InCase" => (
-            ["incase"],
-            ["in case"],
-            "`In case` should be written as two words.",
-            "Corrects `incase` to `in case`.",
-            LintKind::BoundaryError
-        ),
         "InNeedOf" => (
             ["in need for"],
             ["in need of"],
@@ -1023,11 +1009,11 @@ pub fn lint_group() -> LintGroup {
             LintKind::Usage
         ),
         "ThanksALot" => (
-            ["thanks lot", "thanks alot"],
+            ["thanks lot"],
             ["thanks a lot"],
-            "Prefer the two-word expression `thanks a lot`.",
-            "`Thanks a lot` is the fixed, widely accepted form, while variants like `thanks lot` or `thanks alot` are non-standard and can jar readers.",
-            LintKind::Usage
+            "The indefinite article `a` is required in `thanks a lot`.",
+            "Corrects the missing article in `thanks lot`, forming `thanks a lot`.",
+            LintKind::Grammar
         ),
         "ThatChallenged" => (
             ["the challenged"],

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -174,9 +174,6 @@ fn corrects_as_of_lately() {
     )
 }
 
-// AsWell
-// -none-
-
 // AtFaceValue
 #[test]
 fn correct_on_face_value() {
@@ -684,9 +681,6 @@ fn test_in_a_while() {
         "We’ll talk again in a while.",
     );
 }
-
-// InCase
-// -none-
 
 // InNeedOf
 #[test]
@@ -1448,11 +1442,6 @@ fn now_on_hold() {
 #[test]
 fn thanks_lot() {
     assert_suggestion_result("thanks lot", lint_group(), "thanks a lot");
-}
-
-#[test]
-fn thanks_alot() {
-    assert_suggestion_result("thanks alot", lint_group(), "thanks a lot");
 }
 
 #[test]


### PR DESCRIPTION
# Issues 
N/A

# Description

I noticed that a couple of phrases commonly incorrectly joined into single words existing both in `phrase_corrections` and `OpenCompounds`. ("aswell", "incase")
 Some others had remnants left behind in the `mod.rs` or `tests.rs` of `phrase_corrections`. ("alot" in "thanks alot").

Everything duplicated is now only in `OpenCompounds`.
I modified one lint's `description` and `message`.
I changed the `LintKind` of `OpenCompounds` to `BoundaryError`.

# How Has This Been Tested?

The existing tests all still pass after the cleanup.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
