### PR TITLE
fix: format of checkboxes was broken in feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/suggest-a-feature.md
+++ b/.github/ISSUE_TEMPLATE/suggest-a-feature.md
@@ -14,9 +14,9 @@ How should it work?
 Show, don't tell.
 
 **Component**
-[ ] Core engine
-[ ] Plugin/Extension
-[ ] Other: _____
+- [ ] Core engine
+- [ ] Plugin/Extension
+- [ ] Other: _____
 
 **Additional Context**
 Any other relevant info.


### PR DESCRIPTION
# Issues 
N/A

# Description

The Markdown format for checkboxes needs list format apparently.
This PR fixes the ones in the GitHub feature request template to work that way as used elsewhere.

# Demo

With broken format:
<img width="179" height="112" alt="image" src="https://github.com/user-attachments/assets/5a42e647-c910-4f24-b7fd-bb9cdc291209" />
With fixed format:
<img width="205" height="116" alt="image" src="https://github.com/user-attachments/assets/576f16db-ad83-4933-96a1-de3254ebf88e" />

# How Has This Been Tested?
Manually

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
