### PR TITLE
Add more phrasal verb exceptions

### DIFF
--- a/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
+++ b/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
@@ -201,22 +201,27 @@ impl Linter for PhrasalVerbAsCompoundNoun {
             if let Some(next_tok) = maybe_next_tok.filter(|tok| tok.kind.is_noun())
                 && match nountok_lower {
                     ['b', 'a', 'c', 'k', 'u', 'p'] => {
-                        &["file", "images", "location", "snapshots"][..]
+                        &["file", "images", "location", "plan", "snapshots"][..]
                     }
-                    ['c', 'a', 'l', 'l', 'b', 'a', 'c', 'k'] => &["function"][..],
+                    ['c', 'a', 'l', 'l', 'b', 'a', 'c', 'k'] => &["function", "handlers"][..],
                     ['l', 'a', 'y', 'o', 'u', 't'] => &["estimation"][..],
                     ['m', 'a', 'r', 'k', 'u', 'p'] => &["language", "languages"][..],
-                    ['p', 'l', 'a', 'y', 'b', 'a', 'c', 'k'] => &["latency"][..],
+                    ['m', 'o', 'u', 's', 'e', 'o', 'v', 'e', 'r'] => &["hints"][..],
+                    ['p', 'l', 'a', 'y', 'b', 'a', 'c', 'k'] => &["latency", "speed"][..],
                     ['p', 'l', 'u', 'g', 'i', 'n'] => &[
                         "architecture",
+                        "classes",
                         "development",
                         "docs",
                         "ecosystem",
                         "files",
                         "interface",
+                        "name",
                         "packages",
                         "suite",
+                        "support",
                     ][..],
+                    ['s', 't', 'a', 'r', 't', 'u', 'p'] => &["environments"][..],
                     ['r', 'o', 'l', 'l', 'o', 'u', 't'] => &["logic", "status"][..],
                     ['t', 'h', 'r', 'o', 'w', 'b', 'a', 'c', 'k'] => &["machine"][..],
                     ['w', 'o', 'r', 'k', 'o', 'u', 't'] => &["constraints", "preference"][..],


### PR DESCRIPTION
# Issues 
N/A

# Description
While dogfooding on GitHub repo READMEs I found a few false positives where compound nouns were flagged to change to phrasal verbs. For example:

<img width="757" height="67" alt="Screenshot 2025-09-25 at 9 11 41 pm" src="https://github.com/user-attachments/assets/fbb92fd1-c3cc-458c-825b-6097bda254da" />

This PR adds exceptions for those.

# How Has This Been Tested?

Manual testing.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
