### PR TITLE
feat:besides the point→beside the point, don't can→can't

### DIFF
--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -224,6 +224,13 @@ pub fn lint_group() -> LintGroup {
             "Prefer the single-word adverb `beforehand`.",
             "`Beforehand` functions as a fixed adverb meaning ‘in advance’; writing it as two words or with a hyphen is nonstandard and can jar readers."
         ),
+        "BesideThePoint" => (
+            ["besides the point"],
+            ["beside the point"],
+            "Use `beside` in the idiom `beside the point`.",
+            "Corrects `besides the point` to `beside the point`.",
+            LintKind::Eggcorn
+        ),
         "BestRegards" => (
             ["beat regards"],
             ["best regards"],
@@ -327,6 +334,13 @@ pub fn lint_group() -> LintGroup {
             "Use the full verb “want” after negation: “don't want” or “do not want.”",
             "In English, negation still requires the complete verb form (“want”), so avoid truncating it to “wan.”",
             LintKind::Typo
+        ),
+        "DontCan" => (
+            ["don't can"],
+            ["can't", "cannot"],
+            "The grammatically correct form is `can't` or `cannot`.",
+            "Corrects `don't can` to `can't` or `cannot`.",
+            LintKind::Grammar
         ),
         "EachAndEveryOne" => (
             ["each and everyone"],

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -255,6 +255,16 @@ fn allows_beforehand() {
     assert_lint_count("We finished the preparations beforehand.", lint_group(), 0);
 }
 
+// BesideThePoint
+#[test]
+fn beside_the_point() {
+    assert_suggestion_result(
+        "we kind of focus on GPUs a lot but uh that's besides the point so uh sometime ago",
+        lint_group(),
+        "we kind of focus on GPUs a lot but uh that's beside the point so uh sometime ago",
+    );
+}
+
 // BestRegards
 // -none-
 
@@ -334,6 +344,13 @@ fn does_not_flag_other_contexts() {
 // DayAndAge
 // -none
 
+// DegreesKelvin
+#[test]
+fn corrects_degrees_kelvin() {
+    assert_suggestion_result("degrees kelvin", lint_group(), "kelvins");
+    assert_suggestion_result("°K", lint_group(), "K");
+}
+
 // DoNotWant
 #[test]
 fn corrects_dont_wan() {
@@ -354,14 +371,18 @@ fn corrects_mixed_case() {
 }
 
 #[test]
-fn corrects_degrees_kelvin() {
-    assert_suggestion_result("degrees kelvin", lint_group(), "kelvins");
-    assert_suggestion_result("°K", lint_group(), "K");
-}
-
-#[test]
 fn does_not_flag_already_correct() {
     assert_lint_count("I don't want to leave.", lint_group(), 0);
+}
+
+// DontCan
+#[test]
+fn corrects_dont_can() {
+    assert_suggestion_result(
+        "And currently uh I'm looking at it when I don't can see it like you know where it is, right?",
+        lint_group(),
+        "And currently uh I'm looking at it when I can't see it like you know where it is, right?",
+    );
 }
 
 // EachAndEveryOne


### PR DESCRIPTION
# Issues 
N/A

# Description
Watching Tsoding's video that just came out, I quickly noticed two problems we don't yet handle.
- besides the point - instead of beside the point - which I had never heard before
- don't can - instead of can't/cannot - which is pretty common in non-native speakers

# How Has This Been Tested?

I added a snippet from the YouTube transcript as a unit test for each one.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
