### PR TITLE
fix(web): remove faq link

### DIFF
--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -50,10 +50,6 @@ export default defineConfig({
 									title: 'About',
 									to: '/docs/about',
 								},
-								{
-									title: 'FAQ',
-									to: '/docs/faq',
-								},
 							],
 						},
 						{


### PR DESCRIPTION
# Description

The FAQ page was removed and became part of the landing page in #2046, so the link to it now returns a 404.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
