### PR TITLE
fix(obsidian): properly manage dictionary

### DIFF
--- a/harper-wasm/src/lib.rs
+++ b/harper-wasm/src/lib.rs
@@ -332,6 +332,12 @@ impl Linter {
         self.ignored_lints = IgnoredLints::new();
     }
 
+    /// Clear the user dictionary.
+    pub fn clear_words(&mut self) {
+        self.user_dictionary = MutableDictionary::new();
+        self.synchronize_lint_dict();
+    }
+
     /// Import words into the dictionary.
     pub fn import_words(&mut self, additional_words: Vec<String>) {
         let init_len = self.user_dictionary.word_count();

--- a/packages/harper.js/src/Linter.ts
+++ b/packages/harper.js/src/Linter.ts
@@ -81,6 +81,9 @@ export default interface Linter {
 	/** Clear records of all previously ignored lints. */
 	clearIgnoredLints(): Promise<void>;
 
+	/** Clear the words which have been added to the dictionary. This will not clear words from the curated dictionary. */
+	clearWords(): Promise<void>;
+
 	/** Import words into the dictionary. This is a significant operation, so try to batch words. */
 	importWords(words: string[]): Promise<void>;
 

--- a/packages/harper.js/src/LocalLinter.ts
+++ b/packages/harper.js/src/LocalLinter.ts
@@ -149,6 +149,12 @@ export default class LocalLinter implements Linter {
 		inner.clear_ignored_lints();
 	}
 
+	async clearWords(): Promise<void> {
+		const inner = await this.inner;
+
+		return inner.clear_words();
+	}
+
 	async importWords(words: string[]): Promise<void> {
 		const inner = await this.inner;
 

--- a/packages/harper.js/src/WorkerLinter/index.ts
+++ b/packages/harper.js/src/WorkerLinter/index.ts
@@ -153,6 +153,10 @@ export default class WorkerLinter implements Linter {
 		return this.rpc('clearIgnoredLints', []);
 	}
 
+	clearWords(): Promise<void> {
+		return this.rpc('clearWords', []);
+	}
+
 	importWords(words: string[]): Promise<void> {
 		return this.rpc('importWords', [words]);
 	}

--- a/packages/obsidian-plugin/src/State.test.ts
+++ b/packages/obsidian-plugin/src/State.test.ts
@@ -157,3 +157,37 @@ test('getEffectiveLintConfig reflects explicit overrides', async () => {
 		expect(effective[k]).toBe(true);
 	}
 });
+
+test('can persist dictionary words in settings', async () => {
+	const state = createEphemeralState();
+	let settings = await state.getSettings();
+
+	const testWord = 'ajhsbdajshdb';
+	settings.userDictionary = [testWord];
+
+	await state.initializeFromSettings(settings);
+
+	settings = await state.getSettings();
+
+	expect(settings.userDictionary).toStrictEqual([testWord]);
+});
+
+test('can overwrite dictionary words in settings', async () => {
+	const state = createEphemeralState();
+	let settings = await state.getSettings();
+
+	const testWord = 'ajhsbdajshdb';
+	settings.userDictionary = [testWord];
+
+	await state.initializeFromSettings(settings);
+	settings = await state.getSettings();
+
+	expect(settings.userDictionary).toStrictEqual([testWord]);
+
+	settings.userDictionary = [];
+
+	await state.initializeFromSettings(settings);
+	settings = await state.getSettings();
+
+	expect(settings.userDictionary).toStrictEqual([]);
+});

--- a/packages/obsidian-plugin/src/State.ts
+++ b/packages/obsidian-plugin/src/State.ts
@@ -84,8 +84,11 @@ export default class State {
 			await this.harper.importIgnoredLints(settings.ignoredLints);
 		}
 
-		if (settings.userDictionary != null && settings.userDictionary.length > 0) {
-			await this.harper.importWords(settings.userDictionary);
+		if (settings.userDictionary != null) {
+			await this.harper.clearWords();
+			if (settings.userDictionary.length > 0) {
+				await this.harper.importWords(settings.userDictionary);
+			}
 		}
 
 		await this.harper.setLintConfig(settings.lintSettings);


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #2049 

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

The underlying problem was that Harper's dictionary was append-only. When a partial entry was added while typing, it was never removed. I've added a new method `clearWords`, and set up the plugin to call it before pushing new words to the user dictionary.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually + unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
