### PR TITLE
docs: remove or update remaining faq page links

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Just please make sure to read [our contribution guidelines first.](https://githu
 
 ## Links
 
-- [Frequently Asked Questions](https://writewithharper.com/docs/faq)
+- [Frequently Asked Questions](https://writewithharper.com/#faqs)
 - [Obsidian Documentation](https://writewithharper.com/docs/integrations/obsidian)
 - [`harper-ls` Documentation](https://writewithharper.com/docs/integrations/language-server)
 - Supported Editors' Documentation

--- a/packages/web/src/routes/docs/about/+page.md
+++ b/packages/web/src/routes/docs/about/+page.md
@@ -19,5 +19,3 @@ Harper takes advantage of decades of natural language research to analyze exactl
 If something is off, Harper lets you know.
 
 In a way, Harper is an error-tolerant parser for English.
-
-Check out our [FAQs](./faq) to know how you can use Harper and more.

--- a/packages/web/src/routes/docs/contributors/faq/+page.md
+++ b/packages/web/src/routes/docs/contributors/faq/+page.md
@@ -3,7 +3,6 @@ title: Frequently Asked Questions
 ---
 
 This page will be composed of frequently asked questions for contributors.
-If you're reading this page, you might also be interested in [the main FAQ page](/docs/faq).
 
 ## What's the Difference Between a `Linter` and a `PatternLinter`?
 


### PR DESCRIPTION
# Issues 

Fixes #2057

# Description

I only caught the one dead link in #2047. This PR updates or removed all other references to the old FAQ page.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
