### PR TITLE
fix(chrome-plugin): errors saving rule state in Firefox

### DIFF
--- a/packages/chrome-plugin/src/options/Options.svelte
+++ b/packages/chrome-plugin/src/options/Options.svelte
@@ -15,7 +15,7 @@ let activationKey: ActivationKey = $state(ActivationKey.Off);
 let userDict = $state('');
 
 $effect(() => {
-	ProtocolClient.setLintConfig(lintConfig);
+	ProtocolClient.setLintConfig($state.snapshot(lintConfig));
 });
 
 $effect(() => {


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #2058

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

We use a Svelte rune to manage state on the frontend of the options page. When Firefox tried to perform a structured clone to send it to the service worker, it crashed. To fix this, I set it to take a static snapshot before sending it.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
