### PR TITLE
feat(chrome-ext): enable by default on WordPress pages

### DIFF
--- a/packages/chrome-plugin/src/contentScript/index.ts
+++ b/packages/chrome-plugin/src/contentScript/index.ts
@@ -1,6 +1,11 @@
 import '@webcomponents/custom-elements';
 import { isVisible, LintFramework, leafNodes } from 'lint-framework';
 import ProtocolClient from '../ProtocolClient';
+import isWordPress from '../isWordPress';
+
+if (isWordPress()){
+  ProtocolClient.setDomainEnabled(window.location.hostname, true);
+}
 
 const fw = new LintFramework((text, domain) => ProtocolClient.lint(text, domain), {
 	ignoreLint: (hash) => ProtocolClient.ignoreHash(hash),

--- a/packages/chrome-plugin/src/contentScript/index.ts
+++ b/packages/chrome-plugin/src/contentScript/index.ts
@@ -1,10 +1,10 @@
 import '@webcomponents/custom-elements';
 import { isVisible, LintFramework, leafNodes } from 'lint-framework';
-import ProtocolClient from '../ProtocolClient';
 import isWordPress from '../isWordPress';
+import ProtocolClient from '../ProtocolClient';
 
-if (isWordPress()){
-  ProtocolClient.setDomainEnabled(window.location.hostname, true);
+if (isWordPress()) {
+	ProtocolClient.setDomainEnabled(window.location.hostname, true);
 }
 
 const fw = new LintFramework((text, domain) => ProtocolClient.lint(text, domain), {

--- a/packages/chrome-plugin/src/isWordPress.ts
+++ b/packages/chrome-plugin/src/isWordPress.ts
@@ -1,14 +1,12 @@
 /** Does a rough estimate of whether the current page is a WordPress page. */
 export default function isWordPress(): boolean {
-  if (!!document.querySelector(
-    'meta[name="generator"][content*="WordPress"]'
-  )){
-    return true;
-  }
+	if (document.querySelector('meta[name="generator"][content*="WordPress"]')) {
+		return true;
+	}
 
-  if( document.querySelector('link[rel="https://api.w.org/"][href]')){
-    return true;
-  }
+	if (document.querySelector('link[rel="https://api.w.org/"][href]')) {
+		return true;
+	}
 
-  return false;
+	return false;
 }

--- a/packages/chrome-plugin/src/isWordPress.ts
+++ b/packages/chrome-plugin/src/isWordPress.ts
@@ -1,0 +1,14 @@
+/** Does a rough estimate of whether the current page is a WordPress page. */
+export default function isWordPress(): boolean {
+  if (!!document.querySelector(
+    'meta[name="generator"][content*="WordPress"]'
+  )){
+    return true;
+  }
+
+  if( document.querySelector('link[rel="https://api.w.org/"][href]')){
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

For a while now, Harper has performed quite well on WordPress pages. I test this quite a bit in my role at [Automattic](https://automattic.com/). As that is the case, I figured we would just enable Harper automatically for all pages that appear to be WordPress.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
