### PR TITLE
fix(core): detect acronyms in `AnA`

### DIFF
--- a/harper-core/src/char_ext.rs
+++ b/harper-core/src/char_ext.rs
@@ -9,6 +9,10 @@ pub trait CharExt {
     fn is_english_lingual(&self) -> bool;
     fn is_emoji(&self) -> bool;
     fn is_punctuation(&self) -> bool;
+    /// Whether the character is an (English) vowel.
+    ///
+    /// Checks whether the character is in the set (A, E, I, O, U); case-insensitive.
+    fn is_vowel(&self) -> bool;
 }
 
 impl CharExt for char {
@@ -76,6 +80,10 @@ impl CharExt for char {
 
     fn is_punctuation(&self) -> bool {
         Punctuation::from_char(*self).is_some()
+    }
+
+    fn is_vowel(&self) -> bool {
+        matches!(self.to_ascii_lowercase(), 'a' | 'e' | 'i' | 'o' | 'u')
     }
 }
 

--- a/harper-core/src/linting/an_a.rs
+++ b/harper-core/src/linting/an_a.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 
 use itertools::Itertools;
 
+use crate::char_ext::CharExt;
 use crate::linting::{Lint, LintKind, Linter, Suggestion};
 use crate::{Document, TokenStringExt};
 
@@ -192,15 +193,12 @@ fn starts_with_vowel(word: &[char]) -> bool {
 }
 
 fn is_likely_acronym(word: &[char]) -> bool {
-    fn is_upper_vowel(c: char) -> bool {
-        matches!(c, 'A' | 'E' | 'I' | 'O' | 'U')
-    }
     // If the first two letters are not consonants, the initialism might be an acronym.
     // (Like MAC, NASA, LAN, etc.)
     word.get(..2).is_some_and(|first_chars| {
         first_chars
             .iter()
-            .fold(0, |acc, char| acc + !is_upper_vowel(*char) as u8)
+            .fold(0, |acc, char| acc + !char.is_vowel() as u8)
             < 2
     })
 }


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->
Fixes #1718, Fixes #1702

# Description
<!-- Please include a summary of the change. -->
Reduce incorrect lints from `AnA` by attempting to detect when an initialism is an acronym.
<!-- Any details that you think are important to review this PR? -->
The logic assumes that the initialism is an acronym if its first two letters are not consonants. Though this seems to work for the cases covered in the tests, there must exist cases where this is too simple and not correct. It will likely need refinement as time goes on and issues are found.
<!-- Are there other PRs related to this one? -->


# How Has This Been Tested?
- `cargo test`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
