### PR TITLE
2075 -- Harper Auto-submits Reddit Comments

### DIFF
--- a/packages/lint-framework/src/lint/SuggestionBox.ts
+++ b/packages/lint-framework/src/lint/SuggestionBox.ts
@@ -110,6 +110,7 @@ function button(
 			style: extraStyle,
 			onclick: onClick,
 			title: desc,
+			type: 'button',
 			'aria-label': desc,
 			...extraProps,
 		},


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->
Fixes #2075 
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->
The issue seems to be that the lint buttons did not have a 'type' specified, meaning they likely used the default type 'submit'. I believe that somewhere during the render process the 'submit' was triggered and was submitting the reddit comments.

Manually setting the type to 'button' fixes this and the comments no longer submit when interacting with Harper in my tests. 

This PR does not yet fix the sentence copying issue although I suspect this may be occurring somewhere in replaceValue function in computeLintBoxes.ts

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
I tested by repeatedly trying to edit reddit comments. Couldn't get any of them to submit automatically when testing this change, and Harper still seems to function normally in other applications.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
