### PR TITLE
feat: add jjdescription parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2406,6 +2406,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "harper-jjdescription"
+version = "0.68.0"
+dependencies = [
+ "harper-core",
+ "harper-tree-sitter",
+ "paste",
+ "tree-sitter",
+ "tree-sitter-jjdescription",
+]
+
+[[package]]
 name = "harper-literate-haskell"
 version = "0.68.0"
 dependencies = [
@@ -2429,6 +2440,7 @@ dependencies = [
  "harper-core",
  "harper-html",
  "harper-ink",
+ "harper-jjdescription",
  "harper-literate-haskell",
  "harper-python",
  "harper-stats",
@@ -4890,6 +4902,16 @@ checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
 dependencies = [
  "cc",
  "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-jjdescription"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3af4295730637817c988dd0af3ab622505fc91b4bbccf8bbcc20cae0a6e43527"
+dependencies = [
+ "cc",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["harper-cli", "harper-core", "harper-ls", "harper-comments", "harper-wasm", "harper-tree-sitter", "harper-html", "harper-literate-haskell", "harper-typst", "harper-stats", "harper-pos-utils", "harper-brill", "harper-ink", "harper-python"]
+members = ["harper-cli", "harper-core", "harper-ls", "harper-comments", "harper-wasm", "harper-tree-sitter", "harper-html", "harper-literate-haskell", "harper-typst", "harper-stats", "harper-pos-utils", "harper-brill", "harper-ink", "harper-python", "harper-jjdescription"]
 resolver = "2"
 
 # Comment out the below lines if you plan to use a debugger.

--- a/harper-jjdescription/Cargo.toml
+++ b/harper-jjdescription/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "harper-jjdescription"
+version = "0.68.0"
+edition = "2024"
+description = "The language checker for developers."
+license = "Apache-2.0"
+repository = "https://github.com/automattic/harper"
+
+[dependencies]
+harper-core = { path = "../harper-core", version = "0.68.0" }
+harper-tree-sitter = { path = "../harper-tree-sitter", version = "0.68.0" }
+tree-sitter-jjdescription = "0.0.1"
+tree-sitter = "0.25.10"
+
+[dev-dependencies]
+paste = "1.0.15"

--- a/harper-jjdescription/src/lib.rs
+++ b/harper-jjdescription/src/lib.rs
@@ -1,0 +1,30 @@
+use harper_core::Token;
+use harper_core::parsers::{self, Markdown, MarkdownOptions, Parser};
+use harper_tree_sitter::TreeSitterMasker;
+use tree_sitter::Node;
+
+pub struct JJDescriptionParser {
+    /// Used to grab the text nodes, and parse them as markdown.
+    inner: parsers::Mask<TreeSitterMasker, Markdown>,
+}
+
+impl JJDescriptionParser {
+    fn node_condition(n: &Node) -> bool {
+        n.kind() == "text"
+    }
+
+    pub fn new(markdown_options: MarkdownOptions) -> Self {
+        Self {
+            inner: parsers::Mask::new(
+                TreeSitterMasker::new(tree_sitter_jjdescription::language(), Self::node_condition),
+                Markdown::new(markdown_options),
+            ),
+        }
+    }
+}
+
+impl Parser for JJDescriptionParser {
+    fn parse(&self, source: &[char]) -> Vec<Token> {
+        self.inner.parse(source)
+    }
+}

--- a/harper-jjdescription/tests/run_tests.rs
+++ b/harper-jjdescription/tests/run_tests.rs
@@ -1,0 +1,41 @@
+use harper_core::linting::{LintGroup, Linter};
+use harper_core::parsers::MarkdownOptions;
+use harper_core::spell::FstDictionary;
+use harper_core::{Dialect, Document};
+use harper_jjdescription::JJDescriptionParser;
+
+/// Creates a unit test checking that the linting of a git commit document (in
+/// `tests_sources`) produces the expected number of lints.
+macro_rules! create_test {
+    ($filename:ident.txt, $correct_expected:expr) => {
+        paste::paste! {
+            #[test]
+            fn [<lints_ $filename _correctly>](){
+                 let source = include_str!(
+                    concat!(
+                        "./test_sources/",
+                        concat!(stringify!($filename), ".txt")
+                    )
+                 );
+
+                 let dict = FstDictionary::curated();
+                 let document = Document::new(source, &JJDescriptionParser::new(MarkdownOptions::default()), &dict);
+
+                 let mut linter = LintGroup::new_curated(dict, Dialect::American);
+                 let lints = linter.lint(&document);
+
+                 dbg!(&lints);
+                 assert_eq!(lints.len(), $correct_expected);
+
+                 // Make sure that all generated tokens span real characters
+                 for token in document.tokens(){
+                     assert!(token.span.try_get_content(document.get_source()).is_some());
+                 }
+            }
+        }
+    };
+}
+
+create_test!(simple_description.txt, 1);
+create_test!(complex_verbose_description.txt, 2);
+create_test!(conventional_description.txt, 3);

--- a/harper-jjdescription/tests/test_sources/complex_verbose_description.txt
+++ b/harper-jjdescription/tests/test_sources/complex_verbose_description.txt
@@ -1,0 +1,20 @@
+This is the the subject
+
+This is a first line without typos
+JJ: This is a comment with a typoo that should be ignored
+This is a line below the comment with typooos
+
+JJ: This commit contains the following changes:
+JJ:     myfile.txt | 1 +
+JJ:     1 file changed, 1 insertion(+), 0 deletions(-)
+
+JJ: ignore-rest
+diff --git a/myfile.txt b/myfile.txt
+new file mode 100644
+index 0000000000..54f266d2db
+--- /dev/null
++++ b/myfile.txt
+@@ -0,0 +1,1 @@
++typooo in the file
+
+JJ: Lines starting with "JJ:" (like this one) will be removed.

--- a/harper-jjdescription/tests/test_sources/conventional_description.txt
+++ b/harper-jjdescription/tests/test_sources/conventional_description.txt
@@ -1,0 +1,25 @@
+feat(stuff): use session-based authentiation
+
+BREAKING CHANGE: JWT authentication removed. API clients mustt now use
+session cookies instead of Authorization headers with bearer tokens.
+
+Sessions expire after 24 hours of inactvity.
+
+Closes: #247
+Reviewed-by: John Doe <john@example.com>
+
+JJ: Change ID: qrutlxlw
+JJ: This commit contains the following changes:
+JJ:     M Cargo.lock
+JJ:     M Cargo.toml
+JJ:     A harper-jjdescription/Cargo.toml
+JJ:     A harper-jjdescription/src/lib.rs
+JJ:     A harper-jjdescription/tests/run_tests.rs
+JJ:     A harper-jjdescription/tests/test_sources/complex_verbose_description.txt
+JJ:     A harper-jjdescription/tests/test_sources/conventional_description.txt
+JJ:     A harper-jjdescription/tests/test_sources/simple_description.txt
+JJ:     M harper-ls/Cargo.toml
+JJ:     M harper-ls/src/backend.rs
+JJ:
+JJ: Lines starting with "JJ:" (like this one) will be removed.
+

--- a/harper-jjdescription/tests/test_sources/simple_description.txt
+++ b/harper-jjdescription/tests/test_sources/simple_description.txt
@@ -1,0 +1,1 @@
+A simple description with a typo: descrption

--- a/harper-ls/Cargo.toml
+++ b/harper-ls/Cargo.toml
@@ -12,6 +12,7 @@ harper-stats = { path = "../harper-stats", version = "0.68.0" }
 harper-literate-haskell = { path = "../harper-literate-haskell", version = "0.68.0" }
 harper-core = { path = "../harper-core", version = "0.68.0", features = ["concurrent"] }
 harper-comments = { path = "../harper-comments", version = "0.68.0" }
+harper-jjdescription = { path = "../harper-jjdescription", version = "0.68.0" }
 harper-typst = { path = "../harper-typst", version = "0.68.0" }
 harper-html = { path = "../harper-html", version = "0.68.0" }
 harper-python = { path = "../harper-python", version = "0.68.0" }

--- a/harper-ls/src/backend.rs
+++ b/harper-ls/src/backend.rs
@@ -21,6 +21,7 @@ use harper_core::spell::{Dictionary, FstDictionary, MergedDictionary, MutableDic
 use harper_core::{Dialect, DictWordMetadata, Document, IgnoredLints};
 use harper_html::HtmlParser;
 use harper_ink::InkParser;
+use harper_jjdescription::JJDescriptionParser;
 use harper_literate_haskell::LiterateHaskellParser;
 use harper_python::PythonParser;
 use harper_stats::{Record, Stats};
@@ -385,6 +386,7 @@ impl Backend {
             "git-commit" | "gitcommit" => {
                 Some(Box::new(GitCommitParser::new_markdown(markdown_options)))
             }
+            "jjdescription" => Some(Box::new(JJDescriptionParser::new(markdown_options))),
             "html" => Some(Box::new(HtmlParser::default())),
             "mail" | "plaintext" | "text" => Some(Box::new(PlainEnglish)),
             "typst" => Some(Box::new(Typst)),


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->
jjdescription was briefly mentioned in https://github.com/Automattic/harper/issues/79.

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->
jjdescription file types are used by [jujutsu](https://jj-vcs.github.io/jj/latest/) (a VCS) to write messages in, similar to git commits. We can use tree-sitter-jjdescription and the existing markdown parser to parse these kinds of files. It is super helpful to have spell checking on these files as most of the plain English I write as a developer is in jj descriptions.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
I'm running this already for some time (in helix), found no issues.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
