### PR TITLE
fix(chrome-ext): use Harper-specific HTML tag to avoid CSS conflicts

### DIFF
--- a/packages/lint-framework/src/lint/RenderBox.ts
+++ b/packages/lint-framework/src/lint/RenderBox.ts
@@ -13,7 +13,7 @@ export default class RenderBox {
 	private shadowHost: HTMLElement;
 
 	constructor(parent: Node) {
-		this.shadowHost = document.createElement('div');
+		this.shadowHost = document.createElement('harper-render-box');
 		parent.appendChild(this.shadowHost);
 	}
 


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Resolves #2074

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

See issue for problem details.

Almost all of Harper's UI is rendered inside a shadow DOM, which normally protects us from CSS conflicts. The _host_ of the shadow DOM, however, is not protected. To mitigate the problem, as @Ingramz suggested, I've assigned the host a custom HTML tag.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually on hacktoberfest.com

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
