### PR TITLE
fix(chrome-ext): don't override with activation from WordPress page

### DIFF
--- a/packages/chrome-plugin/src/ProtocolClient.ts
+++ b/packages/chrome-plugin/src/ProtocolClient.ts
@@ -51,8 +51,16 @@ export default class ProtocolClient {
 		return (await chrome.runtime.sendMessage({ kind: 'getDomainStatus', domain })).enabled;
 	}
 
-	public static async setDomainEnabled(domain: string, enabled: boolean): Promise<void> {
-		await chrome.runtime.sendMessage({ kind: 'setDomainStatus', enabled, domain });
+	/** Set whether Harper is enabled for a given domain.
+	 *
+	 * @param overrideValue dictates whether this should override a previous setting.
+	 * */
+	public static async setDomainEnabled(
+		domain: string,
+		enabled: boolean,
+		overrideValue = true,
+	): Promise<void> {
+		await chrome.runtime.sendMessage({ kind: 'setDomainStatus', enabled, domain, overrideValue });
 	}
 
 	public static async getDefaultEnabled(): Promise<boolean> {

--- a/packages/chrome-plugin/src/contentScript/index.ts
+++ b/packages/chrome-plugin/src/contentScript/index.ts
@@ -4,7 +4,7 @@ import isWordPress from '../isWordPress';
 import ProtocolClient from '../ProtocolClient';
 
 if (isWordPress()) {
-	ProtocolClient.setDomainEnabled(window.location.hostname, true);
+	ProtocolClient.setDomainEnabled(window.location.hostname, true, false);
 }
 
 const fw = new LintFramework((text, domain) => ProtocolClient.lint(text, domain), {

--- a/packages/chrome-plugin/src/protocol.ts
+++ b/packages/chrome-plugin/src/protocol.ts
@@ -117,6 +117,8 @@ export type SetDomainStatusRequest = {
 	kind: 'setDomainStatus';
 	domain: string;
 	enabled: boolean;
+	/** Dictates whether this should override a previous setting. */
+	overrideValue: boolean;
 };
 
 export type SetDefaultStatusRequest = {


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #2100

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

Previously, Harper would activate itself on WordPress pages (since they are official supported), regardless of their previous setting. That meant, if a user had disabled Harper on a WordPress page, it would get reactivated immediately upon visiting it.

To fix this, I've gone ahead and modified the activation code to permit the WordPress monitoring script to allow the previously set values to override the new ones.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
