### PR TITLE
fix(obsidian): store user dictionary in sorted order

### DIFF
--- a/packages/obsidian-plugin/src/State.test.ts
+++ b/packages/obsidian-plugin/src/State.test.ts
@@ -195,11 +195,11 @@ test('can persist dictionary order in settings', async () => {
 
 	settings = await state.getSettings();
 
-  let roundOne = settings.userDictionary;
+	const roundOne = settings.userDictionary;
 
-  await state.initializeFromSettings(settings);
+	await state.initializeFromSettings(settings);
 	settings = await state.getSettings();
-  let roundTwo = settings.userDictionary;
+	const roundTwo = settings.userDictionary;
 
 	expect(roundOne).toStrictEqual(roundTwo);
 });

--- a/packages/obsidian-plugin/src/State.ts
+++ b/packages/obsidian-plugin/src/State.ts
@@ -217,8 +217,8 @@ export default class State {
 	public async getSettings(): Promise<Settings> {
 		const usingWebWorker = this.harper instanceof WorkerLinter;
 
-    const userDictionary = await this.harper.exportWords();
-    userDictionary.sort();
+		const userDictionary = await this.harper.exportWords();
+		userDictionary.sort();
 
 		return {
 			ignoredLints: await this.harper.exportIgnoredLints(),


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Addresses #2089 

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

To fix the merge-conflict issue, I've gone ahead and modified the Obsidian plugin to store the dictionary in sorted order. It should be consistent between versions from here on out.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Additional unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
