### PR TITLE
fix(core): refine acronym detection in `AnA`

### DIFF
--- a/harper-core/src/linting/an_a.rs
+++ b/harper-core/src/linting/an_a.rs
@@ -316,5 +316,9 @@ mod tests {
 
         // an
         assert_lint_count("an RA message", AnA, 0);
+        assert_lint_count("an SI unit", AnA, 0);
+        assert_lint_count("he is an MA of both Oxford and Cambridge", AnA, 0);
+        assert_lint_count("in an FA Cup 6th Round match", AnA, 0);
+        assert_lint_count("a AM transmitter", AnA, 1);
     }
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
Require that initialisms be at least 3 characters long before considering that they might be an acronym.
<!-- Any details that you think are important to review this PR? -->
This reduces false-positives by preventing short initialisms (like "US", "RA", etc.) from being seen as acronyms.
<!-- Are there other PRs related to this one? -->

# How Has This Been Tested?
- `cargo test`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
