### PR TITLE
feat(vscode): support more platforms

### DIFF
--- a/.github/workflows/vscode_plugin.yml
+++ b/.github/workflows/vscode_plugin.yml
@@ -18,6 +18,9 @@ jobs:
           - os: windows-latest
             rust_target: x86_64-pc-windows-msvc
             code_target: win32-x64
+          - os: windows-latest
+            rust_target: aarch64-pc-windows-msvc
+            code_target: win32-arm64
           - os: macOS-latest
             rust_target: x86_64-apple-darwin
             code_target: darwin-x64
@@ -30,6 +33,15 @@ jobs:
           - os: ubuntu-latest
             rust_target: aarch64-unknown-linux-gnu
             code_target: linux-arm64
+          - os: ubuntu-latest
+            rust_target: armv7-unknown-linux-gnueabihf
+            code_target: linux-armhf
+          - os: ubuntu-latest
+            rust_target: x86_64-unknown-linux-musl
+            code_target: alpine-x64
+          - os: ubuntu-latest
+            rust_target: aarch64-unknown-linux-musl
+            code_target: alpine-arm64
     runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Issues 

Resolves #2110

# Description

Updates the VS Code CI to support all [platforms that VS Code supports](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#platformspecific-extensions) except `web`.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
