### PR TITLE
feat: introduce stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,32 @@
+# Adapted from [Jeff Geerling's Stale Workflow](https://github.com/geerlingguy/mac-dev-playbook/blob/719de3569804fcf4974fc3a14f46f3ebb92989b2/.github/workflows/stale.yml)
+
+---
+name: Close inactive issues
+"on":
+  schedule:
+    - cron: "0 18 * * 1"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-stale: 120
+          days-before-close: 60
+          exempt-issue-labels: bug,pinned,security,planned
+          exempt-pr-labels: bug,pinned,security,planned
+          stale-issue-label: "stale"
+          stale-pr-label: "stale"
+          stale-issue-message: |
+            This issue has been marked 'stale' due to lack of recent activity. If there is no further activity, the issue will be closed in another 30 days. Thank you for your contribution!
+          close-issue-message: |
+            This issue has been closed due to inactivity. If you feel this is in error, please reopen the issue or file a new issue with the relevant details.
+          stale-pr-message: |
+            This pr has been marked 'stale' due to lack of recent activity. If there is no further activity, the issue will be closed in another 30 days. Thank you for your contribution!
+          close-pr-message: |
+            This pr has been closed due to inactivity. If you feel this is in error, please reopen the issue or file a new issue with the relevant details.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

In the recent months, the number of issues on the Harper repo has grown dramatically. This is great, because it means I get to hear from more users, more often. Unfortunately, my ability to respond to and address each of these issues has not grown accordingly. As such, I'm implementing a stale bot derived from Jeff Geerling's that will mark issues as stale, then close them if there isn't further activity.

I understand that systems like these are controversial. I believe implementing this system will allow me to focus more of my time on fixing bugs and delivering new features. I also think that the issues and PRs I _do_ address will be of higher impact and quality than before.