### PR TITLE
feat: `harper-cli audit-dictionary`

### DIFF
--- a/harper-core/annotations.json
+++ b/harper-core/annotations.json
@@ -942,6 +942,24 @@
 					"verb_form": "THIRD_PERSON_SINGULAR"
 				}
 			}
+		},
+		"♂": {
+			"#": "masculine property",
+			"metadata": {
+				"//": "not yet implemented"
+			}
+		},
+		"♀": {
+			"#": "feminine property",
+			"metadata": {
+				"//": "not yet implemented"
+			}
+		},
+		"ª": {
+			"#": "animate property",
+			"metadata": {
+				"//": "not yet implemented"
+			}
 		}
 	}
 }

--- a/justfile
+++ b/justfile
@@ -260,7 +260,7 @@ update-vscode-linters:
   just format
 
 # Run Rust formatting and linting.
-check-rust:
+check-rust: auditdictionary
   #!/usr/bin/env bash
   set -eo pipefail
 


### PR DESCRIPTION
# Issues 
N/A

# Description

Adds a command to `harper-cli` to audit the curated dictionary.

- Checks that every flag defined in `annotations.json` is used
- Checks for flags not defined in `annotations.json` but occurring in `dictionary.dict`
- Checks for the same flag used multiple times in a single entry in `dictionary.dict`

# Demo
<img width="664" height="336" alt="image" src="https://github.com/user-attachments/assets/cfe6724b-4726-4dac-833b-9703c4fbe28c" />

# How Has This Been Tested?
Manually, using the current `dictionary.dict` and `annotations.json`, and also with a modified `annotations.json` to force errors that weren't already in `dictionary.dict`.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
