### PR TITLE
fix(obsidian): ignore files

### DIFF
--- a/packages/obsidian-plugin/src/State.ts
+++ b/packages/obsidian-plugin/src/State.ts
@@ -2,7 +2,7 @@ import type { Extension, StateField } from '@codemirror/state';
 import type { Lint, LintConfig, Linter, Suggestion } from 'harper.js';
 import { binaryInlined, type Dialect, LocalLinter, SuggestionKind, WorkerLinter } from 'harper.js';
 import { minimatch } from 'minimatch';
-import type { MarkdownFileInfo, MarkdownView, Workspace } from 'obsidian';
+import type { MarkdownFileInfo, Workspace } from 'obsidian';
 import { linter } from './lint';
 
 export type Settings = {
@@ -27,7 +27,7 @@ export default class State {
 	private workspace: Workspace;
 	private onExtensionChange: () => void;
 	private ignoredGlobs?: string[];
-	private editorViewField?: StateField<MarkdownFileInfo>;
+	private editorInfoField?: StateField<MarkdownFileInfo>;
 	private lintEnabled?: boolean;
 
 	/** The CodeMirror extension objects that should be inserted by the host. */
@@ -39,13 +39,15 @@ export default class State {
 	constructor(
 		saveDataCallback: (data: any) => Promise<void>,
 		onExtensionChange: () => void,
-		_editorViewField?: StateField<MarkdownFileInfo>,
+		_editorInfoField?: StateField<MarkdownFileInfo>,
 	) {
 		this.harper = new WorkerLinter({ binary: binaryInlined });
 		this.delay = DEFAULT_DELAY;
 		this.saveData = saveDataCallback;
 		this.onExtensionChange = onExtensionChange;
 		this.editorExtensions = [];
+
+		this.editorInfoField = _editorInfoField;
 	}
 
 	public async initializeFromSettings(settings: Settings | null) {
@@ -112,18 +114,15 @@ export default class State {
 			async (view) => {
 				const ignoredGlobs = this.ignoredGlobs ?? [];
 
-				if (this.editorViewField != null) {
-					const mdView = view.state.field(this.editorViewField) as MarkdownView;
+				if (this.editorInfoField != null) {
+					const mdView = view.state.field(this.editorInfoField, false);
 					const file = mdView?.file;
 
 					if (file != null) {
 						const path = file.path;
-
-						if (path != null) {
-							for (const glob of ignoredGlobs) {
-								if (minimatch(path, glob)) {
-									return [];
-								}
+						for (const glob of ignoredGlobs) {
+							if (minimatch(path, glob)) {
+								return [];
 							}
 						}
 					}

--- a/packages/obsidian-plugin/src/index.ts
+++ b/packages/obsidian-plugin/src/index.ts
@@ -1,5 +1,5 @@
 import { Dialect } from 'harper.js';
-import { type App, editorViewField, Menu, Notice, Plugin, type PluginManifest } from 'obsidian';
+import { type App, editorInfoField, Menu, Notice, Plugin, type PluginManifest } from 'obsidian';
 import logoSvg from '../logo.svg?raw';
 import logoSvgDisabled from '../logo-disabled.svg?raw';
 import { HarperSettingTab } from './HarperSettingTab';
@@ -15,7 +15,7 @@ export default class HarperPlugin extends Plugin {
 		this.state = new State(
 			(n) => this.saveData(n),
 			() => this.app.workspace.updateOptions(),
-			editorViewField,
+			editorInfoField,
 		);
 	}
 


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

This got mentioned here #1569 after merge

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->
It previously used the deprecated [editorViewField](https://github.com/obsidianmd/obsidian-api/blob/23947b58d372ea02225324308e31d36b4aa95869/obsidian.d.ts#L1414), but now uses the [editorInfoField](https://github.com/obsidianmd/obsidian-api/blob/23947b58d372ea02225324308e31d36b4aa95869/obsidian.d.ts#L1263) directly from the obsidian import.

But the actual issue was that the editorViewVield was passed to the constructor, but not assigned to the attribute of the class.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I ran the plugin in a testing vault, and it worked perfectly fine.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
