### PR TITLE
fix: `description` and `message` were copypasted from another linter!

### DIFF
--- a/harper-core/src/linting/all_intents_and_purposes.rs
+++ b/harper-core/src/linting/all_intents_and_purposes.rs
@@ -73,17 +73,22 @@ impl ExprLinter for AllIntentsAndPurposes {
             .map(|s| Suggestion::replace_with_match_case_str(s, whole_span.get_content(src)))
             .collect::<Vec<_>>();
 
+        let message = format!(
+            "The correct form is '{} all intents and purposes'.",
+            prep_text.iter().collect::<String>().to_ascii_lowercase()
+        );
+
         Some(Lint {
             span: whole_span,
             lint_kind: LintKind::Nonstandard,
             suggestions: suggs,
-            message: "The time period is redundant because it repeats what's already specified by the AM/PM indicator.".to_owned(),
+            message,
             priority: 50,
         })
     }
 
     fn description(&self) -> &'static str {
-        "Finds redundant am/pm indicators used together with time periods such as 'in the morning' or 'at night'."
+        "Finds and corrects common wrong forms of the phrase 'for all intents and purposes' / 'to all intents and purposes'."
     }
 }
 

--- a/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
+++ b/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
@@ -1765,7 +1765,7 @@ Message: |
      668 | proposing Amendments, which, in either Case, shall be valid to all Intents and
          |                                                             ^~~~~~~~~~~~~~~~~~~
      669 | Purposes, as Part of this Constitution, when ratified by the Legislatures of
-         | ~~~~~~~~ The time period is redundant because it repeats what's already specified by the AM/PM indicator.
+         | ~~~~~~~~ The correct form is 'to all intents and purposes'.
 Suggest:
   - Replace with: “to all Intents and Purposes”
   - Replace with: “for alL intents anD purposes”


### PR DESCRIPTION
# Issues 
N/A

# Description

By sheer luck I noticed that the `AllIntentsAndPurposes` linter had the wrong `description` and `message` fields that actually belonged to the `AmInTheMorning` linter. I must've used the latter as the skeleton for the former, or maybe the LLM copied those fields in from another open editor tab?

Anyway this fixes it with new, appropriate `description` and `message` fields.

# How Has This Been Tested?

The old tests all still pass. No new tests were added.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
