### PR TITLE
feat: nerve wreck→nervous wreck

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -374,6 +374,15 @@ pub fn lint_group() -> LintGroup {
             "Don't inflect `seem` in `make it seem`.",
             "Corrects `make it seems` to `make it seem`."
         ),
+        "NervousWreck" => (
+            &[
+                (&["nerve wreck", "nerve-wreck"], &["nervous wreck"]),
+                (&["nerve wrecks", "nerve-wrecks"], &["nervous wrecks"]),
+            ],
+            "Use `nervous wreck` when referring to a person who is extremely anxious or upset. `Nerve wreck` is non-standard but sometimes used for events or situations.",
+            "Suggests using `nervous wreck` when referring to a person's emotional state.",
+            LintKind::Eggcorn
+        ),
         "RiseTheQuestion" => (
             &[
                 (&["rise the question"], &["raise the question"]),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -1,5 +1,5 @@
 use crate::linting::tests::{
-    assert_lint_count, assert_nth_suggestion_result, assert_suggestion_result,
+    assert_lint_count, assert_no_lints, assert_nth_suggestion_result, assert_suggestion_result,
 };
 
 use super::lint_group;
@@ -1084,6 +1084,63 @@ fn corrects_made_it_seemed() {
         "The path made it seemed a bit \"internal\".",
         lint_group(),
         "The path made it seem a bit \"internal\".",
+    );
+}
+
+// NervousWreck
+
+#[test]
+#[ignore = "Harper matches case by letter index as 'How Not to Be a Complete NervoUs wreck in an Interview'"]
+fn correct_nerve_wreck_space_title_case() {
+    assert_suggestion_result(
+        "How Not to Be a Complete Nerve Wreck in an Interview",
+        lint_group(),
+        "How Not to Be a Complete Nervous Wreck in an Interview",
+    );
+}
+
+#[test]
+fn correct_nerve_wreck_space() {
+    assert_suggestion_result(
+        "The nerve wreck you are makes you seem anxious and agitated so your employer will believe the complaints.",
+        lint_group(),
+        "The nervous wreck you are makes you seem anxious and agitated so your employer will believe the complaints.",
+    );
+}
+
+#[test]
+fn correct_nerve_wreck_hyphen() {
+    assert_suggestion_result(
+        "the child receives little education and grows up to be a nerve-wreck",
+        lint_group(),
+        "the child receives little education and grows up to be a nervous wreck",
+    );
+}
+
+#[test]
+fn correct_nerve_wreck_hyphen_plural() {
+    assert_suggestion_result(
+        "This helps us not to become nerve wrecks while looking at the side mirrors",
+        lint_group(),
+        "This helps us not to become nervous wrecks while looking at the side mirrors",
+    );
+}
+
+#[test]
+#[ignore = "We can't detect when the altered form is used for an event rather than a person."]
+fn dont_correct_it_was_a_nerve_wreck() {
+    assert_no_lints(
+        "It was a nerve-wreck, but I was also excited to see what would happen next.",
+        lint_group(),
+    );
+}
+
+#[test]
+#[ignore = "We can't detect when the altered form is used for an event rather than a person."]
+fn dont_correct_so_much_nerve_wreck() {
+    assert_no_lints(
+        "So much nerve wreck for such a simple game ...",
+        lint_group(),
     );
 }
 


### PR DESCRIPTION
# Issues 
N/A

# Description

I noticed "nerve wreck" somewhere this evening. It's a pretty new eggcorn for "nervous wreck" and is sometimes written with a hyphen.

The message and description hedge a bit because unlike "nervous wreck", "nerve wreck" isn't only used for people but also for situations, events, etc. In those cases it wouldn't be appropriate to change the usage to "nervous wreck". Sentences such as "It was a nerve wreck for her and overall it was awkward for them both."

# How Has This Been Tested?

I added unit tests for with and without hyphen; singular and plural, using sentences found on the Internet.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
