### PR TITLE
feat: add suggestions to mass plurals linter

### DIFF
--- a/harper-core/src/linting/mass_plurals.rs
+++ b/harper-core/src/linting/mass_plurals.rs
@@ -3,7 +3,7 @@ use hashbrown::HashSet;
 use crate::{
     CharStringExt, Token, TokenStringExt,
     expr::{All, Expr, FirstMatchOf, FixedPhrase, SequenceExpr},
-    linting::{ExprLinter, Lint, LintKind},
+    linting::{ExprLinter, Lint, LintKind, Suggestion},
     spell::Dictionary,
 };
 
@@ -24,16 +24,15 @@ where
         });
         let oov_looks_plural = All::new(vec![Box::new(oov), Box::new(looks_plural)]);
 
-        // let source_codes = FixedPhrase::from_phrase("source codes");
         let phrases = FirstMatchOf::new(vec![
             Box::new(FixedPhrase::from_phrase("real estates")),
             Box::new(FixedPhrase::from_phrase("source codes")),
+            Box::new(FixedPhrase::from_phrase("wear and tears")),
         ]);
 
         Self {
             expr: Box::new(FirstMatchOf::new(vec![
                 Box::new(oov_looks_plural),
-                // Box::new(source_codes),
                 Box::new(phrases),
             ])),
             dict,
@@ -62,21 +61,25 @@ where
     }
 
     fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
-        let mistake_toks = toks;
+        let invalid_plural_toks = toks;
 
-        let mut legit_words_found: HashSet<Box<[char]>> = HashSet::new();
+        let mut valid_singulars: HashSet<Box<[char]>> = HashSet::new();
 
-        if mistake_toks.len() == 1 {
-            let mistake_tok = &mistake_toks[0];
+        if invalid_plural_toks.len() != 1 {
+            // Multiple tokens means we matched a fixed phrase
+            let phrase = invalid_plural_toks.span()?.get_content(src);
+            valid_singulars.insert(phrase[..phrase.len() - 1].into());
+        } else {
+            let invalid_plural_tok = &invalid_plural_toks[0];
             // Not a fixed phrase, so it's a single word that's not in the dictionary and ends with -s
-            let mut remaining_chars = mistake_tok.span.get_content(src);
+            let mut remaining_chars = invalid_plural_tok.span.get_content(src);
 
             // -s
             if remaining_chars.ends_with(&['s']) {
                 remaining_chars = &remaining_chars[..remaining_chars.len() - 1];
 
                 if self.is_mass_noun_in_dictionary(remaining_chars) {
-                    legit_words_found.insert(remaining_chars.into());
+                    valid_singulars.insert(remaining_chars.into());
                 }
 
                 // -es
@@ -84,7 +87,7 @@ where
                     remaining_chars = &remaining_chars[..remaining_chars.len() - 1];
 
                     if self.is_mass_noun_in_dictionary(remaining_chars) {
-                        legit_words_found.insert(remaining_chars.into());
+                        valid_singulars.insert(remaining_chars.into());
                     }
 
                     // -ies -> -y
@@ -95,41 +98,46 @@ where
                         if self.is_mass_noun_in_dictionary_str(&y_singular) {
                             let y_singular_chars: Box<[char]> =
                                 y_singular.chars().collect::<Vec<char>>().into_boxed_slice();
-                            legit_words_found.insert(y_singular_chars.clone());
+                            valid_singulars.insert(y_singular_chars.clone());
                         }
                     }
                 }
             }
-        } else {
-            // Multiple tokens means we matched a fixed phrase
-            let phrase = mistake_toks.span()?.get_content(src);
-            legit_words_found.insert(phrase[..phrase.len() - 1].into());
         }
 
-        if legit_words_found.is_empty() {
+        if valid_singulars.is_empty() {
             return None;
         }
 
         let message = format!(
             "The {} `{}` is a mass noun and should not be pluralized.",
-            if mistake_toks.len() == 1 {
+            if invalid_plural_toks.len() == 1 {
                 "word"
             } else {
                 "term"
             },
-            legit_words_found
+            valid_singulars
                 .iter()
                 .map(|s| s.to_string())
                 .collect::<Vec<String>>()
                 .join("`, `")
         );
 
+        let span = invalid_plural_toks.span()?;
+
+        let suggestions: Vec<Suggestion> = valid_singulars
+            .iter()
+            .map(|sing| {
+                Suggestion::replace_with_match_case(sing.clone().into(), span.get_content(src))
+            })
+            .collect();
+
         Some(Lint {
-            span: mistake_toks.span()?,
+            span,
             lint_kind: LintKind::Grammar,
-            suggestions: vec![],
+            suggestions,
             message,
-            priority: 31,
+            ..Default::default()
         })
     }
 
@@ -140,7 +148,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{linting::tests::assert_lint_count, spell::FstDictionary};
+    use crate::{
+        linting::tests::{assert_lint_count, assert_suggestion_result},
+        spell::FstDictionary,
+    };
 
     use super::MassPlurals;
 
@@ -171,13 +182,30 @@ mod tests {
         );
     }
 
-    // instead of giving any of her many luxury real estates or multi-million dollar fortune ...
     #[test]
     fn flag_real_estates() {
         assert_lint_count(
             "Instead of giving any of her many luxury real estates or multi-million dollar fortune ...",
             MassPlurals::new(FstDictionary::curated()),
             1,
+        );
+    }
+
+    #[test]
+    fn flag_wear_and_tears() {
+        assert_lint_count(
+            "Transit costs were high in terms of time, finances, and vehicle wear and tears, which posed significant obstacles to international commerce",
+            MassPlurals::new(FstDictionary::curated()),
+            1,
+        );
+    }
+
+    #[test]
+    fn fix_wear_and_tears() {
+        assert_suggestion_result(
+            "Transit costs were high in terms of time, finances, and vehicle wear and tears, which posed significant obstacles to international commerce",
+            MassPlurals::new(FstDictionary::curated()),
+            "Transit costs were high in terms of time, finances, and vehicle wear and tear, which posed significant obstacles to international commerce",
         );
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

I was adding "wear and tears" to this linter when I noticed it doesn't do `Suggestion`s.
So I added those too.

Note that it doesn't check or suggest anything in relation to plural determiners before the pluralized mass noun. So it will correct "these softwares" to "these software" rather than "this software". That could/should be a separate linter.

I also refactored a tiny bit, mostly making identifiers a bit clearer.

# How Has This Been Tested?

I added a unit test which checks both "wear and tears" and the suggested correction to "wear and tear".

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
