### PR TITLE
fix(core): add JetBrains as a proper noun

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -53010,7 +53010,7 @@ JWT/Ng              # JSON Web Token
 Jacoco/Sg
 JavaDoc/Sg
 JavaScript/ONSg     # programming language
-JetBrains
+JetBrains/Og
 Jetpack/Og
 Jira/Og             # issue tracker
 Joomla/Sg

--- a/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
+++ b/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
@@ -732,4 +732,12 @@ mod tests {
     fn dont_flag_plugin_interface() {
         assert_no_lints("[Plugin interface]", PhrasalVerbAsCompoundNoun::default());
     }
+
+    #[test]
+    fn issue_1918() {
+        assert_no_lints(
+            "Boost your productivity with our JetBrains plugin!",
+            PhrasalVerbAsCompoundNoun::default(),
+        );
+    }
 }


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #1918

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

"Plugin" was being incorrectly changed to "plug in" because Harper wasn't aware "JetBrains" was a proper noun. I've addressed the problem and added a test prove it is resolved.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Unit test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
