### PR TITLE
fix(core): problems with `EffectAffect` linter

### DIFF
--- a/harper-core/src/linting/noun_verb_confusion/effect_affect/affect_to_effect.rs
+++ b/harper-core/src/linting/noun_verb_confusion/effect_affect/affect_to_effect.rs
@@ -85,6 +85,18 @@ impl ExprLinter for AffectToEffect {
         let offending_index = *self.map.lookup(0, matched_tokens, source)?;
         let target = &matched_tokens[offending_index];
 
+        let preceding = matched_tokens[..offending_index]
+            .iter()
+            .rfind(|tok| !tok.kind.is_whitespace());
+
+        if preceding.is_some_and(|tok| {
+            (tok.kind.is_pronoun() || tok.kind.is_upos(UPOS::PRON))
+                && !tok.kind.is_possessive_pronoun()
+        }) {
+            // Pronouns like "it" or "they" almost always introduce the verb form ("it affects").
+            return None;
+        }
+
         let token_text = target.span.get_content_string(source);
         let lower = token_text.to_lowercase();
         let replacement = match lower.as_str() {

--- a/harper-core/src/linting/noun_verb_confusion/effect_affect/effect_to_affect.rs
+++ b/harper-core/src/linting/noun_verb_confusion/effect_affect/effect_to_affect.rs
@@ -125,6 +125,12 @@ impl ExprLinter for EffectToAffect {
         let token_text = target.span.get_content_string(source);
         let lower = token_text.to_lowercase();
 
+        if lower.as_str() == "effects" && preceding.is_some_and(|tok| tok.kind.is_upos(UPOS::VERB))
+        {
+            // Imperative phrases like "Avoid effects" legitimately use the noun.
+            return None;
+        }
+
         let replacement = match lower.as_str() {
             "effect" => "affect",
             "effects" => "affects",

--- a/harper-core/src/linting/noun_verb_confusion/mod.rs
+++ b/harper-core/src/linting/noun_verb_confusion/mod.rs
@@ -30,7 +30,7 @@ merge_linters! {
 #[cfg(test)]
 mod tests {
     use super::NounVerbConfusion;
-    use crate::linting::tests::{assert_lint_count, assert_suggestion_result};
+    use crate::linting::tests::{assert_lint_count, assert_no_lints, assert_suggestion_result};
 
     #[test]
     fn corrects_good_advise() {
@@ -1335,6 +1335,22 @@ mod tests {
             "Sound effects were added in post.",
             NounVerbConfusion::default(),
             0,
+        );
+    }
+
+    #[test]
+    fn issue_1997() {
+        assert_no_lints(
+            "It depends on which sources it affects, what parameters it uses, etc.",
+            NounVerbConfusion::default(),
+        );
+    }
+
+    #[test]
+    fn issue_1996() {
+        assert_no_lints(
+            "Avoid effects outside of functions.",
+            NounVerbConfusion::default(),
         );
     }
 }


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #1996 and fixes #1997 with test to prove it.

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

For #1997, I found that, almost always, the word "affect" preceded by a possessive pronoun is correct.
For #1996, I found the same is true for "effects" when preceded by a verb.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Additional unit tests from the issues.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
