### PR TITLE
feat(chrome-ext): add buttons to reset and toggle all rules

### DIFF
--- a/packages/lint-framework/src/lint/LintFramework.ts
+++ b/packages/lint-framework/src/lint/LintFramework.ts
@@ -146,6 +146,19 @@ export default class LintFramework {
 		}
 	}
 
+	/** Get the individual lints produced the last time the text on the screen was scanned. */
+	public getLastLints(): UnpackedLint[] {
+		const lints = [];
+
+		for (const group of this.lastLints) {
+			for (const groupLints of Object.values(group.lints)) {
+				lints.push(...groupLints);
+			}
+		}
+
+		return lints;
+	}
+
 	private attachTargetListeners(target: Node) {
 		for (const event of INPUT_EVENTS) {
 			target.addEventListener(event, this.updateEventCallback);


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

I personally felt the need for this while working on another feature.

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

I've gone ahead and added two new buttons to the Chrome extension's option page, similar to those introduced in #1789.
They:

1. Allow you to toggle all rules.
2. Allow you to reset all rules to their default value.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
