### PR TITLE
fix(core): use subject pronouns instead

### DIFF
--- a/harper-core/src/linting/didnt.rs
+++ b/harper-core/src/linting/didnt.rs
@@ -9,7 +9,7 @@ pub struct Didnt {
 impl Default for Didnt {
     fn default() -> Self {
         let pattern = SequenceExpr::default()
-            .then_personal_pronoun()
+            .then_subject_pronoun()
             .t_ws()
             .t_aco("dint");
 


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #2086

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

@hippietrail was correct. The `Didnt` rule should only look for subject pronouns. 
When I initially submitted the original PR, I did some LLM-assisted fuzzing and found no false-positives.
From a correctness point-of-view, however, I think the edit is necessary.
