### PR TITLE
fix(core): address false-positives by adding an exception for verbs

### DIFF
--- a/harper-core/src/linting/its_possessive.rs
+++ b/harper-core/src/linting/its_possessive.rs
@@ -47,6 +47,7 @@ impl Default for ItsPossessive {
             .then(UPOSSet::new(&[UPOS::ADJ, UPOS::NOUN, UPOS::PROPN]))
             .t_ws()
             .then_unless(UPOSSet::new(&[
+                UPOS::VERB,
                 UPOS::PART,
                 UPOS::ADP,
                 UPOS::NOUN,
@@ -319,6 +320,14 @@ mod tests {
     fn allow_issue_1658() {
         assert_no_lints(
             "It's kind of a nuisance, but it will work.",
+            ItsPossessive::default(),
+        );
+    }
+
+    #[test]
+    fn allow_issue_2001() {
+        assert_no_lints(
+            "It's worth highlighting that while using a fork instead of a spoon is easy, it sometimes isn't.",
             ItsPossessive::default(),
         );
     }


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #2001

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

This was a pretty simple issue to solve. Verbs are an exception to the rule that I hadn't accounted for when originally writing it.
Adding verbs as an exception solves the problem.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

An additional unit test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
