### PR TITLE
fix(core): false-positive in `affect -> effect`

### DIFF
--- a/harper-core/src/linting/noun_verb_confusion/mod.rs
+++ b/harper-core/src/linting/noun_verb_confusion/mod.rs
@@ -1353,4 +1353,12 @@ mod tests {
             NounVerbConfusion::default(),
         );
     }
+
+    #[test]
+    fn issue_2008() {
+        assert_no_lints(
+            "Changes that only affect static types, without breaking runtime behavior.",
+            NounVerbConfusion::default(),
+        );
+    }
 }

--- a/harper-core/src/linting/noun_verb_confusion/verb_instead_of_noun.rs
+++ b/harper-core/src/linting/noun_verb_confusion/verb_instead_of_noun.rs
@@ -2,7 +2,7 @@ use crate::{
     Lrc, Token,
     expr::{Expr, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
-    patterns::WordSet,
+    patterns::{UPOSSet, WordSet},
 };
 use harper_brill::UPOS;
 
@@ -23,7 +23,7 @@ impl Default for VerbInsteadOfNoun {
         Self {
             expr: Box::new(
                 SequenceExpr::default()
-                    .then_adjective()
+                    .then(UPOSSet::new(&[UPOS::ADJ]))
                     .then_whitespace()
                     .then(verbs.clone()),
             ),
@@ -58,7 +58,7 @@ impl ExprLinter for VerbInsteadOfNoun {
             return None;
         }
 
-        // "Sound" is both adjectve and noun. We want to flag the common "sound advise"
+        // "Sound" is both adjective and noun. We want to flag the common "sound advise"
         // But not "sound affect", which is just as correct as "sound effect".
         if adj_text == "sound" && verb_text == "affect" {
             return None;


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #2008

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

The `VerbInsteadOfNoun` rule used an inaccurate reading for whether a word was an adjective.
By switching it to use the output of our Brill tagger, the problem goes away.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Existing tests pass + a new unit test from the source issue.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
