### PR TITLE
feat(core): support additional initialisms

### DIFF
--- a/harper-core/src/linting/initialisms.rs
+++ b/harper-core/src/linting/initialisms.rs
@@ -29,6 +29,14 @@ pub fn lint_group() -> LintGroup {
         "ToBeHonest"         => ("tbh", "to be honest"),
         "AsFarAsIKnow"       => ("afaik", "as far as I know"),
         "Really"             => ("rly", "really"),
+        "ExplainLikeImFive"  => ("eli5", "explain like i'm five"),
+        "ForWhatItsWorth"    => ("fwiw", "for what it's worth"),
+        "IDontKnow"          => ("idk", "I don't know"),
+        "IfIRecallCorrectly" => ("iirc", "if I recall correctly"),
+        "IfYouKnowYouKnow"   => ("iykyk", "if you know, you know"),
+        "InCaseYouMissedIt"  => ("icymi", "in case you missed it"),
+        "InRealLife"         => ("irl", "in real life"),
+        "PleaseTakeALook"    => ("ptal", "please take a look"),
     });
 
     group.set_all_rules_to(Some(true));
@@ -125,6 +133,78 @@ mod tests {
             "AFAIK, we don't currently have an issue for it.",
             lint_group(),
             "As far as i know, we don't currently have an issue for it.",
+        );
+    }
+
+    #[test]
+    fn corrects_eli5() {
+        assert_suggestion_result(
+            "Can you eli5 how this works?",
+            lint_group(),
+            "Can you explain like i'm five how this works?",
+        );
+    }
+
+    #[test]
+    fn corrects_fwiw() {
+        assert_suggestion_result(
+            "Fwiw, I think it's a good idea.",
+            lint_group(),
+            "For what it's worth, I think it's a good idea.",
+        );
+    }
+
+    #[test]
+    fn corrects_idk() {
+        assert_suggestion_result(
+            "Idk if I'll make it to the party.",
+            lint_group(),
+            "I don't know if I'll make it to the party.",
+        );
+    }
+
+    #[test]
+    fn corrects_iirc() {
+        assert_suggestion_result(
+            "Iirc, the event starts at 6 PM.",
+            lint_group(),
+            "If i recall correctly, the event starts at 6 PM.",
+        );
+    }
+
+    #[test]
+    fn corrects_iykyk() {
+        assert_suggestion_result(
+            "Iykyk, this place is amazing.",
+            lint_group(),
+            "If you know, you know, this place is amazing.",
+        );
+    }
+
+    #[test]
+    fn corrects_icymi() {
+        assert_suggestion_result(
+            "Icymi, the deadline is tomorrow.",
+            lint_group(),
+            "In case you missed it, the deadline is tomorrow.",
+        );
+    }
+
+    #[test]
+    fn corrects_irl() {
+        assert_suggestion_result(
+            "We should meet irl sometime.",
+            lint_group(),
+            "We should meet in real life sometime.",
+        );
+    }
+
+    #[test]
+    fn corrects_ptal() {
+        assert_suggestion_result(
+            "Ptal at the document I sent.",
+            lint_group(),
+            "Please take a look at the document I sent.",
         );
     }
 }

--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -935,7 +935,7 @@ pub fn lint_group() -> LintGroup {
         "RedundantIIRC" => (
             ["if IIRC", "IIRC correctly"], ["IIRC"],
             "`IIRC` already means 'if I recall correctly', so adding 'if' or 'correctly' is redundant.",
-            "Flags redundant use of 'if' or 'correctly' with 'IIRC', since 'IIRC' already stands for 'if I recall correctly'.",
+            "Flags redundant use of 'if' or 'correctly' with `IIRC`, since `IIRC` already stands for 'if I recall correctly'.",
             LintKind::Redundancy
         ),
         "RifeWith" => (


### PR DESCRIPTION
# Description

Add some initialisms I used and would like to correct.

These terms come from my own project, that is MIT licensed.
https://github.com/ccoVeille/jargon-terms

phrase_corrections was updated to do not use `'IIRC'`, but `` `IIRC` `` instead. This change avoids triggering a lint warning when using the initialism in the RedundantIIRC rule.


# How Has This Been Tested?

I launched `just test` and applied the changes I needed.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have performed a self-review of my own code
- [X] I have added tests to cover my changes
