### PR TITLE
feat: `harper-cli` warn setting unknown rules

### DIFF
--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -225,12 +225,18 @@ fn main() -> anyhow::Result<()> {
                 linter.set_all_rules_to(Some(false));
 
                 for rule in rules {
+                    if !linter.contains_key(&rule) {
+                        eprintln!("Warning: Cannot enable unknown rule '{}'.", &rule);
+                    }
                     linter.config.set_rule_enabled(rule, true);
                 }
             }
 
             if let Some(rules) = ignore {
                 for rule in rules {
+                    if !linter.contains_key(&rule) {
+                        eprintln!("Warning: Cannot disable unknown rule '{}'.", &rule);
+                    }
                     linter.config.set_rule_enabled(rule, false);
                 }
             }
@@ -960,7 +966,7 @@ fn load_file(
                 Box::new(comment_parser)
             } else {
                 println!(
-                    "Warning: could not detect language ID; falling back to PlainEnglish parser."
+                    "Warning: Could not detect language ID; falling back to PlainEnglish parser."
                 );
                 Box::new(PlainEnglish)
             }


### PR DESCRIPTION
# Issues 
N/A

# Description

When testing new linters you're working on, you'll often use `harper-cli lint` with the `--only` or `--ignore` options. But if you misspelled any option it'll just silently ignore it and you'll be left confused about what you've done wrong.

This is also common if you have more than one build and you accidentally run the wrong one and see nothing for your new lint, making you think your lint is at fault when it's a build without the new lint.

This is now addressed.

# Demo
<img width="1321" height="109" alt="image" src="https://github.com/user-attachments/assets/6327eb12-9488-4098-af6f-be472a389511" />

# How Has This Been Tested?
Manually

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
