### PR TITLE
fix(chrome-ext): find permanent solution to HN integration test failures

### DIFF
--- a/packages/chrome-plugin/tests/hn.spec.ts
+++ b/packages/chrome-plugin/tests/hn.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from '@playwright/test';
 import { test } from './fixtures';
 import {
 	assertHarperHighlightBoxes,
@@ -8,14 +9,22 @@ import {
 	testCanIgnoreTextareaSuggestion,
 } from './testUtils';
 
-const TEST_PAGE_URL = 'https://news.ycombinator.com/item?id=45798898';
+/** Must be computed. */
+async function getTestPageUrl(page: Page) {
+	await page.goto('https://news.ycombinator.com');
 
-testBasicSuggestionTextarea(TEST_PAGE_URL);
-testCanIgnoreTextareaSuggestion(TEST_PAGE_URL);
-testCanBlockRuleTextareaSuggestion(TEST_PAGE_URL);
+	const firstLink = page.locator('.subline').first().locator('a').last();
+	await firstLink.click();
+
+	return page.url();
+}
+
+testBasicSuggestionTextarea(getTestPageUrl);
+testCanIgnoreTextareaSuggestion(getTestPageUrl);
+testCanBlockRuleTextareaSuggestion(getTestPageUrl);
 
 test('Hacker News wraps correctly', async ({ page }) => {
-	await page.goto(TEST_PAGE_URL);
+	await page.goto(await getTestPageUrl(page));
 
 	await page.waitForTimeout(2000);
 	await page.reload();
@@ -35,7 +44,7 @@ test('Hacker News wraps correctly', async ({ page }) => {
 });
 
 test('Hacker News scrolls correctly', async ({ page }) => {
-	await page.goto(TEST_PAGE_URL);
+	await page.goto(await getTestPageUrl(page));
 
 	await page.waitForTimeout(2000);
 	await page.reload();

--- a/packages/chrome-plugin/tests/testUtils.ts
+++ b/packages/chrome-plugin/tests/testUtils.ts
@@ -67,9 +67,21 @@ export function getTextarea(page: Page): Locator {
 	return page.locator('textarea');
 }
 
-export async function testBasicSuggestionTextarea(testPageUrl: string) {
+/** A string or function that resolves to a test page. */
+export type TestPageUrlProvider = string | ((page: Page) => Promise<string>);
+
+async function resolveTestPage(prov: TestPageUrlProvider, page: Page): Promise<string> {
+	if (typeof prov === 'string') {
+		return prov;
+	} else {
+		return await prov(page);
+	}
+}
+
+export async function testBasicSuggestionTextarea(testPageUrl: TestPageUrlProvider) {
 	test('Can apply basic suggestion.', async ({ page }) => {
-		await page.goto(testPageUrl);
+		const url = await resolveTestPage(testPageUrl, page);
+		await page.goto(url);
 
 		await page.waitForTimeout(2000);
 		await page.reload();
@@ -88,9 +100,10 @@ export async function testBasicSuggestionTextarea(testPageUrl: string) {
 	});
 }
 
-export async function testCanIgnoreTextareaSuggestion(testPageUrl: string) {
+export async function testCanIgnoreTextareaSuggestion(testPageUrl: TestPageUrlProvider) {
 	test('Can ignore suggestion.', async ({ page }) => {
-		await page.goto(testPageUrl);
+		const url = await resolveTestPage(testPageUrl, page);
+		await page.goto(url);
 
 		await page.waitForTimeout(2000);
 		await page.reload();
@@ -116,9 +129,10 @@ export async function testCanIgnoreTextareaSuggestion(testPageUrl: string) {
 	});
 }
 
-export async function testCanBlockRuleTextareaSuggestion(testPageUrl: string) {
+export async function testCanBlockRuleTextareaSuggestion(testPageUrl: TestPageUrlProvider) {
 	test('Can hide with rule block button', async ({ page }) => {
-		await page.goto(testPageUrl);
+		const url = await resolveTestPage(testPageUrl, page);
+		await page.goto(url);
 
 		const editor = getTextarea(page);
 		await replaceEditorContent(editor, 'This is an test.');


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

Multiple times over the last month, we've been getting spurious and somewhat CI failures coming from a HN integration test for the Chrome extension.
These failures came from a foolhardy decision to test on an arbitrary text area on a random discussion page.
Once that page became marked "stale", the textarea would disappear.
This PR updates the integration test to find an active discussion page with a textarea before starting the real test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
