### PR TITLE
feat: in lue of→in lieu of

### DIFF
--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -599,6 +599,13 @@ pub fn lint_group() -> LintGroup {
             "Corrects `I does` to `I do`.",
             LintKind::Agreement
         ),
+        "InLieuOf" => (
+            ["in lue of"],
+            ["in lieu of"],
+            "Did you mean `in lieu of`?",
+            "Corrects the misspelling `in lue of` to `in lieu of`.",
+            LintKind::Spelling
+        ),
         "InOfItself" => (
             ["in of itself"],
             ["in itself", "in and of itself"],

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -917,6 +917,17 @@ fn corrects_i_does() {
     );
 }
 
+// InLieuOf
+
+#[test]
+fn corrects_in_lue_of() {
+    assert_suggestion_result(
+        "Controller Emulation in lue of Direct Controller binding",
+        lint_group(),
+        "Controller Emulation in lieu of Direct Controller binding",
+    );
+}
+
 // InAndOfItself
 #[test]
 fn detect_atomic_in_of_itself() {


### PR DESCRIPTION
# Issues 
N/O

# Description

**In lue of** is a common misspelling of **in lieu of**.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

A unit test using one of the first sentences I found with the mistake on GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
