### PR TITLE
feat: holly war → holy war

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -353,6 +353,15 @@ pub fn lint_group() -> LintGroup {
             "Corrects common misspellings of the idiom `get rid of`.",
             LintKind::Typo
         ),
+        "HolyWar" => (
+            &[
+                (&["holey war", "holly war"], &["holy war"]),
+                (&["holey wars", "holly wars"], &["holy wars"]),
+            ],
+            "Literally for religious conflicts and metaphorically for tech preference debats, the correct spelling is `holy war`.",
+            "Corrects misspellings of `holy war`.",
+            LintKind::Malapropism
+        ),
         "HowItLooksLike" => (
             &[
                 (&["how he looks like"], &["how he looks", "what he looks like"]),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -934,6 +934,27 @@ fn got_ride_of() {
     );
 }
 
+// HolyWar
+
+#[test]
+#[ignore = "Known failure due to replace_with_match_case working by character index"]
+fn correct_holy_war() {
+    assert_suggestion_result(
+        "I know it is Holly War about idempotent in HTTP and DELETE",
+        lint_group(),
+        "I know it is Holy War about idempotent in HTTP and DELETE",
+    );
+}
+
+#[test]
+fn correct_holly_wars() {
+    assert_suggestion_result(
+        "Anyway I'm not starting some holly wars about this point.",
+        lint_group(),
+        "Anyway I'm not starting some holy wars about this point.",
+    );
+}
+
 // HowItLooksLike
 
 #[test]


### PR DESCRIPTION
# Issues 
N/A

# Description

"Holly war" turns out to be a very common misspelling of "holy war". This fixes it in singular and plural.
I included "holey war" even though in searches it seemed to be most used intentionally for jokes or similar. Can always remove it if it's getting in the way.

# How Has This Been Tested?

There's a couple of unit tests using sentences plucked from GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
