### PR TITLE
fix: "will of -> will have" false positives

### DIFF
--- a/harper-core/src/linting/modal_of.rs
+++ b/harper-core/src/linting/modal_of.rs
@@ -24,6 +24,17 @@ impl Default for ModalOf {
                 .t_aco("of"),
         );
 
+        // "will of" is a false positive if "will" is a noun
+        // "The will of the many"
+        let noun_will_of_naive = Lrc::new(
+            SequenceExpr::default()
+                .then_word_set(&["the", "a"])
+                .then_whitespace()
+                .t_aco("will")
+                .then_whitespace()
+                .t_aco("of"),
+        );
+
         let ws_course = Lrc::new(SequenceExpr::default().then_whitespace().t_aco("course"));
 
         let modal_of_course = Lrc::new(
@@ -52,6 +63,7 @@ impl Default for ModalOf {
                 Box::new(anyword_might_of_course),
                 Box::new(modal_of_course),
                 Box::new(anyword_might_of),
+                Box::new(noun_will_of_naive),
                 Box::new(modal_of),
             ])),
         }
@@ -298,5 +310,20 @@ mod tests {
     #[test]
     fn catches_mixed_case_could_of_put() {
         assert_lint_count("... for now you could of Put ...", ModalOf::default(), 1);
+    }
+
+    #[test]
+    fn doesnt_catch_noun_will_of() {
+        assert_lint_count("the will of the many", ModalOf::default(), 0);
+    }
+
+    #[test]
+    fn doesnt_catch_noun_will_of_edgecase() {
+        assert_lint_count("he sent us a will of his", ModalOf::default(), 0);
+    }
+
+    #[test]
+    fn catch_modal_will_of() {
+        assert_lint_count("that will of an impact", ModalOf::default(), 1);
     }
 }


### PR DESCRIPTION
# Issues 
Fixes #2194
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->
Uses a naive approach to detect whether "will" is a noun in the sentence, by ignoring instances where it follows "the" or "a".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
Three new unit tests, one using an example sentence from #2194, one using an odd edge-case, and one to verify that the regular detection still works.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
