### PR TITLE
feat: await for → await / wait for

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -341,6 +341,17 @@ pub fn lint_group() -> LintGroup {
     });
 
     add_many_to_many_mappings!(group, {
+        "AwaitFor" => (
+            &[
+                (&["await for"], &["await", "wait for"]),
+                (&["awaited for"], &["awaited", "waited for"]),
+                (&["awaiting for"], &["awaiting", "waiting for"]),
+                (&["awaits for"], &["awaits", "waits for"])
+            ],
+            "`Await` and `for` are redundant when used together - use one or the other",
+            "Suggests using either `await` or `wait for` but not both, as they express the same meaning.",
+            LintKind::Redundancy
+        ),
         "GetRidOf" => (
             &[
                 (&["get rid off", "get ride of", "get ride off"], &["get rid of"]),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -1,5 +1,6 @@
 use crate::linting::tests::{
-    assert_lint_count, assert_no_lints, assert_nth_suggestion_result, assert_suggestion_result,
+    assert_good_and_bad_suggestions, assert_lint_count, assert_no_lints,
+    assert_nth_suggestion_result, assert_suggestion_result,
 };
 
 use super::lint_group;
@@ -832,6 +833,60 @@ fn correct_passer_bys_hyphen() {
 // -none-
 
 // Many to many tests
+
+// AwaitFor
+
+#[test]
+fn correct_awaits_for() {
+    assert_good_and_bad_suggestions(
+        "Headless mode awaits for requested user feedback without showing any text for what that feedback should be",
+        lint_group(),
+        &[
+            "Headless mode awaits requested user feedback without showing any text for what that feedback should be",
+            "Headless mode waits for requested user feedback without showing any text for what that feedback should be",
+        ],
+        &[],
+    );
+}
+
+#[test]
+fn correct_awaiting_for() {
+    assert_good_and_bad_suggestions(
+        "gpg import fails awaiting for prompt answer",
+        lint_group(),
+        &[
+            "gpg import fails waiting for prompt answer",
+            "gpg import fails awaiting prompt answer",
+        ],
+        &[],
+    );
+}
+
+#[test]
+fn correct_await_for() {
+    assert_good_and_bad_suggestions(
+        "I still await for a college course on \"Followership 101\"",
+        lint_group(),
+        &[
+            "I still wait for a college course on \"Followership 101\"",
+            "I still await a college course on \"Followership 101\"",
+        ],
+        &[],
+    );
+}
+
+#[test]
+fn correct_awaited_for() {
+    assert_good_and_bad_suggestions(
+        "I have long awaited for the rise of the Dagoat agenda, and it is glorious.",
+        lint_group(),
+        &[
+            "I have long awaited the rise of the Dagoat agenda, and it is glorious.",
+            "I have long waited for the rise of the Dagoat agenda, and it is glorious.",
+        ],
+        &[],
+    );
+}
 
 // GetRidOf
 


### PR DESCRIPTION
# Issues 
N/A

# Description

I just saw a video snippet of a non-native speaker use the redundant wording "await for" rather than just "await" or "wait for". A quick search shows it's a common mistake.

There may be false positives when talking about `async await` in programming, but even in that context `await for` seems to be redundant. Report if not.

# How Has This Been Tested?

I've added a unit test for each inflected form source from GitHub or the internet at large.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
