### PR TITLE
feat: per say / per-se → per se

### DIFF
--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -866,6 +866,13 @@ pub fn lint_group() -> LintGroup {
             "Corrects `piece of mind` to `peace of mind`.",
             LintKind::Eggcorn
         ),
+        "PerSe" => (
+            ["per say", "per-se", "per-say"],
+            ["per se"],
+            "The correct spelling is `per se` (with no hyphen)",
+            "Corrects common misspellings of `per se`.",
+            LintKind::Spelling
+        ),
         "PointsOfView" => (
             ["point of views"],
             ["points of view"],

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -1444,6 +1444,34 @@ fn corrects_piece_of_mind() {
     )
 }
 
+// PerSe
+#[test]
+fn corrects_per_se_hyphenated() {
+    assert_suggestion_result(
+        "It's not a problem per-se, but it would make the desktop more consistent when using QT and KDE apps.",
+        lint_group(),
+        "It's not a problem per se, but it would make the desktop more consistent when using QT and KDE apps.",
+    )
+}
+
+#[test]
+fn corrects_per_say() {
+    assert_suggestion_result(
+        "Hi all - not really an issue per say, but more of a request for some suggestions and guidance.",
+        lint_group(),
+        "Hi all - not really an issue per se, but more of a request for some suggestions and guidance.",
+    );
+}
+
+#[test]
+fn corrects_per_say_hyphenated() {
+    assert_suggestion_result(
+        "Whilst I don't think this is wrong per-say, I'm not confident it is necessary.",
+        lint_group(),
+        "Whilst I don't think this is wrong per se, I'm not confident it is necessary.",
+    );
+}
+
 // PointsOfView
 #[test]
 fn corrects_points_of_view() {


### PR DESCRIPTION
# Issues 
N/A

# Description

While asking an LLM to check a paragraph with a different error, it also picked out its use of `per-se` instead of `per se`. While making sure it should never be hyphenated I discovered many more websites talking about the common error `per say`.

So this PR fixes both and also `per-say`.

# How Has This Been Tested?

A unit test using real text from GitHub for each of the three variants is included.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
