### PR TITLE
fix: don't flag 'every day free'

### DIFF
--- a/harper-core/src/expr/sequence_expr.rs
+++ b/harper-core/src/expr/sequence_expr.rs
@@ -420,6 +420,7 @@ impl SequenceExpr {
 
     gen_then_from_is!(noun);
     gen_then_from_is!(proper_noun);
+    gen_then_from_is!(plural_noun);
     gen_then_from_is!(mass_noun_only);
 
     // Pronouns

--- a/harper-core/src/linting/everyday.rs
+++ b/harper-core/src/linting/everyday.rs
@@ -12,7 +12,7 @@ pub struct Everyday {
 impl Default for Everyday {
     fn default() -> Self {
         let everyday = Word::new("everyday");
-        let every_day = Lrc::new(SequenceExpr::default().t_aco("every").t_ws().t_aco("day"));
+        let every_day = Lrc::new(SequenceExpr::aco("every").t_ws().t_aco("day"));
 
         let everyday_bad_after =
             All::new(vec![
@@ -91,7 +91,7 @@ impl Default for Everyday {
                 SequenceExpr::default()
                     .then(every_day.clone())
                     .t_ws()
-                    .then_noun()
+                    .then_plural_noun()
                     .then_punctuation(),
             ),
             Box::new(
@@ -215,7 +215,7 @@ impl ExprLinter for Everyday {
 mod tests {
     use super::Everyday;
     use crate::linting::tests::{
-        assert_lint_count, assert_suggestion_result, assert_top3_suggestion_result,
+        assert_lint_count, assert_no_lints, assert_suggestion_result, assert_top3_suggestion_result,
     };
 
     #[test]
@@ -505,5 +505,10 @@ mod tests {
             Everyday::default(),
             "MEET SOMEONE NEW EVERY DAY.",
         );
+    }
+
+    #[test]
+    fn dont_flag_every_day_singular_noun_2020() {
+        assert_no_lints("50 requests per day, every day free.", Everyday::default());
     }
 }


### PR DESCRIPTION
# Issues 
Fixes #2020

# Description

In the phrase "every day free." we were flagging "every day" to change to "everyday".

This was because "free" has a couple of senses where it can be a noun. But the logic checking for a noun actually only needed to check for plural nouns.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

A unit test using the sentence from the issue.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
