### PR TITLE
refactor: upgrade `Expatriate` to `phrase_set_corrections`

### DIFF
--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -426,13 +426,6 @@ pub fn lint_group() -> LintGroup {
             "Expands the abbreviation `w/o` to the full word `without` for clarity.",
             LintKind::Style
         ),
-        "Expatriate" => (
-            ["ex-patriot"],
-            ["expatriate"],
-            "Use the correct term for someone living abroad.",
-            "Fixes the misinterpretation of `expatriate`, ensuring the correct term is used for individuals residing abroad.",
-            LintKind::Eggcorn
-        ),
         "FaceFirst" => (
             ["face first into"],
             ["face-first into"],

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -770,9 +770,6 @@ fn expand_cuz() {
 // ExpandWithout
 // -none-
 
-// Expatriate
-// -none-
-
 // FaceFirst
 // -none-
 

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -352,6 +352,26 @@ pub fn lint_group() -> LintGroup {
             "Suggests using either `await` or `wait for` but not both, as they express the same meaning.",
             LintKind::Redundancy
         ),
+        "Expat" => (
+            &[
+                (&["ex-pat", "ex pat"], &["expat"]),
+                (&["ex-pats", "ex pats"], &["expats"]),
+                (&["ex-pat's", "ex pat's"], &["expat's"]),
+            ],
+            "The correct spelling is `expat` with no hyphen or space.",
+            "Corrects the mistake of writing `expat` as two words.",
+            LintKind::Spelling
+        ),
+        "Expatriate" => (
+            &[
+                (&["ex-patriot", "expatriot", "ex patriot"], &["expatriate"]),
+                (&["ex-patriots", "expatriots", "ex patriots"], &["expatriates"]),
+                (&["ex-patriot's", "expatriot's", "ex patriot's"], &["expatriate's"]),
+            ],
+            "Use the correct term for someone living abroad.",
+            "Fixes the misinterpretation of `expatriate`, ensuring the correct term is used for individuals residing abroad.",
+            LintKind::Eggcorn
+        ),
         "GetRidOf" => (
             &[
                 (&["get rid off", "get ride of", "get ride off"], &["get rid of"]),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -888,6 +888,83 @@ fn correct_awaited_for() {
     );
 }
 
+// Expat
+
+#[test]
+fn correct_ex_pat_hyphen() {
+    assert_suggestion_result(
+        "It seems ex-pat means the person will be in a foreign country temporarily",
+        lint_group(),
+        "It seems expat means the person will be in a foreign country temporarily",
+    );
+}
+
+#[test]
+fn correct_ex_pats_hyphen() {
+    assert_suggestion_result(
+        "So, it might be correct to call most Brits ex-pats.",
+        lint_group(),
+        "So, it might be correct to call most Brits expats.",
+    );
+}
+
+#[test]
+fn correct_ex_pat_space() {
+    assert_suggestion_result(
+        "For me, the term ex pat embodies the exquisite hypocrisy of certain people feeling entitled",
+        lint_group(),
+        "For me, the term expat embodies the exquisite hypocrisy of certain people feeling entitled",
+    );
+}
+
+#[test]
+#[ignore = "replace_with_match_case results in ExPats"]
+fn correct_ex_pats_space() {
+    assert_suggestion_result(
+        "Why are Brits who emigrate \"Ex Pats\" but people who come here \"immigrants\"?",
+        lint_group(),
+        "Why are Brits who emigrate \"Expats\" but people who come here \"immigrants\"?",
+    );
+}
+
+// Expatriate
+
+#[test]
+fn correct_expatriot() {
+    assert_suggestion_result(
+        "Another expatriot of the era, James Joyce, also followed Papa's writing and drinking schedule.",
+        lint_group(),
+        "Another expatriate of the era, James Joyce, also followed Papa's writing and drinking schedule.",
+    );
+}
+
+#[test]
+fn correct_expatriots() {
+    assert_suggestion_result(
+        "Expatriots, upon discovering the delightful nuances of Dutch pronunciation, often find themselves in stitches.",
+        lint_group(),
+        "Expatriates, upon discovering the delightful nuances of Dutch pronunciation, often find themselves in stitches.",
+    );
+}
+
+#[test]
+fn correct_ex_patriot_hyphen() {
+    assert_suggestion_result(
+        "Then I added we should all be using the word 移民 immigrant, not ex-patriot, not 外国人 gaikokujin, and definitely not 外人 gaijin",
+        lint_group(),
+        "Then I added we should all be using the word 移民 immigrant, not expatriate, not 外国人 gaikokujin, and definitely not 外人 gaijin",
+    );
+}
+
+#[test]
+fn correct_ex_patriots_hyphen() {
+    assert_suggestion_result(
+        "Ex-patriots who move to Hong Kong to seek greener pastures and to experience a new culture seem to bring their own cultural baggage with them.",
+        lint_group(),
+        "Expatriates who move to Hong Kong to seek greener pastures and to experience a new culture seem to bring their own cultural baggage with them.",
+    );
+}
+
 // GetRidOf
 
 #[test]


### PR DESCRIPTION
# Issues 
N/A

# Description

I noticed that Harper corrects "expatriot" to "expatriate", but not the plural, or hyphenated misspelling, or the short versions ex-pat and ex pat, which are at least as common.

I upgraded it from a `phrase_correction` to a pair of `phrase_set_corrections`.

# How Has This Been Tested?

Unit tests with sentences found on YouTube or various websites.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
