### PR TITLE
fix(dict): update webpack entry

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -53305,14 +53305,12 @@ WSL/Og              # windows subsystem for linux
 Waymo/Og
 WeChat/Og
 WebAssembly/g       # see WASM
-Webpack/Og
 WebDAV/Og
 WebGL/Og
 WebGPU/Sg
 WebKit/Og
 WebRTC/Og
 WebSocket/Sg
-Webpack/Og
 WhatsApp/NOgVG      # messaging app
 Wikilink/NSg        # !! please check and comment !! elsewhere we have wikilink
 Wikimedia/Og        # foundation that runs Wikipedia etc.
@@ -53456,6 +53454,7 @@ uptime/NwgS
 vid/NgS             # video
 waitlist/NgS
 watchOS/Og
+webpack/Og
 whitespace/~NSg     # dictionaries prefer: white space
 wikilink/~NSg       # !! please check and comment !! elsewhere we have Wikilink
 XeTeX/Og            # TeX typesetting engine


### PR DESCRIPTION
# Issues

N/A

# Description

I was updating some documentation and noticed that writing webpack with a lowercase w was being flagged by the `OrthographicConsistency` rule. Aside from when it is at the beginning of a sentence, webpack is supposed to be spelled with a lowercase w. See: <https://webpack.js.org/branding/#the-name>

It's my first time contributing to the dictionary, so feel free to tell me if there's anything I messed up.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
