### PR TITLE
feat(ls): add `octo` as a supported filetype

### DIFF
--- a/harper-ls/src/backend.rs
+++ b/harper-ls/src/backend.rs
@@ -359,7 +359,7 @@ impl Backend {
                     Some(Box::new(ts_parser))
                 }
             }
-            "git-commit" | "gitcommit" => {
+            "git-commit" | "gitcommit" | "octo" => {
                 Some(Box::new(GitCommitParser::new_markdown(markdown_options)))
             }
             "html" => Some(Box::new(HtmlParser::default())),


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

I've started using `octo.nvim` for various code reviews. It seems to work well with Harper.
Since the vast majority of GitHub's UI is Markdown, it feels pretty plug-and-play. I'll update this PR if there are any visual errors from `octo.nvim`'s markup.

Note that it requires a small change to Neovim's `harper_ls` config for it to work:

```
{
  cmd = { 'harper-ls', '--stdio' },
  filetypes = {
    'asciidoc',
    'c',
    'cpp',
    'cs',
    'gitcommit',
    'go',
    'html',
    'java',
    'javascript',
    'lua',
    'markdown',
    'nix',
    'python',
    'ruby',
    'rust',
    'swift',
    'toml',
    'typescript',
    'typescriptreact',
    'haskell',
    'cmake',
    'typst',
    'php',
    'dart',
    'clojure',
    'sh',
    'octo' -- Add this
  },
  root_markers = { '.git' },
}
```

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes