### PR TITLE
fix(core): ignore inflections of `be` in compound noun rule

### DIFF
--- a/harper-core/src/expr/mod.rs
+++ b/harper-core/src/expr/mod.rs
@@ -155,6 +155,7 @@ where
 pub trait OwnedExprExt {
     fn or(self, other: impl Expr + 'static) -> FirstMatchOf;
     fn and(self, other: impl Expr + 'static) -> All;
+    fn and_not(self, other: impl Expr + 'static) -> All;
     fn or_longest(self, other: impl Expr + 'static) -> LongestMatchOf;
 }
 
@@ -170,6 +171,11 @@ where
     /// Returns an expression that matches only if both the current one and the expression contained in `other` do.
     fn and(self, other: impl Expr + 'static) -> All {
         All::new(vec![Box::new(self), Box::new(other)])
+    }
+
+    /// Returns an expression that matches only if the current one matches and the expression contained in `other` does not.
+    fn and_not(self, other: impl Expr + 'static) -> All {
+        self.and(UnlessStep::new(other, |_tok: &Token, _src: &[char]| true))
     }
 
     /// Returns an expression that matches the longest of the current one or the expression contained in `other`.

--- a/harper-core/src/linting/compound_nouns/compound_noun_after_det_adj.rs
+++ b/harper-core/src/linting/compound_nouns/compound_noun_after_det_adj.rs
@@ -1,7 +1,9 @@
 use crate::expr::All;
 use crate::expr::Expr;
 use crate::expr::MergeableWords;
+use crate::expr::OwnedExprExt;
 use crate::expr::SequenceExpr;
+use crate::patterns::InflectionOfBe;
 use crate::{CharStringExt, TokenStringExt, linting::ExprLinter};
 
 use super::{Lint, LintKind, Suggestion, is_content_word, predicate};
@@ -31,7 +33,7 @@ impl Default for CompoundNounAfterDetAdj {
             .t_ws()
             .then(is_content_word)
             .t_ws()
-            .then(is_content_word);
+            .then(is_content_word.and_not(InflectionOfBe::default()));
 
         let split_expr = Lrc::new(MergeableWords::new(|meta_closed, meta_open| {
             predicate(meta_closed, meta_open)

--- a/harper-core/tests/run_tests.rs
+++ b/harper-core/tests/run_tests.rs
@@ -89,6 +89,7 @@ create_test!(misc_closed_compound_clean.md, 0, Dialect::American);
 create_test!(yogurt_british_clean.md, 0, Dialect::British);
 create_test!(issue_1581.md, 0, Dialect::British);
 create_test!(issue_2054.md, 6, Dialect::British);
+create_test!(issue_1988.md, 0, Dialect::American);
 create_test!(issue_2054_clean.md, 0, Dialect::British);
 create_test!(issue_1873.md, 0, Dialect::British);
 create_test!(issue_2233.md, 0, Dialect::American);

--- a/harper-core/tests/test_sources/issue_1988.md
+++ b/harper-core/tests/test_sources/issue_1988.md
@@ -1,0 +1,1 @@
+When this test is run, it returns a result.

--- a/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
+++ b/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
@@ -225,16 +225,6 @@ Message: |
 
 
 
-Lint:    WordChoice (63 priority)
-Message: |
-      89 | third Class at the Expiration of the sixth Year, so that one third may be
-         |                                                                    ^~~~~~ Did you mean the closed compound noun “maybe”?
-      90 | chosen every second Year; and when vacancies happen in the representation of
-Suggest:
-  - Replace with: “maybe”
-
-
-
 Lint:    Readability (127 priority)
 Message: |
       96 | No Person shall be a Senator who shall not have attained to the Age of thirty


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes issue #1988

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

Inflections of "be" are rarely included in closed compound nouns like this. We really should just be ignoring them from the get-go. That's exactly what I did.

While I was in there, I added an extension method to `Expr`s so we can compose them with `and_not`. It will make a lot more sense when you read the patch diff.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Additional integration test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
