### PR TITLE
fix(ls): prevent panic when workspace/configuration is unsupported

### DIFF
--- a/harper-ls/src/backend.rs
+++ b/harper-ls/src/backend.rs
@@ -26,7 +26,7 @@ use harper_literate_haskell::LiterateHaskellParser;
 use harper_python::PythonParser;
 use harper_stats::{Record, Stats};
 use harper_typst::Typst;
-use serde_json::Value;
+use serde_json::{Value, json};
 use tokio::sync::{Mutex, RwLock};
 use tower_lsp_server::jsonrpc::Result as JsonResult;
 use tower_lsp_server::lsp_types::notification::PublishDiagnostics;
@@ -483,7 +483,7 @@ impl Backend {
                 section: None,
             }])
             .await
-            .unwrap();
+            .unwrap_or(vec![json!({ "harper-ls": {} })]);
 
         if let Some(first) = new_config.pop() {
             self.update_config_from_obj(first).await;


### PR DESCRIPTION
# Issues 

Should fix #2302

# Description

Addresses crashing when a client returns `MethodNotFound` for `workspace/configuration`.

`pull_config` causes a panic when `self.client.configuration` returns an `Err`. This updates it so that a default empty config is returned instead of panicking.

This could possibly mask other errors when `unwrap`ping configurations, so more robust handling might be required down the line. However, I think this should suffice given that this is the first time we've encountered this type of crash despite many other editors integrating `harper-ls`. So I think this would only affect newer editors like Flow that don't support `workspace/configuration`.

P.S. Thought I would give this a go since it seemed straightforward enough to fix, but I'm still not 100% confident in my Rust so tell me if I missed anything even if it's just a one line change.

# How Has This Been Tested?

Manually

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
