### PR TITLE
feat: wreck havoc→wreak havoc

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -252,6 +252,33 @@ pub fn lint_group() -> LintGroup {
             "`Invest` is traditionally followed by 'in,' not `into.`",
             LintKind::Usage
         ),
+
+        // General litotes (double negatives) → direct positive suggestions
+        "LitotesDirectPositive" => (
+            &[
+                ("not uncommon", "common"),
+                ("not unusual", "common"),
+                ("not insignificant", "significant"),
+                ("not unimportant", "important"),
+                ("not unlikely", "likely"),
+                ("not infrequent", "frequent"),
+                ("not inaccurate", "accurate"),
+                ("not unclear", "clear"),
+                ("not irrelevant", "relevant"),
+                ("not unpredictable", "predictable"),
+                ("not inadequate", "adequate"),
+                ("not unpleasant", "pleasant"),
+                ("not unreasonable", "reasonable"),
+                ("not impossible", "possible"),
+                ("more preferable", "preferable"),
+                ("not online", "offline"),
+                ("not offline", "online"),
+            ],
+            "Consider the direct form.",
+            "Offers direct-positive alternatives when double negatives might feel heavy.",
+            LintKind::Style
+        ),
+
         "MakeDoWith" => (
             &[
                 ("make due with", "make do with"),
@@ -299,33 +326,6 @@ pub fn lint_group() -> LintGroup {
             "Corrects the eggcorn `piggy bag` to `piggyback`, which is the proper term for riding on someone’s back or using an existing system.",
             LintKind::Eggcorn
         ),
-
-        // General litotes (double negatives) → direct positive suggestions
-        "LitotesDirectPositive" => (
-            &[
-                ("not uncommon", "common"),
-                ("not unusual", "common"),
-                ("not insignificant", "significant"),
-                ("not unimportant", "important"),
-                ("not unlikely", "likely"),
-                ("not infrequent", "frequent"),
-                ("not inaccurate", "accurate"),
-                ("not unclear", "clear"),
-                ("not irrelevant", "relevant"),
-                ("not unpredictable", "predictable"),
-                ("not inadequate", "adequate"),
-                ("not unpleasant", "pleasant"),
-                ("not unreasonable", "reasonable"),
-                ("not impossible", "possible"),
-                ("more preferable", "preferable"),
-                ("not online", "offline"),
-                ("not offline", "online"),
-            ],
-            "Consider the direct form.",
-            "Offers direct-positive alternatives when double negatives might feel heavy.",
-            LintKind::Style
-        ),
-
         // Redundant degree modifiers on positives (double positives) → base form
         "RedundantSuperlatives" => (
             &[
@@ -338,6 +338,17 @@ pub fn lint_group() -> LintGroup {
             "Simplifies redundant double positives like `most optimal` to the base form.",
             LintKind::Redundancy
         ),
+        "WreakHavoc" => (
+            &[
+                ("wreck havoc", "wreak havoc"),
+                ("wrecked havoc", "wreaked havoc"),
+                ("wrecking havoc", "wreaking havoc"),
+                ("wrecks havoc", "wreaks havoc"),
+            ],
+            "Did you mean `wreak havoc`?",
+            "Corrects the eggcorn `wreck havoc` to `wreak havoc`, which is the proper term for causing chaos or destruction.",
+            LintKind::Eggcorn
+        )
     });
 
     add_many_to_many_mappings!(group, {

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -832,7 +832,45 @@ fn correct_passer_bys_hyphen() {
 // Piggyback
 // -none-
 
+// WreakHavoc
+
 // Many to many tests
+
+#[test]
+fn fix_wreck_havoc() {
+    assert_suggestion_result(
+        "Tables with a \".\" in the name wreck havoc with the system",
+        lint_group(),
+        "Tables with a \".\" in the name wreak havoc with the system",
+    );
+}
+
+#[test]
+fn fix_wrecked_havoc() {
+    assert_suggestion_result(
+        "It would have been some weird local configuration of LO that wrecked havoc.",
+        lint_group(),
+        "It would have been some weird local configuration of LO that wreaked havoc.",
+    );
+}
+
+#[test]
+fn fix_wrecking_havoc() {
+    assert_suggestion_result(
+        "Multi-line edit is wrecking havoc with indention",
+        lint_group(),
+        "Multi-line edit is wreaking havoc with indention",
+    );
+}
+
+#[test]
+fn fix_wrecks_havoc() {
+    assert_suggestion_result(
+        "Small POC using rust with ptrace that wrecks havoc on msync",
+        lint_group(),
+        "Small POC using rust with ptrace that wreaks havoc on msync",
+    );
+}
 
 // AwaitFor
 


### PR DESCRIPTION
# Issues 
N/A

# Description

Wow I didn't realize we were letting this famous eggcorn continue to obliterate mayhem.

Finally Harper will correct _wreck havoc_ to _wreak havoc_, in all its verb conjugations.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?

A unit test for each inflection, sourced from GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
