### PR TITLE
fix: false positive for "since N years old"

### DIFF
--- a/harper-core/src/linting/since_duration.rs
+++ b/harper-core/src/linting/since_duration.rs
@@ -1,5 +1,5 @@
-use crate::expr::{DurationExpr, Expr, LongestMatchOf, SequenceExpr};
-use crate::{Lrc, Token, TokenStringExt};
+use crate::expr::{DurationExpr, Expr, SequenceExpr};
+use crate::{CharStringExt, Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::linting::expr_linter::Chunk;
@@ -25,23 +25,18 @@ pub struct SinceDuration {
 
 impl Default for SinceDuration {
     fn default() -> Self {
-        let pattern_without_ago = Lrc::new(
-            SequenceExpr::default()
-                .then_any_capitalization_of("since")
-                .then_whitespace()
-                .then(DurationExpr),
-        );
-
-        let pattern_with_ago = SequenceExpr::default()
-            .then(pattern_without_ago.clone())
-            .then_whitespace()
-            .then_any_capitalization_of("ago");
-
         Self {
-            expr: Box::new(LongestMatchOf::new(vec![
-                Box::new(pattern_without_ago),
-                Box::new(pattern_with_ago),
-            ])),
+            expr: Box::new(
+                SequenceExpr::default()
+                    .then_any_capitalization_of("since")
+                    .then_whitespace()
+                    .then(DurationExpr)
+                    .then_optional(
+                        SequenceExpr::default()
+                            .t_ws()
+                            .then_word_set(&["ago", "old"]),
+                    ),
+            ),
         }
     }
 }
@@ -55,7 +50,11 @@ impl ExprLinter for SinceDuration {
 
     fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
         let last = toks.last()?;
-        if last.span.get_content_string(src).to_lowercase() == "ago" {
+        if last
+            .span
+            .get_content(src)
+            .eq_any_ignore_ascii_case_chars(&[&['a', 'g', 'o'], &['o', 'l', 'd']])
+        {
             return None;
         }
 
@@ -94,7 +93,9 @@ impl ExprLinter for SinceDuration {
 #[cfg(test)]
 mod tests {
     use super::SinceDuration;
-    use crate::linting::tests::{assert_lint_count, assert_top3_suggestion_result};
+    use crate::linting::tests::{
+        assert_lint_count, assert_no_lints, assert_top3_suggestion_result,
+    };
 
     #[test]
     fn catches_spelled() {
@@ -107,10 +108,9 @@ mod tests {
 
     #[test]
     fn permits_spelled_with_ago() {
-        assert_lint_count(
+        assert_no_lints(
             "I have been waiting since two hours ago.",
             SinceDuration::default(),
-            0,
         );
     }
 
@@ -125,10 +125,9 @@ mod tests {
 
     #[test]
     fn permits_numerals_with_ago() {
-        assert_lint_count(
+        assert_no_lints(
             "I have been waiting since 2 hours ago.",
             SinceDuration::default(),
-            0,
         );
     }
 
@@ -285,6 +284,14 @@ mod tests {
             "I use a Wacom Cintiq 27QHDT since several years on Linux",
             SinceDuration::default(),
             "I use a Wacom Cintiq 27QHDT for several years on Linux",
+        );
+    }
+
+    #[test]
+    fn ignore_since_years_old() {
+        assert_no_lints(
+            "I've been coding since 11 years old and I'm now 57",
+            SinceDuration::default(),
         );
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

While typing a comment on a YouTube video I hit a new false positive in the `SinceDuration` linter when the following word is "old". This fixes it.

I also refactored the code a bit to simplify it now that I have more Rust experience and more familiarity with the codebase.

# How Has This Been Tested?

Added a unit test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
