### PR TITLE
feat: part of speeches → parts of speech

### DIFF
--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -860,7 +860,7 @@ pub fn lint_group() -> LintGroup {
             LintKind::BoundaryError
         ),
         "PartsOfSpeech" => (
-            ["part of speeches"],
+            ["part of speeches", "parts of speeches"],
             ["parts of speech"],
             "The correct plural is `parts of speech`.",
             "Corrects pluralizing the wrong noun in `part of speech`.",
@@ -881,7 +881,7 @@ pub fn lint_group() -> LintGroup {
             LintKind::Spelling
         ),
         "PointsOfView" => (
-            ["point of views"],
+            ["point of views", "points of views"],
             ["points of view"],
             "The correct plural is `points of view`.",
             "Corrects pluralizing the wrong noun in `point of view`.",
@@ -960,7 +960,7 @@ pub fn lint_group() -> LintGroup {
             LintKind::WordChoice
         ),
         "RulesOfThumb" => (
-            ["rule of thumbs", "rule-of-thumbs"],
+            ["rule of thumbs", "rule-of-thumbs", "rules of thumbs"],
             ["rules of thumb"],
             "The correct plural is `rules of thumb`.",
             "Corrects pluralizing the wrong noun in `rule of thumb`.",

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -1483,6 +1483,16 @@ fn corrects_part_of_speeches() {
     )
 }
 
+// It can connect different parts of speeches e.g noun to adjective, adjective to adverb, noun to verb etc.
+#[test]
+fn corrects_parts_of_speeches() {
+    assert_suggestion_result(
+        "It can connect different parts of speeches e.g noun to adjective, adjective to adverb, noun to verb etc.",
+        lint_group(),
+        "It can connect different parts of speech e.g noun to adjective, adjective to adverb, noun to verb etc.",
+    )
+}
+
 // PeaceOfMind
 #[test]
 fn corrects_piece_of_mind() {
@@ -1523,11 +1533,21 @@ fn corrects_per_say_hyphenated() {
 
 // PointsOfView
 #[test]
-fn corrects_points_of_view() {
+fn corrects_point_of_views() {
     assert_suggestion_result(
         "This will produce a huge amount of raw data, representing the region in multiple point of views.",
         lint_group(),
         "This will produce a huge amount of raw data, representing the region in multiple points of view.",
+    )
+}
+
+// log events, places, moods and self-reflect from various points of views
+#[test]
+fn corrects_points_of_views() {
+    assert_suggestion_result(
+        "log events, places, moods and self-reflect from various points of views",
+        lint_group(),
+        "log events, places, moods and self-reflect from various points of view",
     )
 }
 
@@ -1588,11 +1608,20 @@ fn correct_iirc_correctly() {
 // RulesOfThumb
 
 #[test]
-fn correct_rules_of_thumbs() {
+fn correct_rule_of_thumbs() {
     assert_suggestion_result(
         "Thanks. 0.2 is just from my rule of thumbs.",
         lint_group(),
         "Thanks. 0.2 is just from my rules of thumb.",
+    );
+}
+
+#[test]
+fn correct_rules_of_thumbs() {
+    assert_suggestion_result(
+        "But as rules of thumbs, what is said in config file should be respected whatever parameter (field or directory) is passed to php-cs-fixer.phar.",
+        lint_group(),
+        "But as rules of thumb, what is said in config file should be respected whatever parameter (field or directory) is passed to php-cs-fixer.phar.",
     );
 }
 


### PR DESCRIPTION
# Issues 
N/A

# Description
I found another compound noun that should be pluralized on the first word but which is commonly wrongly pluralized on the final word, much like the previous "point of views": "part of speeches".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I used the first sentence I found it in to make a unit test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
