### PR TITLE
feat(chrome-ext): show Harper version string in the popup

### DIFF
--- a/packages/chrome-plugin/src/popup/Popup.svelte
+++ b/packages/chrome-plugin/src/popup/Popup.svelte
@@ -56,10 +56,10 @@ function openSettings() {
        }}><Fa icon={faArrowLeft}/></Button>
     {:else}
       <div>
-        <span class="text-sm font-mono">{version}</span>
         {#if versionMismatch}
           <span class="ml-1" title={`Newer version available: ${latestVersion ?? ''}`}>⚠️</span>
         {/if}
+        <span class="text-sm font-mono">{version}</span>
       </div>
     {/if}
   </header>


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

This was a problem reported in [Discord](https://discord.com/channels/1335035237213671495/1359600621979832520/1449962305621200966)

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

Apparently it isn't obvious which version of the Harper Chrome extension is installed. I've added it to the main popup menu, so it's easy to find.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

<img width="377" height="318" alt="image" src="https://github.com/user-attachments/assets/abbe42e1-7256-4f3e-a87c-dce02c970090" />

# How Has this Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
