### PR TITLE
docs: add section for projects using Harper

### DIFF
--- a/packages/web/src/routes/docs/about/+page.md
+++ b/packages/web/src/routes/docs/about/+page.md
@@ -47,6 +47,7 @@ Some of the open-source projects using Harper include:
 - [Gherlint](https://github.com/gherlint/gherlint)
 - [walletbeat](https://github.com/walletbeat/walletbeat)
 - [Stencila](https://github.com/stencila/stencila)
+- [fixmyspelling](https://github.com/samedwardes/fixmyspelling)
 
 Are you using Harper in your open source work and want to be included in this list?
 If so, please open a PR. 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

When reading through Harper's Dependabot graph in GitHub, I noticed some projects were using it. I've added a section to the website's "About" page, including a list of projects that use Harper.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

<img width="931" height="334" alt="image" src="https://github.com/user-attachments/assets/4b24eb2a-8320-47f9-8497-1c6cc906cf16" />


# How Has this Been Tested?
<!-- Please describe how you tested your changes. -->

N/A

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
