### PR TITLE
fix: issue 1722

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -51863,8 +51863,9 @@ whamming/V6
 whammy/NSg
 wharf/~NgV
 wharves/~N
-what/~INgS
+what/~INS
 what'll/
+what's/
 whataboutism/Ng
 whatchamacallit/NgS
 whatever/~IJNg

--- a/harper-core/src/linting/its_possessive.rs
+++ b/harper-core/src/linting/its_possessive.rs
@@ -54,6 +54,8 @@ impl Default for ItsPossessive {
                 UPOS::NOUN,
                 UPOS::PRON,
                 UPOS::SCONJ,
+                UPOS::CCONJ,
+                UPOS::ADV,
             ]));
 
         map.insert(start_of_sentence, 0);
@@ -91,7 +93,7 @@ impl ExprLinter for ItsPossessive {
                 "its",
                 span.get_content(source),
             )],
-            message: "Prefer the possessive pronoun `its` here to denote ownership.".to_string(),
+            message: "Use the possessive pronoun `its` (without an apostrophe) to show ownership. The word `it's` (with an apostrophe) is a contraction of 'it is' or 'it has' and should not be used to indicate possession.".to_string(),
             priority: 31,
         })
     }
@@ -333,5 +335,26 @@ mod tests {
             "It's worth highlighting that while using a fork instead of a spoon is easy, it sometimes isn't.",
             ItsPossessive::default(),
         );
+    }
+
+    #[test]
+    fn dont_flag_issue_1722_its_whats_accessible() {
+        assert_no_lints(
+            "The base execution context is the global execution context: it's what's accessible everywhere in your code.",
+            ItsPossessive::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_issue_1722_its_early_and() {
+        assert_no_lints(
+            "it's early and there's plenty of room for novel and potentially",
+            ItsPossessive::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_issue_1722_its_big_enough() {
+        assert_no_lints("It's big enough.", ItsPossessive::default());
     }
 }

--- a/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
+++ b/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
@@ -848,7 +848,7 @@ Lint:    Agreement (31 priority)
 Message: |
      312 | on Imports or Exports, except what may be absolutely necessary for executing
      313 | it's inspection Laws: and the net Produce of all Duties and Imposts, laid by
-         | ^~~~ Prefer the possessive pronoun `its` here to denote ownership.
+         | ^~~~ Use the possessive pronoun `its` (without an apostrophe) to show ownership. The word `it's` (with an apostrophe) is a contraction of 'it is' or 'it has' and should not be used to indicate possession.
 Suggest:
   - Replace with: “its”
 

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -5798,17 +5798,6 @@ Message: |
 
 
 
-Lint:    WordChoice (127 priority)
-Message: |
-    4192 | “I told you what’s been going on,” said Gatsby. “Going on for five years—and you
-         |         ^~~ The possessive version of this word is more common in this context.
-Suggest:
-  - Replace with: “your”
-  - Replace with: “you're a”
-  - Replace with: “you're an”
-
-
-
 Lint:    Formatting (255 priority)
 Message: |
     4201 | sometimes”—but there was no laughter in his eyes—“to think that you didn’t

--- a/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
+++ b/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
@@ -843,7 +843,7 @@
 > “ Speak  English      ! ” said the Eaglet . “ I       don’t know   the meaning   of half      those  long
 # . NSg/VB NPr🅪Sg/VB/J+ . . VP/J D   NSg    . . ISg/#r+ VXB   NSg/VB D   N🅪Sg/Vg/J P  N🅪Sg/J/P+ I/Ddem NPr/VB/J
 > words   , and  , what’s more         , I       don’t believe you    do  either ! ” And  the Eaglet bent
-# NPl/V3+ . VB/C . NSg$   NPr/I/J/R/Dq . ISg/#r+ VXB   VB      ISgPl+ VXB I/C    . . VB/C D   NSg    NSg/VP/J
+# NPl/V3+ . VB/C . K      NPr/I/J/R/Dq . ISg/#r+ VXB   VB      ISgPl+ VXB I/C    . . VB/C D   NSg    NSg/VP/J
 > down        its     head      to hide   a   smile   : some     of the other    birds   tittered audibly .
 # N🅪Sg/VB/J/P ISg/D$+ NPr/VB/J+ P  NSg/VB D/P NSg/VB+ . I/J/R/Dq P  D   NSg/VB/J NPl/V3+ VP/J     R       .
 >
@@ -1331,7 +1331,7 @@
 >
 #
 > “ Now       tell   me       , Pat       , what’s that          in        the window  ? ”
-# . NSg/J/R/C NPr/VB NPr/ISg+ . NPr/VB/J+ . NSg$   NSg/I/C/Ddem+ NPr/J/R/P D   NSg/VB+ . .
+# . NSg/J/R/C NPr/VB NPr/ISg+ . NPr/VB/J+ . K      NSg/I/C/Ddem+ NPr/J/R/P D   NSg/VB+ . .
 >
 #
 > “ Sure , it’s an  arm       , yer honour        ! ” ( He       pronounced it       “ arrum . ” )
@@ -2921,7 +2921,7 @@
 >
 #
 > “ No       , I       give   it       up         , ” Alice replied : “ what’s the answer  ? ”
-# . NPr/Dq/P . ISg/#r+ NSg/VB NPr/ISg+ NSg/VB/J/P . . NPr+  VP/J    . . NSg$   D+  NSg/VB+ . .
+# . NPr/Dq/P . ISg/#r+ NSg/VB NPr/ISg+ NSg/VB/J/P . . NPr+  VP/J    . . K      D+  NSg/VB+ . .
 >
 #
 > “ I       haven’t the slightest idea , ” said the Hatter .
@@ -3461,7 +3461,7 @@
 > “ Idiot  ! ” said the Queen     , tossing her     head      impatiently ; and  , turning to Alice ,
 # . NSg/J+ . . VP/J D+  NPr/VB/J+ . Nᴹ/Vg/J ISg/D$+ NPr/VB/J+ R           . VB/C . Nᴹ/Vg/J P  NPr+  .
 > she  went    on  , “ What’s your name    , child   ? ”
-# ISg+ NSg/VPt J/P . . NSg$   D$+  NSg/VB+ . NSg/VB+ . .
+# ISg+ NSg/VPt J/P . . K      D$+  NSg/VB+ . NSg/VB+ . .
 >
 #
 > “ My  name    is  Alice , so          please your Majesty , ” said Alice very politely ; but     she
@@ -5645,7 +5645,7 @@
 >
 #
 > “ What’s in        it       ? ” said the Queen     .
-# . NSg$   NPr/J/R/P NPr/ISg+ . . VP/J D+  NPr/VB/J+ .
+# . K      NPr/J/R/P NPr/ISg+ . . VP/J D+  NPr/VB/J+ .
 >
 #
 > “ I       haven’t opened it       yet      , ” said the White       Rabbit  , “ but     it       seems to be      a   letter  ,

--- a/harper-core/tests/text/tagged/Difficult sentences.md
+++ b/harper-core/tests/text/tagged/Difficult sentences.md
@@ -849,7 +849,7 @@
 > Three squared or    three to the second    power      is  nine .
 # NSg   VP/J    NPr/C NSg   P  D+  NSg/VB/J+ N🅪Sg/VB/J+ VL3 NSg  .
 > What's the time       ? – It's quarter   to four in        the afternoon ( or    3 : 45 pm      ) .
-# NSg$   D+  N🅪Sg/VB/J+ . . +    NSg/VB/J+ P  NSg  NPr/J/R/P D+  N🅪Sg+     . NPr/C # . #  NSg/VB+ . .
+# K      D+  N🅪Sg/VB/J+ . . +    NSg/VB/J+ P  NSg  NPr/J/R/P D+  N🅪Sg+     . NPr/C # . #  NSg/VB+ . .
 >
 #
 >              Adverb

--- a/harper-core/tests/text/tagged/The Great Gatsby.md
+++ b/harper-core/tests/text/tagged/The Great Gatsby.md
@@ -3615,7 +3615,7 @@
 >
 #
 > “ What’s that          got to do  with it       ? ”
-# . NSg$   NSg/I/C/Ddem+ VP  P  VXB P    NPr/ISg+ . .
+# . K      NSg/I/C/Ddem+ VP  P  VXB P    NPr/ISg+ . .
 >
 #
 > “ They’ll keep   out          of my  way    , ” she  insisted . “ It       takes  two to make   an   accident . ”
@@ -3875,7 +3875,7 @@
 >
 #
 > “ Look   here    , old    sport   , ” he       broke     out          surprisingly , “ what’s your opinion of me       ,
-# . NSg/VB NSg/J/R . NSg/J+ NSg/VB+ . . NPr/ISg+ NSg/VPt/J NSg/VB/J/R/P R            . . NSg$   D$+  N🅪Sg    P  NPr/ISg+ .
+# . NSg/VB NSg/J/R . NSg/J+ NSg/VB+ . . NPr/ISg+ NSg/VPt/J NSg/VB/J/R/P R            . . K      D$+  N🅪Sg    P  NPr/ISg+ .
 > anyhow ? ”
 # J      . .
 >
@@ -4687,7 +4687,7 @@
 >
 #
 > “ What’s the matter   , Daisy ? ”
-# . NSg$   D   N🅪Sg/VB+ . NPr+  . .
+# . K      D   N🅪Sg/VB+ . NPr+  . .
 >
 #
 > I       was scared , I       can     tell   you    ; I’d never seen    a   girl    like         that          before .
@@ -5299,7 +5299,7 @@
 >
 #
 > “ What’s funny ? ”
-# . NSg$   NSg/J . .
+# . K      NSg/J . .
 >
 #
 > She  turned her     head      as    there was a    light      dignified knocking at    the front     door    . I
@@ -5431,7 +5431,7 @@
 >
 #
 > “ What’s the matter   ? ”
-# . NSg$   D+  N🅪Sg/VB+ . .
+# . K      D+  N🅪Sg/VB+ . .
 >
 #
 > “ This    is  a   terrible mistake , ” he       said , shaking his     head      from side      to side     , ‘          ‘          a
@@ -7491,7 +7491,7 @@
 >
 #
 > “ Come       on  ! ” His     temper     cracked a   little     . “ What’s the matter   , anyhow ? If    we’re
-# . NSg/VBPp/P J/P . . ISg/D$+ NSg/VB/JC+ VP/J    D/P NPr/I/J/Dq . . NSg$   D+  N🅪Sg/VB+ . J      . NSg/C K
+# . NSg/VBPp/P J/P . . ISg/D$+ NSg/VB/JC+ VP/J    D/P NPr/I/J/Dq . . K      D+  N🅪Sg/VB+ . J      . NSg/C K
 > going   to town , let’s start  . ”
 # Nᴹ/Vg/J P  NSg  . NSg$  NSg/VB . .
 >
@@ -7779,7 +7779,7 @@
 >
 #
 > “ What’s the matter   ? ”
-# . NSg$   D+  N🅪Sg/VB+ . .
+# . K      D+  N🅪Sg/VB+ . .
 >
 #
 > “ I’m all          run      down        . ”
@@ -8377,11 +8377,11 @@
 > “ Sit    down        , Daisy , ” Tom’s voice   groped unsuccessfully for   the paternal note    .
 # . NSg/VB N🅪Sg/VB/J/P . NPr+  . . NSg$  NSg/VB+ VP/J   R              R/C/P D   J        NSg/VB+ .
 > “ What’s been    going   on  ? I       want   to hear all          about it       . ”
-# . NSg$   NSg/VPp Nᴹ/Vg/J J/P . ISg/#r+ NSg/VB P  VB   NSg/I/J/C/Dq J/P   NPr/ISg+ . .
+# . K      NSg/VPp Nᴹ/Vg/J J/P . ISg/#r+ NSg/VB P  VB   NSg/I/J/C/Dq J/P   NPr/ISg+ . .
 >
 #
 > “ I       told you    what’s been    going   on  , ” said Gatsby . “ Going   on  for   five years — and  you
-# . ISg/#r+ VP   ISgPl+ NSg$   NSg/VPp Nᴹ/Vg/J J/P . . VP/J NPr    . . Nᴹ/Vg/J J/P R/C/P NSg+ NPl+  . VB/C ISgPl+
+# . ISg/#r+ VP   ISgPl+ K      NSg/VPp Nᴹ/Vg/J J/P . . VP/J NPr    . . Nᴹ/Vg/J J/P R/C/P NSg+ NPl+  . VB/C ISgPl+
 > didn’t know   . ”
 # VXPt   NSg/VB . .
 >
@@ -8429,7 +8429,7 @@
 > “ She  does    , though . The trouble  is  that          sometimes she  gets   foolish ideas in        her
 # . ISg+ NPl/VX3 . VB/C   . D+  N🅪Sg/VB+ VL3 NSg/I/C/Ddem+ R         ISg+ NPl/V3 J       NPl+  NPr/J/R/P ISg/D$+
 > head      and  doesn’t know   what   she’s doing   . ” He       nodded sagely . “ And  what’s more         , I
-# NPr/VB/J+ VB/C VX3     NSg/VB NSg/I+ K     Nᴹ/Vg/J . . NPr/ISg+ VP     R      . . VB/C NSg$   NPr/I/J/R/Dq . ISg/#r+
+# NPr/VB/J+ VB/C VX3     NSg/VB NSg/I+ K     Nᴹ/Vg/J . . NPr/ISg+ VP     R      . . VB/C K      NPr/I/J/R/Dq . ISg/#r+
 > love      Daisy too . Once  in        a    while       I       go       off        on  a    spree   and  make   a   fool     of myself ,
 # NPr🅪Sg/VB NPr+  R   . NSg/C NPr/J/R/P D/P+ NSg/VB/C/P+ ISg/#r+ NSg/VB/J NSg/VB/J/P J/P D/P+ NSg/VB+ VB/C NSg/VB D/P NSg/VB/J P  ISg+   .
 > but     I       always come       back     , and  in        my  heart    I       love      her     all           the time       . ”
@@ -8511,7 +8511,7 @@
 > “ Oh     , you    want   too much         ! ” she  cried to Gatsby . “ I       love      you    now       — isn’t   that          enough ?
 # . NPr/VB . ISgPl+ NSg/VB R   NSg/I/J/R/Dq . . ISg+ VP/J  P  NPr    . . ISg/#r+ NPr🅪Sg/VB ISgPl+ NSg/J/R/C . NSg/VX3 NSg/I/C/Ddem+ NSg/I  .
 > I       can’t help   what’s past       . ” She  began to sob    helplessly . “ I       did  love      him  once  — but
-# ISg/#r+ VXB   NSg/VB NSg$   NSg/VB/J/P . . ISg+ VPt   P  NSg/VB R          . . ISg/#r+ VXPt NPr🅪Sg/VB ISg+ NSg/C . NSg/C/P
+# ISg/#r+ VXB   NSg/VB K      NSg/VB/J/P . . ISg+ VPt   P  NSg/VB R          . . ISg/#r+ VXPt NPr🅪Sg/VB ISg+ NSg/C . NSg/C/P
 > I       loved you    too . ”
 # ISg/#r+ VP/J  ISgPl+ R   . .
 >
@@ -9023,7 +9023,7 @@
 >
 #
 > “ What’s the name   of this   place    here    ? ” demanded the officer .
-# . NSg$   D   NSg/VB P  I/Ddem N🅪Sg/VB+ NSg/J/R . . VP/J     D+  NSg/VB+ .
+# . K      D   NSg/VB P  I/Ddem N🅪Sg/VB+ NSg/J/R . . VP/J     D+  NSg/VB+ .
 >
 #
 > “ Hasn’t got any    name    . ”
@@ -9099,7 +9099,7 @@
 >
 #
 > “ What’s all          that          ? ” he       demanded .
-# . NSg$   NSg/I/J/C/Dq NSg/I/C/Ddem+ . . NPr/ISg+ VP/J     .
+# . K      NSg/I/J/C/Dq NSg/I/C/Ddem+ . . NPr/ISg+ VP/J     .
 >
 #
 > “ I’m a   friend   of his     . ” Tom     turned his     head      but     kept his     hands   firm      on  Wilson’s
@@ -11495,7 +11495,7 @@
 >
 #
 > “ What’s the matter   , Nick    ? Do  you    object  to shaking hands   with me       ? ”
-# . NSg$   D   N🅪Sg/VB+ . NPr/VB+ . VXB ISgPl+ NSg/VB+ P  Nᴹ/Vg/J NPl/V3+ P    NPr/ISg+ . .
+# . K      D   N🅪Sg/VB+ . NPr/VB+ . VXB ISgPl+ NSg/VB+ P  Nᴹ/Vg/J NPl/V3+ P    NPr/ISg+ . .
 >
 #
 > “ Yes    . You    know   what   I       think  of you    . ”
@@ -11503,7 +11503,7 @@
 >
 #
 > “ You're crazy , Nick    , ” he       said quickly . “ Crazy as    hell    . I       don’t know   what’s the
-# . +      NSg/J . NPr/VB+ . . NPr/ISg+ VP/J R       . . NSg/J NSg/R NPr/VB+ . ISg/#r+ VXB   NSg/VB NSg$   D
+# . +      NSg/J . NPr/VB+ . . NPr/ISg+ VP/J R       . . NSg/J NSg/R NPr/VB+ . ISg/#r+ VXB   NSg/VB K      D
 > matter   with you    . ”
 # N🅪Sg/VB+ P    ISgPl+ . .
 >


### PR DESCRIPTION
# Issues 
Resolves #1722 

# Description

The three false positives in the issue and its comments were due to different factors:
1. `what's` didn't have its own dedicated entry but was derived from `what` via the `/g` annotation flag. This flag marks derived forms as possessives of nouns but `what` is a relative pronoun and `what's` is a contraction of the relative pronoun with `is`. (Can also be with `has` in other contexts.)
2. The following two words were an adjective and a coordinating conjunction. Prior to this PR only subordinating conjunctions were considered.
3. The following two words were an adjective and an adverb. Adverbs were not considered.

I also changed the wording of the `message` shown to the user doing the linting, which gave the impression that `its` vs `it's` was a preference rather than a question of grammaticality.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

New unit tests, based on each sentence in the issue thread are included.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
