### PR TITLE
fix: expand `BestOfAllTime` linter

### DIFF
--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -509,7 +509,7 @@ impl LintGroup {
         insert_expr_rule!(AvoidCurses, true);
         insert_expr_rule!(BackInTheDay, true);
         insert_expr_rule!(BeAllowed, true);
-        insert_expr_rule!(BestOfAllTime, true);
+        insert_struct_rule!(BestOfAllTime, true);
         insert_expr_rule!(BoringWords, false);
         insert_expr_rule!(Bought, true);
         insert_expr_rule!(BrandBrandish, true);


### PR DESCRIPTION
# Issues 
N/A

# Description

I saw a YouTube video with a title like "the top 10 X of all times" and tested whether Harper would flag it. It didn't.
This turned out to be for three reasons:
- It only checked for adjectives inflected in the superlative, preceded by "most"; or the word "favourite". But not "top".
- It only allowed a noun between the superlative-ish part and "of all times", so the "10" prevented it matching.
- The noun it used wasn't in the dictionary.

So I've added support for "top", allow any sequence of tokens between the superlative part and the fixed "of all times", add accept OOV (out of vocab) words as those are most often nouns.

I also realized this middle part could include commas, so I switched from `Chunk` to `Sentence`.

# How Has This Been Tested?
Three new unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
