### PR TITLE
fix: a vs an for "herb" and "SQL"

### DIFF
--- a/harper-core/src/linting/an_a.rs
+++ b/harper-core/src/linting/an_a.rs
@@ -4,10 +4,25 @@ use itertools::Itertools;
 
 use crate::char_ext::CharExt;
 use crate::linting::{Lint, LintKind, Linter, Suggestion};
-use crate::{Document, TokenStringExt};
+use crate::{Dialect, Document, TokenStringExt};
 
-#[derive(Debug, Default)]
-pub struct AnA;
+#[derive(PartialEq)]
+pub enum InitialSound {
+    Vowel,
+    Consonant,
+    Either, // for SQL
+}
+
+#[derive(Debug)]
+pub struct AnA {
+    dialect: Dialect,
+}
+
+impl AnA {
+    pub fn new(dialect: Dialect) -> Self {
+        Self { dialect }
+    }
+}
 
 impl Linter for AnA {
     fn lint(&mut self, document: &Document) -> Vec<Lint> {
@@ -49,7 +64,11 @@ impl Linter for AnA {
                     continue;
                 };
 
-                let should_be_a_an = !starts_with_vowel(chars_second);
+                let should_be_a_an = match starts_with_vowel(chars_second, self.dialect) {
+                    InitialSound::Vowel => false,
+                    InitialSound::Consonant => true,
+                    InitialSound::Either => return lints,
+                };
 
                 if a_an != should_be_a_an {
                     let replacement = match a_an {
@@ -96,21 +115,28 @@ fn to_lower_word(word: &[char]) -> Cow<'_, [char]> {
 /// It was produced through trial and error.
 /// Matches with 99.71% and 99.77% of vowels and non-vowels in the
 /// Carnegie-Mellon University word -> pronunciation dataset.
-fn starts_with_vowel(word: &[char]) -> bool {
+fn starts_with_vowel(word: &[char], dialect: Dialect) -> InitialSound {
     let is_likely_initialism = word.iter().all(|c| !c.is_alphabetic() || c.is_uppercase());
 
     if is_likely_initialism && !word.is_empty() && !is_likely_acronym(word) {
-        return matches!(
+        if matches!(word, ['S', 'Q', 'L']) {
+            return InitialSound::Either;
+        }
+        return if matches!(
             word[0],
             'A' | 'E' | 'F' | 'H' | 'I' | 'L' | 'M' | 'N' | 'O' | 'R' | 'S' | 'X'
-        );
+        ) {
+            InitialSound::Vowel
+        } else {
+            InitialSound::Consonant
+        };
     }
 
     let word = to_lower_word(word);
     let word = word.as_ref();
 
     if matches!(word, ['e', 'u', 'l', 'e', ..]) {
-        return true;
+        return InitialSound::Vowel;
     }
 
     if matches!(
@@ -121,48 +147,52 @@ fn starts_with_vowel(word: &[char]) -> bool {
             | ['o', 'n', 'e']
             | ['o', 'n', 'c', 'e']
     ) {
-        return false;
+        return InitialSound::Consonant;
     }
 
     if matches!(word, |['h', 'o', 'u', 'r', ..]| ['h', 'o', 'n', ..]
         | ['u', 'n', 'i', 'n' | 'm', ..]
         | ['u', 'n', 'a' | 'u', ..]
-        | ['h', 'e', 'r', 'b', ..]
         | ['u', 'r', 'b', ..]
         | ['i', 'n', 't', ..])
     {
-        return true;
+        return InitialSound::Vowel;
+    }
+
+    if matches!(word, ['h', 'e', 'r', 'b', ..] if dialect == Dialect::American || dialect == Dialect::Canadian)
+    {
+        return InitialSound::Vowel;
     }
 
     if matches!(word, ['u', 'n' | 's', 'i' | 'a' | 'u', ..]) {
-        return false;
+        return InitialSound::Consonant;
     }
 
     if matches!(word, ['u', 'n', ..]) {
-        return true;
+        return InitialSound::Vowel;
     }
 
     if matches!(word, ['u', 'r', 'g', ..]) {
-        return true;
+        return InitialSound::Vowel;
     }
 
     if matches!(word, ['u', 't', 't', ..]) {
-        return true;
+        return InitialSound::Vowel;
     }
 
     if matches!(
         word,
         ['u', 't' | 'r' | 'n', ..] | ['e', 'u', 'r', ..] | ['u', 'w', ..] | ['u', 's', 'e', ..]
     ) {
-        return false;
+        return InitialSound::Consonant;
     }
 
     if matches!(word, ['o', 'n', 'e', 'a' | 'e' | 'i' | 'u', 'l' | 'd', ..]) {
-        return true;
+        return InitialSound::Vowel;
     }
 
     if matches!(word, ['o', 'n', 'e', 'a' | 'e' | 'i' | 'u' | '-' | 's', ..]) {
-        return false;
+        return InitialSound::Consonant;
     }
 
     if matches!(
@@ -176,24 +206,25 @@ fn starts_with_vowel(word: &[char]) -> bool {
             | ['h', 'e', 'i', 'r', ..]
             | ['h', 'o', 'n', 'o', 'r', ..]
     ) {
-        return true;
+        return InitialSound::Vowel;
     }
 
     if matches!(
         word,
         ['j', 'u' | 'o', 'n', ..] | ['j', 'u', 'r', 'a' | 'i' | 'o', ..]
     ) {
-        return false;
+        return InitialSound::Consonant;
     }
 
     if matches!(word, ['x', '-' | '\'' | '.' | 'o' | 's', ..]) {
-        return true;
+        return InitialSound::Vowel;
     }
 
-    matches!(
-        word,
-        ['a', ..] | ['e', ..] | ['i', ..] | ['o', ..] | ['u', ..]
-    )
+    if word[0].is_vowel() {
+        return InitialSound::Vowel;
+    }
+
+    InitialSound::Consonant
 }
 
 fn is_likely_acronym(word: &[char]) -> bool {
@@ -211,124 +242,183 @@ fn is_likely_acronym(word: &[char]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::AnA;
-    use crate::linting::tests::assert_lint_count;
+    use crate::Dialect;
+    use crate::linting::tests::{assert_lint_count, assert_suggestion_result};
 
     #[test]
     fn detects_html_as_vowel() {
-        assert_lint_count("Here is a HTML document.", AnA, 1);
+        assert_lint_count("Here is a HTML document.", AnA::new(Dialect::American), 1);
     }
 
     #[test]
     fn detects_llm_as_vowel() {
-        assert_lint_count("Here is a LLM document.", AnA, 1);
+        assert_lint_count("Here is a LLM document.", AnA::new(Dialect::American), 1);
     }
 
     #[test]
     fn detects_llm_hyphen_as_vowel() {
-        assert_lint_count("Here is a LLM-based system.", AnA, 1);
+        assert_lint_count(
+            "Here is a LLM-based system.",
+            AnA::new(Dialect::American),
+            1,
+        );
     }
 
     #[test]
     fn detects_euler_as_vowel() {
-        assert_lint_count("This is an Euler brick.", AnA, 0);
-        assert_lint_count("The graph has an Eulerian tour.", AnA, 0);
+        assert_lint_count("This is an Euler brick.", AnA::new(Dialect::American), 0);
+        assert_lint_count(
+            "The graph has an Eulerian tour.",
+            AnA::new(Dialect::American),
+            0,
+        );
     }
 
     #[test]
     fn capitalized_fourier() {
-        assert_lint_count("Then, perform a Fourier transform.", AnA, 0);
+        assert_lint_count(
+            "Then, perform a Fourier transform.",
+            AnA::new(Dialect::American),
+            0,
+        );
     }
 
     #[test]
     fn once_over() {
-        assert_lint_count("give this a once-over.", AnA, 0);
+        assert_lint_count("give this a once-over.", AnA::new(Dialect::American), 0);
     }
 
     #[test]
     fn issue_196() {
-        assert_lint_count("This is formatted as an `ext4` file system.", AnA, 0);
+        assert_lint_count(
+            "This is formatted as an `ext4` file system.",
+            AnA::new(Dialect::American),
+            0,
+        );
     }
 
     #[test]
     fn allows_lowercase_vowels() {
-        assert_lint_count("not an error", AnA, 0);
+        assert_lint_count("not an error", AnA::new(Dialect::American), 0);
     }
 
     #[test]
     fn allows_lowercase_consonants() {
-        assert_lint_count("not a crash", AnA, 0);
+        assert_lint_count("not a crash", AnA::new(Dialect::American), 0);
     }
 
     #[test]
     fn disallows_lowercase_vowels() {
-        assert_lint_count("not a error", AnA, 1);
+        assert_lint_count("not a error", AnA::new(Dialect::American), 1);
     }
 
     #[test]
     fn disallows_lowercase_consonants() {
-        assert_lint_count("not an crash", AnA, 1);
+        assert_lint_count("not an crash", AnA::new(Dialect::American), 1);
     }
 
     #[test]
     fn allows_uppercase_vowels() {
-        assert_lint_count("not an Error", AnA, 0);
+        assert_lint_count("not an Error", AnA::new(Dialect::American), 0);
     }
 
     #[test]
     fn allows_uppercase_consonants() {
-        assert_lint_count("not a Crash", AnA, 0);
+        assert_lint_count("not a Crash", AnA::new(Dialect::American), 0);
     }
 
     #[test]
     fn disallows_uppercase_vowels() {
-        assert_lint_count("not a Error", AnA, 1);
+        assert_lint_count("not a Error", AnA::new(Dialect::American), 1);
     }
 
     #[test]
     fn disallows_uppercase_consonants() {
-        assert_lint_count("not an Crash", AnA, 1);
+        assert_lint_count("not an Crash", AnA::new(Dialect::American), 1);
     }
 
     #[test]
     fn disallows_a_interface() {
         assert_lint_count(
             "A interface for an object that can perform linting actions.",
-            AnA,
+            AnA::new(Dialect::American),
             1,
         );
     }
 
     #[test]
     fn allow_issue_751() {
-        assert_lint_count("He got a 52% approval rating.", AnA, 0);
+        assert_lint_count(
+            "He got a 52% approval rating.",
+            AnA::new(Dialect::American),
+            0,
+        );
     }
 
     #[test]
     fn allow_an_mp_and_an_mp3() {
-        assert_lint_count("an MP and an MP3?", AnA, 0);
+        assert_lint_count("an MP and an MP3?", AnA::new(Dialect::American), 0);
     }
 
     #[test]
     fn disallow_a_mp_and_a_mp3() {
-        assert_lint_count("a MP and a MP3?", AnA, 2);
+        assert_lint_count("a MP and a MP3?", AnA::new(Dialect::American), 2);
     }
 
     #[test]
     fn recognize_acronyms() {
         // a
-        assert_lint_count("using a MAC address", AnA, 0);
-        assert_lint_count("a NASA spacecraft", AnA, 0);
-        assert_lint_count("a NAT", AnA, 0);
-        assert_lint_count("a REST API", AnA, 0);
-        assert_lint_count("a LIBERO", AnA, 0);
-        assert_lint_count("a README", AnA, 0);
-        assert_lint_count("a LAN", AnA, 0);
+        assert_lint_count("using a MAC address", AnA::new(Dialect::American), 0);
+        assert_lint_count("a NASA spacecraft", AnA::new(Dialect::American), 0);
+        assert_lint_count("a NAT", AnA::new(Dialect::American), 0);
+        assert_lint_count("a REST API", AnA::new(Dialect::American), 0);
+        assert_lint_count("a LIBERO", AnA::new(Dialect::American), 0);
+        assert_lint_count("a README", AnA::new(Dialect::American), 0);
+        assert_lint_count("a LAN", AnA::new(Dialect::American), 0);
 
         // an
-        assert_lint_count("an RA message", AnA, 0);
-        assert_lint_count("an SI unit", AnA, 0);
-        assert_lint_count("he is an MA of both Oxford and Cambridge", AnA, 0);
-        assert_lint_count("in an FA Cup 6th Round match", AnA, 0);
-        assert_lint_count("a AM transmitter", AnA, 1);
+        assert_lint_count("an RA message", AnA::new(Dialect::American), 0);
+        assert_lint_count("an SI unit", AnA::new(Dialect::American), 0);
+        assert_lint_count(
+            "he is an MA of both Oxford and Cambridge",
+            AnA::new(Dialect::American),
+            0,
+        );
+        assert_lint_count(
+            "in an FA Cup 6th Round match",
+            AnA::new(Dialect::American),
+            0,
+        );
+        assert_lint_count("a AM transmitter", AnA::new(Dialect::American), 1);
+    }
+
+    #[test]
+    fn dont_flag_an_herb_for_american() {
+        assert_lint_count("an herb", AnA::new(Dialect::American), 0);
+    }
+
+    #[test]
+    fn dont_flag_a_herb_for_british() {
+        assert_lint_count("a herb", AnA::new(Dialect::British), 0);
+    }
+
+    #[test]
+    fn correct_an_herb_for_australian() {
+        assert_suggestion_result("an herb", AnA::new(Dialect::Australian), "a herb");
+    }
+
+    #[test]
+    fn correct_a_herb_for_canadian() {
+        assert_suggestion_result("a herb", AnA::new(Dialect::Canadian), "an herb");
+    }
+
+    #[test]
+    fn dont_flag_a_sql() {
+        assert_lint_count("a SQL query", AnA::new(Dialect::American), 0);
+    }
+
+    #[test]
+    fn dont_flag_an_sql() {
+        assert_lint_count("an SQL query", AnA::new(Dialect::Australian), 0);
     }
 }

--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -499,7 +499,6 @@ impl LintGroup {
         insert_expr_rule!(AllowTo, true);
         insert_expr_rule!(AmInTheMorning, true);
         insert_expr_rule!(AmountsFor, true);
-        insert_struct_rule!(AnA, true);
         insert_expr_rule!(AndIn, true);
         insert_expr_rule!(AndTheLike, true);
         insert_expr_rule!(AnotherThingComing, true);
@@ -713,6 +712,9 @@ impl LintGroup {
 
         out.add_chunk_expr_linter("TransposedSpace", TransposedSpace::new(dictionary.clone()));
         out.config.set_rule_enabled("TransposedSpace", true);
+
+        out.add("AnA", AnA::new(dialect));
+        out.config.set_rule_enabled("AnA", true);
 
         out
     }


### PR DESCRIPTION
# Issues 

The "SQL" issue is mentioned in the comments of #534
I don't think the "herb" issue has been mentioned.

# Description

Some words have dialect-dependent pronunciation that affects whether the correct indefinite article should be "a" or "an". "Herb" is the obvious one, implemented here.

Some acronyms/initialisms are pronounced like words by some speakers and letter-by-letter by others, which can make the choice of "a" vs "an" moot. The obvious one in this case is "SQL".

Others can be added easily.

# How Has This Been Tested?

Unit tests for correcting and ignoring, depending on dialect if need be.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
