### PR TITLE
fix: don't change 'you' to 'your' if the previous word is a verb

### DIFF
--- a/harper-core/src/linting/possessive_your.rs
+++ b/harper-core/src/linting/possessive_your.rs
@@ -33,7 +33,20 @@ impl ExprLinter for PossessiveYour {
         self.expr.as_ref()
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint_with_context(
+        &self,
+        matched_tokens: &[Token],
+        source: &[char],
+        ctx: Option<(&[Token], &[Token])>,
+    ) -> Option<Lint> {
+        // Is 'you' the object of a verb? (#1920)
+        if let [.., v, ws] = ctx?.0
+            && ws.kind.is_whitespace()
+            && v.kind.is_verb()
+        {
+            return None;
+        }
+
         let span = matched_tokens.first()?.span;
         let orig_chars = span.get_content(source);
 
@@ -65,7 +78,7 @@ mod tests {
     use super::PossessiveYour;
 
     #[test]
-    #[should_panic] // currently fails because comments is a homographs (verb or noun)
+    #[ignore = "currently fails because comments is a homographs (verb or noun)"]
     fn your_comments() {
         assert_suggestion_result(
             "You comments may end up in the documentation.",
@@ -134,6 +147,24 @@ mod tests {
         assert_no_lints(
             "Note that in a world with modules everywhere, you almost never need an IIFE",
             PossessiveYour::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_1919_brought_you() {
+        assert_lint_count(
+            "team who also brought you [BloodHound Enterprise](http://specterops.io/bloodhound-verview/).",
+            PossessiveYour::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_1919_teaches_you() {
+        assert_lint_count(
+            "Teaches you PyTorch and many machine learning concepts in a hands-on, code-first way.",
+            PossessiveYour::default(),
+            0,
         );
     }
 }

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -1997,17 +1997,6 @@ Message: |
 
 
 
-Lint:    WordChoice (127 priority)
-Message: |
-    1545 | feeble voice: “I heard every word you fellows were saying.”
-         |                                   ^~~ The possessive version of this word is more common in this context.
-Suggest:
-  - Replace with: “your”
-  - Replace with: “you're a”
-  - Replace with: “you're an”
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
     1555 | great hurry; “and their names were Elsie, Lacie, and Tillie; and they lived at

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -1009,17 +1009,6 @@ Suggest:
 
 
 
-Lint:    WordChoice (127 priority)
-Message: |
-     806 | “That dog?” He looked at it admiringly. “That dog will cost you ten dollars.”
-         |                                                             ^~~ The possessive version of this word is more common in this context.
-Suggest:
-  - Replace with: “your”
-  - Replace with: “you're a”
-  - Replace with: “you're an”
-
-
-
 Lint:    Style (31 priority)
 Message: |
      819 | We drove over to Fifth Avenue, warm and soft, almost pastoral, on the summer
@@ -1770,18 +1759,6 @@ Suggest:
   - Replace with: “banjo's”
   - Replace with: “banjos”
   - Replace with: “bandies”
-
-
-
-Lint:    WordChoice (127 priority)
-Message: |
-    1428 | “I was in the Sixteenth until June nineteen-eighteen. I knew I’d seen you
-         |                                                                       ^~~ The possessive version of this word is more common in this context.
-    1429 | somewhere before.”
-Suggest:
-  - Replace with: “your”
-  - Replace with: “you're a”
-  - Replace with: “you're an”
 
 
 
@@ -3032,17 +3009,6 @@ Message: |
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1914 | nervous, sporadic games. This quality was continually breaking through his
          | ~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 44 words long.
-
-
-
-Lint:    WordChoice (127 priority)
-Message: |
-    1951 | “I’ll tell you God’s truth.” His right hand suddenly ordered divine retribution
-         |            ^~~ The possessive version of this word is more common in this context.
-Suggest:
-  - Replace with: “your”
-  - Replace with: “you're a”
-  - Replace with: “you're an”
 
 
 
@@ -4405,17 +4371,6 @@ Suggest:
 
 
 
-Lint:    WordChoice (127 priority)
-Message: |
-    2968 | “I’m all out of practice, you see. I told you I couldn’t play. I’m all out of
-         |                                           ^~~ The possessive version of this word is more common in this context.
-Suggest:
-  - Replace with: “your”
-  - Replace with: “you're a”
-  - Replace with: “you're an”
-
-
-
 Lint:    Repetition (63 priority)
 Message: |
     2968 | “I’m all out of practice, you see. I told you I couldn’t play. I’m all out of
@@ -5752,17 +5707,6 @@ Suggest:
 
 
 
-Lint:    WordChoice (127 priority)
-Message: |
-    4115 | “I told you I went there,” said Gatsby.
-         |         ^~~ The possessive version of this word is more common in this context.
-Suggest:
-  - Replace with: “your”
-  - Replace with: “you're a”
-  - Replace with: “you're an”
-
-
-
 Lint:    Repetition (63 priority)
 Message: |
     4115 | “I told you I went there,” said Gatsby.
@@ -5795,17 +5739,6 @@ Message: |
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     4187 | conceal and it would be a privilege to partake vicariously of their emotions.
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 41 words long.
-
-
-
-Lint:    WordChoice (127 priority)
-Message: |
-    4192 | “I told you what’s been going on,” said Gatsby. “Going on for five years—and you
-         |         ^~~ The possessive version of this word is more common in this context.
-Suggest:
-  - Replace with: “your”
-  - Replace with: “you're a”
-  - Replace with: “you're an”
 
 
 


### PR DESCRIPTION
# Issues 
Resolves #1919

# Description

The `PossessiveYour` linter was flagging "you" to change to "your" even when it was the object of a verb.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

The examples from the bug report are used as unit tests.

As a great bonus a bunch of false positives from the snapshots go away and no new false positives or negatives are introduced there.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
