### PR TITLE
fix: `Handful` was in `linting/mod.rs` but missing from `linting/lint_group.rs`

### DIFF
--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -75,6 +75,7 @@ use super::free_predicate::FreePredicate;
 use super::friend_of_me::FriendOfMe;
 use super::go_so_far_as_to::GoSoFarAsTo;
 use super::good_at::GoodAt;
+use super::handful::Handful;
 use super::have_pronoun::HavePronoun;
 use super::have_take_a_look::HaveTakeALook;
 use super::hedging::Hedging;
@@ -553,6 +554,7 @@ impl LintGroup {
         insert_expr_rule!(FriendOfMe, true);
         insert_expr_rule!(GoSoFarAsTo, true);
         insert_expr_rule!(GoodAt, true);
+        insert_expr_rule!(Handful, true);
         insert_expr_rule!(HavePronoun, true);
         insert_expr_rule!(Hedging, true);
         insert_expr_rule!(HelloGreeting, true);


### PR DESCRIPTION
# Issues 
Closes #2366 

# Description

Last week I discovered an orphaned `Linter` that was only half-integrated and filed an issue about it.
With no feedback I'm assuming that was an oversight and it should be fully integrated.

# How Has This Been Tested?

The linter already had unit tests in it.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
