### PR TITLE
feat(cli): recognize *.markdown as Markdown

### DIFF
--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -937,7 +937,7 @@ fn load_file(
         .extension()
         .map(|v| v.to_str().unwrap())
     {
-        Some("md") => Box::new(Markdown::default()),
+        Some("md") | Some("markdown") => Box::new(Markdown::default()),
         Some("ink") => Box::new(InkParser::default()),
 
         Some("lhs") => Box::new(LiterateHaskellParser::new_markdown(


### PR DESCRIPTION

# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

N/A

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

.markdown is the other official extension for Markdown.

https://www.iana.org/assignments/media-types/text/markdown

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

N/A

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Ran the CLI on a few *.markdown files, noted that it now does the right thing with Markdown links wrt AnA.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
