### PR TITLE
feat: escape goat → scapegoat

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -349,6 +349,16 @@ pub fn lint_group() -> LintGroup {
             "Simplifies redundant double positives like `most optimal` to the base form.",
             LintKind::Redundancy
         ),
+        "ScapeGoat" => (
+            &[
+                ("an escape goat", "a scapegoat"),
+                ("escape goat", "scapegoat"),
+                ("escape goats", "scapegoats"),
+            ],
+            "If you're referring someone is being blamed unfairly, write it as a single word: `scapegoat`.",
+            "Corrects `scape goat` to `scapegoat`, which is the proper term for a person blamed for others' failures.",
+            LintKind::Eggcorn
+        ),
         "WreakHavoc" => (
             &[
                 ("wreck havoc", "wreak havoc"),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -870,7 +870,40 @@ fn correct_passer_bys_hyphen() {
 // Piggyback
 // -none-
 
+// RedundantSuperlatives
+// -none-
+
+// ScapeGoat
+
+#[test]
+fn fix_an_escape_goat() {
+    assert_suggestion_result(
+        "I see too many times the cable and ps thingy being used as an escape goat.",
+        lint_group(),
+        "I see too many times the cable and ps thingy being used as a scapegoat.",
+    );
+}
+
+#[test]
+fn fix_escape_goat() {
+    assert_suggestion_result(
+        "It helps shift the reason for the failure on to what the manager did not do (making them the escape goat when it fails).",
+        lint_group(),
+        "It helps shift the reason for the failure on to what the manager did not do (making them the scapegoat when it fails).",
+    );
+}
+
+#[test]
+fn fix_escape_goats() {
+    assert_suggestion_result(
+        "People might be using Americans as escape goats for this, but these mishearings are becoming as common as a bowl in a china shop!",
+        lint_group(),
+        "People might be using Americans as scapegoats for this, but these mishearings are becoming as common as a bowl in a china shop!",
+    );
+}
+
 // WreakHavoc
+// -none-
 
 // Many to many tests
 


### PR DESCRIPTION
# Issues

N/A

# Description

Came across the very common "escape goat" for "scapegoat" error and we don't already handle it.

- Supports singular and plural.
- Supports changing indefinite article: "an escape goat" → "a scapegoat".
- Does not handle "scape goat" since `MergeWords` picks that up.
- Does not flag hyphenated "escape-goat" which appears to be used intentionally in code to refer to things named using a play on words.
- Does flag title case "Escape Goat" but it seems to be used for at least one product, a game of some type. Because of this the `message` uses a wording asking you whether the term is intended to refer to an unfairly blamed person.

If that last case turns out to be too common we can always split this out to its own linter.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?

Three unit tests to cover the variants, harvested from GitHub and other tech websites.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
