### PR TITLE
docs: fix broken links on Language Server page

### DIFF
--- a/packages/web/src/routes/docs/integrations/language-server/+page.md
+++ b/packages/web/src/routes/docs/integrations/language-server/+page.md
@@ -88,13 +88,13 @@ Each user of `harper-ls` has their own dictionary, created on-demand the first t
 | macOS            |                            `$HOME/Library/Application Support/harper-ls/dictionary.txt` |
 | Windows          |                                    `%FOLDERID_RoamingAppData%/harper-ls/dictionary.txt` |
 
-This dictionary is a simple line-separated word list in plaintext. You can add and remove words at will. Code actions on misspelled words allow you to add elements to this list. Additionally, [its location is configurable](#Dictionaries_).
+This dictionary is a simple line-separated word list in plaintext. You can add and remove words at will. Code actions on misspelled words allow you to add elements to this list. Additionally, [its location is configurable](#Directories).
 
 ### Workspace Dictionary
 
 Each workspace in which you use `harper-ls` has its own dictionary, which by default is located at `.harper-dictionary.txt` in the root of the workspace.
 
-This dictionary is a simple line-separated word list in plaintext. You can add and remove words at will. Code actions on misspelled words allow you to add elements to this list. Additionally, [its location is configurable](#Dictionaries_).
+This dictionary is a simple line-separated word list in plaintext. You can add and remove words at will. Code actions on misspelled words allow you to add elements to this list. Additionally, [its location is configurable](#Directories).
 
 ### File-Local Dictionary
 
@@ -108,7 +108,7 @@ You can find the file-local dictionaries in the following directories by default
 | macOS            |                                  `$HOME/Library/Application Support/harper-ls/file_dictionaries` |
 | Windows          |                                            `%FOLDERID_LocalAppData%/harper-ls/file_dictionaries` |
 
-The format of these files is identical to user dictionaries and [their location can also be configured](#Dictionaries_).
+The format of these files is identical to user dictionaries and [their location can also be configured](#Directories).
 
 ### Static Dictionary
 


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->
N/A

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->
The docs page for the language server has several broken links to `#Dictionaries_`; the relevant info is at `#Directories`.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
`just build-web` works locally and has the changes made.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
