### PR TITLE
feat: alloc→allocate/allocation deref→dereference ptr→pointer

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -162,6 +162,15 @@ pub fn lint_group() -> LintGroup {
             "Expands the abbreviation `deps` to the full word `dependencies` for clarity.",
             LintKind::Style
         ),
+        "ExpandDeref" => (
+            &[
+                ("deref", "dereference"),
+                ("derefs", "dereferences"),
+            ],
+            "Use `dereference` instead of `deref`",
+            "Expands the abbreviation `deref` to the full word `dereference` for clarity.",
+            LintKind::Style
+        ),
         "ExpandParameter" => (
             &[
                 ("param", "parameter"),
@@ -169,6 +178,15 @@ pub fn lint_group() -> LintGroup {
             ],
             "Use `parameter` instead of `param`",
             "Expands the abbreviation `param` to the full word `parameter` for clarity.",
+            LintKind::Style
+        ),
+        "ExpandPointer" => (
+            &[
+                ("ptr", "pointer"),
+                ("ptrs", "pointers"),
+            ],
+            "Use `pointer` instead of `ptr`",
+            "Expands the abbreviation `ptr` to the full word `pointer` for clarity.",
             LintKind::Style
         ),
         "ExpandStandardInputAndOutput" => (
@@ -414,6 +432,15 @@ pub fn lint_group() -> LintGroup {
             "Did you mean `double-edged sword`?",
             "Corrects variants of `double-edged sword`.",
             LintKind::Spelling
+        ),
+        "ExpandAlloc" => (
+            &[
+                (&["alloc"], &["allocate", "allocation"]),
+                (&["allocs"], &["allocates", "allocations"]),
+            ],
+            "Use `allocate` or `allocation` instead of `alloc`",
+            "Expands the abbreviation `alloc` to the full word `allocate` or `allocation` for clarity.",
+            LintKind::Style
         ),
         "ExpandDecl" => (
             &[

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -1,6 +1,6 @@
 use crate::linting::tests::{
     assert_good_and_bad_suggestions, assert_lint_count, assert_no_lints,
-    assert_nth_suggestion_result, assert_suggestion_result,
+    assert_nth_suggestion_result, assert_suggestion_result, assert_top3_suggestion_result,
 };
 
 use super::lint_group;
@@ -505,6 +505,26 @@ fn corrects_decls() {
 // ExpandDependency
 // -none-
 
+// ExpandDereference
+
+#[test]
+fn expand_deref() {
+    assert_suggestion_result(
+        "Should raw pointer deref/projections have to be in-bounds?",
+        lint_group(),
+        "Should raw pointer dereference/projections have to be in-bounds?",
+    );
+}
+
+#[test]
+fn corrects_derefs() {
+    assert_suggestion_result(
+        "A contiguous-in-memory double-ended queue that derefs into a slice - gnzlbg/slice_deque.",
+        lint_group(),
+        "A contiguous-in-memory double-ended queue that dereferences into a slice - gnzlbg/slice_deque.",
+    );
+}
+
 // ExpandParam
 
 #[test]
@@ -522,6 +542,24 @@ fn corrects_params() {
         "the params are not loaded in the R environment when using the terminal",
         lint_group(),
         "the parameters are not loaded in the R environment when using the terminal",
+    );
+}
+
+// ExpandPointer
+
+fn correct_ptr() {
+    assert_suggestion_result(
+        "How else would you construct a slice from a ptr and a length?",
+        lint_group(),
+        "How else would you construct a slice from a pointer and a length?",
+    );
+}
+
+fn correct_ptrs() {
+    assert_suggestion_result(
+        "FixedBufferAllocator.free not freeing ptrs",
+        lint_group(),
+        "FixedBufferAllocator.free not freeing pointers",
     );
 }
 
@@ -965,9 +1003,6 @@ fn fix_escape_goats() {
 }
 
 // WreakHavoc
-// -none-
-
-// Many to many tests
 
 #[test]
 fn fix_wreck_havoc() {
@@ -1004,6 +1039,8 @@ fn fix_wrecks_havoc() {
         "Small POC using rust with ptrace that wreaks havoc on msync",
     );
 }
+
+// Many to many tests
 
 // AwaitFor
 
@@ -1150,6 +1187,26 @@ fn correct_double_edged_space_plural() {
         "Change: Ambushers and Crusaders now protect their targets too, making them double edged swords",
         lint_group(),
         "Change: Ambushers and Crusaders now protect their targets too, making them double-edged swords",
+    );
+}
+
+// ExpandAlloc
+
+#[test]
+fn corrects_allocs() {
+    assert_top3_suggestion_result(
+        "cmd/compile: avoid allocs by better tracking of literals for interface conversions and make",
+        lint_group(),
+        "cmd/compile: avoid allocations by better tracking of literals for interface conversions and make",
+    );
+}
+
+#[test]
+fn expand_alloc() {
+    assert_top3_suggestion_result(
+        "Used to find system libraries that alloc RWX regions on load.",
+        lint_group(),
+        "Used to find system libraries that allocate RWX regions on load.",
     );
 }
 


### PR DESCRIPTION
# Issues 
N/A

# Description

After I got Neovim working with Harper I spotted several more programming terms we can expand as phrase corrections:
- alloc → allocate / allocation
- deref → dereference
- ptr → pointer

# How Has This Been Tested?

Unit tests have been added for singular and plural use using extracts from GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
