### PR TITLE
feat: foam out the mouth → foam at the mouth

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -203,6 +203,17 @@ pub fn lint_group() -> LintGroup {
             // ConfusedPair??
             LintKind::WordChoice
         ),
+        "FoamAtTheMouth" => (
+            &[
+                ("foam out the mouth", "foam at the mouth"),
+                ("foamed out the mouth", "foamed at the mouth"),
+                ("foaming out the mouth", "foaming at the mouth"),
+                ("foams out the mouth", "foams at the mouth"),
+            ],
+            "The correct idiom is `foam at the mouth`.",
+            "Corrects the idiom `foam out the mouth` to the standard `foam at the mouth`.",
+            LintKind::Nonstandard
+        ),
         "FootTheBill" => (
             &[
                 ("flip the bill", "foot the bill"),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -614,6 +614,44 @@ fn correct_to_an_extend() {
     );
 }
 
+// FoamAtTheMouth
+
+#[test]
+fn correct_foam_out_the_mouth() {
+    assert_suggestion_result(
+        "and he gave him a drink that made him foam out the mouth and die",
+        lint_group(),
+        "and he gave him a drink that made him foam at the mouth and die",
+    );
+}
+
+#[test]
+fn correct_foamed_out_the_mouth() {
+    assert_suggestion_result(
+        "You can see in some shots they've foamed out the mouth, and it's apparent their poisoned.",
+        lint_group(),
+        "You can see in some shots they've foamed at the mouth, and it's apparent their poisoned.",
+    );
+}
+
+#[test]
+fn correct_foaming_out_the_mouth() {
+    assert_suggestion_result(
+        "choking or foaming out the mouth or something like that, leading up to death",
+        lint_group(),
+        "choking or foaming at the mouth or something like that, leading up to death",
+    );
+}
+
+#[test]
+fn correct_foams_out_the_mouth() {
+    assert_suggestion_result(
+        "Elaine can't swallow, foams out the mouth and Kramer says she has rabies just like his friend Bob Sacamano after she gets bit by the guy's dog",
+        lint_group(),
+        "Elaine can't swallow, foams at the mouth and Kramer says she has rabies just like his friend Bob Sacamano after she gets bit by the guy's dog",
+    );
+}
+
 // FootTheBill
 
 #[test]


### PR DESCRIPTION
# Issues 
N/A

# Description

I just heard somebody on YouTube say "foam out the mouth", verified that it's not a legit alternative to "foam at the mouth", and whipped up a quick phrase set correction.

# How Has This Been Tested?

This error doesn't occur on GitHub at least the way I search it using Google. I made unit tests using sentences found on Stack Exchange, Medium, and Reddit.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
