### PR TITLE
feat: initiatively→proactively / initially

### DIFF
--- a/harper-core/src/linting/phrase_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_corrections/mod.rs
@@ -613,6 +613,13 @@ pub fn lint_group() -> LintGroup {
             "Corrects `I does` to `I do`.",
             LintKind::Agreement
         ),
+        "Initiatively" => (
+            ["initiatively"],
+            ["proactively", "initially"],
+            "Did you mean `proactive` (taking initiative, acting in advance) or `initially` (at first, in the beginning)?",
+            "Corrects nonstandard `initiatively`.",
+            LintKind::Nonstandard
+        ),
         "InLieuOf" => (
             ["in lue of"],
             ["in lieu of"],

--- a/harper-core/src/linting/phrase_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_corrections/tests.rs
@@ -959,6 +959,16 @@ fn corrects_i_does() {
     );
 }
 
+// Initiatively
+#[test]
+fn corrects_initiatively_2422() {
+    assert_suggestion_result(
+        "I have initiatively signed up for the course.",
+        lint_group(),
+        "I have proactively signed up for the course.",
+    );
+}
+
 // InLieuOf
 
 #[test]


### PR DESCRIPTION
# Issues 

Fixes #2422

# Description

Offers two corrections for the nonstandard word "initiatively":
- "proactively" ~ using one's initiative
- "initially" ~ in the beginning

# How Has This Been Tested?

A unit test using the sentence from the issue.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
