### PR TITLE
fix: don't flag "need to run into"

### DIFF
--- a/harper-core/src/linting/need_to_noun.rs
+++ b/harper-core/src/linting/need_to_noun.rs
@@ -24,7 +24,7 @@ impl Default for NeedToNoun {
                     || tok.kind.is_unlintable()
                     || tok.kind.is_pronoun()
             }),
-            Box::new(WordSet::new(&["about", "it"])),
+            Box::new(WordSet::new(&["about", "into", "it"])),
         ]);
 
         let exceptions = SequenceExpr::anything()
@@ -446,6 +446,14 @@ mod tests {
     fn allows_overcome() {
         assert_no_lints(
             "We believe every family deserves the opportunity to flourish, and we are committed to providing the resources they need to overcome adversity.",
+            NeedToNoun::default(),
+        );
+    }
+
+    #[test]
+    fn allows_need_to_run_into_2433() {
+        assert_no_lints(
+            "So that they don't need to run into this problem in the future.",
             NeedToNoun::default(),
         );
     }


### PR DESCRIPTION
# Issues 

Fixes #2433

# Description

Fixes false positive "need to run into" from being flagged.

# How Has This Been Tested?

A unit test using the example in the issue.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
