### PR TITLE
feat: Make the dialect indicator in the VS Code status bar clickable to change dialect

### DIFF
--- a/packages/vscode-plugin/src/extension.ts
+++ b/packages/vscode-plugin/src/extension.ts
@@ -1,5 +1,5 @@
-import type { ExtensionContext, QuickPickItem } from 'vscode';
-import { ConfigurationTarget, commands, StatusBarAlignment, type StatusBarItem, Uri, window, workspace } from 'vscode';
+import type { ExtensionContext, QuickPickItem, StatusBarItem } from 'vscode';
+import { ConfigurationTarget, commands, StatusBarAlignment, Uri, window, workspace } from 'vscode';
 import type { Executable, LanguageClientOptions } from 'vscode-languageclient/node';
 import { LanguageClient, ResponseError, TransportKind } from 'vscode-languageclient/node';
 
@@ -100,9 +100,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 		commands.registerCommand('harper.languageserver.restart', startLanguageServer),
 	);
 
-	context.subscriptions.push(
-		commands.registerCommand('harper.changeDialect', changeDialect),
-	);
+	context.subscriptions.push(commands.registerCommand('harper.changeDialect', changeDialect));
 
 	await startLanguageServer();
 


### PR DESCRIPTION
# Issues 

Closes #1095

# Description

Simply click the <img width="71" height="20" alt="image" src="https://github.com/user-attachments/assets/68000cca-9cf5-4ec7-8c14-64df8f509fe0" /> indicator in the VS Code status bar and a popup will appear where you can choose a different dialect. You no longer have to open the settings.

It took me longer to figure out how to build and test this than it did for the Amp Free agent to implement it.

# Demo

<img width="676" height="391" alt="image" src="https://github.com/user-attachments/assets/48da7fad-10fb-427c-82e0-c2c612842855" />

# How Has this Been Tested?

Manually in both VS Code and Windsurf

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
