### PR TITLE
fix(obsidian): bug causing the Indian dialect to crash the settings page

### DIFF
--- a/harper-wasm/src/lib.rs
+++ b/harper-wasm/src/lib.rs
@@ -72,6 +72,7 @@ pub enum Dialect {
     British,
     Australian,
     Canadian,
+    Indian,
 }
 
 impl From<Dialect> for harper_core::Dialect {
@@ -81,6 +82,7 @@ impl From<Dialect> for harper_core::Dialect {
             Dialect::Canadian => harper_core::Dialect::Canadian,
             Dialect::Australian => harper_core::Dialect::Australian,
             Dialect::British => harper_core::Dialect::British,
+            Dialect::Indian => harper_core::Dialect::Indian,
         }
     }
 }


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Bug was introduced in #2397

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

It looks like the Indian dialect was omitted from the WebAssembly mirror of the `Dialect` enum. When the Obsidian plugin tried to query it, it was crash the settings page.
This PR adds the dialect, which should resolve the problem.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
