### PR TITLE
fix: Allow exception `need to match` for `NeedToNoun`

### DIFF
--- a/harper-core/src/linting/need_to_noun.rs
+++ b/harper-core/src/linting/need_to_noun.rs
@@ -31,7 +31,7 @@ impl Default for NeedToNoun {
             .t_any()
             .t_any()
             .t_any()
-            .then_word_set(&["be"]);
+            .then_word_set(&["be", "match"]);
 
         let a = SequenceExpr::default()
             .then_kind_where(|kind| kind.is_nominal())
@@ -456,5 +456,18 @@ mod tests {
             "So that they don't need to run into this problem in the future.",
             NeedToNoun::default(),
         );
+    }
+
+    #[test]
+    fn allows_need_to_match_2446() {
+        assert_no_lints(
+            "You don't need to match string errors explicitly.",
+            NeedToNoun::default(),
+        );
+    }
+
+    #[test]
+    fn allows_need_to_match_exactly_2446() {
+        assert_no_lints("They need to match exactly.", NeedToNoun::default());
     }
 }


### PR DESCRIPTION
# Issues 
Fixes #2446 

# Description
Prevents false positive `need to match` from being flagged.

# How Has This Been Tested?
Two unit tests: One with the original sentence, and another with a simpler sentence.

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
