### PR TITLE
fix(core): don't replace non-alphabetic characters when title-casing

### DIFF
--- a/harper-core/src/title_case.rs
+++ b/harper-core/src/title_case.rs
@@ -77,7 +77,9 @@ pub fn try_make_title_case(
             if let Some(correct_caps) = dict.get_correct_capitalization_of(orig_text) {
                 // It should match the dictionary verbatim
                 for (i, c) in correct_caps.iter().enumerate() {
-                    set_output_char(word.span.start - start_index + i, *c);
+                    if c.is_alphabetic() {
+                        set_output_char(word.span.start - start_index + i, *c);
+                    }
                 }
             }
         };
@@ -503,6 +505,18 @@ mod tests {
         assert_eq!(
             make_title_case_str("winter road", &PlainEnglish, &FstDictionary::curated()),
             "Winter Road",
+        );
+    }
+
+    #[test]
+    fn maintains_same_apostrophe_type() {
+        assert_eq!(
+            make_title_case_str(
+                "Alice’s Adventures in Wonderland",
+                &PlainEnglish,
+                &FstDictionary::curated()
+            ),
+            "Alice’s Adventures in Wonderland",
         );
     }
 }

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -1,12 +1,3 @@
-Lint:    Capitalization (127 priority)
-Message: |
-       1 | # Alice’s Adventures in Wonderland
-         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Try to use title case in headings.
-Suggest:
-  - Replace with: “# Alice's Adventures in Wonderland”
-
-
-
 Lint:    Readability (127 priority)
 Message: |
        9 | Alice was beginning to get very tired of sitting by her sister on the bank, and
@@ -2094,15 +2085,6 @@ Message: |
 
 
 
-Lint:    Capitalization (127 priority)
-Message: |
-    1668 | ## CHAPTER VIII: The Queen’s Croquet-Ground
-         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Try to use title case in headings.
-Suggest:
-  - Replace with: “## CHAPTER VIII: The Queen's Croquet-Ground”
-
-
-
 Lint:    Readability (127 priority)
 Message: |
     1691 | Seven flung down his brush, and had just begun “Well, of all the unjust things—”
@@ -3815,15 +3797,6 @@ Message: |
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2724 | sight, he said in a deep voice, “What are tarts made of?”
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 42 words long.
-
-
-
-Lint:    Capitalization (127 priority)
-Message: |
-    2745 | ## CHAPTER XII: Alice’s Evidence
-         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Try to use title case in headings.
-Suggest:
-  - Replace with: “## CHAPTER XII: Alice's Evidence”
 
 
 


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Bug was revealed in snapshot tests modified in #2399

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

We were seeing that the title-case linter would throw erroneous suggestions when it encountered smart apostrophes in proper nouns. I've modified it to ignore non-alphabetic characters entirely.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Additional unit tests + existing snapshots

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes