### PR TITLE
chore: add "discoverable", "handoff"

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -34843,6 +34843,7 @@ multiculturalism/~Nmg
 multicurrency/J
 multidevice/J
 multidimensional/J
+multidirectional/J
 multidisciplinary/~J
 multidomain/J
 multiethnic/J


### PR DESCRIPTION
# Issues 
N/A

# Description

Adds missing words I've noticed in `SpellCheck` false positives during normal use.

Comment about handoff vs handover being US vs Commonwealth, but not marked for dialect as of yet. [For which, see this discussion.](https://english.stackexchange.com/a/522838/3175)

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
