### PR TITLE
chore: add "different tact" to "change tacts" linter

### DIFF
--- a/harper-core/src/linting/change_tack.rs
+++ b/harper-core/src/linting/change_tack.rs
@@ -1,8 +1,9 @@
-use crate::Token;
-use crate::expr::{Expr, SequenceExpr};
-use crate::linting::expr_linter::Chunk;
-use crate::linting::{ExprLinter, Lint, LintKind, Suggestion};
-use crate::patterns::Word;
+use crate::{
+    Token,
+    expr::{Expr, FirstMatchOf, SequenceExpr},
+    linting::{ExprLinter, Lint, LintKind, Suggestion, expr_linter::Chunk},
+    patterns::Word,
+};
 
 pub struct ChangeTack {
     expr: Box<dyn Expr>,
@@ -15,20 +16,23 @@ impl Default for ChangeTack {
         let eggcorns = &["tact", "tacks", "tacts"];
 
         Self {
-            expr: Box::new(
-                SequenceExpr::default()
-                    .then_longest_of(vec![
-                        Box::new(SequenceExpr::word_set(verb_forms).then_optional(
-                            SequenceExpr::default().t_ws().then_any_of(vec![
-                                Box::new(SequenceExpr::default().then_possessive_determiner()),
-                                Box::new(Word::new("it's")),
-                            ]),
-                        )),
-                        Box::new(SequenceExpr::word_set(noun_forms).t_ws().t_aco("of")),
-                    ])
-                    .t_ws()
-                    .then_word_set(eggcorns),
-            ),
+            expr: Box::new(FirstMatchOf::new(vec![
+                Box::new(
+                    SequenceExpr::default()
+                        .then_longest_of(vec![
+                            Box::new(SequenceExpr::word_set(verb_forms).then_optional(
+                                SequenceExpr::default().t_ws().then_any_of(vec![
+                                    Box::new(SequenceExpr::default().then_possessive_determiner()),
+                                    Box::new(Word::new("it's")),
+                                ]),
+                            )),
+                            Box::new(SequenceExpr::word_set(noun_forms).t_ws().t_aco("of")),
+                        ])
+                        .t_ws()
+                        .then_word_set(eggcorns),
+                ),
+                Box::new(SequenceExpr::aco("different").t_ws().t_aco("tact")),
+            ])),
         }
     }
 }
@@ -203,6 +207,15 @@ mod tests {
             "As we become inoculated to attention grifts, the grifter changes their tact.",
             ChangeTack::default(),
             "As we become inoculated to attention grifts, the grifter changes their tack.",
+        );
+    }
+
+    #[test]
+    fn different_tact() {
+        assert_suggestion_result(
+            "So, I recently took a different tact: I put all my models etc. in a single folder.",
+            ChangeTack::default(),
+            "So, I recently took a different tack: I put all my models etc. in a single folder.",
         );
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

I noticed another context in which people confuse "tact" for correct "tack".

It fits in easily with the linter that corrects "change tacts", "change of tact", etc.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

A new unit test using a sentence found on GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
