### PR TITLE
feat: better of with → better off with

### DIFF
--- a/harper-core/src/linting/weir_rules/BetterOffWith.weir
+++ b/harper-core/src/linting/weir_rules/BetterOffWith.weir
@@ -1,0 +1,8 @@
+expr main (better of with)
+
+let message "This phrase uses the word `off`."
+let description "Corrects `better of with` to `better off with`."
+let kind "Typo"
+let becomes "better off with"
+
+test "If you're wanting dynamic meta data, your might be better of with getServerSideProps ." "If you're wanting dynamic meta data, your might be better off with getServerSideProps ."


### PR DESCRIPTION
# Issues 
N/A

# Description

My first bit of Weirage.

Another common mistake I first saw while checking what's up with Audacity lately. It turns out to be very common:

> Depending on your exact use case, you might be better **of** with a Popover component

"Of" should be "off". I doubt it's actually a typo but went with `LintKind::Typo`. People who mix up "of" and "off" don't know which word is right or how to spell each one, rather than slip up with their fingers. Maybe I should change it?

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I chose a usage from GitHub to use as a unit test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
