### PR TITLE
feat: very less → much less/far less/a lot less

### DIFF
--- a/harper-core/src/linting/weir_rules/VeryLess.weir
+++ b/harper-core/src/linting/weir_rules/VeryLess.weir
@@ -3,8 +3,8 @@ expr main (very less)
 let message "English doesn't use `very` with `less`."
 let description "Corrects `very less`."
 let kind "Grammar"
-let becomes ["much less", "far less"]
+let becomes ["much less", "far less", "a lot less"]
 
 test "here is a simple way to do it with very less coding ... ;)" "here is a simple way to do it with much less coding ... ;)"
 test "algorithm for processing large datasets with very less pre-configuration" "algorithm for processing large datasets with far less pre-configuration"
-#test "Also the gpu memory usage is very less. " "Also the gpu memory usage is a lot less."
+test "Also the gpu memory usage is very less." "Also the gpu memory usage is a lot less."


### PR DESCRIPTION
# Issues 

N/A

# Description

The common mistake especially by German speakers "very less" is addressed in this PR.
It suggests "much less", "far less", and "a lot less".

# How Has This Been Tested?

A unit test for each correction is included, all using sentences from GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
