### PR TITLE
fix: WASM/thesaurus `just test` failure

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 
-harper-core = { path = "../harper-core" }
+harper-core = { path = "../harper-core", features = ["thesaurus"] }
 harper-typst = { path = "../harper-typst" }
 harper-literate-haskell = { path = "../harper-literate-haskell" }
 harper-html = { path = "../harper-html" }

--- a/harper-asciidoc/Cargo.toml
+++ b/harper-asciidoc/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/automattic/harper"
 
 [dependencies]
-harper-core = { path = "../harper-core", version = "1.0.0" }
+harper-core = { path = "../harper-core", version = "1.0.0", features = ["thesaurus"] }
 harper-tree-sitter = { path = "../harper-tree-sitter", version = "1.0.0" }
 tree-sitter-asciidoc = "0.6.0"
 tree-sitter = "0.25.10"

--- a/harper-cli/Cargo.toml
+++ b/harper-cli/Cargo.toml
@@ -14,7 +14,7 @@ dirs = "6.0.0"
 harper-literate-haskell = { path = "../harper-literate-haskell", version = "1.0.0" }
 harper-python = { path = "../harper-python", version = "1.0.0" }
 harper-asciidoc = { path = "../harper-asciidoc", version = "1.0.0" }
-harper-core = { path = "../harper-core", version = "1.0.0" }
+harper-core = { path = "../harper-core", version = "1.0.0", features = ["thesaurus"] }
 harper-pos-utils = { path = "../harper-pos-utils", version = "1.0.0", features = [] }
 harper-comments = { path = "../harper-comments", version = "1.0.0" }
 harper-typst = { path = "../harper-typst", version = "1.0.0" }

--- a/harper-comments/Cargo.toml
+++ b/harper-comments/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/automattic/harper"
 
 [dependencies]
-harper-core = { path = "../harper-core", version = "1.0.0" }
+harper-core = { path = "../harper-core", version = "1.0.0", features = ["thesaurus"] }
 harper-html = { path = "../harper-html", version = "1.0.0" }
 harper-tree-sitter = { path = "../harper-tree-sitter", version = "1.0.0" }
 itertools = "0.14.0"

--- a/harper-core/Cargo.toml
+++ b/harper-core/Cargo.toml
@@ -49,6 +49,6 @@ name = "parse_essay"
 harness = false
 
 [features]
-default = ["thesaurus"]
+default = []
 concurrent = []
 thesaurus = ["dep:harper-thesaurus"]

--- a/harper-html/Cargo.toml
+++ b/harper-html/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/automattic/harper"
 
 [dependencies]
-harper-core = { path = "../harper-core", version = "1.0.0" }
+harper-core = { path = "../harper-core", version = "1.0.0", features = ["thesaurus"] }
 harper-tree-sitter = { path = "../harper-tree-sitter", version = "1.0.0" }
 tree-sitter-html = "0.23.2"
 tree-sitter = "0.25.10"

--- a/harper-ink/Cargo.toml
+++ b/harper-ink/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/automattic/harper"
 
 [dependencies]
-harper-core = { path = "../harper-core", version = "1.0.0" }
+harper-core = { path = "../harper-core", version = "1.0.0", features = ["thesaurus"] }
 harper-tree-sitter = { path = "../harper-tree-sitter", version = "1.0.0" }
 tree-sitter-ink-lbz = "0.0.1"
 tree-sitter = "0.25.10"

--- a/harper-jjdescription/Cargo.toml
+++ b/harper-jjdescription/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/automattic/harper"
 
 [dependencies]
-harper-core = { path = "../harper-core", version = "1.0.0" }
+harper-core = { path = "../harper-core", version = "1.0.0", features = ["thesaurus"] }
 harper-tree-sitter = { path = "../harper-tree-sitter", version = "1.0.0" }
 tree-sitter-jjdescription = "0.0.1"
 tree-sitter = "0.25.10"

--- a/harper-literate-haskell/Cargo.toml
+++ b/harper-literate-haskell/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/automattic/harper"
 
 [dependencies]
-harper-core = { path = "../harper-core", version = "1.0.0" }
+harper-core = { path = "../harper-core", version = "1.0.0", features = ["thesaurus"] }
 harper-tree-sitter = { path = "../harper-tree-sitter", version = "1.0.0" }
 harper-comments = { path = "../harper-comments", version = "1.0.0" }
 itertools = "0.14.0"

--- a/harper-python/Cargo.toml
+++ b/harper-python/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/automattic/harper"
 
 [dependencies]
-harper-core = { path = "../harper-core", version = "1.0.0" }
+harper-core = { path = "../harper-core", version = "1.0.0", features = ["thesaurus"] }
 harper-tree-sitter = { path = "../harper-tree-sitter", version = "1.0.0" }
 tree-sitter-python = "0.25.0"
 tree-sitter = "0.25.10"

--- a/harper-stats/Cargo.toml
+++ b/harper-stats/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/automattic/harper"
 
 [dependencies]
 serde = { version = "1.0.228", features = ["derive"] }
-harper-core = { path = "../harper-core", version = "1.0.0", features = ["concurrent"] }
+harper-core = { path = "../harper-core", version = "1.0.0", default-features = false, features = ["concurrent"] }
 uuid = { version = "1.19.0", features = ["serde", "v4"] }
 serde_json = "1.0.149"
 chrono = "0.4.42"

--- a/harper-tree-sitter/Cargo.toml
+++ b/harper-tree-sitter/Cargo.toml
@@ -7,5 +7,5 @@ license = "Apache-2.0"
 repository = "https://github.com/automattic/harper"
 
 [dependencies]
-harper-core = { path = "../harper-core", version = "1.0.0" }
+harper-core = { path = "../harper-core", version = "1.0.0", features = ["thesaurus"] }
 tree-sitter = "0.25.10"

--- a/harper-typst/Cargo.toml
+++ b/harper-typst/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/automattic/harper"
 
 [dependencies]
-harper-core = { path = "../harper-core", version = "1.0.0" }
+harper-core = { path = "../harper-core", version = "1.0.0", features = ["thesaurus"] }
 typst-syntax = { version = "0.13.1" }
 ordered-float = { version = "5.1.0", features = ["serde"] }
 itertools = "0.14.0"

--- a/harper-wasm/Cargo.toml
+++ b/harper-wasm/Cargo.toml
@@ -13,7 +13,7 @@ console_error_panic_hook = "0.1.7"
 tracing = "0.1.44"
 tracing-wasm = "0.2.1"
 wasm-bindgen = "0.2.97"
-harper-core = { path = "../harper-core", version = "1.0.0", features = ["concurrent"] }
+harper-core = { path = "../harper-core", version = "1.0.0", default-features = false, features = ["concurrent"] }
 once_cell = "1.21.3"
 serde-wasm-bindgen = "0.6.5"
 serde_json = "1.0.149"


### PR DESCRIPTION
# Issues 
N/A

# Description

I was getting failures in `just test` on my system. This is outside my fields of expertise and the changes were found with an AI agent that's been impressing me lately. They definitely need to be analysed by somebody knowledgeable.

@elijah-potter this pertains to the thread in discord where I mentioned the problems I was having testing.

The agent's summary upon completion of the session:
```
Perfect. Summary of all changes:

Summary of Fixes

1. WASM Build Errors (Resolved ✅)

Root cause: zstd-sys can't compile to wasm32-unknown-unknown on macOS
Solution:
Removed thesaurus from harper-core default features
Added explicit features = ["thesaurus"] to all non-WASM crates
Added default-features = false to WASM-building crates
```

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
