### PR TITLE
fix: don't flag "no two" etc.

### DIFF
--- a/harper-core/src/linting/quantifier_numeral_conflict.rs
+++ b/harper-core/src/linting/quantifier_numeral_conflict.rs
@@ -24,9 +24,9 @@ impl Default for QuantifierNumeralConflict {
                 ),
                 Box::new(
                     SequenceExpr::default().then_unless(SequenceExpr::any_of(vec![
-                        Box::new(WordSet::new(&["all", "any", "every"])),
+                        Box::new(WordSet::new(&["all", "any", "every", "no"])),
                         Box::new(
-                            SequenceExpr::word_set(&["each", "no", "some"])
+                            SequenceExpr::word_set(&["each", "some"])
                                 .t_ws()
                                 .t_aco("one"),
                         ),
@@ -174,6 +174,14 @@ mod tests {
             "OSSEC by default run rootkit check each 2 hours.",
             QuantifierNumeralConflict::default(),
             "OSSEC by default run rootkit check every 2 hours.",
+        );
+    }
+
+    #[test]
+    fn ignore_no_two_adjacent_characters_2486() {
+        assert_no_lints(
+            "No two adjacent characters are the same.",
+            QuantifierNumeralConflict::default(),
         );
     }
 }


### PR DESCRIPTION
# Issues 

Fixes #2486

# Description

Will no longer flag the quantifier "no" followed by a number.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

A unit test using the phrase from the bug report.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
