### PR TITLE
fix(thesaurus): MacOS builds by using `ruzstd`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2919,6 +2919,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "indexmap",
  "itertools 0.14.0",
+ "ruzstd",
  "zstd",
 ]
 
@@ -4793,6 +4794,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
+name = "ruzstd"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6062,6 +6072,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "type-map"

--- a/harper-thesaurus/Cargo.toml
+++ b/harper-thesaurus/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/automattic/harper"
 hashbrown = "0.16.0"
 indexmap = "2.12.1"
 itertools = "0.14.0"
-zstd = { version = "0.13.3", default-features = false }
+ruzstd = "0.8.2"
 
 [build-dependencies]
 zstd = { version = "0.13.3", default-features = false }


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Supercedes #2488

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

This PR changes the library we use to decompress the thesaurus at runtime to a Rust-only library, `ruzstd`. This avoids the compiler problems illustrated by #2488 on MacOS systems.

@hippietrail, would you mind checking if this PR actually fixes your problem?

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
