### PR TITLE
fix(core): capitalization issue in `SpellCheck`

### DIFF
--- a/harper-core/src/linting/spell_check.rs
+++ b/harper-core/src/linting/spell_check.rs
@@ -87,7 +87,15 @@ impl<T: Dictionary> Linter for SpellCheck<T> {
             if let Some(mis_f) = word_chars.first()
                 && mis_f.is_uppercase()
             {
-                for sug_f in possibilities.iter_mut().filter_map(|w| w.first_mut()) {
+                for sug_f in possibilities.iter_mut().filter_map(|w| {
+                    // Skip words that have uppercase chars in any position except the first.
+                    // (For words with specific capitalization, like 'macOS')
+                    w.iter()
+                        .skip(1)
+                        .all(|c| !c.is_uppercase())
+                        .then_some(w.first_mut())
+                        .flatten()
+                }) {
                     *sug_f = sug_f.to_uppercase().next().unwrap();
                 }
             }


### PR DESCRIPTION
# Issues 
Fixes #2524

# Description
<!-- Please include a summary of the change. -->
Skips capitalization of suggestions that contain uppercase characters in any position except the first in `SpellCheck`. The intention is to avoid uppercasing words that have fixed-casing(?), like "macOS".
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
- `cargo test`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
