### PR TITLE
feat: to loose/too lose→too loose/to lose

### DIFF
--- a/harper-core/src/linting/weir_rules/ToLoseTooLoose.weir
+++ b/harper-core/src/linting/weir_rules/ToLoseTooLoose.weir
@@ -1,0 +1,9 @@
+expr main [(to loose), (too lose)]
+
+let message "For `not to win`, use `to lose`. For `not tight enough`, use `too loose`."
+let description "Corrects mixing up `to` with `too` and `lose` with `loose`."
+let kind "Spelling"
+let becomes ["to lose", "too loose"]
+
+test "Bits and pieces of legacy code that are lying around on my system and that it would be a pity to loose" "Bits and pieces of legacy code that are lying around on my system and that it would be a pity to lose"
+test "infinite recursion caused by transforms that have their preconditions too lose and/or conflict with each other" "infinite recursion caused by transforms that have their preconditions too loose and/or conflict with each other"


### PR DESCRIPTION
# Issues 

Fixes #2387

# Description

The errors "to loose" and "too lose" are both ambiguous. The writer may have meant either "to lose" or "too loose". So far we were only detecting "too lose" and only suggesting "to lose" as the sole fix.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
