### PR TITLE
fix(core): allow both a/an for "LED" in `AnA`

### DIFF
--- a/harper-core/src/linting/an_a.rs
+++ b/harper-core/src/linting/an_a.rs
@@ -123,6 +123,10 @@ fn starts_with_vowel(word: &[char], dialect: Dialect) -> Option<InitialSound> {
         return None;
     }
 
+    if matches!(word, ['S', 'Q', 'L'] | ['L', 'E', 'D']) {
+        return Some(InitialSound::Either);
+    }
+
     // Try to get the first chunk of a word that appears to be a partial initialism.
     // For example:
     // - `RFL` from `RFLink`
@@ -145,9 +149,6 @@ fn starts_with_vowel(word: &[char], dialect: Dialect) -> Option<InitialSound> {
     let is_likely_initialism = word.iter().all(|c| !c.is_alphabetic() || c.is_uppercase());
 
     if word.len() == 1 || (is_likely_initialism && !is_likely_acronym(word)) {
-        if matches!(word, ['S', 'Q', 'L']) {
-            return Some(InitialSound::Either);
-        }
         return Some(
             if matches!(
                 word[0].to_ascii_uppercase(),


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->
Fixes #2550

# Description
<!-- Please include a summary of the change. -->
Allows both a/an to precede LED by returning `InitialSound::Either` from `starts_with_vowel()`.

[According to Wiktionary](https://en.wiktionary.org/wiki/LED), both the acronym and initialism pronunciation of the word is used.
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
- `cargo test`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
