### PR TITLE
fix(harper-typst): condense contractions

### DIFF
--- a/harper-core/src/document.rs
+++ b/harper-core/src/document.rs
@@ -1000,6 +1000,11 @@ mod tests {
     }
 
     #[test]
+    fn simple_contraction4() {
+        assert_condensed_contractions("doesn't", 1);
+    }
+
+    #[test]
     fn medium_contraction() {
         assert_condensed_contractions("isn't wasn't", 3);
     }

--- a/harper-typst/src/lib.rs
+++ b/harper-typst/src/lib.rs
@@ -1,7 +1,6 @@
 mod offset_cursor;
 mod typst_translator;
 
-use offset_cursor::OffsetCursor;
 use typst_translator::TypstTranslator;
 
 use harper_core::{Token, parsers::Parser};
@@ -28,11 +27,7 @@ impl Parser for Typst {
         let mut buf = Vec::new();
         let exprs = typst_tree.exprs().collect_vec();
         let exprs = convert_parbreaks(&mut buf, &exprs);
-        exprs
-            .into_iter()
-            .filter_map(|ex| parse_helper.parse_expr(ex, OffsetCursor::new(&typst_document)))
-            .flatten()
-            .collect_vec()
+        parse_helper.parse_exprs(&exprs)
     }
 }
 

--- a/harper-typst/tests/run_tests.rs
+++ b/harper-typst/tests/run_tests.rs
@@ -41,3 +41,4 @@ create_test!(complex_document_with_spelling_mistakes.typ, 4);
 // create_test!(issue_399.typ, 3);
 create_test!(function_with_ignorable_args.typ, 9);
 create_test!(issue_1926.typ, 1);
+create_test!(contractions.typ, 0);

--- a/harper-typst/tests/test_sources/contractions.typ
+++ b/harper-typst/tests/test_sources/contractions.typ
@@ -1,0 +1,1 @@
+Typst used to have problems with contractions. Doesn't it still?


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

This PR resolves an issue brought to me by @lukasmwerner.

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

When linting a Typst file, Harper would erroneously parse contractions (like `doesn't`) as two separate words. This would result in lint noise from the spell checker.

To fix this, I've modified the parser to condense WORD APOSTROPHE WORD sequences into single words.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Additional integration test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
