### PR TITLE
refactor(core): remove dependency on `lazy_static`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2775,7 +2775,6 @@ dependencies = [
  "hashbrown 0.16.1",
  "is-macro",
  "itertools 0.14.0",
- "lazy_static",
  "levenshtein_automata",
  "lru",
  "once_cell",

--- a/harper-core/Cargo.toml
+++ b/harper-core/Cargo.toml
@@ -13,7 +13,6 @@ fst = "0.4.7"
 hashbrown = { version = "0.16.1", features = ["serde"] }
 is-macro = "0.3.6"
 itertools = "0.14.0"
-lazy_static = "1.5.0"
 ordered-float = { version = "5.1.0", features = ["serde"] }
 paste = "1.0.14"
 pulldown-cmark = "0.13.0"

--- a/harper-core/src/irregular_nouns.rs
+++ b/harper-core/src/irregular_nouns.rs
@@ -1,6 +1,5 @@
-use lazy_static::lazy_static;
 use serde::Deserialize;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 type Noun = (String, String);
 
@@ -17,9 +16,7 @@ fn uncached_inner_new() -> Arc<IrregularNouns> {
         .unwrap_or_else(|e| panic!("Failed to load irregular noun table: {}", e))
 }
 
-lazy_static! {
-    static ref NOUNS: Arc<IrregularNouns> = uncached_inner_new();
-}
+static NOUNS: LazyLock<Arc<IrregularNouns>> = LazyLock::new(uncached_inner_new);
 
 impl IrregularNouns {
     pub fn new() -> Self {

--- a/harper-core/src/irregular_verbs.rs
+++ b/harper-core/src/irregular_verbs.rs
@@ -1,6 +1,5 @@
-use lazy_static::lazy_static;
 use serde::Deserialize;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 type Verb = (String, String, String);
 
@@ -17,9 +16,7 @@ fn uncached_inner_new() -> Arc<IrregularVerbs> {
         .unwrap_or_else(|e| panic!("Failed to load irregular verb table: {}", e))
 }
 
-lazy_static! {
-    static ref VERBS: Arc<IrregularVerbs> = uncached_inner_new();
-}
+static VERBS: LazyLock<Arc<IrregularVerbs>> = LazyLock::new(uncached_inner_new);
 
 impl IrregularVerbs {
     pub fn new() -> Self {

--- a/harper-core/src/linting/throw_rubbish.rs
+++ b/harper-core/src/linting/throw_rubbish.rs
@@ -1,19 +1,17 @@
+use std::sync::LazyLock;
+
 use super::{Lint, LintKind, Linter};
 use crate::{Document, Span, TokenStringExt, linting::Suggestion};
 use hashbrown::HashSet;
-use lazy_static::lazy_static;
 
-lazy_static! {
-    static ref THROW: HashSet<&'static str> =
-        HashSet::from(["throw", "throws", "threw", "thrown", "throwing"]);
-}
+static THROW: LazyLock<HashSet<&'static str>> =
+    LazyLock::new(|| HashSet::from(["throw", "throws", "threw", "thrown", "throwing"]));
 
-lazy_static! {
-    static ref JUNK: HashSet<&'static str> = HashSet::from(["rubbish", "trash", "garbage", "junk"]);
-}
+static JUNK: LazyLock<HashSet<&'static str>> =
+    LazyLock::new(|| HashSet::from(["rubbish", "trash", "garbage", "junk"]));
 
-lazy_static! {
-    static ref ADV_PREP: HashSet<&'static str> = HashSet::from([
+static ADV_PREP: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+    HashSet::from([
         // adverbs
         "away",
         "out",
@@ -23,9 +21,9 @@ lazy_static! {
         "in",
         "into",
         "at",
-        "on"
-    ]);
-}
+        "on",
+    ])
+});
 
 #[derive(Debug, Default)]
 pub struct ThrowRubbish;

--- a/harper-core/src/patterns/prepositional_preceder.rs
+++ b/harper-core/src/patterns/prepositional_preceder.rs
@@ -1,4 +1,4 @@
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 
 use super::{SingleTokenPattern, WordSet};
 use crate::Token;
@@ -50,10 +50,8 @@ impl SingleTokenPattern for PrepositionalPrecederPattern {
     }
 }
 
-lazy_static! {
-    static ref PREPOSITIONAL_PRECEDER_PATTERN: PrepositionalPrecederPattern =
-        PrepositionalPrecederPattern::default();
-}
+static PREPOSITIONAL_PRECEDER_PATTERN: LazyLock<PrepositionalPrecederPattern> =
+    LazyLock::new(PrepositionalPrecederPattern::default);
 
 /// Shared accessor for the lazily-initialized [`PrepositionalPrecederPattern`].
 pub fn prepositional_preceder() -> &'static PrepositionalPrecederPattern {

--- a/harper-core/src/spell/fst_dictionary.rs
+++ b/harper-core/src/spell/fst_dictionary.rs
@@ -1,9 +1,9 @@
 use super::{MutableDictionary, WordId};
 use fst::{IntoStreamer, Map as FstMap, Streamer, map::StreamWithState};
 use hashbrown::HashMap;
-use lazy_static::lazy_static;
 use levenshtein_automata::{DFA, LevenshteinAutomatonBuilder};
 use std::borrow::Cow;
+use std::sync::LazyLock;
 use std::{cell::RefCell, sync::Arc};
 
 use crate::{CharString, CharStringExt, DictWordMetadata};
@@ -27,9 +27,8 @@ pub struct FstDictionary {
 const EXPECTED_DISTANCE: u8 = 3;
 const TRANSPOSITION_COST_ONE: bool = true;
 
-lazy_static! {
-    static ref DICT: Arc<FstDictionary> = Arc::new((*MutableDictionary::curated()).clone().into());
-}
+static DICT: LazyLock<Arc<FstDictionary>> =
+    LazyLock::new(|| Arc::new((*MutableDictionary::curated()).clone().into()));
 
 thread_local! {
     // Builders are computationally expensive and do not depend on the word, so we store a

--- a/harper-core/src/spell/mutable_dictionary.rs
+++ b/harper-core/src/spell/mutable_dictionary.rs
@@ -5,9 +5,8 @@ use super::{
 };
 use crate::edit_distance::edit_distance_min_alloc;
 use itertools::Itertools;
-use lazy_static::lazy_static;
-use std::borrow::Cow;
 use std::sync::Arc;
+use std::{borrow::Cow, sync::LazyLock};
 
 use crate::{CharString, CharStringExt, DictWordMetadata};
 
@@ -39,9 +38,7 @@ fn uncached_inner_new() -> Arc<MutableDictionary> {
     .unwrap_or_else(|e| panic!("Failed to load curated dictionary: {}", e))
 }
 
-lazy_static! {
-    static ref DICT: Arc<MutableDictionary> = uncached_inner_new();
-}
+static DICT: LazyLock<Arc<MutableDictionary>> = LazyLock::new(uncached_inner_new);
 
 impl MutableDictionary {
     pub fn new() -> Self {

--- a/harper-core/src/spell/trie_dictionary.rs
+++ b/harper-core/src/spell/trie_dictionary.rs
@@ -1,6 +1,5 @@
-use lazy_static::lazy_static;
 use std::borrow::Cow;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use trie_rs::Trie;
 use trie_rs::iter::{Keys, PrefixIter, SearchIter};
@@ -16,10 +15,8 @@ pub struct TrieDictionary<D: Dictionary> {
     inner: D,
 }
 
-lazy_static! {
-    static ref DICT: Arc<TrieDictionary<Arc<FstDictionary>>> =
-        Arc::new(TrieDictionary::new(FstDictionary::curated()));
-}
+pub static DICT: LazyLock<Arc<TrieDictionary<Arc<FstDictionary>>>> =
+    LazyLock::new(|| Arc::new(TrieDictionary::new(FstDictionary::curated())));
 
 impl TrieDictionary<Arc<FstDictionary>> {
     /// Create a dictionary from the curated dictionary included

--- a/harper-core/src/title_case.rs
+++ b/harper-core/src/title_case.rs
@@ -1,10 +1,10 @@
 use std::borrow::Cow;
+use std::sync::LazyLock;
 
 use crate::Lrc;
 use crate::Token;
 use crate::TokenKind;
 use hashbrown::HashSet;
-use lazy_static::lazy_static;
 
 use crate::Punctuation;
 use crate::spell::Dictionary;
@@ -132,17 +132,18 @@ fn should_capitalize_token(tok: &Token, source: &[char]) -> bool {
     match &tok.kind {
         TokenKind::Word(Some(metadata)) => {
             // Only specific conjunctions are not capitalized.
-            lazy_static! {
-                static ref SPECIAL_CONJUNCTIONS: HashSet<Vec<char>> =
-                    ["and", "but", "for", "or", "nor", "as"]
-                        .iter()
-                        .map(|v| v.chars().collect())
-                        .collect();
-                static ref SPECIAL_ARTICLES: HashSet<Vec<char>> = ["a", "an", "the"]
+            static SPECIAL_CONJUNCTIONS: LazyLock<HashSet<Vec<char>>> = LazyLock::new(|| {
+                ["and", "but", "for", "or", "nor", "as"]
                     .iter()
                     .map(|v| v.chars().collect())
-                    .collect();
-            }
+                    .collect()
+            });
+            static SPECIAL_ARTICLES: LazyLock<HashSet<Vec<char>>> = LazyLock::new(|| {
+                ["a", "an", "the"]
+                    .iter()
+                    .map(|v| v.chars().collect())
+                    .collect()
+            });
 
             let chars = tok.span.get_content(source);
             let chars_lower = chars.to_lower();


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
Removes harper-core's dependency on `lazy_static` via replacement with `std::sync::LazyLock`.
<!-- Any details that you think are important to review this PR? -->
I ran the benchmarks with/without these changes, and there didn't appear to be any notable difference in performance.
<!-- Are there other PRs related to this one? -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
- `cargo test`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
