### PR TITLE
feat: `harper-cli` accept common dialect synonyms, abbreviations

### DIFF
--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -215,7 +215,8 @@ fn main() -> anyhow::Result<()> {
             user_dict_path,
             file_dict_path,
         } => {
-            let dialect = parse_dialect(&dialect_str).map_err(|e| anyhow!("Invalid dialect '{}': {}", dialect_str, e))?;
+            let dialect = parse_dialect(&dialect_str)
+                .map_err(|e| anyhow!("Invalid dialect '{}': {}", dialect_str, e))?;
 
             lint(
                 markdown_options,


### PR DESCRIPTION
# Issues 
N/A

# Description

When testing linters or dictionary changes that take dialect into account, this makes `harper-cli` less fussy about whether it should be `American` or `America` etc. ISO codes like `US`, `en-US`, etc are also accepted.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
