### PR TITLE
fix(chrome-ext): remove mention of Chrome Extension to avoid confusion for Firefox users

### DIFF
--- a/packages/chrome-plugin/src/options/Options.svelte
+++ b/packages/chrome-plugin/src/options/Options.svelte
@@ -211,7 +211,7 @@ function startHotkeyCapture(_modifyHotkeyButton: Button) {
       </div>
       <div class="flex flex-col">
         <h1 class="text-base tracking-wide font-serif">Harper</h1>
-        <p class="text-xs">Chrome Extension Settings</p>
+        <p class="text-xs">Settings</p>
       </div>
     </Card>
 

--- a/packages/web/src/routes/install-browser-extension/+page.svelte
+++ b/packages/web/src/routes/install-browser-extension/+page.svelte
@@ -63,7 +63,7 @@ let demoText =
         Harper will only enable itself automatically on sites we've tested before. 
         <br/>
         <br/>
-        If you work somewhere that isn't on our list of supported sites, you can enable the Chrome extension anyway by opening the Harper extension popup and clicking the power button.
+        If you work somewhere that isn't on our list of supported sites, you can enable the extension anyway by opening the Harper extension popup and clicking the power button.
         <br/>
         <br/>
         Alternatively, <Link href="/request-browser-support">let us know</Link> which sites you want us to support and we'll add it as soon as we can.


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

This  is mostly a cosmetic change. There were places where the UI mentioned a "Chrome Extension", even when viewed from the Firefox add-on.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Not necessary.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
