### PR TITLE
fix(chrome-ext): problems with incorrect dialect selection and reversion

### DIFF
--- a/packages/chrome-plugin/src/background/detectDialect.ts
+++ b/packages/chrome-plugin/src/background/detectDialect.ts
@@ -27,6 +27,8 @@ function localeToDialect(locale: string): Dialect {
 	if (lower.startsWith('en')) {
 		// New Zealand → Australian (closest match)
 		if (lower.includes('en-nz') || lower.includes('en_nz')) return Dialect.Australian;
+		// American
+		if (lower.includes('en-us') || lower.includes('en_us')) return Dialect.American;
 		// Other English variants → British as fallback
 		if (lower.match(/^en[-_]/)) return Dialect.British;
 		// Plain 'en' → American (default)

--- a/packages/chrome-plugin/src/background/index.ts
+++ b/packages/chrome-plugin/src/background/index.ts
@@ -407,7 +407,7 @@ async function getIgnoredLints(): Promise<string> {
 }
 
 async function getDialect(): Promise<Dialect> {
-	const resp = await chrome.storage.local.get({ dialect: undefined });
+	const resp = await chrome.storage.local.get('dialect');
 
 	// If user hasn't set a dialect, try to detect from browser language
 	if (resp.dialect === undefined) {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

While testing version `1.5.0` of the Chrome extension, I observed two issues related to dialect management. I believe both were introduced in #2485.

The biggest issue was that the Chrome extension would not properly persist the dialect. If a user changed their dialect, it would be saved, then immediately overwritten by the default path `getDialect` function.
The second issue, which exacerbated the first, was that the browser would incorrectly infer the dialect from the locale. My browser had the `en-US` locale, which would be mapped to British English.

I've gone ahead and tweaked the logic to fix both problems. I've confirmed that the fix works with manual testing.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
