### PR TITLE
build: `panic = abort` and `lto = fat` for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ opt-level = 3
 
 [profile.release]
 opt-level = 3
+panic = "abort"
+lto = "fat"
 # Stripping binaries triggers a bug in `wasm-opt`.
 # Disable it for now.
 # strip = true


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
Related to #1945

# Description
<!-- Please include a summary of the change. -->
Reduces binary size of harper-ls by about ~7MiB. Both `panic = "abort"` and `lto = "fat"` contribute to approximately half of this reduction.
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->
Some rudimentary test results I gathered from experimentation:
| Config                      | Size of harper-ls (MiB) |
| ---------------             | ---------------         |
| Current                     | 60.56                   |
| `panic = "abort"`           | 57.67                   |
| `panic = "abort"` + ThinLTO | 57.46                   |
| `panic = "abort"` + FatLTO  | 53.53                   |


`cargo bench --bench parse_essay` also shows a ~4.4-11.5% performance improvement across the board.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
- `cargo test`
- `cargo bench`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
