### PR TITLE
fix: `rm` old vscode versions after `just test-vscode`

### DIFF
--- a/justfile
+++ b/justfile
@@ -205,6 +205,7 @@ test-vscode:
     pnpm test
   fi
 
+  # Over time, VSCode test versions take up space that can be hard to track down
   if [[ -d .vscode-test ]]; then
     all_versions=$(ls -1 .vscode-test | grep "^vscode-" | sort -V)
     latest_version=$(echo "$all_versions" | tail -n 1)


### PR DESCRIPTION
# Issues 
Resolves #2573

# Description

Using an agent to find out why my SSD is always full, I found one of the culprits was copies of VS Code used for testing Harper over the last year.

I used the same agent to come up with this fix. I've tested it and will test it some more but as with all AI stuff please give it a solid looking over. Shell scripting is outside my wheelhouse but this version works on vanilla macOS without homebrew extras, so should work on any random Linux box.

# Demo
```
✓ Deleted        2 old VSCode versions, keeping vscode-darwin-arm64-1.108.2
```
vs
```
✓ No old versions to clean (keeping vscode-darwin-arm64-1.108.2)
```

# How Has This Been Tested?

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
