### PR TITLE
fix: confusing wording in `OneOfTheSingular`

### DIFF
--- a/harper-core/src/linting/one_of_the_singular.rs
+++ b/harper-core/src/linting/one_of_the_singular.rs
@@ -141,7 +141,7 @@ impl<D: Dictionary + 'static> ExprLinter for OneOfTheSingular<D> {
             span: nounspan,
             lint_kind: LintKind::Usage,
             suggestions,
-            message: "The construction `one of the ...` uses a singular noun.".to_string(),
+            message: "The construction `one of the ...` should use a plural noun.".to_string(),
             ..Default::default()
         })
     }


### PR DESCRIPTION
The construction one of the ... uses a singular noun. → ... should use a plural noun.

<img width="753" height="259" alt="image" src="https://github.com/user-attachments/assets/bbe7046a-9c10-4333-87d2-d19105c91786" />

The people who write this mistake probably think they're writing correct English which would lead them to wonder why the popup is telling them what they wrote.

I'm not sure whether I thought the original wording made sense or whether it was a brainfart. But I just hit it in my regular dogfooding with Harper Glasses and saw it gives the wrong impression.

Should be clearer now.