### PR TITLE
feat: as of currently→ currently / as of now

### DIFF
--- a/harper-core/src/linting/weir_rules/AsOfCurrently.weir
+++ b/harper-core/src/linting/weir_rules/AsOfCurrently.weir
@@ -1,0 +1,9 @@
+expr main (as of currently)
+
+let message "Standard equivalents are `currently` or `as of now`."
+let description "Corrects `as of currently` to `currently` or `as of now`."
+let kind "WordChoice"
+let becomes ["currently", "as of now"]
+
+test "Note that, as of currently, selecting a method on the list leaves it highlighted as such, until the script is changed." "Note that, currently, selecting a method on the list leaves it highlighted as such, until the script is changed."
+test "As of currently, Cervo offers a set of inferers, noise generators (for continuous-action/parametrized policies), and a unified asset format." "As of now, Cervo offers a set of inferers, noise generators (for continuous-action/parametrized policies), and a unified asset format."

--- a/harper-core/src/linting/weir_rules/AsOfLate.weir
+++ b/harper-core/src/linting/weir_rules/AsOfLate.weir
@@ -1,8 +1,0 @@
-expr main (as of lately)
-
-let message "The standard form is `as of late`."
-let description "Corrects `as of lately` to `as of late`."
-let kind "WordChoice"
-let becomes "as of late"
-
-test "I haven't noticed any crashing with AMDGPU as of lately, so this looks to not be an issue anymore." "I haven't noticed any crashing with AMDGPU as of late, so this looks to not be an issue anymore."

--- a/harper-core/src/linting/weir_rules/AsOfLately.weir
+++ b/harper-core/src/linting/weir_rules/AsOfLately.weir
@@ -1,0 +1,9 @@
+expr main (as of lately)
+
+let message "Standard equivalents are `lately` or `as of late`."
+let description "Corrects `as of lately` to `lately` or `as of late`."
+let kind "WordChoice"
+let becomes ["lately", "as of late"]
+
+test "I haven't noticed any crashing with AMDGPU as of lately, so this looks to not be an issue anymore." "I haven't noticed any crashing with AMDGPU as of late, so this looks to not be an issue anymore."
+test "As of lately, I've been more active on Gitlab." "As of late, I've been more active on Gitlab."


### PR DESCRIPTION
# Issues 
N/A

# Description

- Corrects "as of currently" to "currently" and "as of now".
- Also renamed `AsOfLate` to `AsOfLately` since it now maps one bad form to two correct forms: "lately" and "as of late".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Unit tests using sentences from GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
