### PR TITLE
docs(chrome-ext): notify users that Harper will clash with Gmail's grammar checker

### DIFF
--- a/packages/web/src/routes/+page.svelte
+++ b/packages/web/src/routes/+page.svelte
@@ -407,6 +407,11 @@ const testimonials = [
 					<Link class="text-blue-600 dark:text-blue-400" href="https://github.com/Automattic/harper/discussions">GitHub</Link>.
 				</p>
 			</Collapsible>
+			<Collapsible title="Why Isn't Harper Working in Gmail?">
+				<p>
+          Harper will not run in Gmail unless the built-in grammar checker is disabled. If you wish to use Harper in Gmail, please <Link class="text-blue-600 dark:text-blue-400" href="https://support.google.com/mail/answer/7987?hl=en">disable the built-in grammar checker.</Link>
+				</p>
+			</Collapsible>
 		</div>
 	</Section>
 


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

N/A

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

I've added a section to the FAQ that notifies users that the Chrome extension is incompatible with Gmail's grammar checker. In order to use Harper, it must be disabled.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

N/A

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
