### PR TITLE
fix(obsidian-plugin): allow initialization to complete asynchronously

### DIFF
--- a/packages/obsidian-plugin/src/index.ts
+++ b/packages/obsidian-plugin/src/index.ts
@@ -26,7 +26,7 @@ export default class HarperPlugin extends Plugin {
 		}
 
 		const data = await this.loadData();
-		await this.state.initializeFromSettings(data);
+		this.state.initializeFromSettings(data);
 		this.registerEditorExtension(this.state.getCMEditorExtensions());
 		this.setupCommands();
 		this.setupStatusBar();


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #2601

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

As it turns out, most of the work that was being done in `onload` could be deferred. Instead of waiting for the internal state of the plugin to be initialized at startup, we simply kick off the task and let it complete at its own pace. 

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
