### PR TITLE
feat: no only is there → not only is there

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -533,6 +533,17 @@ pub fn lint_group() -> LintGroup {
             "Suggests using `nervous wreck` when referring to a person's emotional state.",
             LintKind::Eggcorn
         ),
+        "NotOnly" => (
+            &[
+                (&["no only are"], &["not only are"]),
+                (&["no only is"], &["not only is"]),
+                (&["no only was"], &["not only was"]),
+                (&["no only were"], &["not only were"]),
+            ],
+            "Use `not only` instead of `no only` in this expression.",
+            "Corrects `no only` to `not only` before forms of `to be`.",
+            LintKind::Grammar
+        ),
         "RiseTheQuestion" => (
             &[
                 (&["rise the question", "arise the question"], &["raise the question"]),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -1657,6 +1657,48 @@ fn dont_correct_so_much_nerve_wreck() {
     );
 }
 
+// NotOnly
+
+// -not only are-
+#[test]
+fn fix_no_only_are() {
+    assert_suggestion_result(
+        "No only are tests run on my pipeline but once successful, my app is deployed differently",
+        lint_group(),
+        "Not only are tests run on my pipeline but once successful, my app is deployed differently",
+    );
+}
+
+// -not only is-
+#[test]
+fn fix_no_only_is() {
+    assert_suggestion_result(
+        "No only is it simple, it's efficient!",
+        lint_group(),
+        "Not only is it simple, it's efficient!",
+    );
+}
+
+// -not only was-
+#[test]
+fn fix_no_only_was() {
+    assert_suggestion_result(
+        "No only was he happily creating shapes, but he was actively using distances and angles to do so.",
+        lint_group(),
+        "Not only was he happily creating shapes, but he was actively using distances and angles to do so.",
+    );
+}
+
+// -not only were-
+#[test]
+fn fix_no_only_were() {
+    assert_suggestion_result(
+        "No only were there UI inconsistencies, but Safari lags behind chrome with things like the Popover API",
+        lint_group(),
+        "Not only were there UI inconsistencies, but Safari lags behind chrome with things like the Popover API",
+    );
+}
+
 // RaiseTheQuestion
 
 // -raise the question-


### PR DESCRIPTION
# Issues 
N/A

# Description

This one only occurs a dozen or fewer times on GitHub but it's more common on the rest of the web.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Found sentences using "am", "is", "was", and "were", mostly on GitHub, to make unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
