### PR TITLE
fix(obsidian-plugin): postpone initialization until layout is ready

### DIFF
--- a/packages/obsidian-plugin/src/HarperSettingTab.ts
+++ b/packages/obsidian-plugin/src/HarperSettingTab.ts
@@ -11,7 +11,6 @@ import { linesToString, stringToLines } from './textUtils';
 const LintSettingId = 'HarperLintSettings';
 
 export class HarperSettingTab extends PluginSettingTab {
-	private state: State;
 	private settings: Settings;
 	private descriptionsHTML: Record<string, string>;
 	private defaultLintConfig: Record<string, boolean>;
@@ -19,12 +18,13 @@ export class HarperSettingTab extends PluginSettingTab {
 	private plugin: HarperPlugin;
 	private toggleAllButton?: ButtonComponent;
 
-	constructor(app: App, plugin: HarperPlugin, state: State) {
-		super(app, plugin);
-		this.state = state;
-		this.plugin = plugin;
+	private get state() {
+		return this.plugin.state;
+	}
 
-		this.update();
+	constructor(app: App, plugin: HarperPlugin) {
+		super(app, plugin);
+		this.plugin = plugin;
 	}
 
 	update() {
@@ -54,10 +54,9 @@ export class HarperSettingTab extends PluginSettingTab {
 	}
 
 	display(update = true) {
-
 		if (update) {
-		    this.update();
-		    this.display(false);
+			this.update();
+			this.display(false);
 		}
 
 		const { containerEl } = this;

--- a/packages/obsidian-plugin/src/index.ts
+++ b/packages/obsidian-plugin/src/index.ts
@@ -6,9 +6,10 @@ import { HarperSettingTab } from './HarperSettingTab';
 import State from './State';
 
 export default class HarperPlugin extends Plugin {
-	private state: State;
+	state: State;
 	private dialectSpan: HTMLSpanElement | null = null;
 	private logo: HTMLSpanElement | null = null;
+	private settings: HarperSettingTab | null = null;
 
 	constructor(app: App, manifest: PluginManifest) {
 		super(app, manifest);
@@ -23,22 +24,26 @@ export default class HarperPlugin extends Plugin {
 		const data = await this.loadData();
 
 		this.app.workspace.onLayoutReady(async () => {
-                    this.state = new State(
-                        (n) => this.saveData(n),
-                        () => this.app.workspace.updateOptions(),
-                        editorInfoField,
-                    );
+			this.state = new State(
+				(n) => this.saveData(n),
+				() => this.app.workspace.updateOptions(),
+				editorInfoField,
+			);
 
-                    await this.state.initializeFromSettings(data);
-                    this.registerEditorExtension(this.state.getCMEditorExtensions());
-                    this.setupCommands();
-                    this.setupStatusBar();
-                    if (!(data?.lintEnabled ?? true)) {
-                        this.state.disableEditorLinter();
-                    } else this.state.enableEditorLinter();
+			await this.state.initializeFromSettings(data);
+			this.registerEditorExtension(this.state.getCMEditorExtensions());
+			if (!(data?.lintEnabled ?? true)) {
+				this.state.disableEditorLinter(false);
+			} else this.state.enableEditorLinter(false);
+			this.settings?.update();
 
-		    this.addSettingTab(new HarperSettingTab(this.app, this, this.state));
-                });
+			this.setupStatusBar();
+		});
+
+		this.settings = new HarperSettingTab(this.app, this);
+		this.addSettingTab(this.settings);
+
+		this.setupCommands();
 	}
 
 	private getDialectStatus(dialectNum: Dialect): string {


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
#2416
#2601
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

The whole initialization is postponed until the layout is ready. This allows the user to see their files start editing them while harper is still loading.

In addition, I saw that the settings pane continuously reloads the current config every second. I don't think this is necessary as the settings pane is not opened often and reloading it every seconds seems a bit strange. Instead it refreshes the view now on open.

I also added false as argument to `enableEditorLinter` to prevent it to flicker at start. It is not necessary to reinit at that point, because it simply calls `initializeFromSettings` which is already done before.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
manually

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
