### PR TITLE
fix(chrome-ext): improve test reliability

### DIFF
--- a/packages/chrome-plugin/tests/slate.spec.ts
+++ b/packages/chrome-plugin/tests/slate.spec.ts
@@ -27,10 +27,10 @@ test('Can apply basic suggestion.', async ({ page }) => {
 
 	// Verify editor state is preserved: arrow keys and backspace must work.
 	// Position cursor before 's' in 'test', then backspace to delete 'e'.
-	await slate.press('End');
-	await slate.press('ArrowLeft');
-	await slate.press('ArrowLeft');
-	await slate.press('Backspace');
+	await page.press('body', 'End');
+	await page.press('body', 'ArrowLeft');
+	await page.press('body', 'ArrowLeft');
+	await page.press('body', 'Backspace');
 	await expect(slate).toContainText('This is a tst');
 
 	// Verify typing still works.

--- a/packages/chrome-plugin/tests/testUtils.ts
+++ b/packages/chrome-plugin/tests/testUtils.ts
@@ -246,7 +246,7 @@ export async function testMultipleSuggestionsAndUndo(
 
 export async function assertHarperHighlightBoxes(page: Page, boxes: Box[]): Promise<void> {
 	const highlights = getHarperHighlights(page);
-	expect(await highlights.count()).toBe(boxes.length);
+	await expect(highlights).toHaveCount(boxes.length);
 
 	for (let i = 0; i < (await highlights.count()); i++) {
 		const box = await highlights.nth(i).boundingBox();


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

I've noticied that we've been seeing some increased flakiness in the Chrome extension tests, and it's been blocking me from merging some pull requests.

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

In the Slate editor tests, we were unintentionally relying on Slate to maintain focus during a specific operation. I've addressed this by passing the relevant key events to the page, rather than just the Slate editor.
In the simple textarea tests, we weren't waiting long enough for the Harper engine to start. I've set it up to wait longer.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
