### PR TITLE
feat(core): improve debug formatting for `Suggestion`

### DIFF
--- a/harper-core/src/linting/suggestion.rs
+++ b/harper-core/src/linting/suggestion.rs
@@ -86,6 +86,9 @@ impl Display for Suggestion {
     }
 }
 
+// To make debug output more readable.
+// The default debug implementation for Vec<char> isn't ideal in this scenario, as it prints
+// characters one at a time, line by line.
 impl Debug for Suggestion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         <Self as Display>::fmt(self, f)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
Uses the `Display` implementation of `Suggestion` as its `Debug` implementation. This causes the suggestion strings to be rendered as words rather than multi-line character arrays, improving readability and making more efficient use of screenspace.
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

# Demo
### Old
<img width="728" height="805" alt="image" src="https://github.com/user-attachments/assets/bac1f039-796e-4abc-a7ea-0463a3dfba0c" />

### New
<img width="672" height="324" alt="image" src="https://github.com/user-attachments/assets/72a24e43-28f0-4ad8-83b3-bf41e5e5925c" />

# How Has This Been Tested?
- `cargo test`
- Manually

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
