### PR TITLE
feat: peak behind the curtain→peek behind the curtain

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -365,6 +365,17 @@ pub fn lint_group() -> LintGroup {
             "Corrects `passerbys` and `passer-bys` to `passersby` or `passers-by`.",
             LintKind::Grammar
         ),
+        "PeeekBehindTheCurtain" => (
+            &[
+                ("peak behind the curtain", "peek behind the curtain"),
+                ("peaked behind the curtain", "peeked behind the curtain"),
+                ("peaking behind the curtain", "peeking behind the curtain"),
+                ("peaks behind the curtain", "peeks behind the curtain"),
+            ],
+            "The correct idiom is `peek behind the curtain`.",
+            "Corrects `peak behind the curtain` to `peek behind the curtain`.",
+            LintKind::Eggcorn
+        ),
         "Piggyback" => (
             &[
                 ("piggy bag", "piggyback"),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -1005,6 +1005,44 @@ fn correct_passer_bys_hyphen() {
     );
 }
 
+// PeekBehindTheCurtain
+
+#[test]
+fn fix_peak() {
+    assert_suggestion_result(
+        "Offer a peak behind the curtain of what I look for when baselining a software installation.",
+        lint_group(),
+        "Offer a peek behind the curtain of what I look for when baselining a software installation.",
+    );
+}
+
+#[test]
+fn fix_peaked() {
+    assert_suggestion_result(
+        "I peaked behind the curtain of the new Autodraw tool and noticed some expected similarities to what I saw in Quickdraw.",
+        lint_group(),
+        "I peeked behind the curtain of the new Autodraw tool and noticed some expected similarities to what I saw in Quickdraw.",
+    );
+}
+
+#[test]
+fn fix_peaking() {
+    assert_suggestion_result(
+        "I can see how peaking behind the curtain got me to where I am today.",
+        lint_group(),
+        "I can see how peeking behind the curtain got me to where I am today.",
+    );
+}
+
+#[test]
+fn fix_peaks() {
+    assert_suggestion_result(
+        "The Daily Vlog Series that peaks behind the curtain of an Entrepreneur's day to day life in 2016 building a business.",
+        lint_group(),
+        "The Daily Vlog Series that peeks behind the curtain of an Entrepreneur's day to day life in 2016 building a business.",
+    );
+}
+
 // Piggyback
 // -none-
 


### PR DESCRIPTION
# Issues 
N/A

# Description

Peak behind the curtain 👉 peek behind the curtain

Just saw this mistake somewhere on the internet, verified that it's common, and whipped up a quick linter via `phrase_set_corrections`. All four inflections of "peak"/"peek".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Three unit tests using sentences found on GitHub plus one found on Reddit.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
