### PR TITLE
docs: add Tally to section for projects using Harper

### DIFF
--- a/packages/web/src/routes/docs/about/+page.md
+++ b/packages/web/src/routes/docs/about/+page.md
@@ -48,6 +48,7 @@ Some of the open-source projects using Harper include:
 - [walletbeat](https://github.com/walletbeat/walletbeat)
 - [Stencila](https://github.com/stencila/stencila)
 - [fixmyspelling](https://github.com/samedwardes/fixmyspelling)
+- [Tally](https://tally.johng.io)
 
 Are you using Harper in your open source work and want to be included in this list?
 If so, please open a PR. 


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

N/A

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

I've recently implemented grammar checking, powered by Harper, to one of my projects. This PR adds [Tally](https://tally.johng.io) to the list of projects using Harper in the documentation. Tally is a free, open-source online tool to count the number of characters, words, paragraphs, and lines in your text.

Homepage: https://tally.johng.io
Source: https://github.com/twocaretcat/Tally

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

<img width="1200" height="675" alt="twitter" src="https://github.com/user-attachments/assets/2af3f881-da27-4fce-9cc1-ba1dbcb1c7f0" />

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

N/A

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
