### PR TITLE
build(test): improve test build time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ members = ["harper-cli", "harper-core", "harper-ls", "harper-comments", "harper-
 resolver = "2"
 
 [profile.test]
+opt-level = 1
+
+[profile.test.package."*"]
 opt-level = 3
 
 [profile.release]


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
Builds tests faster by reducing their opt-level from 3 to 1. Retains opt-level 3 for test dependencies, since those don't need to be rebuilt very often.

On my machine, running `cargo test` after changing a single character inside a harper-core source file takes ~135s without these changes. With these changes, it takes ~57s.
<!-- Any details that you think are important to review this PR? -->

<!-- Are there other PRs related to this one? -->


# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
- Timing the amount of time it takes to complete `cargo test` after changing a single character (inside a comment) inside a harper-core source file.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
