### PR TITLE
fix: don't lowercase "This"

### DIFF
--- a/harper-core/src/linting/use_title_case.rs
+++ b/harper-core/src/linting/use_title_case.rs
@@ -44,7 +44,7 @@ impl<D: Dictionary + 'static> Linter for UseTitleCase<D> {
 
 #[cfg(test)]
 mod tests {
-    use crate::linting::tests::assert_suggestion_result;
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
     use crate::spell::FstDictionary;
 
     use super::UseTitleCase;
@@ -64,6 +64,23 @@ mod tests {
             "# This is a title\n\n## This is a subtitle",
             UseTitleCase::new(FstDictionary::curated()),
             "# This Is a Title\n\n## This Is a Subtitle",
+        );
+    }
+
+    #[test]
+    fn doesnt_lowercase_this_in_github_template_title() {
+        assert_no_lints(
+            "# How Has This Been Tested?",
+            UseTitleCase::new(FstDictionary::curated()),
+        );
+    }
+
+    #[test]
+    fn shoud_uppercase_possessive_determiners() {
+        assert_suggestion_result(
+            "# my/our/your/his/her/its/their",
+            UseTitleCase::new(FstDictionary::curated()),
+            "# My/Our/Your/His/Her/Its/Their",
         );
     }
 }

--- a/harper-core/src/title_case.rs
+++ b/harper-core/src/title_case.rs
@@ -157,7 +157,6 @@ fn should_capitalize_token(tok: &Token, source: &[char]) -> bool {
             }
 
             !is_short_preposition
-                && !metadata.is_non_possessive_determiner()
                 && !SPECIAL_CONJUNCTIONS.contains(chars_lower.as_ref())
                 && !SPECIAL_ARTICLES.contains(chars_lower.as_ref())
         }
@@ -518,6 +517,18 @@ mod tests {
                 &FstDictionary::curated()
             ),
             "Alice’s Adventures in Wonderland",
+        );
+    }
+
+    #[test]
+    fn doesnt_lowercase_this_in_github_template_title() {
+        assert_eq!(
+            make_title_case_str(
+                "# How Has This Been Tested?",
+                &PlainEnglish,
+                &FstDictionary::curated()
+            ),
+            "# How Has This Been Tested?",
         );
     }
 }

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -985,15 +985,6 @@ Suggest:
 
 
 
-Lint:    Capitalization (127 priority)
-Message: |
-     558 | ## CHAPTER IV: The Rabbit Sends in a Little Bill
-         | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Try to use title case in headings.
-Suggest:
-  - Replace with: “## CHAPTER IV: The Rabbit Sends in a little Bill”
-
-
-
 Lint:    Readability (127 priority)
 Message: |
      564 | wonder?” Alice guessed in a moment that it was looking for the fan and the pair


### PR DESCRIPTION
# Issues 

Fixes #2459

# Description

The code has some special logic that was confusing due to using a double negative, around handling non-possessive determiners (my, our, your, his, her, its, their).

I just removed that check and nothing broke.

I did want to disable this linter by default but doing so causes `harper-core/tests/test_sources/title_case_errors.md` to fail. I think `harper-core/tests/run_tests.rs` assumes tested linters are enabled by default and a way to test linters that default off is lacking?

If I'm missing something please let me know!

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I added some new unit tests based on the GitHub template heading from the bug report and using all of the possessive determiners.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
