### PR TITLE
refactor: use `Span::empty` to create empty spans

### DIFF
--- a/harper-comments/src/comment_parsers/lua.rs
+++ b/harper-comments/src/comment_parsers/lua.rs
@@ -29,7 +29,7 @@ impl Parser for Lua {
         for line in source.split(|c| *c == '\n') {
             if starts_with_prefix(line) {
                 tokens.push(Token::new(
-                    Span::new_with_len(chars_traversed, 0),
+                    Span::empty(chars_traversed),
                     harper_core::TokenKind::Newline(2),
                 ));
                 chars_traversed += line.len() + 1;

--- a/harper-core/src/expr/optional.rs
+++ b/harper-core/src/expr/optional.rs
@@ -22,7 +22,7 @@ impl Expr for Optional {
         let res = self.inner.run(cursor, tokens, source);
 
         if res.is_none() {
-            Some(Span::new_with_len(cursor, 0))
+            Some(Span::empty(cursor))
         } else {
             res
         }

--- a/harper-core/src/expr/repeating.rs
+++ b/harper-core/src/expr/repeating.rs
@@ -20,7 +20,7 @@ impl Repeating {
 
 impl Expr for Repeating {
     fn run(&self, mut cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span<Token>> {
-        let mut window = Span::new_with_len(cursor, 0);
+        let mut window = Span::empty(cursor);
         let mut repetition = 0;
 
         loop {

--- a/harper-core/src/expr/sequence_expr.rs
+++ b/harper-core/src/expr/sequence_expr.rs
@@ -53,7 +53,7 @@ impl Expr for SequenceExpr {
     ///
     /// If any step returns `None`, the entire expression does as well.
     fn run(&self, mut cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span<Token>> {
-        let mut window = Span::new_with_len(cursor, 0);
+        let mut window = Span::empty(cursor);
 
         for cur_expr in &self.exprs {
             let out = cur_expr.run(cursor, tokens, source)?;

--- a/harper-core/src/parsers/markdown.rs
+++ b/harper-core/src/parsers/markdown.rs
@@ -199,7 +199,7 @@ impl Parser for Markdown {
                 }
                 pulldown_cmark::Event::Start(pulldown_cmark::Tag::List(v)) => {
                     tokens.push(Token {
-                        span: Span::new_with_len(span_start, 0),
+                        span: Span::empty(span_start),
                         kind: TokenKind::Newline(2),
                     });
                     stack.push(pulldown_cmark::Tag::List(v));
@@ -207,7 +207,7 @@ impl Parser for Markdown {
                 pulldown_cmark::Event::Start(tag) => {
                     if matches!(tag, pulldown_cmark::Tag::Heading { .. }) {
                         tokens.push(Token {
-                            span: Span::new_with_len(span_start, 0),
+                            span: Span::empty(span_start),
                             kind: TokenKind::HeadingStart,
                         });
                     }
@@ -225,7 +225,7 @@ impl Parser for Markdown {
                         // position of the previous token's last character. This ensures the
                         // paragraph break is placed at the end of the content, not its beginning.
                         // For more info, see: https://github.com/Automattic/harper/pull/1239.
-                        span: Span::new_with_len(tokens.last().map_or(0, |last| last.span.end), 0),
+                        span: Span::empty(tokens.last().map_or(0, |last| last.span.end)),
                         kind: TokenKind::ParagraphBreak,
                     });
                     stack.pop();

--- a/harper-core/src/parsers/oops_all_headings.rs
+++ b/harper-core/src/parsers/oops_all_headings.rs
@@ -30,7 +30,7 @@ impl<P: Parser + 'static> Parser for OopsAllHeadings<P> {
                 && iter.peek().is_some_and(|t| !t.kind.is_heading_start())
             {
                 Some(Token {
-                    span: Span::new_with_len(tok.span.end, 0),
+                    span: Span::empty(tok.span.end),
                     kind: TokenKind::HeadingStart,
                 })
             } else {

--- a/harper-core/src/parsers/org_mode.rs
+++ b/harper-core/src/parsers/org_mode.rs
@@ -179,7 +179,7 @@ impl Parser for OrgMode {
 
                 // Add paragraph break after header
                 tokens.push(Token {
-                    span: Span::new_with_len(line_end.saturating_sub(1), 0),
+                    span: Span::empty(line_end.saturating_sub(1)),
                     kind: TokenKind::ParagraphBreak,
                 });
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
Replaces instances of `Span::new_with_len(..., 0)` with `Span::empty(...)`.
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
- `cargo test`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
