### PR TITLE
feat: atall→at all

### DIFF
--- a/harper-core/src/linting/split_words.rs
+++ b/harper-core/src/linting/split_words.rs
@@ -164,13 +164,4 @@ mod tests {
     fn ignores_prefix_without_valid_remainder() {
         assert_no_lints("The monkeyxyz escaped unnoticed.", SplitWords::default());
     }
-
-    #[test]
-    fn test_atall_to_at_all() {
-        assert_suggestion_result(
-            "don't seem to support symbolic links atall.",
-            SplitWords::default(),
-            "don't seem to support symbolic links at all.",
-        );
-    }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

I saw "at all" written as a single word in GitHub thread and used Harper Glasses to make sure the `SplitWords` linter catches it.
It turns out the `SplitWords` linter doesn't currently catch anything. And when I test it in isolation it only suggest "a tall" and not "at all".

It turns out to be a very common error so I've added it to the `OpenCompounds` linter.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Picked a recent example from GitHub to use as a unit test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
