### PR TITLE
feat: thru→through

### DIFF
--- a/harper-core/src/linting/weir_rules/ExpandThrough.weir
+++ b/harper-core/src/linting/weir_rules/ExpandThrough.weir
@@ -1,0 +1,8 @@
+expr main (thru)
+
+let message "Use `thru` instead of `through`"
+let description "Expands the informal spelling `thru` to the standard word `through`."
+let kind "Style"
+let becomes "through"
+
+test "Switch with coloned value parsed differently when invoking with pass thru args" "Switch with coloned value parsed differently when invoking with pass through args"


### PR DESCRIPTION
# Issues 
N/A

# Description

I noticed that the spelling "thru", mostly used in advertising but probably also texting, doesn't get flagged at all.
I've added a Weir rule to change it to "through".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I added a sentence from GitHub as a unit test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
