### PR TITLE
build(thesaurus): reduce compression level for debug builds

### DIFF
--- a/harper-thesaurus/build.rs
+++ b/harper-thesaurus/build.rs
@@ -17,6 +17,12 @@ fn main() {
     let reader = BufReader::new(in_file);
     let writer = BufWriter::new(out_file);
 
-    zstd::stream::copy_encode(reader, writer, zstd::zstd_safe::max_c_level())
+    // Use a lesser compression level to speed up debug builds.
+    let compression_level = match env::var("OPT_LEVEL").unwrap().as_str() {
+        "3" | "2" | "s" | "z" => zstd::zstd_safe::max_c_level(), // 3.84 MiB
+        _ => 4,                                                  // 7.02 MiB
+    };
+
+    zstd::stream::copy_encode(reader, writer, compression_level)
         .expect("Able to write compressed thesaurus");
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
Reduces thesaurus compression level for less optimized builds.
<!-- Any details that you think are important to review this PR? -->
I noticed the build time issue when I was experimenting with adding/adjusting Clippy flags in `harper-core/Cargo.toml`. Every time a Clippy option was changed and `cargo clippy` ran, the thesaurus would be recompressed using the maximum compression level.

This might also reduce the amount of time rust-analyzer takes to start/refresh in some cases, since (afaict) it will also run build scripts by default.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
- Building a release build of harper-ls, ensuring that the size of the binary has not increased.


# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
