### PR TITLE
feat(chrome-ext): move the review request to 14 days after installation

### DIFF
--- a/packages/chrome-plugin/src/popup/Main.svelte
+++ b/packages/chrome-plugin/src/popup/Main.svelte
@@ -120,7 +120,7 @@ function daysSince(date: Date): number {
     </section>
   </section>
   
-  {#if !isFirefox && installDate != null && daysSince(installDate) > 7 && hasBeenReviewed === false}
+  {#if !isFirefox && installDate != null && daysSince(installDate) > 14 && hasBeenReviewed === false}
     <section class="bg-primary flex flex-row justify-between p-4">
       <div class="font-bold">
         It looks like you're enjoying Harper.<br>

--- a/packages/chrome-plugin/tests/review_banner.spec.ts
+++ b/packages/chrome-plugin/tests/review_banner.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from './fixtures';
 test.describe('review banner', () => {
 	test.skip(({ browserName }) => browserName === 'firefox', 'Review prompt disabled in Firefox');
 
-	test('review request hidden before 7 days', async ({ context, page }) => {
+	test('review request hidden before 14 days', async ({ context, page }) => {
 		const background = context.serviceWorkers()[0] ?? (await context.waitForEvent('serviceworker'));
 		const extensionId = background.url().split('/')[2];
 
@@ -16,7 +16,7 @@ test.describe('review banner', () => {
 		await expect(page.getByText('Would you mind giving us a review?')).toHaveCount(0);
 	});
 
-	test('review request shown after 7 days', async ({ context, page }) => {
+	test('review request shown after 14 days', async ({ context, page }) => {
 		const background = context.serviceWorkers()[0] ?? (await context.waitForEvent('serviceworker'));
 		const extensionId = background.url().split('/')[2];
 
@@ -25,7 +25,7 @@ test.describe('review banner', () => {
 
 		// 8 days
 		await page.clock.install();
-		await page.clock.fastForward(8 * 1000 * 60 * 60 * 24);
+		await page.clock.fastForward(15 * 1000 * 60 * 60 * 24);
 
 		await page.getByText("Let's start writing").click();
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

The Chrome extension currently requests that a user give us a review after 7 days of having the extension installed. I've adjusted that timeline to be 14 days. I think they'll get a better idea of what we offer after a longer period.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

N/A

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
