### PR TITLE
fix(core): the `NoLonger` lint will now also flag preceding an adjective

### DIFF
--- a/harper-core/src/linting/no_longer.rs
+++ b/harper-core/src/linting/no_longer.rs
@@ -154,11 +154,29 @@ mod tests {
     }
 
     #[test]
+    fn fix_able_adjective() {
+        assert_suggestion_result(
+            "After the migration, we were not longer able to sign in.",
+            NoLonger::default(),
+            "After the migration, we were no longer able to sign in.",
+        );
+    }
+
+    #[test]
     fn fix_possible_adjective() {
         assert_suggestion_result(
             "That workaround is not longer possible after the upgrade.",
             NoLonger::default(),
             "That workaround is no longer possible after the upgrade.",
+        );
+    }
+
+    #[test]
+    fn fix_responsive_adjective() {
+        assert_suggestion_result(
+            "The service is not longer responsive under heavy load.",
+            NoLonger::default(),
+            "The service is no longer responsive under heavy load.",
         );
     }
 }


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #2696

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

I've added an adjective match to the expression and added some new tests. See original issue for more details.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Additional unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
