### PR TITLE
fix(chrome-ext): tips should refer to "Dismiss" button, not an "Ignore" button

### DIFF
--- a/packages/lint-framework/src/assets/hints.json
+++ b/packages/lint-framework/src/assets/hints.json
@@ -7,7 +7,7 @@
 	"You can easily write em-dashes by typing out three hyphens in a row.",
 	"You can easily write en-dashes by typing out two hyphens in a row.",
 	"Harper can be configured to open with a hotkey. Check the extension's settings.",
-	"Don't agree with a suggestion? Click 'Ignore' and Harper will adapt to your writing style.",
+	"Don't agree with a suggestion? Click 'Dismiss' and Harper will adapt to your writing style.",
 	"You can add specialized terms, names, or acronyms to your personal dictionary in Harper's settings.",
 	"Check your language preferences in Settings to get suggestions for different dialects (e.g., American vs. British English)."
 ]


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #2715

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

In a previous commit, we changed the label on the suggestion popup from "Ignore" to "Dismiss", without updating the hints. I've updated the hint to the right label.


# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

N/A

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
