### PR TITLE
fix(core): false positive in the `ToTwoToo` rule

### DIFF
--- a/harper-core/src/linting/to_two_too/mod.rs
+++ b/harper-core/src/linting/to_two_too/mod.rs
@@ -408,6 +408,14 @@ mod tests {
     }
 
     #[test]
+    fn no_lint_asking_to_simply_in_scare_quotes() {
+        assert_no_lints(
+            "He was asking to simply \"show up\" for the meeting.",
+            ToTwoToo::default(),
+        );
+    }
+
+    #[test]
     fn no_lint_llm_as_judge_to_automatically_score() {
         assert_no_lints(
             "We used an LLM-as-judge to automatically score agent trajectories.",

--- a/harper-core/src/linting/to_two_too/to_too_adverb.rs
+++ b/harper-core/src/linting/to_two_too/to_too_adverb.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
-use crate::linting::expr_linter::Chunk;
+use crate::linting::expr_linter::Sentence;
 
 pub struct ToTooAdverb {
     expr: Box<dyn Expr>,
@@ -35,7 +35,7 @@ impl Default for ToTooAdverb {
 }
 
 impl ExprLinter for ToTooAdverb {
-    type Unit = Chunk;
+    type Unit = Sentence;
 
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #2522

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

Fixing the false positive outline in the issue was as simple as making the expression match over chunk boundaries. It seems to be working just fine now.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

An additional unit test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
