### PR TITLE
fix(web): hide the erroring "Last Updated" field

### DIFF
--- a/packages/web/src/app.css
+++ b/packages/web/src/app.css
@@ -185,3 +185,7 @@ th[align="right"] {
 .skew-hover-left {
 	@apply transition-all hover:-rotate-3 hover:scale-105;
 }
+
+.last-update {
+	display: none;
+}


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #1018

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

The "Last Updated" field on every documentation page has been erroring out for quite some time. The actual cause is our somewhat convoluted build pipeline. I've decided that simply hiding the field is the best use of my time that actually solves the problem.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
