### PR TITLE
feat: add adjective support to not longer→no longer

### DIFF
--- a/harper-core/src/linting/no_longer.rs
+++ b/harper-core/src/linting/no_longer.rs
@@ -21,6 +21,7 @@ impl Default for NoLonger {
                             TokenKind::is_verb_third_person_singular_present_form,
                             TokenKind::is_verb_past_participle_form,
                             TokenKind::is_verb_progressive_form,
+                            TokenKind::is_adjective,
                         ][..],
                     ))
                     .and_not(
@@ -65,10 +66,14 @@ mod tests {
     use super::NoLonger;
     use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
 
+    // Don't flag
+
     #[test]
     fn ignore_than() {
         assert_no_lints("My arm is not longer than my leg.", NoLonger::default())
     }
+
+    // Flag not longer <verb>
 
     #[test]
     fn fix_can_modal() {
@@ -140,6 +145,152 @@ mod tests {
             "I get this error and the fasta file is not longer written",
             NoLonger::default(),
             "I get this error and the fasta file is no longer written",
+        );
+    }
+
+    // Flag not longer <adjective>
+
+    #[test]
+    fn fix_able() {
+        assert_suggestion_result(
+            "I am not longer able to set multi-cursors in Zed 0.190.6.",
+            NoLonger::default(),
+            "I am no longer able to set multi-cursors in Zed 0.190.6.",
+        );
+    }
+
+    #[test]
+    fn fix_affordable() {
+        assert_suggestion_result(
+            "No not Oakland, it's not longer affordable.",
+            NoLonger::default(),
+            "No not Oakland, it's no longer affordable.",
+        );
+    }
+
+    #[test]
+    fn fix_bad() {
+        assert_suggestion_result(
+            "How many times does this have to happen before its not longer bad luck?",
+            NoLonger::default(),
+            "How many times does this have to happen before its no longer bad luck?",
+        );
+    }
+
+    #[test]
+    fn fix_best() {
+        assert_suggestion_result(
+            "AWS Java V1 is not longer best practice as specified in this Github page",
+            NoLonger::default(),
+            "AWS Java V1 is no longer best practice as specified in this Github page",
+        );
+    }
+
+    #[test]
+    fn fix_effective() {
+        assert_suggestion_result(
+            "when you delete those keys from the dict, it is not longer effective",
+            NoLonger::default(),
+            "when you delete those keys from the dict, it is no longer effective",
+        );
+    }
+
+    #[test]
+    fn fix_empty() {
+        assert_suggestion_result(
+            "not only set as username, it sets common name as well and is not longer empty",
+            NoLonger::default(),
+            "not only set as username, it sets common name as well and is no longer empty",
+        );
+    }
+
+    #[test]
+    fn fix_enough() {
+        assert_suggestion_result(
+            "the message body is not longer enough",
+            NoLonger::default(),
+            "the message body is no longer enough",
+        );
+    }
+
+    #[test]
+    fn fix_equal() {
+        assert_suggestion_result(
+            "once the size of the current batch is not longer equal to batch_size , I used the temporary batch",
+            NoLonger::default(),
+            "once the size of the current batch is no longer equal to batch_size , I used the temporary batch",
+        );
+    }
+
+    #[test]
+    fn fix_equivalent() {
+        assert_suggestion_result(
+            "the lambda is not longer equivalent to how std::isspace would behave as a unary predicate",
+            NoLonger::default(),
+            "the lambda is no longer equivalent to how std::isspace would behave as a unary predicate",
+        );
+    }
+
+    #[test]
+    fn fix_free() {
+        assert_suggestion_result(
+            "so if i understand it correct, myteslamate is not longer free? ",
+            NoLonger::default(),
+            "so if i understand it correct, myteslamate is no longer free? ",
+        );
+    }
+
+    #[test]
+    fn fix_good() {
+        assert_suggestion_result(
+            "Just in case that link is not longer good I'll reproduce the code here.",
+            NoLonger::default(),
+            "Just in case that link is no longer good I'll reproduce the code here.",
+        );
+    }
+
+    #[test]
+    fn fix_near() {
+        assert_suggestion_result(
+            "reminder that they are not longer near each other",
+            NoLonger::default(),
+            "reminder that they are no longer near each other",
+        );
+    }
+
+    #[test]
+    fn fix_open() {
+        assert_suggestion_result(
+            "removing old breakpoints from a project which was not longer open",
+            NoLonger::default(),
+            "removing old breakpoints from a project which was no longer open",
+        );
+    }
+
+    #[test]
+    fn fix_possible() {
+        assert_suggestion_result(
+            "As far as I can set tell it is not longer possible to set these programmatically.",
+            NoLonger::default(),
+            "As far as I can set tell it is no longer possible to set these programmatically.",
+        );
+    }
+
+    #[test]
+    fn fix_relevant() {
+        assert_suggestion_result(
+            "individual remuneration is not longer relevant as we can produce enough",
+            NoLonger::default(),
+            "individual remuneration is no longer relevant as we can produce enough",
+        );
+    }
+
+    #[test]
+    fn fix_sufficient() {
+        assert_suggestion_result(
+            "the fichier.close() command is not longer sufficient to close the file",
+            NoLonger::default(),
+            "the fichier.close() command is no longer sufficient to close the file",
         );
     }
 }


### PR DESCRIPTION
# Issues 
Fixes #2696

# Description

Makes the `NoLonger` linter work with adjectives in addition to verbs.

Despite my efforts, I didn't find any false positives but I'm not convinced that none exist. Report any found.

# How Has This Been Tested?

A bunch of new unit tests with adjectives, preferentially using sentences found on GitHub, but also using other sites.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
