### PR TITLE
feat(cli): add support for TeX and derivative languages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2715,6 +2715,7 @@ dependencies = [
  "harper-pos-utils",
  "harper-python",
  "harper-stats",
+ "harper-tex",
  "harper-typst",
  "hashbrown 0.16.1",
  "rayon",

--- a/harper-cli/Cargo.toml
+++ b/harper-cli/Cargo.toml
@@ -17,6 +17,7 @@ harper-asciidoc = { path = "../harper-asciidoc", version = "1.0.0" }
 harper-core = { path = "../harper-core", version = "1.0.0" }
 harper-pos-utils = { path = "../harper-pos-utils", version = "1.0.0", features = [] }
 harper-comments = { path = "../harper-comments", version = "1.0.0" }
+harper-tex = { path = "../harper-tex", version = "1.0.0" }
 harper-typst = { path = "../harper-typst", version = "1.0.0" }
 hashbrown = "0.16.1"
 rayon = "1.11.0"

--- a/harper-cli/src/input/single_input.rs
+++ b/harper-cli/src/input/single_input.rs
@@ -143,6 +143,7 @@ impl SingleInputTrait for FileInput {
                 MarkdownOptions::default(),
             )),
             Some("org") => Box::new(OrgMode),
+            Some("tex" | "latex" | "sty" | "cls" | "dtx") => Box::new(harper_tex::TeX::default()),
             Some("typ") => Box::new(harper_typst::Typst),
             Some("py") | Some("pyi") => Box::new(PythonParser::default()),
             Some("adoc") | Some("asciidoc") => Box::new(AsciidocParser::default()),


### PR DESCRIPTION
# Issues 

Related to #79. Follow-up to #2689.

# Description

PR #2689 added TeX support to `harper-ls` but did not update `harper-cli`. This means running `harper-cli lint` on a `.tex` file falls through to the `CommentParser`/`PlainEnglish` fallback, causing issues from TeX commands.

This PR adds the `harper-tex` dependency to `harper-cli` and a match arm in `FileInput::get_parser` for `.tex`, `.latex`, `.sty`, `.cls`, and `.dtx` extensions.


# Demo

After this change, linting a TeX file only reports real grammar issues:

```
$ cargo run --bin harper-cli -- lint harper-tex/tests/test_sources/simple.tex
simple.tex: 1 lints
Advice:
   ╭─[ simple.tex:1:1 ]
   │
 5 │ This is an test.
   │         ─┬
   │          ╰── [Miscellaneous::AnA] (pri 31): Incorrect indefinite article.
───╯
```

# How Has This Been Tested?

- `cargo build -p harper-cli` succeeds
- `cargo test -p harper-cli` passes
- Manual verification: `cargo run --bin harper-cli -- lint harper-tex/tests/test_sources/simple.tex` correctly uses the TeX parser and only reports legitimate grammar lints

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes

I saw no tests for any parser integration in harper-cli, so I am not sure how to proceed.