### PR TITLE
fix: `is_possessive_nominal()` had wrong logic

### DIFF
--- a/harper-core/src/dict_word_metadata.rs
+++ b/harper-core/src/dict_word_metadata.rs
@@ -1821,6 +1821,40 @@ pub mod tests {
         }
     }
 
+    mod nominal {
+        use crate::dict_word_metadata::tests::md;
+
+        #[test]
+        fn my_is_possessive_nominal() {
+            assert!(md("my").is_possessive_nominal());
+        }
+
+        #[test]
+        fn mine_is_not_possessive_nominal() {
+            assert!(!md("mine").is_possessive_nominal());
+        }
+
+        #[test]
+        fn freds_is_possessive_nominal() {
+            assert!(md("Fred's").is_possessive_nominal());
+        }
+
+        #[test]
+        fn fred_is_not_possessive_nominal() {
+            assert!(!md("Fred").is_possessive_nominal());
+        }
+
+        #[test]
+        fn dogs_is_possessive_nominal() {
+            assert!(md("dog's").is_possessive_nominal());
+        }
+
+        #[test]
+        fn microsofts_is_possessive_nominal() {
+            assert!(md("Microsoft's").is_possessive_nominal());
+        }
+    }
+
     mod adjective {
         use crate::{Degree, dict_word_metadata::tests::md};
 


### PR DESCRIPTION
# Issues 
N/A

# Description

While looking into #2353 I realized that `is_possessive_nominal()` (and its derivative functions) had the wrong logic due to confusing standard terminology.

Basically "nominal" is an umbrella term for nouns and pronouns.
But a "possessive noun" is one ending in `'s` that can be used as a qualifier "**Fred's** cat" or standalone "the cat is **Fred's**".
While a possessive pronoun is only the latter "the cat is **mine**" while the former is called a possessive determiner "**my** cat".

So this PR changes `is_possessive_nominal` from a combo of `is_possessive_noun() and is_possessive_pronoun()` to a combo of `self.is_possessive_noun` and `is_possessive_determiner`

I considered changing the name but after some research I decided this name is as good as any. But I did add an explanatory comment.

I also removed a negative equivalent, `is_non_possessive_nominal()` since it's not actually used yet I couldn't be sure of coming up with the right unit tests so it can be implemented again once there's a use case for it.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I added unit tests that ensure "possessive nominal" covers the correct subset of nouns and pronouns and does not cover the wrong kinds of pronouns.
All tests in `cargo test` are unaffected by the change.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
