### PR TITLE
fix: adaptive `message` to address issue #2743

### DIFF
--- a/harper-core/src/linting/obsess_preposition.rs
+++ b/harper-core/src/linting/obsess_preposition.rs
@@ -86,7 +86,7 @@ impl ExprLinter for ObsessPreposition {
             .collect();
 
         let message = if ok_prep_vec.len() == 1 {
-            "Use 'over' instead of 'with'".to_string()
+            format!("Use 'over' instead of '{}'.", String::from_iter(prep_chars))
         } else {
             "For `excessively preoccupied with` use `obsessed with`. For `paid close attention to details` use `obsessed over`".to_string()
         };
@@ -104,7 +104,9 @@ impl ExprLinter for ObsessPreposition {
 #[cfg(test)]
 mod tests {
     use super::ObsessPreposition;
-    use crate::linting::tests::{assert_suggestion_result, assert_top3_suggestion_result};
+    use crate::linting::tests::{
+        assert_lint_message, assert_suggestion_result, assert_top3_suggestion_result,
+    };
 
     #[test]
     fn fix_obsess_on() {
@@ -157,6 +159,15 @@ mod tests {
             "Secondly, if you get obsessed on any idea, then delve in it and don't worry about anything others until you get there.",
             ObsessPreposition::default(),
             "Secondly, if you get obsessed with any idea, then delve in it and don't worry about anything others until you get there.",
+        );
+    }
+
+    #[test]
+    fn fix_obsess_about_2743() {
+        assert_lint_message(
+            "but don't obsess about it",
+            ObsessPreposition::default(),
+            "Use 'over' instead of 'about'.",
         );
     }
 }


### PR DESCRIPTION
# Issues 

Fixes #2743

# Description

The `message` field was hardcoded but now mentions the actual preposition that it is replacing.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?

I used the text from the issue to form a new unit test which tests the message rather than the result.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
