### PR TITLE
Propagating newer methods of `SequenceExpr` through the codebase

### DIFF
--- a/harper-core/src/document.rs
+++ b/harper-core/src/document.rs
@@ -8,7 +8,6 @@ use paste::paste;
 
 use crate::expr::{Expr, ExprExt, FirstMatchOf, Repeating, SequenceExpr};
 use crate::parsers::{Markdown, MarkdownOptions, Parser, PlainEnglish};
-use crate::patterns::WordSet;
 use crate::punctuation::Punctuation;
 use crate::spell::{Dictionary, FstDictionary};
 use crate::vec_ext::VecExt;
@@ -507,11 +506,7 @@ impl Document {
 
     fn uncached_latin_expr() -> Lrc<FirstMatchOf> {
         Lrc::new(FirstMatchOf::new(vec![
-            Box::new(
-                SequenceExpr::default()
-                    .then(WordSet::new(&["etc", "vs"]))
-                    .then_period(),
-            ),
+            Box::new(SequenceExpr::word_set(&["etc", "vs"]).then_period()),
             Box::new(
                 SequenceExpr::aco("et")
                     .then_whitespace()

--- a/harper-core/src/expr/mergeable_words.rs
+++ b/harper-core/src/expr/mergeable_words.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use super::{Expr, SequenceExpr, SpaceOrHyphen};
+use super::{Expr, SequenceExpr};
 use crate::spell::{Dictionary, FstDictionary};
 use crate::{CharString, DictWordMetadata, Span, Token};
 
@@ -25,10 +25,7 @@ impl MergeableWords {
         + 'static,
     ) -> Self {
         Self {
-            inner: SequenceExpr::default()
-                .then_any_word()
-                .then(SpaceOrHyphen)
-                .then_any_word(),
+            inner: SequenceExpr::any_word().t_ws_h().then_any_word(),
             dict: FstDictionary::curated(),
             predicate: Box::new(predicate),
         }

--- a/harper-core/src/expr/sequence_expr.rs
+++ b/harper-core/src/expr/sequence_expr.rs
@@ -138,6 +138,10 @@ impl SequenceExpr {
         Self::default().then_longest_of(exprs)
     }
 
+    pub fn whitespace() -> Self {
+        Self::default().then_whitespace()
+    }
+
     /// Will be accepted unless the condition matches.
     pub fn unless(condition: impl Expr + 'static) -> Self {
         Self::default().then_unless(condition)
@@ -219,20 +223,23 @@ impl SequenceExpr {
         self.then_whitespace_or_hyphen()
     }
 
+    /// Match against zero or more occurrences of the given expression. Like `*` in regex.
+    pub fn then_zero_or_more(self, expr: impl Expr + 'static) -> Self {
+        self.then(Repeating::new(Box::new(expr), 0))
+    }
+
+    /// Match against one or more occurrences of the given expression. Like `+` in regex.
     pub fn then_one_or_more(self, expr: impl Expr + 'static) -> Self {
         self.then(Repeating::new(Box::new(expr), 1))
     }
 
-    pub fn then_one_or_more_spaced(self, expr: impl Expr + 'static) -> Self {
+    /// Match against zero or more whitespace-separated occurrences of the given expression.
+    pub fn then_zero_or_more_spaced(self, expr: impl Expr + 'static) -> Self {
         let expr = Lrc::new(expr);
-        self.then(
-            SequenceExpr::default()
-                .then(expr.clone())
-                .then(Repeating::new(
-                    Box::new(SequenceExpr::default().t_ws().then(expr)),
-                    0,
-                )),
-        )
+        self.then(SequenceExpr::with(expr.clone()).then(Repeating::new(
+            Box::new(SequenceExpr::default().t_ws().then(expr)),
+            0,
+        )))
     }
 
     /// Create a new condition that will step one token forward if met.

--- a/harper-core/src/expr/spelled_number_expr.rs
+++ b/harper-core/src/expr/spelled_number_expr.rs
@@ -51,13 +51,12 @@ impl Expr for SpelledNumberExpr {
                 .collect::<Vec<&str>>(),
         );
 
-        let tens_units_compounds = SequenceExpr::default()
-            .then(WordSet::new(tens))
+        let tens_units_compounds = SequenceExpr::word_set(tens)
             .then_any_of(vec![
                 Box::new(|t: &Token, _s: &[char]| t.kind.is_hyphen()),
                 Box::new(WhitespacePattern),
             ])
-            .then(WordSet::new(units));
+            .then_word_set(units);
 
         let expr =
             LongestMatchOf::new(vec![Box::new(single_words), Box::new(tens_units_compounds)]);

--- a/harper-core/src/linting/a_while.rs
+++ b/harper-core/src/linting/a_while.rs
@@ -19,8 +19,7 @@ impl Default for AWhile {
     fn default() -> Self {
         let mut map = ExprMap::default();
 
-        let a = SequenceExpr::default()
-            .then(UPOSSet::new(&[UPOS::VERB]))
+        let a = SequenceExpr::with(UPOSSet::new(&[UPOS::VERB]))
             .t_ws()
             .t_aco("a")
             .t_ws()
@@ -34,8 +33,7 @@ impl Default for AWhile {
             ),
         );
 
-        let b = SequenceExpr::default()
-            .then_unless(UPOSSet::new(&[UPOS::VERB]))
+        let b = SequenceExpr::unless(UPOSSet::new(&[UPOS::VERB]))
             .t_ws()
             .t_aco("awhile");
 

--- a/harper-core/src/linting/am_in_the_morning.rs
+++ b/harper-core/src/linting/am_in_the_morning.rs
@@ -17,21 +17,23 @@ impl Default for AmInTheMorning {
 
         let maybe_ws_am = LongestMatchOf::new(vec![
             Box::new(SequenceExpr::with(am.clone())),
-            Box::new(SequenceExpr::default().then_whitespace().then(am)),
+            Box::new(SequenceExpr::whitespace().then(am)),
         ]);
         let maybe_ws_pm = LongestMatchOf::new(vec![
             Box::new(SequenceExpr::with(pm.clone())),
-            Box::new(SequenceExpr::default().then_whitespace().then(pm)),
+            Box::new(SequenceExpr::whitespace().then(pm)),
         ]);
 
-        let ws_in_periods = SequenceExpr::default()
-            .then(FixedPhrase::from_phrase(" in the "))
-            .then(WordSet::new(&["morning", "afternoon", "evening", "night"]));
+        let ws_in_periods = SequenceExpr::fixed_phrase(" in the ").then_word_set(&[
+            "morning",
+            "afternoon",
+            "evening",
+            "night",
+        ]);
 
         let ws_at_periods = FixedPhrase::from_phrase(" at night");
 
-        let expr = SequenceExpr::default()
-            .then_any_of(vec![Box::new(maybe_ws_am), Box::new(maybe_ws_pm)])
+        let expr = SequenceExpr::any_of(vec![Box::new(maybe_ws_am), Box::new(maybe_ws_pm)])
             .then_any_of(vec![Box::new(ws_in_periods), Box::new(ws_at_periods)]);
 
         Self {

--- a/harper-core/src/linting/amounts_for.rs
+++ b/harper-core/src/linting/amounts_for.rs
@@ -1,6 +1,5 @@
 use crate::expr::Expr;
 use crate::expr::FirstMatchOf;
-use crate::expr::FixedPhrase;
 use crate::expr::SequenceExpr;
 use crate::{Token, TokenStringExt, patterns::WordSet};
 
@@ -15,19 +14,17 @@ impl Default for AmountsFor {
     fn default() -> Self {
         let singular_context = WordSet::new(&["that", "which", "it", "this"]);
 
-        let singular_pattern = SequenceExpr::default()
-            .then(singular_context)
+        let singular_pattern = SequenceExpr::with(singular_context)
             .then_whitespace()
-            .then(FixedPhrase::from_phrase("amounts for"));
+            .then_fixed_phrase("amounts for");
 
         let singular_context = WordSet::new(&[
             "they", "can", "could", "may", "might", "must", "should", "will", "would",
         ]);
 
-        let plural_pattern = SequenceExpr::default()
-            .then(singular_context)
+        let plural_pattern = SequenceExpr::with(singular_context)
             .then_whitespace()
-            .then(FixedPhrase::from_phrase("amount for"));
+            .then_fixed_phrase("amount for");
 
         Self {
             expr: Box::new(FirstMatchOf::new(vec![

--- a/harper-core/src/linting/another_thing_coming.rs
+++ b/harper-core/src/linting/another_thing_coming.rs
@@ -1,9 +1,8 @@
 use crate::linting::expr_linter::Chunk;
 use crate::{
     Token, TokenStringExt,
-    expr::{Expr, FixedPhrase, SequenceExpr},
+    expr::{Expr, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
-    patterns::WordSet,
 };
 
 /// Both `another thing coming` and `another think coming` are correct, but `another think coming` is more common.
@@ -15,9 +14,8 @@ impl Default for AnotherThingComing {
     fn default() -> Self {
         Self {
             expr: Box::new(
-                SequenceExpr::default()
-                    .then(WordSet::new(&["had", "has", "have", "got"]))
-                    .then(FixedPhrase::from_phrase(" another think coming")),
+                SequenceExpr::word_set(&["had", "has", "have", "got"])
+                    .then_fixed_phrase(" another think coming"),
             ),
         }
     }

--- a/harper-core/src/linting/another_think_coming.rs
+++ b/harper-core/src/linting/another_think_coming.rs
@@ -1,9 +1,8 @@
 use crate::linting::expr_linter::Chunk;
 use crate::{
     Token, TokenStringExt,
-    expr::{Expr, FixedPhrase, SequenceExpr},
+    expr::{Expr, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
-    patterns::WordSet,
 };
 
 /// Both `another thing coming` and `another think coming` are correct, but `another think coming` is the original.
@@ -15,9 +14,8 @@ impl Default for AnotherThinkComing {
     fn default() -> Self {
         Self {
             expr: Box::new(
-                SequenceExpr::default()
-                    .then(WordSet::new(&["had", "has", "have", "got"]))
-                    .then(FixedPhrase::from_phrase(" another thing coming")),
+                SequenceExpr::word_set(&["had", "has", "have", "got"])
+                    .then_fixed_phrase(" another thing coming"),
             ),
         }
     }

--- a/harper-core/src/linting/ask_no_preposition.rs
+++ b/harper-core/src/linting/ask_no_preposition.rs
@@ -19,8 +19,7 @@ impl Default for AskNoPreposition {
 
         let objs = WordSet::new(&["me", "you", "him", "her", "it", "us", "them", "one"]);
 
-        let pattern = SequenceExpr::default()
-            .then(verbs)
+        let pattern = SequenceExpr::with(verbs)
             .then_whitespace()
             .t_aco("to")
             .then_whitespace()

--- a/harper-core/src/linting/back_in_the_day.rs
+++ b/harper-core/src/linting/back_in_the_day.rs
@@ -21,8 +21,7 @@ impl Default for BackInTheDay {
         let exceptions = Lrc::new(WordSet::new(&["before", "of", "when"]));
         let phrase = Lrc::new(FixedPhrase::from_phrase("back in the days"));
 
-        let pattern = SequenceExpr::default()
-            .then(phrase.clone())
+        let pattern = SequenceExpr::with(phrase.clone())
             .then_whitespace()
             .then(exceptions.clone())
             .or_longest(phrase);

--- a/harper-core/src/linting/best_of_all_time.rs
+++ b/harper-core/src/linting/best_of_all_time.rs
@@ -1,5 +1,5 @@
 use crate::Token;
-use crate::expr::{Expr, Repeating, SequenceExpr};
+use crate::expr::{Expr, SequenceExpr};
 use crate::linting::{ExprLinter, Lint, LintKind, Suggestion, expr_linter::Sentence};
 
 pub struct BestOfAllTime {
@@ -19,29 +19,22 @@ impl Default for BestOfAllTime {
         let fave_or_top = SequenceExpr::word_set(&["favorite", "favourite", "top"]);
 
         // We can't use the noun phrase Expr because it allows determiners before the nouns and "best the thing" wouldn't be right
-        let expr = SequenceExpr::default()
-            .then_any_of(vec![
-                Box::new(inflection_superlative),
-                Box::new(most_superlative),
-                Box::new(fave_or_top),
-            ])
-            // There is no non-greedy `Repeating` in Harper, so we have to do match non-noun-oov tokens
-            // rather than matching arbitrary tokens.
-            // We include OOV because novel words not in the dictionary tend to be nouns.
-            .then(Repeating::new(
-                Box::new(|tok: &Token, _: &[char]| !tok.kind.is_noun() && !tok.kind.is_oov()),
-                0,
-            ))
-            .then_kind_where(|kind| kind.is_noun() || kind.is_oov())
-            .then(Repeating::new(
-                Box::new(
-                    SequenceExpr::default()
-                        .t_ws()
-                        .then_kind_where(|kind| kind.is_noun() || kind.is_oov()),
-                ),
-                0,
-            ))
-            .then_fixed_phrase(" of all times");
+        let expr = SequenceExpr::any_of(vec![
+            Box::new(inflection_superlative),
+            Box::new(most_superlative),
+            Box::new(fave_or_top),
+        ])
+        // There is no non-greedy `Repeating` in Harper, so we have to do match non-noun-oov tokens
+        // rather than matching arbitrary tokens.
+        // We include OOV because novel words not in the dictionary tend to be nouns.
+        .then_zero_or_more(|tok: &Token, _: &[char]| !tok.kind.is_noun() && !tok.kind.is_oov())
+        .then_kind_where(|kind| kind.is_noun() || kind.is_oov())
+        .then_zero_or_more(
+            SequenceExpr::default()
+                .t_ws()
+                .then_kind_where(|kind| kind.is_noun() || kind.is_oov()),
+        )
+        .then_fixed_phrase(" of all times");
 
         Self {
             expr: Box::new(expr),

--- a/harper-core/src/linting/bought.rs
+++ b/harper-core/src/linting/bought.rs
@@ -10,8 +10,7 @@ pub struct Bought {
 
 impl Default for Bought {
     fn default() -> Self {
-        let subject = SequenceExpr::default()
-            .then(Self::is_subject_pronoun_like)
+        let subject = SequenceExpr::with(Self::is_subject_pronoun_like)
             .t_ws()
             .then_optional(SequenceExpr::default().then_adverb().t_ws())
             .then_optional(SequenceExpr::default().then_auxiliary_verb().t_ws())

--- a/harper-core/src/linting/call_them.rs
+++ b/harper-core/src/linting/call_them.rs
@@ -1,7 +1,7 @@
 use std::{ops::Range, sync::Arc};
 
 use crate::expr::{Expr, ExprMap, SequenceExpr};
-use crate::patterns::{DerivedFrom, WordSet};
+use crate::patterns::DerivedFrom;
 use crate::{Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
@@ -16,15 +16,10 @@ impl Default for CallThem {
     fn default() -> Self {
         let mut map = ExprMap::default();
 
-        let post_exception = Arc::new(
-            SequenceExpr::default()
-                .t_ws()
-                .then(WordSet::new(&["if", "it"])),
-        );
+        let post_exception = Arc::new(SequenceExpr::default().t_ws().then_word_set(&["if", "it"]));
 
         map.insert(
-            SequenceExpr::default()
-                .then(DerivedFrom::new_from_str("call"))
+            SequenceExpr::with(DerivedFrom::new_from_str("call"))
                 .t_ws()
                 .then_pronoun()
                 .t_ws()
@@ -34,8 +29,7 @@ impl Default for CallThem {
         );
 
         map.insert(
-            SequenceExpr::default()
-                .then(DerivedFrom::new_from_str("call"))
+            SequenceExpr::with(DerivedFrom::new_from_str("call"))
                 .t_ws()
                 .t_aco("as")
                 .t_ws()

--- a/harper-core/src/linting/cautionary_tale.rs
+++ b/harper-core/src/linting/cautionary_tale.rs
@@ -16,10 +16,7 @@ impl Default for CautionaryTale {
     fn default() -> Self {
         let adjectives = WordSet::new(&["cautionary", "inspirational"]);
 
-        let pattern = SequenceExpr::default()
-            .then(adjectives)
-            .t_ws()
-            .t_aco("tail");
+        let pattern = SequenceExpr::with(adjectives).t_ws().t_aco("tail");
 
         Self {
             expr: Box::new(pattern),

--- a/harper-core/src/linting/compound_nouns/compound_noun_after_det_adj.rs
+++ b/harper-core/src/linting/compound_nouns/compound_noun_after_det_adj.rs
@@ -24,16 +24,14 @@ pub struct CompoundNounAfterDetAdj {
 //    that is not also an adjective
 impl Default for CompoundNounAfterDetAdj {
     fn default() -> Self {
-        let context_expr = SequenceExpr::default()
-            .then(|tok: &Token, src: &[char]| {
-                tok.kind.is_determiner()
-                    || (tok.kind.is_adjective()
-                        && *tok.span.get_content(src).to_lower() != ['g', 'o'])
-            })
-            .t_ws()
-            .then(is_content_word)
-            .t_ws()
-            .then(is_content_word.and_not(InflectionOfBe::default()));
+        let context_expr = SequenceExpr::with(|tok: &Token, src: &[char]| {
+            tok.kind.is_determiner()
+                || (tok.kind.is_adjective() && *tok.span.get_content(src).to_lower() != ['g', 'o'])
+        })
+        .t_ws()
+        .then(is_content_word)
+        .t_ws()
+        .then(is_content_word.and_not(InflectionOfBe::default()));
 
         let split_expr = Lrc::new(MergeableWords::new(|meta_closed, meta_open| {
             predicate(meta_closed, meta_open)

--- a/harper-core/src/linting/compound_nouns/compound_noun_after_possessive.rs
+++ b/harper-core/src/linting/compound_nouns/compound_noun_after_possessive.rs
@@ -2,7 +2,6 @@ use crate::expr::All;
 use crate::expr::Expr;
 use crate::expr::MergeableWords;
 use crate::expr::SequenceExpr;
-use crate::patterns::AnyPattern;
 use crate::{CharStringExt, Lrc, TokenStringExt, linting::ExprLinter};
 
 use super::{Lint, LintKind, Suggestion, is_content_word, predicate};
@@ -38,12 +37,7 @@ impl Default for CompoundNounAfterPossessive {
         let mut pattern = All::default();
 
         pattern.add(context_pattern);
-        pattern.add(
-            SequenceExpr::default()
-                .then(AnyPattern)
-                .then(AnyPattern)
-                .then(split_pattern.clone()),
-        );
+        pattern.add(SequenceExpr::anything().t_any().then(split_pattern.clone()));
 
         Self {
             expr: Box::new(pattern),

--- a/harper-core/src/linting/compound_nouns/compound_noun_before_aux_verb.rs
+++ b/harper-core/src/linting/compound_nouns/compound_noun_before_aux_verb.rs
@@ -2,7 +2,6 @@ use crate::expr::All;
 use crate::expr::Expr;
 use crate::expr::MergeableWords;
 use crate::expr::SequenceExpr;
-use crate::patterns::AnyPattern;
 use crate::{CharStringExt, Lrc, TokenStringExt, linting::ExprLinter};
 
 use super::{Lint, LintKind, Suggestion, is_content_word, predicate};
@@ -18,8 +17,7 @@ pub struct CompoundNounBeforeAuxVerb {
 
 impl Default for CompoundNounBeforeAuxVerb {
     fn default() -> Self {
-        let context_pattern = SequenceExpr::default()
-            .then(is_content_word)
+        let context_pattern = SequenceExpr::with(is_content_word)
             .t_ws()
             .then(is_content_word)
             .then_auxiliary_verb();
@@ -30,12 +28,7 @@ impl Default for CompoundNounBeforeAuxVerb {
 
         let mut expr = All::default();
         expr.add(context_pattern);
-        expr.add(
-            SequenceExpr::default()
-                .then(split_pattern.clone())
-                .then(AnyPattern)
-                .then(AnyPattern),
-        );
+        expr.add(SequenceExpr::with(split_pattern.clone()).t_any().t_any());
 
         Self {
             expr: Box::new(expr),

--- a/harper-core/src/linting/compound_subject_i.rs
+++ b/harper-core/src/linting/compound_subject_i.rs
@@ -13,8 +13,7 @@ pub struct CompoundSubjectI {
 
 impl Default for CompoundSubjectI {
     fn default() -> Self {
-        let expr = SequenceExpr::default()
-            .then(AnchorStart)
+        let expr = SequenceExpr::with(AnchorStart)
             .then_optional(
                 SequenceExpr::default()
                     .then_quote()

--- a/harper-core/src/linting/confident.rs
+++ b/harper-core/src/linting/confident.rs
@@ -12,15 +12,14 @@ pub struct Confident {
 
 impl Default for Confident {
     fn default() -> Self {
-        let pattern = SequenceExpr::default()
-            .then(
-                SequenceExpr::from(|tok: &Token, _source: &[char]| {
-                    tok.kind.is_verb() || tok.kind.is_determiner()
-                })
-                .or(Word::new("very")),
-            )
-            .then_whitespace()
-            .t_aco("confidant");
+        let pattern = SequenceExpr::with(
+            SequenceExpr::from(|tok: &Token, _source: &[char]| {
+                tok.kind.is_verb() || tok.kind.is_determiner()
+            })
+            .or(Word::new("very")),
+        )
+        .then_whitespace()
+        .t_aco("confidant");
 
         Self {
             expr: Box::new(pattern),

--- a/harper-core/src/linting/criteria_phenomena.rs
+++ b/harper-core/src/linting/criteria_phenomena.rs
@@ -22,8 +22,7 @@ impl CriteriaPhenomena {
 
         Self {
             expr: Box::new(
-                SequenceExpr::default()
-                    .then(singular_modifiers.clone())
+                SequenceExpr::with(singular_modifiers.clone())
                     .then_whitespace()
                     .then(plural_words.clone()),
             ),

--- a/harper-core/src/linting/cure_for.rs
+++ b/harper-core/src/linting/cure_for.rs
@@ -3,7 +3,7 @@ use crate::{
     expr::{Expr, SequenceExpr},
     linting::expr_linter::Chunk,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
-    patterns::{DerivedFrom, Word},
+    patterns::DerivedFrom,
 };
 
 pub struct CureFor {
@@ -12,10 +12,9 @@ pub struct CureFor {
 
 impl Default for CureFor {
     fn default() -> Self {
-        let expr = SequenceExpr::default()
-            .then(DerivedFrom::new_from_str("cure"))
+        let expr = SequenceExpr::with(DerivedFrom::new_from_str("cure"))
             .t_ws()
-            .then(Word::new("against"));
+            .t_aco("against");
 
         Self {
             expr: Box::new(expr),

--- a/harper-core/src/linting/day_and_age.rs
+++ b/harper-core/src/linting/day_and_age.rs
@@ -12,8 +12,7 @@ impl Default for DayAndAge {
     fn default() -> Self {
         Self {
             expr: Box::new(
-                SequenceExpr::default()
-                    .then_word_set(&["this", "these"])
+                SequenceExpr::word_set(&["this", "these"])
                     .t_ws()
                     .then_word_set(&["day", "days"])
                     .t_ws()

--- a/harper-core/src/linting/discourse_markers.rs
+++ b/harper-core/src/linting/discourse_markers.rs
@@ -46,8 +46,7 @@ impl DiscourseMarkers {
         );
 
         Self {
-            expr: SequenceExpr::default()
-                .then(phrases_expr)
+            expr: SequenceExpr::with(phrases_expr)
                 .t_ws()
                 .then_unless(UPOSSet::new(&[UPOS::ADJ, UPOS::ADV, UPOS::ADP])),
         }

--- a/harper-core/src/linting/double_modal.rs
+++ b/harper-core/src/linting/double_modal.rs
@@ -13,8 +13,7 @@ pub struct DoubleModal {
 
 impl Default for DoubleModal {
     fn default() -> Self {
-        let expr = SequenceExpr::default()
-            .then(ModalVerb::default())
+        let expr = SequenceExpr::with(ModalVerb::default())
             .t_ws()
             .then(ModalVerb::default());
 

--- a/harper-core/src/linting/else_possessive.rs
+++ b/harper-core/src/linting/else_possessive.rs
@@ -25,8 +25,7 @@ impl Default for ElsePossessive {
         ])
         .or(SequenceExpr::aco("no").then_whitespace().t_aco("one"));
 
-        let pattern = SequenceExpr::default()
-            .then(pronouns)
+        let pattern = SequenceExpr::with(pronouns)
             .then_whitespace()
             .t_aco("elses");
 

--- a/harper-core/src/linting/everyday.rs
+++ b/harper-core/src/linting/everyday.rs
@@ -16,24 +16,14 @@ impl Default for Everyday {
         let every_day = Lrc::new(SequenceExpr::aco("every").t_ws().t_aco("day"));
 
         let everyday_bad_after = All::new(vec![
-            Box::new(
-                SequenceExpr::default()
-                    .then(everyday.clone())
-                    .t_ws()
-                    .then_any_word(),
-            ),
+            Box::new(SequenceExpr::with(everyday.clone()).t_ws().then_any_word()),
             Box::new(SequenceExpr::anything().t_any().then_kind_where(|kind| {
                 !kind.is_noun() && !kind.is_oov() && !kind.is_verb_progressive_form()
             })),
         ]);
 
         let bad_before_every_day = All::new(vec![
-            Box::new(
-                SequenceExpr::default()
-                    .then_any_word()
-                    .t_ws()
-                    .then(every_day.clone()),
-            ),
+            Box::new(SequenceExpr::any_word().t_ws().then(every_day.clone())),
             Box::new(|tok: &Token, _src: &[char]| {
                 // "this" and "that" are both determiners and pronouns
                 tok.kind.is_determiner() && !tok.kind.is_pronoun()
@@ -43,8 +33,7 @@ impl Default for Everyday {
         // (why does) everyday feel the (same ?)
         let everyday_ambiverb_after_then_noun = All::new(vec![
             Box::new(
-                SequenceExpr::default()
-                    .then(everyday.clone())
+                SequenceExpr::with(everyday.clone())
                     .t_ws()
                     .then_any_word()
                     .t_ws()
@@ -61,11 +50,7 @@ impl Default for Everyday {
 
         // (Do you actually improve if you draw) everyday?
         let everyday_punctuation_after = All::new(vec![
-            Box::new(
-                SequenceExpr::default()
-                    .then(everyday.clone())
-                    .then_punctuation(),
-            ),
+            Box::new(SequenceExpr::with(everyday.clone()).then_punctuation()),
             Box::new(SequenceExpr::anything().then_kind_where(|kind| {
                 matches!(
                     kind,
@@ -79,8 +64,7 @@ impl Default for Everyday {
         // (However, the message goes far beyond) every day things.
         let every_day_noun_after_then_punctuation = All::new(vec![
             Box::new(
-                SequenceExpr::default()
-                    .then(every_day.clone())
+                SequenceExpr::with(every_day.clone())
                     .t_ws()
                     .then_plural_noun()
                     .then_punctuation(),

--- a/harper-core/src/linting/expand_memory_shorthands.rs
+++ b/harper-core/src/linting/expand_memory_shorthands.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use super::{ExprLinter, Lint, LintKind};
 use crate::Token;
-use crate::expr::{Expr, SequenceExpr, SpaceOrHyphen};
+use crate::expr::{Expr, SequenceExpr};
 use crate::linting::Suggestion;
 use crate::linting::expr_linter::Chunk;
 use crate::patterns::{ImpliesQuantity, WordSet};
@@ -19,18 +19,10 @@ impl ExpandMemoryShorthands {
         ]));
 
         Self {
-            expr: Box::new(
-                SequenceExpr::default()
-                    .then(ImpliesQuantity)
-                    .then_longest_of(vec![
-                        Box::new(SequenceExpr::with(hotwords.clone())),
-                        Box::new(
-                            SequenceExpr::default()
-                                .then(SpaceOrHyphen)
-                                .then(hotwords.clone()),
-                        ),
-                    ]),
-            ),
+            expr: Box::new(SequenceExpr::with(ImpliesQuantity).then_longest_of(vec![
+                Box::new(SequenceExpr::with(hotwords.clone())),
+                Box::new(SequenceExpr::default().t_ws_h().then(hotwords.clone())),
+            ])),
         }
     }
 

--- a/harper-core/src/linting/expand_time_shorthands.rs
+++ b/harper-core/src/linting/expand_time_shorthands.rs
@@ -1,6 +1,5 @@
 use crate::expr::Expr;
 use crate::expr::SequenceExpr;
-use crate::expr::SpaceOrHyphen;
 use std::sync::Arc;
 
 use super::{ExprLinter, Lint, LintKind};
@@ -20,18 +19,10 @@ impl ExpandTimeShorthands {
         ]));
 
         Self {
-            expr: Box::new(
-                SequenceExpr::default()
-                    .then(ImpliesQuantity)
-                    .then_longest_of(vec![
-                        Box::new(SequenceExpr::with(hotwords.clone())),
-                        Box::new(
-                            SequenceExpr::default()
-                                .then(SpaceOrHyphen)
-                                .then(hotwords.clone()),
-                        ),
-                    ]),
-            ),
+            expr: Box::new(SequenceExpr::with(ImpliesQuantity).then_longest_of(vec![
+                Box::new(SequenceExpr::with(hotwords.clone())),
+                Box::new(SequenceExpr::default().t_ws_h().then(hotwords.clone())),
+            ])),
         }
     }
 

--- a/harper-core/src/linting/feel_fell.rs
+++ b/harper-core/src/linting/feel_fell.rs
@@ -11,8 +11,7 @@ pub struct FeelFell {
 
 impl Default for FeelFell {
     fn default() -> Self {
-        let with_word_before = SequenceExpr::default()
-            .then_word_set(&["didn't", "doesn't"])
+        let with_word_before = SequenceExpr::word_set(&["didn't", "doesn't"])
             .t_ws()
             .t_aco("fell");
 

--- a/harper-core/src/linting/few_units_of_time_ago.rs
+++ b/harper-core/src/linting/few_units_of_time_ago.rs
@@ -18,8 +18,7 @@ impl Default for FewUnitsOfTimeAgo {
         let start = SequenceExpr::default().then_word_except(&["a"]).t_ws();
 
         let expr = Lrc::new(
-            SequenceExpr::default()
-                .then(start)
+            SequenceExpr::with(start)
                 .t_aco("few")
                 .then_whitespace()
                 .then(units)

--- a/harper-core/src/linting/filler_words.rs
+++ b/harper-core/src/linting/filler_words.rs
@@ -15,13 +15,9 @@ impl Default for FillerWords {
     fn default() -> Self {
         let filler_words = Lrc::new(WordSet::new(&["uh", "um"]));
 
-        let pattern = SequenceExpr::default().then_any_of(vec![
-            Box::new(
-                SequenceExpr::default()
-                    .then(filler_words.clone())
-                    .then_whitespace(),
-            ),
-            Box::new(SequenceExpr::default().then_whitespace().then(filler_words)),
+        let pattern = SequenceExpr::any_of(vec![
+            Box::new(SequenceExpr::with(filler_words.clone()).then_whitespace()),
+            Box::new(SequenceExpr::whitespace().then(filler_words)),
         ]);
 
         Self {

--- a/harper-core/src/linting/find_fine.rs
+++ b/harper-core/src/linting/find_fine.rs
@@ -12,8 +12,7 @@ pub struct FindFine {
 
 impl Default for FindFine {
     fn default() -> Self {
-        let expr = SequenceExpr::default()
-            .then(InflectionOfBe::default())
+        let expr = SequenceExpr::with(InflectionOfBe::default())
             .t_ws()
             .t_aco("find");
 

--- a/harper-core/src/linting/first_aid_kit.rs
+++ b/harper-core/src/linting/first_aid_kit.rs
@@ -14,8 +14,7 @@ pub struct FirstAidKit {
 impl Default for FirstAidKit {
     fn default() -> Self {
         let supply_words = WordSet::new(&["aid", "starter", "travel", "tool"]);
-        let pattern = SequenceExpr::default()
-            .then(supply_words)
+        let pattern = SequenceExpr::with(supply_words)
             .then_whitespace()
             .then_any_capitalization_of("kid");
         Self {

--- a/harper-core/src/linting/free_predicate.rs
+++ b/harper-core/src/linting/free_predicate.rs
@@ -18,8 +18,7 @@ impl Default for FreePredicate {
     fn default() -> Self {
         let mut map = ExprMap::default();
 
-        let no_modifier = SequenceExpr::default()
-            .then(linking_like)
+        let no_modifier = SequenceExpr::with(linking_like)
             .t_ws()
             .then(matches_fee)
             .then_optional(WhitespacePattern)
@@ -27,8 +26,7 @@ impl Default for FreePredicate {
 
         map.insert(no_modifier, 2);
 
-        let with_adverb = SequenceExpr::default()
-            .then(linking_like)
+        let with_adverb = SequenceExpr::with(linking_like)
             .t_ws()
             .then_adverb()
             .t_ws()

--- a/harper-core/src/linting/good_at.rs
+++ b/harper-core/src/linting/good_at.rs
@@ -11,23 +11,22 @@ pub struct GoodAt {
 
 impl Default for GoodAt {
     fn default() -> Self {
-        let we_re_not_always_very_good_in_sth = SequenceExpr::default()
-            .then_any_of(vec![
-                Box::new(InflectionOfBe::default()),
-                Box::new(WordSet::new(&[
-                    "I'm", "we're", "you're", "he's", "she's", "it's", "they're", "Im", "were",
-                    "youre", "your", "hes", "shes", "its", "theyre",
-                ])),
-            ])
-            .t_ws()
-            .then_optional(SequenceExpr::aco("not").t_ws())
-            .then_optional(SequenceExpr::default().then_frequency_adverb().t_ws())
-            .then_optional(SequenceExpr::default().then_degree_adverb().t_ws())
-            .then_word_set(&["good", "bad", "great", "okay", "OK"])
-            .t_ws()
-            .t_aco("in")
-            .t_ws()
-            .then_any_word();
+        let we_re_not_always_very_good_in_sth = SequenceExpr::any_of(vec![
+            Box::new(InflectionOfBe::default()),
+            Box::new(WordSet::new(&[
+                "I'm", "we're", "you're", "he's", "she's", "it's", "they're", "Im", "were",
+                "youre", "your", "hes", "shes", "its", "theyre",
+            ])),
+        ])
+        .t_ws()
+        .then_optional(SequenceExpr::aco("not").t_ws())
+        .then_optional(SequenceExpr::default().then_frequency_adverb().t_ws())
+        .then_optional(SequenceExpr::default().then_degree_adverb().t_ws())
+        .then_word_set(&["good", "bad", "great", "okay", "OK"])
+        .t_ws()
+        .t_aco("in")
+        .t_ws()
+        .then_any_word();
 
         let good_in_skill_or_subject =
             SequenceExpr::word_set(&["good", "bad", "great", "okay", "OK"])

--- a/harper-core/src/linting/handful.rs
+++ b/harper-core/src/linting/handful.rs
@@ -10,8 +10,7 @@ pub struct Handful {
 
 impl Default for Handful {
     fn default() -> Self {
-        let expr = SequenceExpr::default()
-            .then_any_capitalization_of("hand")
+        let expr = SequenceExpr::any_capitalization_of("hand")
             .then_one_or_more(SpaceOrHyphen)
             .then_any_capitalization_of("full")
             .then_one_or_more(SpaceOrHyphen)

--- a/harper-core/src/linting/have_pronoun.rs
+++ b/harper-core/src/linting/have_pronoun.rs
@@ -10,8 +10,7 @@ pub struct HavePronoun {
 
 impl Default for HavePronoun {
     fn default() -> Self {
-        let expr = SequenceExpr::default()
-            .then(AnchorStart)
+        let expr = SequenceExpr::with(AnchorStart)
             .t_aco("has")
             .t_ws()
             .then_kind_either(

--- a/harper-core/src/linting/have_take_a_look.rs
+++ b/harper-core/src/linting/have_take_a_look.rs
@@ -1,9 +1,8 @@
 use crate::linting::expr_linter::Chunk;
 use crate::{
     Dialect, Token,
-    expr::{Expr, FixedPhrase, SequenceExpr},
+    expr::{Expr, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
-    patterns::WordSet,
 };
 
 pub struct HaveTakeALook {
@@ -19,10 +18,9 @@ impl HaveTakeALook {
             _ => &["have", "had", "had", "has", "having"],
         };
 
-        let expr = SequenceExpr::default()
-            .then(WordSet::new(light_verb))
+        let expr = SequenceExpr::word_set(light_verb)
             .t_ws()
-            .then(FixedPhrase::from_phrase("a look"));
+            .then_fixed_phrase("a look");
 
         Self {
             expr: Box::new(expr),

--- a/harper-core/src/linting/hello_greeting.rs
+++ b/harper-core/src/linting/hello_greeting.rs
@@ -11,8 +11,7 @@ pub struct HelloGreeting {
 
 impl Default for HelloGreeting {
     fn default() -> Self {
-        let expr = SequenceExpr::default()
-            .then(AnchorStart)
+        let expr = SequenceExpr::with(AnchorStart)
             .then_optional(SequenceExpr::default().t_ws())
             .then_optional(
                 SequenceExpr::default()

--- a/harper-core/src/linting/hop_hope/to_hop.rs
+++ b/harper-core/src/linting/hop_hope/to_hop.rs
@@ -3,7 +3,6 @@ use crate::expr::Expr;
 use crate::expr::SequenceExpr;
 use crate::linting::Suggestion;
 use crate::linting::expr_linter::Chunk;
-use crate::patterns::WordSet;
 use crate::{CharString, CharStringExt};
 use crate::{Token, char_string::char_string};
 
@@ -13,14 +12,13 @@ pub struct ToHop {
 
 impl Default for ToHop {
     fn default() -> Self {
-        let pattern = SequenceExpr::default()
-            .then(WordSet::new(&["hoping", "hoped", "hope"]))
+        let pattern = SequenceExpr::word_set(&["hoping", "hoped", "hope"])
             .then_whitespace()
             .t_aco("on")
             .then_whitespace()
             .then_determiner()
             .then_whitespace()
-            .then(WordSet::new(&["airplane", "plane", "bus", "call", "train"]));
+            .then_word_set(&["airplane", "plane", "bus", "call", "train"]);
 
         Self {
             expr: Box::new(pattern),

--- a/harper-core/src/linting/hop_hope/to_hope.rs
+++ b/harper-core/src/linting/hop_hope/to_hope.rs
@@ -3,7 +3,6 @@ use crate::expr::Expr;
 use crate::expr::SequenceExpr;
 use crate::linting::Suggestion;
 use crate::linting::expr_linter::Chunk;
-use crate::patterns::WordSet;
 use crate::{Token, char_string::char_string};
 
 pub struct ToHope {
@@ -15,7 +14,7 @@ impl Default for ToHope {
         let pattern = SequenceExpr::default()
             .then_nominal()
             .then_whitespace()
-            .then(WordSet::new(&["hop", "hopped"]))
+            .then_word_set(&["hop", "hopped"])
             .then_whitespace()
             .then_nominal();
 

--- a/harper-core/src/linting/how_to.rs
+++ b/harper-core/src/linting/how_to.rs
@@ -23,8 +23,7 @@ impl Default for HowTo {
             .then_verb_lemma();
         pattern.add(pos_pattern);
 
-        let exceptions = SequenceExpr::default()
-            .then_unless(UPOSSet::new(&[UPOS::PART]))
+        let exceptions = SequenceExpr::unless(UPOSSet::new(&[UPOS::PART]))
             .then_anything()
             .then_unless(|tok: &Token, _: &[char]| tok.kind.is_np_member())
             .then_anything()

--- a/harper-core/src/linting/hyphenate_number_day.rs
+++ b/harper-core/src/linting/hyphenate_number_day.rs
@@ -16,11 +16,7 @@ impl Default for HyphenateNumberDay {
             .then_whitespace()
             .t_aco("day")
             .then_longest_of(vec![
-                Box::new(
-                    SequenceExpr::default()
-                        .then_whitespace()
-                        .then(NominalPhrase),
-                ),
+                Box::new(SequenceExpr::whitespace().then(NominalPhrase)),
                 Box::new(
                     SequenceExpr::default()
                         .then_hyphen()

--- a/harper-core/src/linting/i_am_agreement.rs
+++ b/harper-core/src/linting/i_am_agreement.rs
@@ -13,9 +13,7 @@ impl Default for IAmAgreement {
     fn default() -> Self {
         let i_are = Lrc::new(FixedPhrase::from_phrase("I are"));
 
-        let nothing_before_i_are = SequenceExpr::default()
-            .then(AnchorStart)
-            .then(i_are.clone());
+        let nothing_before_i_are = SequenceExpr::with(AnchorStart).then(i_are.clone());
 
         let non_and_word_before_i_are = SequenceExpr::default()
             .then_word_except(&["and"])

--- a/harper-core/src/linting/if_wouldve.rs
+++ b/harper-core/src/linting/if_wouldve.rs
@@ -19,8 +19,7 @@ impl Default for IfWouldve {
                     .t_ws()
                     .then_any_of(vec![
                         Box::new(
-                            SequenceExpr::default()
-                                .then_word_set(&["would", "had"])
+                            SequenceExpr::word_set(&["would", "had"])
                                 .t_ws()
                                 .then_word_set(&["have", "of"]),
                         ),

--- a/harper-core/src/linting/in_on_the_cards.rs
+++ b/harper-core/src/linting/in_on_the_cards.rs
@@ -1,6 +1,6 @@
 use crate::{
     CharStringExt, Dialect, Token,
-    expr::{Expr, FirstMatchOf, FixedPhrase, SequenceExpr},
+    expr::{Expr, FirstMatchOf, SequenceExpr},
     linting::{LintKind, Suggestion},
     patterns::{InflectionOfBe, WordSet},
 };
@@ -28,11 +28,10 @@ impl InOnTheCards {
             ])),
         ]);
 
-        let expr = SequenceExpr::default()
-            .then(pre_context)
+        let expr = SequenceExpr::with(pre_context)
             .t_ws()
             .t_aco(preposition)
-            .then(FixedPhrase::from_phrase(" the cards"));
+            .then_fixed_phrase(" the cards");
 
         Self {
             expr: Box::new(expr),

--- a/harper-core/src/linting/it_looks_like_that.rs
+++ b/harper-core/src/linting/it_looks_like_that.rs
@@ -12,8 +12,7 @@ impl Default for ItLooksLikeThat {
     fn default() -> Self {
         Self {
             expr: Box::new(
-                SequenceExpr::default()
-                    .then_fixed_phrase("it looks like that")
+                SequenceExpr::fixed_phrase("it looks like that")
                     .then_whitespace()
                     .then_kind_where(|kind| {
                         // Heuristics on the word after "that" which show "that" was used

--- a/harper-core/src/linting/it_would_be.rs
+++ b/harper-core/src/linting/it_would_be.rs
@@ -33,8 +33,7 @@ impl Default for ItWouldBe {
         ]);
 
         let branch = |has_not: bool, has_adj: bool| {
-            let mut p = SequenceExpr::default()
-                .then(head_verbs.clone())
+            let mut p = SequenceExpr::with(head_verbs.clone())
                 .then_whitespace()
                 .t_aco("i") // the mistaken pronoun
                 .then_whitespace()

--- a/harper-core/src/linting/its_contraction/general.rs
+++ b/harper-core/src/linting/its_contraction/general.rs
@@ -20,9 +20,9 @@ impl Default for General {
 
         let exceptions = SequenceExpr::anything()
             .then_anything()
-            .then(WordSet::new(&["own", "intended"]));
+            .then_word_set(&["own", "intended"]);
 
-        let inverted = SequenceExpr::default().then_unless(exceptions);
+        let inverted = SequenceExpr::unless(exceptions);
 
         let expr = All::new(vec![Box::new(positive), Box::new(inverted)]).or_longest(
             SequenceExpr::aco("its")

--- a/harper-core/src/linting/its_contraction/proper_noun.rs
+++ b/harper-core/src/linting/its_contraction/proper_noun.rs
@@ -40,8 +40,7 @@ impl Default for ProperNoun {
         let lookahead_word = SequenceExpr::default().t_ws().then_any_word();
 
         map.insert(
-            SequenceExpr::default()
-                .then(opinion_verbs)
+            SequenceExpr::with(opinion_verbs)
                 .t_ws()
                 .t_aco("its")
                 .t_ws()

--- a/harper-core/src/linting/its_possessive.rs
+++ b/harper-core/src/linting/its_possessive.rs
@@ -9,7 +9,6 @@ use crate::expr::ExprMap;
 use crate::expr::OwnedExprExt;
 use crate::expr::SequenceExpr;
 use crate::patterns::UPOSSet;
-use crate::patterns::WordSet;
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::linting::expr_linter::Chunk;
@@ -27,8 +26,7 @@ impl Default for ItsPossessive {
             .t_ws()
             .then(UPOSSet::new(&[UPOS::ADJ]));
 
-        let mid_sentence = SequenceExpr::default()
-            .then(UPOSSet::new(&[UPOS::VERB, UPOS::ADP]))
+        let mid_sentence = SequenceExpr::with(UPOSSet::new(&[UPOS::VERB, UPOS::ADP]))
             .t_ws()
             .t_aco("it's")
             .then_optional(adj_term)
@@ -41,8 +39,7 @@ impl Default for ItsPossessive {
 
         map.insert(mid_sentence, 2);
 
-        let start_of_sentence = SequenceExpr::default()
-            .then(AnchorStart)
+        let start_of_sentence = SequenceExpr::with(AnchorStart)
             .t_aco("it's")
             .t_ws()
             .then(UPOSSet::new(&[UPOS::ADJ, UPOS::NOUN, UPOS::PROPN]))
@@ -60,9 +57,7 @@ impl Default for ItsPossessive {
 
         map.insert(start_of_sentence, 0);
 
-        let special = SequenceExpr::aco("it's")
-            .t_ws()
-            .then(WordSet::new(&["various"]));
+        let special = SequenceExpr::aco("it's").t_ws().t_aco("various");
 
         map.insert(special, 0);
 

--- a/harper-core/src/linting/johns_hopkins.rs
+++ b/harper-core/src/linting/johns_hopkins.rs
@@ -11,19 +11,17 @@ pub struct JohnsHopkins {
 
 impl Default for JohnsHopkins {
     fn default() -> Self {
-        let expr = SequenceExpr::default()
-            .then(|tok: &Token, src: &[char]| {
-                tok.kind.is_proper_noun()
-                    && tok.span.get_content(src).eq_ignore_ascii_case_str("john")
-            })
-            .t_ws()
-            .then(|tok: &Token, src: &[char]| {
-                tok.kind.is_proper_noun()
-                    && tok
-                        .span
-                        .get_content(src)
-                        .eq_ignore_ascii_case_str("hopkins")
-            });
+        let expr = SequenceExpr::with(|tok: &Token, src: &[char]| {
+            tok.kind.is_proper_noun() && tok.span.get_content(src).eq_ignore_ascii_case_str("john")
+        })
+        .t_ws()
+        .then(|tok: &Token, src: &[char]| {
+            tok.kind.is_proper_noun()
+                && tok
+                    .span
+                    .get_content(src)
+                    .eq_ignore_ascii_case_str("hopkins")
+        });
 
         Self {
             expr: Box::new(expr),

--- a/harper-core/src/linting/left_right_hand.rs
+++ b/harper-core/src/linting/left_right_hand.rs
@@ -1,6 +1,6 @@
+use crate::Token;
 use crate::expr::Expr;
 use crate::expr::SequenceExpr;
-use crate::{Token, patterns::WordSet};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::linting::expr_linter::Chunk;
@@ -11,8 +11,7 @@ pub struct LeftRightHand {
 
 impl Default for LeftRightHand {
     fn default() -> Self {
-        let pattern = SequenceExpr::default()
-            .then(WordSet::new(&["left", "right"]))
+        let pattern = SequenceExpr::word_set(&["left", "right"])
             .then_whitespace()
             .t_aco("hand")
             .then_whitespace()

--- a/harper-core/src/linting/less_worse.rs
+++ b/harper-core/src/linting/less_worse.rs
@@ -1,5 +1,4 @@
-use crate::expr::{Expr, SequenceExpr, SpaceOrHyphen};
-use crate::patterns::WordSet;
+use crate::expr::{Expr, SequenceExpr};
 use crate::{CharStringExt, Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
@@ -13,10 +12,9 @@ impl Default for LessWorse {
     fn default() -> Self {
         Self {
             expr: Box::new(
-                SequenceExpr::default()
-                    .then(WordSet::new(&["less", "least"]))
-                    .then(SpaceOrHyphen)
-                    .then(WordSet::new(&["worse", "worst"])),
+                SequenceExpr::word_set(&["less", "least"])
+                    .t_ws_h()
+                    .then_word_set(&["worse", "worst"]),
             ),
         }
     }

--- a/harper-core/src/linting/let_to_do.rs
+++ b/harper-core/src/linting/let_to_do.rs
@@ -14,8 +14,7 @@ impl Default for LetToDo {
     fn default() -> Self {
         Self {
             expr: Box::new(
-                SequenceExpr::default()
-                    .then_word_set(&["let", "lets", "let's"])
+                SequenceExpr::word_set(&["let", "lets", "let's"])
                     .t_ws()
                     .then_any_of(vec![
                         Box::new(SequenceExpr::default().then_object_pronoun()),

--- a/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
+++ b/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
@@ -5,7 +5,6 @@ use crate::expr::SequenceExpr;
 use crate::{
     Token,
     linting::{Lint, LintKind, Suggestion},
-    patterns::WordSet,
 };
 
 use crate::linting::ExprLinter;
@@ -23,9 +22,7 @@ pub struct NoContractionWithVerb {
 impl Default for NoContractionWithVerb {
     fn default() -> Self {
         // Only tests "let".
-        let let_ws = SequenceExpr::default()
-            .then(WordSet::new(&["lets", "let"]))
-            .then_whitespace();
+        let let_ws = SequenceExpr::word_set(&["lets", "let"]).then_whitespace();
 
         let non_ing_verb = SequenceExpr::default().then_kind_is_but_isnt_any_of(
             TokenKind::is_verb,

--- a/harper-core/src/linting/likewise.rs
+++ b/harper-core/src/linting/likewise.rs
@@ -14,15 +14,13 @@ impl Default for Likewise {
         let mut expr = All::default();
 
         expr.add(SequenceExpr::aco("like").then_whitespace().t_aco("wise"));
-        expr.add(
-            SequenceExpr::default().then_unless(
-                SequenceExpr::anything()
-                    .then_whitespace()
-                    .then_anything()
-                    .then_whitespace()
-                    .then_noun(),
-            ),
-        );
+        expr.add(SequenceExpr::unless(
+            SequenceExpr::anything()
+                .then_whitespace()
+                .then_anything()
+                .then_whitespace()
+                .then_noun(),
+        ));
 
         Self {
             expr: Box::new(expr),

--- a/harper-core/src/linting/looking_forward_to.rs
+++ b/harper-core/src/linting/looking_forward_to.rs
@@ -15,8 +15,7 @@ impl Default for LookingForwardTo {
     fn default() -> Self {
         let looking_forward_to = FixedPhrase::from_phrase("looking forward to");
 
-        let pattern = SequenceExpr::default()
-            .then(looking_forward_to)
+        let pattern = SequenceExpr::with(looking_forward_to)
             .t_ws()
             // TODO: update the use the verb with progressive tense function later
             .then_verb();

--- a/harper-core/src/linting/mass_nouns/noun_countability.rs
+++ b/harper-core/src/linting/mass_nouns/noun_countability.rs
@@ -1,7 +1,7 @@
 use crate::linting::expr_linter::Chunk;
 use crate::{
     Lrc, Span, Token, TokenStringExt,
-    expr::{Expr, FirstMatchOf, LongestMatchOf, SequenceExpr},
+    expr::{Expr, LongestMatchOf, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
     patterns::{IndefiniteArticle, WordSet},
 };
@@ -33,24 +33,19 @@ impl Default for NounCountability {
 
         // A determiner or quantifier followed by a mass noun
         let detquant_mass = Lrc::new(
-            SequenceExpr::default()
-                .then(FirstMatchOf::new(vec![
-                    Box::new(IndefiniteArticle::default()),
-                    Box::new(quantifier),
-                ]))
-                .then_whitespace()
-                .then_mass_noun_only(),
+            SequenceExpr::any_of(vec![
+                Box::new(IndefiniteArticle::default()),
+                Box::new(quantifier),
+            ])
+            .then_whitespace()
+            .then_mass_noun_only(),
         );
 
-        let detauant_mass_then_hyphen = Lrc::new(
-            SequenceExpr::default()
-                .then(detquant_mass.clone())
-                .then_hyphen(),
-        );
+        let detauant_mass_then_hyphen =
+            Lrc::new(SequenceExpr::with(detquant_mass.clone()).then_hyphen());
 
         let detquant_mass_following_context = Lrc::new(
-            SequenceExpr::default()
-                .then(detquant_mass.clone())
+            SequenceExpr::with(detquant_mass.clone())
                 .then_whitespace()
                 // If we don't get the word, this won't be the longest match
                 .then_any_word(),

--- a/harper-core/src/linting/missing_preposition.rs
+++ b/harper-core/src/linting/missing_preposition.rs
@@ -17,23 +17,22 @@ pub struct MissingPreposition {
 
 impl Default for MissingPreposition {
     fn default() -> Self {
-        let expr = SequenceExpr::default()
-            .then(
-                AnchorStart.or_longest(
-                    SequenceExpr::default()
-                        .then_non_quantifier_determiner()
-                        .t_ws(),
-                ),
-            )
-            .then(UPOSSet::new(&[UPOS::NOUN, UPOS::PRON, UPOS::PROPN]))
-            .t_ws()
-            .then(UPOSSet::new(&[UPOS::AUX]))
-            .t_ws()
-            .then(UPOSSet::new(&[UPOS::ADJ]))
-            .t_ws()
-            .then(UPOSSet::new(&[UPOS::NOUN, UPOS::PRON, UPOS::PROPN]))
-            .then_optional(AnyPattern)
-            .then_optional(AnyPattern);
+        let expr = SequenceExpr::with(
+            AnchorStart.or_longest(
+                SequenceExpr::default()
+                    .then_non_quantifier_determiner()
+                    .t_ws(),
+            ),
+        )
+        .then(UPOSSet::new(&[UPOS::NOUN, UPOS::PRON, UPOS::PROPN]))
+        .t_ws()
+        .then(UPOSSet::new(&[UPOS::AUX]))
+        .t_ws()
+        .then(UPOSSet::new(&[UPOS::ADJ]))
+        .t_ws()
+        .then(UPOSSet::new(&[UPOS::NOUN, UPOS::PRON, UPOS::PROPN]))
+        .then_optional(AnyPattern)
+        .then_optional(AnyPattern);
 
         Self {
             expr: Box::new(expr),

--- a/harper-core/src/linting/missing_to.rs
+++ b/harper-core/src/linting/missing_to.rs
@@ -200,8 +200,7 @@ impl Default for MissingTo {
     fn default() -> Self {
         let mut map = ExprMap::default();
 
-        let pattern = SequenceExpr::default()
-            .then(Self::controller_words())
+        let pattern = SequenceExpr::with(Self::controller_words())
             .t_ws()
             .then_kind_where(|kind| kind.is_verb_lemma());
 

--- a/harper-core/src/linting/misspell.rs
+++ b/harper-core/src/linting/misspell.rs
@@ -3,7 +3,6 @@ use crate::{
     Token, TokenStringExt,
     expr::{Expr, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
-    patterns::WordSet,
 };
 
 pub struct Misspell {
@@ -12,16 +11,13 @@ pub struct Misspell {
 
 impl Default for Misspell {
     fn default() -> Self {
-        let expr = SequenceExpr::default()
-            .then(WordSet::new(&["miss"]))
-            .t_ws_h()
-            .then(WordSet::new(&[
-                "spell",
-                "spelled",
-                "spelling",
-                "spells",
-                "spellings",
-            ]));
+        let expr = SequenceExpr::word_set(&["miss"]).t_ws_h().then_word_set(&[
+            "spell",
+            "spelled",
+            "spelling",
+            "spells",
+            "spellings",
+        ]);
 
         Self {
             expr: Box::new(expr),

--- a/harper-core/src/linting/modal_be_adjective.rs
+++ b/harper-core/src/linting/modal_be_adjective.rs
@@ -13,8 +13,7 @@ impl Default for ModalBeAdjective {
     fn default() -> Self {
         Self {
             expr: Box::new(
-                SequenceExpr::default()
-                    .then(ModalVerb::default())
+                SequenceExpr::with(ModalVerb::default())
                     .t_ws()
                     .then_kind_is_but_isnt_any_of_except(
                         TokenKind::is_adjective,

--- a/harper-core/src/linting/modal_of.rs
+++ b/harper-core/src/linting/modal_of.rs
@@ -19,8 +19,7 @@ impl Default for ModalOf {
         // "The code I had of this used to work fine ..."
 
         let modal_of = Lrc::new(
-            SequenceExpr::default()
-                .then(ModalVerb::default())
+            SequenceExpr::with(ModalVerb::default())
                 .then_whitespace()
                 .t_aco("of"),
         );
@@ -28,36 +27,28 @@ impl Default for ModalOf {
         // "will of" is a false positive if "will" is a noun
         // "The will of the many"
         let noun_will_of_naive = Lrc::new(
-            SequenceExpr::default()
-                .then_word_set(&["the", "a"])
+            SequenceExpr::word_set(&["the", "a"])
                 .then_whitespace()
                 .t_aco("will")
                 .then_whitespace()
                 .t_aco("of"),
         );
 
-        let ws_course = Lrc::new(SequenceExpr::default().then_whitespace().t_aco("course"));
+        let ws_course = Lrc::new(SequenceExpr::whitespace().t_aco("course"));
 
-        let modal_of_course = Lrc::new(
-            SequenceExpr::default()
-                .then(modal_of.clone())
-                .then(ws_course.clone()),
-        );
+        let modal_of_course =
+            Lrc::new(SequenceExpr::with(modal_of.clone()).then(ws_course.clone()));
 
         let anyword_might_of = Lrc::new(
-            SequenceExpr::default()
-                .then_any_word()
+            SequenceExpr::any_word()
                 .then_whitespace()
                 .t_aco("might")
                 .then_whitespace()
                 .t_aco("of"),
         );
 
-        let anyword_might_of_course = Lrc::new(
-            SequenceExpr::default()
-                .then(anyword_might_of.clone())
-                .then(ws_course.clone()),
-        );
+        let anyword_might_of_course =
+            Lrc::new(SequenceExpr::with(anyword_might_of.clone()).then(ws_course.clone()));
 
         Self {
             expr: Box::new(LongestMatchOf::new(vec![

--- a/harper-core/src/linting/modal_seem.rs
+++ b/harper-core/src/linting/modal_seem.rs
@@ -20,8 +20,7 @@ pub struct ModalSeem {
 
 impl ModalSeem {
     fn base_sequence() -> SequenceExpr {
-        SequenceExpr::default()
-            .then(ModalVerb::default())
+        SequenceExpr::with(ModalVerb::default())
             .t_ws()
             .t_aco("seen")
     }

--- a/harper-core/src/linting/months.rs
+++ b/harper-core/src/linting/months.rs
@@ -68,14 +68,12 @@ impl Default for Months {
         let month_expr = SequenceExpr::with(FirstMatchOf::new(vec![
             Box::new(only_months),
             Box::new(
-                SequenceExpr::default()
-                    .then(before_month_sense_only)
+                SequenceExpr::with(before_month_sense_only)
                     .then_whitespace()
                     .then(ambiguous_months.clone()),
             ),
             Box::new(
-                SequenceExpr::default()
-                    .then(ambiguous_months)
+                SequenceExpr::with(ambiguous_months)
                     .then_whitespace()
                     .then(year_or_day_of_month),
             ),

--- a/harper-core/src/linting/most_number.rs
+++ b/harper-core/src/linting/most_number.rs
@@ -1,7 +1,7 @@
 use crate::expr::All;
 use crate::expr::Expr;
 use crate::expr::SequenceExpr;
-use crate::{Token, TokenStringExt, patterns::WordSet};
+use crate::{Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::linting::expr_linter::Chunk;
@@ -19,7 +19,7 @@ impl Default for MostNumber {
                     SequenceExpr::default()
                         .t_aco("most")
                         .t_ws()
-                        .then(WordSet::new(&["amount", "number"])),
+                        .then_word_set(&["amount", "number"]),
                 ),
                 // Context pattern
                 Box::new(

--- a/harper-core/src/linting/multiple_sequential_pronouns.rs
+++ b/harper-core/src/linting/multiple_sequential_pronouns.rs
@@ -49,13 +49,8 @@ impl MultipleSequentialPronouns {
 
         Self {
             expr: Box::new(
-                SequenceExpr::default()
-                    .then(pronouns.clone())
-                    .then_one_or_more(
-                        SequenceExpr::default()
-                            .then_whitespace()
-                            .then(pronouns.clone()),
-                    ),
+                SequenceExpr::with(pronouns.clone())
+                    .then_one_or_more(SequenceExpr::whitespace().then(pronouns.clone())),
             ),
             subject_pronouns,
             object_pronouns,

--- a/harper-core/src/linting/need_to_noun.rs
+++ b/harper-core/src/linting/need_to_noun.rs
@@ -41,8 +41,7 @@ impl Default for NeedToNoun {
         let b =
             SequenceExpr::default().then_kind_where(|kind| kind.is_nominal() && !kind.is_verb());
 
-        let expr = SequenceExpr::default()
-            .then(DerivedFrom::new_from_str("need"))
+        let expr = SequenceExpr::with(DerivedFrom::new_from_str("need"))
             .t_ws()
             .t_aco("to")
             .t_ws()

--- a/harper-core/src/linting/no_match_for.rs
+++ b/harper-core/src/linting/no_match_for.rs
@@ -20,8 +20,7 @@ impl Default for NoMatchFor {
             ])),
         ]);
 
-        let expr = SequenceExpr::default()
-            .then(pre_context)
+        let expr = SequenceExpr::with(pre_context)
             .then_whitespace()
             .t_aco("no")
             .then_whitespace()

--- a/harper-core/src/linting/no_oxford_comma.rs
+++ b/harper-core/src/linting/no_oxford_comma.rs
@@ -1,9 +1,6 @@
 use crate::expr::ExprExt;
 use crate::expr::SequenceExpr;
-use crate::{
-    Document, Token, TokenStringExt,
-    patterns::{NominalPhrase, WordSet},
-};
+use crate::{Document, Token, TokenStringExt, patterns::NominalPhrase};
 
 use super::{Lint, LintKind, Linter, Suggestion};
 
@@ -25,7 +22,7 @@ impl NoOxfordComma {
             }
             .then_comma()
             .then_whitespace()
-            .then(WordSet::new(&["and", "or", "nor"])),
+            .then_word_set(&["and", "or", "nor"]),
         }
     }
 

--- a/harper-core/src/linting/nominal_wants.rs
+++ b/harper-core/src/linting/nominal_wants.rs
@@ -46,8 +46,7 @@ impl Default for NominalWants {
         }
 
         let miss = WordSet::new(&["wont", "wonts", "want", "wants"]);
-        let pattern = SequenceExpr::default()
-            .then(is_applicable_pronoun)
+        let pattern = SequenceExpr::with(is_applicable_pronoun)
             .then_whitespace()
             .then(miss);
 

--- a/harper-core/src/linting/noun_verb_confusion/effect_affect/affect_to_effect.rs
+++ b/harper-core/src/linting/noun_verb_confusion/effect_affect/affect_to_effect.rs
@@ -19,45 +19,49 @@ impl Default for AffectToEffect {
     fn default() -> Self {
         let mut map = ExprMap::default();
 
-        let adj_then_noun_follow = SequenceExpr::default()
-            .then(|tok: &Token, source: &[char]| matches_preceding_context_adj_noun(tok, source))
-            .t_ws()
-            .then(|tok: &Token, source: &[char]| is_affect_word(tok, source))
-            .t_ws()
-            .then(UPOSSet::new(&[UPOS::ADJ]))
-            .t_ws()
-            .then(UPOSSet::new(&[UPOS::NOUN]));
+        let adj_then_noun_follow = SequenceExpr::with(|tok: &Token, source: &[char]| {
+            matches_preceding_context_adj_noun(tok, source)
+        })
+        .t_ws()
+        .then(|tok: &Token, source: &[char]| is_affect_word(tok, source))
+        .t_ws()
+        .then(UPOSSet::new(&[UPOS::ADJ]))
+        .t_ws()
+        .then(UPOSSet::new(&[UPOS::NOUN]));
 
         map.insert(adj_then_noun_follow, 2);
 
-        let word_follow = SequenceExpr::default()
-            .then(|tok: &Token, source: &[char]| matches_preceding_context(tok, source))
-            .t_ws()
-            .then(|tok: &Token, source: &[char]| is_affect_word(tok, source))
-            .t_ws()
-            .then(UPOSSet::new(&[
-                UPOS::PROPN,
-                UPOS::INTJ,
-                UPOS::ADP,
-                UPOS::SCONJ,
-            ]));
+        let word_follow = SequenceExpr::with(|tok: &Token, source: &[char]| {
+            matches_preceding_context(tok, source)
+        })
+        .t_ws()
+        .then(|tok: &Token, source: &[char]| is_affect_word(tok, source))
+        .t_ws()
+        .then(UPOSSet::new(&[
+            UPOS::PROPN,
+            UPOS::INTJ,
+            UPOS::ADP,
+            UPOS::SCONJ,
+        ]));
 
         map.insert(word_follow, 2);
 
-        let verb_follow = SequenceExpr::default()
-            .then(|tok: &Token, source: &[char]| matches_preceding_context_verb_follow(tok, source))
-            .t_ws()
-            .then(|tok: &Token, source: &[char]| is_affect_word(tok, source))
-            .t_ws()
-            .then(UPOSSet::new(&[UPOS::AUX, UPOS::VERB]));
+        let verb_follow = SequenceExpr::with(|tok: &Token, source: &[char]| {
+            matches_preceding_context_verb_follow(tok, source)
+        })
+        .t_ws()
+        .then(|tok: &Token, source: &[char]| is_affect_word(tok, source))
+        .t_ws()
+        .then(UPOSSet::new(&[UPOS::AUX, UPOS::VERB]));
 
         map.insert(verb_follow, 2);
 
-        let punctuation_follow = SequenceExpr::default()
-            .then(|tok: &Token, source: &[char]| matches_preceding_context(tok, source))
-            .t_ws()
-            .then(|tok: &Token, source: &[char]| is_affect_word(tok, source))
-            .then_kind_where(|kind| kind.is_punctuation());
+        let punctuation_follow = SequenceExpr::with(|tok: &Token, source: &[char]| {
+            matches_preceding_context(tok, source)
+        })
+        .t_ws()
+        .then(|tok: &Token, source: &[char]| is_affect_word(tok, source))
+        .then_kind_where(|kind| kind.is_punctuation());
 
         map.insert(punctuation_follow, 2);
 

--- a/harper-core/src/linting/noun_verb_confusion/effect_affect/effect_to_affect.rs
+++ b/harper-core/src/linting/noun_verb_confusion/effect_affect/effect_to_affect.rs
@@ -19,8 +19,7 @@ impl Default for EffectToAffect {
     fn default() -> Self {
         let mut map = ExprMap::default();
 
-        let context = SequenceExpr::default()
-            .then(matches_preceding_context)
+        let context = SequenceExpr::with(matches_preceding_context)
             .t_ws()
             .then(|tok: &Token, source: &[char]| is_effect_word(tok, source))
             .t_ws()

--- a/harper-core/src/linting/noun_verb_confusion/noun_instead_of_verb/general.rs
+++ b/harper-core/src/linting/noun_verb_confusion/noun_instead_of_verb/general.rs
@@ -43,18 +43,15 @@ impl Default for GeneralNounInsteadOfVerb {
         ));
 
         let basic_pattern = Lrc::new(
-            SequenceExpr::default()
-                .then(pre_context)
+            SequenceExpr::with(pre_context)
                 .then_whitespace()
                 .then(nouns.clone()),
         );
 
-        let pattern_followed_by_punctuation = SequenceExpr::default()
-            .then(basic_pattern.clone())
-            .then_punctuation();
+        let pattern_followed_by_punctuation =
+            SequenceExpr::with(basic_pattern.clone()).then_punctuation();
 
-        let pattern_followed_by_word = SequenceExpr::default()
-            .then(basic_pattern.clone())
+        let pattern_followed_by_word = SequenceExpr::with(basic_pattern.clone())
             .then_whitespace()
             .then_any_word();
 

--- a/harper-core/src/linting/noun_verb_confusion/verb_instead_of_noun.rs
+++ b/harper-core/src/linting/noun_verb_confusion/verb_instead_of_noun.rs
@@ -23,8 +23,7 @@ impl Default for VerbInsteadOfNoun {
         ));
         Self {
             expr: Box::new(
-                SequenceExpr::default()
-                    .then(UPOSSet::new(&[UPOS::ADJ, UPOS::ADP]))
+                SequenceExpr::with(UPOSSet::new(&[UPOS::ADJ, UPOS::ADP]))
                     .then_whitespace()
                     .then(verbs.clone()),
             ),

--- a/harper-core/src/linting/oldest_in_the_book.rs
+++ b/harper-core/src/linting/oldest_in_the_book.rs
@@ -21,7 +21,7 @@ impl Default for OldestInTheBook {
         };
 
         // Zero or more adjectives
-        let adjseq = Repeating::new(Box::new(SequenceExpr::default().then(adj).t_ws()), 0);
+        let adjseq = Repeating::new(Box::new(SequenceExpr::with(adj).t_ws()), 0);
 
         let noun = |t: &Token, s: &[char]| {
             let k = &t.kind;
@@ -33,14 +33,12 @@ impl Default for OldestInTheBook {
         };
 
         // One or more nouns
-        let nounseq = SequenceExpr::default()
-            .then(noun)
-            .then_optional(Repeating::new(
-                Box::new(SequenceExpr::default().t_ws().then(noun)),
-                1,
-            ));
+        let nounseq = SequenceExpr::with(noun).then_optional(Repeating::new(
+            Box::new(SequenceExpr::default().t_ws().then(noun)),
+            1,
+        ));
 
-        let noun_phrase = SequenceExpr::default().then_optional(adjseq).then(nounseq);
+        let noun_phrase = SequenceExpr::optional(adjseq).then(nounseq);
 
         Self {
             expr: Box::new(

--- a/harper-core/src/linting/on_floor.rs
+++ b/harper-core/src/linting/on_floor.rs
@@ -18,8 +18,7 @@ impl Default for OnFloor {
         let preposition = WordSet::new(&["in", "at"]);
 
         let on_the_floor = Lrc::new(
-            SequenceExpr::default()
-                .then(preposition)
+            SequenceExpr::with(preposition)
                 .t_ws()
                 .t_aco("the")
                 .t_ws()
@@ -29,8 +28,7 @@ impl Default for OnFloor {
         );
 
         let look_up_phrase = Lrc::new(
-            SequenceExpr::default()
-                .then(WordSet::new(&["look", "looking", "looks", "looked"]))
+            SequenceExpr::word_set(&["look", "looking", "looks", "looked"])
                 .t_ws()
                 .t_aco("up"),
         );
@@ -44,8 +42,7 @@ impl Default for OnFloor {
         let pattern = LongestMatchOf::new(vec![
             Box::new(on_the_floor.clone()),
             Box::new(
-                SequenceExpr::default()
-                    .then(exceptions.clone())
+                SequenceExpr::with(exceptions.clone())
                     .t_ws()
                     .then(on_the_floor.clone()),
             ),

--- a/harper-core/src/linting/one_and_the_same.rs
+++ b/harper-core/src/linting/one_and_the_same.rs
@@ -2,7 +2,7 @@ use crate::expr::Expr;
 use crate::expr::FixedPhrase;
 use crate::expr::LongestMatchOf;
 use crate::expr::SequenceExpr;
-use crate::{Lrc, Token, TokenStringExt, patterns::WordSet};
+use crate::{Lrc, Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::linting::expr_linter::Chunk;
@@ -18,14 +18,12 @@ impl Default for OneAndTheSame {
         Self {
             expr: Box::new(LongestMatchOf::new(vec![
                 Box::new(
-                    SequenceExpr::default()
-                        .then(WordSet::new(&["are", "were"]))
+                    SequenceExpr::word_set(&["are", "were"])
                         .t_ws()
                         .then(one_in_the_same.clone()),
                 ),
                 Box::new(
-                    SequenceExpr::default()
-                        .then(one_in_the_same.clone())
+                    SequenceExpr::with(one_in_the_same.clone())
                         .t_ws()
                         .t_aco("as"),
                 ),

--- a/harper-core/src/linting/one_of_the_singular.rs
+++ b/harper-core/src/linting/one_of_the_singular.rs
@@ -35,18 +35,15 @@ impl SeqExprExt for SequenceExpr {
 impl<D: Dictionary + 'static> OneOfTheSingular<D> {
     pub fn new(dict: D) -> Self {
         let advs =
-            SequenceExpr::default().then_one_or_more_spaced(SequenceExpr::default().then_adverb());
+            SequenceExpr::default().then_zero_or_more_spaced(SequenceExpr::default().then_adverb());
 
         let adj_or_nouns = SequenceExpr::default()
-            .then_one_or_more_spaced(SequenceExpr::default().then_my_noun_or_adjective());
+            .then_zero_or_more_spaced(SequenceExpr::default().then_my_noun_or_adjective());
 
         Self {
             expr: Box::new(
-                SequenceExpr::fixed_phrase("one of the ").then(
-                    SequenceExpr::default()
-                        .then_optional(advs.t_ws())
-                        .then(adj_or_nouns),
-                ),
+                SequenceExpr::fixed_phrase("one of the ")
+                    .then(SequenceExpr::optional(advs.t_ws()).then(adj_or_nouns)),
             ),
             dict,
         }

--- a/harper-core/src/linting/open_compounds.rs
+++ b/harper-core/src/linting/open_compounds.rs
@@ -43,9 +43,7 @@ impl Default for OpenCompounds {
 
         let with_prev = SequenceExpr::anything().then(compound.clone());
 
-        let with_next = SequenceExpr::default()
-            .then(compound.clone())
-            .then_anything();
+        let with_next = SequenceExpr::with(compound.clone()).then_anything();
 
         let with_prev_and_next = SequenceExpr::anything()
             .then(compound.clone())

--- a/harper-core/src/linting/open_the_light.rs
+++ b/harper-core/src/linting/open_the_light.rs
@@ -4,7 +4,6 @@ use crate::expr::SequenceExpr;
 use crate::{
     Lrc, Token, TokenStringExt,
     linting::{LintKind, Suggestion},
-    patterns::WordSet,
 };
 
 use super::{ExprLinter, Lint};
@@ -36,16 +35,14 @@ impl Default for OpenTheLight {
         ];
 
         let open_the_device = Lrc::new(
-            SequenceExpr::default()
-                .then(WordSet::new(TO_OPEN))
+            SequenceExpr::word_set(TO_OPEN)
                 .t_ws()
                 .then_determiner()
                 .t_ws()
-                .then(WordSet::new(DEVICES)),
+                .then_word_set(DEVICES),
         );
 
-        let open_the_device_then_noun = SequenceExpr::default()
-            .then(open_the_device.clone())
+        let open_the_device_then_noun = SequenceExpr::with(open_the_device.clone())
             .t_ws()
             .then_noun();
 

--- a/harper-core/src/linting/ought_to_be.rs
+++ b/harper-core/src/linting/ought_to_be.rs
@@ -1,5 +1,5 @@
 use crate::TokenKind;
-use crate::expr::{AnchorStart, Expr, ExprMap, FixedPhrase, SequenceExpr};
+use crate::expr::{AnchorStart, Expr, ExprMap, SequenceExpr};
 use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
@@ -27,15 +27,14 @@ impl Default for OughtToBe {
             .then_whitespace()
             .then_pronoun()
             .then_whitespace()
-            .then(FixedPhrase::from_phrase("out to be"));
+            .then_fixed_phrase("out to be");
 
         // 2) start-of-sentence + pronoun + "out to be" → index of `out` = 2 tokens after start
         //    [AnchorStart] [pronoun] [ws] [out] [ws] [to] [ws] [be]
-        let branch_anchor_pronoun = SequenceExpr::default()
-            .then(AnchorStart)
+        let branch_anchor_pronoun = SequenceExpr::with(AnchorStart)
             .then_pronoun()
             .then_whitespace()
-            .then(FixedPhrase::from_phrase("out to be"));
+            .then_fixed_phrase("out to be");
 
         // 3) punctuation + pronoun + "out to be" → index of `out` = 4 tokens after start
         //    [punct] [ws] [pronoun] [ws] [out] [ws] [to] [ws] [be]
@@ -44,7 +43,7 @@ impl Default for OughtToBe {
             .then_whitespace()
             .then_pronoun()
             .then_whitespace()
-            .then(FixedPhrase::from_phrase("out to be"));
+            .then_fixed_phrase("out to be");
 
         let mut map = ExprMap::default();
         map.insert(branch_nonverb_pronoun, 4);

--- a/harper-core/src/linting/oxford_comma.rs
+++ b/harper-core/src/linting/oxford_comma.rs
@@ -2,7 +2,7 @@ use crate::expr::Expr;
 use crate::expr::ExprExt;
 use crate::expr::OwnedExprExt;
 use crate::expr::SequenceExpr;
-use crate::{Lrc, Token, TokenStringExt, linting::Linter, patterns::WordSet};
+use crate::{Lrc, Token, TokenStringExt, linting::Linter};
 
 use super::{super::Lint, LintKind, Suggestion};
 
@@ -20,8 +20,7 @@ impl Default for OxfordComma {
                 .or_longest(SequenceExpr::default().then_nominal()),
         );
 
-        let item_chunk = SequenceExpr::default()
-            .then(item.clone())
+        let item_chunk = SequenceExpr::with(item.clone())
             .then_comma()
             .then_whitespace();
 
@@ -29,7 +28,7 @@ impl Default for OxfordComma {
             .then_one_or_more(item_chunk)
             .then(item.clone())
             .then_whitespace()
-            .then(WordSet::new(&["and", "or", "nor"]))
+            .then_word_set(&["and", "or", "nor"])
             .then_whitespace()
             .then(item.clone());
 

--- a/harper-core/src/linting/pique_interest.rs
+++ b/harper-core/src/linting/pique_interest.rs
@@ -1,7 +1,7 @@
 use crate::TokenKind;
 use crate::expr::Expr;
 use crate::expr::SequenceExpr;
-use crate::{CharString, CharStringExt, Token, char_string::char_string, patterns::WordSet};
+use crate::{CharString, CharStringExt, Token, char_string::char_string};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::linting::expr_linter::Chunk;
@@ -12,17 +12,15 @@ pub struct PiqueInterest {
 
 impl Default for PiqueInterest {
     fn default() -> Self {
-        let pattern = SequenceExpr::default()
-            .then(WordSet::new(&[
-                "peak", "peaked", "peek", "peeked", "peeking", "peaking",
-            ]))
-            .then_whitespace()
-            .then_kind_either(
-                TokenKind::is_non_plural_nominal,
-                TokenKind::is_possessive_determiner,
-            )
-            .then_whitespace()
-            .t_aco("interest");
+        let pattern =
+            SequenceExpr::word_set(&["peak", "peaked", "peek", "peeked", "peeking", "peaking"])
+                .then_whitespace()
+                .then_kind_either(
+                    TokenKind::is_non_plural_nominal,
+                    TokenKind::is_possessive_determiner,
+                )
+                .then_whitespace()
+                .t_aco("interest");
 
         Self {
             expr: Box::new(pattern),

--- a/harper-core/src/linting/plural_wrong_word_of_phrase.rs
+++ b/harper-core/src/linting/plural_wrong_word_of_phrase.rs
@@ -22,13 +22,13 @@ const PATTERNS: &[(&[&str], &str, &[&str])] = &[
 impl Default for PluralWrongWordOfPhrase {
     fn default() -> Self {
         let word_str = |w| {
-            SequenceExpr::default().then(move |t: &Token, s: &[char]| {
+            SequenceExpr::with(move |t: &Token, s: &[char]| {
                 t.kind.is_word() && t.span.get_content(s).eq_ignore_ascii_case_str(w)
             })
         };
 
         let word_string = |w: String| {
-            SequenceExpr::default().then(move |t: &Token, s: &[char]| {
+            SequenceExpr::with(move |t: &Token, s: &[char]| {
                 t.kind.is_word() && t.span.get_content(s).eq_ignore_ascii_case_str(&w)
             })
         };

--- a/harper-core/src/linting/possessive_noun.rs
+++ b/harper-core/src/linting/possessive_noun.rs
@@ -17,8 +17,7 @@ where
     D: Dictionary,
 {
     pub fn new(dict: D) -> Self {
-        let expr = SequenceExpr::default()
-            .then(UPOSSet::new(&[UPOS::DET, UPOS::PROPN]))
+        let expr = SequenceExpr::with(UPOSSet::new(&[UPOS::DET, UPOS::PROPN]))
             .t_ws()
             .then_kind_is_but_is_not(TokenKind::is_plural_nominal, TokenKind::is_singular_nominal)
             .t_ws()
@@ -27,12 +26,12 @@ where
 
         let additional_req = SequenceExpr::anything().t_any().t_any().t_any().then_noun();
 
-        let exceptions = SequenceExpr::default()
-            .then_unless(|tok: &Token, _: &[char]| tok.kind.is_demonstrative_determiner())
-            .t_any()
-            .then_unless(WordSet::new(&["flags", "checks", "catches", "you"]))
-            .t_any()
-            .then_unless(WordSet::new(&["form", "go"]));
+        let exceptions =
+            SequenceExpr::unless(|tok: &Token, _: &[char]| tok.kind.is_demonstrative_determiner())
+                .t_any()
+                .then_unless(WordSet::new(&["flags", "checks", "catches", "you"]))
+                .t_any()
+                .then_unless(WordSet::new(&["form", "go"]));
 
         Self {
             expr: Box::new(All::new(vec![

--- a/harper-core/src/linting/pronoun_contraction/should_contract.rs
+++ b/harper-core/src/linting/pronoun_contraction/should_contract.rs
@@ -23,8 +23,7 @@ pub struct ShouldContract {
 impl Default for ShouldContract {
     fn default() -> Self {
         let cap = Arc::new(
-            SequenceExpr::default()
-                .then(WordSet::new(&["your", "were"]))
+            SequenceExpr::word_set(&["your", "were"])
                 .then_whitespace()
                 .then_kind_is_but_is_not(
                     TokenKind::is_non_quantifier_determiner,
@@ -35,8 +34,7 @@ impl Default for ShouldContract {
         );
 
         let start = SequenceExpr::with(AnchorStart).then(cap.clone());
-        let mid = SequenceExpr::default()
-            .then_unless(WordSet::new(&["what"]))
+        let mid = SequenceExpr::unless(WordSet::new(&["what"]))
             .t_ws()
             .then(cap);
 

--- a/harper-core/src/linting/pronoun_inflection_be.rs
+++ b/harper-core/src/linting/pronoun_inflection_be.rs
@@ -32,8 +32,7 @@ impl PronounInflectionBe {
             .then_unless(NominalPhrase);
         map.insert(are, "is");
 
-        let are_at_start = SequenceExpr::default()
-            .then(AnchorStart)
+        let are_at_start = SequenceExpr::with(AnchorStart)
             .then_third_person_singular_pronoun()
             .then_optional(mod_term.clone())
             .t_ws()
@@ -67,8 +66,7 @@ impl PronounInflectionBe {
             .t_any();
         map.insert(is, "are");
 
-        let is_at_start = SequenceExpr::default()
-            .then(AnchorStart)
+        let is_at_start = SequenceExpr::with(AnchorStart)
             .then_third_person_plural_pronoun()
             .then_optional(mod_term.clone())
             .t_ws()
@@ -96,8 +94,7 @@ impl PronounInflectionBe {
         map.insert(was, "were");
 
         // Special case for second and third-person
-        let was_third = SequenceExpr::default()
-            .then(AnchorStart)
+        let was_third = SequenceExpr::with(AnchorStart)
             .then_kind_either(
                 TokenKind::is_third_person_plural_pronoun,
                 TokenKind::is_second_person_pronoun,
@@ -109,8 +106,7 @@ impl PronounInflectionBe {
             .t_any();
         map.insert(was_third, "were");
 
-        let were = SequenceExpr::default()
-            .then(AnchorStart)
+        let were = SequenceExpr::with(AnchorStart)
             .then_kind_either(
                 TokenKind::is_first_person_singular_pronoun,
                 TokenKind::is_third_person_singular_pronoun,

--- a/harper-core/src/linting/pronoun_knew.rs
+++ b/harper-core/src/linting/pronoun_knew.rs
@@ -7,7 +7,6 @@ use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
-    patterns::WordSet,
 };
 
 pub struct PronounKnew {
@@ -37,15 +36,13 @@ impl Default for PronounKnew {
             !excluded.contains(&&*pronorm)
         };
 
-        let pronoun_then_new = SequenceExpr::default()
-            .then(pronoun_pattern)
+        let pronoun_then_new = SequenceExpr::with(pronoun_pattern)
             .then_whitespace()
             .then_any_capitalization_of("new");
 
-        let pronoun_adverb_then_new = SequenceExpr::default()
-            .then(pronoun_pattern)
+        let pronoun_adverb_then_new = SequenceExpr::with(pronoun_pattern)
             .then_whitespace()
-            .then(WordSet::new(&["always", "never", "also", "often"]))
+            .then_word_set(&["always", "never", "also", "often"])
             .then_whitespace()
             .then_any_capitalization_of("new");
 

--- a/harper-core/src/linting/quantifier_needs_of.rs
+++ b/harper-core/src/linting/quantifier_needs_of.rs
@@ -1,6 +1,5 @@
 use crate::Token;
 use crate::expr::{Expr, SequenceExpr};
-use crate::patterns::WordSet;
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::linting::expr_linter::Chunk;
@@ -15,7 +14,7 @@ impl Default for QuantifierNeedsOf {
         let expr = SequenceExpr::default()
             .then_indefinite_article()
             .t_ws()
-            .then(WordSet::new(&["couple", "lot"]))
+            .then_word_set(&["couple", "lot"])
             .t_ws()
             .then_plural_nominal();
 

--- a/harper-core/src/linting/quantifier_numeral_conflict.rs
+++ b/harper-core/src/linting/quantifier_numeral_conflict.rs
@@ -22,16 +22,14 @@ impl Default for QuantifierNumeralConflict {
                             Box::new(SequenceExpr::default().then_cardinal_number()),
                         ]),
                 ),
-                Box::new(
-                    SequenceExpr::default().then_unless(SequenceExpr::any_of(vec![
-                        Box::new(WordSet::new(&["all", "any", "every", "no"])),
-                        Box::new(
-                            SequenceExpr::word_set(&["each", "some"])
-                                .t_ws()
-                                .t_aco("one"),
-                        ),
-                    ])),
-                ),
+                Box::new(SequenceExpr::unless(SequenceExpr::any_of(vec![
+                    Box::new(WordSet::new(&["all", "any", "every", "no"])),
+                    Box::new(
+                        SequenceExpr::word_set(&["each", "some"])
+                            .t_ws()
+                            .t_aco("one"),
+                    ),
+                ]))),
             ])),
         }
     }

--- a/harper-core/src/linting/quite_quiet.rs
+++ b/harper-core/src/linting/quite_quiet.rs
@@ -22,17 +22,16 @@ impl Default for QuiteQuiet {
                 &["here", "up"],
             );
 
-        let negative_contraction_quiet = SequenceExpr::default()
-            .then(|tok: &Token, src: &[char]| {
-                if !tok.kind.is_verb() || !tok.kind.is_apostrophized() {
-                    return false;
-                }
-                tok.span
-                    .get_content(src)
-                    .ends_with_any_ignore_ascii_case_chars(&[&['n', '\'', 't'], &['n', '’', 't']])
-            })
-            .t_ws()
-            .t_aco("quiet");
+        let negative_contraction_quiet = SequenceExpr::with(|tok: &Token, src: &[char]| {
+            if !tok.kind.is_verb() || !tok.kind.is_apostrophized() {
+                return false;
+            }
+            tok.span
+                .get_content(src)
+                .ends_with_any_ignore_ascii_case_chars(&[&['n', '\'', 't'], &['n', '’', 't']])
+        })
+        .t_ws()
+        .t_aco("quiet");
 
         let adverb_quite = SequenceExpr::default()
             .then_kind_except(

--- a/harper-core/src/linting/quote_spacing.rs
+++ b/harper-core/src/linting/quote_spacing.rs
@@ -11,10 +11,7 @@ pub struct QuoteSpacing {
 impl QuoteSpacing {
     pub fn new() -> Self {
         Self {
-            expr: SequenceExpr::default()
-                .then_any_word()
-                .then_quote()
-                .then_any_word(),
+            expr: SequenceExpr::any_word().then_quote().then_any_word(),
         }
     }
 }

--- a/harper-core/src/linting/redundant_additive_adverbs.rs
+++ b/harper-core/src/linting/redundant_additive_adverbs.rs
@@ -20,14 +20,9 @@ impl Default for RedundantAdditiveAdverbs {
             Box::new(as_well),
         ]));
 
-        let multiple_additive_adverbs = SequenceExpr::default()
-            .then(additive_adverb.clone())
-            .then_one_or_more(
-                SequenceExpr::default()
-                    .then_whitespace()
-                    .then(additive_adverb.clone()),
-            )
-            .then_optional(SequenceExpr::default().then_whitespace().t_aco("as"));
+        let multiple_additive_adverbs = SequenceExpr::with(additive_adverb.clone())
+            .then_one_or_more(SequenceExpr::whitespace().then(additive_adverb.clone()))
+            .then_optional(SequenceExpr::whitespace().t_aco("as"));
 
         Self {
             expr: Box::new(multiple_additive_adverbs),

--- a/harper-core/src/linting/respond.rs
+++ b/harper-core/src/linting/respond.rs
@@ -4,7 +4,6 @@ use crate::Token;
 use crate::expr::{Expr, ExprMap, SequenceExpr};
 use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, Lint, LintKind, Suggestion};
-use crate::patterns::Word;
 
 pub struct Respond {
     expr: Box<dyn Expr>,
@@ -37,7 +36,7 @@ impl Default for Respond {
                 .t_ws()
                 .then(helper_verb)
                 .t_ws()
-                .then(Word::new("response")),
+                .t_aco("response"),
             4,
         );
 
@@ -49,7 +48,7 @@ impl Default for Respond {
                 .t_ws()
                 .then_adverb()
                 .t_ws()
-                .then(Word::new("response")),
+                .t_aco("response"),
             6,
         );
 

--- a/harper-core/src/linting/right_click.rs
+++ b/harper-core/src/linting/right_click.rs
@@ -18,8 +18,7 @@ impl Default for RightClick {
         let mut map = ExprMap::default();
 
         map.insert(
-            SequenceExpr::default()
-                .then_word_set(&["right", "left", "middle"])
+            SequenceExpr::word_set(&["right", "left", "middle"])
                 .t_ws()
                 .then(DerivedFrom::new_from_str("click")),
             0,

--- a/harper-core/src/linting/roller_skated.rs
+++ b/harper-core/src/linting/roller_skated.rs
@@ -53,9 +53,7 @@ impl Default for RollerSkated {
         );
 
         map.insert(
-            SequenceExpr::default()
-                .then(AnchorStart)
-                .then_seq(Self::roller_pair()),
+            SequenceExpr::with(AnchorStart).then_seq(Self::roller_pair()),
             0,
         );
 

--- a/harper-core/src/linting/safe_to_save.rs
+++ b/harper-core/src/linting/safe_to_save.rs
@@ -16,8 +16,7 @@ pub struct SafeToSave {
 
 impl Default for SafeToSave {
     fn default() -> Self {
-        let with_adv = SequenceExpr::default()
-            .then(ModalVerb::default())
+        let with_adv = SequenceExpr::with(ModalVerb::default())
             .then_whitespace()
             .then(UPOSSet::new(&[UPOS::ADV]))
             .then_whitespace()
@@ -25,8 +24,7 @@ impl Default for SafeToSave {
             .then_whitespace()
             .then_unless(WordSet::new(&["to"]));
 
-        let without_adv = SequenceExpr::default()
-            .then(ModalVerb::default())
+        let without_adv = SequenceExpr::with(ModalVerb::default())
             .then_whitespace()
             .t_aco("safe")
             .then_whitespace()

--- a/harper-core/src/linting/save_to_safe.rs
+++ b/harper-core/src/linting/save_to_safe.rs
@@ -14,8 +14,7 @@ pub struct SaveToSafe {
 
 impl Default for SaveToSafe {
     fn default() -> Self {
-        let pattern = SequenceExpr::default()
-            .then(InflectionOfBe::new().or(Word::new("it")))
+        let pattern = SequenceExpr::with(InflectionOfBe::new().or(Word::new("it")))
             .then_whitespace()
             .t_aco("save")
             .then_whitespace()

--- a/harper-core/src/linting/semicolon_apostrophe.rs
+++ b/harper-core/src/linting/semicolon_apostrophe.rs
@@ -3,7 +3,6 @@ use crate::{
     Token, TokenStringExt,
     expr::{Expr, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
-    patterns::WordSet,
 };
 
 const CONTRACTION_AND_POSSESSIVE_ENDINGS: [&str; 7] = ["d", "ll", "m", "re", "s", "t", "ve"];
@@ -16,10 +15,9 @@ impl Default for SemicolonApostrophe {
     fn default() -> Self {
         Self {
             expr: Box::new(
-                SequenceExpr::default()
-                    .then_any_word()
+                SequenceExpr::any_word()
                     .then_semicolon()
-                    .then(WordSet::new(&CONTRACTION_AND_POSSESSIVE_ENDINGS)),
+                    .then_word_set(&CONTRACTION_AND_POSSESSIVE_ENDINGS),
             ),
         }
     }

--- a/harper-core/src/linting/shoot_oneself_in_the_foot.rs
+++ b/harper-core/src/linting/shoot_oneself_in_the_foot.rs
@@ -18,8 +18,7 @@ impl Default for ShootOneselfInTheFoot {
 
         let body_parts = WordSet::new(&["foot", "feet", "leg", "legs"]);
 
-        let pattern = SequenceExpr::default()
-            .then(verb_forms)
+        let pattern = SequenceExpr::with(verb_forms)
             .t_ws()
             .then(ReflexivePronoun::default())
             .t_ws()

--- a/harper-core/src/linting/simple_past_to_past_participle.rs
+++ b/harper-core/src/linting/simple_past_to_past_participle.rs
@@ -18,40 +18,38 @@ impl Default for SimplePastToPastParticiple {
             expr: Box::new(All::new(vec![
                 // positive: the general case
                 Box::new(
-                    SequenceExpr::default()
-                        .then_any_of(vec![
-                            // for perfect tenses
-                            Box::new(WordSet::new(&["have", "had", "has", "having"])),
-                            // for passive voice
-                            Box::new(InflectionOfBe::default()),
-                            // pronoun + have contractions
-                            Box::new(WordSet::new(&[
-                                "I've", "I'd", "we've", "we'd", "you've", "you'd", "he's", "he'd",
-                                "she's", "she'd", "it's", "it'd", "they've", "they'd",
-                            ])),
-                            // pronoun + have contractions missing apostrophes
-                            Box::new(WordSet::new(&[
-                                "Ive", "Id", "weve", "wed", "youve", "youd", "hes", "hed", "shes",
-                                "shed", "its", "itd", "theyve", "theyd",
-                            ])),
-                        ])
-                        .t_ws()
-                        .then_verb_simple_past_form(),
+                    SequenceExpr::any_of(vec![
+                        // for perfect tenses
+                        Box::new(WordSet::new(&["have", "had", "has", "having"])),
+                        // for passive voice
+                        Box::new(InflectionOfBe::default()),
+                        // pronoun + have contractions
+                        Box::new(WordSet::new(&[
+                            "I've", "I'd", "we've", "we'd", "you've", "you'd", "he's", "he'd",
+                            "she's", "she'd", "it's", "it'd", "they've", "they'd",
+                        ])),
+                        // pronoun + have contractions missing apostrophes
+                        Box::new(WordSet::new(&[
+                            "Ive", "Id", "weve", "wed", "youve", "youd", "hes", "hed", "shes",
+                            "shed", "its", "itd", "theyve", "theyd",
+                        ])),
+                    ])
+                    .t_ws()
+                    .then_verb_simple_past_form(),
                 ),
                 // negative: exceptions
-                Box::new(SequenceExpr::default().then_unless(FirstMatchOf::new(vec![
-                        Box::new(
-                            SequenceExpr::default()
-                                .then(InflectionOfBe::default())
-                                .t_any()
-                                .t_aco("woke"),
-                        ),
-                        Box::new(
-                            SequenceExpr::aco("id")
-                                .t_any()
-                                .then_word_set(&["came", "did", "went"]),
-                        ),
-                    ]))),
+                Box::new(SequenceExpr::unless(FirstMatchOf::new(vec![
+                    Box::new(
+                        SequenceExpr::with(InflectionOfBe::default())
+                            .t_any()
+                            .t_aco("woke"),
+                    ),
+                    Box::new(
+                        SequenceExpr::aco("id")
+                            .t_any()
+                            .then_word_set(&["came", "did", "went"]),
+                    ),
+                ]))),
             ])),
         }
     }

--- a/harper-core/src/linting/since_duration.rs
+++ b/harper-core/src/linting/since_duration.rs
@@ -27,8 +27,7 @@ impl Default for SinceDuration {
     fn default() -> Self {
         Self {
             expr: Box::new(
-                SequenceExpr::default()
-                    .then_any_capitalization_of("since")
+                SequenceExpr::any_capitalization_of("since")
                     .then_whitespace()
                     .then(DurationExpr)
                     .then_optional(

--- a/harper-core/src/linting/single_be.rs
+++ b/harper-core/src/linting/single_be.rs
@@ -70,8 +70,7 @@ impl Default for SingleBe {
             ])
         }
 
-        let expr = SequenceExpr::default()
-            .then(be_like_expr())
+        let expr = SequenceExpr::with(be_like_expr())
             .t_ws()
             .then(be_like_expr());
 

--- a/harper-core/src/linting/some_without_article.rs
+++ b/harper-core/src/linting/some_without_article.rs
@@ -11,8 +11,7 @@ pub struct SomeWithoutArticle {
 
 impl Default for SomeWithoutArticle {
     fn default() -> Self {
-        let expr = SequenceExpr::default()
-            .then_any_capitalization_of("the")
+        let expr = SequenceExpr::any_capitalization_of("the")
             .t_ws()
             .then_any_capitalization_of("some");
 

--- a/harper-core/src/linting/something_is.rs
+++ b/harper-core/src/linting/something_is.rs
@@ -13,8 +13,7 @@ impl Default for SomethingIs {
     fn default() -> Self {
         let forms = WordSet::new(&["somethings", "anythings", "everythings", "nothings"]);
 
-        let expr = SequenceExpr::default()
-            .then(forms)
+        let expr = SequenceExpr::with(forms)
             .t_ws()
             .then_optional(SequenceExpr::default().then_one_or_more_adverbs().t_ws())
             .then_kind_any(&[TokenKind::is_verb_progressive_form]);

--- a/harper-core/src/linting/soon_to_be.rs
+++ b/harper-core/src/linting/soon_to_be.rs
@@ -49,7 +49,7 @@ impl Default for SoonToBe {
         };
 
         let trailing_phrase = || {
-            SequenceExpr::default().then_any_of(vec![
+            SequenceExpr::any_of(vec![
                 Box::new(hyphenated_number_modifier()),
                 Box::new(hyphenated_compound()),
                 Box::new(nominal_tail()),

--- a/harper-core/src/linting/sought_after.rs
+++ b/harper-core/src/linting/sought_after.rs
@@ -1,4 +1,4 @@
-use crate::expr::{Expr, SequenceExpr, SpaceOrHyphen};
+use crate::expr::{Expr, SequenceExpr};
 use crate::{Token, TokenKind};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
@@ -26,7 +26,7 @@ impl Default for SoughtAfter {
         ])
         .t_ws()
         .t_aco("sort")
-        .then(SpaceOrHyphen)
+        .t_ws_h()
         .t_aco("after");
 
         Self {

--- a/harper-core/src/linting/subject_pronoun.rs
+++ b/harper-core/src/linting/subject_pronoun.rs
@@ -10,8 +10,7 @@ pub struct SubjectPronoun {
 
 impl Default for SubjectPronoun {
     fn default() -> Self {
-        let expr = SequenceExpr::default()
-            .then(AnchorStart)
+        let expr = SequenceExpr::with(AnchorStart)
             .t_aco("me")
             .t_ws()
             .t_aco("and")

--- a/harper-core/src/linting/take_medicine.rs
+++ b/harper-core/src/linting/take_medicine.rs
@@ -26,18 +26,16 @@ impl Default for TakeMedicine {
             .or(DerivedFrom::new_from_str("aspirin"))
             .or(DerivedFrom::new_from_str("paracetamol"));
 
-        let modifiers = SequenceExpr::default()
-            .then_any_of(vec![
-                Box::new(SequenceExpr::default().then_determiner()),
-                Box::new(SequenceExpr::default().then_possessive_determiner()),
-                Box::new(SequenceExpr::default().then_quantifier()),
-            ])
-            .t_ws();
+        let modifiers = SequenceExpr::any_of(vec![
+            Box::new(SequenceExpr::default().then_determiner()),
+            Box::new(SequenceExpr::default().then_possessive_determiner()),
+            Box::new(SequenceExpr::default().then_quantifier()),
+        ])
+        .t_ws();
 
         let adjectives = SequenceExpr::default().then_one_or_more_adjectives().t_ws();
 
-        let pattern = SequenceExpr::default()
-            .then(eat_verb)
+        let pattern = SequenceExpr::with(eat_verb)
             .t_ws()
             .then_optional(modifiers)
             .then_optional(adjectives)

--- a/harper-core/src/linting/take_serious.rs
+++ b/harper-core/src/linting/take_serious.rs
@@ -3,7 +3,7 @@ use crate::{
     Token, TokenStringExt,
     expr::{Expr, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
-    patterns::{NominalPhrase, WordSet},
+    patterns::NominalPhrase,
 };
 
 /// Linter that corrects "take X serious" to "take X seriously".
@@ -22,8 +22,7 @@ impl Default for TakeSerious {
     /// - Followed by a nominal phrase
     /// - Ending with "serious"
     fn default() -> Self {
-        let pattern = SequenceExpr::default()
-            .then(WordSet::new(&["take", "taken", "takes", "taking", "took"]))
+        let pattern = SequenceExpr::word_set(&["take", "taken", "takes", "taking", "took"])
             .t_ws()
             .then(NominalPhrase)
             .t_ws()

--- a/harper-core/src/linting/that_which.rs
+++ b/harper-core/src/linting/that_which.rs
@@ -17,8 +17,7 @@ impl Default for ThatWhich {
         let mut pattern = WordExprGroup::default();
 
         let matching_pattern = Lrc::new(
-            SequenceExpr::default()
-                .then_any_capitalization_of("that")
+            SequenceExpr::any_capitalization_of("that")
                 .then_whitespace()
                 .then_any_capitalization_of("that"),
         );

--- a/harper-core/src/linting/the_how_why.rs
+++ b/harper-core/src/linting/the_how_why.rs
@@ -19,15 +19,14 @@ impl Default for TheHowWhy {
             .t_aco("the")
             .then_whitespace()
             .t_aco("how")
-            .then_unless(SequenceExpr::default().then_whitespace().t_aco("to"));
+            .then_unless(SequenceExpr::whitespace().t_aco("to"));
 
         let the_who = SequenceExpr::default()
             .t_aco("the")
             .then_whitespace()
             .t_aco("who")
             .then_unless(
-                SequenceExpr::default()
-                    .then_whitespace()
+                SequenceExpr::whitespace()
                     .t_aco("'s")
                     .then_whitespace()
                     .t_aco("who"),

--- a/harper-core/src/linting/the_my.rs
+++ b/harper-core/src/linting/the_my.rs
@@ -17,13 +17,11 @@ impl Default for TheMy {
         let the = Word::new("the");
         let any_possessive = WordSet::new(&["my", "your", "his", "her", "its", "our", "their"]);
 
-        let the_poss = SequenceExpr::default()
-            .then(the.clone())
+        let the_poss = SequenceExpr::with(the.clone())
             .then_whitespace()
             .then(any_possessive.clone());
 
-        let poss_the = SequenceExpr::default()
-            .then(any_possessive)
+        let poss_the = SequenceExpr::with(any_possessive)
             .then_whitespace()
             .then(the);
 

--- a/harper-core/src/linting/then_than.rs
+++ b/harper-core/src/linting/then_than.rs
@@ -16,19 +16,17 @@ impl ThenThan {
             Box::new(FirstMatchOf::new(vec![
                 // Comparative form of adjective
                 Box::new(
-                    SequenceExpr::default()
-                        .then(Box::new(|tok: &Token, source: &[char]| {
-                            is_comparative(tok, source)
-                        }))
-                        .t_ws()
-                        .t_aco("then")
-                        .t_ws()
-                        .then_unless(Word::new("that")),
+                    SequenceExpr::with(Box::new(|tok: &Token, source: &[char]| {
+                        is_comparative(tok, source)
+                    }))
+                    .t_ws()
+                    .t_aco("then")
+                    .t_ws()
+                    .then_unless(Word::new("that")),
                 ),
                 // Positive form of adjective following "more" or "less"
                 Box::new(
-                    SequenceExpr::default()
-                        .then(WordSet::new(&["more", "less"]))
+                    SequenceExpr::word_set(&["more", "less"])
                         .t_ws()
                         .then_kind_either(TokenKind::is_adjective, TokenKind::is_adverb)
                         .t_ws()

--- a/harper-core/src/linting/thing_think.rs
+++ b/harper-core/src/linting/thing_think.rs
@@ -29,13 +29,12 @@ impl Default for ThingThink {
             Box::new(indefinite_pronouns),
         ]);
 
-        let verb_to = SequenceExpr::default()
-            .then(WordSet::new(&[
-                "have", "had", "has", "having", "need", "needed", "needs", "needing", "want",
-                "wanted", "wants", "wanting", "try", "tried", "tries", "trying",
-            ]))
-            .t_ws()
-            .t_aco("to");
+        let verb_to = SequenceExpr::word_set(&[
+            "have", "had", "has", "having", "need", "needed", "needs", "needing", "want", "wanted",
+            "wants", "wanting", "try", "tried", "tries", "trying",
+        ])
+        .t_ws()
+        .t_aco("to");
 
         let modal = WordSet::new(&[
             "can",
@@ -66,10 +65,7 @@ impl Default for ThingThink {
             Box::new(adverb_of_frequency),
         ]);
 
-        let pattern = SequenceExpr::default()
-            .then(pre_context)
-            .t_ws()
-            .t_aco("thing");
+        let pattern = SequenceExpr::with(pre_context).t_ws().t_aco("thing");
 
         Self {
             expr: Box::new(pattern),

--- a/harper-core/src/linting/this_type_of_thing.rs
+++ b/harper-core/src/linting/this_type_of_thing.rs
@@ -21,7 +21,8 @@ impl Default for ThisTypeOfThing {
                         ])
                         .t_ws(),
                     )
-                    .then(SequenceExpr::aco("of").t_ws())
+                    .t_aco("of")
+                    .t_ws()
                     .then_any_of(vec![
                         // "thing" is common in this construction and won't be part of a compound noun.
                         Box::new(WordSet::new(&["thing", "things"])),

--- a/harper-core/src/linting/to_two_too/to_too_adjective_end.rs
+++ b/harper-core/src/linting/to_two_too/to_too_adjective_end.rs
@@ -14,18 +14,18 @@ pub struct ToTooAdjectiveEnd {
 
 impl Default for ToTooAdjectiveEnd {
     fn default() -> Self {
-        let expr = SequenceExpr::optional(
-            SequenceExpr::default()
-                .then_any_word()
-                .then(WhitespacePattern),
-        )
-        .t_aco("to")
-        .t_ws()
-        .then_kind_is_but_is_not_except(TokenKind::is_adjective, TokenKind::is_verb, &["standard"])
-        .then_optional(WhitespacePattern)
-        .then_optional(SequenceExpr::default().then_any_word())
-        .then_optional(WhitespacePattern)
-        .then_optional(SequenceExpr::default().then_punctuation());
+        let expr = SequenceExpr::optional(SequenceExpr::any_word().t_ws())
+            .t_aco("to")
+            .t_ws()
+            .then_kind_is_but_is_not_except(
+                TokenKind::is_adjective,
+                TokenKind::is_verb,
+                &["standard"],
+            )
+            .then_optional(WhitespacePattern)
+            .then_optional(SequenceExpr::any_word())
+            .then_optional(WhitespacePattern)
+            .then_optional(SequenceExpr::default().then_punctuation());
 
         Self {
             expr: Box::new(expr),

--- a/harper-core/src/linting/to_two_too/to_too_adjective_punct.rs
+++ b/harper-core/src/linting/to_two_too/to_too_adjective_punct.rs
@@ -14,16 +14,16 @@ pub struct ToTooAdjectivePunct {
 
 impl Default for ToTooAdjectivePunct {
     fn default() -> Self {
-        let expr = SequenceExpr::optional(
-            SequenceExpr::default()
-                .then_any_word()
-                .then(WhitespacePattern),
-        )
-        .t_aco("to")
-        .t_ws()
-        .then_kind_is_but_is_not_except(TokenKind::is_adjective, TokenKind::is_verb, &["standard"])
-        .then_optional(WhitespacePattern)
-        .then_sentence_terminator();
+        let expr = SequenceExpr::optional(SequenceExpr::any_word().t_ws())
+            .t_aco("to")
+            .t_ws()
+            .then_kind_is_but_is_not_except(
+                TokenKind::is_adjective,
+                TokenKind::is_verb,
+                &["standard"],
+            )
+            .then_optional(WhitespacePattern)
+            .then_sentence_terminator();
 
         Self {
             expr: Box::new(expr),

--- a/harper-core/src/linting/to_two_too/to_too_chunk_start_comma.rs
+++ b/harper-core/src/linting/to_two_too/to_too_chunk_start_comma.rs
@@ -14,8 +14,7 @@ pub struct ToTooChunkStartComma {
 
 impl Default for ToTooChunkStartComma {
     fn default() -> Self {
-        let expr = SequenceExpr::default()
-            .then(AnchorStart)
+        let expr = SequenceExpr::with(AnchorStart)
             .t_aco("to")
             .then_optional(WhitespacePattern)
             .then_comma();

--- a/harper-core/src/linting/to_two_too/to_too_pronoun_end.rs
+++ b/harper-core/src/linting/to_two_too/to_too_pronoun_end.rs
@@ -16,30 +16,29 @@ impl Default for ToTooPronounEnd {
     fn default() -> Self {
         // Match at clause start or after punctuation to avoid cases like
         // "leave it to." where `it` is an object pronoun.
-        let expr = SequenceExpr::default()
-            .then_any_of(vec![
-                Box::new(SequenceExpr::with(AnchorStart)),
-                Box::new(
-                    SequenceExpr::default()
-                        .then_kind_is_but_is_not_except(
-                            TokenKind::is_punctuation,
-                            |_| false,
-                            &["`", "\"", "'", "“", "”", "‘", "’"],
-                        )
-                        .then_optional(WhitespacePattern),
-                ),
-            ])
-            .then_pronoun()
-            .t_ws()
-            .t_aco("to")
-            .then_any_of(vec![
-                Box::new(SequenceExpr::default().then_kind_is_but_is_not_except(
-                    TokenKind::is_punctuation,
-                    |_| false,
-                    &["`", "\"", "'", "“", "”", "‘", "’"],
-                )),
-                Box::new(AnchorEnd),
-            ]);
+        let expr = SequenceExpr::any_of(vec![
+            Box::new(SequenceExpr::with(AnchorStart)),
+            Box::new(
+                SequenceExpr::default()
+                    .then_kind_is_but_is_not_except(
+                        TokenKind::is_punctuation,
+                        |_| false,
+                        &["`", "\"", "'", "“", "”", "‘", "’"],
+                    )
+                    .then_optional(WhitespacePattern),
+            ),
+        ])
+        .then_pronoun()
+        .t_ws()
+        .t_aco("to")
+        .then_any_of(vec![
+            Box::new(SequenceExpr::default().then_kind_is_but_is_not_except(
+                TokenKind::is_punctuation,
+                |_| false,
+                &["`", "\"", "'", "“", "”", "‘", "’"],
+            )),
+            Box::new(AnchorEnd),
+        ]);
 
         Self {
             expr: Box::new(expr),

--- a/harper-core/src/linting/touristic.rs
+++ b/harper-core/src/linting/touristic.rs
@@ -59,17 +59,13 @@ const WHITELIST: &[&str] = &[
 
 impl Default for Touristic {
     fn default() -> Self {
-        let with_prev_and_next_word = SequenceExpr::default()
-            .then_any_word()
+        let with_prev_and_next_word = SequenceExpr::any_word()
             .t_ws()
             .t_aco("touristic")
             .t_ws()
             .then_any_word();
 
-        let with_prev_word = SequenceExpr::default()
-            .then_any_word()
-            .t_ws()
-            .t_aco("touristic");
+        let with_prev_word = SequenceExpr::any_word().t_ws().t_aco("touristic");
 
         let with_next_word = SequenceExpr::default()
             .t_aco("touristic")

--- a/harper-core/src/linting/transposed_space.rs
+++ b/harper-core/src/linting/transposed_space.rs
@@ -24,7 +24,7 @@ impl<D: Dictionary + 'static> TransposedSpace<D> {
         Self {
             expr: Box::new(FirstMatchOf::new(vec![
                 Box::new(SequenceExpr::default().then_oov().t_ws().then_any_word()),
-                Box::new(SequenceExpr::default().then_any_word().t_ws().then_oov()),
+                Box::new(SequenceExpr::any_word().t_ws().then_oov()),
                 Box::new(SequenceExpr::default().then_oov().t_ws().then_oov()),
             ])),
             dict,

--- a/harper-core/src/linting/verb_to_adjective.rs
+++ b/harper-core/src/linting/verb_to_adjective.rs
@@ -16,8 +16,7 @@ pub struct VerbToAdjective {
 
 impl Default for VerbToAdjective {
     fn default() -> Self {
-        let expr = SequenceExpr::default()
-            .then(WordSet::new(&["the", "a", "an"]))
+        let expr = SequenceExpr::word_set(&["the", "a", "an"])
             .t_ws()
             .then_kind_where(|kind| {
                 (kind.is_verb()

--- a/harper-core/src/linting/very_unique.rs
+++ b/harper-core/src/linting/very_unique.rs
@@ -3,7 +3,6 @@ use crate::{
     Token, TokenStringExt,
     expr::{Expr, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
-    patterns::WordSet,
 };
 
 pub struct VeryUnique {
@@ -14,12 +13,11 @@ impl Default for VeryUnique {
     fn default() -> Self {
         Self {
             expr: Box::new(
-                SequenceExpr::default()
-                    .then(WordSet::new(&[
-                        "fairly", "pretty", "rather", "quite", "somewhat", "very",
-                    ]))
-                    .t_ws()
-                    .t_aco("unique"),
+                SequenceExpr::word_set(&[
+                    "fairly", "pretty", "rather", "quite", "somewhat", "very",
+                ])
+                .t_ws()
+                .t_aco("unique"),
             ),
         }
     }

--- a/harper-core/src/linting/vice_versa.rs
+++ b/harper-core/src/linting/vice_versa.rs
@@ -78,7 +78,7 @@ impl Default for ViceVersa {
         let expr = SequenceExpr::word_set(&["vice", "vise"])
             .then(matches_hyphen)
             .then_optional(SequenceExpr::aco("a").then(matches_hyphen))
-            .then(SequenceExpr::aco("versa"));
+            .t_aco("versa");
 
         Self {
             expr: Box::new(expr),

--- a/harper-core/src/linting/was_aloud.rs
+++ b/harper-core/src/linting/was_aloud.rs
@@ -5,7 +5,6 @@ use crate::expr::Expr;
 use crate::expr::SequenceExpr;
 use crate::linting::Suggestion;
 use crate::linting::expr_linter::Chunk;
-use crate::patterns::WordSet;
 
 pub struct WasAloud {
     expr: Box<dyn Expr>,
@@ -13,8 +12,7 @@ pub struct WasAloud {
 
 impl Default for WasAloud {
     fn default() -> Self {
-        let pattern = SequenceExpr::default()
-            .then(WordSet::new(&["was", "were", "be", "been"]))
+        let pattern = SequenceExpr::word_set(&["was", "were", "be", "been"])
             .then_whitespace()
             .then_exact_word("aloud");
 

--- a/harper-core/src/linting/way_too_adjective.rs
+++ b/harper-core/src/linting/way_too_adjective.rs
@@ -24,11 +24,11 @@ impl Default for WayTooAdjective {
             .t_any()
             .t_any()
             .t_any()
-            .then(WordSet::new(&["surface", "return", "aqua"]));
+            .then_word_set(&["surface", "return", "aqua"]);
 
         let expr = All::new(vec![
             Box::new(base),
-            Box::new(SequenceExpr::default().then_unless(exceptions)),
+            Box::new(SequenceExpr::unless(exceptions)),
         ]);
 
         Self {

--- a/harper-core/src/linting/well_educated.rs
+++ b/harper-core/src/linting/well_educated.rs
@@ -22,8 +22,7 @@ impl Default for WellEducated {
             .then_optional(WhitespacePattern)
             .t_aco("educated");
 
-        let expr =
-            SequenceExpr::default().then_any_of(vec![Box::new(combined), Box::new(separated)]);
+        let expr = SequenceExpr::any_of(vec![Box::new(combined), Box::new(separated)]);
 
         Self {
             expr: Box::new(expr),

--- a/harper-core/src/linting/widely_accepted.rs
+++ b/harper-core/src/linting/widely_accepted.rs
@@ -4,7 +4,6 @@ use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
-    patterns::{Word, WordSet},
 };
 
 pub struct WidelyAccepted {
@@ -14,9 +13,9 @@ pub struct WidelyAccepted {
 impl Default for WidelyAccepted {
     fn default() -> Self {
         let expr = SequenceExpr::default()
-            .then(Word::new("wide"))
+            .t_aco("wide")
             .then_whitespace()
-            .then(WordSet::new(&["accepted", "acceptable", "used"]));
+            .then_word_set(&["accepted", "acceptable", "used"]);
 
         Self { expr }
     }

--- a/harper-core/src/linting/win_prize.rs
+++ b/harper-core/src/linting/win_prize.rs
@@ -16,18 +16,12 @@ impl Default for WinPrize {
         let verbs = Lrc::new(WordSet::new(&["win", "wins", "won", "winning"]));
         let miss = Lrc::new(WordSet::new(&["price", "prices", "prise", "prises"]));
 
-        let pattern = SequenceExpr::default()
-            .then(verbs.clone())
+        let pattern = SequenceExpr::with(verbs.clone())
             .then_whitespace()
             .then_determiner()
             .then_whitespace()
             .then(miss.clone())
-            .or_longest(
-                SequenceExpr::default()
-                    .then(verbs)
-                    .then_whitespace()
-                    .then(miss),
-            );
+            .or_longest(SequenceExpr::with(verbs).then_whitespace().then(miss));
 
         Self {
             expr: Box::new(pattern),

--- a/harper-core/src/parsers/collapse_identifiers.rs
+++ b/harper-core/src/parsers/collapse_identifiers.rs
@@ -25,8 +25,7 @@ impl CollapseIdentifiers {
 }
 
 thread_local! {
-    static WORD_OR_NUMBER: Lrc<SequenceExpr> = Lrc::new(SequenceExpr::default()
-                .then_any_word()
+    static WORD_OR_NUMBER: Lrc<SequenceExpr> = Lrc::new(SequenceExpr::any_word()
                 .then_one_or_more(SequenceExpr::default()
         .then_case_separator()
         .then_any_word()));

--- a/harper-core/src/span.rs
+++ b/harper-core/src/span.rs
@@ -273,8 +273,7 @@ mod tests {
         assert!(converted.is_empty());
 
         // Span from `Expr`.
-        let token_span = SequenceExpr::default()
-            .then_any_word()
+        let token_span = SequenceExpr::any_word()
             .t_ws()
             .then_any_word()
             .iter_matches_in_doc(&doc)


### PR DESCRIPTION
# Issues 
N/A

# Description

This PR is to simplify linter code to use more succinct methods on `SequenceExpr` in favour of more wordy code:

- `SequenceExpr::default().then(WordSet::new())` → `SequenceExpr::word_set()`
- `then(WordSet::new())` → `then_word_set()`
- `then(Word::new())` → `t_aco()`
- `SequenceExpr::default().then(FixedPhrase::from_phrase()` → `SequenceExpr::fixed_phrase()`
- `SequenceExpr::default().then(FirstMatchOf::new())` → `SequenceExpr::any_of()`
- `then(SpaceOrHyphen)` → `t_ws_h()`
- `SequenceExpr::default().then()` → `SequenceExpr::with()`
- `then(AnyPattern)`→`t_any()`
- `then(FixedPhrase::from_phrase())`→`then_fxed_phrase()`
- Add `then_zero_or_more` to accompany `then_one_or_more`
- `then(Repeating::new(0))` → `then_zero_or_more()`
- Rename `then_one_or_more_spaced` → `then_zero_or_more_spaced` to reflect how it's used
- `then(SequenceExpr::aco())`→`t_aco()`
- `then(WhitespacePattern)`→`t_ws()`
- `SequenceExpr::default().then_any_word()`→`SequenceExpr::any_word()`
- `SequenceExpr::default().then_any_of()`→`SequenceExpr::any_of()`
- `SequenceExpr::default().then_any_capitalization_of()`→`SequenceExpr::any_capitalization_of()`
- `SequenceExpr::default().then_fixed_phrase()`→`SequenceExpr::fixed_phrase()`
- `SequenceExpr::default().then_optional()`→`SequenceExpr::optional()`
- `SequenceExpr::default().then_unless()`→`SequenceExpr:unless()`
- `SequenceExpr::default().then_word_set()`→`SequenceExpr::word_set()`
- `SequenceExpr::default().then_whitespace()`→`SequenceExpr::whitespace()` (a newly added method)

Saves about 160 lines.

# How Has This Been Tested?

All of `cargo test` still passes.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
