### PR TITLE
feat: for argument sake→for argument's sake

### DIFF
--- a/harper-core/src/linting/weir_rules/ForArgumentsSake.weir
+++ b/harper-core/src/linting/weir_rules/ForArgumentsSake.weir
@@ -1,0 +1,9 @@
+expr main [(for argument sake), (for arguments sake)]
+
+let message "Use the possessive `argument's`."
+let description "Corrects `for argument sake` to `for argument's sake`."
+let kind "Usage"
+let becomes "for argument's sake"
+
+test "I'm sure it would be incorrect to do so, but for argument sake, if I change" "I'm sure it would be incorrect to do so, but for argument's sake, if I change"
+test "In my app, for arguments sake user hits button which sets search_term" "In my app, for argument's sake user hits button which sets search_term"


### PR DESCRIPTION
# Issues 
N/A

# Description

I was reading YouTube comments and happened across "for argument sake" and thought "That should be a possessive".
While looking for examples I discovered that "for arguments sake" with the "s" but missing the apostrophe is also common.

So this linter fixes both.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

One unit test for each variant, using text found on GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
