### PR TITLE
feat: wrote→rote

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -428,6 +428,21 @@ pub fn lint_group() -> LintGroup {
             "Did you mean `wreak havoc`?",
             "Corrects the eggcorn `wreck havoc` to `wreak havoc`, which is the proper term for causing chaos or destruction.",
             LintKind::Eggcorn
+        ),
+        "WroteToRote" => (
+            &[
+                ("by wrote", "by rote"),
+                ("by-wrote", "by-rote"),
+                ("wrote learning", "rote learning"),
+                ("wrote memorisation", "rote memorisation"),
+                ("wrote-memorisation", "rote-memorisation"),
+                ("wrote memorization", "rote memorization"),
+                ("wrote-memorization", "rote-memorization"),
+                ("wrote memorizing", "rote memorizing"),
+            ],
+            "Did you mean `rote` (mechanical memorization) instead of `wrote`?",
+            "Corrects `by wrote` to `by rote`.",
+            LintKind::Eggcorn
         )
     });
 

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -1136,6 +1136,80 @@ fn fix_wrecks_havoc() {
     );
 }
 
+// WroteToRote
+
+#[test]
+fn fix_by_wrote() {
+    assert_suggestion_result(
+        "Until one repeats and learns a fact by wrote it is the picture that sustains us.",
+        lint_group(),
+        "Until one repeats and learns a fact by rote it is the picture that sustains us.",
+    );
+}
+
+#[test]
+fn fix_by_wrote_hyphen() {
+    assert_suggestion_result(
+        "This specification may then be translated into a recursive-decent parser almost by-wrote.",
+        lint_group(),
+        "This specification may then be translated into a recursive-decent parser almost by-rote.",
+    );
+}
+
+#[test]
+fn fix_wrote_learning() {
+    assert_suggestion_result(
+        "I found that what turned me off math class was that teachers encouraged wrote learning instead of understanding.",
+        lint_group(),
+        "I found that what turned me off math class was that teachers encouraged rote learning instead of understanding.",
+    );
+}
+
+#[test]
+fn fix_wrote_memorisation() {
+    assert_suggestion_result(
+        "Not much of a wrote memorisation kind of guy, so I preferred to commit them to memory by framing them in the context of a paragraph.",
+        lint_group(),
+        "Not much of a rote memorisation kind of guy, so I preferred to commit them to memory by framing them in the context of a paragraph.",
+    );
+}
+
+#[test]
+fn fix_wrote_memorisation_hyphen() {
+    assert_suggestion_result(
+        "I find it helps me retain information much better and for longer compared to when I just blindly did wrote-memorisation.",
+        lint_group(),
+        "I find it helps me retain information much better and for longer compared to when I just blindly did rote-memorisation.",
+    );
+}
+
+#[test]
+fn fix_wrote_memorization() {
+    assert_suggestion_result(
+        "Outside websites are also no-go, exacerbating the need for wrote memorization.",
+        lint_group(),
+        "Outside websites are also no-go, exacerbating the need for rote memorization.",
+    );
+}
+
+#[test]
+fn fix_wrote_memorization_hyphen() {
+    assert_suggestion_result(
+        "The voicings was the biggest game-changer for me, coming from a wrote-memorization type classical piano background.",
+        lint_group(),
+        "The voicings was the biggest game-changer for me, coming from a rote-memorization type classical piano background.",
+    );
+}
+
+#[test]
+fn fix_wrote_memorizing() {
+    assert_suggestion_result(
+        "I have never been good at wrote memorizing abbreviations, initialisms, or acronyms.",
+        lint_group(),
+        "I have never been good at rote memorizing abbreviations, initialisms, or acronyms.",
+    );
+}
+
 // Many to many tests
 
 // AwaitFor


### PR DESCRIPTION
# Issues 
N/A

# Description

I read a YouTube comment where somebody wrote that they learned something "by wrote" and then thought up a few more phrases the same error might occur in.

I went with a `phrase_set_correction` linter for this one so all variants would be under a single `WroteToRote` rule.

False positives I found were mostly extremely bad grammar such as "wrote" for "written", or missing commas or quote marks between the words. If any turn out to be common they should be filed as issues to be addressed.

# How Has This Been Tested?

This doesn't seem to be a common error on GitHub so I found instances for unit tests on Stack Overflow, Medium, and Reddit instead.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
