### PR TITLE
fix: don't flag "May of"

### DIFF
--- a/harper-core/src/linting/modal_of.rs
+++ b/harper-core/src/linting/modal_of.rs
@@ -330,10 +330,7 @@ mod tests {
     }
 
     #[test]
-    fn dont_flag_in_may_of_next_year_2786() {
-        assert_no_lints(
-            "In May of next year a new version will be released.",
-            ModalOf::default(),
-        );
+    fn dont_flag_in_may_of_last_year_bug_2786() {
+        assert_no_lints("This happened in May of last year.", ModalOf::default());
     }
 }


### PR DESCRIPTION
# Issues 

Fixes #2786

# Description

Flag lowercase "may of" as in "I may of done something silly". But don't flag title case "May of" as in "May of last year was warmer than usual".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
