### PR TITLE
fix(core): stop flagging "Czech Republic" as outdated

### DIFF
--- a/harper-core/src/linting/update_place_names.rs
+++ b/harper-core/src/linting/update_place_names.rs
@@ -29,7 +29,6 @@ impl<'a> Default for UpdatePlaceNames<'a> {
             ((1945, "Taiwan"), &["Formosa"]),
             ((1991, "Ulaanbaatar"), &["Ulan Bator"]),
             // Europe (and nearby)
-            ((2016, "Czechia"), &["Czech Republic"]),
             ((1945, "Gdańsk"), &["Danzig"]), // TODO: Can we recommend Gdansk as well?
             ((1992, "Podgorica"), &["Titograd"]),
             ((1936, "Tbilisi"), &["Tiflis"]),
@@ -247,6 +246,15 @@ mod tests {
             UpdatePlaceNames::default(),
             "Burkina Faso is in Africa.",
         )
+    }
+
+    #[test]
+    fn dont_flag_czech_republic() {
+        assert_lint_count(
+            "The Czech Republic is in Europe.",
+            UpdatePlaceNames::default(),
+            0,
+        );
     }
 
     // NOTE: Can't handle place names with obligatory or compulsory "The" perfectly.


### PR DESCRIPTION
## Summary

Fixes #2692

- Removed the `Czech Republic → Czechia` mapping from `UpdatePlaceNames`
- "Czech Republic" is the country's formal name; "Czechia" is the official short name and both are valid (like "French Republic" vs "France")
- Added a regression test to ensure "Czech Republic" is not flagged

## Test plan

- [x] `cargo test -p harper-core update_place_names` : all 17 tests pass
- [x] `cargo fmt` : applied
- [x] `cargo clippy -p harper-core` : no new warnings