### PR TITLE
feat(chrome-ext): enable on all Substack sites

### DIFF
--- a/packages/chrome-plugin/src/contentScript/index.ts
+++ b/packages/chrome-plugin/src/contentScript/index.ts
@@ -6,10 +6,11 @@ import {
 	leafNodes,
 	type UnpackedLint,
 } from 'lint-framework';
+import isSubstack from '../isSubstack';
 import isWordPress from '../isWordPress';
 import ProtocolClient from '../ProtocolClient';
 
-if (isWordPress()) {
+if (isWordPress() || isSubstack()) {
 	ProtocolClient.setDomainEnabled(window.location.hostname, true, false);
 }
 

--- a/packages/chrome-plugin/src/isSubstack.ts
+++ b/packages/chrome-plugin/src/isSubstack.ts
@@ -1,0 +1,22 @@
+/** Does a rough estimate of whether the current page is a Substack page. */
+export default function isSubstack(): boolean {
+	const hostname = window.location.hostname.toLowerCase();
+
+	if (hostname === 'substack.com' || hostname.endsWith('.substack.com')) {
+		return true;
+	}
+
+	if (document.querySelector('link[rel="preconnect"][href*="substackcdn.com"]')) {
+		return true;
+	}
+
+	if (document.querySelector('meta[property="og:title"][content*="| Substack"]')) {
+		return true;
+	}
+
+	if (document.querySelector('meta[name="description"][content*="a Substack publication"]')) {
+		return true;
+	}
+
+	return false;
+}


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

N/A

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

The Harper Chrome Extension works on Substack, but it isn't enabled by default on all relevant domains. This is because each user is assigned their own subdomain (for example, `elijahpotter.substack.com`).

This PR adds logic to detect previously unseen Substack domains and add them to the list of enabled sites, similar to what we already do with WordPress.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
