### PR TITLE
feat: do diligence→due diligence/do due diligence

### DIFF
--- a/harper-core/src/linting/weir_rules/DueDiligence.weir
+++ b/harper-core/src/linting/weir_rules/DueDiligence.weir
@@ -1,0 +1,9 @@
+expr main (do diligence)
+
+let message "If this phrase should function as a noun it should be `due diligence`. If it should function as a verb it should be `do due diligence"
+let description "Corrects `do diligence` to `due diligence`."
+let kind "Usage"
+let becomes ["due diligence", "do due diligence"]
+
+test "Thank you for your time, I am trying to do my do diligence and find some answers." "Thank you for your time, I am trying to do my due diligence and find some answers."
+test "The Technical Committee (TC) will do diligence, write a report, and attach that report to the GitHub issue." "The Technical Committee (TC) will do due diligence, write a report, and attach that report to the GitHub issue."


### PR DESCRIPTION
# Issues 
N/A

# Description

I noticed that though we have some linting for mixing up "do" and "due", we do not flag "do diligence".

While looking into it I discovered that people write this not only instead of "due diligence" but also instead of "do due diligence".

I couldn't find a wide enough variety of usages to confidently build a proper linter with context to differentiate between the two. So instead made a Weir rule with a `message` that should hopefully allow the user to choose the right suggestion.

I hereby invite anyone to improve this linter with logic that can determine which of the two possible suggestions would be the right one.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Two unit tests are included, one for each variant.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
