### PR TITLE
feat(web): add loading message to lazily-loaded editor

### DIFF
--- a/packages/web/src/lib/components/LazyEditor.svelte
+++ b/packages/web/src/lib/components/LazyEditor.svelte
@@ -17,7 +17,8 @@ function onReady() {
 {/await}
 
 {#if loading}
-  <div class="flex flex-row h-full max-w-full items-center justify-center">
+  <div class="flex h-full max-w-full flex-col items-center justify-center gap-2">
     <Spinner color="green" />
+    <p class="text-sm">Loading Harper's grammar engine...</p>
   </div>
 {/if}


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

N/A

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

Simply added an explainer for what the page is doing while lazily loading the editor.

# Demo 
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

<img width="1399" height="1666" alt="image" src="https://github.com/user-attachments/assets/c58adfec-5e82-4678-8d7c-1ed2d482a673" />


# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Not really needed. Manually checked.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
