### PR TITLE
fix(obsidian): find temporary fix for escape button override

### DIFF
--- a/packages/obsidian-plugin/src/index.ts
+++ b/packages/obsidian-plugin/src/index.ts
@@ -208,7 +208,6 @@ export default class HarperPlugin extends Plugin {
 		this.addCommand({
 			id: 'harper-dismiss-focused-tooltip',
 			name: 'Dismiss focused suggestion tooltip',
-			hotkeys: [{ modifiers: [], key: 'Escape' }],
 			checkCallback: (checking) => {
 				const editorView = this.getActiveEditorView();
 				if (!editorView) return false;


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #2770

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

@stanley-910, this is a suitable temporary fix for the underling issue? We can revisit this later to improve how people can close the popup, but I want a quick fix now that I can release to those affected.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
