### PR TITLE
feat: in hurry→in a hurry

### DIFF
--- a/harper-core/src/linting/weir_rules/InAHurry.weir
+++ b/harper-core/src/linting/weir_rules/InAHurry.weir
@@ -1,0 +1,9 @@
+expr main (in hurry)
+
+let message "The correct idiom is `in a hurry`."
+let description "Corrects `in hurry` to `in a hurry`."
+let kind "Usage"
+let becomes "in a hurry"
+
+test "helpful when JSON is huge and developer is in hurry" "helpful when JSON is huge and developer is in a hurry"
+test "eLab report making service for people in hurry." "eLab report making service for people in a hurry."


### PR DESCRIPTION
# Issues 
N/A

# Description

Saw "in hurry" in a text overlay in a YouTube video. It's probably a typo sometimes but I'm going to assume it's more often a usage error by people still learning English.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I picked two examples of this mistake from GitHub to use as unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
