### PR TITLE
fear: for most part→for the most part

### DIFF
--- a/harper-core/src/linting/weir_rules/ForTheMostPart.weir
+++ b/harper-core/src/linting/weir_rules/ForTheMostPart.weir
@@ -1,0 +1,9 @@
+expr main (for most part)
+
+let message "Use `for the most part` instead of `for most part`."
+let description "Corrects `for most part` to `for the most part`."
+let kind "Usage"
+let becomes ["for the most part"]
+
+test "Got bot working for most part but he has trouble with vendor potions" "Got bot working for the most part but he has trouble with vendor potions"
+test "it's unresponsive for most part and the only thing you can do is to restart for most part" "it's unresponsive for the most part and the only thing you can do is to restart for the most part"


### PR DESCRIPTION
# Issues 
N/A

# Description

Saw "for most part" somewhere while working on other linters. Turns out to be a common mistake for "for the most part", probably by nonnative English speakers.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I picked two sentences from GitHub with this mistake to use as unit tests - one manages to use it twice!

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
