### PR TITLE
feat: support adjectives in "on accident"

### DIFF
--- a/harper-core/src/linting/by_accident.rs
+++ b/harper-core/src/linting/by_accident.rs
@@ -1,0 +1,138 @@
+/*
+let message "Did you mean `by accident`?"
+let description "Incorrect preposition: `by accident` is the idiomatic expression."
+ */
+
+use crate::{
+    Lint, Token,
+    expr::{Expr, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+};
+
+pub struct ByAccident {
+    expr: Box<dyn Expr>,
+}
+
+impl Default for ByAccident {
+    fn default() -> Self {
+        Self {
+            expr: Box::new(
+                SequenceExpr::aco("on")
+                    .t_ws()
+                    .then_optional(
+                        SequenceExpr::word_set(&[
+                            "complete", "happy", "literal", "mere", "pure", "sheer", "total",
+                        ])
+                        .t_ws(),
+                    )
+                    .t_aco("accident"),
+            ),
+        }
+    }
+}
+
+impl ExprLinter for ByAccident {
+    type Unit = Chunk;
+
+    fn description(&self) -> &str {
+        "Incorrect preposition: `by accident` is the idiomatic expression."
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        self.expr.as_ref()
+    }
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        let span = toks.first()?.span;
+        let suggestions = vec![Suggestion::replace_with_match_case_str(
+            "by",
+            span.get_content(src),
+        )];
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::Usage,
+            suggestions,
+            message: "Did you mean `by accident`?".to_string(),
+            ..Default::default()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ByAccident;
+    use crate::linting::tests::assert_suggestion_result;
+
+    #[test]
+    fn fix_on_accident() {
+        assert_suggestion_result(
+            "Snapshot revert feature is unintuitive and easy to use on accident.",
+            ByAccident::default(),
+            "Snapshot revert feature is unintuitive and easy to use by accident.",
+        );
+    }
+
+    #[test]
+    fn fix_on_complete_accident() {
+        assert_suggestion_result(
+            "I Came across this comment on complete accident, however, I did notice the same thing with a slowdown in chrome for android",
+            ByAccident::default(),
+            "I Came across this comment by complete accident, however, I did notice the same thing with a slowdown in chrome for android",
+        );
+    }
+
+    #[test]
+    fn fix_on_happy_accident() {
+        assert_suggestion_result(
+            "Just did this on happy accident the other day with my partner.",
+            ByAccident::default(),
+            "Just did this by happy accident the other day with my partner.",
+        );
+    }
+
+    #[test]
+    fn fix_on_literal_accident() {
+        assert_suggestion_result(
+            "I did this on literal accident, trying to prove someone wrong that its not that easy.",
+            ByAccident::default(),
+            "I did this by literal accident, trying to prove someone wrong that its not that easy.",
+        );
+    }
+
+    #[test]
+    fn fix_on_mere_accident() {
+        assert_suggestion_result(
+            "I hated this challenge and nope I don't I completed it on mere accident.",
+            ByAccident::default(),
+            "I hated this challenge and nope I don't I completed it by mere accident.",
+        );
+    }
+
+    #[test]
+    fn fix_on_pure_accident() {
+        assert_suggestion_result(
+            "I got this on pure accident after forgetting to enable WebGL on LibreWolf",
+            ByAccident::default(),
+            "I got this by pure accident after forgetting to enable WebGL on LibreWolf",
+        );
+    }
+
+    #[test]
+    fn fix_on_sheer_accident() {
+        assert_suggestion_result(
+            "I more of think of things that got discovered on sheer accident, something no normal human would just do and expect results.",
+            ByAccident::default(),
+            "I more of think of things that got discovered by sheer accident, something no normal human would just do and expect results.",
+        );
+    }
+
+    #[test]
+    fn fix_on_total_accident() {
+        assert_suggestion_result(
+            "On Total Accident, I Found Out Yona's True Title.",
+            ByAccident::default(),
+            "By Total Accident, I Found Out Yona's True Title.",
+        );
+    }
+}

--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -36,6 +36,7 @@ use super::best_of_all_time::BestOfAllTime;
 use super::boring_words::BoringWords;
 use super::bought::Bought;
 use super::brand_brandish::BrandBrandish;
+use super::by_accident::ByAccident;
 use super::cant::Cant;
 use super::capitalize_personal_pronouns::CapitalizePersonalPronouns;
 use super::cautionary_tale::CautionaryTale;
@@ -446,6 +447,7 @@ impl LintGroup {
         insert_expr_rule!(BoringWords, false);
         insert_expr_rule!(Bought, true);
         insert_expr_rule!(BrandBrandish, true);
+        insert_expr_rule!(ByAccident, true);
         insert_expr_rule!(Cant, true);
         insert_struct_rule!(CapitalizePersonalPronouns, true);
         insert_expr_rule!(CautionaryTale, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -27,6 +27,7 @@ mod best_of_all_time;
 mod boring_words;
 mod bought;
 mod brand_brandish;
+mod by_accident;
 mod call_them;
 mod cant;
 mod capitalize_personal_pronouns;

--- a/harper-core/src/linting/weir_rules/ByAccident.weir
+++ b/harper-core/src/linting/weir_rules/ByAccident.weir
@@ -1,7 +1,0 @@
-expr main (on accident)
-
-let message "Did you mean `by accident`?"
-let description "Incorrect preposition: `by accident` is the idiomatic expression."
-let kind "Usage"
-let becomes "by accident"
-


### PR DESCRIPTION
# Issues 
N/A

# Description

I heard a YouTuber say "on complete accident" but Harper only supports unadorned "on accident".
I did some research and found half a dozen adjectives that people use between "on" or "by" and "accident".
I couldn't find a way to enhance the Weir rule to support an optional set of adjectives so I converted this to a Rust implementation.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I made unit tests for all variants, choosing sentences found on GitHub if possible, and using the rest of the internet such as Reddit when no examples could be found on GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
