### PR TITLE
feat: out of sink→out of sync/synch

### DIFF
--- a/harper-core/src/linting/weir_rules/OutOfSync.weir
+++ b/harper-core/src/linting/weir_rules/OutOfSync.weir
@@ -1,0 +1,9 @@
+expr main (out of sink)
+
+let message "Did you mean `out of sync` or `out of synch`?"
+let description "Corrects `out of sink` to `out of sync` or `out of synch`."
+let kind "Spelling"
+let becomes ["out of sync", "out of synch"]
+
+test "This results in the NavigationStack getting out of sink" "This results in the NavigationStack getting out of sync"
+test "Currently, data/costs.scv file is out of sink with the model and must be updated to match the requirements of the sector-coupled version." "Currently, data/costs.scv file is out of synch with the model and must be updated to match the requirements of the sector-coupled version."


### PR DESCRIPTION
# Issues 
N/A

# Description

I wondered if anybody mistakes "sink" for "sync"/"synch", and indeed some people do.

# How Has This Been Tested?

Unit tests created using sentences found on GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
