### PR TITLE
feat: get used of→get used to

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -243,6 +243,18 @@ pub fn lint_group() -> LintGroup {
             "Corrects `flip the bill` to `foot the bill`.",
             LintKind::Nonstandard
         ),
+        "GetUsedTo" => (
+            &[
+                ("get used of", "get used to"),
+                ("gets used of", "gets used to"),
+                ("getting used of", "getting used to"),
+                ("got used of", "got used to"),
+                ("gotten used of", "gotten used to"),
+            ],
+            "Use `used to` instead of `used of`.",
+            "Corrects `used of` to `used to`.",
+            LintKind::Usage
+        ),
         "HavePassed" => (
             &[
                 ("had past", "had passed"),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -683,6 +683,58 @@ fn correct_flips_the_bill() {
     );
 }
 
+// GetUsedTo
+
+//-get used of-
+#[test]
+fn corrects_get_used_of() {
+    assert_suggestion_result(
+        "I am following the examples in the documentation in order to get used of comets.",
+        lint_group(),
+        "I am following the examples in the documentation in order to get used to comets.",
+    );
+}
+
+//-gets used of-
+#[test]
+fn corrects_gets_used_of() {
+    assert_suggestion_result(
+        "its like she gets used of her food and becomes spoiled",
+        lint_group(),
+        "its like she gets used to her food and becomes spoiled",
+    );
+}
+
+//-getting used of-
+#[test]
+fn corrects_getting_used_of() {
+    assert_suggestion_result(
+        "Here you can find a guide to getting used of the most important methods of magum.",
+        lint_group(),
+        "Here you can find a guide to getting used to the most important methods of magum.",
+    );
+}
+
+//-got used of-
+#[test]
+fn corrects_got_used_of() {
+    assert_suggestion_result(
+        "we users actually got used of such delays",
+        lint_group(),
+        "we users actually got used to such delays",
+    );
+}
+
+//-gotten used of-
+#[test]
+fn corrects_gotten_used_of() {
+    assert_suggestion_result(
+        "The tutorial has indeed been of help, and I've gotten used of using Hull.",
+        lint_group(),
+        "The tutorial has indeed been of help, and I've gotten used to using Hull.",
+    );
+}
+
 // HavePassed
 
 #[test]


### PR DESCRIPTION
# Issues 
N/A

# Description

This is a mistake an old friend used to make many years ago and today I noticed it somewhere online so I did some Googling and it seems to be out there.

It's probably from people learning it via hearing it used where both "of" and "to" have their vowels reduced to schwa /ə/ and, after a syllable ending in /t/, /ə/ and /tə/ would sound alike.

I could only find examples for a couple of forms on GitHub and some mistakes were not totally clear that this is the correct or only fix. So please comment if you have any critiques.
But when I expanded my search to Reddit, I could find definite examples for every inflection.

I'm expecting there to be some false positives so report any found.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

There's a unit test for each inflection using sentences found in the wild, GitHub given preference and Reddit used where no examples could be found on GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
