### PR TITLE
feat: fed up of→fed up with

### DIFF
--- a/harper-core/src/linting/fed_up_with.rs
+++ b/harper-core/src/linting/fed_up_with.rs
@@ -1,0 +1,104 @@
+use crate::{
+    Dialect, Token,
+    expr::{Expr, SequenceExpr},
+    linting::{ExprLinter, Lint, LintKind, Suggestion, expr_linter::Chunk},
+};
+
+pub struct FedUpWith {
+    expr: Box<dyn Expr>,
+    dialect: Dialect,
+}
+
+impl FedUpWith {
+    pub fn new(dialect: Dialect) -> Self {
+        let expr = SequenceExpr::fixed_phrase("fed up of");
+
+        Self {
+            expr: Box::new(expr),
+            dialect,
+        }
+    }
+}
+
+impl ExprLinter for FedUpWith {
+    type Unit = Chunk;
+
+    fn expr(&self) -> &dyn Expr {
+        self.expr.as_ref()
+    }
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        if self.dialect == Dialect::British {
+            return None;
+        }
+
+        let oftok = toks.last()?;
+        let ofspan = oftok.span;
+
+        Some(Lint {
+            span: ofspan,
+            lint_kind: LintKind::Usage,
+            suggestions: vec![Suggestion::replace_with_match_case_str(
+                "with",
+                ofspan.get_content(src),
+            )],
+            message: "`Fed up of` is not accepted outside of British English.".to_string(),
+            ..Default::default()
+        })
+    }
+
+    fn description(&self) -> &str {
+        "Corrects `fed up of` to `fed up with` in dialects other than British English."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FedUpWith;
+    use crate::Dialect;
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    #[test]
+    fn correct_fed_up_of_in_us_english() {
+        assert_suggestion_result(
+            "I am fed up of Bugzilla reports being ignored.",
+            FedUpWith::new(Dialect::American),
+            "I am fed up with Bugzilla reports being ignored.",
+        );
+    }
+
+    #[test]
+    fn correct_fed_up_of_in_canadian_english() {
+        assert_suggestion_result(
+            "Fed up of long links ??? Use ✨ Linsh ✨, a CLI tool to shorten links.",
+            FedUpWith::new(Dialect::Canadian),
+            "Fed up with long links ??? Use ✨ Linsh ✨, a CLI tool to shorten links.",
+        );
+    }
+
+    #[test]
+    fn correct_fed_up_of_in_aus_english() {
+        assert_suggestion_result(
+            "Fed up of the lack of Twitter embedded timeline styling options?",
+            FedUpWith::new(Dialect::Australian),
+            "Fed up with the lack of Twitter embedded timeline styling options?",
+        );
+    }
+
+    #[test]
+    fn correct_fed_up_of_in_indian_english() {
+        assert_suggestion_result(
+            "I got fed up of finding my IP (v4) address in the big pile of text that ifconfig outputs on OS X.",
+            FedUpWith::new(Dialect::Indian),
+            "I got fed up with finding my IP (v4) address in the big pile of text that ifconfig outputs on OS X.",
+        );
+    }
+
+    #[test]
+    fn dont_flag_fed_up_of_in_british_english() {
+        assert_no_lints(
+            "Fed up of having to repeat the same actions for installing webmin so here's a script for 16.04+",
+            FedUpWith::new(Dialect::British),
+        );
+    }
+}

--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -71,6 +71,7 @@ use super::expand_time_shorthands::ExpandTimeShorthands;
 use super::expr_linter::run_on_chunk;
 use super::far_be_it::FarBeIt;
 use super::fascinated_by::FascinatedBy;
+use super::fed_up_with::FedUpWith;
 use super::feel_fell::FeelFell;
 use super::few_units_of_time_ago::FewUnitsOfTimeAgo;
 use super::filler_words::FillerWords;
@@ -637,7 +638,7 @@ impl LintGroup {
         );
         out.config.set_rule_enabled("InflectedVerbAfterTo", true);
 
-        out.add("InOnTheCards", InOnTheCards::new(dialect));
+        out.add_chunk_expr_linter("InOnTheCards", InOnTheCards::new(dialect));
         out.config.set_rule_enabled("InOnTheCards", true);
 
         out.add(
@@ -649,10 +650,10 @@ impl LintGroup {
         out.add("PossessiveNoun", PossessiveNoun::new(dictionary.clone()));
         out.config.set_rule_enabled("PossessiveNoun", false);
 
-        out.add("Regionalisms", Regionalisms::new(dialect));
+        out.add_chunk_expr_linter("Regionalisms", Regionalisms::new(dialect));
         out.config.set_rule_enabled("Regionalisms", true);
 
-        out.add("HaveTakeALook", HaveTakeALook::new(dialect));
+        out.add_chunk_expr_linter("HaveTakeALook", HaveTakeALook::new(dialect));
         out.config.set_rule_enabled("HaveTakeALook", true);
 
         out.add("MassNouns", MassNouns::new(dictionary.clone()));
@@ -698,6 +699,9 @@ impl LintGroup {
 
         out.add_chunk_expr_linter("DidPast", DidPast::new(dictionary.clone()));
         out.config.set_rule_enabled("DidPast", true);
+
+        out.add_chunk_expr_linter("FedUpWith", FedUpWith::new(dialect));
+        out.config.set_rule_enabled("FedUpWith", true);
 
         out
     }

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -66,6 +66,7 @@ mod expand_time_shorthands;
 mod expr_linter;
 mod far_be_it;
 mod fascinated_by;
+mod fed_up_with;
 mod feel_fell;
 mod few_units_of_time_ago;
 mod filler_words;


### PR DESCRIPTION
# Issues 
N/A

# Description

Corrects "fed up of" to "fed up with" when the dialect is not British

I saw this usage in a Slashdot comment but when I looked into it I found it's actually acceptable in British English. From what I can tell even the other Commonwealth English dialects don't accept it.

I don't think there's a way to do this in Weir yet and I don't think there's a way to check the `Dialect` in the `SequenceExpr` part either, so I just match it in all cases and then return early in `match_to_lint()` if the `Dialect` is British English. - Let me know if I missed a simpler way to do it!

Also changes `out.add()` to `out.add_chunk_expr_linter()` in `lint_group.rs` for three other linters that use `Dialect` with `ExprLinter` since I noticed they were wrong when looking for similar linters to base the new one on.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I added a unit test for each currently supported dialect, using the original sentence that led me here plus others sourced from GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
