### PR TITLE
feat(core): more edge cases in `MissingTo` rule

### DIFF
--- a/harper-core/src/linting/missing_to.rs
+++ b/harper-core/src/linting/missing_to.rs
@@ -304,6 +304,12 @@ impl ExprLinter for MissingTo {
             return None;
         }
 
+        if previous_word.is_some_and(|word| word.ends_with("ly"))
+            && (controller_text.ends_with('d') || controller_text.ends_with("en"))
+        {
+            return None;
+        }
+
         if controller_text.starts_with("hope") && previous_word == Some("of") {
             return None;
         }


### PR DESCRIPTION
# Issues 

Relates to #2521 & #2818.

# Description

Follow up on some additional edge cases from #2818 to add coverage of interaction between adverbs and collective nouns.

First noticed this on the sentence "A fully resolved set of configuration", it suggested adding the MissingTo.

Eventually narrowed it down to words listed in the `permissive_controller_words` AND preceded with an `ly` adverb AND followed by a collective noun.

# Demo

<img width="995" height="822" alt="Screenshot 2026-02-28 at 6 04 59 pm" src="https://github.com/user-attachments/assets/10e987e3-3612-424f-92ec-7e473af90a50" />

# How Has This Been Tested?

Adds unit tests for a bunch of cases, with/without adverbs, with/without collective nouns.
I was unsure how many or what to get test coverage of here, I reworked it a few times.
Happy to make changes to add more / cut down cases.

Push commit without a fix first so that the failed test cases can be reproduced in PR's CI. Then push the fix and watch CI go green.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
