### PR TITLE
fix(harper-cli): replace process::exit(1) with anyhow::bail!() in AuditDictionary and Test

### DIFF
--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -7,7 +7,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
 // use std::sync::Arc;
-use std::{fs, process};
+use std::fs;
 
 use anyhow::anyhow;
 use ariadne::{Color, Label, Report, ReportKind, Source};
@@ -812,7 +812,7 @@ fn main() -> anyhow::Result<()> {
                 if unused_flag_total > 0 {
                     eprintln!("  - {} unused flags found", unused_flag_total);
                 }
-                std::process::exit(1);
+                anyhow::bail!("Audit found issues in dictionary");
             }
 
             Ok(())
@@ -966,7 +966,7 @@ fn main() -> anyhow::Result<()> {
                 Ok(())
             } else {
                 eprintln!("{:?}", failing_tests);
-                process::exit(1);
+                anyhow::bail!("Some tests failed");
             }
         }
     }


### PR DESCRIPTION
## Summary

- Replace `process::exit(1)` with `anyhow::bail!()` in `audit-dictionary` and `test` subcommands
- Remove the now-unused `process` import from `main.rs`

`process::exit()` terminates immediately, skipping destructors and buffered I/O flushes. Since `main()` returns `anyhow::Result<()>`, errors should be propagated through the normal error handling path.

Follow-up to #2836, as suggested in [this comment](https://github.com/Automattic/harper/pull/2836#issuecomment-3979049893).

Fixes #2840

## Test plan

- [x] `cargo build -p harper-cli` — compiles successfully
- [x] `cargo test -p harper-cli` — all 3 tests pass
- [x] Both commands still exit with code 1 on failure (now via anyhow instead of process::exit)