### PR TITLE
feat: hidden into→hidden in

### DIFF
--- a/harper-core/src/linting/weir_rules/HiddenIn.weir
+++ b/harper-core/src/linting/weir_rules/HiddenIn.weir
@@ -1,0 +1,8 @@
+expr main (hidden into)
+
+let message "Did you mean `hidden in`?"
+let description "Corrects `hidden into` to `hidden in`."
+let kind "Usage"
+let becomes "hidden in"
+
+test "The button is hidden into the exam settings menu or something like that." "The button is hidden in the exam settings menu or something like that."

--- a/harper-core/src/linting/weir_rules/OnTopOf.weir
+++ b/harper-core/src/linting/weir_rules/OnTopOf.weir
@@ -1,8 +1,9 @@
-expr main (ontop of)
+expr main [(ontop of), (in top of)]
 
 let message "Did you mean `on top of`?"
-let description "Corrects `ontop of` to `on top of`."
-let kind "BoundaryError"
+let description "Corrects `ontop of` and `in top of` to `on top of`."
+let kind "Usage"
 let becomes "on top of"
 
 test "Initcpio hooks for overlayfs ontop of root." "Initcpio hooks for overlayfs on top of root."
+test "This project is a proof of concept to enable all the awesome features of BrowserSync in top of a Play Framework server." "This project is a proof of concept to enable all the awesome features of BrowserSync on top of a Play Framework server."


### PR DESCRIPTION
# Issues 
N/A

# Description

I was watching a European YouTube video and heard a couple of odd English constructions which I looked into and found to be pretty common:

- "hidden into" instead of just "hidden in" - I made a new Weir rule for this one.
- "in top of" instead of "on top of" - I extended the existing Weir rule that corrected "ontop of" and changed its `LintType` to `Usage`.

I'm not expecting false positives for the first one but for the second I feel like there might be cases where, while it still sounds unnatural, the correction might be something different such as "near the top". But I didn't hit enough to get a clear picture. If this is so then `OnTopOf.weir` should probably be split into one that only handles `OntopOf` and another that handles `InTopOf` but suggests multiple corrections.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

A sentence from GitHub was chosen to use as a unit test for each.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
