### PR TITLE
fix(core): edge case in `ItsPossessive` rule

### DIFF
--- a/harper-core/src/linting/its_possessive.rs
+++ b/harper-core/src/linting/its_possessive.rs
@@ -60,6 +60,22 @@ impl Default for ItsPossessive {
 
         map.insert(start_of_sentence_noun, 0);
 
+        let start_of_sentence_noun_subject = SequenceExpr::with(AnchorStart)
+            .t_aco("it's")
+            .t_ws()
+            .then(
+                UPOSSet::new(&[UPOS::NOUN, UPOS::PROPN]).or(|tok: &Token, _: &[char]| {
+                    tok.kind.as_number().is_some_and(|n| n.suffix.is_some())
+                        || ((tok.kind.is_noun() || tok.kind.is_proper_noun())
+                            && !tok.kind.is_adjective()
+                            && !tok.kind.is_adverb())
+                }),
+            )
+            .t_ws()
+            .then(UPOSSet::new(&[UPOS::VERB, UPOS::AUX]));
+
+        map.insert(start_of_sentence_noun_subject, 0);
+
         let start_of_sentence_adjective = SequenceExpr::with(AnchorStart)
             .t_aco("it's")
             .t_ws()
@@ -199,6 +215,15 @@ mod tests {
             "It's benefits are numerous.",
             ItsPossessive::default(),
             "Its benefits are numerous.",
+        );
+    }
+
+    #[test]
+    fn fixes_its_ancestor() {
+        assert_suggestion_result(
+            "It's ancestor is still around.",
+            ItsPossessive::default(),
+            "Its ancestor is still around.",
         );
     }
 
@@ -395,6 +420,11 @@ mod tests {
     #[test]
     fn dont_flag_issue_1722_its_big_enough() {
         assert_no_lints("It's big enough.", ItsPossessive::default());
+    }
+
+    #[test]
+    fn allows_its_awesome() {
+        assert_no_lints("It's awesome.", ItsPossessive::default());
     }
 
     #[test]


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

N/A

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

I found an edge case in the rule while writing a blog post. Seems like a simple fix.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Additional unit testing.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
