### PR TITLE
feat(core): `chalkboard` is a closed compound

### DIFF
--- a/harper-core/src/linting/closed_compounds.rs
+++ b/harper-core/src/linting/closed_compounds.rs
@@ -26,6 +26,7 @@ pub fn lint_group() -> LintGroup {
         "Anywhere"        => ("any where", "anywhere"),
         "Backplane"       => ("back plane", "backplane"),
         "Bypass"          => ("by pass", "bypass"),
+        "Chalkboard"      => ("chalk board", "chalkboard"),
         "Deadlift"        => ("dead lift", "deadlift"),
         "Desktop"         => ("desk top", "desktop"),
         "Devops"          => ("dev ops", "devops"),
@@ -243,6 +244,13 @@ mod tests {
     fn dead_lift() {
         let test_sentence = "I can dead lift 200 kg.";
         let expected = "I can deadlift 200 kg.";
+        assert_suggestion_result(test_sentence, lint_group(), expected);
+    }
+
+    #[test]
+    fn chalk_board() {
+        let test_sentence = "The teacher wrote the equation on the chalk board.";
+        let expected = "The teacher wrote the equation on the chalkboard.";
         assert_suggestion_result(test_sentence, lint_group(), expected);
     }
 


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

N/A

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

While writing a blog post, I noticed that Harper did not respect that chalkboard is pretty much always a closed compound and therefore should be condensed from "chalk board".

I've added it to the list of closed compounds.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Addtional unit test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
