### PR TITLE
feat(obsidian): listen to changes to `data.json`

### DIFF
--- a/packages/obsidian-plugin/src/index.ts
+++ b/packages/obsidian-plugin/src/index.ts
@@ -42,8 +42,6 @@ export default class HarperPlugin extends Plugin {
 			return;
 		}
 
-		const data = await this.loadData();
-
 		this.app.workspace.onLayoutReady(async () => {
 			this.state = new State(
 				(n) => this.saveData(n),
@@ -51,13 +49,8 @@ export default class HarperPlugin extends Plugin {
 				editorInfoField,
 			);
 
-			await this.state.initializeFromSettings(data);
 			this.registerEditorExtension(this.state.getCMEditorExtensions());
-			if (!(data?.lintEnabled ?? true)) {
-				this.state.disableEditorLinter(false);
-			} else this.state.enableEditorLinter(false);
-			this.settings?.update();
-
+			await this.reloadSettingsFromDisk();
 			this.setupStatusBar();
 		});
 
@@ -65,6 +58,28 @@ export default class HarperPlugin extends Plugin {
 		this.addSettingTab(this.settings);
 
 		this.setupCommands();
+	}
+
+	async onExternalSettingsChange() {
+		await this.reloadSettingsFromDisk();
+	}
+
+	private async reloadSettingsFromDisk() {
+		const data = await this.loadData();
+		if (this.state == null) {
+			return;
+		}
+
+		await this.state.initializeFromSettings(data);
+
+		if (!(data?.lintEnabled ?? true)) {
+			this.state.disableEditorLinter(false);
+		} else {
+			this.state.enableEditorLinter(false);
+		}
+
+		this.settings?.update();
+		this.updateStatusBar(data?.dialect ?? Dialect.American);
 	}
 
 	private getDialectStatus(dialectNum: Dialect): string {


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #2356

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

As it turns out, there's an existing API in Obsidian for listening to changes to the config file. Addressing the problem outlined in the issue was as simple as hooking into this API and running the same code we already use on startup. 

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
