### PR TITLE
fix(obsidian): remove default hotkey

### DIFF
--- a/packages/obsidian-plugin/src/index.ts
+++ b/packages/obsidian-plugin/src/index.ts
@@ -196,7 +196,7 @@ export default class HarperPlugin extends Plugin {
 		this.addCommand({
 			id: 'harper-ignore-focused-diagnostic',
 			name: 'Ignore focused diagnostic',
-			hotkeys: [{ modifiers: ['Mod', 'Shift'], key: 'i' }],
+			hotkeys: [],
 			checkCallback: (checking) => {
 				const editorView = this.getActiveEditorView();
 				if (!editorView) return false;


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #2838

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

Removes the default hotkey which was making it difficult to open the inspector.
From now on, users will need to manually configure the "Ignore diagnostic" hotkey themselves.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
