### PR TITLE
fix: don't flag "our IT"

### DIFF
--- a/harper-core/src/linting/multiple_sequential_pronouns.rs
+++ b/harper-core/src/linting/multiple_sequential_pronouns.rs
@@ -1,73 +1,30 @@
-use super::Suggestion;
-use super::expr_linter::ExprLinter;
-use crate::expr::Expr;
-use crate::expr::SequenceExpr;
-use crate::linting::LintKind;
-use crate::linting::expr_linter::Chunk;
-use crate::patterns::WordSet;
-use crate::{CharStringExt, Lint, Lrc, Token, TokenStringExt};
+use crate::{
+    expr::{Expr, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+    {Lint, Lrc, Token, TokenStringExt},
+};
 
 /// Linter that checks if multiple pronouns are being used right after each
 /// other. This is a common mistake to make during the revision process.
 pub struct MultipleSequentialPronouns {
     expr: Box<dyn Expr>,
-    subject_pronouns: Lrc<WordSet>,
-    object_pronouns: Lrc<WordSet>,
-    possessive_adjectives: Lrc<WordSet>,
 }
 
 impl MultipleSequentialPronouns {
     fn new() -> Self {
-        // Some words occur in multiple positions in the paradigm
-        // but this is a set, so it doesn't matter and is much clearer
-        let pronouns = Lrc::new(WordSet::new(&[
-            "i", "you", "he", "she", "it", // subject case, singular
-            "me", "you", "him", "her", "it", // object case, singular
-            "we", "you", "they", // subject case, plural
-            "us", "you", "them", // object case, plural
-            "mine", "yours", "his", "hers", // possessive pronouns, singular
-            "ours", "yours", "theirs", // possessive pronouns, plural
-            "my", "your", "his", "her", "its", // possessive adjectives, singular
-            "our", "your", "their", // possessive adjectives, plural
-        ]));
-
-        // TODO: temporary sets of pronouns - remove when DictWordMetadata has this info
-        let subject_pronouns = Lrc::new(WordSet::new(&[
-            "i", "you", "he", "she", "it", // subject case, singular
-            "we", "you", "they", // subject case, plural
-        ]));
-
-        let object_pronouns = Lrc::new(WordSet::new(&[
-            "me", "you", "him", "her", "it", // object case, singular
-            "us", "you", "them", // object case, plural
-        ]));
-
-        let possessive_adjectives = Lrc::new(WordSet::new(&[
-            "my", "your", "his", "her", "its", // possessive adjectives, singular
-            "our", "your", "their", // possessive adjectives, plural
-        ]));
+        let pronouns = Lrc::new(|t: &Token, _s: &[char]| {
+            t.kind.is_subject_pronoun() // e.g. I
+                || t.kind.is_object_pronoun() // e.g. me
+                || t.kind.is_possessive_pronoun() // e.g. mine
+                || t.kind.is_possessive_determiner() // e.g. my
+        });
 
         Self {
             expr: Box::new(
                 SequenceExpr::with(pronouns.clone())
                     .then_one_or_more(SequenceExpr::whitespace().then(pronouns.clone())),
             ),
-            subject_pronouns,
-            object_pronouns,
-            possessive_adjectives,
         }
-    }
-
-    fn is_subject_pronoun(&self, word: &str) -> bool {
-        self.subject_pronouns.contains(word)
-    }
-
-    fn is_object_pronoun(&self, word: &str) -> bool {
-        self.object_pronouns.contains(word)
-    }
-
-    fn is_possessive_adjective(&self, word: &str) -> bool {
-        self.possessive_adjectives.contains(word)
     }
 }
 
@@ -82,25 +39,33 @@ impl ExprLinter for MultipleSequentialPronouns {
         let mut suggestions = Vec::new();
 
         if matched_tokens.len() == 3 {
-            let first_word_raw = matched_tokens[0].span.get_content(source).to_string();
-            let first_word = first_word_raw.to_ascii_lowercase();
-            let second_word = matched_tokens[2].span.get_content(source).to_string();
+            let first_word_tok = &matched_tokens[0];
+            let second_word_tok = &matched_tokens[2];
+
+            let first_word_raw = first_word_tok.span.get_content(source);
+            let second_word_raw = second_word_tok.span.get_content(source);
             // Bug 578: "I can lend you my car" - if 1st is object and second is possessive adjective, don't lint
-            if self.is_object_pronoun(&first_word) && self.is_possessive_adjective(&second_word) {
+            if first_word_tok.kind.is_object_pronoun()
+                && second_word_tok.kind.is_possessive_determiner()
+            {
                 return None;
             }
             // Bug 724: "One told me they were able to begin reading" - if 1st is object ans second is subject, don't lint
-            if self.is_object_pronoun(&first_word) && self.is_subject_pronoun(&second_word) {
+            if first_word_tok.kind.is_object_pronoun() && second_word_tok.kind.is_subject_pronoun()
+            {
                 return None;
             }
 
             // US is a qualifier meaning American, so uppercase after a possessive is OK.
-            if self.is_possessive_adjective(&first_word) && second_word == "US" {
+            // Likewise, IT means Information Technology, as in "our IT director"
+            if first_word_tok.kind.is_possessive_determiner()
+                && (second_word_raw == ['U', 'S'] || second_word_raw == ['I', 'T'])
+            {
                 return None;
             }
 
             // The same applies to uppercase before a subject pronoun
-            if first_word_raw == "US" && self.is_subject_pronoun(&second_word) {
+            if first_word_raw == ['U', 'S'] && second_word_tok.kind.is_subject_pronoun() {
                 return None;
             }
 
@@ -227,6 +192,15 @@ mod tests {
     fn dont_flag_case_insensitive_cost_him_his_life() {
         assert_lint_count(
             "to the point where it very well likely cost Him his life",
+            MultipleSequentialPronouns::new(),
+            0,
+        )
+    }
+
+    #[test]
+    fn dont_flag_2870() {
+        assert_lint_count(
+            "their sales derp was just having none of it when our IT director told him, point blank, that we're not moving anything into the cloud",
             MultipleSequentialPronouns::new(),
             0,
         )

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -1536,16 +1536,6 @@ Message: |
 
 
 
-Lint:    Repetition (63 priority)
-Message: |
-     971 | to? And oh, my poor hands, how is it I can’t see you?” She was moving them about
-         |                                   ^~~~ There are too many personal pronouns in sequence here.
-Suggest:
-  - Replace with: “it”
-  - Replace with: “I”
-
-
-
 Lint:    Readability (127 priority)
 Message: |
      975 | As there seemed to be no chance of getting her hands up to her head, she tried
@@ -2626,16 +2616,6 @@ Message: |
          |      ^~~~ This sentence does not start with a capital letter
 Suggest:
   - Replace with: “Then”
-
-
-
-Lint:    Repetition (63 priority)
-Message: |
-    2177 | great relief. “Now at ours they had at the end of the bill, ‘French, music, and
-         |                       ^~~~~~~~~ There are too many personal pronouns in sequence here.
-Suggest:
-  - Replace with: “ours”
-  - Replace with: “they”
 
 
 

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -1112,16 +1112,6 @@ Suggest:
 
 
 
-Lint:    Repetition (63 priority)
-Message: |
-     950 | “Two studies. One of them I call ‘Montauk Point—The Gulls,’ and the other I call
-         |                      ^~~~~~ There are too many personal pronouns in sequence here.
-Suggest:
-  - Replace with: “them”
-  - Replace with: “I”
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
      950 | “Two studies. One of them I call ‘Montauk Point—The Gulls,’ and the other I call
@@ -1228,28 +1218,6 @@ Message: |
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1081 | chair. Yet high over the city our line of yellow windows must have contributed
          | ~~~~~~ This sentence is 41 words long.
-
-
-
-Lint:    Repetition (63 priority)
-Message: |
-    1092 | eyes off him, but every time he looked at me I had to pretend to be looking at
-         |                                           ^~~~ There are too many personal pronouns in sequence here.
-    1093 | the advertisement over his head. When we came into the station he was next to
-Suggest:
-  - Replace with: “me”
-  - Replace with: “I”
-
-
-
-Lint:    Repetition (63 priority)
-Message: |
-    1095 | to call a policeman, but he knew I lied. I was so excited that when I got into a
-    1096 | taxi with him I didn’t hardly know I wasn’t getting into a subway train. All I
-         |           ^~~~~ There are too many personal pronouns in sequence here.
-Suggest:
-  - Replace with: “him”
-  - Replace with: “I”
 
 
 
@@ -3571,17 +3539,6 @@ Message: |
 
 
 
-Lint:    Repetition (63 priority)
-Message: |
-    2314 | girl wants to be looked at sometime, and because it seemed romantic to me I have
-         |                                                                        ^~~~ There are too many personal pronouns in sequence here.
-    2315 | remembered the incident ever since. His name was Jay Gatsby, and I didn’t lay
-Suggest:
-  - Replace with: “me”
-  - Replace with: “I”
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
     2319 | That was nineteen-seventeen. By the next year I had a few beaux myself, and I
@@ -3673,27 +3630,6 @@ Suggest:
   - Replace with: “dear's”
   - Replace with: “dares”
   - Replace with: “dearest”
-
-
-
-Lint:    Repetition (63 priority)
-Message: |
-    2351 | whoever they belong to. Tell ’em all Daisy’s change’ her mine. Say: ‘Daisy’s
-         |                                                      ^~~~~~~~ There are too many personal pronouns in sequence here.
-Suggest:
-  - Replace with: “her”
-  - Replace with: “mine”
-
-
-
-Lint:    Repetition (63 priority)
-Message: |
-    2351 | whoever they belong to. Tell ’em all Daisy’s change’ her mine. Say: ‘Daisy’s
-    2352 | change’ her mine!’”
-         |         ^~~~~~~~ There are too many personal pronouns in sequence here.
-Suggest:
-  - Replace with: “her”
-  - Replace with: “mine”
 
 
 
@@ -4297,16 +4233,6 @@ Message: |
          |      ^~~~~~~~~~~~ Did you mean `Kissinger`?
 Suggest:
   - Replace with: “Kissinger”
-
-
-
-Lint:    Repetition (63 priority)
-Message: |
-    2968 | “I’m all out of practice, you see. I told you I couldn’t play. I’m all out of
-         |                                           ^~~~~ There are too many personal pronouns in sequence here.
-Suggest:
-  - Replace with: “you”
-  - Replace with: “I”
 
 
 
@@ -5545,16 +5471,6 @@ Suggest:
   - Replace with: “Biko's”
   - Replace with: “Bilbo's”
   - Replace with: “Biro's”
-
-
-
-Lint:    Repetition (63 priority)
-Message: |
-    4115 | “I told you I went there,” said Gatsby.
-         |         ^~~~~ There are too many personal pronouns in sequence here.
-Suggest:
-  - Replace with: “you”
-  - Replace with: “I”
 
 
 
@@ -7123,17 +7039,6 @@ Suggest:
 
 
 
-Lint:    Repetition (63 priority)
-Message: |
-    5313 | Dear Mr. Carraway. This has been one of the most terrible shocks of my life to
-    5314 | me I hardly can believe it that it is true at all. Such a mad act as that man
-         | ^~~~ There are too many personal pronouns in sequence here.
-Suggest:
-  - Replace with: “me”
-  - Replace with: “I”
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
     5322 | >
@@ -7625,16 +7530,6 @@ Suggest:
   - Replace with: “smoking”
   - Replace with: “shoeing”
   - Replace with: “smocking”
-
-
-
-Lint:    Repetition (63 priority)
-Message: |
-    5613 | great for that. He told me I et like a hog once, and I beat him for it.”
-         |                         ^~~~ There are too many personal pronouns in sequence here.
-Suggest:
-  - Replace with: “me”
-  - Replace with: “I”
 
 
 


### PR DESCRIPTION
# Issues 

Fixes #2870

# Description

- Don't flag "our IT director" etc.
- Refactored to use newer methods.
- As a bonus it stops flagging 12 non-errors in Alice and Gatsby snapshots.

I also noticed that `.is_possessive_pronoun()` is kind of a "null" implementation as "mine", "ours", "yours", "his", "hers", "its", and "theirs" are just marked as pronouns. This may need to be addressed at some point.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

A new unit test using the sentence that inspired the false positive report.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
