### PR TITLE
fix(core): adjust how words are iterated in `title_case`

### DIFF
--- a/harper-core/src/linting/use_title_case.rs
+++ b/harper-core/src/linting/use_title_case.rs
@@ -83,4 +83,21 @@ mod tests {
             "# My/Our/Your/His/Her/Its/Their",
         );
     }
+
+    #[test]
+    fn ignores_leading_number_list_marker_in_heading() {
+        assert_no_lints(
+            "### 1. To Do a Thing",
+            UseTitleCase::new(FstDictionary::curated()),
+        );
+    }
+
+    #[test]
+    fn still_fixes_non_first_small_words_after_leading_number() {
+        assert_suggestion_result(
+            "### 1. To do a thing",
+            UseTitleCase::new(FstDictionary::curated()),
+            "### 1. To Do a Thing",
+        );
+    }
 }

--- a/harper-core/src/title_case.rs
+++ b/harper-core/src/title_case.rs
@@ -40,7 +40,7 @@ pub fn try_make_title_case(
     let start_index = toks.first().unwrap().span.start;
     let relevant_text = toks.span().unwrap().get_content(source);
 
-    let mut word_likes = toks.iter_word_like_indices().enumerate().peekable();
+    let mut word_likes = toks.iter_word_like_indices().peekable();
 
     let mut output = None;
     let mut previous_word_index = 0;
@@ -65,8 +65,15 @@ pub fn try_make_title_case(
         }
     };
 
-    while let Some((index, word_idx)) = word_likes.next() {
+    let mut seen_alphabetic_word = false;
+
+    while let Some(word_idx) = word_likes.next() {
         let word = &toks[word_idx];
+        let is_alphabetic_word = word
+            .span
+            .get_content(source)
+            .iter()
+            .any(|c| c.is_alphabetic());
 
         if let Some(Some(metadata)) = word.kind.as_word()
             && metadata.is_proper_noun()
@@ -89,9 +96,10 @@ pub fn try_make_title_case(
             .iter()
             .any(|tok| matches!(tok.kind, TokenKind::Punctuation(Punctuation::Colon)));
 
+        let is_first_alphabetic_word = is_alphabetic_word && !seen_alphabetic_word;
         let should_capitalize = is_after_colon
             || should_capitalize_token(word, source)
-            || index == 0
+            || is_first_alphabetic_word
             || word_likes.peek().is_none();
 
         if should_capitalize {
@@ -107,6 +115,10 @@ pub fn try_make_title_case(
                     relevant_text[i - start_index].to_ascii_lowercase(),
                 );
             }
+        }
+
+        if is_alphabetic_word {
+            seen_alphabetic_word = true;
         }
 
         previous_word_index = word_idx


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #2861

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

Adjusts how words are iterated in the `title_case` module (and the related rule) to allow `to` to be capitalized at the start of sentences.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Additional unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
