### PR TITLE
feat: off coarse→of course

### DIFF
--- a/harper-core/src/linting/weir_rules/OfCourse.weir
+++ b/harper-core/src/linting/weir_rules/OfCourse.weir
@@ -1,10 +1,11 @@
-expr main [(off course), (o course), (ofcourse)]
+expr main [(off course), (o course), (ofcourse), (off coarse)]
 
 let message "Did you mean `of course`?"
-let description "Detects the common mistake `off course` and suggests the correct form `of course`."
+let description "Detects common mistaken forms of `of course`."
 let kind "Eggcorn"
 let becomes "of course"
 
 test "Yes, off course we should do that." "Yes, of course we should do that."
 test "Yes, o course we should do that." "Yes, of course we should do that."
 test "Ofcourse, I like other languages.. uzulla has 183 repositories available." "Of course, I like other languages.. uzulla has 183 repositories available."
+test "Off coarse, the web service will still be operational." "Of course, the web service will still be operational."


### PR DESCRIPTION
# Issues 
N/A

# Description

Adds "off coarse" to the Weir rule that corrects "off course", "o course", and "ofcourse" to "of course".

I actually came across "of coarse" in a YouTube comment but that's a common legit phrase where "coarse" is an adjective describing a following noun, so requires a more complex Linter.
But when looking for examples I decided to also check for "off coarse" and it turns out to be a common mistake too and I didn't see it in potential false positives like with "of coarse".

I also updated the `description` since it now addresses four separate common mistakes for "of course", not just one.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

A unit test using the first sentence found on GitHub with this mistake in it.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
