### PR TITLE
feat: take/claim/assume responsibility of→responsibility for

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -420,6 +420,26 @@ pub fn lint_group() -> LintGroup {
             "Simplifies redundant double positives like `most optimal` to the base form.",
             LintKind::Redundancy
         ),
+        "ResponsibilityFor" => (
+            &[
+                ("take responsibility of", "take responsibility for"),
+                ("took responsibility of", "took responsibility for"),
+                ("taken responsibility of", "taken responsibility for"),
+                ("taking responsibility of", "taking responsibility for"),
+                ("takes responsibility of", "takes responsibility for"),
+                ("assume responsibility of", "assume responsibility for"),
+                ("assumed responsibility of", "assumed responsibility for"),
+                ("assuming responsibility of", "assuming responsibility for"),
+                ("assumes responsibility of", "assumes responsibility for"),
+                ("claim responsibility of", "claim responsibility for"),
+                ("claimed responsibility of", "claimed responsibility for"),
+                ("claiming responsibility of", "claiming responsibility for"),
+                ("claims responsibility of", "claims responsibility for"),
+            ],
+            "The correct preposition is `for`, not `of`.",
+            "Corrects `take/assume/claim responsibility of` to `take/assume/claim responsibility for`.",
+            LintKind::Usage
+        ),
         "ScapeGoat" => (
             &[
                 ("an escape goat", "a scapegoat"),
@@ -471,22 +491,6 @@ pub fn lint_group() -> LintGroup {
             "Use the subjunctive mood with `if only` or `I wish`. The correct form is `were`, not `was`.",
             "Ensures proper use of the subjunctive mood in counterfactual conditional statements starting with `if only` or `I wish`.",
             LintKind::Grammar
-        ),
-        "TakeResponsibilityFor" => (
-            &[
-                ("take responsibility of", "take responsibility for"),
-                ("took responsibility of", "took responsibility for"),
-                ("taken responsibility of", "taken responsibility for"),
-                ("taking responsibility of", "taking responsibility for"),
-                ("takes responsibility of", "takes responsibility for"),
-                ("assume responsibility of", "assume responsibility for"),
-                ("assumed responsibility of", "assumed responsibility for"),
-                ("assuming responsibility of", "assuming responsibility for"),
-                ("assumes responsibility of", "assumes responsibility for"),
-            ],
-            "The correct preposition is `for`, not `of`.",
-            "Corrects `take or assume responsibility of` to `take or assume responsibility for`.",
-            LintKind::Usage
         ),
         "WreakHavoc" => (
             &[

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -1120,6 +1120,125 @@ fn fix_peaks() {
 // RedundantSuperlatives
 // -none-
 
+// ResponsibilityFor
+
+#[test]
+fn fix_take() {
+    assert_suggestion_result(
+        "Is anyone wanting to step up and take responsibility of this library, or should I put it in EOL and redirect to another tool? ",
+        lint_group(),
+        "Is anyone wanting to step up and take responsibility for this library, or should I put it in EOL and redirect to another tool? ",
+    );
+}
+
+#[test]
+fn fix_taken() {
+    assert_suggestion_result(
+        "if it had only taken responsibility of the manifest/info additions and extensionsID it would have made our life easier",
+        lint_group(),
+        "if it had only taken responsibility for the manifest/info additions and extensionsID it would have made our life easier",
+    );
+}
+
+#[test]
+fn fix_takes() {
+    assert_suggestion_result(
+        "If I have a message that i want to encode, who takes responsibility of pointers?",
+        lint_group(),
+        "If I have a message that i want to encode, who takes responsibility for pointers?",
+    );
+}
+
+#[test]
+fn fix_taking() {
+    assert_suggestion_result(
+        "This issue is about taking responsibility of the feature area auto indentation and start solving the bugs in the feature area.",
+        lint_group(),
+        "This issue is about taking responsibility for the feature area auto indentation and start solving the bugs in the feature area.",
+    );
+}
+
+#[test]
+fn fix_took() {
+    assert_suggestion_result(
+        "If the driver took responsibility of the locking, it could let these HTTP calls happen in parallel",
+        lint_group(),
+        "If the driver took responsibility for the locking, it could let these HTTP calls happen in parallel",
+    );
+}
+
+#[test]
+fn fix_assume() {
+    assert_suggestion_result(
+        "it's a relatively big chunk of behavior to assume responsibility of",
+        lint_group(),
+        "it's a relatively big chunk of behavior to assume responsibility for",
+    );
+}
+
+#[test]
+fn fix_assumed() {
+    assert_suggestion_result(
+        "and assumed responsibility of project managing the transition of Barclays",
+        lint_group(),
+        "and assumed responsibility for project managing the transition of Barclays",
+    );
+}
+
+#[test]
+fn fix_assumes() {
+    assert_suggestion_result(
+        "It means that the core development team assumes responsibility of the module",
+        lint_group(),
+        "It means that the core development team assumes responsibility for the module",
+    );
+}
+
+#[test]
+fn fix_assuming() {
+    assert_suggestion_result(
+        "The point of extract is essentially that you're assuming responsibility of maintenance for that version of the formula.",
+        lint_group(),
+        "The point of extract is essentially that you're assuming responsibility for maintenance for that version of the formula.",
+    );
+}
+
+#[test]
+fn fix_claim() {
+    assert_suggestion_result(
+        "so it doesn't need to claim responsibility of the reappearing containers lifecycle",
+        lint_group(),
+        "so it doesn't need to claim responsibility for the reappearing containers lifecycle",
+    );
+}
+
+#[test]
+fn fix_claimed() {
+    assert_suggestion_result(
+        "a group called The Impact Team had claimed responsibility of the data breach",
+        lint_group(),
+        "a group called The Impact Team had claimed responsibility for the data breach",
+    );
+}
+
+#[test]
+fn fix_claiming() {
+    assert_suggestion_result(
+        "I feel that there should be some other way of claiming responsibility of the promise's continuation.",
+        lint_group(),
+        "I feel that there should be some other way of claiming responsibility for the promise's continuation.",
+    );
+}
+
+#[test]
+fn fix_claims() {
+    assert_suggestion_result(
+        "yet the Lord claims responsibility of those boundaries",
+        lint_group(),
+        "yet the Lord claims responsibility for those boundaries",
+    );
+}
+
 // ScapeGoat
 
 #[test]
@@ -1430,89 +1549,6 @@ fn i_wish_it_was() {
         "but I wish it was more friendly to existing ecosystems",
         lint_group(),
         "but I wish it were more friendly to existing ecosystems",
-    );
-}
-
-// TakeResponsibilityFor
-
-#[test]
-fn fix_take() {
-    assert_suggestion_result(
-        "Is anyone wanting to step up and take responsibility of this library, or should I put it in EOL and redirect to another tool? ",
-        lint_group(),
-        "Is anyone wanting to step up and take responsibility for this library, or should I put it in EOL and redirect to another tool? ",
-    );
-}
-
-#[test]
-fn fix_taken() {
-    assert_suggestion_result(
-        "if it had only taken responsibility of the manifest/info additions and extensionsID it would have made our life easier",
-        lint_group(),
-        "if it had only taken responsibility for the manifest/info additions and extensionsID it would have made our life easier",
-    );
-}
-
-#[test]
-fn fix_takes() {
-    assert_suggestion_result(
-        "If I have a message that i want to encode, who takes responsibility of pointers?",
-        lint_group(),
-        "If I have a message that i want to encode, who takes responsibility for pointers?",
-    );
-}
-
-#[test]
-fn fix_taking() {
-    assert_suggestion_result(
-        "This issue is about taking responsibility of the feature area auto indentation and start solving the bugs in the feature area.",
-        lint_group(),
-        "This issue is about taking responsibility for the feature area auto indentation and start solving the bugs in the feature area.",
-    );
-}
-
-#[test]
-fn fix_took() {
-    assert_suggestion_result(
-        "If the driver took responsibility of the locking, it could let these HTTP calls happen in parallel",
-        lint_group(),
-        "If the driver took responsibility for the locking, it could let these HTTP calls happen in parallel",
-    );
-}
-
-#[test]
-fn fix_assume() {
-    assert_suggestion_result(
-        "it's a relatively big chunk of behavior to assume responsibility of",
-        lint_group(),
-        "it's a relatively big chunk of behavior to assume responsibility for",
-    );
-}
-
-#[test]
-fn fix_assumed() {
-    assert_suggestion_result(
-        "and assumed responsibility of project managing the transition of Barclays",
-        lint_group(),
-        "and assumed responsibility for project managing the transition of Barclays",
-    );
-}
-
-#[test]
-fn fix_assumes() {
-    assert_suggestion_result(
-        "It means that the core development team assumes responsibility of the module",
-        lint_group(),
-        "It means that the core development team assumes responsibility for the module",
-    );
-}
-
-#[test]
-fn fix_assuming() {
-    assert_suggestion_result(
-        "The point of extract is essentially that you're assuming responsibility of maintenance for that version of the formula.",
-        lint_group(),
-        "The point of extract is essentially that you're assuming responsibility for maintenance for that version of the formula.",
     );
 }
 


### PR DESCRIPTION
# Issues 
N/A

# Description

Just another oddity I heard for the first time in a YouTube video, researched online, and found countless instances of.

_take responsibility **of**_ when it should be _take responsibility **for**_

A few minutes after opening this PR I discovered the same thing happens with
_assume responsibility **of**_ instead of correct _assume responsibility **for**_

And the next day I found **claim responsibility of** so I renamed the linter to `ResponsibilityFor` and added all the inflections of "claim".

(I also re-sorted two other `phrase_set_correction` linters which were not sorted alphabetically.)

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I found a sentence which each inflected form of each verb on GitHub, or failing that on other sites such as Stack Overflow and Medium, which are now used in unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
