### PR TITLE
refactor(core): refactor `TokenStringExt`

### DIFF
--- a/harper-core/src/document.rs
+++ b/harper-core/src/document.rs
@@ -4,7 +4,6 @@ use std::fmt::Display;
 
 use harper_brill::{Chunker, Tagger, brill_tagger, burn_chunker};
 use itertools::Itertools;
-use paste::paste;
 
 use crate::expr::{Expr, ExprExt, FirstMatchOf, Repeating, SequenceExpr};
 use crate::parsers::{Markdown, MarkdownOptions, Parser, PlainEnglish};
@@ -909,97 +908,13 @@ impl Document {
     }
 }
 
-/// Creates functions necessary to implement [`TokenStringExt]` on a document.
-macro_rules! create_fns_on_doc {
-    ($thing:ident) => {
-        paste! {
-            fn [< first_ $thing >](&self) -> Option<&Token> {
-                self.tokens.[< first_ $thing >]()
-            }
-
-            fn [< last_ $thing >](&self) -> Option<&Token> {
-                self.tokens.[< last_ $thing >]()
-            }
-
-            fn [< last_ $thing _index>](&self) -> Option<usize> {
-                self.tokens.[< last_ $thing _index >]()
-            }
-
-            fn [<iter_ $thing _indices>](&self) -> impl DoubleEndedIterator<Item = usize> + '_ {
-                self.tokens.[< iter_ $thing _indices >]()
-            }
-
-            fn [<iter_ $thing s>](&self) -> impl Iterator<Item = &Token> + '_ {
-                self.tokens.[< iter_ $thing s >]()
-            }
-        }
-    };
-}
-
 impl TokenStringExt for Document {
-    create_fns_on_doc!(adjective);
-    create_fns_on_doc!(apostrophe);
-    create_fns_on_doc!(at);
-    create_fns_on_doc!(chunk_terminator);
-    create_fns_on_doc!(comma);
-    create_fns_on_doc!(conjunction);
-    create_fns_on_doc!(currency);
-    create_fns_on_doc!(ellipsis);
-    create_fns_on_doc!(hostname);
-    create_fns_on_doc!(likely_homograph);
-    create_fns_on_doc!(noun);
-    create_fns_on_doc!(number);
-    create_fns_on_doc!(paragraph_break);
-    create_fns_on_doc!(pipe);
-    create_fns_on_doc!(preposition);
-    create_fns_on_doc!(punctuation);
-    create_fns_on_doc!(quote);
-    create_fns_on_doc!(sentence_terminator);
-    create_fns_on_doc!(space);
-    create_fns_on_doc!(unlintable);
-    create_fns_on_doc!(verb);
-    create_fns_on_doc!(word);
-    create_fns_on_doc!(word_like);
-    create_fns_on_doc!(heading_start);
-
-    fn first_sentence_word(&self) -> Option<&Token> {
-        self.tokens.first_sentence_word()
+    fn tokens(&self) -> &[Token] {
+        &self.tokens
     }
 
-    fn first_non_whitespace(&self) -> Option<&Token> {
-        self.tokens.first_non_whitespace()
-    }
-
-    fn span(&self) -> Option<Span<char>> {
-        self.tokens.span()
-    }
-
-    fn iter_linking_verb_indices(&self) -> impl Iterator<Item = usize> + '_ {
-        self.tokens.iter_linking_verb_indices()
-    }
-
-    fn iter_linking_verbs(&self) -> impl Iterator<Item = &Token> + '_ {
-        self.tokens.iter_linking_verbs()
-    }
-
-    fn iter_chunks(&self) -> impl Iterator<Item = &'_ [Token]> + '_ {
-        self.tokens.iter_chunks()
-    }
-
-    fn iter_paragraphs(&self) -> impl Iterator<Item = &'_ [Token]> + '_ {
-        self.tokens.iter_paragraphs()
-    }
-
-    fn iter_headings(&self) -> impl Iterator<Item = &'_ [Token]> + '_ {
-        self.tokens.iter_headings()
-    }
-
-    fn iter_sentences(&self) -> impl Iterator<Item = &'_ [Token]> + '_ {
-        self.tokens.iter_sentences()
-    }
-
-    fn iter_sentences_mut(&mut self) -> impl Iterator<Item = &'_ mut [Token]> + '_ {
-        self.tokens.iter_sentences_mut()
+    fn tokens_mut(&mut self) -> &mut [Token] {
+        &mut self.tokens
     }
 }
 

--- a/harper-core/src/token_string_ext.rs
+++ b/harper-core/src/token_string_ext.rs
@@ -2,46 +2,34 @@ use crate::{Span, Token};
 use itertools::Itertools;
 use paste::paste;
 
-macro_rules! create_decl_for {
-    ($thing:ident) => {
-        paste! {
-            fn [< first_ $thing >](&self) -> Option<&Token>;
-
-            fn [< last_ $thing >](&self) -> Option<&Token>;
-
-            fn [< last_ $thing _index >](&self) -> Option<usize>;
-
-            fn [<iter_ $thing _indices>](&self) -> impl DoubleEndedIterator<Item = usize> + '_;
-
-            fn [<iter_ $thing s>](&self) -> impl Iterator<Item = &Token> + '_;
-        }
-    };
-}
-
 macro_rules! create_fns_for {
     ($thing:ident) => {
         paste! {
             fn [< first_ $thing >](&self) -> Option<&Token> {
-                self.iter().find(|v| v.kind.[<is_ $thing>]())
+                self.tokens().iter().find(|v| v.kind.[<is_ $thing>]())
             }
 
             fn [< last_ $thing >](&self) -> Option<&Token> {
-                self.iter().rev().find(|v| v.kind.[<is_ $thing>]())
+                self.tokens().iter().rev().find(|v| v.kind.[<is_ $thing>]())
             }
 
             fn [< last_ $thing _index >](&self) -> Option<usize> {
-                self.iter().rev().position(|v| v.kind.[<is_ $thing>]()).map(|i| self.len() - i - 1)
+                let tokens = self.tokens();
+
+                tokens.iter().rev().position(|v| v.kind.[<is_ $thing>]()).map(|i| tokens.len() - i - 1)
             }
 
             fn [<iter_ $thing _indices>](&self) -> impl DoubleEndedIterator<Item = usize> + '_ {
-                self.iter()
+                self.tokens().iter()
                     .enumerate()
                     .filter(|(_, t)| t.kind.[<is_ $thing>]())
                     .map(|(i, _)| i)
             }
 
             fn [<iter_ $thing s>](&self) -> impl Iterator<Item = &Token> + '_ {
-                self.[<iter_ $thing _indices>]().map(|i| &self[i])
+                let tokens = self.tokens();
+
+                tokens.[<iter_ $thing _indices>]().map(|i| &tokens[i])
             }
         }
     };
@@ -59,36 +47,68 @@ mod private {
 
 /// Extension methods for [`Token`] sequences that make them easier to wrangle and query.
 pub trait TokenStringExt: private::Sealed {
-    fn first_sentence_word(&self) -> Option<&Token>;
-    fn first_non_whitespace(&self) -> Option<&Token>;
+    // Used by the default implementations.
+    fn tokens(&self) -> &[Token];
+
+    // Used by the default implementations.
+    fn tokens_mut(&mut self) -> &mut [Token];
+
+    create_fns_for!(adjective);
+    create_fns_for!(apostrophe);
+    create_fns_for!(at);
+    create_fns_for!(comma);
+    create_fns_for!(conjunction);
+    create_fns_for!(chunk_terminator);
+    create_fns_for!(currency);
+    create_fns_for!(ellipsis);
+    create_fns_for!(hostname);
+    create_fns_for!(likely_homograph);
+    create_fns_for!(number);
+    create_fns_for!(noun);
+    create_fns_for!(paragraph_break);
+    create_fns_for!(pipe);
+    create_fns_for!(preposition);
+    create_fns_for!(punctuation);
+    create_fns_for!(quote);
+    create_fns_for!(sentence_terminator);
+    create_fns_for!(space);
+    create_fns_for!(unlintable);
+    create_fns_for!(verb);
+    create_fns_for!(word);
+    create_fns_for!(word_like);
+    create_fns_for!(heading_start);
+
+    fn first_sentence_word(&self) -> Option<&Token> {
+        let tokens = self.tokens();
+
+        let (w_idx, word) = tokens.iter().find_position(|v| v.kind.is_word())?;
+
+        let Some(u_idx) = tokens.iter().position(|v| v.kind.is_unlintable()) else {
+            return Some(word);
+        };
+
+        if w_idx < u_idx { Some(word) } else { None }
+    }
+
+    fn first_non_whitespace(&self) -> Option<&Token> {
+        self.tokens().iter().find(|t| !t.kind.is_whitespace())
+    }
+
     /// Grab the span that represents the beginning of the first element and the
     /// end of the last element.
-    fn span(&self) -> Option<Span<char>>;
+    fn span(&self) -> Option<Span<char>> {
+        let min_max = self
+            .tokens()
+            .iter()
+            .flat_map(|v| [v.span.start, v.span.end].into_iter())
+            .minmax();
 
-    create_decl_for!(adjective);
-    create_decl_for!(apostrophe);
-    create_decl_for!(at);
-    create_decl_for!(comma);
-    create_decl_for!(conjunction);
-    create_decl_for!(chunk_terminator);
-    create_decl_for!(currency);
-    create_decl_for!(ellipsis);
-    create_decl_for!(hostname);
-    create_decl_for!(likely_homograph);
-    create_decl_for!(number);
-    create_decl_for!(noun);
-    create_decl_for!(paragraph_break);
-    create_decl_for!(pipe);
-    create_decl_for!(preposition);
-    create_decl_for!(punctuation);
-    create_decl_for!(quote);
-    create_decl_for!(sentence_terminator);
-    create_decl_for!(space);
-    create_decl_for!(unlintable);
-    create_decl_for!(verb);
-    create_decl_for!(word);
-    create_decl_for!(word_like);
-    create_decl_for!(heading_start);
+        match min_max {
+            itertools::MinMaxResult::NoElements => None,
+            itertools::MinMaxResult::OneElement(min) => Some(Span::new(min, min)),
+            itertools::MinMaxResult::MinMax(min, max) => Some(Span::new(min, max)),
+        }
+    }
 
     /// Get a reference to a token by index, with negative numbers counting from the end.
     ///
@@ -168,94 +188,11 @@ pub trait TokenStringExt: private::Sealed {
         Some(&slice[start_idx..end_idx_plus_one])
     }
 
-    fn iter_linking_verb_indices(&self) -> impl Iterator<Item = usize> + '_;
-    fn iter_linking_verbs(&self) -> impl Iterator<Item = &Token> + '_;
-
-    /// Iterate over chunks.
-    ///
-    /// For example, the following sentence contains two chunks separated by a
-    /// comma:
-    ///
-    /// ```text
-    /// Here is an example, it is short.
-    /// ```
-    fn iter_chunks(&self) -> impl Iterator<Item = &'_ [Token]> + '_;
-
-    /// Get an iterator over token slices that represent the individual
-    /// paragraphs in a document.
-    fn iter_paragraphs(&self) -> impl Iterator<Item = &'_ [Token]> + '_;
-
-    /// Get an iterator over token slices that represent headings.
-    ///
-    /// A heading begins with a [`TokenKind::HeadingStart`](crate::TokenKind::HeadingStart) token and ends with
-    /// the next [`TokenKind::ParagraphBreak`](crate::TokenKind::ParagraphBreak).
-    fn iter_headings(&self) -> impl Iterator<Item = &'_ [Token]> + '_;
-
-    /// Get an iterator over token slices that represent the individual
-    /// sentences in a document.
-    fn iter_sentences(&self) -> impl Iterator<Item = &'_ [Token]> + '_;
-
-    /// Get an iterator over mutable token slices that represent the individual
-    /// sentences in a document.
-    fn iter_sentences_mut(&mut self) -> impl Iterator<Item = &'_ mut [Token]> + '_;
-}
-
-impl TokenStringExt for [Token] {
-    create_fns_for!(adjective);
-    create_fns_for!(apostrophe);
-    create_fns_for!(at);
-    create_fns_for!(chunk_terminator);
-    create_fns_for!(comma);
-    create_fns_for!(conjunction);
-    create_fns_for!(currency);
-    create_fns_for!(ellipsis);
-    create_fns_for!(hostname);
-    create_fns_for!(likely_homograph);
-    create_fns_for!(noun);
-    create_fns_for!(number);
-    create_fns_for!(paragraph_break);
-    create_fns_for!(pipe);
-    create_fns_for!(preposition);
-    create_fns_for!(punctuation);
-    create_fns_for!(quote);
-    create_fns_for!(sentence_terminator);
-    create_fns_for!(space);
-    create_fns_for!(unlintable);
-    create_fns_for!(verb);
-    create_fns_for!(word_like);
-    create_fns_for!(word);
-    create_fns_for!(heading_start);
-
-    fn first_non_whitespace(&self) -> Option<&Token> {
-        self.iter().find(|t| !t.kind.is_whitespace())
-    }
-
-    fn first_sentence_word(&self) -> Option<&Token> {
-        let (w_idx, word) = self.iter().find_position(|v| v.kind.is_word())?;
-
-        let Some(u_idx) = self.iter().position(|v| v.kind.is_unlintable()) else {
-            return Some(word);
-        };
-
-        if w_idx < u_idx { Some(word) } else { None }
-    }
-
-    fn span(&self) -> Option<Span<char>> {
-        let min_max = self
-            .iter()
-            .flat_map(|v| [v.span.start, v.span.end].into_iter())
-            .minmax();
-
-        match min_max {
-            itertools::MinMaxResult::NoElements => None,
-            itertools::MinMaxResult::OneElement(min) => Some(Span::new(min, min)),
-            itertools::MinMaxResult::MinMax(min, max) => Some(Span::new(min, max)),
-        }
-    }
-
     fn iter_linking_verb_indices(&self) -> impl Iterator<Item = usize> + '_ {
-        self.iter_word_indices().filter(|idx| {
-            let word = &self[*idx];
+        let tokens = self.tokens();
+
+        tokens.iter_word_indices().filter(|idx| {
+            let word = &tokens[*idx];
             let Some(Some(meta)) = word.kind.as_word() else {
                 return false;
             };
@@ -265,33 +202,58 @@ impl TokenStringExt for [Token] {
     }
 
     fn iter_linking_verbs(&self) -> impl Iterator<Item = &Token> + '_ {
-        self.iter_linking_verb_indices().map(|idx| &self[idx])
+        let tokens = self.tokens();
+
+        tokens.iter_linking_verb_indices().map(|idx| &tokens[idx])
     }
 
+    /// Iterate over chunks.
+    ///
+    /// For example, the following sentence contains two chunks separated by a
+    /// comma:
+    ///
+    /// ```text
+    /// Here is an example, it is short.
+    /// ```
     fn iter_chunks(&self) -> impl Iterator<Item = &'_ [Token]> + '_ {
-        self.split_inclusive(|tok| tok.kind.is_chunk_terminator())
+        self.tokens()
+            .split_inclusive(|tok| tok.kind.is_chunk_terminator())
     }
 
+    /// Get an iterator over token slices that represent the individual
+    /// paragraphs in a document.
     fn iter_paragraphs(&self) -> impl Iterator<Item = &'_ [Token]> + '_ {
-        self.split_inclusive(|tok| tok.kind.is_paragraph_break())
+        self.tokens()
+            .split_inclusive(|tok| tok.kind.is_paragraph_break())
     }
 
+    /// Get an iterator over token slices that represent headings.
+    ///
+    /// A heading begins with a [`TokenKind::HeadingStart`](crate::TokenKind::HeadingStart) token and ends with
+    /// the next [`TokenKind::ParagraphBreak`](crate::TokenKind::ParagraphBreak).
     fn iter_headings(&self) -> impl Iterator<Item = &'_ [Token]> + '_ {
-        self.iter_heading_start_indices().map(|start| {
-            let end = self[start..]
+        let tokens = self.tokens();
+
+        tokens.iter_heading_start_indices().map(|start| {
+            let end = tokens[start..]
                 .iter()
                 .position(|t| t.kind.is_paragraph_break())
-                .unwrap_or(self[start..].len() - 1);
+                .unwrap_or(tokens[start..].len() - 1);
 
-            &self[start..=start + end]
+            &tokens[start..=start + end]
         })
     }
 
+    /// Get an iterator over token slices that represent the individual
+    /// sentences in a document.
     fn iter_sentences(&self) -> impl Iterator<Item = &'_ [Token]> + '_ {
-        self.split_inclusive(|token| token.kind.is_sentence_terminator())
+        self.tokens()
+            .split_inclusive(|tok| tok.kind.is_sentence_terminator())
     }
 
-    fn iter_sentences_mut(&mut self) -> impl Iterator<Item = &mut [Token]> + '_ {
+    /// Get an iterator over mutable token slices that represent the individual
+    /// sentences in a document.
+    fn iter_sentences_mut(&mut self) -> impl Iterator<Item = &'_ mut [Token]> + '_ {
         struct SentIter<'a> {
             rem: &'a mut [Token],
         }
@@ -316,6 +278,18 @@ impl TokenStringExt for [Token] {
             }
         }
 
-        SentIter { rem: self }
+        let tokens = self.tokens_mut();
+
+        SentIter { rem: tokens }
+    }
+}
+
+impl TokenStringExt for [Token] {
+    fn tokens(&self) -> &[Token] {
+        self
+    }
+
+    fn tokens_mut(&mut self) -> &mut [Token] {
+        self
     }
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
Refactor `TokenStringExt` to provide default implementations for most of the trait's methods. This reduces the amount boilerplate needed to implement the trait.

With the changes, `TokenStringExt` has only 2 required methods: `tokens` and `tokens_mut`. The rest of the methods now have a default implementation that uses one of those 2 methods.
<!-- Any details that you think are important to review this PR? -->
I don't *think* this is a breaking change, since (IIUC) the `TokenStringExt` trait is sealed, so it can't be implemented outside the crate. Not 100% sure though.
<!-- Are there other PRs related to this one? -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
- `cargo test`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
