### PR TITLE
feat: aware about→aware of

### DIFF
--- a/harper-core/src/linting/weir_rules/AwareOf.weir
+++ b/harper-core/src/linting/weir_rules/AwareOf.weir
@@ -1,7 +1,7 @@
 expr main (aware about)
 
-let message "Use 'aware of' instead of 'aware about'."
-let description "Corrects 'aware about' to the standard 'aware of'."
+let message "Use `aware of` instead of `aware about`."
+let description "Corrects `aware about` to the standard `aware of`."
 let kind "Usage"
 let becomes "aware of"
 


### PR DESCRIPTION
# Issues 
N/A

# Description

I just heard or read "aware about" online where it should obviously have been "aware of". Googling shows it is very common.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Two unit tests made from the first Google results in the GitHub domain.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
