### PR TITLE
fix(chrome-ext): formatted text in Google Docs causing false-positives

### DIFF
--- a/packages/chrome-plugin/src/contentScript/googleDocs.ts
+++ b/packages/chrome-plugin/src/contentScript/googleDocs.ts
@@ -1,5 +1,13 @@
 import type { LintFramework } from 'lint-framework';
 import GoogleDocsBridgeClient from './GoogleDocsBridgeClient';
+import {
+	createGoogleDocsLineBand,
+	extendGoogleDocsLineBand,
+	type GoogleDocsLineBand,
+	type GoogleDocsRectLayout,
+	rectSharesGoogleDocsLineBand,
+	shouldInsertGoogleDocsSpace,
+} from './googleDocsLayout';
 
 declare global {
 	interface Window {
@@ -12,7 +20,6 @@ const GOOGLE_DOCS_MAIN_WORLD_BRIDGE_ID = 'harper-google-docs-main-world-bridge';
 const GOOGLE_DOCS_SCROLL_LAYOUT_REASONS = new Set(['scroll', 'wheel', 'key-scroll']);
 const GOOGLE_DOCS_EDITOR_SELECTOR = '.kix-appview-editor';
 const GOOGLE_DOCS_SVG_RECT_SELECTOR = 'rect[aria-label]';
-const GOOGLE_DOCS_LINE_BREAK_THRESHOLD_PX = 6;
 const GOOGLE_DOCS_TABLE_CELL_GAP_THRESHOLD_PX = 60;
 
 type LayoutRefreshFramework = LintFramework & {
@@ -181,7 +188,9 @@ export function createGoogleDocsBridgeSync(fw: LintFramework): () => Promise<voi
 		const fragment = document.createDocumentFragment();
 		const parts: string[] = [];
 		let nextHash = 5381;
-		let lastTop: number | null = null;
+		let currentLineBand: GoogleDocsLineBand | null = null;
+		let lastLayoutRect: GoogleDocsRectLayout | null = null;
+		let lastLabel = '';
 		let lastRight: number | null = null;
 		let segmentCount = 0;
 
@@ -202,22 +211,31 @@ export function createGoogleDocsBridgeSync(fw: LintFramework): () => Promise<voi
 			if (!Number.isFinite(left)) continue;
 			if (!Number.isFinite(right)) continue;
 
-			if (lastTop != null && Math.abs(top - lastTop) >= GOOGLE_DOCS_LINE_BREAK_THRESHOLD_PX) {
-				if (parts.length > 0 && !parts[parts.length - 1].endsWith('\n')) {
-					parts.push('\n');
-					fragment.appendChild(document.createTextNode('\n'));
-				}
+			const layoutRect: GoogleDocsRectLayout = {
+				top,
+				left,
+				width: rect.width,
+				height: rect.height,
+			};
+			const sharesVisualLine =
+				currentLineBand != null && rectSharesGoogleDocsLineBand(layoutRect, currentLineBand);
+			const shouldInsertLineBreak =
+				(currentLineBand != null && !sharesVisualLine) ||
+				(sharesVisualLine &&
+					lastRight != null &&
+					left - lastRight >= GOOGLE_DOCS_TABLE_CELL_GAP_THRESHOLD_PX);
+
+			if (shouldInsertLineBreak && parts.length > 0 && !parts[parts.length - 1].endsWith('\n')) {
+				parts.push('\n');
+				fragment.appendChild(document.createTextNode('\n'));
 			}
 			if (
-				lastTop != null &&
-				lastRight != null &&
-				Math.abs(top - lastTop) < GOOGLE_DOCS_LINE_BREAK_THRESHOLD_PX &&
-				left - lastRight >= GOOGLE_DOCS_TABLE_CELL_GAP_THRESHOLD_PX
+				!shouldInsertLineBreak &&
+				lastLayoutRect != null &&
+				shouldInsertGoogleDocsSpace(lastLayoutRect, layoutRect, lastLabel, normalizedLabel)
 			) {
-				if (parts.length > 0 && !parts[parts.length - 1].endsWith('\n')) {
-					parts.push('\n');
-					fragment.appendChild(document.createTextNode('\n'));
-				}
+				parts.push(' ');
+				fragment.appendChild(document.createTextNode(' '));
 			}
 
 			const span = document.createElement('span');
@@ -237,7 +255,12 @@ export function createGoogleDocsBridgeSync(fw: LintFramework): () => Promise<voi
 			fragment.appendChild(span);
 
 			parts.push(normalizedLabel);
-			lastTop = top;
+			currentLineBand =
+				currentLineBand == null || shouldInsertLineBreak
+					? createGoogleDocsLineBand(layoutRect)
+					: extendGoogleDocsLineBand(currentLineBand, layoutRect);
+			lastLayoutRect = layoutRect;
+			lastLabel = normalizedLabel;
 			lastRight = right;
 			segmentCount += 1;
 

--- a/packages/chrome-plugin/src/contentScript/googleDocs.ts
+++ b/packages/chrome-plugin/src/contentScript/googleDocs.ts
@@ -142,11 +142,6 @@ export function createGoogleDocsBridgeSync(fw: LintFramework): () => Promise<voi
 				continue;
 			}
 
-			if (token.length === 1 && !token.match(/[a-zA-Z]/)) {
-				tokens[i] = ` ${token} `;
-				continue;
-			}
-
 			const isLast = i === tokens.length - 1;
 			const lastChar = token.charAt(token.length - 1);
 			const nextFirstChar = tokens[i + 1]?.charAt(0) ?? '';

--- a/packages/chrome-plugin/src/contentScript/googleDocsLayout.ts
+++ b/packages/chrome-plugin/src/contentScript/googleDocsLayout.ts
@@ -1,0 +1,71 @@
+export type GoogleDocsRectLayout = {
+	top: number;
+	left: number;
+	width: number;
+	height: number;
+};
+
+export type GoogleDocsLineBand = {
+	top: number;
+	bottom: number;
+};
+
+const GOOGLE_DOCS_LINE_OVERLAP_TOLERANCE_PX = 1;
+const GOOGLE_DOCS_SPACE_GAP_RATIO = 0.2;
+const GOOGLE_DOCS_MIN_SPACE_GAP_PX = 3;
+
+export function createGoogleDocsLineBand(rect: GoogleDocsRectLayout): GoogleDocsLineBand {
+	return {
+		top: rect.top,
+		bottom: rect.top + rect.height,
+	};
+}
+
+export function extendGoogleDocsLineBand(
+	lineBand: GoogleDocsLineBand,
+	rect: GoogleDocsRectLayout,
+): GoogleDocsLineBand {
+	return {
+		top: Math.min(lineBand.top, rect.top),
+		bottom: Math.max(lineBand.bottom, rect.top + rect.height),
+	};
+}
+
+export function rectSharesGoogleDocsLineBand(
+	rect: GoogleDocsRectLayout,
+	lineBand: GoogleDocsLineBand,
+): boolean {
+	const rectBottom = rect.top + rect.height;
+
+	return (
+		rect.top <= lineBand.bottom + GOOGLE_DOCS_LINE_OVERLAP_TOLERANCE_PX &&
+		rectBottom >= lineBand.top - GOOGLE_DOCS_LINE_OVERLAP_TOLERANCE_PX
+	);
+}
+
+export function shouldInsertGoogleDocsSpace(
+	previousRect: GoogleDocsRectLayout,
+	currentRect: GoogleDocsRectLayout,
+	previousText: string,
+	currentText: string,
+): boolean {
+	if (previousText.length === 0 || currentText.length === 0) {
+		return false;
+	}
+
+	if (/\s$/.test(previousText) || /^\s/.test(currentText)) {
+		return false;
+	}
+
+	if (/[([{"'“‘-]$/.test(previousText) || /^[,.;:!?)\]}"'”’]/.test(currentText)) {
+		return false;
+	}
+
+	const gap = currentRect.left - (previousRect.left + previousRect.width);
+	const threshold = Math.max(
+		GOOGLE_DOCS_MIN_SPACE_GAP_PX,
+		Math.min(previousRect.height, currentRect.height) * GOOGLE_DOCS_SPACE_GAP_RATIO,
+	);
+
+	return gap >= threshold;
+}

--- a/packages/chrome-plugin/tests/google_docs.spec.ts
+++ b/packages/chrome-plugin/tests/google_docs.spec.ts
@@ -1,0 +1,270 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from './fixtures';
+
+type MockGoogleDocsRect = {
+	label: string;
+	left: number;
+	top: number;
+	width: number;
+	height: number;
+	fontCss?: string;
+};
+
+const TEST_PAGE_URL = 'https://docs.google.com/document/d/harper-formatting-regression/edit';
+const FORMATTED_WORD_GAP_RECTS: MockGoogleDocsRect[] = [
+	{
+		label: 'not',
+		left: 48,
+		top: 48,
+		width: 24,
+		height: 18,
+		fontCss: '16px Arial',
+	},
+	{
+		label: 'smart',
+		left: 80,
+		top: 56,
+		width: 42,
+		height: 18,
+		fontCss: 'italic 16px Arial',
+	},
+	{
+		label: 'enough.',
+		left: 130,
+		top: 48,
+		width: 60,
+		height: 18,
+		fontCss: '16px Arial',
+	},
+];
+const ITALIC_SHIFTED_RECTS: MockGoogleDocsRect[] = [
+	{
+		label: 'This is an ',
+		left: 48,
+		top: 48,
+		width: 96,
+		height: 18,
+		fontCss: '16px Arial',
+	},
+	{
+		label: 'test.',
+		left: 144,
+		top: 56,
+		width: 48,
+		height: 18,
+		fontCss: 'italic 16px Arial',
+	},
+];
+const PUNCTUATION_BOUNDARY_RECTS: MockGoogleDocsRect[] = [
+	{
+		label: 'not',
+		left: 48,
+		top: 48,
+		width: 24,
+		height: 18,
+		fontCss: '16px Arial',
+	},
+	{
+		label: 'smart',
+		left: 80,
+		top: 56,
+		width: 42,
+		height: 18,
+		fontCss: 'italic 16px Arial',
+	},
+	{
+		label: 'enough',
+		left: 130,
+		top: 48,
+		width: 54,
+		height: 18,
+		fontCss: '16px Arial',
+	},
+	{
+		label: '.',
+		left: 184,
+		top: 48,
+		width: 6,
+		height: 18,
+		fontCss: '16px Arial',
+	},
+	{
+		label: 'But',
+		left: 202,
+		top: 48,
+		width: 26,
+		height: 18,
+		fontCss: '16px Arial',
+	},
+];
+const SUPERSCRIPT_LIKE_RECTS: MockGoogleDocsRect[] = [
+	{
+		label: 'Testing ',
+		left: 48,
+		top: 96,
+		width: 68,
+		height: 18,
+		fontCss: '16px Arial',
+	},
+	{
+		label: 'formatting',
+		left: 116,
+		top: 88,
+		width: 72,
+		height: 11,
+		fontCss: 'bold 11px Arial',
+	},
+	{
+		label: ' matters.',
+		left: 188,
+		top: 96,
+		width: 64,
+		height: 18,
+		fontCss: '16px Arial',
+	},
+];
+
+function buildMockGoogleDocsHtml(rects: MockGoogleDocsRect[]): string {
+	const rectMarkup = rects
+		.map(
+			(rect, index) => `
+				<rect
+					data-rect-index="${index}"
+					x="${rect.left}"
+					y="${rect.top}"
+					width="${rect.width}"
+					height="${rect.height}"
+					fill="rgba(15, 23, 42, 0.001)"
+					aria-label="${escapeHtml(rect.label)}"
+					data-font-css="${escapeHtml(rect.fontCss ?? '')}"
+				/>
+			`,
+		)
+		.join('');
+
+	return `<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Mock Google Docs</title>
+		<style>
+			body {
+				margin: 0;
+				font: 16px/1.4 sans-serif;
+				background: #f3f4f6;
+			}
+
+			#docs-editor {
+				position: relative;
+				width: 900px;
+				height: 240px;
+				margin: 32px auto;
+				background: white;
+				border: 1px solid #d1d5db;
+			}
+
+			svg {
+				width: 100%;
+				height: 100%;
+			}
+		</style>
+	</head>
+	<body>
+		<div id="docs-editor" class="kix-appview-editor">
+			<svg>${rectMarkup}</svg>
+		</div>
+	</body>
+</html>`;
+}
+
+function escapeHtml(text: string): string {
+	return text
+		.replaceAll('&', '&amp;')
+		.replaceAll('"', '&quot;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;');
+}
+
+async function mockGoogleDocsPage(page: Page, rects: MockGoogleDocsRect[]) {
+	await page.route(TEST_PAGE_URL, async (route) => {
+		await route.fulfill({
+			contentType: 'text/html',
+			body: buildMockGoogleDocsHtml(rects),
+		});
+	});
+}
+
+async function installMockGoogleDocsGeometry(page: Page, rects: MockGoogleDocsRect[]) {
+	await page.evaluate((pageRects) => {
+		(
+			window as Window & {
+				_docs_annotate_getAnnotatedText?: () => Promise<{
+					getText: () => string;
+					setSelection: () => void;
+					getSelection: () => Array<{ start: number; end: number }>;
+				}>;
+			}
+		)._docs_annotate_getAnnotatedText = async () => ({
+			getText: () => pageRects.map((rect) => rect.label).join(''),
+			setSelection: () => {},
+			getSelection: () => [{ start: 0, end: 0 }],
+		});
+	}, rects);
+}
+
+async function openMockGoogleDocsPage(page: Page, rects: MockGoogleDocsRect[]) {
+	await mockGoogleDocsPage(page, rects);
+	await page.goto(TEST_PAGE_URL);
+	await installMockGoogleDocsGeometry(page, rects);
+	await page.locator('#harper-google-docs-target').waitFor({ state: 'attached' });
+}
+
+async function getRawBridgeText(page: Page) {
+	return await page
+		.locator('#harper-google-docs-target')
+		.evaluate((node) => node.textContent ?? '');
+}
+
+async function getNormalizedBridgeText(page: Page) {
+	return await page
+		.locator('#harper-google-docs-target')
+		.evaluate((node) =>
+			(node.textContent ?? '').replaceAll('\u00a0', ' ').replace(/\s+/g, ' ').trim(),
+		);
+}
+
+test('Google Docs restores spaces around formatted inline words', async ({ page }) => {
+	await openMockGoogleDocsPage(page, FORMATTED_WORD_GAP_RECTS);
+
+	await expect
+		.poll(() => getNormalizedBridgeText(page), { timeout: 10000 })
+		.toBe('not smart enough.');
+	await expect.poll(() => getRawBridgeText(page), { timeout: 10000 }).not.toContain('\n');
+});
+
+test('Google Docs formatted rects stay in the same sentence', async ({ page }) => {
+	await openMockGoogleDocsPage(page, ITALIC_SHIFTED_RECTS);
+
+	await expect
+		.poll(() => getNormalizedBridgeText(page), { timeout: 10000 })
+		.toBe('This is an test.');
+	await expect.poll(() => getRawBridgeText(page), { timeout: 10000 }).not.toContain('\n');
+});
+
+test('Google Docs does not invent spaces around standalone punctuation rects', async ({ page }) => {
+	await openMockGoogleDocsPage(page, PUNCTUATION_BOUNDARY_RECTS);
+
+	await expect
+		.poll(() => getNormalizedBridgeText(page), { timeout: 10000 })
+		.toBe('not smart enough. But');
+	await expect.poll(() => getRawBridgeText(page), { timeout: 10000 }).not.toContain(' .');
+});
+
+test('Google Docs superscript-like rects do not create a fake line break', async ({ page }) => {
+	await openMockGoogleDocsPage(page, SUPERSCRIPT_LIKE_RECTS);
+
+	await expect
+		.poll(() => getNormalizedBridgeText(page), { timeout: 10000 })
+		.toBe('Testing formatting matters.');
+	await expect.poll(() => getRawBridgeText(page), { timeout: 10000 }).not.toContain('\n');
+});


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #2882

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

As it turns out, formatted text in Google Docs is rendered to separate elements from their containing sentences. As a result, Harper would assume they are their own sentences, which would create false positives.

I've fixed this by updating the merge logic to respectfully consider formatted text to be a part of any and all containing sentences. 

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manual tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
