### PR TITLE
fix(core): false positives in the `NeedToNoun` rule

### DIFF
--- a/harper-core/src/linting/need_to_noun.rs
+++ b/harper-core/src/linting/need_to_noun.rs
@@ -41,8 +41,9 @@ impl Default for NeedToNoun {
         // Bare words after infinitive `to` are the hardest cases to disambiguate.
         // If the token is a noun/verb homograph, prefer not linting over inserting
         // `the` into a potentially valid verb phrase.
-        let b = SequenceExpr::default()
-            .then_kind_where(|kind| kind.is_nominal() && !kind.is_verb() && !kind.is_likely_homograph());
+        let b = SequenceExpr::default().then_kind_where(|kind| {
+            kind.is_nominal() && !kind.is_verb() && !kind.is_likely_homograph()
+        });
 
         let expr = SequenceExpr::with(DerivedFrom::new_from_str("need"))
             .t_ws()
@@ -301,10 +302,7 @@ mod tests {
 
     #[test]
     fn allows_need_to_silence() {
-        assert_no_lints(
-            "I need to silence to think clearly.",
-            NeedToNoun::default(),
-        );
+        assert_no_lints("I need to silence to think clearly.", NeedToNoun::default());
     }
 
     #[test]


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Attempts to address problems reported on Bluesky.

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

There were some significant false positives reported about this rule. I've expanded the test set to locate them, and fixed the resulting problems. It should be much better now.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Additional unit testing + fuzzing.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
