### PR TITLE
fix(core): `VerbToAdjective` false positives

### DIFF
--- a/harper-core/src/linting/verb_to_adjective.rs
+++ b/harper-core/src/linting/verb_to_adjective.rs
@@ -34,7 +34,10 @@ impl ExprLinter for VerbToAdjective {
     }
 
     fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
-        let words: Vec<_> = matched_tokens.iter().filter(|tok| tok.kind.is_word()).collect();
+        let words: Vec<_> = matched_tokens
+            .iter()
+            .filter(|tok| tok.kind.is_word())
+            .collect();
         let [_, adverb, noun, _] = words.as_slice() else {
             return None;
         };

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -3518,14 +3518,6 @@ Suggest:
 
 
 
-Lint:    Typo (31 priority)
-Message: |
-    2286 | (said Jordan Baker that afternoon, sitting up very straight on a straight chair
-         |                                                                ^~~~~~~~~~~~~~~~ Did you intend to use an adjective here?
-    2287 | in the tea-garden at the Plaza Hotel)
-
-
-
 Lint:    Readability (127 priority)
 Message: |
     2291 | with rubber nobs on the soles that bit into the soft ground. I had on a new


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #2855

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

I've rewritten the linter to avoid false positives by properly addressing the edge cases involved.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

In addition to tests derived from the source issue, I've also added tests from the output of a fuzzing session. They all pass.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
