### PR TITLE
feat: compulse→compel

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -81,6 +81,17 @@ pub fn lint_group() -> LintGroup {
             "Corrects extraneous apostrophe in `client's side` and `server's side`.",
             LintKind::Punctuation
         ),
+        "CompulseToCompel" => (
+            &[
+                ("compulse", "compel"),
+                ("compulsed", "compelled"),
+                ("compulses", "compels"),
+                ("compulsing", "compelling"),
+            ],
+            "Did you mean `compel` rather than the obsolete or archaic (and non-standard) `compulse`?",
+            "Suggests replacing the obsolete or archaic verb `compulse` with the standard `compel`.",
+            LintKind::Nonstandard
+        ),
         "ConfirmThat" => (
             &[
                 ("conform that", "confirm that"),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -86,6 +86,44 @@ fn correct_servers_side() {
     );
 }
 
+// CompulseToCompel
+
+#[test]
+fn correct_compulse() {
+    assert_suggestion_result(
+        "Play Store will soon compulse to use SDK 30 on any app updates , and it's mandatory to have SDK 30 for new apps.",
+        lint_group(),
+        "Play Store will soon compel to use SDK 30 on any app updates , and it's mandatory to have SDK 30 for new apps.",
+    );
+}
+
+#[test]
+fn correct_compulsed() {
+    assert_suggestion_result(
+        "Just alpha, but now i am compulsed to work 10.6 into the github actions and insane docker environment :)",
+        lint_group(),
+        "Just alpha, but now i am compelled to work 10.6 into the github actions and insane docker environment :)",
+    );
+}
+
+#[test]
+fn correct_compulses() {
+    assert_suggestion_result(
+        "Occasionally, a film comes along that compulses me to make a fan poster.",
+        lint_group(),
+        "Occasionally, a film comes along that compels me to make a fan poster.",
+    );
+}
+
+#[test]
+fn correct_compulsing() {
+    assert_suggestion_result(
+        "We have an button enabled to prompt user to download the app whenever we find difference in version number in our servlet war file and apk verision compulsing user to update.",
+        lint_group(),
+        "We have an button enabled to prompt user to download the app whenever we find difference in version number in our servlet war file and apk verision compelling user to update.",
+    );
+}
+
 // ConfirmThat
 
 #[test]


### PR DESCRIPTION
# Issues 
N/A

# Description
I heard somebody say "compulse" in a YouTube video yesterday in a context where the correct word was obviously "compel".

It turns out that "compulse" is an obsolete or archaic word related to compel and mixing them up is a known English usage issue, if not as common as other issues.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I added unit tests for each inflected form, using GitHub preferably, then Stack Overflow, and finally Medium.com, which has tons of nonnative English writing and is thus a goldmine of grammar mistakes.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
