### PR TITLE
feat: hit the nail in the head→on the head

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -278,6 +278,17 @@ pub fn lint_group() -> LintGroup {
             // ConfusedPair?
             LintKind::WordChoice
         ),
+        "HitTheNailOnTheHead" => (
+            &[
+                ("hit the nail in the head", "hit the nail on the head"),
+                ("hits the nail in the head", "hits the nail on the head"),
+                ("hitting the nail in the head", "hitting the nail on the head"),
+                ("hitted the nail in the head", "hitted the nail on the head")
+            ],
+            "The correct preposition in this idiom is `on`.",
+            "Corrects the eggcorn `hit the nail in the head` to the standard `hit the nail on the head`.",
+            LintKind::Eggcorn
+        ),
         "HomeInOn" => (
             &[
                 ("hone in on", "home in on"),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -811,6 +811,44 @@ fn correct_having_past() {
     );
 }
 
+// HitTheNailOnTheHead
+
+#[test]
+fn correct_hit_the_nail() {
+    assert_suggestion_result(
+        "Ahh, found it! You hit the nail in the head once again.",
+        lint_group(),
+        "Ahh, found it! You hit the nail on the head once again.",
+    );
+}
+
+#[test]
+fn correct_hits_the_nail() {
+    assert_suggestion_result(
+        "I'm not sure if this sentence hits the nail in the head",
+        lint_group(),
+        "I'm not sure if this sentence hits the nail on the head",
+    );
+}
+
+#[test]
+fn correct_hitting_the_nail() {
+    assert_suggestion_result(
+        "You are hitting the nail in the head of my issue with this game, too.",
+        lint_group(),
+        "You are hitting the nail on the head of my issue with this game, too.",
+    );
+}
+
+#[test]
+fn correct_hitted_the_nail() {
+    assert_suggestion_result(
+        "I mean, you just kinda hitted the nail in the head. You cannot do anything with this that you couldn't do in a Raspberry PI.",
+        lint_group(),
+        "I mean, you just kinda hitted the nail on the head. You cannot do anything with this that you couldn't do in a Raspberry PI.",
+    );
+}
+
 // HomeInOn
 
 #[test]


### PR DESCRIPTION
# Issues 
N/A

# Description

I thought I heard somebody say "hit the nail **in** the head" on YouTube. Even if they didn't I searched for it and plenty of people do use this eggcorn.

I included a fix for the wrong past tense "hitted" since I found it in the wild but it only fixes "in" and leaves "hitted" to other linters.

# How Has This Been Tested?

Unit tests made from examples found on GitHub or on other websites for the inflected forms I couldn't find on GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
