### PR TITLE
feat: bump spell fixes differing by an apostrophe

### DIFF
--- a/harper-core/src/linting/spell_check.rs
+++ b/harper-core/src/linting/spell_check.rs
@@ -982,4 +982,31 @@ mod tests {
             "THE CHEIF RECEIVED A LETTER.",
         );
     }
+
+    #[test]
+    fn fix_vs_apostrophe() {
+        assert_top3_suggestion_result(
+            "v's",
+            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            "vs",
+        );
+    }
+
+    #[test]
+    fn fix_vs_typographical_apostrophe() {
+        assert_top3_suggestion_result(
+            "v’s",
+            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            "vs",
+        );
+    }
+
+    #[test]
+    fn fix_childrens_missing_apostrophe() {
+        assert_top3_suggestion_result(
+            "childrens",
+            SpellCheck::new(FstDictionary::curated(), Dialect::British),
+            "children's",
+        );
+    }
 }

--- a/harper-core/src/spell/mod.rs
+++ b/harper-core/src/spell/mod.rs
@@ -313,6 +313,31 @@ fn score_suggestion(misspelled_word: &[char], sug: &FuzzyMatchResult) -> i32 {
         score -= 5;
     }
 
+    // Promote suggestions that differ only by an apostrophe
+    let check_apostrophe_diff = |longer: &[char], shorter: &[char]| -> bool {
+        if let Some(pos) = longer.iter().position(|&c| c == '\'' || c == '’') {
+            longer.len() - 1 == shorter.len()
+                && longer.starts_with(&shorter[..pos])
+                && longer.ends_with(&shorter[pos..])
+        } else {
+            false
+        }
+    };
+
+    match (
+        misspelled_word.len() as i32 - sug.word.len() as i32,
+        sug.metadata.is_apostrophized(),
+    ) {
+        (1, _)
+            if (misspelled_word.contains(&'\'') || misspelled_word.contains(&'\u{2019}'))
+                && check_apostrophe_diff(misspelled_word, sug.word) =>
+        {
+            score -= 8
+        }
+        (-1, true) if check_apostrophe_diff(sug.word, misspelled_word) => score -= 8,
+        _ => {} // not a single-character apostrophe difference
+    }
+
     // Boost common words.
     if sug.metadata.common {
         score -= 5;
@@ -549,5 +574,20 @@ mod tests {
     #[test]
     fn conciousness_correction() {
         assert_suggests_correction("conciousness", "consciousness");
+    }
+
+    #[test]
+    fn v_apostrophe_s_suggests_vs() {
+        assert_suggests_correction("v's", "vs");
+    }
+
+    #[test]
+    fn v_apostrophe_typographical_s_suggests_vs() {
+        assert_suggests_correction("v’s", "vs");
+    }
+
+    #[test]
+    fn missing_apostrophe_childrens_suggests_childrens() {
+        assert_suggests_correction("childrens", "children's");
     }
 }

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -2375,8 +2375,8 @@ Message: |
     1986 | love, that makes the world go round!’”
 Suggest:
   - Replace with: “this”
-  - Replace with: “tic”
   - Replace with: “ti's”
+  - Replace with: “tic”
 
 
 
@@ -2387,8 +2387,8 @@ Message: |
     1986 | love, that makes the world go round!’”
 Suggest:
   - Replace with: “this”
-  - Replace with: “tic”
   - Replace with: “ti's”
+  - Replace with: “tic”
 
 
 

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -1641,8 +1641,8 @@ Message: |
     1377 | fooled me. This fella’s a regular Belasco. It’s a triumph. What thoroughness!
          |                 ^~~~~~~ Did you mean to spell `fella’s` this way?
 Suggest:
-  - Replace with: “fell's”
   - Replace with: “fellas”
+  - Replace with: “fell's”
   - Replace with: “Bella's”
 
 


### PR DESCRIPTION
# Issues 

Fixes #2924

# Description

Adds logic to promote misspellings that differ only by the absence of an apostrophe or presence of an extra apostrophe.

This fixes typos mixing up possessive and plural endings and well as spellos like thinking the way to abbreviate `versus` is `v's`.

# How Has This Been Tested?

Added tests for both directions both at the low-level spelling module level and downstream at the spellcheck linter level.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
