### PR TITLE
fix(core): test which was testing the wrong thing

### DIFF
--- a/harper-core/src/title_case.rs
+++ b/harper-core/src/title_case.rs
@@ -249,9 +249,9 @@ mod tests {
     #[quickcheck]
     fn a_stays_lowercase(prefix: String, postfix: String) -> TestResult {
         // There must be words other than the `a`.
-        if prefix.chars().any(|c| !c.is_ascii_alphanumeric())
+        if prefix.chars().any(|c| !c.is_ascii_alphabetic())
             || prefix.is_empty()
-            || postfix.chars().any(|c| !c.is_ascii_alphanumeric())
+            || postfix.chars().any(|c| !c.is_ascii_alphabetic())
             || postfix.is_empty()
         {
             return TestResult::discard();


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

The problem was caused in #2875.

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

In #2875, we changed how words were itereated to fix #2861. In doing so, we unknowningly broke a property test, which asserted that any number or word prior to "a" would coerce "a" to lowercase. The linked PR changed this behavior to exclude numbers. This PR addresses that inconcsistence and has the test only use alphabetic characters rather than alphanumeric characters.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Fuzzed.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
