### PR TITLE
deps: bump rand to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,6 +792,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,6 +1013,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -2812,7 +2832,7 @@ dependencies = [
  "pulldown-cmark",
  "quickcheck",
  "quickcheck_macros",
- "rand 0.8.5",
+ "rand 0.10.0",
  "rayon",
  "regex",
  "serde",
@@ -2912,7 +2932,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "is-macro",
  "lru",
- "rand 0.9.2",
+ "rand 0.10.0",
  "rayon",
  "rs-conllu",
  "serde",
@@ -4456,8 +4476,6 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "serde",
 ]
@@ -4468,7 +4486,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.3",
 ]
 
@@ -4478,18 +4496,9 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
+ "chacha20",
  "getrandom 0.4.1",
  "rand_core 0.10.0",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4508,7 +4517,6 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
  "serde",
 ]
 
@@ -5057,7 +5065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 

--- a/harper-core/Cargo.toml
+++ b/harper-core/Cargo.toml
@@ -39,7 +39,7 @@ regex = "1.12.3"
 
 [dev-dependencies]
 criterion = { version = "0.8.2", default-features = false }
-rand = "0.8.5"
+rand = "0.10.0"
 quickcheck = "1.1.0"
 quickcheck_macros = "1.2.0"
 once_cell = "1.21.3"

--- a/harper-core/src/lexing/email_address.rs
+++ b/harper-core/src/lexing/email_address.rs
@@ -125,7 +125,7 @@ fn valid_unquoted_character(c: char) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use rand::Rng;
+    use rand::RngExt;
 
     use super::super::hostname::tests::example_domain_parts;
     use super::{lex_email_address, validate_local_part};
@@ -194,12 +194,12 @@ mod tests {
     /// situations.
     #[test]
     fn survives_random_chars() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         let mut buf = [' '; 128];
 
         for _ in 0..1 << 16 {
-            rng.try_fill(&mut buf).unwrap();
+            buf.fill_with(|| rng.random());
 
             lex_email_address(&buf);
         }

--- a/harper-core/src/lexing/url.rs
+++ b/harper-core/src/lexing/url.rs
@@ -195,7 +195,7 @@ fn lex_uchar(source: &[char]) -> Option<usize> {
 
 #[cfg(test)]
 mod tests {
-    use rand::Rng;
+    use rand::RngExt;
 
     use super::lex_url;
 
@@ -243,12 +243,12 @@ mod tests {
     /// situations.
     #[test]
     fn survives_random_chars() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         let mut buf = [' '; 128];
 
         for _ in 0..1 << 16 {
-            rng.try_fill(&mut buf).unwrap();
+            buf.fill_with(|| rng.random());
 
             lex_url(&buf);
         }

--- a/harper-pos-utils/Cargo.toml
+++ b/harper-pos-utils/Cargo.toml
@@ -13,7 +13,7 @@ strum = "0.28.0"
 strum_macros = "0.28.0"
 serde = { version = "1.0.228", features = ["derive"] }
 is-macro = "0.3.7"
-rand = { version = "0.9.1", optional = true }
+rand = { version = "0.10.0", optional = true }
 burn = { version = "0.19.1", default-features = false, features = ["std"] }
 burn-ndarray = { version = "0.19.0", default-features = false }
 serde_json = "1.0.149"

--- a/harper-pos-utils/src/chunker/brill_chunker/mod.rs
+++ b/harper-pos-utils/src/chunker/brill_chunker/mod.rs
@@ -191,7 +191,7 @@ impl BrillChunker {
         }
 
         let all_candidates = Patch::generate_candidate_patches(&relevant_words);
-        let mut pruned_candidates: Vec<Patch> = rand::seq::IndexedRandom::choose_multiple(
+        let mut pruned_candidates: Vec<Patch> = rand::seq::IndexedRandom::sample(
             all_candidates.as_slice(),
             &mut rand::rng(),
             (all_candidates.len() as f32 * candidate_selection_chance) as usize,

--- a/harper-pos-utils/src/tagger/brill_tagger/mod.rs
+++ b/harper-pos-utils/src/tagger/brill_tagger/mod.rs
@@ -192,7 +192,7 @@ impl BrillTagger<FreqDict> {
         }
 
         let all_candidates = Patch::generate_candidate_patches(&error_counter);
-        let mut pruned_candidates: Vec<Patch> = rand::seq::IndexedRandom::choose_multiple(
+        let mut pruned_candidates: Vec<Patch> = rand::seq::IndexedRandom::sample(
             all_candidates.as_slice(),
             &mut rand::rng(),
             (all_candidates.len() as f32 * candidate_selection_chance) as usize,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
Same as the referenced PR, but fixes the use of a deprecated function that was causing checks to fail.
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->
Related to: #2892

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
- `just check-rust`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
