### PR TITLE
feat: commitment toward(s) → commitment to

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -543,6 +543,15 @@ pub fn lint_group() -> LintGroup {
             "Suggests using either `await` or `wait for` but not both, as they express the same meaning.",
             LintKind::Redundancy
         ),
+        "CommitmentTo" => (
+            &[
+                (&["commitment toward", "commitment towards"], &["commitment to"]),
+                (&["commitments toward", "commitments towards"], &["commitments to"]),
+            ],
+            "The correct preposition to use with `commitment` is `to`, not `toward` or `towards`.",
+            "Corrects `commitment toward/towards` to `commitment to`.",
+            LintKind::Usage
+        ),
         "Copyright" => (
             &[
                 (&["copywrite"], &["copyright"]),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -1758,6 +1758,44 @@ fn correct_awaited_for() {
     );
 }
 
+// CommitmentTo
+
+#[test]
+fn singular_towards() {
+    assert_suggestion_result(
+        "the platform's focus on multimedia projects and VideoLAN's long history of commitment towards free and open multimedia",
+        lint_group(),
+        "the platform's focus on multimedia projects and VideoLAN's long history of commitment to free and open multimedia",
+    );
+}
+
+#[test]
+fn plural_towards() {
+    assert_suggestion_result(
+        "the signer may express multiple commitments towards the data objects",
+        lint_group(),
+        "the signer may express multiple commitments to the data objects",
+    );
+}
+
+#[test]
+fn singular_toward() {
+    assert_suggestion_result(
+        "This document outlines the current level of commitment toward Linux distributions and packaging formats.",
+        lint_group(),
+        "This document outlines the current level of commitment to Linux distributions and packaging formats.",
+    );
+}
+
+#[test]
+fn plural_toward() {
+    assert_suggestion_result(
+        "... and are expected to inform parties in updating their commitments toward the Paris Agreement",
+        lint_group(),
+        "... and are expected to inform parties in updating their commitments to the Paris Agreement",
+    );
+}
+
 // Copyright
 
 #[test]


### PR DESCRIPTION
# Issues 
N/A

# Description

There seems to be a revolution happening in English prepositions. One facet of that I've noticed is using "toward/towards" when a nice little "to" is perfectly fine. This is my first concrete linter addressing this. I had a YouTube video on in the background by what sounded like a native English speaker younger than a Millennial. There's plenty of usage of this if you Google for it.

# How Has This Been Tested?

Unit tests using sentences found on GitHub for all four combinations of singular vs plural and toward vs towards.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
