### PR TITLE
feat(chrome-ext): replace icons with cleaner variants

### DIFF
--- a/packages/lint-framework/src/lint/SuggestionBox.ts
+++ b/packages/lint-framework/src/lint/SuggestionBox.ts
@@ -1,6 +1,6 @@
 /** biome-ignore-all lint/complexity/useArrowFunction: It cannot be an arrow function for the logic to work. */
 import { type IconDefinition, icon } from '@fortawesome/fontawesome-svg-core';
-import { faBan, faGear } from '@fortawesome/free-solid-svg-icons';
+import { faSliders, faToggleOff } from '@fortawesome/free-solid-svg-icons';
 import { SuggestionKind } from 'harper.js';
 import type { VNode } from 'virtual-dom';
 import h from 'virtual-dom/h';
@@ -14,8 +14,8 @@ function iconSvg(definition: IconDefinition): string {
 	return icon(definition).html.join('');
 }
 
-const settingsIconSvg = iconSvg(faGear);
-const disableIconSvg = iconSvg(faBan);
+const settingsIconSvg = iconSvg(faSliders);
+const disableIconSvg = iconSvg(faToggleOff);
 
 let previouslyActiveElement: null | HTMLElement = null;
 


### PR DESCRIPTION
I was growing tired of the plain icons that we have on the suggestion popup for disabling a rule and for opening the settings menu. I've replaced them with better versions. See the screenshot below.

<img width="810" height="455" alt="image" src="https://github.com/user-attachments/assets/c1a7e84a-9349-4758-a77e-1ba9d6f53667" />
