### PR TITLE
feat: the different(s) between→the difference between

### DIFF
--- a/harper-core/src/linting/weir_rules/TheDifferenceBetween.weir
+++ b/harper-core/src/linting/weir_rules/TheDifferenceBetween.weir
@@ -1,0 +1,9 @@
+expr main [(the different between), (the differents between)]
+
+let message "The correct word is `difference`, not `different` or `differents`."
+let description "Corrects `the different(s) between to `the difference between`."
+let kind "Usage"
+let becomes "the difference between"
+
+test "What is the different between the two msi files of the latest version?" "What is the difference between the two msi files of the latest version?"
+test "what's the differents between \"await page.$(selector)\" and \"page.$(selector)\" ?" "what's the difference between \"await page.$(selector)\" and \"page.$(selector)\" ?"


### PR DESCRIPTION
# Issues 
N/A

# Description

This is a very common error made by English learners:
- "the different between" or "the differents between" instead of "the difference between"

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I made two unit tests from search results in GitHub. One for the singular and one for the plural.

I was surprised to find the plural seemed more common. I suppose it sounds more similar to the correct word.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
