### PR TITLE
fix: solve issue #2966

### DIFF
--- a/harper-core/src/linting/discourse_markers.rs
+++ b/harper-core/src/linting/discourse_markers.rs
@@ -299,7 +299,6 @@ mod tests {
 
     #[test]
     fn check_2966_is_avoided() {
-        // "Honestly and graciously convince someone of something."
         assert_no_lints(
             "Honestly and graciously convince someone of something.",
             DiscourseMarkers::default(),


### PR DESCRIPTION
# Issues 
Fixes #2966

# Description

Added the UPOS for "conjunction" to the set of POS that will prevent the lint from flagging.

# How Has This Been Tested?

Added the sentence from the bug report as a unit test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
