### PR TITLE
fix: correct typos and grammar in docs and comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Importantly, all of the tools available in this repository are available via `ju
 - `harper-core`: The core grammar checking engine. This is a dependency to pretty much everything related to Harper.
 - `harper-ls`: A Language Server compatible with a number of text editors, including Neovim, Zed, and Helix. See above linked documentation for more details.
 - `harper-cli`: A command-line binary for debugging Harper's core engine and markup language support.
-- `harper-comments`: Provides parsers for a number of programming langauges to support linting their comments.
+- `harper-comments`: Provides parsers for a number of programming languages to support linting their comments.
 - `harper-wasm`: The WebAssembly build target that powers browser and JavaScript integrations such as `harper.js`.
 - `packages/lint-framework`: A package containing the tooling necessary to read/write/highlight text on the web for the purpose of linting.
 - `packages/components`: Shared Svelte component package used by web-facing packages.

--- a/harper-core/README.md
+++ b/harper-core/README.md
@@ -39,7 +39,7 @@ for lint in lints {
 ## Features
 
 `concurrent`: Whether to use thread-safe primitives (`Arc` vs `Rc`). Disabled by default.
-It is not recommended unless you need thread-safely (i.e. you want to use something like `tokio`).
+It is not recommended unless you need thread safety (i.e. you want to use something like `tokio`).
 
 ## Other Relevant Packages
 

--- a/harper-core/src/linting/it_looks_like_that.rs
+++ b/harper-core/src/linting/it_looks_like_that.rs
@@ -180,7 +180,7 @@ mod tests {
         #[test]
         fn fix_that_it_verb_lemma() {
             // "that" is being wrongly used as a relative pronoun
-            // But it's hard to check becuase 'renovate' is a verb but is being used as a noun
+            // But it's hard to check because 'renovate' is a verb but is being used as a noun
             assert_suggestion_result(
                 "It looks like that Renovate decides to not reuse the branch when there are no changes in it",
                 ItLooksLikeThat::default(),

--- a/packages/wordpress-plugin/README.md
+++ b/packages/wordpress-plugin/README.md
@@ -7,4 +7,4 @@ It is a work-in-progress. Here be dragons!
 
 ## Contributing
 
-Refer to [the online documentation](https://writewithharper.com/docs/contributors/wordpress) for instruction to contribute to the plugin.
+Refer to [the online documentation](https://writewithharper.com/docs/contributors/wordpress) for instructions to contribute to the plugin.


### PR DESCRIPTION
## Summary

- `AGENTS.md`: Fix typo "langauges" → "languages"
- `harper-core/README.md`: Fix grammar "thread-safely" → "thread safety"
- `harper-core/src/linting/it_looks_like_that.rs`: Fix typo "becuase" → "because" in comment
- `packages/wordpress-plugin/README.md`: Fix grammar "instruction" → "instructions"

## Test plan

- [x] Changes are limited to documentation and comments — no functional code affected
- [x] Verified each fix is a genuine typo/grammar error, not intentional test data

🤖 Generated with [Claude Code](https://claude.com/claude-code)