### PR TITLE
feat: add subcommand to generate shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,6 +876,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2749,6 +2758,7 @@ dependencies = [
  "anyhow",
  "ariadne",
  "clap",
+ "clap_complete",
  "dirs 6.0.0",
  "enum_dispatch",
  "harper-asciidoc",

--- a/harper-cli/Cargo.toml
+++ b/harper-cli/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/automattic/harper"
 anyhow = "1.0.102"
 ariadne = "0.6.0"
 clap = { version = "4.6.0", features = ["derive", "std", "string"], default-features = false }
+clap_complete = "4.6.0"
 harper-stats = { path = "../harper-stats", version = "1.0.0" }
 dirs = "6.0.0"
 harper-literate-haskell = { path = "../harper-literate-haskell", version = "1.0.0" }

--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -4,14 +4,15 @@ use harper_core::spell::{Dictionary, FstDictionary, MutableDictionary, WordId};
 use hashbrown::HashMap;
 use std::collections::BTreeMap;
 use std::fs::File;
-use std::io::BufReader;
+use std::io::{self, BufReader};
 use std::path::PathBuf;
 // use std::sync::Arc;
 use std::{fs, process};
 
 use anyhow::anyhow;
 use ariadne::{Color, Label, Report, ReportKind, Source};
-use clap::Parser;
+use clap::{CommandFactory, Parser, ValueHint};
+use clap_complete::{Shell, generate};
 use dirs::{config_dir, data_local_dir};
 use harper_core::linting::LintGroup;
 use harper_core::parsers::{IsolateEnglish, MarkdownOptions};
@@ -77,10 +78,10 @@ enum Args {
         #[arg(short, long, default_value = "us")]
         dialect: String,
         /// Path to the user dictionary.
-        #[arg(short, long, default_value = config_dir().unwrap().join("harper-ls/dictionary.txt").into_os_string())]
+        #[arg(short, long, default_value = config_dir().unwrap().join("harper-ls/dictionary.txt").into_os_string(), value_hint = ValueHint::FilePath)]
         user_dict_path: PathBuf,
         /// Path to the directory for file-local dictionaries.
-        #[arg(short, long, default_value = data_local_dir().unwrap().join("harper-ls/file_dictionaries/").into_os_string())]
+        #[arg(short, long, default_value = data_local_dir().unwrap().join("harper-ls/file_dictionaries/").into_os_string(), value_hint = ValueHint::FilePath)]
         file_dict_path: PathBuf,
         /// Path to a Weirpack file to load. May be supplied multiple times.
         #[arg(long, value_name = "WEIRPACK")]
@@ -128,7 +129,10 @@ enum Args {
     /// Emit a decompressed, line-separated list of the words in Harper's dictionary.
     Words,
     /// Summarize a lint record
-    SummarizeLintRecord { file: PathBuf },
+    SummarizeLintRecord {
+        #[arg(value_hint = ValueHint::FilePath)]
+        file: PathBuf,
+    },
     /// Print the default config with descriptions.
     Config,
     /// Print a list of all the words in a document, sorted by frequency.
@@ -167,8 +171,8 @@ enum Args {
         // The number of embedding dimensions
         #[arg(long)]
         dim: usize,
-        /// The path to write the final  model file to.
-        #[arg(short, long)]
+        /// The path to write the final model file to.
+        #[arg(short, long, value_hint = ValueHint::FilePath)]
         output: PathBuf,
         /// The number of epochs to train.
         #[arg(short, long)]
@@ -189,12 +193,14 @@ enum Args {
         old: String,
         /// The new flag.
         new: String,
+        #[arg(value_hint = ValueHint::DirPath)]
         /// The directory containing the dictionary and affixes.
         dir: PathBuf,
     },
     /// Audit the `dictionary.dict` file.
     AuditDictionary {
         /// The directory containing the dictionary and affixes.
+        #[arg(value_hint = ValueHint::DirPath)]
         dir: PathBuf,
     },
     /// Emit a decompressed, line-separated list of the compounds in Harper's dictionary.
@@ -211,7 +217,14 @@ enum Args {
     /// Run the tests contained within a Weir file.
     Test {
         /// The location of the Weir file to test
+        #[arg(value_hint = ValueHint::FilePath)]
         input: PathBuf,
+    },
+    /// Generate shell completions.
+    #[command(hide = true)]
+    Completion {
+        /// Generate completions for this shell.
+        shell: Shell,
     },
 }
 
@@ -973,6 +986,15 @@ fn main() -> anyhow::Result<()> {
                 eprintln!("{:?}", failing_tests);
                 process::exit(1);
             }
+        }
+        Args::Completion { shell } => {
+            generate(
+                shell,
+                &mut Cli::command(),
+                env!("CARGO_BIN_NAME"),
+                &mut io::stdout(),
+            );
+            Ok(())
         }
     }
 }


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Closes: https://github.com/Automattic/harper/issues/2830

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

I've kept this simple for now to allow iterating over this later. Only added completions hints for paths. The completion subcommand is hidden for now. My view is that this will be used either by packagers or in a single file like `~/.config/fish/completions/harper-cli.fish`:

```fish
harper-cli completion fish | source
```

(that's why I've hidden it (for now), it doesn't seem like a "public API" to me).

# How Has This Been Tested?

I've source the generated script with fish, works as expected :+1: 

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
