### PR TITLE
feat: as evident by -> as evidenced by

### DIFF
--- a/harper-core/src/linting/weir_rules/AsEvidentBy.weir
+++ b/harper-core/src/linting/weir_rules/AsEvidentBy.weir
@@ -1,0 +1,27 @@
+expr main [<(as is evident by), evident>, <(as evident by), evident>, <(is evident by), evident>]
+
+let message "Did you mean `evidenced`? The correct phrase uses the past participle of the verb `evidence`."
+let description "Corrects `evident by` to `evidenced by` in passive constructions where `evidence` is used as a verb."
+let kind "Grammar"
+let becomes "evidenced"
+let strategy "MatchCase"
+
+# True positives (from real-world examples in issue #2895)
+
+test "as many others have differing preferences as is evident by the differing feedback" "as many others have differing preferences as is evidenced by the differing feedback"
+test "But as is evident by this bug, I'm not certain this will always be the case." "But as is evidenced by this bug, I'm not certain this will always be the case."
+test "This is evident by the call to remove_connection by the establish_connection method." "This is evidenced by the call to remove_connection by the establish_connection method."
+test "I noticed it always gets compiled, as evident by the cranelift log." "I noticed it always gets compiled, as evidenced by the cranelift log."
+test "As evident by gits history, it was made on purpose." "As evidenced by gits history, it was made on purpose."
+test "Errors thrown synchronously are caught (as evident by the stacktrace)." "Errors thrown synchronously are caught (as evidenced by the stacktrace)."
+test "I had the wrong username (as evident by my server's ssh log)." "I had the wrong username (as evidenced by my server's ssh log)."
+test "AS IS EVIDENT BY the data, this approach works." "AS IS EVIDENCED BY the data, this approach works."
+
+# True negatives
+
+allows "As evidenced by the data, this approach works."
+allows "This is evidenced by the test results."
+allows "The trend is evident from the chart."
+allows "It was evident in his tone of voice."
+allows "The answer is self-evident."
+allows "This problem is not evident to new users."


### PR DESCRIPTION
# Issues

Fixes #2895

# Description

Adds a weir rule to correct "as is evident by", "as evident by", and "is evident by" to their proper forms using "evidenced" (past participle of the verb "evidence").

The adjective "evident" cannot take an agent introduced by "by" in a passive construction. The correct form uses the verb "evidence" in passive voice: "as is **evidenced** by". [Merriam-Webster has an entry for the correct form](https://www.merriam-webster.com/dictionary/as%20%28is%29%20evidenced%20by), and the error is [discussed on English Stack Exchange](https://english.stackexchange.com/questions/143022).

The rule uses the `<expr, selector>` syntax to target only the word "evident" for replacement to "evidenced", preserving the surrounding phrase structure.

Patterns matched:
- "as is evident by" -> "as is evidenced by"
- "as evident by" -> "as evidenced by"
- "is evident by" -> "is evidenced by"

True negatives verified: "as evidenced by", "evident from", "evident in", "self-evident".

Test cases use real-world examples from the issue.

This contribution was developed with AI assistance (Claude Code).

# Demo

```
Before: "But as is evident by this bug, I'm not certain."
After:  "But as is evidenced by this bug, I'm not certain."
```

# How Has This Been Tested?

- 8 true positive `test` cases (real-world examples from #2895)
- 6 true negative `allows` cases (correct "evidenced by", "evident from", "evident in", "self-evident")
- `cargo fmt -- --check` passes
- `cargo clippy -- -Dwarnings` passes
- `cargo test -q` passes

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes