### PR TITLE
fix(core): skip PronounVerbAgreement for hyphenated compound words

### DIFF
--- a/harper-core/src/linting/pronoun_verb_agreement.rs
+++ b/harper-core/src/linting/pronoun_verb_agreement.rs
@@ -190,6 +190,15 @@ where
 
         let verb_tok = toks.last()?;
 
+        // If the verb is immediately followed by a hyphen, it's a compound word prefix
+        // (e.g. "co-founded"), not a standalone verb. Skip it.
+        if let Some((_, after)) = ctx
+            && let [next_tok, ..] = after
+            && next_tok.kind.is_hyphen()
+        {
+            return None;
+        }
+
         if let Some((before, _)) = ctx
             && let [.., prev_word_tok, ws_tok] = before
             && ws_tok.kind.is_whitespace()
@@ -649,6 +658,14 @@ mod lints {
     fn false_positive_she_hung_up() {
         assert_no_lints(
             "When I reiterated the conditions I'd previously set, she hung up on me.",
+            PronounVerbAgreement::new(FstDictionary::curated()),
+        );
+    }
+
+    #[test]
+    fn false_positive_co_founded() {
+        assert_no_lints(
+            "In 2014, he co-founded Social Chain.",
             PronounVerbAgreement::new(FstDictionary::curated()),
         );
     }


### PR DESCRIPTION
## Summary

Fixes a false positive where "co-founded" triggers `PronounVerbAgreement` because "co" is annotated as a pronoun in the dictionary. The linter sees "he" (pronoun) + "co" (verb-like pronoun) and suggests changing "co" to "cos".

## Changes

In `match_to_lint_with_context`, added an early return that checks the `after` context: if the token immediately following the matched verb is a hyphen, the verb is actually a compound word prefix (like "co-" in "co-founded" or "re-" in "re-established"), not a standalone verb. The lint is skipped in this case.

Added a regression test for "In 2014, he co-founded Social Chain." which previously triggered the false positive.

**Files changed:** `harper-core/src/linting/pronoun_verb_agreement.rs`

## Testing

All 44 existing tests pass. The 2 pre-existing `#[ignore]` tests remain unchanged.

```
test result: ok. 44 passed; 0 failed; 2 ignored; 0 measured; 4963 filtered out
```

Fixes #3006

This contribution was developed with AI assistance (Claude Code).