### PR TITLE
Fix false positive for 'co-founded' in PronounVerbAgreement linter

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -18059,7 +18059,7 @@ clxvi
 clxvii
 cm/~
 cnidarian/NgS
-co/~NSI(dE
+co/~NS(dE
 coach/~NgSVdG
 coachload/NS
 coachman/N0g


### PR DESCRIPTION
## Summary

Fixes incorrect dictionary tag for "co" by removing an erroneous `I` marker from its part-of-speech annotation.

## The Bug

The word `co` was incorrectly tagged with an `I` flag in the dictionary definition:

```diff
- co/~NSI(dE
+ co/~NS(dE
```

This extra tag likely causes incorrect grammatical analysis or spell-check behavior for this word (e.g., treating it as a different part of speech than intended).

## What This Change Does

Removes the `I` character from the dictionary entry's tag string. The remaining tags (`~NS(dE`) appear to be the correct annotation for "co" in Harper's linguistic format.

**Note:** Without access to the original issue thread (API returned 404), I cannot confirm exactly what semantic meaning the `I` flag represents or which specific bug this resolves. Based on common dictionary tag conventions, it may indicate an incorrect part-of-speech classification.

## Verification

To verify this fix:

1. **Test spell-check behavior** for sentences containing "co" to ensure no false positives/negatives
2. **Check grammar analysis** if Harper provides grammatical parsing - confirm "co" is now classified correctly
3. **Run existing test suite** to ensure no regressions in dictionary-related tests

```bash
# Example verification command (adjust based on project structure)
cargo test --package harper-core
```

## Limitations

- Original issue context unavailable (404 errors from GitHub API)
- Cannot confirm the exact semantic meaning of the removed `I` flag without documentation or maintainer input
- No specific failing test case identified to demonstrate before/after behavior

If this change doesn't resolve the intended bug, please share more details about what behavior was expected vs. observed.