### PR TITLE
Improve embedded form support in iframes

### DIFF
--- a/packages/chrome-plugin/src/background/index.ts
+++ b/packages/chrome-plugin/src/background/index.ts
@@ -62,8 +62,8 @@ chrome.runtime.onInstalled.addListener((details) => {
 	}
 });
 
-chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
-	handleRequest(request).then(sendResponse);
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+	handleRequest(request, sender).then(sendResponse);
 
 	return true;
 });
@@ -137,12 +137,15 @@ async function enableDefaultDomains() {
 
 enableDefaultDomains();
 
-function handleRequest(message: Request): Promise<Response> {
+function handleRequest(
+	message: Request,
+	sender?: chrome.runtime.MessageSender,
+): Promise<Response> {
 	console.log(`Handling ${message.kind} request`);
 
 	switch (message.kind) {
 		case 'lint':
-			return handleLint(message);
+			return handleLint(message, sender);
 		case 'getConfig':
 			return handleGetConfig(message);
 		case 'setConfig':
@@ -202,8 +205,11 @@ function handleRequest(message: Request): Promise<Response> {
 }
 
 /** Handle a request for linting. */
-async function handleLint(req: LintRequest): Promise<LintResponse> {
-	if (!(await enabledForDomain(req.domain))) {
+async function handleLint(
+	req: LintRequest,
+	sender?: chrome.runtime.MessageSender,
+): Promise<LintResponse> {
+	if (!(await shouldLintForRequest(req, sender))) {
 		return { kind: 'lints', lints: {} };
 	}
 
@@ -216,6 +222,39 @@ async function handleLint(req: LintRequest): Promise<LintResponse> {
 	);
 	const unpackedBySource = Object.fromEntries(unpackedEntries) as UnpackedLintGroups;
 	return { kind: 'lints', lints: unpackedBySource };
+}
+
+async function shouldLintForRequest(
+	req: LintRequest,
+	sender?: chrome.runtime.MessageSender,
+): Promise<boolean> {
+	if (await enabledForDomain(req.domain)) {
+		return true;
+	}
+
+	if (await isDomainSet(req.domain)) {
+		return false;
+	}
+
+	const parentDomain = getParentDomain(sender);
+	if (parentDomain == null || parentDomain === req.domain) {
+		return false;
+	}
+
+	return await enabledForDomain(parentDomain);
+}
+
+function getParentDomain(sender?: chrome.runtime.MessageSender): string | null {
+	const url = sender?.tab?.url;
+	if (url == null) {
+		return null;
+	}
+
+	try {
+		return new URL(url).hostname;
+	} catch {
+		return null;
+	}
 }
 
 async function handleGetConfig(_req: GetConfigRequest): Promise<GetConfigResponse> {

--- a/packages/chrome-plugin/src/background/index.ts
+++ b/packages/chrome-plugin/src/background/index.ts
@@ -137,10 +137,7 @@ async function enableDefaultDomains() {
 
 enableDefaultDomains();
 
-function handleRequest(
-	message: Request,
-	sender?: chrome.runtime.MessageSender,
-): Promise<Response> {
+function handleRequest(message: Request, sender?: chrome.runtime.MessageSender): Promise<Response> {
 	console.log(`Handling ${message.kind} request`);
 
 	switch (message.kind) {
@@ -209,6 +206,11 @@ async function handleLint(
 	req: LintRequest,
 	sender?: chrome.runtime.MessageSender,
 ): Promise<LintResponse> {
+	// Keep the content-script keepalive ping cheap; empty requests should not hit inheritance or linting.
+	if (req.text.length === 0) {
+		return { kind: 'lints', lints: {} };
+	}
+
 	if (!(await shouldLintForRequest(req, sender))) {
 		return { kind: 'lints', lints: {} };
 	}
@@ -577,12 +579,33 @@ function formatDomainKey(domain: string): string {
 	return `domainStatus ${domain}`;
 }
 
+function getDomainLookupCandidates(domain: string): string[] {
+	const withoutWww = domain.replace(/^www\./, '');
+	return withoutWww === domain ? [domain] : [domain, withoutWww];
+}
+
+async function getStoredDomainStatus(domain: string): Promise<boolean | undefined> {
+	const candidates = getDomainLookupCandidates(domain);
+	const response = await chrome.storage.local.get(candidates.map(formatDomainKey));
+
+	for (const candidate of candidates) {
+		const value = response[formatDomainKey(candidate)];
+		if (typeof value === 'boolean') {
+			return value;
+		}
+	}
+
+	return undefined;
+}
+
 /** Check if Harper has been enabled for a given domain. */
 async function enabledForDomain(domain: string): Promise<boolean | null> {
-	const req = await chrome.storage.local.get({
-		[formatDomainKey(domain)]: await enabledByDefault(),
-	});
-	return req[formatDomainKey(domain)];
+	const stored = await getStoredDomainStatus(domain);
+	if (stored !== undefined) {
+		return stored;
+	}
+
+	return await enabledByDefault();
 }
 
 /** Set whether Harper is enabled for a given domain.
@@ -614,8 +637,7 @@ async function enabledByDefault(): Promise<boolean> {
 
 /** Check whether Harper's state has been set for a given domain. */
 async function isDomainSet(domain: string): Promise<boolean> {
-	const resp = await chrome.storage.local.get(formatDomainKey(domain));
-	return typeof resp[formatDomainKey(domain)] == 'boolean';
+	return (await getStoredDomainStatus(domain)) !== undefined;
 }
 
 /** Reset the persistent user dictionary. */

--- a/packages/chrome-plugin/src/background/index.ts
+++ b/packages/chrome-plugin/src/background/index.ts
@@ -584,6 +584,12 @@ function getDomainLookupCandidates(domain: string): string[] {
 	return withoutWww === domain ? [domain] : [domain, withoutWww];
 }
 
+/**
+ * Looks up a domain-specific enable/disable setting in local storage.
+ * The lookup is normalized through `getDomainLookupCandidates` so we can try
+ * both the exact hostname and a `www.`-stripped variant when sites are stored
+ * under either form. Returns `undefined` when no stored override exists.
+ */
 async function getStoredDomainStatus(domain: string): Promise<boolean | undefined> {
 	const candidates = getDomainLookupCandidates(domain);
 	const response = await chrome.storage.local.get(candidates.map(formatDomainKey));

--- a/packages/chrome-plugin/src/contentScript/index.ts
+++ b/packages/chrome-plugin/src/contentScript/index.ts
@@ -56,6 +56,37 @@ const keepAliveCallback = () => {
 
 keepAliveCallback();
 
+function getTextareaReasons(element: HTMLTextAreaElement, requireVisible: boolean): string[] {
+	const reasons = [];
+
+	if (requireVisible && !isVisible(element)) {
+		reasons.push('not-visible');
+	}
+
+	if (element.getAttribute('data-enable-grammarly') === 'false') {
+		reasons.push('grammarly-disabled');
+	}
+
+	if (element.disabled) {
+		reasons.push('disabled');
+	}
+
+	if (element.readOnly) {
+		reasons.push('readonly');
+	}
+
+	return reasons;
+}
+
+function maybeAddTextareaTarget(element: HTMLTextAreaElement, requireVisible: boolean) {
+	const reasons = getTextareaReasons(element, requireVisible);
+	if (reasons.length > 0) {
+		return;
+	}
+
+	fw.addTarget(element);
+}
+
 function scan() {
 	void syncGoogleDocsBridge();
 
@@ -64,16 +95,7 @@ function scan() {
 	}
 
 	document.querySelectorAll<HTMLTextAreaElement>('textarea').forEach((element) => {
-		if (
-			!isVisible(element) ||
-			element.getAttribute('data-enable-grammarly') === 'false' ||
-			element.disabled ||
-			element.readOnly
-		) {
-			return;
-		}
-
-		fw.addTarget(element);
+		maybeAddTextareaTarget(element, true);
 	});
 
 	document
@@ -191,5 +213,18 @@ new MutationObserver(scan).observe(document.body, {
 	childList: true,
 	subtree: true,
 });
+
+document.addEventListener(
+	'focusin',
+	(event) => {
+		const target = event.target;
+		if (!(target instanceof HTMLTextAreaElement)) {
+			return;
+		}
+
+		maybeAddTextareaTarget(target, false);
+	},
+	{ capture: true },
+);
 
 setTimeout(scan, 1000);

--- a/packages/chrome-plugin/src/contentScript/index.ts
+++ b/packages/chrome-plugin/src/contentScript/index.ts
@@ -56,6 +56,10 @@ const keepAliveCallback = () => {
 
 keepAliveCallback();
 
+/**
+ * Returns the reasons Harper should skip this textarea while scanning for targets.
+ * An empty array means the textarea is eligible to be added.
+ */
 function getTextareaReasons(element: HTMLTextAreaElement, requireVisible: boolean): string[] {
 	const reasons = [];
 

--- a/packages/chrome-plugin/tests/iframe_domain_inheritance.spec.ts
+++ b/packages/chrome-plugin/tests/iframe_domain_inheritance.spec.ts
@@ -1,0 +1,138 @@
+import type { BrowserContext, Page } from '@playwright/test';
+import { expect, test } from './fixtures';
+import { replaceEditorContent } from './testUtils';
+
+const PARENT_DOMAIN = 'localhost';
+const CHILD_DOMAIN = '127.0.0.1';
+const TEST_PAGE_URL = 'http://localhost:8081/iframe_parent_origin.html';
+
+async function getBackground(context: BrowserContext) {
+	return (
+		context.serviceWorkers()[0] ??
+		context.backgroundPages()[0] ??
+		(await context.waitForEvent('serviceworker'))
+	);
+}
+
+async function seedDomainSettings(
+	context: BrowserContext,
+	domains: Record<string, boolean>,
+	defaultEnable = false,
+) {
+	const background = await getBackground(context);
+	const storageEntries = Object.fromEntries(
+		Object.entries(domains).map(([domain, enabled]) => [`domainStatus ${domain}`, enabled]),
+	);
+
+	await background.evaluate(
+		async ({ defaultEnable, storageEntries }) => {
+			await chrome.storage.local.set({ defaultEnable, ...storageEntries });
+		},
+		{ defaultEnable, storageEntries },
+	);
+}
+
+function getChildFrame(page: Page) {
+	return page.frameLocator('#editor-frame');
+}
+
+function getChildTextarea(page: Page) {
+	return getChildFrame(page).locator('textarea');
+}
+
+function getChildHighlights(page: Page) {
+	return getChildFrame(page).locator('#harper-highlight');
+}
+
+function getChildPopup(page: Page) {
+	return getChildFrame(page).locator('.harper-container');
+}
+
+async function typeLintableText(page: Page) {
+	await replaceEditorContent(getChildTextarea(page), 'This is an test');
+}
+
+async function waitForChildHighlight(page: Page) {
+	const highlight = getChildHighlights(page).first();
+	await highlight.waitFor({ state: 'visible', timeout: 12000 });
+	return highlight;
+}
+
+async function clickChildHighlight(page: Page) {
+	const highlight = await waitForChildHighlight(page);
+	const box = await highlight.boundingBox();
+
+	if (box == null) {
+		throw new Error('Expected iframe highlight to have a bounding box.');
+	}
+
+	await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+}
+
+async function expectNoChildHighlights(page: Page) {
+	await page.waitForTimeout(3000);
+	await expect(getChildHighlights(page)).toHaveCount(0);
+}
+
+test.describe('parent-origin inheritance', () => {
+	test('inherits the parent enabled state when the iframe host is unset', async ({
+		context,
+		page,
+	}) => {
+		test.slow();
+		await seedDomainSettings(context, { [PARENT_DOMAIN]: true });
+
+		await page.goto(TEST_PAGE_URL);
+		await typeLintableText(page);
+		await clickChildHighlight(page);
+
+		await expect(getChildPopup(page)).toBeVisible();
+	});
+
+	test('preserves an explicit iframe opt-out when the parent is enabled', async ({
+		context,
+		page,
+	}) => {
+		await seedDomainSettings(context, {
+			[PARENT_DOMAIN]: true,
+			[CHILD_DOMAIN]: false,
+		});
+
+		await page.goto(TEST_PAGE_URL);
+		await typeLintableText(page);
+
+		await expectNoChildHighlights(page);
+	});
+
+	test('does not inherit when the parent is disabled and the iframe host is unset', async ({
+		context,
+		page,
+	}) => {
+		await seedDomainSettings(context, { [PARENT_DOMAIN]: false });
+
+		await page.goto(TEST_PAGE_URL);
+		await typeLintableText(page);
+
+		await expectNoChildHighlights(page);
+	});
+
+	test('preserves an explicit iframe opt-in even when the parent is disabled', async ({
+		context,
+		page,
+	}) => {
+		test.slow();
+		await seedDomainSettings(context, {
+			[PARENT_DOMAIN]: false,
+			[CHILD_DOMAIN]: true,
+		});
+
+		await page.goto(TEST_PAGE_URL);
+		await typeLintableText(page);
+
+		// This precedence is intentional for now because explicit user overrides should win.
+		// Confirm it with maintainers if the project wants parent-level disablement to dominate.
+		await clickChildHighlight(page);
+
+		await expect(getChildPopup(page)).toBeVisible();
+	});
+});

--- a/packages/chrome-plugin/tests/iframe_domain_inheritance.spec.ts
+++ b/packages/chrome-plugin/tests/iframe_domain_inheritance.spec.ts
@@ -2,9 +2,10 @@ import type { BrowserContext, Page } from '@playwright/test';
 import { expect, test } from './fixtures';
 import { replaceEditorContent } from './testUtils';
 
-const PARENT_DOMAIN = 'localhost';
+const PARENT_DOMAIN = 'parent.localhost';
 const CHILD_DOMAIN = '127.0.0.1';
-const TEST_PAGE_URL = 'http://localhost:8081/iframe_parent_origin.html';
+const TEST_PAGE_URL = 'http://parent.localhost:8081/iframe_parent_origin.html';
+const TEST_PAGE_WWW_URL = 'http://www.parent.localhost:8081/iframe_parent_origin.html';
 
 async function getBackground(context: BrowserContext) {
 	return (
@@ -83,6 +84,20 @@ test.describe('parent-origin inheritance', () => {
 		await seedDomainSettings(context, { [PARENT_DOMAIN]: true });
 
 		await page.goto(TEST_PAGE_URL);
+		await typeLintableText(page);
+		await clickChildHighlight(page);
+
+		await expect(getChildPopup(page)).toBeVisible();
+	});
+
+	test('inherits when the parent is `www.` but the stored key follows the popup pattern', async ({
+		context,
+		page,
+	}) => {
+		test.slow();
+		await seedDomainSettings(context, { [PARENT_DOMAIN]: true });
+
+		await page.goto(TEST_PAGE_WWW_URL);
 		await typeLintableText(page);
 		await clickChildHighlight(page);
 

--- a/packages/chrome-plugin/tests/iframe_domain_inheritance.spec.ts
+++ b/packages/chrome-plugin/tests/iframe_domain_inheritance.spec.ts
@@ -76,6 +76,11 @@ async function expectNoChildHighlights(page: Page) {
 }
 
 test.describe('parent-origin inheritance', () => {
+	test.skip(
+		({ browserName }) => browserName === 'firefox',
+		'Firefox MV3 background context is not exposed reliably in playwright-webextext.',
+	);
+
 	test('inherits the parent enabled state when the iframe host is unset', async ({
 		context,
 		page,

--- a/packages/chrome-plugin/tests/iframe_dynamic_textarea.spec.ts
+++ b/packages/chrome-plugin/tests/iframe_dynamic_textarea.spec.ts
@@ -59,10 +59,7 @@ async function clickChildHighlight(page: Page) {
 	await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
 }
 
-test('attaches to a dynamically revealed iframe textarea on focus', async ({
-	context,
-	page,
-}) => {
+test('attaches to a dynamically revealed iframe textarea on focus', async ({ context, page }) => {
 	test.slow();
 	await seedDomainSettings(context, { [PARENT_DOMAIN]: true });
 

--- a/packages/chrome-plugin/tests/iframe_dynamic_textarea.spec.ts
+++ b/packages/chrome-plugin/tests/iframe_dynamic_textarea.spec.ts
@@ -31,6 +31,11 @@ async function seedDomainSettings(
 	);
 }
 
+test.skip(
+	({ browserName }) => browserName === 'firefox',
+	'Firefox MV3 background context is not exposed reliably in playwright-webextext.',
+);
+
 function getChildFrame(page: Page) {
 	return page.frameLocator('#editor-frame');
 }

--- a/packages/chrome-plugin/tests/iframe_dynamic_textarea.spec.ts
+++ b/packages/chrome-plugin/tests/iframe_dynamic_textarea.spec.ts
@@ -1,0 +1,78 @@
+import type { BrowserContext, Page } from '@playwright/test';
+import { expect, test } from './fixtures';
+import { replaceEditorContent } from './testUtils';
+
+const PARENT_DOMAIN = 'localhost';
+const TEST_PAGE_URL = 'http://localhost:8081/iframe_dynamic_textarea_parent.html';
+
+async function getBackground(context: BrowserContext) {
+	return (
+		context.serviceWorkers()[0] ??
+		context.backgroundPages()[0] ??
+		(await context.waitForEvent('serviceworker'))
+	);
+}
+
+async function seedDomainSettings(
+	context: BrowserContext,
+	domains: Record<string, boolean>,
+	defaultEnable = false,
+) {
+	const background = await getBackground(context);
+	const storageEntries = Object.fromEntries(
+		Object.entries(domains).map(([domain, enabled]) => [`domainStatus ${domain}`, enabled]),
+	);
+
+	await background.evaluate(
+		async ({ defaultEnable, storageEntries }) => {
+			await chrome.storage.local.set({ defaultEnable, ...storageEntries });
+		},
+		{ defaultEnable, storageEntries },
+	);
+}
+
+function getChildFrame(page: Page) {
+	return page.frameLocator('#editor-frame');
+}
+
+function getRevealButton(page: Page) {
+	return getChildFrame(page).getByRole('button', { name: 'Enter manually' });
+}
+
+function getChildTextarea(page: Page) {
+	return getChildFrame(page).locator('#editor');
+}
+
+function getChildHighlights(page: Page) {
+	return getChildFrame(page).locator('#harper-highlight');
+}
+
+async function clickChildHighlight(page: Page) {
+	const highlight = getChildHighlights(page).first();
+	await highlight.waitFor({ state: 'visible', timeout: 12000 });
+
+	const box = await highlight.boundingBox();
+	if (box == null) {
+		throw new Error('Expected iframe highlight to have a bounding box.');
+	}
+
+	await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+}
+
+test('attaches to a dynamically revealed iframe textarea on focus', async ({
+	context,
+	page,
+}) => {
+	test.slow();
+	await seedDomainSettings(context, { [PARENT_DOMAIN]: true });
+
+	await page.goto(TEST_PAGE_URL);
+	await getRevealButton(page).click();
+
+	const editor = getChildTextarea(page);
+	await editor.waitFor({ state: 'visible', timeout: 5000 });
+	await replaceEditorContent(editor, 'This is an test');
+
+	await clickChildHighlight(page);
+	await expect(getChildFrame(page).locator('.harper-container')).toBeVisible();
+});

--- a/packages/chrome-plugin/tests/pages/iframe_dynamic_textarea_child.html
+++ b/packages/chrome-plugin/tests/pages/iframe_dynamic_textarea_child.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dynamic child editor</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 24px;
+        font-family: sans-serif;
+        background: white;
+      }
+
+      button {
+        margin-bottom: 16px;
+        padding: 10px 18px;
+        border: 1px solid #6a3be5;
+        border-radius: 999px;
+        background: white;
+        color: #6a3be5;
+        cursor: pointer;
+      }
+
+      textarea {
+        width: 100%;
+        min-height: 120px;
+        padding: 12px;
+        font: 16px/1.4 sans-serif;
+        border: 1px solid #a1a1aa;
+        box-sizing: border-box;
+        opacity: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <button id="reveal" type="button">Enter manually</button>
+    <div id="editor-root"></div>
+    <script>
+      const revealButton = document.getElementById('reveal');
+      const editorRoot = document.getElementById('editor-root');
+
+      revealButton.addEventListener('click', () => {
+        if (document.getElementById('editor') != null) {
+          return;
+        }
+
+        const textarea = document.createElement('textarea');
+        textarea.id = 'editor';
+        textarea.spellcheck = true;
+
+        editorRoot.appendChild(textarea);
+
+        // Reveal after Harper's one-shot delayed scan so focus is what triggers attachment.
+        window.setTimeout(() => {
+          textarea.style.opacity = '1';
+        }, 1500);
+      });
+    </script>
+  </body>
+</html>

--- a/packages/chrome-plugin/tests/pages/iframe_dynamic_textarea_parent.html
+++ b/packages/chrome-plugin/tests/pages/iframe_dynamic_textarea_parent.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dynamic iframe textarea parent</title>
+    <style>
+      body {
+        margin: 0;
+        font-family: sans-serif;
+        background: #f4f4f5;
+      }
+
+      main {
+        max-width: 960px;
+        margin: 32px auto;
+        padding: 24px;
+      }
+
+      iframe {
+        width: 100%;
+        height: 320px;
+        border: 1px solid #d4d4d8;
+        background: white;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Dynamic iframe textarea test</h1>
+      <iframe
+        id="editor-frame"
+        title="Cross-origin child editor"
+        src="http://127.0.0.1:8081/iframe_dynamic_textarea_child.html"
+      ></iframe>
+    </main>
+  </body>
+</html>

--- a/packages/chrome-plugin/tests/pages/iframe_parent_origin.html
+++ b/packages/chrome-plugin/tests/pages/iframe_parent_origin.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Parent Origin Inheritance</title>
+    <style>
+      body {
+        margin: 0;
+        font-family: sans-serif;
+        background: #f4f4f5;
+      }
+
+      main {
+        max-width: 960px;
+        margin: 32px auto;
+        padding: 24px;
+      }
+
+      iframe {
+        width: 100%;
+        height: 240px;
+        border: 1px solid #d4d4d8;
+        background: white;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Parent origin inheritance test</h1>
+      <iframe
+        id="editor-frame"
+        title="Cross-origin child editor"
+        src="http://127.0.0.1:8081/iframe_parent_origin_child.html"
+      ></iframe>
+    </main>
+  </body>
+</html>

--- a/packages/chrome-plugin/tests/pages/iframe_parent_origin_child.html
+++ b/packages/chrome-plugin/tests/pages/iframe_parent_origin_child.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Child Editor</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 24px;
+        font-family: sans-serif;
+        background: white;
+      }
+
+      textarea {
+        width: 100%;
+        min-height: 120px;
+        padding: 12px;
+        font: 16px/1.4 sans-serif;
+        border: 1px solid #a1a1aa;
+        box-sizing: border-box;
+      }
+    </style>
+  </head>
+  <body>
+    <label for="editor">Cross-origin editor</label>
+    <textarea id="editor" autofocus spellcheck="true"></textarea>
+  </body>
+</html>


### PR DESCRIPTION
# Issues

Related: [Discussion #2990](https://github.com/Automattic/harper/discussions/2990)

Depends on: [PR #2998](https://github.com/Automattic/harper/pull/2998) for the full end-to-end behaviour on pages that replace the body/DOM after load.

# Description

## User Impact

This PR improves Harper's behaviour in embedded third-party forms in the chrome extension.

Before this patch:
- Harper could be enabled on the top-level page
- the embedded iframe would still not lint unless its own host was explicitly enabled
- even when the iframe was eligible, a textarea revealed after user interaction could still be missed by the initial scan

After this patch:
- an enabled parent page can allow linting in an unset embedded iframe
- popup-style `www.` keys continue to work for parent-origin fallback
- explicit iframe overrides still take precedence over inherited parent state
- a dynamically revealed iframe textarea is attached when the user focuses it

## Technical Details

This PR makes two focused changes that are needed for the end-to-end embedded-form flow:

1. Parent-origin inheritance for iframe lint requests:
If an iframe host does not have an explicit stored setting, Harper now falls back to the top-level tab host and allows linting when that parent domain is enabled.

    This remains a narrow lookup change:
    - inheritance only applies when the iframe host is unset
    - explicit iframe opt-in still wins when the parent is disabled
    - explicit iframe opt-out still wins when the parent is enabled
    - this does not introduce suffix matching, registrable-domain matching, or a broader domain inheritance model

2. Focus-based attachment for lazily revealed textareas:
Some embedded form providers only insert or reveal the actual textarea after the user interacts with the form. To cover that flow, the content script now also attaches to eligible textareas (`HTMLTextAreaElement`) when they receive focus.

I also aligned the background read path with the popup's existing `www.` behaviour. When the parent page is `www.example.com`, background lookups now also check the popup-style `example.com` key during reads.

# Demo

One concrete example is the embedded Greenhouse form on [emnify page](https://www.emnify.com/careers/openings/job-detail?gh_jid=4805742101&jobtitle=Ausbildung%20zum%20Fachinformatiker%20(m%2Fw%2Fd)).

In this example part of the manual-entry flow is revealed only after user clicks `Enter manually` causing textarea to appear after Harper's normal initial scan window, which is why the focus-based attachment fallback matters here.

# How Has This Been Tested?

I verified this locally with extension builds and Playwright coverage. The new iframe inheritance coverage includes:
- parent enabled, child unset
- parent enabled through a `www.` parent host when the stored key follows the popup's existing `www.`-stripped pattern
- parent enabled, child explicitly disabled
- parent disabled, child unset
- parent disabled, child explicitly enabled

The dynamic textarea regression verifies that Harper still attaches after the textarea is inserted or revealed after the normal initial scan window.

Firefox notes:
- manually verified on the emnify/Greenhouse flow when combined with [PR #2998](https://github.com/Automattic/harper/pull/2998)
- the new iframe Playwright specs work with Chrome only because Firefox extension-state seeding is not reliable in the current test harness


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
