### PR TITLE
feat: add corpus subcommand to harper-cli

### DIFF
--- a/harper-cli/src/corpus.rs
+++ b/harper-cli/src/corpus.rs
@@ -1,0 +1,141 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use harper_core::linting::LintGroup;
+use harper_core::parsers::PlainEnglish;
+use harper_core::spell::FstDictionary;
+use harper_core::{Dialect, Document};
+
+/// A single corpus entry with its expected outcome and optional rule filter.
+struct CorpusEntry {
+    /// The sentence text (marker stripped).
+    text: String,
+    /// Whether the sentence is expected to pass (no lints).
+    expect_pass: bool,
+    /// Optional rule name to test only that specific linter.
+    rule: Option<String>,
+    /// Original line number in the corpus file.
+    line_number: usize,
+}
+
+/// Run corpus mode: read marked sentences and report false positives/negatives.
+pub fn corpus(path: &Path, rule: Option<&str>, dialect: Dialect) -> anyhow::Result<bool> {
+    let content = std::fs::read_to_string(path)?;
+
+    let entries = parse_corpus(&content, rule)?;
+    if entries.is_empty() {
+        eprintln!("No corpus entries found.");
+        return Ok(true);
+    }
+
+    let dictionary = FstDictionary::curated();
+    let parser = PlainEnglish;
+
+    let mut passed = 0usize;
+    let mut failed = 0usize;
+
+    for entry in &entries {
+        let doc = Document::new(&entry.text, &parser, &dictionary);
+        let mut lint_group = LintGroup::new_curated(Arc::clone(&dictionary), dialect);
+
+        // If a rule filter is specified, disable all rules except the named one.
+        if let Some(ref only_rule) = entry.rule {
+            lint_group.set_all_rules_to(Some(false));
+            lint_group.config.set_rule_enabled(only_rule, true);
+        }
+
+        let named_lints = lint_group.organized_lints(&doc);
+        let lint_count: usize = named_lints.values().map(|v| v.len()).sum();
+
+        let ok = if entry.expect_pass {
+            lint_count == 0
+        } else {
+            lint_count > 0
+        };
+
+        if ok {
+            passed += 1;
+            let pass = yansi::Paint::green("[PASS]");
+            println!("{pass} {}", entry.text);
+        } else {
+            failed += 1;
+            let fail = yansi::Paint::red("[FAIL]");
+            println!("{fail} {}", entry.text);
+
+            if entry.expect_pass {
+                // False positive: lints found on a sentence expected to pass.
+                let rules: Vec<&String> = named_lints.keys().collect();
+                eprintln!(
+                    "  line {}: expected no lints, but found: {}",
+                    entry.line_number,
+                    rules
+                        .iter()
+                        .map(|r| r.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+            } else {
+                // False negative: no lints on a sentence expected to fail.
+                eprintln!(
+                    "  line {}: expected lints, but none found",
+                    entry.line_number
+                );
+            }
+        }
+    }
+
+    let total = passed + failed;
+    println!("\n{total} total, {passed} passed, {failed} failed");
+
+    Ok(failed == 0)
+}
+
+/// Parse corpus file content into entries.
+fn parse_corpus(content: &str, global_rule: Option<&str>) -> anyhow::Result<Vec<CorpusEntry>> {
+    let mut entries = Vec::new();
+
+    for (i, line) in content.lines().enumerate() {
+        let trimmed = line.trim();
+
+        // Skip blank lines and comments.
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        let (expect_pass, rest) = if let Some(rest) = trimmed.strip_prefix('✅') {
+            (true, rest)
+        } else if let Some(rest) = trimmed.strip_prefix('❌') {
+            (false, rest)
+        } else {
+            return Err(anyhow::anyhow!(
+                "line {}: expected line to start with ✅ or ❌",
+                i + 1
+            ));
+        };
+
+        let rest = rest.trim_start();
+
+        // Check for inline rule: `` `RuleName` rest of sentence ``
+        let (rule, text) = if let Some(after_bt) = rest.strip_prefix('`') {
+            if let Some((rule_name, after_rule)) = after_bt.split_once('`') {
+                (
+                    Some(rule_name.to_owned()),
+                    after_rule.trim_start().to_owned(),
+                )
+            } else {
+                (global_rule.map(str::to_owned), rest.to_owned())
+            }
+        } else {
+            (global_rule.map(str::to_owned), rest.to_owned())
+        };
+
+        entries.push(CorpusEntry {
+            text,
+            expect_pass,
+            rule,
+            line_number: i + 1,
+        });
+    }
+
+    Ok(entries)
+}

--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -36,6 +36,7 @@ use input::{
 mod annotate;
 use annotate::AnnotationType;
 
+mod corpus;
 mod lint;
 use crate::lint::{OutputFormat, lint};
 use lint::LintOptions;
@@ -213,6 +214,18 @@ enum Args {
     NominalPhrases {
         /// The text or file to analyze. If not provided, it will be read from standard input.
         input: Option<SingleInput>,
+    },
+    /// Run a corpus file of marked sentences to detect false positives and negatives.
+    Corpus {
+        /// Path to the corpus file.
+        #[arg(value_hint = ValueHint::FilePath)]
+        input: PathBuf,
+        /// Restrict testing to only a specific lint rule.
+        #[arg(long)]
+        rule: Option<String>,
+        /// Specify the dialect.
+        #[arg(short, long, default_value = "us")]
+        dialect: String,
     },
     /// Run the tests contained within a Weir file.
     Test {
@@ -971,6 +984,20 @@ fn main() -> anyhow::Result<()> {
 
             println!();
 
+            Ok(())
+        }
+        Args::Corpus {
+            input,
+            rule,
+            dialect: dialect_str,
+        } => {
+            let dialect = parse_dialect(&dialect_str)
+                .map_err(|e| anyhow!("Invalid dialect '{}': {}", dialect_str, e))?;
+
+            let all_passed = corpus::corpus(&input, rule.as_deref(), dialect)?;
+            if !all_passed {
+                process::exit(1);
+            }
             Ok(())
         }
         Args::Test { input } => {

--- a/harper-cli/tests/corpus.rs
+++ b/harper-cli/tests/corpus.rs
@@ -1,0 +1,137 @@
+use std::io::Write;
+use std::process::Command;
+
+use tempfile::NamedTempFile;
+
+fn harper_cli() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_harper-cli"));
+    cmd.arg("--no-color");
+    cmd
+}
+
+fn write_corpus(content: &str) -> NamedTempFile {
+    let mut f = NamedTempFile::new().unwrap();
+    f.write_all(content.as_bytes()).unwrap();
+    f.flush().unwrap();
+    f
+}
+
+#[test]
+fn correct_sentence_passes() {
+    let f = write_corpus("✅ This sentence is perfectly grammatical.\n");
+    let output = harper_cli()
+        .args(["corpus", f.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("[PASS]"));
+    assert!(!stdout.contains("[FAIL]"));
+    assert!(output.status.success());
+}
+
+#[test]
+fn incorrect_sentence_passes() {
+    let f = write_corpus("❌ This is an test.\n");
+    let output = harper_cli()
+        .args(["corpus", f.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("[PASS]"));
+    assert!(!stdout.contains("[FAIL]"));
+    assert!(output.status.success());
+}
+
+#[test]
+fn false_positive_detected() {
+    // Marking a correct sentence as expected-to-fail → false negative detection.
+    let f = write_corpus("❌ This is correct.\n");
+    let output = harper_cli()
+        .args(["corpus", f.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("[FAIL]"));
+    assert!(!output.status.success());
+}
+
+#[test]
+fn false_negative_detected() {
+    // Marking a bad sentence as expected-to-pass → false positive detection.
+    let f = write_corpus("✅ This is an test.\n");
+    let output = harper_cli()
+        .args(["corpus", f.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("[FAIL]"));
+    assert!(!output.status.success());
+}
+
+#[test]
+fn inline_rule_filter() {
+    let f = write_corpus("❌ `AnA` This is an test.\n");
+    let output = harper_cli()
+        .args(["corpus", f.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("[PASS]"));
+    assert!(output.status.success());
+}
+
+#[test]
+fn global_rule_flag() {
+    let f = write_corpus("❌ This is an test.\n");
+    let output = harper_cli()
+        .args(["corpus", "--rule", "AnA", f.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("[PASS]"));
+    assert!(output.status.success());
+}
+
+#[test]
+fn comments_and_blanks_skipped() {
+    let f = write_corpus("# This is a comment\n\n✅ This is fine.\n");
+    let output = harper_cli()
+        .args(["corpus", f.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("[PASS]"));
+    assert!(stdout.contains("1 total"));
+    assert!(output.status.success());
+}
+
+#[test]
+fn summary_line_printed() {
+    let f = write_corpus("✅ Good sentence.\n❌ This is an test.\n");
+    let output = harper_cli()
+        .args(["corpus", f.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("2 total, 2 passed, 0 failed"));
+    assert!(output.status.success());
+}
+
+#[test]
+fn exit_code_nonzero_on_failure() {
+    let f = write_corpus("✅ This is an test.\n");
+    let output = harper_cli()
+        .args(["corpus", f.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+}


### PR DESCRIPTION
## Summary

Adds a `corpus` subcommand to `harper-cli` that reads a file of marked sentences and detects false positives and negatives.

- Lines prefixed with ✅ are expected to produce **no** lints (pass)
- Lines prefixed with ❌ are expected to produce **one or more** lints (fail)
- Supports optional `--rule` flag to restrict testing to a single linter
- Supports inline `` `RuleName` `` syntax per line (as described in the issue)
- Outputs colored `[PASS]`/`[FAIL]` per line with a summary
- Exits non-zero if any expectations are violated (CI-friendly)
- Blank lines and `#` comments are skipped

### Example corpus file

```
# Test basic grammar rules
✅ This sentence is perfectly grammatical.
❌ This sentance has one or more problems.
❌ `AnA` This is an test.
✅ `SpellCheck` This sentence is correct.
```

### Example output

```
[PASS] This sentence is perfectly grammatical.
[PASS] This sentance has one or more problems.
[PASS] This is an test.
[PASS] This sentence is correct.

4 total, 4 passed, 0 failed
```

Closes #2629

## Test plan

- [x] `cargo test -p harper-cli` — all 18 tests pass (9 new corpus tests)
- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy -- -Dwarnings` — clean
- [x] `cargo check -p harper-cli` and `cargo check -p harper-cli --features training` — clean
- [x] `cargo build -p harper-cli` — clean