### PR TITLE
test: add regression tests for need_to_noun false positives (#2320)

### DIFF
--- a/harper-core/src/linting/need_to_noun.rs
+++ b/harper-core/src/linting/need_to_noun.rs
@@ -513,4 +513,52 @@ mod tests {
             NeedToNoun::default(),
         );
     }
+
+    #[test]
+    fn allows_need_to_start_2320() {
+        assert_no_lints(
+            "You need to start the server before running tests.",
+            NeedToNoun::default(),
+        );
+    }
+
+    #[test]
+    fn allows_need_to_have_2320() {
+        assert_no_lints(
+            "You need to have a valid license to use this software.",
+            NeedToNoun::default(),
+        );
+    }
+
+    #[test]
+    fn allows_need_to_configure_2320() {
+        assert_no_lints(
+            "You need to configure the database connection first.",
+            NeedToNoun::default(),
+        );
+    }
+
+    #[test]
+    fn allows_need_to_set_2320() {
+        assert_no_lints(
+            "You need to set the environment variable before deploying.",
+            NeedToNoun::default(),
+        );
+    }
+
+    #[test]
+    fn allows_need_to_send_2320() {
+        assert_no_lints(
+            "You need to send the request with the correct headers.",
+            NeedToNoun::default(),
+        );
+    }
+
+    #[test]
+    fn allows_need_to_receive_2320() {
+        assert_no_lints(
+            "You need to receive confirmation before proceeding.",
+            NeedToNoun::default(),
+        );
+    }
 }


### PR DESCRIPTION
## Issues

Fixes #2320

## Description

The core fix for this issue was already merged in PR #2905, which added the `!is_likely_homograph()` check to prevent false positives when verb/noun homographs follow "need to". However, the specific words reported in the issue comments lacked dedicated test coverage.

This PR adds 6 regression tests for the exact words reported in #2320:
- `start` — original reporter's example
- `have` — reported by @gautaz
- `configure` — reported by @gautaz
- `set` — reported by @gautaz
- `send` — reported by @gautaz
- `receive` — reported by @gautaz

Each test verifies that "need to \<verb\>" produces no lints when the word is a verb/noun homograph.

## How Has This Been Tested?

- `cargo test -p harper-core -- need_to_noun` — all 57 tests pass (51 existing + 6 new)
- `cargo fmt -- --check` — no formatting issues
- `cargo check -p harper-core` — compiles cleanly

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes