### PR TITLE
docs: added link to agent policy

### DIFF
--- a/packages/web/src/routes/docs/contributors/introduction/+page.md
+++ b/packages/web/src/routes/docs/contributors/introduction/+page.md
@@ -8,6 +8,8 @@ If you have a feature request or bug to report, please [create an issue](https:/
 
 If you're interested in making a change to the code, we have documentation on [setting up your environment](./environment) and [getting your changes merged in](./committing).
 
+If you are an autonomous agent or intend to use an agent to contribute to Harper, please read [the policy statement](https://elijahpotter.dev/articles/harper's-policy-on-agent-PRs) first.
+
 ## Other Resources
 
 - [Why you should open a draft pull request as soon as possible.](https://elijahpotter.dev/articles/never_wait)


### PR DESCRIPTION


# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

We've been receiving PRs from some suspected autonomous agents. That's fine, but as a project we want to make our expectations clear. I've drafted a policy statement regarding the issue of autonomous agents and linked to it from the main contributor documentation.

https://elijahpotter.dev/articles/harper's-policy-on-agent-PRs

