### PR TITLE
perf(core): cache `WordSet` in `ModalVerb`

### DIFF
--- a/harper-core/src/patterns/modal_verb.rs
+++ b/harper-core/src/patterns/modal_verb.rs
@@ -2,24 +2,23 @@ use std::sync::LazyLock;
 
 use super::{Pattern, WordSet};
 
+static MODALS: [&str; 14] = [
+    "can", "can't", "could", "may", "might", "must", "shall", "shan't", "should", "will", "won't",
+    "would", "ought", "dare",
+];
+
 pub struct ModalVerb {
     inner: &'static WordSet,
 }
 
 impl Default for ModalVerb {
     fn default() -> Self {
-        let words = Self::init(false);
-        Self { inner: words }
+        Self::without_common_errors()
     }
 }
 
 impl ModalVerb {
-    fn init(include_common_errors: bool) -> &'static WordSet {
-        const MODALS: [&str; 14] = [
-            "can", "can't", "could", "may", "might", "must", "shall", "shan't", "should", "will",
-            "won't", "would", "ought", "dare",
-        ];
-
+    pub fn without_common_errors() -> Self {
         static CACHED_WITHOUT_COMMON_ERRORS: LazyLock<WordSet> = LazyLock::new(|| {
             let mut words = WordSet::new(&MODALS);
             MODALS.iter().for_each(|word| {
@@ -29,6 +28,12 @@ impl ModalVerb {
             words
         });
 
+        Self {
+            inner: &CACHED_WITHOUT_COMMON_ERRORS,
+        }
+    }
+
+    pub fn with_common_errors() -> Self {
         static CACHED_WITH_COMMON_ERRORS: LazyLock<WordSet> = LazyLock::new(|| {
             let mut words = WordSet::new(&MODALS);
             MODALS.iter().for_each(|word| {
@@ -39,16 +44,9 @@ impl ModalVerb {
             words
         });
 
-        if include_common_errors {
-            &CACHED_WITH_COMMON_ERRORS
-        } else {
-            &CACHED_WITHOUT_COMMON_ERRORS
+        Self {
+            inner: &CACHED_WITH_COMMON_ERRORS,
         }
-    }
-
-    pub fn with_common_errors() -> Self {
-        let words = Self::init(true);
-        Self { inner: words }
     }
 }
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
Improves performance on the lint_essay benchmark by 20-25% by caching the `WordSet` used in `ModalVerb`.
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->
(Cherry-picked from #2630)

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
- `cargo test`
- `cargo bench`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
