### PR TITLE
fix(chrome-ext): reverse the toggle button to it appears "on"

### DIFF
--- a/packages/lint-framework/src/lint/SuggestionBox.ts
+++ b/packages/lint-framework/src/lint/SuggestionBox.ts
@@ -331,6 +331,9 @@ function styleTag(lintKind: LintKind) {
       height:18px;
       display:block;
       }
+      .harper-disable-btn{
+        transform: scaleX(-1);
+      }
       .harper-controls{display:flex;align-items:center;gap:3px;}
       .harper-child-cont{
       display:flex;


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #3007 

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

The toggle button in the suggestion box in the Chrome extension appeared to be "off", when it in fact reflected a status of "on". It was a simple fix. I just flipped the toggle button.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

<img width="320" height="176" alt="image" src="https://github.com/user-attachments/assets/a6150e1c-0250-41cc-b43b-0f8322692611" />


# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
