### PR TITLE
fix(chrome-ext): persist lint rule changes from settings page

### DIFF
--- a/packages/chrome-plugin/src/options/Options.svelte
+++ b/packages/chrome-plugin/src/options/Options.svelte
@@ -433,7 +433,7 @@ async function removeWeirpack(id: string) {
               <Select
                 size="md"
                 value={configValueToString(value)}
-                on:change={(e) => {
+                onchange={(e) => {
                   lintConfig[key] = configStringToValue(e.target.value);
                 }}
               >


### PR DESCRIPTION
## Summary

- **Bug:** Toggling a lint rule (Default/On/Off) in the browser extension settings page never persisted. The UI updated visually but no `storage.set()` call was made, so changes were lost on page reload.
- **Root cause:** The rules `<Select>` used `on:change` (Svelte event directive syntax) to handle value changes. The `Select` component is a Svelte 4 legacy-mode component that does **not** forward DOM events (it has no `on:change` shorthand or `createEventDispatcher`). As a result, the handler was silently ignored.
- **Fix:** Replace `on:change` with `onchange` (Svelte 5 attribute syntax), which passes through `$$restProps` to the native `<select>` element where it fires correctly.

This is a one-line change. Other settings (dialect, activation key, etc.) already work because they use `bind:value` on the Select, which goes through the component's `export let value` prop. Only the rules section used `on:change`.

Fixes #1822

## Test plan

- [ ] Open the extension settings page
- [ ] Toggle any lint rule from "Default" to "On" or "Off"
- [ ] Close and reopen the settings page — the rule should remain as set
- [ ] Verify that `chrome.storage.onChanged` fires when toggling a rule (it did not before this fix)
- [ ] Build passes: `pnpm --filter chrome-plugin build` exits 0
- [ ] Linting passes: `biome check` reports no errors
- [ ] Rust tests pass: `cargo test` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)