### PR TITLE
feat: in 1 day from now→in one day/one day from now

### DIFF
--- a/harper-core/src/expr/duration_expr.rs
+++ b/harper-core/src/expr/duration_expr.rs
@@ -13,8 +13,8 @@ impl Expr for DurationExpr {
         }
 
         let units = WordSet::new(&[
-            "minute", "minutes", "hour", "hours", "day", "days", "week", "weeks", "month",
-            "months", "year", "years",
+            "second", "seconds", "minute", "minutes", "hour", "hours", "day", "days", "week",
+            "weeks", "month", "months", "year", "years",
         ]);
 
         let expr = SequenceExpr::longest_of(vec![

--- a/harper-core/src/linting/in_time_from_now.rs
+++ b/harper-core/src/linting/in_time_from_now.rs
@@ -1,0 +1,144 @@
+use crate::{
+    Token,
+    expr::{DurationExpr, Expr, SequenceExpr},
+    linting::{ExprLinter, Lint, LintKind, Suggestion, expr_linter::Chunk},
+    token_string_ext::TokenStringExt,
+};
+
+pub struct InTimeFromNow {
+    expr: SequenceExpr,
+}
+
+impl Default for InTimeFromNow {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::aco("in")
+                .t_ws()
+                .then_optional(
+                    SequenceExpr::word_set(&[
+                        "about",
+                        "almost",
+                        "approximately",
+                        "around",
+                        "circa",
+                        "exactly",
+                        "just",
+                        "maybe",
+                        "nearly",
+                        "only",
+                        "perhaps",
+                        "precisely",
+                        "probably",
+                        "roughly",
+                    ])
+                    .t_ws(),
+                )
+                .then(DurationExpr)
+                .t_ws()
+                .t_aco("from")
+                .t_ws()
+                .t_aco("now"),
+        }
+    }
+}
+
+impl ExprLinter for InTimeFromNow {
+    type Unit = Chunk;
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        let without_in: Vec<char> = toks[2..].span()?.get_content(src).to_vec();
+        let without_from_now: Vec<char> = toks[..toks.len() - 4].span()?.get_content(src).to_vec();
+
+        let template_chars = toks.span()?.get_content(src);
+
+        Some(Lint {
+            span: toks.span()?,
+            lint_kind: LintKind::Redundancy,
+            message: "Avoid redundancy by using either `in [period of time]` or `[period of time] from now`, but not both together.".to_string(),
+            suggestions: vec![
+                Suggestion::replace_with_match_case(without_in, template_chars),
+                Suggestion::replace_with_match_case(without_from_now, template_chars),
+            ],
+            ..Default::default()
+        })
+    }
+
+    fn description(&self) -> &str {
+        "Checks for redundant use of `in` before [period of time] together with `from now` after it."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::InTimeFromNow;
+    use crate::linting::tests::assert_good_and_bad_suggestions;
+
+    #[test]
+    fn in_three_years_from_now() {
+        assert_good_and_bad_suggestions(
+            "Closing this issue now to prevent it from still being open in three years from now.",
+            InTimeFromNow::default(),
+            &[
+                "Closing this issue now to prevent it from still being open in three years.",
+                "Closing this issue now to prevent it from still being open three years from now.",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn in_2_seconds_from_now() {
+        assert_good_and_bad_suggestions(
+            "The task will be executed in 2 seconds from now.",
+            InTimeFromNow::default(),
+            &[
+                "The task will be executed 2 seconds from now.",
+                "The task will be executed in 2 seconds.",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn in_three_weeks_from_now() {
+        assert_good_and_bad_suggestions(
+            "I have created a pull request, which can be merged in three weeks from now",
+            InTimeFromNow::default(),
+            &[
+                "I have created a pull request, which can be merged in three weeks",
+                "I have created a pull request, which can be merged three weeks from now",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn in_2_hours_from_now() {
+        assert_good_and_bad_suggestions(
+            "send a notification every 30 minutes, starting in 2 hours from now",
+            InTimeFromNow::default(),
+            &[
+                "send a notification every 30 minutes, starting 2 hours from now",
+                "send a notification every 30 minutes, starting in 2 hours",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn in_two_weeks_from_now() {
+        assert_good_and_bad_suggestions(
+            "That problem will be solved in two weeks from now by Bintray people.",
+            InTimeFromNow::default(),
+            &[
+                "That problem will be solved two weeks from now by Bintray people.",
+                "That problem will be solved in two weeks by Bintray people.",
+            ],
+            &[],
+        );
+    }
+}

--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -100,6 +100,7 @@ use super::hyphenate_number_day::HyphenateNumberDay;
 use super::i_am_agreement::IAmAgreement;
 use super::if_wouldve::IfWouldve;
 use super::in_on_the_cards::InOnTheCards;
+use super::in_time_from_now::InTimeFromNow;
 use super::inflected_verb_after_to::InflectedVerbAfterTo;
 use super::interested_in::InterestedIn;
 use super::it_looks_like_that::ItLooksLikeThat;
@@ -689,6 +690,7 @@ impl LintGroup {
         insert_expr_rule!(IAmAgreement, true);
         insert_expr_rule!(IfWouldve, true);
         insert_struct_rule_with_dialect!(InOnTheCards, true);
+        insert_expr_rule!(InTimeFromNow, true);
         insert_struct_rule_with_dict!(InflectedVerbAfterTo, true);
         insert_expr_rule!(InterestedIn, true);
         insert_expr_rule!(ItLooksLikeThat, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -96,6 +96,7 @@ mod hyphenate_number_day;
 mod i_am_agreement;
 mod if_wouldve;
 mod in_on_the_cards;
+mod in_time_from_now;
 mod inflected_verb_after_to;
 mod initialism_linter;
 mod initialisms;


### PR DESCRIPTION
# Issues 
N/A

# Description

I read or heard "in five years from now" and thought "that's redundant" and the Google AI agrees.
So I made a linter that suggests both:
- in five years
- five years from now

I realized it's extremely similar to the `AfterLater` linter so started by copying it. If we find a third similar pattern it will probably be worthwhile converting them to be generated by a macro.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Unit tests using sentences found on GitHub.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
