### PR TITLE
refactor!: take argument by value instead of mut ref

### DIFF
--- a/harper-cli/src/lint.rs
+++ b/harper-cli/src/lint.rs
@@ -448,8 +448,8 @@ fn lint_one_input(
                 let mut lint_group = LintGroup::new_curated(merged_dictionary.into(), *dialect);
 
                 for pack in weirpacks {
-                    let mut pack_group = pack.to_lint_group()?;
-                    lint_group.merge_from(&mut pack_group);
+                    let pack_group = pack.to_lint_group()?;
+                    lint_group.merge_from(pack_group);
                 }
 
                 // Turn specified rules on or off

--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -327,26 +327,23 @@ impl LintGroupConfig {
     }
 
     /// Merge the contents of another [`LintGroupConfig`] into this one.
-    /// The other config will be left empty after this operation.
     ///
     /// Conflicting keys will be overridden by the value in the other group.
-    pub fn merge_from(&mut self, other: &mut LintGroupConfig) {
-        for (key, val) in other.inner.iter() {
+    pub fn merge_from(&mut self, other: LintGroupConfig) {
+        for (key, val) in other.inner {
             if val.is_none() {
                 continue;
             }
 
-            self.inner.insert(key.to_string(), *val);
+            self.inner.insert(key.to_string(), val);
         }
-
-        other.clear();
     }
 
     /// Fill the group with the values for the curated lint group.
     pub fn fill_with_curated(&mut self) {
         let mut temp = Self::new_curated();
         mem::swap(self, &mut temp);
-        self.merge_from(&mut temp);
+        self.merge_from(temp);
     }
 
     pub fn new_curated() -> Self {
@@ -452,12 +449,10 @@ impl LintGroup {
     }
 
     /// Merge the contents of another [`LintGroup`] into this one.
-    /// The other lint group will be left empty after this operation.
-    pub fn merge_from(&mut self, other: &mut LintGroup) {
-        self.config.merge_from(&mut other.config);
+    pub fn merge_from(&mut self, other: LintGroup) {
+        self.config.merge_from(other.config);
 
-        let other_linters = std::mem::take(&mut other.linters);
-        if let Some((conflicting_key, _)) = other_linters.iter().find(|(k, _)| self.contains_key(k))
+        if let Some((conflicting_key, _)) = other.linters.iter().find(|(k, _)| self.contains_key(k))
         {
             if self.clashing_linter_names.is_none() {
                 self.clashing_linter_names = Some(vec![conflicting_key.clone()]);
@@ -465,10 +460,10 @@ impl LintGroup {
                 clashing_names.push(conflicting_key.clone());
             }
         }
-        self.linters.extend(other_linters);
+        self.linters.extend(other.linters);
 
-        let other_expr_linters = std::mem::take(&mut other.chunk_expr_linters);
-        if let Some((conflicting_key, _)) = other_expr_linters
+        if let Some((conflicting_key, _)) = other
+            .chunk_expr_linters
             .iter()
             .find(|(k, _)| self.contains_key(k))
         {
@@ -478,7 +473,7 @@ impl LintGroup {
                 clashing_names.push(conflicting_key.clone());
             }
         }
-        self.chunk_expr_linters.extend(other_expr_linters);
+        self.chunk_expr_linters.extend(other.chunk_expr_linters);
     }
 
     pub fn iter_keys(&self) -> impl Iterator<Item = &str> {
@@ -592,13 +587,13 @@ impl LintGroup {
             };
         }
 
-        out.merge_from(&mut weir_rules::lint_group());
-        out.merge_from(&mut phrase_set_corrections::lint_group());
-        out.merge_from(&mut proper_noun_capitalization_linters::lint_group(
+        out.merge_from(weir_rules::lint_group());
+        out.merge_from(phrase_set_corrections::lint_group());
+        out.merge_from(proper_noun_capitalization_linters::lint_group(
             dictionary.clone(),
         ));
-        out.merge_from(&mut closed_compounds::lint_group());
-        out.merge_from(&mut initialisms::lint_group());
+        out.merge_from(closed_compounds::lint_group());
+        out.merge_from(initialisms::lint_group());
 
         // Add all the more complex rules to the group.
         // Please maintain alphabetical order.

--- a/harper-wasm/src/lib.rs
+++ b/harper-wasm/src/lib.rs
@@ -135,7 +135,7 @@ impl Linter {
     /// Update the dictionary inside [`Self::lint_group`] to include [`Self::user_dictionary`].
     /// This clears any linter caches, so use it sparingly.
     fn synchronize_lint_dict(&mut self) {
-        let mut lint_config = self.lint_group.config.clone();
+        let lint_config = self.lint_group.config.clone();
 
         let mut constituent_dictionaries = vec![Arc::new(self.user_dictionary.clone())];
         constituent_dictionaries.extend(self.weirpack_dictionaries.iter().cloned());
@@ -145,7 +145,7 @@ impl Linter {
         self.lint_group =
             LintGroup::new_curated_empty_config(self.dictionary.clone(), self.dialect.into());
 
-        self.lint_group.config.merge_from(&mut lint_config);
+        self.lint_group.config.merge_from(lint_config);
     }
 
     /// Construct the actual dictionary to be used for linting and parsing from the curated dictionary
@@ -518,8 +518,8 @@ impl Linter {
             self.synchronize_lint_dict();
         }
 
-        let mut group = pack.to_lint_group().map_err(|err| err.to_string())?;
-        self.lint_group.merge_from(&mut group);
+        let group = pack.to_lint_group().map_err(|err| err.to_string())?;
+        self.lint_group.merge_from(group);
         Ok(JsValue::UNDEFINED)
     }
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
Uses a more idiomatic function signature by moving/consuming value, instead of taking a mutable reference to it and clearing it.

BREAKING CHANGE: `LintGroup::merge_from` and `LintGroupConfig::merge_from` now take `other` by value instead of mutable reference.
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->
(Cherry-picked from #2630, with adjustments.)

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
- `cargo test`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
