### PR TITLE
feat: thrive off (of)→thrive on

### DIFF
--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -218,6 +218,7 @@ use super::theyre_confusions::TheyreConfusions;
 use super::thing_think::ThingThink;
 use super::this_type_of_thing::ThisTypeOfThing;
 use super::though_thought::ThoughThought;
+use super::thrive_on::ThriveOn;
 use super::throw_away::ThrowAway;
 use super::throw_rubbish::ThrowRubbish;
 use super::to_adverb::ToAdverb;
@@ -804,6 +805,7 @@ impl LintGroup {
         insert_expr_rule!(ThingThink, true);
         insert_expr_rule!(ThisTypeOfThing, true);
         insert_expr_rule!(ThoughThought, true);
+        insert_expr_rule!(ThriveOn, true);
         insert_expr_rule!(ThrowAway, true);
         insert_struct_rule!(ThrowRubbish, true);
         insert_expr_rule!(ToAdverb, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -229,6 +229,7 @@ mod theyre_confusions;
 mod thing_think;
 mod this_type_of_thing;
 mod though_thought;
+mod thrive_on;
 mod throw_away;
 mod throw_rubbish;
 mod to_adverb;

--- a/harper-core/src/linting/thrive_on.rs
+++ b/harper-core/src/linting/thrive_on.rs
@@ -1,0 +1,148 @@
+use crate::{
+    Lint, Token, TokenStringExt,
+    expr::{Expr, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+};
+
+pub struct ThriveOn {
+    expr: SequenceExpr,
+}
+
+impl Default for ThriveOn {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::word_set(&["thrive", "thrived", "thrives", "thriving"])
+                .t_ws()
+                .t_aco("off")
+                .then_optional(SequenceExpr::whitespace().t_aco("of")),
+        }
+    }
+}
+
+impl ExprLinter for ThriveOn {
+    type Unit = Chunk;
+
+    fn description(&self) -> &str {
+        "Corrects `thrive off` and `thrive off of` to `thrive on`."
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        let span = toks[2..].span()?;
+        Some(Lint {
+            span,
+            lint_kind: LintKind::Style,
+            suggestions: vec![Suggestion::replace_with_match_case_str(
+                "on",
+                span.get_content(src),
+            )],
+            message: "Consider using `thrive on` instead of `thrive off` or `thrive off of`."
+                .to_string(),
+            ..Default::default()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    use super::ThriveOn;
+
+    // definite mistakes
+
+    #[test]
+    fn ignore_thrive_off() {
+        assert_suggestion_result(
+            "I thrive off open source projects.",
+            ThriveOn::default(),
+            "I thrive on open source projects.",
+        );
+    }
+
+    #[test]
+    fn fix_thrive_off_of() {
+        assert_suggestion_result(
+            "I thrive off of criticism and constructive feedback.",
+            ThriveOn::default(),
+            "I thrive on criticism and constructive feedback.",
+        );
+    }
+
+    #[test]
+    fn ignore_thrived_off() {
+        assert_suggestion_result(
+            "The decision hurt the emulator community who thrived off AVX512 chips at the low to medium end, not for the large registers, but for the masking capabilities.",
+            ThriveOn::default(),
+            "The decision hurt the emulator community who thrived on AVX512 chips at the low to medium end, not for the large registers, but for the masking capabilities.",
+        );
+    }
+    #[test]
+    fn ignore_thrived_off_of() {
+        assert_suggestion_result(
+            "All my life I have been determined to succeed in my education and have thrived off of an overwhelming amount of creativity.",
+            ThriveOn::default(),
+            "All my life I have been determined to succeed in my education and have thrived on an overwhelming amount of creativity.",
+        );
+    }
+
+    #[test]
+    fn ignore_thrives_off_collaboration() {
+        assert_suggestion_result(
+            "Open source thrives off collaboration.",
+            ThriveOn::default(),
+            "Open source thrives on collaboration.",
+        );
+    }
+
+    #[test]
+    fn ignore_thrives_off_of_community() {
+        assert_suggestion_result(
+            "An all-in-one technical interview prep platform which fosters and thrives off of community engagement.",
+            ThriveOn::default(),
+            "An all-in-one technical interview prep platform which fosters and thrives on community engagement.",
+        );
+    }
+
+    #[test]
+    fn fix_thriving_off() {
+        assert_suggestion_result(
+            "So the government granted monopolies to those companies willing to risk the investment, and our teleco's have been thriving off it ever since.",
+            ThriveOn::default(),
+            "So the government granted monopolies to those companies willing to risk the investment, and our teleco's have been thriving on it ever since.",
+        );
+    }
+
+    fn fix_thriving_off_of() {
+        assert_suggestion_result(
+            "Thriving off of solving problems on the wall AND in front of my computer screen",
+            ThriveOn::default(),
+            "Thriving on solving problems on the wall AND in front of my computer screen",
+        );
+    }
+
+    // changing to "thrive on" isn't always a definite win when "thrive off" seems to mix with "live off"
+
+    // Obviously confusing "live off the land" with "thrive on". The phrase "thrive on the land" gets no Google hits.
+    #[test]
+    fn ignore_thrive_off_the_land() {
+        assert_suggestion_result(
+            "A great collection of resources to thrive off the land.",
+            ThriveOn::default(),
+            "A great collection of resources to thrive off the land.",
+        );
+    }
+
+    // This one definitely doesn't sound right with "thrive on his back" - but is it common enough to check for?
+    #[test]
+    #[ignore = "Analogy with 'live off his back'"]
+    fn ignore_thriving_off_of_his_back() {
+        assert_no_lints(
+            "We're getting free software, that we ALL use, and the person who has worked tirelessly on it is struggling financially, while we are all thriving off of his back.",
+            ThriveOn::default(),
+        );
+    }
+}


### PR DESCRIPTION
# Issues 
N/A

# Description

I came across "thrive off" on the internet and when I researched it also found "thrive off of".
Most of the time they should just be "thrive on".

But there are times when people are using "thrive off" as a mix of "thrive on" with "live off" as in "live off the land". I can't tell if those are common or not so I'm not yet filtering them out. Let me know if they need to be!

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Unit tests are included for all verb inflections and combinations with both "off" and "off of".

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
