### PR TITLE
feat: worth while/worth-while → worthwhile

### DIFF
--- a/harper-core/src/linting/closed_compounds.rs
+++ b/harper-core/src/linting/closed_compounds.rs
@@ -6,11 +6,11 @@ pub fn lint_group() -> LintGroup {
     let mut group = LintGroup::empty();
 
     macro_rules! add_compound_mappings {
-        ($group:expr, { $($name:expr => ($bad:expr, $good:expr)),+ $(,)? }) => {
+        ($group:expr, { $($name:expr => ($bads:expr, $good:expr)),+ $(,)? }) => {
             $(
                 $group.add(
                     $name,
-                    Box::new(MapPhraseLinter::new_closed_compound($bad, $good)),
+                    Box::new(MapPhraseLinter::new_closed_compound($bads, $good)),
                 );
             )+
         };
@@ -21,64 +21,65 @@ pub fn lint_group() -> LintGroup {
     // The second column is the incorrect form of the word and the third column is the correct
     // form.
     add_compound_mappings!(group, {
-        "Anybody"         => ("any body", "anybody"),
-        "Anyhow"          => ("any how", "anyhow"),
-        "Anywhere"        => ("any where", "anywhere"),
-        "Backplane"       => ("back plane", "backplane"),
-        "Bypass"          => ("by pass", "bypass"),
-        "Chalkboard"      => ("chalk board", "chalkboard"),
-        "Deadlift"        => ("dead lift", "deadlift"),
-        "Desktop"         => ("desk top", "desktop"),
-        "Devops"          => ("dev ops", "devops"),
-        "Everybody"       => ("every body", "everybody"),
-        "Everyone"        => ("every one", "everyone"),
-        "Everywhere"      => ("every where", "everywhere"),
-        "Furthermore"     => ("further more", "furthermore"),
-        "Henceforth"      => ("hence forth", "henceforth"),
-        "However"         => ("how ever", "however"),
-        "Insofar"         => ("in so far", "insofar"),
-        "Instead"         => ("in stead", "instead"),
-        "Intact"          => ("in tact", "intact"),
-        "Itself"          => ("it self", "itself"),
-        "Keystroke"       => ("key stoke", "keystroke"),
-        "Keystrokes"      => ("key stokes", "keystrokes"),
-        "Laptop"          => ("lap top", "laptop"),
-        "Middleware"      => ("middle ware", "middleware"),
-        "Misunderstand"   => ("miss understand", "misunderstand"),
-        "Misunderstood"   => ("miss understood", "misunderstood"),
-        "Misuse"          => ("miss use", "misuse"),
-        "Misused"         => ("miss used", "misused"),
-        "Multicore"       => ("multi core", "multicore"),
-        "Multimedia"      => ("multi media", "multimedia"),
-        "Multithreading"  => ("multi threading", "multithreading"),
-        "Myself"          => ("my self", "myself"),
-        "Nonetheless"     => ("none the less", "nonetheless"),
-        "Nowhere"         => ("no where", "nowhere"),
-        "Nothing"         => ("no thing", "nothing"),
-        "Notwithstanding" => ("not with standing", "notwithstanding"),
-        "Overall"         => ("over all", "overall"),
-        "Overclocking"    => ("over clocking", "overclocking"),
-        "Overload"        => ("over load", "overload"),
-        "Overnight"       => ("over night", "overnight"),
-        "Postpone"        => ("post pone", "postpone"),
-        "Proofread"       => ("proof read", "proofread"),
-        "Regardless"      => ("regard less", "regardless"),
-        "Shortcoming"     => ("short coming", "shortcoming"),
-        "Shortcomings"    => ("short comings", "shortcomings"),
-        "Somebody"        => ("some body", "somebody"),
-        "Somehow"         => ("some how", "somehow"),
-        "Someone"         => ("some one", "someone"),
-        "Somewhere"       => ("some where", "somewhere"),
-        "There"           => ("the re", "there"),
-        "Therefore"       => ("there fore", "therefore"),
-        "Thereupon"       => ("there upon", "thereupon"),
-        "Underclock"      => ("under clock", "underclock"),
-        "Upset"           => ("up set", "upset"),
-        "Upward"          => ("up ward", "upward"),
-        "Whereupon"       => ("where upon", "whereupon"),
-        "Widespread"      => ("wide spread", "widespread"),
-        "Without"         => ("with out", "without"),
-        "Worldwide"       => ("world wide", "worldwide"),
+        "Anybody"         => (&["any body"][..], "anybody"),
+        "Anyhow"          => (&["any how"][..], "anyhow"),
+        "Anywhere"        => (&["any where"][..], "anywhere"),
+        "Backplane"       => (&["back plane"][..], "backplane"),
+        "Bypass"          => (&["by pass"][..], "bypass"),
+        "Chalkboard"      => (&["chalk board"][..], "chalkboard"),
+        "Deadlift"        => (&["dead lift"][..], "deadlift"),
+        "Desktop"         => (&["desk top"][..], "desktop"),
+        "Devops"          => (&["dev ops"][..], "devops"),
+        "Everybody"       => (&["every body"][..], "everybody"),
+        "Everyone"        => (&["every one"][..], "everyone"),
+        "Everywhere"      => (&["every where"][..], "everywhere"),
+        "Furthermore"     => (&["further more"][..], "furthermore"),
+        "Henceforth"      => (&["hence forth"][..], "henceforth"),
+        "However"         => (&["how ever"][..], "however"),
+        "Insofar"         => (&["in so far"][..], "insofar"),
+        "Instead"         => (&["in stead"][..], "instead"),
+        "Intact"          => (&["in tact"][..], "intact"),
+        "Itself"          => (&["it self"][..], "itself"),
+        "Keystroke"       => (&["key stoke"][..], "keystroke"),
+        "Keystrokes"      => (&["key stokes"][..], "keystrokes"),
+        "Laptop"          => (&["lap top"][..], "laptop"),
+        "Middleware"      => (&["middle ware"][..], "middleware"),
+        "Misunderstand"   => (&["miss understand"][..], "misunderstand"),
+        "Misunderstood"   => (&["miss understood"][..], "misunderstood"),
+        "Misuse"          => (&["miss use"][..], "misuse"),
+        "Misused"         => (&["miss used"][..], "misused"),
+        "Multicore"       => (&["multi core"][..], "multicore"),
+        "Multimedia"      => (&["multi media"][..], "multimedia"),
+        "Multithreading"  => (&["multi threading"][..], "multithreading"),
+        "Myself"          => (&["my self"][..], "myself"),
+        "Nonetheless"     => (&["none the less"][..], "nonetheless"),
+        "Nothing"         => (&["no thing"][..], "nothing"),
+        "Notwithstanding" => (&["not with standing"][..], "notwithstanding"),
+        "Nowhere"         => (&["no where"][..], "nowhere"),
+        "Overall"         => (&["over all"][..], "overall"),
+        "Overclocking"    => (&["over clocking"][..], "overclocking"),
+        "Overload"        => (&["over load"][..], "overload"),
+        "Overnight"       => (&["over night"][..], "overnight"),
+        "Postpone"        => (&["post pone"][..], "postpone"),
+        "Proofread"       => (&["proof read"][..], "proofread"),
+        "Regardless"      => (&["regard less"][..], "regardless"),
+        "Shortcoming"     => (&["short coming"][..], "shortcoming"),
+        "Shortcomings"    => (&["short comings"][..], "shortcomings"),
+        "Somebody"        => (&["some body"][..], "somebody"),
+        "Somehow"         => (&["some how"][..], "somehow"),
+        "Someone"         => (&["some one"][..], "someone"),
+        "Somewhere"       => (&["some where"][..], "somewhere"),
+        "There"           => (&["the re"][..], "there"),
+        "Therefore"       => (&["there fore"][..], "therefore"),
+        "Thereupon"       => (&["there upon"][..], "thereupon"),
+        "Underclock"      => (&["under clock"][..], "underclock"),
+        "Upset"           => (&["up set"][..], "upset"),
+        "Upward"          => (&["up ward"][..], "upward"),
+        "Whereupon"       => (&["where upon"][..], "whereupon"),
+        "Widespread"      => (&["wide spread"][..], "widespread"),
+        "Without"         => (&["with out"][..], "without"),
+        "Worldwide"       => (&["world wide"][..], "worldwide"),
+        "Worthwhile"      => (&["worth while", "worth-while"][..], "worthwhile"),
     });
 
     group.set_all_rules_to(Some(true));
@@ -304,6 +305,22 @@ mod tests {
     fn short_comings() {
         let test_sentence = "We listed three short comings in the postmortem.";
         let expected = "We listed three shortcomings in the postmortem.";
+        assert_suggestion_result(test_sentence, lint_group(), expected);
+    }
+
+    #[test]
+    fn worth_while() {
+        let test_sentence =
+            "It's worth while documenting all the clientside events that the eventsService emits?";
+        let expected =
+            "It's worthwhile documenting all the clientside events that the eventsService emits?";
+        assert_suggestion_result(test_sentence, lint_group(), expected);
+    }
+
+    #[test]
+    fn worth_hyphen_while() {
+        let test_sentence = "I feel that the special case of looping over sequences that follow a standard iterator protocol (i.e. optionals) is important enough to be worth-while.";
+        let expected = "I feel that the special case of looping over sequences that follow a standard iterator protocol (i.e. optionals) is important enough to be worthwhile.";
         assert_suggestion_result(test_sentence, lint_group(), expected);
     }
 }

--- a/harper-core/src/linting/map_phrase_linter.rs
+++ b/harper-core/src/linting/map_phrase_linter.rs
@@ -85,7 +85,10 @@ impl MapPhraseLinter {
         )
     }
 
-    pub fn new_closed_compound(phrase: impl AsRef<str>, correct_form: impl ToString) -> Self {
+    pub fn new_closed_compound(
+        phrases: impl IntoIterator<Item = impl AsRef<str>>,
+        correct_form: impl ToString,
+    ) -> Self {
         let message = format!(
             "Did you mean the closed compound `{}`?",
             correct_form.to_string()
@@ -96,8 +99,8 @@ impl MapPhraseLinter {
             correct_form.to_string()
         );
 
-        Self::new_fixed_phrase(
-            phrase,
+        Self::new_fixed_phrases(
+            phrases,
             [correct_form],
             message,
             description,

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -2235,6 +2235,16 @@ Message: |
 
 
 
+Lint:    Miscellaneous (31 priority)
+Message: |
+    1869 | Queen was close behind her, listening: so she went on, “—likely to win, that
+    1870 | it’s hardly worth while finishing the game.”
+         |             ^~~~~~~~~~~ Did you mean the closed compound `worthwhile`?
+Suggest:
+  - Replace with: “worthwhile”
+
+
+
 Lint:    Style (31 priority)
 Message: |
     1894 | The Queen had only one way of settling all difficulties, great or small. “Off


### PR DESCRIPTION
# Issues 
N/A

# Description

I came across "worth while" in the thumbnail of a YouTube video and, while checking if it's common, also came across "worth-while".

I modified `closed_compounds` to allow multiple wrong forms to be mapped to a single correct form.

The open version "worth while" might've formerly been acceptable since it occurs in our Alice in Wonderland snapshot.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

A unit test for each of the open and hyphenated wrong forms, both sourced from GitHub, are included.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
