### PR TITLE
refactor(core)!: `Lrc<[char]>` instead of `Lrc<Vec<char>>`

### DIFF
--- a/harper-core/src/document.rs
+++ b/harper-core/src/document.rs
@@ -55,7 +55,7 @@ impl Document {
     pub fn new(text: &str, parser: &impl Parser, dictionary: &impl Dictionary) -> Self {
         let source: Lrc<_> = text.chars().collect();
 
-        Self::new_from_vec(source, parser, dictionary)
+        Self::new_from_chars(source, parser, dictionary)
     }
 
     /// Lexes and parses text to produce a document using a provided language
@@ -63,12 +63,12 @@ impl Document {
     pub fn new_curated(text: &str, parser: &impl Parser) -> Self {
         let source: Lrc<_> = text.chars().collect();
 
-        Self::new_from_vec(source, parser, &FstDictionary::curated())
+        Self::new_from_chars(source, parser, &FstDictionary::curated())
     }
 
     /// Lexes and parses text to produce a document using a provided language
     /// parser and dictionary.
-    pub fn new_from_vec(
+    pub fn new_from_chars(
         source: Lrc<[char]>,
         parser: &impl Parser,
         dictionary: &impl Dictionary,
@@ -84,7 +84,7 @@ impl Document {
     /// Create a new document from character data using the built-in [`PlainEnglish`]
     /// parser and curated dictionary. This avoids string-to-char conversions.
     pub fn new_plain_english_curated_chars(source: &[char]) -> Self {
-        Self::new_from_vec(Lrc::from(source), &PlainEnglish, &FstDictionary::curated())
+        Self::new_from_chars(Lrc::from(source), &PlainEnglish, &FstDictionary::curated())
     }
 
     /// Parse text to produce a document using the built-in [`PlainEnglish`]
@@ -125,7 +125,7 @@ impl Document {
     /// Create a new document from character data using the built-in [`Markdown`] parser
     /// and curated dictionary. This avoids string-to-char conversions.
     pub fn new_markdown_default_curated_chars(chars: &[char]) -> Self {
-        Self::new_from_vec(
+        Self::new_from_chars(
             chars.to_vec().into(),
             &Markdown::default(),
             &FstDictionary::curated(),

--- a/harper-core/src/title_case.rs
+++ b/harper-core/src/title_case.rs
@@ -23,7 +23,7 @@ pub fn make_title_case_chars(
     parser: &impl Parser,
     dict: &impl Dictionary,
 ) -> Vec<char> {
-    let document = Document::new_from_vec(source.clone(), parser, dict);
+    let document = Document::new_from_chars(source.clone(), parser, dict);
 
     make_title_case(document.get_tokens(), &source, dict)
 }

--- a/harper-core/src/weir/mod.rs
+++ b/harper-core/src/weir/mod.rs
@@ -171,7 +171,7 @@ impl WeirLinter {
                     continue;
                 }
 
-                let doc = Document::new_from_vec(
+                let doc = Document::new_from_chars(
                     current.chars().collect::<Vec<_>>().into(),
                     &Markdown::default(),
                     &FstDictionary::curated(),
@@ -197,7 +197,7 @@ impl WeirLinter {
             let mut iter_count = 0;
 
             loop {
-                let test = Document::new_from_vec(
+                let test = Document::new_from_chars(
                     text_chars.clone().into(),
                     &Markdown::default(),
                     &FstDictionary::curated(),
@@ -224,7 +224,7 @@ impl WeirLinter {
         }
 
         fn lint_count(text: &str, linter: &mut impl Linter) -> usize {
-            let document = Document::new_from_vec(
+            let document = Document::new_from_chars(
                 text.chars().collect::<Vec<_>>().into(),
                 &Markdown::default(),
                 &FstDictionary::curated(),

--- a/harper-wasm/src/lib.rs
+++ b/harper-wasm/src/lib.rs
@@ -250,7 +250,7 @@ impl Linter {
         let source: Lrc<_> = source_text.chars().collect();
 
         let document =
-            Document::new_from_vec(source, &lint.language.create_parser(), &self.dictionary);
+            Document::new_from_chars(source, &lint.language.create_parser(), &self.dictionary);
 
         self.ignored_lints.ignore_lint(&lint.inner, &document);
     }
@@ -264,7 +264,7 @@ impl Linter {
     pub fn context_hash(&self, source_text: String, lint: &Lint) -> u64 {
         let source: Vec<_> = source_text.chars().collect();
 
-        let document = Document::new_from_vec(
+        let document = Document::new_from_chars(
             source.into(),
             &lint.language.create_parser(),
             &self.dictionary,
@@ -298,7 +298,7 @@ impl Linter {
             parser = Box::new(OopsAllHeadings::new(parser));
         }
 
-        let document = Document::new_from_vec(source.clone(), &parser, &self.dictionary);
+        let document = Document::new_from_chars(source.clone(), &parser, &self.dictionary);
 
         let temp = self.lint_group.config.clone();
         self.lint_group.config.fill_with_curated();
@@ -357,7 +357,7 @@ impl Linter {
             parser = Box::new(OopsAllHeadings::new(parser));
         }
 
-        let document = Document::new_from_vec(source.clone(), &parser, &self.dictionary);
+        let document = Document::new_from_chars(source.clone(), &parser, &self.dictionary);
 
         let temp = self.lint_group.config.clone();
         self.lint_group.config.fill_with_curated();
@@ -448,7 +448,7 @@ impl Linter {
     ) -> Result<String, String> {
         let mut source: Vec<_> = source_text.chars().collect();
 
-        let doc = Document::new_from_vec(
+        let doc = Document::new_from_chars(
             source.clone().into(),
             &lint.language.create_parser(),
             &self.dictionary,


### PR DESCRIPTION

# Description
<!-- Please include a summary of the change. -->
- **refactor(core)!: `Lrc<[char]>` instead of `Lrc<Vec<char>>`**
- **refactor(core)!: rename `Document::new_from_vec` to `new_from_chars`**
    - Uses a more appropriate name since the method no longer takes a `Vec`.

<!-- Any details that you think are important to review this PR? -->
Not 100% sure on this one. This should remove a pointer indirection and avoid needing to store unnecessary Vec metadata, but I don't see it making any measurable performance difference. It's more of a pedantic code-quality change, which I'm not sure is worth the breakage. However, given that the requirement for an `Lrc<Vec<char>>` can spill into other code over time (as it has done into the title_case code), I think if we're going to make the change, it will be easier to do it sooner rather than later.

<!-- Are there other PRs related to this one? -->
(Cherry-picked from #2630)

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
- `cargo test`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
