### PR TITLE
fix: don't flag "each of whom"

### DIFF
--- a/harper-core/src/linting/whom_subject_of_verb.rs
+++ b/harper-core/src/linting/whom_subject_of_verb.rs
@@ -47,7 +47,9 @@ impl ExprLinter for WhomSubjectOfVerb {
             && ws2.kind.is_whitespace()
             && prep.get_ch(src).eq_ch(&['o', 'f'])
             && ws1.kind.is_whitespace()
-            && word.get_ch(src).eq_str("many")
+            && word
+                .get_ch(src)
+                .eq_any_ignore_ascii_case_str(&["each", "many"])
         {
             return None;
         }
@@ -144,5 +146,13 @@ mod tests {
             "it's far from straightforward for new users, many of whom will likely have a lot to learn",
             WhomSubjectOfVerb::default(),
         );
+    }
+
+    #[test]
+    fn dont_flag_each_of_whom() {
+        assert_no_lints(
+            "Horace Silver (piano), Tyrone Washington (tenor sax), and Roger Humphries (drums), each of whom has a wikipedia article about him.",
+            WhomSubjectOfVerb::default(),
+        )
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

While testing Harper on some websites using Harper Glasses I got a false positive in the `WhomSubjectOfVerb` linter: 
<img width="1346" height="39" alt="Screenshot 2026-04-01 at 8 16 13 pm" src="https://github.com/user-attachments/assets/38ddeb0d-40e2-4a49-a132-4514858a6452" />

The linter now checks for "each of whom" in addition to the "many of whom" it already checked for.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

I used the sentence from the article in a new unit test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
