### PR TITLE
feat: at all cost → at all costs

### DIFF
--- a/harper-core/src/linting/weir_rules/AtAllCosts.weir
+++ b/harper-core/src/linting/weir_rules/AtAllCosts.weir
@@ -1,0 +1,9 @@
+expr main (at all cost)
+
+let message "Did you mean `at all costs`?"
+let description "Corrects `at all cost` to `at all costs`."
+let kind "Usage"
+let becomes "at all costs"
+
+test "Configs for my Arch system for maximum performance at all cost." "Configs for my Arch system for maximum performance at all costs."
+test "If ComfyUI wouldn't be such a helpful tool I would avoid it at all cost." "If ComfyUI wouldn't be such a helpful tool I would avoid it at all costs."


### PR DESCRIPTION
# Issues 
N/A

# Description

I noticed "at all cost" instead of "at all costs" somewhere. It's common. Couldn't find false positives.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo run --bin harper-cli test harper-core/src/linting/weir_rules/AtAllCosts.weir`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
