### PR TITLE
fix: skip PronounVerbAgreement for hyphenated compounds

### DIFF
--- a/harper-core/src/linting/pronoun_verb_agreement.rs
+++ b/harper-core/src/linting/pronoun_verb_agreement.rs
@@ -185,6 +185,13 @@ where
         let pron_tok = &toks[0];
         let is_3psg = pron_tok.kind.is_third_person_singular_pronoun();
 
+        // Skip when the pronoun is part of a hyphenated compound (e.g. "co-founded").
+        // The tokenizer splits "co-founded" into separate tokens, but "co" as a prefix
+        // is not acting as a pronoun.
+        if pron_tok.span.end < src.len() && src[pron_tok.span.end] == '-' {
+            return None;
+        }
+
         let verb_tok = toks.last()?;
 
         if let Some((before, _)) = ctx


### PR DESCRIPTION
## Summary

Fixes false positive where "co-founded" triggers PronounVerbAgreement because "co" is recognized as a pronoun.

## Why this matters

In sentences like "he co-founded Social Chain", the tokenizer splits "co-founded" into separate tokens. The rule then matches "co" (pronoun) + "founded" (verb) and suggests changing "co" to "cos". But "co" here is a prefix, not a standalone pronoun.

## Changes

`harper-core/src/linting/pronoun_verb_agreement.rs` (line 188): Added an early return in `match_to_lint_with_context` that checks whether the character immediately following the pronoun token is a hyphen. If so, the word is part of a hyphenated compound and should not be treated as a pronoun for agreement purposes.

## Testing

- "he co-founded Social Chain" -- no longer flagged
- "he walks" -- still correctly unflagged (correct agreement)
- "I walks" -- still correctly flagged (disagreement)
- "co works here" (without hyphen) -- still flagged if applicable (no hyphen = standalone pronoun)

Fixes #3006

This contribution was developed with AI assistance (Claude Code).