### PR TITLE
feat: add styling for user-defined monospace fonts

### DIFF
--- a/packages/obsidian-plugin/src/lint.ts
+++ b/packages/obsidian-plugin/src/lint.ts
@@ -574,6 +574,7 @@ const baseTheme = EditorView.baseTheme({
 	},
 
 	'.cm-diagnosticText code': {
+		fontFamily: 'var(--font-monospace)',
 		borderRadius: '0.25rem',
 		backgroundColor: 'var(--background-secondary) !important',
 		border:


### PR DESCRIPTION
# Issues
N/A

# Description
This PR updates the Obsidian plugin's lint tooltip styling so inline `code` inside diagnostic messages respects Obsidian's configured monospace font.

Specifically, it adds `font-family: var(--font-monospace)` to `.cm-diagnosticText code` in `packages/obsidian-plugin/src/lint.ts`, which makes code snippets in Harper diagnostics match the user's editor/UI monospace styling more closely.

# Demo
Before:
- Inline code in lint tooltips could render with a font that did not match the user's configured monospace font

After:
- Inline code in lint tooltips uses `var(--font-monospace)`

# How Has This Been Tested?
- Performed a self-review of the change in `packages/obsidian-plugin/src/lint.ts`
- Verified the committed diff only adds a single `fontFamily` rule to the tooltip code styling
- Did not run automated tests for this commit

# Checklist
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes