### PR TITLE
Fix indentation handling in harper-tex

### DIFF
--- a/harper-tex/src/masker.rs
+++ b/harper-tex/src/masker.rs
@@ -22,6 +22,8 @@ impl harper_core::Masker for Masker {
 
             if matches!(c, '%') {
                 actions.push_back(CursorAction::PushMaskAndIncBy(1));
+            } else if let Some(ws) = newline_whitespace_at_cursor(cursor, source) {
+                actions.push_back(CursorAction::PushMaskAndIncBy(ws));
             } else if let Some(s) = math_mode_at_cursor(cursor, source) {
                 actions.push_back(CursorAction::PushMaskAndIncBy(s));
             } else if let Some(s) = equation_at_cursor(cursor, source) {
@@ -53,6 +55,21 @@ impl harper_core::Masker for Masker {
 
         mask
     }
+}
+
+/// If the cursor is at a newline, mask the newline and any following whitespace (indentation).
+/// This prevents indentation at the start of lines from being grammar-checked.
+fn newline_whitespace_at_cursor(cursor: usize, source: &[char]) -> Option<usize> {
+    if source.get(cursor) != Some(&'\n') {
+        return None;
+    }
+    let ws_len = source[cursor..]
+        .iter()
+        .take_while(|&&c| c.is_whitespace())
+        .count();
+    // Only mask if there is actual indentation after the newline, not a bare line break.
+    // A bare \n between sentences should remain visible to preserve sentence boundaries.
+    if ws_len > 1 { Some(ws_len) } else { None }
 }
 
 /// Check whether there is a math mode block at the current cursor. If so, this function will return the amount cursor needs to be incremented by in order to escape the block.
@@ -241,6 +258,19 @@ mod tests {
     use super::{Masker, deconstruct_command};
 
     #[test]
+    fn does_not_mask_spaces_within_sentence() {
+        // Spaces between words (not before %) must remain in allowed spans
+        // so that lints like double-space detection can still fire.
+        let source: Vec<_> = "word  word".chars().collect();
+        let mask = Masker::default().create_mask(&source);
+        let allowed: String = mask
+            .iter_allowed(&source)
+            .flat_map(|(_, chars)| chars.iter().copied())
+            .collect();
+        assert_eq!(allowed, "word  word");
+    }
+
+    #[test]
     fn ignores_many_comment_signs() {
         let source: Vec<_> = "%%%".chars().collect();
         let mask = Masker::default().create_mask(&source);
@@ -270,6 +300,25 @@ mod tests {
         let mask = Masker::default().create_mask(&source);
 
         assert_eq!(mask.iter_allowed(&source).count(), 2)
+    }
+
+    #[test]
+    fn masks_indentation_before_item() {
+        let source: Vec<_> = "\\begin{itemize}\n  \\item Hello world.\n\\end{itemize}"
+            .chars()
+            .collect();
+        let mask = Masker::default().create_mask(&source);
+        let allowed: Vec<String> = mask
+            .iter_allowed(&source)
+            .map(|(_, chars)| chars.iter().collect::<String>())
+            .collect();
+        for span in &allowed {
+            let trimmed = span.trim();
+            assert!(
+                !trimmed.is_empty() || span.len() <= 1,
+                "Whitespace-only span with multiple spaces leaked through: {span:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->
Partly fixes https://github.com/Automattic/harper/issues/2901
the spacing before/after comment symbol `%` issue is not addressed yet.

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->
Fixes false-positives for indentation such as with
```
\begin{itemize}
    \item very long item that spills over
    into multiple lines
    \item other item
\end{itemize}
```
practically ignores all spaces after newline.
Prepared with assistance of an agent/LLM.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
Verified that the indentations no longer get flagged on an active tex file.
Added unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
