### PR TITLE
feat: ppl→people

### DIFF
--- a/harper-core/src/linting/expand_people.rs
+++ b/harper-core/src/linting/expand_people.rs
@@ -1,0 +1,88 @@
+use crate::{
+    Lint, Token, TokenStringExt,
+    expr::Expr,
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+    patterns::Word,
+};
+
+pub struct ExpandPeople {
+    expr: Word,
+}
+
+impl Default for ExpandPeople {
+    fn default() -> Self {
+        Self {
+            expr: Word::new_exact("ppl"),
+        }
+    }
+}
+
+impl ExprLinter for ExpandPeople {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        let span = toks.span()?;
+        let lint_kind = LintKind::Style;
+        let suggestions = vec![Suggestion::replace_with_match_case_str(
+            "people",
+            span.get_content(src),
+        )];
+        let message = "Use `people` instead of `ppl`.".to_string();
+        Some(Lint {
+            span,
+            lint_kind,
+            suggestions,
+            message,
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Expands the abbreviation `ppl` to the full word `people` for clarity."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    use super::ExpandPeople;
+
+    #[test]
+    fn fix_some_people() {
+        assert_suggestion_result(
+            "some ppl told my this problem from (ImGui_ImplWin32_WndProcHandler) and u need to add (WM_SIZE) but i don't know what should i do now :(",
+            ExpandPeople::default(),
+            "some people told my this problem from (ImGui_ImplWin32_WndProcHandler) and u need to add (WM_SIZE) but i don't know what should i do now :(",
+        );
+    }
+
+    #[test]
+    fn fix_all_people() {
+        assert_suggestion_result(
+            "Hi all, maybe all ppl with some experience on R, would know is not easy to debug or work with a language where there is no checks on types",
+            ExpandPeople::default(),
+            "Hi all, maybe all people with some experience on R, would know is not easy to debug or work with a language where there is no checks on types",
+        );
+    }
+
+    #[test]
+    fn dont_flag_protected_process_light() {
+        assert_no_lints(
+            "Processes started as an Anti Malware 'Protected Process-Light' (PPL) are restricted in what they can do, can only load signed code, but cannot be debugged",
+            ExpandPeople::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_paired_point_lifting() {
+        assert_no_lints(
+            "In this work, we present an alternative lightweight strategy called Paired-Point Lifting (PPL) for constructing 3D line clouds.",
+            ExpandPeople::default(),
+        );
+    }
+}

--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -69,6 +69,7 @@ use super::ever_every::EverEvery;
 use super::everyday::Everyday;
 use super::except_of::ExceptOf;
 use super::expand_memory_shorthands::ExpandMemoryShorthands;
+use super::expand_people::ExpandPeople;
 use super::expand_time_shorthands::ExpandTimeShorthands;
 use super::expr_linter::run_on_chunk;
 use super::far_be_it::FarBeIt;
@@ -660,6 +661,7 @@ impl LintGroup {
         insert_expr_rule!(Everyday, true);
         insert_expr_rule!(ExceptOf, true);
         insert_expr_rule!(ExpandMemoryShorthands, true);
+        insert_expr_rule!(ExpandPeople, true);
         insert_expr_rule!(ExpandTimeShorthands, true);
         insert_expr_rule!(FarBeIt, true);
         insert_expr_rule!(FascinatedBy, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -65,6 +65,7 @@ mod ever_every;
 mod everyday;
 mod except_of;
 mod expand_memory_shorthands;
+mod expand_people;
 mod expand_time_shorthands;
 mod expr_linter;
 mod far_be_it;


### PR DESCRIPTION
# Issues 
N/A

# Description

Testing my Harper YouTube comment linter I noticed "ppl" flagged when it's an abbreviation for "people".
I first implemented a simple Weir rule, but then I found that PPL is an extremely common initialism in the tech world. It seems Weir doesn't support case-sensitive matches, so I converted it to Rust.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Unit tests for both the abbreviation and to ensure initialisms in all caps are not also flagged.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
