### PR TITLE
fix: all to/too linters now use same `LintKind`

### DIFF
--- a/harper-core/src/linting/to_two_too/to_too_eos.rs
+++ b/harper-core/src/linting/to_two_too/to_too_eos.rs
@@ -38,7 +38,7 @@ impl Linter for ToTooEos {
 
                 Lint {
                     span: tok.span,
-                    lint_kind: LintKind::Typo,
+                    lint_kind: LintKind::WordChoice,
                     suggestions: vec![Suggestion::replace_with_match_case_str(
                         "too",
                         tok.get_ch(document.get_source()),

--- a/harper-core/src/linting/to_two_too/too_to.rs
+++ b/harper-core/src/linting/to_two_too/too_to.rs
@@ -48,7 +48,7 @@ impl ExprLinter for TooTo {
 
         Some(Lint {
             span,
-            lint_kind: LintKind::Typo,
+            lint_kind: LintKind::WordChoice,
             suggestions: vec![
                 Suggestion::replace_with_match_case("to".chars().collect(), text)
             ],


### PR DESCRIPTION
# Issues 
N/A

# Description

Of the 9 linters in the "too" vs "to" set, 7 used `WordChoice` and 2 used `Typo` as their `LintKind`.

A typo is a slip of the fingers like "teh" but the to/too mistake is more often made by people who genuinely don't know which word to use for which purpose. Hence `WordChoice` is more fitting than `Typo`.

Another way to address this could be to introduce a new `Homophones` `LintKind`.

# How Has This Been Tested?

`cargo test`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
