### PR TITLE
feat(cli): add `--format github` output for GitHub Actions annotations

### DIFF
--- a/harper-cli/src/lint.rs
+++ b/harper-cli/src/lint.rs
@@ -81,6 +81,8 @@ pub enum OutputFormat {
     Json,
     /// One line per lint, no source context.
     Compact,
+    /// GitHub Actions workflow commands (::warning / ::error annotations).
+    Github,
 }
 
 pub struct LintOptions {
@@ -99,6 +101,7 @@ enum ReportStyle {
     BriefCountsOnly,
     Json,
     Compact,
+    Github,
 }
 
 #[derive(Serialize)]
@@ -255,6 +258,7 @@ pub fn lint(
     let report_mode = match (lint_options.format, count) {
         (OutputFormat::Json, _) => ReportStyle::Json,
         (OutputFormat::Compact, _) => ReportStyle::Compact,
+        (OutputFormat::Github, _) => ReportStyle::Github,
         (OutputFormat::Default, true) => ReportStyle::BriefCountsOnly,
         (OutputFormat::Default, false) => ReportStyle::FullAriadne,
     };
@@ -347,7 +351,7 @@ pub fn lint(
         ReportStyle::Json => {
             println!("{}", serde_json::to_string_pretty(&json_results)?);
         }
-        ReportStyle::Compact => {}
+        ReportStyle::Compact | ReportStyle::Github => {}
         _ => {
             final_report(
                 dialect,
@@ -652,6 +656,31 @@ fn single_input_report(
                     lint.lint_kind,
                     rule_name,
                     lint.message
+                );
+            }
+        }
+        return;
+    }
+
+    // GitHub Actions workflow command format
+    // See: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-a-warning-message
+    if matches!(report_mode, ReportStyle::Github) {
+        let source_chars = doc.get_source();
+        for (rule_name, lints) in named_lints {
+            for lint in lints {
+                let (line, col) = char_index_to_line_col(source_chars, lint.span.start);
+                let (end_line, end_col) = char_index_to_line_col(source_chars, lint.span.end);
+                let file = input.plain_path();
+                let title = format!("{}::{}", lint.lint_kind, rule_name);
+                // Escape special characters in the message per GitHub Actions spec:
+                // '%' -> '%25', '\r' -> '%0D', '\n' -> '%0A'
+                let message = lint
+                    .message
+                    .replace('%', "%25")
+                    .replace('\r', "%0D")
+                    .replace('\n', "%0A");
+                println!(
+                    "::warning file={file},line={line},col={col},endLine={end_line},endColumn={end_col},title={title}::{message}",
                 );
             }
         }

--- a/harper-cli/tests/output_format.rs
+++ b/harper-cli/tests/output_format.rs
@@ -166,3 +166,85 @@ fn default_format_unchanged() {
         "default format should include lint count summary"
     );
 }
+
+#[test]
+fn github_format_emits_workflow_commands() {
+    let output = harper_cli()
+        .args(["--no-color", "lint", "--format", "github", BAD_INPUT])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(
+        !lines.is_empty(),
+        "github format should have at least one line"
+    );
+
+    for line in &lines {
+        assert!(
+            line.starts_with("::warning ") || line.starts_with("::error "),
+            "each github format line must start with ::warning or ::error, got: {line}"
+        );
+        assert!(
+            line.contains("file="),
+            "github format line must contain file= parameter: {line}"
+        );
+        assert!(
+            line.contains("line="),
+            "github format line must contain line= parameter: {line}"
+        );
+        assert!(
+            line.contains("col="),
+            "github format line must contain col= parameter: {line}"
+        );
+        assert!(
+            line.contains("title="),
+            "github format line must contain title= parameter: {line}"
+        );
+    }
+}
+
+#[test]
+fn github_format_no_ansi() {
+    let output = harper_cli()
+        .args(["lint", "--format", "github", BAD_INPUT])
+        .env_remove("NO_COLOR")
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains('\x1b'),
+        "github format output must not contain ANSI escapes"
+    );
+}
+
+#[test]
+fn github_directory_paths_no_ansi() {
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("bad.md");
+    {
+        let mut f = std::fs::File::create(&file_path).unwrap();
+        write!(f, "{BAD_INPUT}").unwrap();
+    }
+
+    let output = harper_cli()
+        .args(["lint", "--format", "github", dir.path().to_str().unwrap()])
+        .env_remove("NO_COLOR")
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains('\x1b'),
+        "github output for directories must not contain ANSI escapes"
+    );
+
+    for line in stdout.lines() {
+        assert!(
+            line.starts_with("::warning ") || line.starts_with("::error "),
+            "each line must be a workflow command: {line}"
+        );
+    }
+}


### PR DESCRIPTION
> **Disclaimer:** Parts of this PR were produced with assistance from an LLM (GitHub Copilot).

# Issues

Closes #3128

# Description

Add a new `github` variant to the `--format` flag for `harper-cli lint`. When used, each lint is emitted as a GitHub Actions workflow command:

```
::warning file={file},line={line},col={col},endLine={end_line},endColumn={end_col},title={kind}::{rule}::{message}
```

This enables inline annotations on pull requests when `harper-cli` is run inside a GitHub Actions workflow.

Special characters in messages are escaped per the [workflow commands spec](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-a-warning-message):
- `%` → `%25`
- `\r` → `%0D`
- `\n` → `%0A`

**Changes:**
- `harper-cli/src/lint.rs` — Added `Github` variant to `OutputFormat` and `ReportStyle` enums, wired up the report mode, and implemented the output logic.
- `harper-cli/tests/output_format.rs` — Added 3 integration tests: workflow command format validation, no ANSI escape leakage, and directory input handling.

# Demo

```bash
$ echo "This is an tset of the grammer checker." | harper-cli lint --format github
::warning file=<stdin>,line=1,col=9,endLine=1,endColumn=11,title=Grammar::AnA::Did you mean `a`?
::warning file=<stdin>,line=1,col=12,endLine=1,endColumn=16,title=Spelling::SpellCheck::Did you mean to spell `tset` this way?
::warning file=<stdin>,line=1,col=24,endLine=1,endColumn=31,title=Spelling::SpellCheck::Did you mean to spell `grammer` this way?
```

# How Has This Been Tested?

- All 12 existing + new tests pass (`cargo test -p harper-cli`)
- `cargo fmt` — no formatting issues
- `cargo clippy -p harper-cli -- -D warnings` — zero warnings
- Manual testing with stdin and file inputs

# Checklist
- [x] My code follows the conventions of this project
- [x] My commits follow [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) practices
- [x] I have tested my changes locally
