### PR TITLE
Copyright linter: stop flagging "copywriting" as a misspelling

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -676,7 +676,6 @@ pub fn lint_group() -> LintGroup {
             &[
                 (&["copywrite"], &["copyright"]),
                 (&["copywrites"], &["copyrights"]),
-                (&["copywriting"], &["copyrighting"]),
                 (&["copywritten", "copywrited", "copywrote"], &["copyrighted"]),
             ],
             "Did you mean `copyright`? `Copywrite` means to write copy (advertising text), while `copyright` is the legal right to control use of creative works.",


### PR DESCRIPTION
"Copywriting" is a legitimate English word for the profession of writing advertising or marketing copy. The `Copyright` phrase-set rule rewrote it to "copyrighting", producing false positives on sentences like *"one price for copywriting"* where the writer really meant the copy-writing trade.

This patch drops the `copywriting` -> `copyrighting` pair from the rule while keeping the other entries (`copywrite`, `copywrites`, `copywritten`, `copywrited`, `copywrote`), which remain valid corrections.

Fixes #3138