### PR TITLE
fix: "it damages the environment"

### DIFF
--- a/harper-core/src/linting/damages.rs
+++ b/harper-core/src/linting/damages.rs
@@ -93,7 +93,10 @@ impl ExprLinter for Damages {
                 can = CanPrecede::Noun;
             }
 
-            if prev_word.kind.is_auxiliary_verb() || prev_word.kind.is_subject_pronoun() {
+            if prev_word.kind.is_auxiliary_verb()
+                || (prev_word.kind.is_subject_pronoun()
+                    && prev_word.kind.is_third_person_singular_pronoun())
+            {
                 can = if can == CanPrecede::Noun {
                     CanPrecede::EitherNounOrVerb
                 } else {

--- a/harper-core/src/linting/damages.rs
+++ b/harper-core/src/linting/damages.rs
@@ -93,7 +93,7 @@ impl ExprLinter for Damages {
                 can = CanPrecede::Noun;
             }
 
-            if prev_word.kind.is_auxiliary_verb() {
+            if prev_word.kind.is_auxiliary_verb() || prev_word.kind.is_subject_pronoun() {
                 can = if can == CanPrecede::Noun {
                     CanPrecede::EitherNounOrVerb
                 } else {
@@ -296,5 +296,13 @@ mod tests {
             "It would be useful to be able to see asset-level damages after running FDA 2.0.",
             Damages::default(),
         );
+    }
+
+    // Issues reported on GitHub or Discord
+
+    // https://discord.com/channels/1335035237213671495/1491949288060751952/1491949288060751952
+    #[test]
+    fn ignore_it_damages_the_environment() {
+        assert_no_lints("it damages the environment", Damages::default());
     }
 }


### PR DESCRIPTION
# Issues 

No GitHub issue but this report on Discord: https://discord.com/channels/1335035237213671495/1491949288060751952/1491949288060751952

# Description

The linter was falsely flagging "it damages the environment".
The heuristic to determine if "damages" is being used as a noun or a verb has been enhanced to check if the preceding word is a 3rd person singular subject pronoun (he damages, she damages, it damages).

All the previous tests still pass and the sentence from the issue is no longer flagged.

There's a tiny chance I suppose of something like "caused it damages" but even "caused it damage" sounds unnatural so until we see it in the wild I think it's OK for now.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

A new unit test using the sentence in the Discord report.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
