### PR TITLE
PronounVerbAgreement: skip plural nouns to fix 'you guys' false positive

### DIFF
--- a/harper-core/src/linting/pronoun_verb_agreement.rs
+++ b/harper-core/src/linting/pronoun_verb_agreement.rs
@@ -217,6 +217,14 @@ where
             }
         }
 
+        // When a non-3p-singular pronoun is followed by a word that is both a
+        // plural noun and a verb form (e.g. "you guys", "they colors"), the noun
+        // reading is far more likely than the verb reading.  Skip the lint to
+        // avoid false positives on common constructions like "you guys".
+        if !is_3psg && verb_tok.kind.is_plural_noun() {
+            return None;
+        }
+
         let verb_span = verb_tok.span;
         let verb_chars = verb_tok.get_ch(src);
         let verb_str = verb_tok.get_str(src);


### PR DESCRIPTION
"Guys" is tagged as both a verb (to guide/steer) and a plural noun, so `PronounVerbAgreement` matched "you" (non-3p-singular pronoun) + "guys" (3p-singular verb form) and flagged agreement.

Skip the lint when the matched verb token is also a plural noun and the pronoun is non-third-person-singular, since the noun reading dominates in those constructions.

Fixes #3132