### PR TITLE
fix(dict): remove stale ElasticSearch entry in favour of Elasticsearch

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -53842,7 +53842,6 @@ ESP32/Og            # microcontroller family
 ESP8266/Og          # microcontroller family
 EV/NSg              # electric vehicle
 EXIF                # metadata
-ElasticSearch/Sg
 Electron/Og         # web-tech framework for desktop apps
 Elon/Og
 Erdoğan/Og          # surname, Turkish politician


### PR DESCRIPTION
# Issues 
N/A

# Description
 The dictionary contained two entries for the same word:
 - `Elasticsearch/g` (line 3153) — correct modern spelling
 - `ElasticSearch/Sg` (line 53845) — old branding

 Since `WordId` is hashed from the lowercase form, both map to the
 same key. The second entry was inserted after the first and overwrote
 the canonical spelling, causing Harper to suggest `ElasticSearch`
 instead of the correct `Elasticsearch`.

 Removes the stale `ElasticSearch/Sg` entry so the canonical spelling
 reflects Elastic's current branding.

# Demo
<img width="1655" height="42" alt="image" src="https://github.com/user-attachments/assets/f8fa7e22-1114-4ff2-93da-5b7e1a10672d" />

# How Has This Been Tested?
`just check`

# Checklist

- [x] I have performed a self-review of my own code
- [] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
