### PR TITLE
config: return defaults when LSP settings is null or non-object

### DIFF
--- a/harper-ls/src/config.rs
+++ b/harper-ls/src/config.rs
@@ -89,7 +89,10 @@ impl Config {
         let workspace_root = workspace_root.as_path();
 
         let Value::Object(value) = value else {
-            bail!("Settings must be an object.");
+            // Some editors (e.g. Kate) send null or a non-object value on
+            // workspace/didChangeConfiguration.  Treat this the same as
+            // an empty settings object — return defaults rather than erroring.
+            return Ok(base);
         };
 
         let Some(Value::Object(value)) = value.get("harper-ls") else {


### PR DESCRIPTION
Some editors (e.g. Kate) send `null` or a non-object value as `params.settings` on `workspace/didChangeConfiguration`. The LSP spec allows this — it just means the client has no settings to push. Previously `from_lsp_config` bailed with *"Settings must be an object"*, which caused `harper-ls` to fail on startup in Kate.

Return the default config instead of erroring when the value is not a JSON object.

Fixes #3151