### PR TITLE
fix(core): address several outstanding issues

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -1221,6 +1221,13 @@
 						},
 						{
 							"Bool": {
+								"name": "Payed",
+								"state": true,
+								"label": "Payed"
+							}
+						},
+						{
+							"Bool": {
 								"name": "RiseTheQuestion",
 								"state": true,
 								"label": "Rise The Question"

--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -4978,6 +4978,13 @@
 						},
 						{
 							"Bool": {
+								"name": "FindOut",
+								"state": true,
+								"label": "Find Out"
+							}
+						},
+						{
+							"Bool": {
 								"name": "GoSoFarAsTo",
 								"state": true,
 								"label": "Go So Far As To"

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -38465,7 +38465,6 @@ pay's
 payback/NmSg
 paycheck/~NgS
 payday/NgS
-payed/V
 payee/NSg
 payer/NSg
 payload/~NSg

--- a/harper-core/src/document.rs
+++ b/harper-core/src/document.rs
@@ -418,6 +418,8 @@ impl Document {
                             | Some(Punctuation::OpenRound)
                             | Some(Punctuation::OpenSquare)
                             | Some(Punctuation::OpenCurly)
+                            | Some(Punctuation::EmDash)
+                            | Some(Punctuation::EnDash)
                             | Some(Punctuation::Apostrophe)
                     );
 

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -728,7 +728,6 @@ impl LintGroup {
         insert_expr_rule!(WasAloud, true);
         insert_expr_rule!(WayTooAdjective, true);
         insert_expr_rule!(WellEducated, true);
-        insert_expr_rule!(WereWhere, true);
         insert_expr_rule!(Whereas, true);
         insert_expr_rule!(WhomSubjectOfVerb, true);
         insert_expr_rule!(WidelyAccepted, true);
@@ -759,6 +758,10 @@ impl LintGroup {
         // Uses Sentence rather than Chunk
         out.add("PluralDecades", PluralDecades::default());
         out.config.set_rule_enabled("PluralDecades", true);
+
+        // Uses Sentence rather than Chunk
+        out.add("WereWhere", WereWhere::default());
+        out.config.set_rule_enabled("WereWhere", true);
 
         // Uses Dictionary and Dialect
         out.add("SpellCheck", SpellCheck::new(dictionary.clone(), dialect));

--- a/harper-core/src/linting/lint_group/structured_config/mod.rs
+++ b/harper-core/src/linting/lint_group/structured_config/mod.rs
@@ -116,9 +116,34 @@ impl Setting {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
+    use crate::Dialect;
     use crate::linting::FlatConfig;
+    use crate::linting::LintGroup;
+    use crate::spell::MutableDictionary;
 
     use super::{Setting, StructuredConfig};
+
+    fn collect_rule_names(config: &StructuredConfig) -> BTreeSet<String> {
+        let mut out = BTreeSet::new();
+
+        for setting in &config.settings {
+            match setting {
+                Setting::Bool { name, .. } => {
+                    out.insert(name.clone());
+                }
+                Setting::OneOfMany { names, .. } => {
+                    out.extend(names.iter().cloned());
+                }
+                Setting::Group { child, .. } => {
+                    out.extend(collect_rule_names(child));
+                }
+            }
+        }
+
+        out
+    }
 
     #[test]
     fn validates_bool_true() {
@@ -282,5 +307,33 @@ mod tests {
     #[test]
     fn curated_is_valid() {
         assert!(StructuredConfig::curated().validate());
+    }
+
+    #[test]
+    fn curated_default_config_lists_every_registered_rule() {
+        let curated = StructuredConfig::curated();
+        let curated_rule_names = collect_rule_names(&curated);
+
+        let runtime_rule_names =
+            LintGroup::new_curated(MutableDictionary::new().into(), Dialect::American)
+                .iter_keys()
+                .map(str::to_owned)
+                .collect::<BTreeSet<_>>();
+
+        let missing_from_default_config = runtime_rule_names
+            .difference(&curated_rule_names)
+            .cloned()
+            .collect::<Vec<_>>();
+        let extra_in_default_config = curated_rule_names
+            .difference(&runtime_rule_names)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        assert!(
+            missing_from_default_config.is_empty() && extra_in_default_config.is_empty(),
+            "default_config.json drifted from the registered rule set\nmissing from default_config.json: {:?}\nextra in default_config.json: {:?}\nDid you forget to add the missing rule(s) to default_config.json?",
+            missing_from_default_config,
+            extra_in_default_config,
+        );
     }
 }

--- a/harper-core/src/linting/missing_to.rs
+++ b/harper-core/src/linting/missing_to.rs
@@ -1,6 +1,6 @@
 use harper_brill::UPOS;
 
-use crate::linting::expr_linter::Chunk;
+use crate::linting::expr_linter::{Chunk, followed_by_word, preceded_by_word};
 use crate::{
     Token,
     expr::{Expr, ExprMap, SequenceExpr},
@@ -252,13 +252,28 @@ impl ExprLinter for MissingTo {
         &self.map
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint_with_context(
+        &self,
+        matched_tokens: &[Token],
+        source: &[char],
+        context: Option<(&[Token], &[Token])>,
+    ) -> Option<Lint> {
         let offending_idx = *self.map.lookup(0, matched_tokens, source)?;
         let controller = &matched_tokens[offending_idx];
         let span = controller.span;
 
         let controller_text = controller.get_str(source).to_lowercase();
         let controller_text = controller_text.as_str();
+
+        if controller.kind.is_verb()
+            && controller.kind.is_adjective()
+            && preceded_by_word(context, |tok| tok.kind.is_nominal())
+            && followed_by_word(context, |tok| {
+                tok.kind.is_auxiliary_verb() || tok.kind.is_adverb()
+            })
+        {
+            return None;
+        }
 
         let is_adjective_controller = matches!(controller_text, "eager" | "inclined" | "ready");
 
@@ -529,6 +544,15 @@ mod tests {
     fn no_lint_delays_meant_decisions() {
         assert_lint_count(
             "The delays meant decisions were often made on outdated information, hindering agility and potentially impacting return on investment.",
+            MissingTo::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn no_lint_reduced_relative_clause_after_participle() {
+        assert_lint_count(
+            "The techniques learned would probably not change much with resolution so 480i would seem almost as usable for educational use as 8K video.",
             MissingTo::default(),
             0,
         );

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -683,6 +683,15 @@ pub fn lint_group() -> LintGroup {
             "Corrects `copywrite` to `copyright`. `Copywrite` refers to writing copy, while `copyright` is the legal right to creative works.",
             LintKind::WordChoice
         ),
+        "Payed" => (
+            &[
+                (&["payed"], &["paid"]),
+                (&["overpayed"], &["overpaid"]),
+            ],
+            "Use `paid` or `overpaid` here. `Payed` is a rare nautical spelling.",
+            "Corrects `payed` to `paid` and `overpayed` to `overpaid`.",
+            LintKind::Spelling
+        ),
         "DateBackFrom" => (
             &[
                 (&["date back from"], &["date from", "date back to"]),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -2199,6 +2199,26 @@ fn copywrote() {
     );
 }
 
+// Payed
+
+#[test]
+fn correct_payed() {
+    assert_suggestion_result(
+        "He payed the bill yesterday.",
+        lint_group(),
+        "He paid the bill yesterday.",
+    );
+}
+
+#[test]
+fn correct_overpayed() {
+    assert_suggestion_result(
+        "He overpayed in part to have the specification met.",
+        lint_group(),
+        "He overpaid in part to have the specification met.",
+    );
+}
+
 // DateBackFrom
 
 #[test]

--- a/harper-core/src/linting/unclosed_quotes.rs
+++ b/harper-core/src/linting/unclosed_quotes.rs
@@ -30,3 +30,22 @@ impl Linter for UnclosedQuotes {
         "Quotation marks should always be closed. Unpaired quotation marks are a hallmark of sloppy work."
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::UnclosedQuotes;
+    use crate::linting::tests::{assert_lint_count, assert_no_lints};
+
+    #[test]
+    fn allows_dialogue_with_em_dash_interruption() {
+        assert_no_lints(
+            "\"It'll be our\"—she leaned to his ear—\"shared secret.\"",
+            UnclosedQuotes::default(),
+        );
+    }
+
+    #[test]
+    fn still_flags_unclosed_quotes() {
+        assert_lint_count("\"It'll be our", UnclosedQuotes::default(), 1);
+    }
+}

--- a/harper-core/src/linting/weir_rules/FindOut.weir
+++ b/harper-core/src/linting/weir_rules/FindOut.weir
@@ -1,0 +1,28 @@
+expr phrase (find out)
+expr main <(@phrase ![about, by, from, how, if, more, that, what, when, where, whether, who, whom, whose, why, through, via, ., ?, :, ;, -, –, —, (,)]), @phrase>
+
+let message "Use `find` instead of `find out` when you mean to discover something directly."
+let description "Flags `find out` when a plain `find` is the better choice."
+let kind "WordChoice"
+let becomes "find"
+let strategy "MatchCase"
+
+# True positives
+test "I need to find out ways to do the work that I want to do while walking." "I need to find ways to do the work that I want to do while walking."
+test "We should find out the answer." "We should find the answer."
+test "They will find out latest supported hugo version." "They will find latest supported hugo version."
+test "Can you find out plain text of given cipher text?" "Can you find plain text of given cipher text?"
+test "Please find out number of bits read from a file." "Please find number of bits read from a file."
+test "I wanted to find out branch coverage." "I wanted to find branch coverage."
+test "She tried to find out the proper query." "She tried to find the proper query."
+test "Find out latest supported version?" "Find latest supported version?"
+
+# True negatives
+allows "I need to find out what time the meeting starts."
+allows "We need to find out whether it works."
+allows "She found out that the server was down."
+allows "Can you find out if the build passed?"
+allows "We find out about the surprise party."
+allows "I need to find out more about the topic."
+allows "They were able to find out from the logs."
+allows "I asked them to find out why it failed."

--- a/harper-core/src/linting/were_where.rs
+++ b/harper-core/src/linting/were_where.rs
@@ -1,6 +1,6 @@
 use harper_brill::UPOS;
 
-use crate::linting::expr_linter::Chunk;
+use crate::linting::expr_linter::Sentence;
 use crate::{
     CharStringExt, Token, TokenKind,
     expr::{Expr, SequenceExpr},
@@ -32,6 +32,13 @@ impl Default for WereWhere {
             .t_ws()
             .then(UPOSSet::new(&[UPOS::VERB, UPOS::AUX, UPOS::ADJ]));
 
+        // "where you ..." can be a typo for "were you ..." when it starts a question.
+        let where_you_verb = SequenceExpr::aco("where")
+            .t_ws()
+            .t_aco("you")
+            .t_ws()
+            .then(UPOSSet::new(&[UPOS::VERB, UPOS::AUX, UPOS::ADJ]));
+
         // === were → where ===
 
         // A verb of cognition or motion followed directly by "were" and then a
@@ -53,6 +60,7 @@ impl Default for WereWhere {
             expr: SequenceExpr::any_of(vec![
                 Box::new(unambiguous_pronoun_where),
                 Box::new(you_where_verb),
+                Box::new(where_you_verb),
                 Box::new(verb_were_clause),
             ]),
         }
@@ -60,13 +68,18 @@ impl Default for WereWhere {
 }
 
 impl ExprLinter for WereWhere {
-    type Unit = Chunk;
+    type Unit = Sentence;
 
     fn expr(&self) -> &dyn Expr {
         &self.expr
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint_with_context(
+        &self,
+        toks: &[Token],
+        src: &[char],
+        context: Option<(&[Token], &[Token])>,
+    ) -> Option<Lint> {
         const WHERE: &[char] = &['w', 'h', 'e', 'r', 'e'];
         const WERE: &[char] = &['w', 'e', 'r', 'e'];
 
@@ -81,6 +94,9 @@ impl ExprLinter for WereWhere {
         });
 
         if let Some(tok) = where_tok {
+            if !crate::linting::expr_linter::at_start_of_sentence(context) {
+                return None;
+            }
             Some(Lint {
                 span: tok.span,
                 lint_kind: LintKind::Typo,
@@ -263,6 +279,15 @@ mod tests {
         );
     }
 
+    #[test]
+    fn fix_where_you_able() {
+        assert_suggestion_result(
+            "Where you able to make forward progress here?",
+            WereWhere::default(),
+            "Were you able to make forward progress here?",
+        );
+    }
+
     // ── were → where: more verbs and pronouns ────────────────────────────────
 
     #[test]
@@ -366,6 +391,27 @@ mod tests {
     fn no_flag_showed_me_where() {
         // Object pronoun "me" sits between "showed" and "where" — no direct adjacency
         assert_no_lints("He showed me where the exit was.", WereWhere::default());
+    }
+
+    #[test]
+    fn no_flag_where_you_go() {
+        assert_no_lints("I wonder where you go from here.", WereWhere::default());
+    }
+
+    #[test]
+    fn no_flag_where_you_can_customize() {
+        assert_no_lints(
+            "Click the menu item where you can customize the settings.",
+            WereWhere::default(),
+        );
+    }
+
+    #[test]
+    fn no_flag_where_you_allocate() {
+        assert_no_lints(
+            "Use the panel where you allocate resources for the task.",
+            WereWhere::default(),
+        );
     }
 
     // ── known limitations (documented but not yet handled) ───────────────────

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -1048,21 +1048,6 @@ Message: |
 
 
 
-Lint:    Formatting (255 priority)
-Message: |
-     659 | Next came an angry voice—the Rabbit’s—“Pat! Pat! Where are you?” And then a
-         |                                       ^ This quote has no termination.
-
-
-
-Lint:    Formatting (255 priority)
-Message: |
-     659 | Next came an angry voice—the Rabbit’s—“Pat! Pat! Where are you?” And then a
-         |                                                                ^ This quote has no termination.
-     660 | voice she had never heard before, “Sure then I’m here! Digging for apples, yer
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
      668 | “Sure, it’s an arm, yer honour!” (He pronounced it “arrum.”)
@@ -1111,13 +1096,6 @@ Suggest:
 
 
 
-Lint:    Formatting (255 priority)
-Message: |
-     692 | below!” (a loud crash)—“Now, who did that?—It was Bill, I fancy—Who’s to go down
-         |                        ^ This quote has no termination.
-
-
-
 Lint:    Capitalization (31 priority)
 Message: |
      692 | below!” (a loud crash)—“Now, who did that?—It was Bill, I fancy—Who’s to go down
@@ -1137,13 +1115,6 @@ Suggest:
 
 
 
-Lint:    Formatting (255 priority)
-Message: |
-     694 | down—Here, Bill! the master says you’re to go down the chimney!”
-         |                                                                ^ This quote has no termination.
-
-
-
 Lint:    Readability (127 priority)
 Message: |
      701 | She drew her foot as far down the chimney as she could, and waited till she
@@ -1154,37 +1125,6 @@ Message: |
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      704 | is Bill,” she gave one sharp kick, and waited to see what would happen next.
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 58 words long.
-
-
-
-Lint:    Formatting (255 priority)
-Message: |
-     706 | The first thing she heard was a general chorus of “There goes Bill!” then the
-     707 | Rabbit’s voice along—“Catch him, you by the hedge!” then silence, and then
-         |                      ^ This quote has no termination.
-
-
-
-Lint:    Formatting (255 priority)
-Message: |
-     707 | Rabbit’s voice along—“Catch him, you by the hedge!” then silence, and then
-         |                                                   ^ This quote has no termination.
-     708 | another confusion of voices—“Hold up his head—Brandy now—Don’t choke him—How was
-
-
-
-Lint:    Formatting (255 priority)
-Message: |
-     707 | Rabbit’s voice along—“Catch him, you by the hedge!” then silence, and then
-     708 | another confusion of voices—“Hold up his head—Brandy now—Don’t choke him—How was
-         |                             ^ This quote has no termination.
-
-
-
-Lint:    Formatting (255 priority)
-Message: |
-     709 | it, old fellow? What happened to you? Tell us all about it!”
-         |                                                            ^ This quote has no termination.
 
 
 
@@ -1733,6 +1673,15 @@ Message: |
 
 
 
+Lint:    WordChoice (31 priority)
+Message: |
+    1394 | “Do you mean that you think you can find out the answer to it?” said the March
+         |                                     ^~~~~~~~ Use `find` instead of `find out` when you mean to discover something directly.
+Suggest:
+  - Replace with: “find”
+
+
+
 Lint:    Miscellaneous (31 priority)
 Message: |
     1415 | dropped, and the party sat silent for a minute, while Alice thought over all she
@@ -1763,6 +1712,14 @@ Suggest:
 
 
 
+Lint:    Formatting (255 priority)
+Message: |
+    1497 | The Hatter shook his head mournfully. “Not I!” he replied. “We quarrelled last
+         |                                                            ^ This quote has no termination.
+    1498 | March—just before he went mad, you know—” (pointing with his tea spoon at the
+
+
+
 Lint:    WordChoice (63 priority)
 Message: |
     1498 | March—just before he went mad, you know—” (pointing with his tea spoon at the
@@ -1770,14 +1727,6 @@ Message: |
     1499 | March Hare,) “—it was at the great concert given by the Queen of Hearts, and I
 Suggest:
   - Replace with: “teaspoon”
-
-
-
-Lint:    Formatting (255 priority)
-Message: |
-    1498 | March—just before he went mad, you know—” (pointing with his tea spoon at the
-    1499 | March Hare,) “—it was at the great concert given by the Queen of Hearts, and I
-         |              ^ This quote has no termination.
 
 
 
@@ -2584,22 +2533,6 @@ Message: |
 
 
 
-Lint:    Formatting (255 priority)
-Message: |
-    2252 | “You may not have lived much under the sea—” (“I haven’t,” said Alice)—“and
-         |                                                                        ^ This quote has no termination.
-    2253 | perhaps you were never even introduced to a lobster—” (Alice began to say “I
-
-
-
-Lint:    Formatting (255 priority)
-Message: |
-    2253 | perhaps you were never even introduced to a lobster—” (Alice began to say “I
-         |                                                     ^ This quote has no termination.
-    2254 | once tasted—” but checked herself hastily, and said “No, never”) “—so you can
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
     2259 | “Why,” said the Gryphon, “you first form into a line along the sea-shore—”
@@ -2731,22 +2664,6 @@ Suggest:
   - Replace with: “Din”
   - Replace with: “Dine”
   - Replace with: “Diann”
-
-
-
-Lint:    Formatting (255 priority)
-Message: |
-    2343 | here the Mock Turtle yawned and shut his eyes.—“Tell her about the reason and
-         |                                                ^ This quote has no termination.
-    2344 | all that,” he said to the Gryphon.
-
-
-
-Lint:    Formatting (255 priority)
-Message: |
-    2343 | here the Mock Turtle yawned and shut his eyes.—“Tell her about the reason and
-    2344 | all that,” he said to the Gryphon.
-         |          ^ This quote has no termination.
 
 
 
@@ -3383,22 +3300,6 @@ Message: |
 
 
 
-Lint:    Formatting (255 priority)
-Message: |
-    2513 | so good, that it made Alice quite hungry to look at them—“I wish they’d get the
-         |                                                          ^ This quote has no termination.
-    2514 | trial done,” she thought, “and hand round the refreshments!” But there seemed to
-
-
-
-Lint:    Formatting (255 priority)
-Message: |
-    2513 | so good, that it made Alice quite hungry to look at them—“I wish they’d get the
-    2514 | trial done,” she thought, “and hand round the refreshments!” But there seemed to
-         |            ^ This quote has no termination.
-
-
-
 Lint:    Readability (127 priority)
 Message: |
     2523 | The judge, by the way, was the King; and as he wore his crown over the wig,
@@ -3605,21 +3506,6 @@ Lint:    Formatting (255 priority)
 Message: |
     2886 | > from all the rest, Between yourself and me.”
          |                                              ^ This quote has no termination.
-
-
-
-Lint:    Formatting (255 priority)
-Message: |
-    2900 | spreading out the verses on his knee, and looking at them with one eye; “I seem
-         |                                                                         ^ This quote has no termination.
-    2901 | to see some meaning in them, after all. “—said I could not swim—” you can’t
-
-
-
-Lint:    Formatting (255 priority)
-Message: |
-    2902 | swim, can you?” he added, turning to the Knave.
-         |               ^ This quote has no termination.
 
 
 

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -504,6 +504,13 @@ Message: |
 
 
 
+Lint:    Formatting (255 priority)
+Message: |
+     392 | “This idea is that we’re Nordics. I am, and you are, and you are, and—” After an
+         | ^ This quote has no termination.
+
+
+
 Lint:    Style (31 priority)
 Message: |
      394 | me again. ‘‘—And we’ve produced all the things that go to make civilization—oh,
@@ -511,13 +518,6 @@ Message: |
          | ^~~~~~~ An Oxford comma is necessary here.
 Suggest:
   - Insert “,”
-
-
-
-Lint:    Formatting (255 priority)
-Message: |
-     395 | science and art, and all that. Do you see?”
-         |                                           ^ This quote has no termination.
 
 
 
@@ -558,7 +558,7 @@ Suggest:
 Lint:    Formatting (255 priority)
 Message: |
      452 | “Why—” she said hesitantly, ‘‘Tom’s got some woman in New York.”
-         |                                                                ^ This quote has no termination.
+         | ^ This quote has no termination.
 
 
 
@@ -5517,21 +5517,6 @@ Message: |
 
 
 
-Lint:    Formatting (255 priority)
-Message: |
-    4201 | sometimes”—but there was no laughter in his eyes—“to think that you didn’t
-         |                                                  ^ This quote has no termination.
-    4202 | know.”
-
-
-
-Lint:    Formatting (255 priority)
-Message: |
-    4202 | know.”
-         |      ^ This quote has no termination.
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
     4241 | “Not at Kapiolani?” demanded Tom suddenly.
@@ -6130,14 +6115,6 @@ Suggest:
 
 
 
-Lint:    Formatting (255 priority)
-Message: |
-    4509 | “One goin’ each way. Well, she”—his hand rose toward the blankets but stopped
-    4510 | half way and fell to his side—“she ran out there an’ the one comin’ from N’York
-         |                               ^ This quote has no termination.
-
-
-
 Lint:    Miscellaneous (31 priority)
 Message: |
     4510 | half way and fell to his side—“she ran out there an’ the one comin’ from N’York
@@ -6200,13 +6177,6 @@ Message: |
          |                       ^~~~ `goin` should probably be written as `go in`.
 Suggest:
   - Replace with: “go in”
-
-
-
-Lint:    Formatting (255 priority)
-Message: |
-    4511 | knock right into her, goin’ thirty or forty miles an hour.”
-         |                                                           ^ This quote has no termination.
 
 
 
@@ -6376,6 +6346,15 @@ Message: |
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     4818 | hot struggles of the poor.
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 53 words long.
+
+
+
+Lint:    WordChoice (31 priority)
+Message: |
+    4820 | “I can’t describe to you how surprised I was to find out I loved her, old sport.
+         |                                                 ^~~~~~~~ Use `find` instead of `find out` when you mean to discover something directly.
+Suggest:
+  - Replace with: “find”
 
 
 
@@ -6751,21 +6730,6 @@ Message: |
     5147 | fantastic shapes and scurried here and there in the faint dawn wind.
 Suggest:
   - Replace with: “ash heaps”
-
-
-
-Lint:    Formatting (255 priority)
-Message: |
-    5151 | and walked to the rear window and leaned with his face pressed against it—“and I
-         |                                                                           ^ This quote has no termination.
-    5152 | said ‘God knows what you’ve been doing, everything you’ve been doing. You may
-
-
-
-Lint:    Formatting (255 priority)
-Message: |
-    5153 | fool me, but you can’t fool God!’”
-         |                                  ^ This quote has no termination.
 
 
 
@@ -7469,21 +7433,6 @@ Suggest:
 
 
 
-Lint:    Formatting (255 priority)
-Message: |
-    5522 | of mine up to Albany. We were so thick like that in everything”—he held up two
-    5523 | bulbous fingers—“always together.”
-         |                 ^ This quote has no termination.
-
-
-
-Lint:    Formatting (255 priority)
-Message: |
-    5523 | bulbous fingers—“always together.”
-         |                                  ^ This quote has no termination.
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
     5552 | For a moment I thought he was going to suggest a “gonnegtion,” but he only
@@ -7940,20 +7889,6 @@ Lint:    Formatting (255 priority)
 Message: |
     5723 | for me, and I felt a little dizzy for a while.”
          |                                               ^ This quote has no termination.
-
-
-
-Lint:    Formatting (255 priority)
-Message: |
-    5727 | “Oh, and do you remember”—she added—“a conversation we had once about driving a
-         |                                     ^ This quote has no termination.
-
-
-
-Lint:    Formatting (255 priority)
-Message: |
-    5728 | car?”
-         |     ^ This quote has no termination.
 
 
 


### PR DESCRIPTION
# Issues
- Fixes #2917
- Fixes #2952
- Fixes #3129
- Fixes #3140
- Fixes #3155

# Description
This batch fixes five recently reported lint issues in `harper-core`.

Changes made:
- Tightened `WereWhere` so it runs at sentence scope and only reports `where you ...` at sentence start.
- Rewrote `FindOut` as a Weir rule with tests and enabled it in the curated default config.
- Refined `MissingTo` to avoid a reduced-relative-clause false positive.
- Updated quote handling so em dash and en dash dialogue interruptions do not trigger `UnclosedQuotes`.
- Removed the dictionary entry for `payed` and added phrase-set corrections for `payed` and `overpayed`.

I also updated the snapshot fixtures affected by the rule changes.

# Demo
N/A

# How Has This Been Tested?
- `cargo fmt --all`
- `cargo test -p harper-core --lib were_where -- --nocapture`
- `cargo test -p harper-core --lib run_tests_for_find_out -- --nocapture`
- `target/debug/harper-cli test harper-core/src/linting/weir_rules/FindOut.weir`
- `cargo test -p harper-core --test linters`
- `cargo build -p harper-cli`
- `PATH="/tmp/fakebin:$PATH" bash -lc 'cd ~/Projects/harper-llm-fuzz && ./check.sh WereWhere'`
- `just check-rust`
- `just test-rust`

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
