### PR TITLE
fix: Add `Payed` rule entry to default config JSON

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -1221,6 +1221,13 @@
 						},
 						{
 							"Bool": {
+								"name": "Payed",
+								"state": true,
+								"label": "Payed"
+							}
+						},
+						{
+							"Bool": {
 								"name": "RiseTheQuestion",
 								"state": true,
 								"label": "Rise The Question"


### PR DESCRIPTION
# Issues 

#3169

# Description

Adds a default config entry for `Payed` to the JSON file

Let me know if this is the right / wrong way to submit a PR to a PR - or if this is something that shouldn't be done

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`just test-obsidian`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
