### PR TITLE
fix: don't flag "should soft-fork"

### DIFF
--- a/harper-core/src/linting/modal_be_adjective.rs
+++ b/harper-core/src/linting/modal_be_adjective.rs
@@ -3,7 +3,7 @@ use crate::{
     expr::{Expr, SequenceExpr},
     linting::{
         ExprLinter, Suggestion,
-        expr_linter::{Chunk, followed_by_word},
+        expr_linter::{Chunk, followed_by_hyphen, followed_by_word},
     },
     patterns::ModalVerb,
 };
@@ -54,7 +54,8 @@ impl ExprLinter for ModalBeAdjective {
                     .get_ch(src)
                     .eq_any_ignore_ascii_case_str(&["at", "by", "if"]))
                 || (toks.last().unwrap().get_ch(src).eq_str("kind") && nw.get_ch(src).eq_str("of"))
-        }) {
+        }) || followed_by_hyphen(ctx)
+        {
             return None;
         }
 
@@ -144,6 +145,14 @@ mod tests {
         );
         assert_no_lints(
             "some older software (filezilla on debian-stable) cannot passive-mode with TLS",
+            ModalBeAdjective::default(),
+        );
+    }
+
+    #[test]
+    fn ignore_soft_fork_3168() {
+        assert_no_lints(
+            "You should soft-fork the repository.",
             ModalBeAdjective::default(),
         );
     }


### PR DESCRIPTION
# Issues 
Fixes #3168

# Description

`ModalBeAdjective` was flagging hyphenated compound verbs whose first part was an adjective.
It now checks for a hyphen after the adjective.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

The example from the issue has been used for a new unit test.
`cargo test`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
