### PR TITLE
feat: add SolveFor lint rule

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -4013,6 +4013,13 @@
 						},
 						{
 							"Bool": {
+								"name": "SolveFor",
+								"state": true,
+								"label": "Solve For"
+							}
+						},
+						{
+							"Bool": {
 								"name": "SomethingIs",
 								"state": true,
 								"label": "Something Is"

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -195,6 +195,7 @@ use super::simple_past_to_past_participle::SimplePastToPastParticiple;
 use super::since_duration::SinceDuration;
 use super::single_be::SingleBe;
 use super::sneaked_snuck::SneakedSnuck;
+use super::solve_for::SolveFor;
 use super::some_without_article::SomeWithoutArticle;
 use super::something_is::SomethingIs;
 use super::somewhat_something::SomewhatSomething;
@@ -683,6 +684,7 @@ impl LintGroup {
         insert_expr_rule!(SinceDuration, true);
         insert_expr_rule!(SingleBe, true);
         insert_struct_rule!(SneakedSnuck, true);
+        insert_expr_rule!(SolveFor, true);
         insert_expr_rule!(SomeWithoutArticle, true);
         insert_expr_rule!(SomethingIs, true);
         insert_expr_rule!(SomewhatSomething, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -206,6 +206,7 @@ mod simple_past_to_past_participle;
 mod since_duration;
 mod single_be;
 mod sneaked_snuck;
+mod solve_for;
 mod some_without_article;
 mod something_is;
 mod somewhat_something;

--- a/harper-core/src/linting/solve_for.rs
+++ b/harper-core/src/linting/solve_for.rs
@@ -166,7 +166,6 @@ mod tests {
 
     #[test]
     fn issue_613_solve_for_this_issue() {
-        // "How can i solve for this issue with the logical flow"
         assert_suggestion_result(
             "How can I solve for this issue with the logical flow?",
             SolveFor::default(),
@@ -176,7 +175,6 @@ mod tests {
 
     #[test]
     fn issue_613_solve_for_the_problem_email() {
-        // "Can you help me solve for the problem email message"
         assert_suggestion_result(
             "Can you help me solve for the problem email message?",
             SolveFor::default(),
@@ -186,7 +184,6 @@ mod tests {
 
     #[test]
     fn issue_613_solve_for_the_wrong_problem() {
-        // "when you solve for the wrong problem not only do you not get the solution"
         assert_suggestion_result(
             "When you solve for the wrong problem you miss the solution.",
             SolveFor::default(),
@@ -196,7 +193,6 @@ mod tests {
 
     #[test]
     fn issue_613_solve_for_this_git_problem() {
-        // "this is a how to solve for this git problem: fatal: unable ..."
         assert_suggestion_result(
             "This is how to solve for this git problem.",
             SolveFor::default(),
@@ -205,9 +201,8 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // "solved for because" — no determiner after "for", linter doesn't match this pattern
+    #[ignore = "\"solved for because\" — no determiner after \"for\", linter doesn't match this pattern"]
     fn issue_613_solved_for_because() {
-        // "this has already been solved for because the ad520 also has its own ways"
         assert_suggestion_result(
             "This has already been solved for because the ad520 has its own ways.",
             SolveFor::default(),
@@ -216,9 +211,8 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // "solve for" at end of clause — no determiner follows, linter can't detect this
+    #[ignore = "\"solve for\" at end of clause — no determiner follows, linter can't detect this"]
     fn issue_613_solve_for_end_of_clause() {
-        // "the actual word that you couldn't solve for"
         assert_suggestion_result(
             "The word that you couldn't solve for.",
             SolveFor::default(),

--- a/harper-core/src/linting/solve_for.rs
+++ b/harper-core/src/linting/solve_for.rs
@@ -1,0 +1,103 @@
+use crate::{
+    Lint, Token, TokenStringExt,
+    expr::{Expr, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+};
+
+pub struct SolveFor {
+    expr: SequenceExpr,
+}
+
+impl Default for SolveFor {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::word_set(&["solve", "solved", "solves", "solving"])
+                .t_ws()
+                .t_aco("for")
+                .t_ws()
+                .then_word_set(&[
+                    "the", "a", "an", "this", "that", "my", "your", "his", "her", "its", "our",
+                    "their", "these", "those", "any", "some",
+                ]),
+        }
+    }
+}
+
+impl ExprLinter for SolveFor {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        // toks: [solve(0), ws(1), "for"(2), ws(3), article(4)]
+        // Remove "for " (toks[2..4]) to turn "solve for the X" into "solve the X"
+        let span = toks[2..4].span()?;
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::Usage,
+            suggestions: vec![Suggestion::Remove],
+            message: "Use `solve` instead of `solve for` when followed by a determiner or article. Reserve `solve for` for mathematical equations (e.g., \"solve for x\").".to_string(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Flags incorrect use of `solve for` followed by a determiner, suggesting removal of `for`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    use super::SolveFor;
+
+    #[test]
+    fn fix_solve_for_the_problem() {
+        assert_suggestion_result(
+            "We need to solve for the problem.",
+            SolveFor::default(),
+            "We need to solve the problem.",
+        );
+    }
+
+    #[test]
+    fn fix_solve_for_this_issue() {
+        assert_suggestion_result(
+            "How can we solve for this issue?",
+            SolveFor::default(),
+            "How can we solve this issue?",
+        );
+    }
+
+    #[test]
+    fn fix_solved_for_the_bug() {
+        assert_suggestion_result(
+            "They solved for the bug quickly.",
+            SolveFor::default(),
+            "They solved the bug quickly.",
+        );
+    }
+
+    #[test]
+    fn fix_solving_for_the_bottleneck() {
+        assert_suggestion_result(
+            "We are solving for the bottleneck.",
+            SolveFor::default(),
+            "We are solving the bottleneck.",
+        );
+    }
+
+    #[test]
+    fn no_lint_solve_for_x() {
+        assert_no_lints("Solve for x in the equation.", SolveFor::default());
+    }
+
+    #[test]
+    fn no_lint_solve_for_n() {
+        assert_no_lints("We need to solve for n.", SolveFor::default());
+    }
+}

--- a/harper-core/src/linting/solve_for.rs
+++ b/harper-core/src/linting/solve_for.rs
@@ -32,7 +32,7 @@ impl ExprLinter for SolveFor {
             span,
             lint_kind: LintKind::Usage,
             suggestions: vec![Suggestion::Remove],
-            message: "Use `solve` instead of `solve for` when followed by a determiner or article. Reserve `solve for` for mathematical equations (e.g., \"solve for x\").".to_string(),
+            message: "\"Solve for\" is typically used in math or science contexts (e.g., \"solve for x\"). In general writing, \"solve\" alone is usually correct here.".to_string(),
             ..Default::default()
         })
     }
@@ -42,7 +42,7 @@ impl ExprLinter for SolveFor {
     }
 
     fn description(&self) -> &str {
-        "Flags incorrect use of `solve for` followed by a determiner, suggesting removal of `for`."
+        "Flags incorrect use of `solve for` when `solve` is correct."
     }
 }
 
@@ -160,5 +160,69 @@ mod tests {
     #[test]
     fn no_lint_solve_for_x_in_equation() {
         assert_no_lints("Can you solve for x in this equation?", SolveFor::default());
+    }
+
+    // Real-world examples from issue #613
+
+    #[test]
+    fn issue_613_solve_for_this_issue() {
+        // "How can i solve for this issue with the logical flow"
+        assert_suggestion_result(
+            "How can I solve for this issue with the logical flow?",
+            SolveFor::default(),
+            "How can I solve this issue with the logical flow?",
+        );
+    }
+
+    #[test]
+    fn issue_613_solve_for_the_problem_email() {
+        // "Can you help me solve for the problem email message"
+        assert_suggestion_result(
+            "Can you help me solve for the problem email message?",
+            SolveFor::default(),
+            "Can you help me solve the problem email message?",
+        );
+    }
+
+    #[test]
+    fn issue_613_solve_for_the_wrong_problem() {
+        // "when you solve for the wrong problem not only do you not get the solution"
+        assert_suggestion_result(
+            "When you solve for the wrong problem you miss the solution.",
+            SolveFor::default(),
+            "When you solve the wrong problem you miss the solution.",
+        );
+    }
+
+    #[test]
+    fn issue_613_solve_for_this_git_problem() {
+        // "this is a how to solve for this git problem: fatal: unable ..."
+        assert_suggestion_result(
+            "This is how to solve for this git problem.",
+            SolveFor::default(),
+            "This is how to solve this git problem.",
+        );
+    }
+
+    #[test]
+    #[ignore] // "solved for because" — no determiner after "for", linter doesn't match this pattern
+    fn issue_613_solved_for_because() {
+        // "this has already been solved for because the ad520 also has its own ways"
+        assert_suggestion_result(
+            "This has already been solved for because the ad520 has its own ways.",
+            SolveFor::default(),
+            "This has already been solved because the ad520 has its own ways.",
+        );
+    }
+
+    #[test]
+    #[ignore] // "solve for" at end of clause — no determiner follows, linter can't detect this
+    fn issue_613_solve_for_end_of_clause() {
+        // "the actual word that you couldn't solve for"
+        assert_suggestion_result(
+            "The word that you couldn't solve for.",
+            SolveFor::default(),
+            "The word that you couldn't solve.",
+        );
     }
 }

--- a/harper-core/src/linting/solve_for.rs
+++ b/harper-core/src/linting/solve_for.rs
@@ -120,4 +120,45 @@ mod tests {
     fn no_lint_solve_for_y() {
         assert_no_lints("Solve for y when x equals zero.", SolveFor::default());
     }
+
+    #[test]
+    fn fix_solve_for_a_better_solution() {
+        assert_suggestion_result(
+            "We need to solve for a better solution.",
+            SolveFor::default(),
+            "We need to solve a better solution.",
+        );
+    }
+
+    #[test]
+    fn fix_solve_for_the_missing_variable() {
+        assert_suggestion_result(
+            "I will solve for the missing variable.",
+            SolveFor::default(),
+            "I will solve the missing variable.",
+        );
+    }
+
+    #[test]
+    fn fix_solved_for_the_unknown() {
+        assert_suggestion_result(
+            "They solved for the unknown.",
+            SolveFor::default(),
+            "They solved the unknown.",
+        );
+    }
+
+    #[test]
+    fn fix_solves_for_this_challenge() {
+        assert_suggestion_result(
+            "Our team solves for this challenge every day.",
+            SolveFor::default(),
+            "Our team solves this challenge every day.",
+        );
+    }
+
+    #[test]
+    fn no_lint_solve_for_x_in_equation() {
+        assert_no_lints("Can you solve for x in this equation?", SolveFor::default());
+    }
 }

--- a/harper-core/src/linting/solve_for.rs
+++ b/harper-core/src/linting/solve_for.rs
@@ -24,15 +24,13 @@ impl ExprLinter for SolveFor {
     type Unit = Chunk;
 
     fn match_to_lint(&self, toks: &[Token], _src: &[char]) -> Option<Lint> {
-        // toks: [solve(0), ws(1), "for"(2), ws(3), article(4)]
-        // Remove "for " (toks[2..4]) to turn "solve for the X" into "solve the X"
         let span = toks[2..4].span()?;
 
         Some(Lint {
             span,
             lint_kind: LintKind::Usage,
             suggestions: vec![Suggestion::Remove],
-            message: "\"Solve for\" is typically used in math or science contexts (e.g., \"solve for x\"). In general writing, \"solve\" alone is usually correct here.".to_string(),
+            message: "\"Solve for\" is a math term used to find the value of a variable (e.g., \"solve for x\"). When referring to fixing or resolving something, use \"solve\" without \"for\".".to_string(),
             ..Default::default()
         })
     }

--- a/harper-core/src/linting/solve_for.rs
+++ b/harper-core/src/linting/solve_for.rs
@@ -15,10 +15,7 @@ impl Default for SolveFor {
                 .t_ws()
                 .t_aco("for")
                 .t_ws()
-                .then_word_set(&[
-                    "the", "a", "an", "this", "that", "my", "your", "his", "her", "its", "our",
-                    "their", "these", "those", "any", "some",
-                ]),
+                .then_determiner(),
         }
     }
 }
@@ -92,6 +89,24 @@ mod tests {
     }
 
     #[test]
+    fn fix_solve_for_our_customers() {
+        assert_suggestion_result(
+            "We want to solve for our customers' needs.",
+            SolveFor::default(),
+            "We want to solve our customers' needs.",
+        );
+    }
+
+    #[test]
+    fn fix_solves_for_every_edge_case() {
+        assert_suggestion_result(
+            "This approach solves for every edge case.",
+            SolveFor::default(),
+            "This approach solves every edge case.",
+        );
+    }
+
+    #[test]
     fn no_lint_solve_for_x() {
         assert_no_lints("Solve for x in the equation.", SolveFor::default());
     }
@@ -99,5 +114,10 @@ mod tests {
     #[test]
     fn no_lint_solve_for_n() {
         assert_no_lints("We need to solve for n.", SolveFor::default());
+    }
+
+    #[test]
+    fn no_lint_solve_for_y() {
+        assert_no_lints("Solve for y when x equals zero.", SolveFor::default());
     }
 }

--- a/harper-core/src/linting/solve_for.rs
+++ b/harper-core/src/linting/solve_for.rs
@@ -23,7 +23,7 @@ impl Default for SolveFor {
 impl ExprLinter for SolveFor {
     type Unit = Chunk;
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, toks: &[Token], _src: &[char]) -> Option<Lint> {
         // toks: [solve(0), ws(1), "for"(2), ws(3), article(4)]
         // Remove "for " (toks[2..4]) to turn "solve for the X" into "solve the X"
         let span = toks[2..4].span()?;


### PR DESCRIPTION
Closes #613

## What this does

Adds a `SolveFor` lint rule that flags incorrect usage of `solve for` followed by a determiner or article.

**Examples flagged:**
- `solve for the problem` → `solve the problem`
- `solve for this issue` → `solve this issue`
- `solved for the bug` → `solved the bug`
- `solving for the bottleneck` → `solving the bottleneck`

**Not flagged (mathematical usage):**
- `solve for x`
- `solve for n`

## Implementation

Follows the same pattern as the existing `ArriveTo` lint rule:
- `harper-core/src/linting/solve_for.rs`: New lint rule
- `harper-core/src/linting/mod.rs`: Register `solve_for` module
- `harper-core/src/linting/lint_group/mod.rs`: Register `SolveFor` rule

The rule matches `solve/solved/solves/solving` + `for` + determiner/article, then suggests removing `for ` from the text.

🤖 Generated with Claude Code