### PR TITLE
feat: more than what meets the eye/more that meets the eye→more than meets the eye

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -4780,6 +4780,13 @@
 								"state": true,
 								"label": "Web Scraping"
 							}
+						},
+						{
+							"Bool": {
+								"name": "MoreThanMeetsTheEye",
+								"state": true,
+								"label": "More Than Meets The Eye"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/weir_rules/MoreThanMeetsTheEye.weir
+++ b/harper-core/src/linting/weir_rules/MoreThanMeetsTheEye.weir
@@ -1,0 +1,10 @@
+expr main [(more than what meets the eye), (more that meets the eye), (more that what meets the eye)]
+
+let message "For something that has hidden complexity or depth, `more than meets the eye` is the most idiomatic and most standard."
+let description "Corrects nonstandard and less idiomatic variants of `more than meets the eye`."
+let kind "Usage"
+let becomes "more than meets the eye"
+
+test "They decided to investigate and found out that there was more than what meets the eye here." "They decided to investigate and found out that there was more than meets the eye here."
+test "But there might be more that meets the eye there, too:" "But there might be more than meets the eye there, too:"
+test "As i have said before, there is at times more that what meets the eye." "As i have said before, there is at times more than meets the eye."


### PR DESCRIPTION
# Issues 
N/A

# Description

I heard a YouTuber say "more than what meets the eye" and thought "that 'what' isn't usually there".
I checked to make sure the variant I use is truly the more standard one and in doing so found people also using "more that meets the eye", which is probably a typo made by native speakers and a grammar mistake made by nonnative speakers.
For good measure I threw in the combo "more that what meets the eye" and found an example of it on Stack Exchange.

# How Has This Been Tested?

- Added unit tests found online for each variant.
- `cargo test`
- `just test-obsidian`
- 
# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
