### PR TITLE
fix(vscode): pre-select current dialect in the dialect picker

### DIFF
--- a/packages/vscode-plugin/src/extension.ts
+++ b/packages/vscode-plugin/src/extension.ts
@@ -204,8 +204,12 @@ async function changeDialect(): Promise<void> {
 		label: name,
 	}));
 
+	const currentDialect = workspace.getConfiguration('harper').get<string>('dialect', 'American');
+	const currentItem = dialects.find((d) => d.label === currentDialect);
+
 	const selected = await window.showQuickPick(dialects, {
 		placeHolder: 'Select Harper dialect',
+		activeItems: currentItem ? [currentItem] : [],
 	});
 
 	if (selected && typeof selected !== 'string') {


### PR DESCRIPTION
I noticed issue #2667 while exploring the extension — when you click the dialect indicator in the status bar, the quick-pick list always had **American** highlighted at the top, even if the workspace was already set to, say, British or Australian. That makes it easy to accidentally revert your dialect if you just press Enter.

The root cause is simple: `window.showQuickPick` was called without an `activeItems` option, so VS Code defaults to highlighting the first item. The fix reads the current `harper.dialect` setting before opening the picker, finds the matching `QuickPickItem`, and passes it as `activeItems` so the picker scrolls to and highlights the active dialect right away.

**Changes:** `packages/vscode-plugin/src/extension.ts` — 4 lines added to `changeDialect()`.

Fixes #2667