### PR TITLE
fix: lint comments after shebangs

### DIFF
--- a/harper-comments/src/masker.rs
+++ b/harper-comments/src/masker.rs
@@ -1,5 +1,5 @@
-use harper_core::Masker;
 use harper_core::spell::MutableDictionary;
+use harper_core::{Mask, Masker, Span};
 use harper_tree_sitter::TreeSitterMasker;
 
 pub struct CommentMasker {
@@ -28,7 +28,6 @@ impl CommentMasker {
                     || text.contains("spellcheck: ignore")
                     || text.contains("harper:ignore")
                     || text.contains("harper: ignore")
-                    || text.starts_with("#!")
             }),
         )
     }
@@ -46,13 +45,44 @@ impl CommentMasker {
 }
 
 impl Masker for CommentMasker {
-    fn create_mask(&self, source: &[char]) -> harper_core::Mask {
+    fn create_mask(&self, source: &[char]) -> Mask {
         self.inner
             .create_mask(source)
             .iter_allowed(source)
-            .map(|(span, chars)| (span, chars.iter().collect::<String>()))
-            .filter(|(_, text)| !(self.ignore_condition)(text))
-            .map(|(span, _)| span)
+            .filter_map(|(span, chars)| {
+                let mut span = span;
+                let mut text: String = chars.iter().collect();
+
+                // A real shebang only applies to the first line of the file.
+                // If tree-sitter merged the shebang with following comments,
+                // keep linting the remainder of the comment block.
+                if span.start == 0 && text.starts_with("#!") {
+                    span = trim_leading_shebang(span, chars)?;
+                    text = span.get_content(source).iter().collect();
+                }
+
+                if (self.ignore_condition)(&text) {
+                    None
+                } else {
+                    Some(span)
+                }
+            })
             .collect()
     }
+}
+
+fn trim_leading_shebang(span: Span<char>, chars: &[char]) -> Option<Span<char>> {
+    let first_line_end = chars
+        .iter()
+        .position(|c| *c == '\n')
+        .map_or(chars.len(), |index| index + 1);
+
+    let next_content = chars[first_line_end..]
+        .iter()
+        .position(|c| !c.is_whitespace())?;
+
+    Some(Span::new(
+        span.start + first_line_end + next_content,
+        span.end,
+    ))
 }

--- a/harper-comments/tests/language_support.rs
+++ b/harper-comments/tests/language_support.rs
@@ -60,6 +60,7 @@ create_test!(ignore_shebang_1.sh, 0);
 create_test!(ignore_shebang_2.sh, 0);
 create_test!(ignore_shebang_3.sh, 0);
 create_test!(ignore_shebang_4.sh, 1);
+create_test!(issue_962.sh, 1);
 create_test!(common.mill, 1);
 create_test!(basic_kotlin.kt, 0);
 create_test!(basic_groovy.groovy, 1);

--- a/harper-comments/tests/language_support_sources/issue_962.sh
+++ b/harper-comments/tests/language_support_sources/issue_962.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Thiss comment should be linted.
+echo ok


### PR DESCRIPTION
Disclaimer: This PR was authored by an agent and reviewed against the reproduced issue and local test results.

Fixes #962.

Before this change, `CommentMasker` ignored any merged comment span that started with a shebang. When tree-sitter merged the first-line shebang with the following comment block, the later comments were skipped too.

This change only strips the first line of a real shebang at the start of the file, then keeps linting the rest of the merged comment span.

How I tested this:
- `cargo test -p harper-comments`
- `cargo run -q -p harper-cli -- lint /tmp/harper-962-with-shebang.sh --count --no-color`
- `cargo run -q -p harper-cli -- lint /tmp/harper-962-no-shebang.sh --count --no-color`
- `cargo run -q -p harper-cli -- lint /tmp/harper-962-fake-shebang.sh --count --no-color`
