### PR TITLE
feat: close/tight nit → knit

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -2622,6 +2622,13 @@
 								"state": true,
 								"label": "Without Out"
 							}
+						},
+						{
+							"Bool": {
+								"name": "CloseTightKnit",
+								"state": true,
+								"label": "Close Tight Knit"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/close_tight_knit.rs
+++ b/harper-core/src/linting/close_tight_knit.rs
@@ -1,0 +1,131 @@
+use crate::{
+    Lint, Token,
+    expr::{Expr, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+};
+
+pub struct CloseTightKnit {
+    expr: SequenceExpr,
+}
+
+impl Default for CloseTightKnit {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::word_set(&["close", "closely", "tight", "tightly"])
+                .t_ws_h()
+                .t_aco("nit"),
+        }
+    }
+}
+
+impl ExprLinter for CloseTightKnit {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        let (sep_tok, nit_tok) = (&toks[1], &toks[2]);
+
+        let suggestions = vec![Suggestion::replace_with_match_case_str(
+            "knit",
+            nit_tok.get_ch(src),
+        )];
+        let message = format!(
+            "A `nit` is a louse egg. The correct idiom is `tight{}knit`.",
+            if sep_tok.kind.is_hyphen() { '-' } else { ' ' }
+        );
+
+        Some(Lint {
+            span: nit_tok.span,
+            lint_kind: LintKind::Malapropism,
+            suggestions,
+            message,
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects `close-nit` and `tight-nit` to `close-knit` and `tight-knit`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::assert_suggestion_result;
+
+    use super::CloseTightKnit;
+
+    #[test]
+    fn fix_tight_nit_space() {
+        assert_suggestion_result(
+            "To keep components theme-able and tight nit, an ideal scenario",
+            CloseTightKnit::default(),
+            "To keep components theme-able and tight knit, an ideal scenario",
+        );
+    }
+
+    #[test]
+    fn fix_tight_nit_hyphenated() {
+        assert_suggestion_result(
+            "We're a small, tight-nit, experienced team from Google, Optimizely, Uber, & DraftKings",
+            CloseTightKnit::default(),
+            "We're a small, tight-knit, experienced team from Google, Optimizely, Uber, & DraftKings",
+        );
+    }
+
+    #[test]
+    fn fix_close_nit_space() {
+        assert_suggestion_result(
+            "I get its all a close nit set of Github folks driving both projects but...",
+            CloseTightKnit::default(),
+            "I get its all a close knit set of Github folks driving both projects but...",
+        );
+    }
+
+    #[test]
+    fn fix_close_nit_hyphen() {
+        assert_suggestion_result(
+            "Within a group of more senior engineers working on close-nit teams (like MX) there's a lot of trust in the author during the review process.",
+            CloseTightKnit::default(),
+            "Within a group of more senior engineers working on close-knit teams (like MX) there's a lot of trust in the author during the review process.",
+        );
+    }
+
+    #[test]
+    fn fix_tightly_nit_space() {
+        assert_suggestion_result(
+            "Initially public keys and aliases are tightly nit, changes in key values break expectations of EVM authorization checks",
+            CloseTightKnit::default(),
+            "Initially public keys and aliases are tightly knit, changes in key values break expectations of EVM authorization checks",
+        );
+    }
+
+    #[test]
+    fn fix_tightly_nit_hyphen() {
+        assert_suggestion_result(
+            "... will result, in my opinion and from what I have witnessed, in a more tightly-nit community",
+            CloseTightKnit::default(),
+            "... will result, in my opinion and from what I have witnessed, in a more tightly-knit community",
+        );
+    }
+
+    #[test]
+    fn fix_closely_nit_space() {
+        assert_suggestion_result(
+            "For a small family, the boys have a nice network of closely nit family members.",
+            CloseTightKnit::default(),
+            "For a small family, the boys have a nice network of closely knit family members.",
+        );
+    }
+
+    #[test]
+    fn fix_closely_nit_hyphen() {
+        assert_suggestion_result(
+            "However this time around we are aiming for a much smaller more \"closely-nit\" town.",
+            CloseTightKnit::default(),
+            "However this time around we are aiming for a much smaller more \"closely-knit\" town.",
+        );
+    }
+}

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -43,6 +43,7 @@ use super::capitalize_personal_pronouns::CapitalizePersonalPronouns;
 use super::cautionary_tale::CautionaryTale;
 use super::change_tack::ChangeTack;
 use super::chock_full::ChockFull;
+use super::close_tight_knit::CloseTightKnit;
 use super::code_in_write_in::CodeInWriteIn;
 use super::comma_fixes::CommaFixes;
 use super::compound_nouns::CompoundNouns;
@@ -534,6 +535,7 @@ impl LintGroup {
         insert_expr_rule!(CautionaryTale, true);
         insert_expr_rule!(ChangeTack, true);
         insert_expr_rule!(ChockFull, true);
+        insert_expr_rule!(CloseTightKnit, true);
         insert_expr_rule!(CodeInWriteIn, true);
         insert_struct_rule!(CommaFixes, true);
         insert_struct_rule!(CompoundNouns, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -37,6 +37,7 @@ mod capitalize_personal_pronouns;
 mod cautionary_tale;
 mod change_tack;
 mod chock_full;
+mod close_tight_knit;
 mod closed_compounds;
 mod code_in_write_in;
 mod comma_fixes;


### PR DESCRIPTION
# Issues 
N/A

# Description

A blog I was reading contained "tight nit". Since a nit is the egg of a louse I checked around and found a range of common variants of the mistake with "close" and "tight" and their adverb forms, with and without hyphens.

# How Has This Been Tested?

Sentences for each combination of variants was found on GitHub, except for those with "closely", which were found on Medium and Reddit. A unit test was made from each.

Thence `just test-rust && just test-obsidian`

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
