### PR TITLE
refactor: don't flag "a fun and fantastic"

### DIFF
--- a/harper-core/src/linting/mass_nouns/mass_plurals.rs
+++ b/harper-core/src/linting/mass_nouns/mass_plurals.rs
@@ -1,15 +1,14 @@
 use hashbrown::HashSet;
 
-use crate::linting::expr_linter::Chunk;
 use crate::{
     CharStringExt, Token, TokenStringExt,
     expr::{All, Expr, FirstMatchOf, FixedPhrase, SequenceExpr},
-    linting::{ExprLinter, Lint, LintKind, Suggestion},
+    linting::{ExprLinter, Lint, LintKind, Suggestion, expr_linter::Chunk},
     spell::Dictionary,
 };
 
 pub struct MassPlurals<D> {
-    expr: Box<dyn Expr>,
+    expr: FirstMatchOf,
     dict: D,
 }
 
@@ -31,10 +30,10 @@ where
         ]);
 
         Self {
-            expr: Box::new(FirstMatchOf::new(vec![
+            expr: FirstMatchOf::new(vec![
                 Box::new(oov_looks_plural),
-                Box::new(phrases),
-            ])),
+                Box::new(phrases) as Box<dyn Expr>,
+            ]),
             dict,
         }
     }
@@ -59,7 +58,7 @@ where
     type Unit = Chunk;
 
     fn expr(&self) -> &dyn Expr {
-        self.expr.as_ref()
+        &self.expr
     }
 
     fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {

--- a/harper-core/src/linting/mass_nouns/mod.rs
+++ b/harper-core/src/linting/mass_nouns/mod.rs
@@ -60,7 +60,7 @@ mod tests {
     #[test]
     fn flag_advices_and_an_advice() {
         assert_lint_count(
-            "I asked for an advice and he gave me two advices!",
+            "I asked for an advice. He gave me two advices!",
             MassNouns::new(FstDictionary::curated()),
             2,
         );
@@ -81,6 +81,15 @@ mod tests {
             "I managed to pack all my clothings into one suitcase.",
             MassNouns::new(FstDictionary::curated()),
             "I managed to pack all my clothing into one suitcase.",
+        );
+    }
+
+    #[test]
+    fn ignore_a_fun_and_fantastic() {
+        assert_lint_count(
+            "It was such a fun and fantastic adventure together that ...",
+            MassNouns::new(FstDictionary::curated()),
+            0,
         );
     }
 }

--- a/harper-core/src/linting/mass_nouns/noun_countability.rs
+++ b/harper-core/src/linting/mass_nouns/noun_countability.rs
@@ -1,8 +1,10 @@
-use crate::linting::expr_linter::Chunk;
 use crate::{
-    Lrc, Span, Token, TokenStringExt,
-    expr::{Expr, LongestMatchOf, SequenceExpr},
-    linting::{ExprLinter, Lint, LintKind, Suggestion},
+    CharStringExt, Span, Token, TokenStringExt,
+    expr::{Expr, SequenceExpr},
+    linting::{
+        ExprLinter, Lint, LintKind, Suggestion,
+        expr_linter::{Chunk, followed_by_hyphen, followed_by_word},
+    },
     patterns::{IndefiniteArticle, WordSet},
 };
 
@@ -21,7 +23,7 @@ pub enum Correction {
 use Correction::*;
 
 pub struct NounCountability {
-    expr: Box<dyn Expr>,
+    expr: SequenceExpr,
 }
 
 impl Default for NounCountability {
@@ -31,32 +33,13 @@ impl Default for NounCountability {
             "several",
         ]);
 
-        // A determiner or quantifier followed by a mass noun
-        let detquant_mass = Lrc::new(
-            SequenceExpr::any_of(vec![
+        Self {
+            expr: SequenceExpr::any_of(vec![
                 Box::new(IndefiniteArticle::default()),
-                Box::new(quantifier),
+                Box::new(quantifier) as Box<dyn Expr>,
             ])
             .then_whitespace()
             .then_mass_noun_only(),
-        );
-
-        let detauant_mass_then_hyphen =
-            Lrc::new(SequenceExpr::with(detquant_mass.clone()).then_hyphen());
-
-        let detquant_mass_following_context = Lrc::new(
-            SequenceExpr::with(detquant_mass.clone())
-                .then_whitespace()
-                // If we don't get the word, this won't be the longest match
-                .then_any_word(),
-        );
-
-        Self {
-            expr: Box::new(LongestMatchOf::new(vec![
-                Box::new(detquant_mass),
-                Box::new(detauant_mass_then_hyphen),
-                Box::new(detquant_mass_following_context),
-            ])),
         }
     }
 }
@@ -65,21 +48,23 @@ impl ExprLinter for NounCountability {
     type Unit = Chunk;
 
     fn expr(&self) -> &dyn Expr {
-        self.expr.as_ref()
+        &self.expr
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint_with_context(
+        &self,
+        toks: &[Token],
+        src: &[char],
+        ctx: Option<(&[Token], &[Token])>,
+    ) -> Option<Lint> {
         let toks_chars = toks.span()?.get_content(src);
 
-        // 4 tokens means the phrase was followed by a hyphen
-        if toks.len() == 4 {
-            return None;
-        }
-        // 3 tokens means the phrase was at the end of a chunk/sentence.
-        // 5 tokens means the phrase was in the middle of a chunk/sentence.
-        // If it's in the middle then we check if the next word token is a noun or OOV.
-        // Since the last token of our phrase is the mass noun, this would make it part of a compound noun.
-        if toks.len() == 5 && (toks.last()?.kind.is_noun() || toks.last()?.kind.is_oov()) {
+        if toks.len() != 3
+            || followed_by_hyphen(ctx)
+            || followed_by_word(ctx, |t| {
+                t.kind.is_noun() || t.kind.is_oov() || t.get_ch(src).eq_str("and")
+            })
+        {
             return None;
         }
 


### PR DESCRIPTION
# Issues 
This may fix an existing issue but a quick look didn't uncover it if so.

# Description

I noticed that "a fun" was flagged by the mass noun linter in "It was such a fun and fantastic adventure together that ...".

I made the rule ignore a mass noun that's part of a list due to being followed by "and".
In doing so I noticed the linter predates `match_to_lint_with_context()` and had some convoluted logic to handle whether the main phrase was followed by a hyphen or certain POSes. I refactored it to use cleaner, newer techniques that are now available.

I had to modify one existing test that used "and" in a slightly difference usage since "and" is marginally also a noun (as in "no ifs ands or buts".)

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

A new unit test using the sentence that led me to the bug. `cargo test` passes.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
