### PR TITLE
feat: govt → government

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -1260,6 +1260,13 @@
 								"state": true,
 								"label": "Worse Or Worst"
 							}
+						},
+						{
+							"Bool": {
+								"name": "ExpandGovt",
+								"state": true,
+								"label": "Expand Govt"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -730,6 +730,15 @@ pub fn lint_group() -> LintGroup {
             "Expands the abbreviation `decl` to the full word `declaration` or `declarator` for clarity.",
             LintKind::Style
         ),
+        "ExpandGovt" => (
+            &[
+                (&["govt", "govt."], &["government"]),
+                (&["govts"], &["governments"])
+            ],
+            "Use `government` instead of `govt` or `govt.`",
+            "Expands the abbreviation `govt` or `govt.` to the full word `government` for clarity.",
+            LintKind::Style
+        ),
         "Expat" => (
             &[
                 (&["ex-pat", "ex pat"], &["expat"]),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -2326,6 +2326,35 @@ fn expand_alloc() {
     );
 }
 
+// ExpandGovt
+
+#[test]
+fn corrects_govt_no_dot() {
+    assert_suggestion_result(
+        "Separation between privately issued credentials vs govt issued identity credentials",
+        lint_group(),
+        "Separation between privately issued credentials vs government issued identity credentials",
+    );
+}
+
+#[test]
+fn corrects_govt_do() {
+    assert_suggestion_result(
+        "Demystifying public comments on govt. regulations.",
+        lint_group(),
+        "Demystifying public comments on government regulations.",
+    );
+}
+
+#[test]
+fn corrects_govts() {
+    assert_suggestion_result(
+        "Those 'elite' economists have been advising govts for years.",
+        lint_group(),
+        "Those 'elite' economists have been advising governments for years.",
+    );
+}
+
 // Expat
 
 #[test]


### PR DESCRIPTION
# Issues 
N/A

# Description

I saw `govts` in a YouTube comment when I was dogfooding Harper. Some dictionary research showed that both `govt` and `govt.` are legitimate abbreviations, but not a plural.

So I've made a phrase set linter that offers to expand the singular with or without the period and also the informal plural form to full words "government" and "governments".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

3 unit tests, one for each case.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
