### PR TITLE
Hereby: require verb that is not also a noun

### DIFF
--- a/harper-core/src/linting/hereby.rs
+++ b/harper-core/src/linting/hereby.rs
@@ -1,6 +1,6 @@
 use crate::expr::Expr;
 use crate::expr::SequenceExpr;
-use crate::{Token, TokenStringExt};
+use crate::{Token, TokenKind, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::linting::expr_linter::Chunk;
@@ -11,11 +11,14 @@ pub struct Hereby {
 
 impl Default for Hereby {
     fn default() -> Self {
+        // Require a verb that is not also a noun. Otherwise sentences like
+        // "I got here by skill" — where "skill" is a noun object of "by" —
+        // match because "skill" is tagged as both verb and noun.
         let pattern = SequenceExpr::aco("here")
             .then_whitespace()
             .t_aco("by")
             .then_whitespace()
-            .then_verb();
+            .then_kind_is_but_is_not(TokenKind::is_verb, TokenKind::is_noun);
 
         Self { expr: pattern }
     }
@@ -61,5 +64,11 @@ mod tests {
             Hereby::default(),
             "I hereby declare this state to be free.",
         );
+    }
+
+    #[test]
+    fn allows_here_by_noun() {
+        use crate::linting::tests::assert_no_lints;
+        assert_no_lints("I got here by skill.", Hereby::default());
     }
 }


### PR DESCRIPTION
The rule flagged *"I got here by skill"* because "skill" is tagged as both verb and noun, and `then_verb()` accepts either sense. "I got here by NP" is grammatical "by" plus a noun phrase, not a mis-spaced "hereby".

Replace `then_verb()` with `then_kind_is_but_is_not(is_verb, is_noun)` so only unambiguous verb usages trigger the suggestion. Added a regression test.

Fixes #3211