### PR TITLE
feat: infliction point → inflection point

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -1267,6 +1267,13 @@
 								"state": true,
 								"label": "Expand Govt"
 							}
+						},
+						{
+							"Bool": {
+								"name": "InflectionPoint",
+								"state": true,
+								"label": "Inflection Point"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -365,6 +365,15 @@ pub fn lint_group() -> LintGroup {
             "Corrects unidiomatic plural `in details` to `in detail`.",
             LintKind::Usage
         ),
+        "InflectionPoint" => (
+            &[
+                ("infliction point", "inflection point"),
+                ("infliction points", "inflection points"),
+            ],
+            "To refer to a significant change in a trend, `inflection point` is the correct term.",
+            "Corrects `infliction point` to `inflection point`.",
+            LintKind::Malapropism
+        ),
         "InvestIn" => (
             &[
                 // Verb

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -1112,6 +1112,26 @@ fn in_more_detail_real_world() {
     );
 }
 
+// InflectionPoint
+
+#[test]
+fn corrects_infliction_point() {
+    assert_suggestion_result(
+        "You can also position the infliction point of the curve. By default it's exactly at the center in between the two connecting nodes.",
+        lint_group(),
+        "You can also position the inflection point of the curve. By default it's exactly at the center in between the two connecting nodes.",
+    );
+}
+
+#[test]
+fn corrects_infliction_points() {
+    assert_suggestion_result(
+        "... find where it touches the other side, and measure the distance. Potentially, I'd only have to do it for \"infliction points\".",
+        lint_group(),
+        "... find where it touches the other side, and measure the distance. Potentially, I'd only have to do it for \"inflection points\".",
+    );
+}
+
 // InvestIn
 
 #[test]
@@ -1226,7 +1246,6 @@ fn litotes_more_preferable() {
 
 #[test]
 fn fix_look_forward_for() {
-    // I will mark this issue as an enhancement and will look forward for enrolling it.
     assert_suggestion_result(
         "I will mark this issue as an enhancement and will look forward for enrolling it.",
         lint_group(),


### PR DESCRIPTION
# Issues 
N/A

# Description

I heard DHH say "infliction point" multiple times in an interview. Some research shows he's not alone.
This linter corrects the singular and plural using a phrase set.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Found a singular and a plural example of this mistake on GitHub and made a unit test from each.

`cargo fmt && cargo clippy && just test-rust && just test-obsidian`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
