### PR TITLE
fix(chrome-plugin): auto-close report page on tab switch or navigation #3225

### DIFF
--- a/packages/chrome-plugin/src/background/index.ts
+++ b/packages/chrome-plugin/src/background/index.ts
@@ -74,6 +74,21 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 	return true;
 });
 
+chrome.tabs.onActivated.addListener(async ({ tabId }) => {
+	const result = await chrome.storage.local.get(['popupState', 'reportTabId']);
+	if (result.popupState?.page === 'report-error' && result.reportTabId !== tabId) {
+		await chrome.storage.local.set({ popupState: { page: 'main' } });
+	}
+});
+
+chrome.tabs.onUpdated.addListener(async (tabId, changeInfo) => {
+	if (!changeInfo.url) return;
+	const result = await chrome.storage.local.get(['popupState', 'reportTabId']);
+	if (result.popupState?.page === 'report-error' && result.reportTabId === tabId) {
+		await chrome.storage.local.set({ popupState: { page: 'main' } });
+	}
+});
+
 let linter: LocalLinter;
 const WEIRPACKS_KEY = 'weirpacks';
 
@@ -201,7 +216,7 @@ function handleRequest(message: Request, sender?: chrome.runtime.MessageSender):
 		case 'setHotkey':
 			return handleSetHotkey(message);
 		case 'openReportError':
-			return handleOpenReportError(message);
+			return handleOpenReportError(message, sender);
 		case 'openOptions':
 			chrome.runtime.openOptionsPage();
 			return Promise.resolve(createUnitResponse());
@@ -431,7 +446,10 @@ async function handleSetHotkey(req: SetHotkeyRequest): Promise<UnitResponse> {
 	await setHotkey(hotkey);
 }
 
-async function handleOpenReportError(req: OpenReportErrorRequest): Promise<UnitResponse> {
+async function handleOpenReportError(
+	req: OpenReportErrorRequest,
+	sender?: chrome.runtime.MessageSender,
+): Promise<UnitResponse> {
 	const popupState: PopupState = {
 		page: 'report-error',
 		example: req.example,
@@ -439,7 +457,7 @@ async function handleOpenReportError(req: OpenReportErrorRequest): Promise<UnitR
 		feedback: req.feedback,
 	};
 
-	await chrome.storage.local.set({ popupState });
+	await chrome.storage.local.set({ popupState, reportTabId: sender?.tab?.id });
 
 	if (chrome.action?.openPopup) {
 		try {

--- a/packages/chrome-plugin/src/background/index.ts
+++ b/packages/chrome-plugin/src/background/index.ts
@@ -74,18 +74,32 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 	return true;
 });
 
-chrome.tabs.onActivated.addListener(async ({ tabId }) => {
+/** Read the current popup state and the tab that triggered it from storage. */
+async function getReportTabState() {
 	const result = await chrome.storage.local.get(['popupState', 'reportTabId']);
-	if (result.popupState?.page === 'report-error' && result.reportTabId !== tabId) {
-		await chrome.storage.local.set({ popupState: { page: 'main' } });
+	return {
+		popupPage: result.popupState?.page as string | undefined,
+		reportTabId: result.reportTabId as number | undefined,
+	};
+}
+
+/** Reset the popup back to the main page, clearing any in-progress report. */
+async function clearReportState(): Promise<void> {
+	await chrome.storage.local.set({ popupState: { page: 'main' } });
+}
+
+chrome.tabs.onActivated.addListener(async ({ tabId }) => {
+	const { popupPage, reportTabId } = await getReportTabState();
+	if (popupPage === 'report-error' && reportTabId !== tabId) {
+		await clearReportState();
 	}
 });
 
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo) => {
 	if (!changeInfo.url) return;
-	const result = await chrome.storage.local.get(['popupState', 'reportTabId']);
-	if (result.popupState?.page === 'report-error' && result.reportTabId === tabId) {
-		await chrome.storage.local.set({ popupState: { page: 'main' } });
+	const { popupPage, reportTabId } = await getReportTabState();
+	if (popupPage === 'report-error' && reportTabId === tabId) {
+		await clearReportState();
 	}
 });
 


### PR DESCRIPTION
# Issues
Closes #3225

# Description
The "Report a Problematic Lint" popup page was persisting in
`chrome.storage.local` even after the user navigated away or switched
tabs. The next time the popup opened (on any page), it would still
show the report form.

Fix: store the triggering tab ID (`reportTabId`) when the report page
is opened, then add two listeners in the background service worker:
- `chrome.tabs.onActivated` — resets popup state when the user switches
  to a different tab
- `chrome.tabs.onUpdated` — resets popup state when the originating tab
  navigates to a new URL

# Demo
N/A (bug fix — report page no longer re-appears after tab switching or navigation)

# How Has This Been Tested?
Manually: triggered the report page, switched tabs, reopened the popup — 
confirmed it shows the main page instead of the report form.

# Checklist
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
