### PR TITLE
feat: formidable years→formative years

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -1274,6 +1274,13 @@
 								"state": true,
 								"label": "Inflection Point"
 							}
+						},
+						{
+							"Bool": {
+								"name": "FormativeYears",
+								"state": true,
+								"label": "Formative Years"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/weir_rules/FormativeYears.weir
+++ b/harper-core/src/linting/weir_rules/FormativeYears.weir
@@ -1,0 +1,9 @@
+expr main (formidable years)
+
+let message "Did you mean `formative years`? Use `formative` to describe a period of growth or influence. `Formidable` is typically used for something intimidating."
+let description "Flags the misuse of `formidable years` when `formative years` is likely intended. This rule distinguishes between the shaping of character (`formative`) and the inspiring of fear or awe (`formidable`)."
+let kind "Malapropism"
+let becomes "formative years"
+
+test "Here's how I would approach it, a little earlier than my formidable years there was music I was \“Forced\” to listen to." "Here's how I would approach it, a little earlier than my formative years there was music I was \“Forced\” to listen to."
+test "The 60's were full of turmoil as a country but my most formidable years as a person." "The 60's were full of turmoil as a country but my most formative years as a person."


### PR DESCRIPTION
# Issues 
N/A

# Description

I was watching a YouTube video from a creator I've never seen before and he made several mistakes I was hearing for the first time. Including "formidable years".

This phrase is sometimes used intentionally but is more often a malapropism. Because of this, both the `message` and the `description` briefly describe the difference between the terms so the user can decide whether a real mistake is flagged.

AI Disclaimer: I used Google's AI to help choose the wording for the `message` and `description` and to make sure this mistake is a malapropism and not an eggcorn.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

The only use on GitHub is a legit use, talking about years in the future which will be challenging. I instead chose one mistake from medium.com and one mistake from Reddit.

`just test-rust`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
