### PR TITLE
feat: fond on→found on/fond of

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5171,6 +5171,13 @@
 								"state": true,
 								"label": "Whereas"
 							}
+						},
+						{
+							"Bool": {
+								"name": "FondOn",
+								"state": true,
+								"label": "Fond On"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/weir_rules/FondOn.weir
+++ b/harper-core/src/linting/weir_rules/FondOn.weir
@@ -1,0 +1,9 @@
+expr main (fond on)
+
+let message "Use `found on` or `fond of` instead of `fond on`."
+let description "Flags `fond on` and suggests `found on` or `fond of`."
+let kind "Miscellaneous"
+let becomes ["found on", "fond of"]
+
+test "The only answer I fond on the question seems to imply that the 10s value was never discussed." "The only answer I found on the question seems to imply that the 10s value was never discussed."
+test "I'm not necessarily too fond on such a tool but I can see how this would be hugely useful in practice..." "I'm not necessarily too fond of such a tool but I can see how this would be hugely useful in practice..."


### PR DESCRIPTION
# Issues 
N/A

# Description

I was watching a YouTube video with a native English speaker I've never seen before who made several mistakes I was hearing for the first time. Including "fond on" when he obviously meant "fond of" or "keen on".

Googling around I found this is not an uncommon error these days, but a much more common error is the same "fond on" when it's a typo for "found on". On GitHub the "found on" mistake is about 5 to 10 times more common than the "fond of" mistake. But on Medium it's overwhelmingly a mistake for "fond of".

I just made a Weir rule that offers both corrections and the `LintKind` `Miscellaneous` since it's sometimes `Typo` and sometimes `Usage`. If rewritten in Rust with logic that distinguishes the two it could then offer the two more accurate `LintKind`s each in its own logic path.

# How Has This Been Tested?

I chose a typical error of each type, both from GitHub, to use as unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
