### PR TITLE
docs: remove mentions of `Matcher` and `WrongQuotes` linters

### DIFF
--- a/packages/web/src/routes/docs/integrations/helix/+page.md
+++ b/packages/web/src/routes/docs/integrations/helix/+page.md
@@ -56,11 +56,10 @@ SpelledNumbers = false
 AnA = true
 SentenceCapitalization = true
 UnclosedQuotes = true
-WrongQuotes = false
+WrongApostrophe = false
 LongSentences = true
 RepeatedWords = true
 Spaces = true
-Matcher = true
 CorrectNumberSuffix = true
 
 [language-server.harper-ls.config.harper-ls.codeActions]

--- a/packages/web/src/routes/docs/integrations/language-server/+page.md
+++ b/packages/web/src/routes/docs/integrations/language-server/+page.md
@@ -206,11 +206,10 @@ The list of linters together with their descriptions can be found at our [rules 
 			"AnA": true,
 			"SentenceCapitalization": true,
 			"UnclosedQuotes": true,
-			"WrongQuotes": false,
+			"WrongApostrophe": false,
 			"LongSentences": true,
 			"RepeatedWords": true,
 			"Spaces": true,
-			"Matcher": true,
 			"CorrectNumberSuffix": true
 		}
 	}

--- a/packages/web/src/routes/docs/integrations/neovim/+page.md
+++ b/packages/web/src/routes/docs/integrations/neovim/+page.md
@@ -33,11 +33,10 @@ require('lspconfig').harper_ls.setup {
         AnA = true,
         SentenceCapitalization = true,
         UnclosedQuotes = true,
-        WrongQuotes = false,
+        WrongApostrophe = false,
         LongSentences = true,
         RepeatedWords = true,
         Spaces = true,
-        Matcher = true,
         CorrectNumberSuffix = true
       },
       codeActions = {

--- a/packages/web/src/routes/docs/integrations/sublime-text/+page.md
+++ b/packages/web/src/routes/docs/integrations/sublime-text/+page.md
@@ -35,11 +35,10 @@ Open `Preferences > Package Settings > LSP > Settings` and add the `harper-ls` c
             "AnA": true,
             "SentenceCapitalization": true,
             "UnclosedQuotes": true,
-            "WrongQuotes": false,
+            "WrongApostrophe": false,
             "LongSentences": true,
             "RepeatedWords": true,
             "Spaces": true,
-            "Matcher": true,
             "CorrectNumberSuffix": true
           },
           "codeActions": {


### PR DESCRIPTION
# Issues 

Fixes #3235

# Description

It was discovered that the long-dead linter `Matcher` was still referenced in a few places.
I found it was in the config docs for the Helix, Neovim, LSP, and Sublime integrations.
I asked the Windsurf built-in coding AI to check if any of those docs mention any other dead linters and it found `WrongQuotes` listed in all of them. It decided to replace the latter with `WrongApostrophes`, which seems like a fair idea to me.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
