### PR TITLE
feat: monumentously→momentously/monumentally

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -810,6 +810,15 @@ pub fn lint_group() -> LintGroup {
             "Don't inflect `seem` in `make it seem`.",
             "Corrects `make it seems` to `make it seem`."
         ),
+        "Monumentous" => (
+            &[
+                (&["monumentous"], &["momentous", "monumental"]),
+                (&["monumentously"], &["momentously", "monumentally"]),
+            ],
+            "Retain `monumentous` for jocular effect. Otherwise `momentous` indicates great signifcance while `monumental` indicates imposing size.",
+            "Advises using `momentous` or `monumental` instead of `monumentous` for serious usage.",
+            LintKind::Nonstandard
+        ),
         "NervousWreck" => (
             &[
                 (&["nerve wreck", "nerve-wreck"], &["nervous wreck"]),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -2721,6 +2721,26 @@ fn corrects_made_it_seemed() {
     );
 }
 
+// Monumentous
+
+#[test]
+fn corrects_monumentous() {
+    assert_suggestion_result(
+        "I think that would be a monumentous step in the right direction, and would DEFINATLY turn heads in not just the music industry, but every ...",
+        lint_group(),
+        "I think that would be a momentous step in the right direction, and would DEFINATLY turn heads in not just the music industry, but every ...",
+    );
+}
+
+#[test]
+fn corrects_monumentously() {
+    assert_suggestion_result(
+        "the most impressive thing out of all of this is that GitHub created such a monumentously good name",
+        lint_group(),
+        "the most impressive thing out of all of this is that GitHub created such a monumentally good name",
+    );
+}
+
 // NervousWreck
 
 #[test]

--- a/harper-core/src/linting/weir_rules/Monumentous.weir
+++ b/harper-core/src/linting/weir_rules/Monumentous.weir
@@ -1,9 +1,0 @@
-expr main (monumentous)
-
-let message "Retain `monumentous` for jocular effect. Otherwise `momentous` indicates great signifcance while `monumental` indicates imposing size."
-let description "Advises using `momentous` or `monumental` instead of `monumentous` for serious usage."
-let kind "Nonstandard"
-let becomes ["momentous", "monumental"]
-
-test "monumentous" "momentous"
-test "I think that would be a monumentous step in the right direction, and would DEFINATLY turn heads in not just the music industry, but every ..." "I think that would be a momentous step in the right direction, and would DEFINATLY turn heads in not just the music industry, but every ..."


### PR DESCRIPTION
# Issues 
N/A

# Description

I was watching a Primeagen video on YouTube (always a good source of strange English) and he said "monumentously".  I knew we had a linter for "momentous" and checked and found we didn't handle the adverb version.

I don't think it's possibly to handle both in one Weir file so I converted the Weir monumentous linter to a `pharse_set_corrections` that fixes both "moumountous" and "monumentously" under one linter name in the config.

# How Has This Been Tested?

I used part of Prime's sentence to make a new unit test for the adverb.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
