### PR TITLE
feat: less confident `SplitWords` `message` when either word is only 1 char

### DIFF
--- a/harper-core/src/linting/split_words.rs
+++ b/harper-core/src/linting/split_words.rs
@@ -205,7 +205,8 @@ fn should_defer_to_spellcheck(
 #[cfg(test)]
 mod tests {
     use crate::linting::tests::{
-        assert_good_and_bad_suggestions, assert_lint_message, assert_no_lints, assert_suggestion_result,
+        assert_good_and_bad_suggestions, assert_lint_message, assert_no_lints,
+        assert_suggestion_result,
     };
 
     use super::SplitWords;

--- a/harper-core/src/linting/split_words.rs
+++ b/harper-core/src/linting/split_words.rs
@@ -123,8 +123,13 @@ impl ExprLinter for SplitWords {
 
             suggestions.push(Suggestion::ReplaceWith(suggestion));
             if suggestions.len() == 1 {
+                let certainty = if candidate.len() == 1 || remainder.len() == 1 {
+                    "possibly"
+                } else {
+                    "probably"
+                };
                 message = Some(format!(
-                    "`{}` should probably be written as `{} {}`.",
+                    "`{}` should {certainty} be written as `{} {}`.",
                     chars.iter().collect::<String>(),
                     candidate.iter().collect::<String>(),
                     remainder.iter().collect::<String>()
@@ -200,7 +205,7 @@ fn should_defer_to_spellcheck(
 #[cfg(test)]
 mod tests {
     use crate::linting::tests::{
-        assert_good_and_bad_suggestions, assert_no_lints, assert_suggestion_result,
+        assert_good_and_bad_suggestions, assert_lint_message, assert_no_lints, assert_suggestion_result,
     };
 
     use super::SplitWords;
@@ -328,6 +333,24 @@ mod tests {
             "I would love to eat a cornleaf.",
             SplitWords::default(),
             "I would love to eat a corn leaf.",
+        );
+    }
+
+    #[test]
+    fn not_confident_proc_should_be_pro_c() {
+        assert_lint_message(
+            "proc",
+            SplitWords::default(),
+            "`proc` should possibly be written as `pro c`.",
+        );
+    }
+
+    #[test]
+    fn confident_thankyou_should_be_thank_you() {
+        assert_lint_message(
+            "thankyou",
+            SplitWords::default(),
+            "`thankyou` should probably be written as `thank you`.",
         );
     }
 }

--- a/harper-core/tests/text/linters/Computer science.snap.yml
+++ b/harper-core/tests/text/linters/Computer science.snap.yml
@@ -431,7 +431,7 @@ Suggest:
 Lint:    Typo (31 priority)
 Message: |
      131 | expression "automatic information" (e.g. "informazione automatica" in Italian)
-         |                                                        ^~~~~~~~~~ `automatica` should probably be written as `automatic a`.
+         |                                                        ^~~~~~~~~~ `automatica` should possibly be written as `automatic a`.
      132 | or "information and mathematics" are often used, e.g. informatique (French),
 Suggest:
   - Replace with: “automatic a”

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -1967,7 +1967,7 @@ Suggest:
 Lint:    Typo (31 priority)
 Message: |
     1693 | “Wha’s matter?” he inquired calmly. “Did we run outa gas?”
-         |                                                 ^~~~ `outa` should probably be written as `out a`.
+         |                                                 ^~~~ `outa` should possibly be written as `out a`.
 Suggest:
   - Replace with: “out a”
 


### PR DESCRIPTION
# Issues 
N/A

# Description

While dogfooding my Harper Tauri on YouTube video comments I noticed `SplitWords` often suggests unlikely pairs where one side is a one-letter "word" yet the message said "... should **probably** be written as ... ...".

I changed the logic to use the adverb "**possibly**" instead in such cases.

# How Has This Been Tested?

I picked two examples from my test files as unit tests for the different `message`s.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
