### PR TITLE
chore: add "day of age" to `DayAndAge` rule

### DIFF
--- a/harper-core/src/linting/day_and_age.rs
+++ b/harper-core/src/linting/day_and_age.rs
@@ -15,7 +15,7 @@ impl Default for DayAndAge {
                 .t_ws()
                 .then_word_set(&["day", "days"])
                 .t_ws()
-                .then_word_set(&["and", "in", "an", "on"])
+                .then_word_set(&["and", "in", "an", "on", "of"])
                 .t_ws()
                 .then_word_set(&["age", "ages"]),
         }
@@ -279,6 +279,15 @@ mod tests {
             "and since these days and age storage is usually not a problem, I usually play it safe and just don't bother",
             DayAndAge::default(),
             "and since in this day and age storage is usually not a problem, I usually play it safe and just don't bother",
+        );
+    }
+
+    #[test]
+    fn fix_day_of_age() {
+        assert_suggestion_result(
+            "If you want in this day of age an AI agent can probably implement what you are looking for.",
+            DayAndAge::default(),
+            "If you want in this day and age an AI agent can probably implement what you are looking for.",
         );
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

Was watching a YouTube video by an Australian living in Japan who has inspired some of my recent linters with English oddities I'd never heard before. This time I heard him say "in this current **day of age**". The transcript said "**day and age**" but that could be the autotranscript correcting. Anyway Google searches confirm it's a common mistake if still somewhat rare on GitHub.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Added a unit test from an example on GitHub. Then `just test-rust`.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
