### PR TITLE
feat: (since) indefinite durations

### DIFF
--- a/harper-core/src/expr/duration_expr.rs
+++ b/harper-core/src/expr/duration_expr.rs
@@ -1,5 +1,7 @@
-use crate::patterns::{IndefiniteArticle, WordSet};
-use crate::{Span, Token};
+use crate::{
+    Span, Token,
+    patterns::{IndefiniteArticle, WordSet},
+};
 
 use super::{Expr, SequenceExpr, SpelledNumberExpr};
 
@@ -17,10 +19,23 @@ impl Expr for DurationExpr {
             "weeks", "month", "months", "year", "years",
         ]);
 
+        // standard "a couple of" and colloquial "a couple"
+        let a_couple_of = SequenceExpr::default()
+            .t_aco("a")
+            .t_ws()
+            .t_aco("couple")
+            .then_optional(SequenceExpr::default().t_ws().t_aco("of"));
+
+        // positive "a few" and negative "few"
+        let a_few = SequenceExpr::optional(SequenceExpr::aco("a").t_ws()).t_aco("few");
+
         let expr = SequenceExpr::longest_of(vec![
             Box::new(SpelledNumberExpr),
             Box::new(SequenceExpr::default().then_number()),
             Box::new(IndefiniteArticle::default()),
+            Box::new(a_couple_of),
+            Box::new(a_few),
+            Box::new(SequenceExpr::default().then_quantifier()),
         ])
         .then_whitespace()
         .then(units);
@@ -48,5 +63,14 @@ pub mod tests {
         let doc = Document::new_markdown_default_curated("I think ten days is a long time.");
         let matches = DurationExpr.iter_matches_in_doc(&doc).collect::<Vec<_>>();
         assert_eq!(matches.to_strings(&doc), vec!["ten days"]);
+    }
+
+    #[test]
+    fn detect_a_few_months() {
+        let doc = Document::new_markdown_default_curated(
+            "I am struggling since a few months with the rebuild of an old FORTRAN program.",
+        );
+        let matches = DurationExpr.iter_matches_in_doc(&doc).collect::<Vec<_>>();
+        assert_eq!(matches.to_strings(&doc), vec!["a few months"]);
     }
 }

--- a/harper-core/src/linting/since_duration.rs
+++ b/harper-core/src/linting/since_duration.rs
@@ -1,8 +1,8 @@
-use crate::expr::{DurationExpr, Expr, SequenceExpr};
-use crate::{CharStringExt, Token, TokenStringExt};
-
-use super::{ExprLinter, Lint, LintKind, Suggestion};
-use crate::linting::expr_linter::Chunk;
+use crate::{
+    CharStringExt, Token, TokenStringExt,
+    expr::{DurationExpr, Expr, SequenceExpr},
+    linting::{ExprLinter, Lint, LintKind, Suggestion, expr_linter::Chunk},
+};
 
 const AGO_VARIANTS: [&[char]; 3] = [&['a', 'g', 'o'], &['A', 'g', 'o'], &['A', 'G', 'O']];
 const FOR_VARIANTS: [&[char]; 3] = [&['f', 'o', 'r'], &['F', 'o', 'r'], &['F', 'O', 'R']];
@@ -272,7 +272,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "We can't yet handle indefinite numbers."]
     fn not_yet_handled_3() {
         assert_suggestion_result(
             "I use a Wacom Cintiq 27QHDT since several years on Linux",
@@ -286,6 +285,46 @@ mod tests {
         assert_no_lints(
             "I've been coding since 11 years old and I'm now 57",
             SinceDuration::default(),
+        );
+    }
+
+    fn correct_since_a_few_months() {
+        assert_suggestion_result(
+            "I am struggling since a few months with the rebuild of an old FORTRAN program.",
+            SinceDuration::default(),
+            "I am struggling for a few months with the rebuild of an old FORTRAN program.",
+        );
+    }
+
+    // Note: Expects "few" to be corrected to "a few" by a different linter
+    fn correct_since_few_days() {
+        assert_suggestion_result(
+            "I've been struggling since few days with the rebuild of an old FORTRAN program.",
+            SinceDuration::default(),
+            "I've been struggling for few days with the rebuild of an old FORTRAN program.",
+        );
+    }
+
+    fn dont_flag_since_a_couple_hours_ago() {
+        assert_no_lints(
+            "[BUG] since a couple hours ago, the claude code agent often gets stuck while working.",
+            SinceDuration::default(),
+        );
+    }
+
+    fn fix_since_a_couple_of_days() {
+        assert_suggestion_result(
+            "Since a couple of days, I got this error",
+            SinceDuration::default(),
+            "For a couple of days, I got this error",
+        );
+    }
+
+    fn fix_since_a_couple_days() {
+        assert_suggestion_result(
+            "Values at 0 all the time since a couple days · Issue #91551",
+            SinceDuration::default(),
+            "Values at 0 all the time since a couple days ago · Issue #91551",
         );
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

While dogfooding I noticed "since a few days" wasn't corrected by the `SinceDuration` linter to either "for a few days" or "since a few days ago".

Looking into the linter I realized that indefinite durations were omitted to allow time to see if there were false positives etc. before growing the linter too big.

Since it hasn't received too many issues over the months it's been live, it's worth adding to now.

This PR expands the `DurationExpr` expression which the `SinceDuration` linter is based on with:
- a couple (of) [units of time]
- (a) few [units of time]
- [quantifier] [units of time]

# How Has This Been Tested?

I added unit tests for the various variants of "couple" and "few" using sentences found on GitHub.
Then `cargo test`.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
