### PR TITLE
feat: expand coord, vuln, notif, algo

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -1288,6 +1288,13 @@
 								"state": true,
 								"label": "Expand Coord"
 							}
+						},
+						{
+							"Bool": {
+								"name": "ExpandVuln",
+								"state": true,
+								"label": "Expand Vuln"
+							}
 						}
 					]
 				}

--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -1291,6 +1291,13 @@
 						},
 						{
 							"Bool": {
+								"name": "ExpandNotification",
+								"state": true,
+								"label": "Expand Notification"
+							}
+						},
+						{
+							"Bool": {
 								"name": "ExpandVuln",
 								"state": true,
 								"label": "Expand Vuln"

--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -1286,7 +1286,7 @@
 							"Bool": {
 								"name": "ExpandCoord",
 								"state": true,
-								"label": "Expand Coors"
+								"label": "Expand Coord"
 							}
 						}
 					]

--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -1284,9 +1284,16 @@
 						},
 						{
 							"Bool": {
-								"name": "ExpandCoord",
+								"name": "ExpandAlgorithm",
 								"state": true,
-								"label": "Expand Coord"
+								"label": "Expand Algorithm"
+							}
+						},
+						{
+							"Bool": {
+								"name": "ExpandCoordinate",
+								"state": true,
+								"label": "Expand Coordinate"
 							}
 						},
 						{
@@ -1298,9 +1305,9 @@
 						},
 						{
 							"Bool": {
-								"name": "ExpandVuln",
+								"name": "ExpandVulnerability",
 								"state": true,
-								"label": "Expand Vuln"
+								"label": "Expand Vulnerability"
 							}
 						}
 					]

--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -1281,6 +1281,13 @@
 								"state": true,
 								"label": "Formative Years"
 							}
+						},
+						{
+							"Bool": {
+								"name": "ExpandCoord",
+								"state": true,
+								"label": "Expand Coors"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -231,6 +231,15 @@ pub fn lint_group() -> LintGroup {
             "Expands the abbreviations `stdin`, `stdout`, and `stderr` to the full words `standard input`, etc. for clarity.",
             LintKind::Style
         ),
+        "ExpandVuln" => (
+            &[
+                ("vuln", "vulnerability"),
+                ("vulns", "vulnerabilities"),
+            ],
+            "Use `vulnerability` instead of `vuln`",
+            "Expands the abbreviation `vuln` to the full word `vulnerability` for clarity.",
+            LintKind::Style
+        ),
         "ExplanationMark" => (
             &[
                 ("explanation mark", "exclamation mark"),

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -176,6 +176,15 @@ pub fn lint_group() -> LintGroup {
             "Tries to correct typos of `dose` to `does`.",
             LintKind::Typo
         ),
+        "ExpandAlgorithm" => (
+            &[
+                ("algo", "algorithm"),
+                ("algos", "algorithms"),
+            ],
+            "Use `algorithm` instead of `algo`",
+            "Expands the abbreviation `algo` to the full word `algorithm` for clarity.",
+            LintKind::Style
+        ),
         "ExpandArgument" => (
             &[
                 ("arg", "argument"),
@@ -240,7 +249,7 @@ pub fn lint_group() -> LintGroup {
             "Expands the abbreviations `stdin`, `stdout`, and `stderr` to the full words `standard input`, etc. for clarity.",
             LintKind::Style
         ),
-        "ExpandVuln" => (
+        "ExpandVulnerability" => (
             &[
                 ("vuln", "vulnerability"),
                 ("vulns", "vulnerabilities"),
@@ -748,7 +757,7 @@ pub fn lint_group() -> LintGroup {
             "Expands the abbreviation `alloc` to the full word `allocate` or `allocation` for clarity.",
             LintKind::Style
         ),
-        "ExpandCoord" => (
+        "ExpandCoordinate" => (
             &[
                 (&["coord"], &["coordinate"]),
                 (&["coords"], &["coordinates"]),

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -203,6 +203,15 @@ pub fn lint_group() -> LintGroup {
             "Expands the abbreviation `deref` to the full word `dereference` for clarity.",
             LintKind::Style
         ),
+        "ExpandNotification" => (
+            &[
+                ("notif", "notification"),
+                ("notifs", "notifications"),
+            ],
+            "Use `notification` instead of `notif`",
+            "Expands the abbreviation `notif` to the full word `notification` for clarity.",
+            LintKind::Style
+        ),
         "ExpandParameter" => (
             &[
                 ("param", "parameter"),

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -730,6 +730,15 @@ pub fn lint_group() -> LintGroup {
             "Expands the abbreviation `alloc` to the full word `allocate` or `allocation` for clarity.",
             LintKind::Style
         ),
+        "ExpandCoord" => (
+            &[
+                (&["coord"], &["coordinate"]),
+                (&["coords"], &["coordinates"]),
+            ],
+            "Use `coordinate` instead of `coord`",
+            "Expands the abbreviation `coord` to the full word `coordinate` for clarity.",
+            LintKind::Style
+        ),
         "ExpandDecl" => (
             &[
                 (&["decl"], &["declaration", "declarator"]),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -692,6 +692,26 @@ fn correct_ptrs() {
 // ExpandStandardOutput
 // -none-
 
+// ExpandVuln
+
+#[test]
+fn corrects_vuln() {
+    assert_suggestion_result(
+        "I did not understand this vuln in first place now I do not understand in 2nd place as well😢",
+        lint_group(),
+        "I did not understand this vulnerability in first place now I do not understand in 2nd place as well😢",
+    );
+}
+
+#[test]
+fn corrects_vulns() {
+    assert_suggestion_result(
+        "... when persisted, containing endpoints, vulns, WAF bypasses, sensitive params, and auth endpoints.",
+        lint_group(),
+        "... when persisted, containing endpoints, vulnerabilities, WAF bypasses, sensitive parameters, and auth endpoints.",
+    );
+}
+
 // ExplanationMark
 #[test]
 fn detect_explanation_mark_atomic() {

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -585,6 +585,24 @@ fn corrects_args() {
     );
 }
 
+#[test]
+fn corrects_coord() {
+    assert_suggestion_result(
+        "Prompted by #5684, we should probably emit more meaningful messages when position guides are specified in coord systems that do not support them",
+        lint_group(),
+        "Prompted by #5684, we should probably emit more meaningful messages when position guides are specified in coordinate systems that do not support them",
+    );
+}
+
+#[test]
+fn corrects_coords() {
+    assert_suggestion_result(
+        "Here is how you can extract the list of coords from any geometry:",
+        lint_group(),
+        "Here is how you can extract the list of coordinates from any geometry:",
+    );
+}
+
 // ExpandDecl
 
 #[test]

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -565,6 +565,26 @@ fn corrects_why_dose() {
 
 // Note: no false positive detected for 'why does'. Only true positives.
 
+// ExpandAlgorithm
+
+#[test]
+fn corrects_algo() {
+    assert_suggestion_result(
+        "Always glad when the algo feeds me a new dissident.",
+        lint_group(),
+        "Always glad when the algorithm feeds me a new dissident.",
+    );
+}
+
+#[test]
+fn corrects_algos() {
+    assert_suggestion_result(
+        "I moved algos development to a private repository.",
+        lint_group(),
+        "I moved algorithms development to a private repository.",
+    );
+}
+
 // ExpandArgument
 
 #[test]
@@ -585,7 +605,7 @@ fn corrects_args() {
     );
 }
 
-// ExpandCoord
+// ExpandCoordinate
 
 #[test]
 fn corrects_coord() {
@@ -714,7 +734,7 @@ fn correct_ptrs() {
 // ExpandStandardOutput
 // -none-
 
-// ExpandVuln
+// ExpandVulnerability
 
 #[test]
 fn corrects_vuln() {
@@ -730,7 +750,9 @@ fn corrects_vulns() {
     // Fix just this lint
     let mut only_expand_vuln = lint_group();
     only_expand_vuln.set_all_rules_to(None); // Disable all linters
-    only_expand_vuln.config.set_rule_enabled("ExpandVuln", true); // Enable only ExpandVuln
+    only_expand_vuln
+        .config
+        .set_rule_enabled("ExpandVulnerability", true); // Enable only ExpandVuln
 
     assert_suggestion_result(
         "... when persisted, containing endpoints, vulns, WAF bypasses, sensitive params, and auth endpoints.",

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -705,6 +705,17 @@ fn corrects_vuln() {
 
 #[test]
 fn corrects_vulns() {
+    // Fix just this lint
+    let mut only_expand_vuln = lint_group();
+    only_expand_vuln.set_all_rules_to(None); // Disable all linters
+    only_expand_vuln.config.set_rule_enabled("ExpandVuln", true); // Enable only ExpandVuln
+
+    assert_suggestion_result(
+        "... when persisted, containing endpoints, vulns, WAF bypasses, sensitive params, and auth endpoints.",
+        only_expand_vuln,
+        "... when persisted, containing endpoints, vulnerabilities, WAF bypasses, sensitive params, and auth endpoints.",
+    );
+    // Fix all lints in the `LintGroup`
     assert_suggestion_result(
         "... when persisted, containing endpoints, vulns, WAF bypasses, sensitive params, and auth endpoints.",
         lint_group(),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -585,6 +585,8 @@ fn corrects_args() {
     );
 }
 
+// ExpandCoord
+
 #[test]
 fn corrects_coord() {
     assert_suggestion_result(
@@ -643,6 +645,26 @@ fn corrects_derefs() {
         "A contiguous-in-memory double-ended queue that derefs into a slice - gnzlbg/slice_deque.",
         lint_group(),
         "A contiguous-in-memory double-ended queue that dereferences into a slice - gnzlbg/slice_deque.",
+    );
+}
+
+// ExpandNotification
+
+#[test]
+fn corrects_notif() {
+    assert_suggestion_result(
+        "Amazing to see the notif of this on my phone!",
+        lint_group(),
+        "Amazing to see the notification of this on my phone!",
+    );
+}
+
+#[test]
+fn corrects_notifs() {
+    assert_suggestion_result(
+        "I don't encourage you spending all your time on social media or keeping the notifs on if you're working on something serious.",
+        lint_group(),
+        "I don't encourage you spending all your time on social media or keeping the notifications on if you're working on something serious.",
     );
 }
 


### PR DESCRIPTION
# Issues 
N/A

# Description

- Expands "coord" to "coordinate" and "coords" to "coordinates".
- Expands "vuln" to "vulnerability" and "vulns" to "vulnerabilities".
- Expands "notif" to "notification" and "notifs" to "notifications".
- Expands "algo" to "algorithm" and "algos" to "algorithms".

# How Has This Been Tested?

- Unit tests based on sentences from YouTube comments and GitHub.
- `cargo test`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
