### PR TITLE
feat: in favour doing→in favour of doing

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -4822,6 +4822,13 @@
 								"state": true,
 								"label": "More Than Meets The Eye"
 							}
+						},
+						{
+							"Bool": {
+								"name": "InFavourOfDoing",
+								"state": true,
+								"label": "In Favour Of Doing"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/in_favour_of_doing.rs
+++ b/harper-core/src/linting/in_favour_of_doing.rs
@@ -1,0 +1,115 @@
+use crate::{
+    Lint, Token,
+    expr::{Expr, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+};
+
+pub struct InFavourOfDoing {
+    expr: SequenceExpr,
+}
+
+impl Default for InFavourOfDoing {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::aco("in")
+                .t_ws()
+                .t_set(&["favour", "favor"])
+                .t_ws()
+                .then_verb_progressive_form(),
+        }
+    }
+}
+
+impl ExprLinter for InFavourOfDoing {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, toks: &[Token], _src: &[char]) -> Option<Lint> {
+        let fav_idx = 2;
+
+        Some(Lint {
+            span: toks[fav_idx].span,
+            lint_kind: LintKind::Usage,
+            suggestions: vec![Suggestion::InsertAfter(" of".chars().collect())],
+            message: "The word `of` is missing.".to_string(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects missing `of` in `in favor/favour of doing`, etc."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::assert_suggestion_result;
+
+    use super::InFavourOfDoing;
+
+    #[test]
+    fn fix_favour_doing() {
+        assert_suggestion_result(
+            "I don't think anyone is in favour doing nothing, but I wouldn't know which of the first two is best.",
+            InFavourOfDoing::default(),
+            "I don't think anyone is in favour of doing nothing, but I wouldn't know which of the first two is best.",
+        );
+    }
+
+    #[test]
+    fn fix_favor_getting() {
+        assert_suggestion_result(
+            "I've definitely been in favor getting Observable as a language primitive since the beginning.",
+            InFavourOfDoing::default(),
+            "I've definitely been in favor of getting Observable as a language primitive since the beginning.",
+        );
+    }
+
+    #[test]
+    fn fix_favor_having() {
+        assert_suggestion_result(
+            "I'm in favor having all-in-one @std/std as convenient entrypoint for all modules.",
+            InFavourOfDoing::default(),
+            "I'm in favor of having all-in-one @std/std as convenient entrypoint for all modules.",
+        );
+    }
+
+    #[test]
+    fn fix_favor_using() {
+        assert_suggestion_result(
+            "I'm closing this in favor using the official guide.",
+            InFavourOfDoing::default(),
+            "I'm closing this in favor of using the official guide.",
+        );
+    }
+
+    #[test]
+    fn fix_favour_having() {
+        assert_suggestion_result(
+            "Would you be in favour having a feature to suppress local configuration files via an env var e.g. DISABLE_LOCAL_CONFIG or similar?",
+            InFavourOfDoing::default(),
+            "Would you be in favour of having a feature to suppress local configuration files via an env var e.g. DISABLE_LOCAL_CONFIG or similar?",
+        );
+    }
+
+    #[test]
+    fn fix_favour_putting() {
+        assert_suggestion_result(
+            "I've abandoned just optimising the cpu renderers (which could then just be compiled on linux as well) in favour putting the work onto gpu.",
+            InFavourOfDoing::default(),
+            "I've abandoned just optimising the cpu renderers (which could then just be compiled on linux as well) in favour of putting the work onto gpu.",
+        );
+    }
+
+    #[test]
+    fn fix_favour_using() {
+        assert_suggestion_result(
+            "This is also the reason I am personally not in favour using AI for this task because of the latter.",
+            InFavourOfDoing::default(),
+            "This is also the reason I am personally not in favour of using AI for this task because of the latter.",
+        );
+    }
+}

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -100,6 +100,7 @@ use super::how_to::HowTo;
 use super::hyphenate_number_day::HyphenateNumberDay;
 use super::i_am_agreement::IAmAgreement;
 use super::if_wouldve::IfWouldve;
+use super::in_favour_of_doing::InFavourOfDoing;
 use super::in_on_the_cards::InOnTheCards;
 use super::in_time_from_now::InTimeFromNow;
 use super::inflected_verb_after_to::InflectedVerbAfterTo;
@@ -592,6 +593,7 @@ impl LintGroup {
         insert_expr_rule!(HyphenateNumberDay, true);
         insert_expr_rule!(IAmAgreement, true);
         insert_expr_rule!(IfWouldve, true);
+        insert_expr_rule!(InFavourOfDoing, true);
         insert_struct_rule_with_dialect!(InOnTheCards, true);
         insert_expr_rule!(InTimeFromNow, true);
         insert_struct_rule_with_dict!(InflectedVerbAfterTo, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -98,6 +98,7 @@ mod how_to;
 mod hyphenate_number_day;
 mod i_am_agreement;
 mod if_wouldve;
+mod in_favour_of_doing;
 mod in_on_the_cards;
 mod in_time_from_now;
 mod inflected_verb_after_to;


### PR DESCRIPTION
# Issues 
N/A

# Description

I heard or read "in favour doing" with the missing "of" where it should be "in favour of doing". I did some Googling and it's actually common with various verbs.

This linter handles UK and US spelling and all verbs in the gerund/progressive form.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Half a dozen examples were found on GitHub and used to make unit tests.
Then `cargo test`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
