### PR TITLE
feat: on hindsight/in hind sight etc.→in hindsight

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -4822,6 +4822,13 @@
 								"state": true,
 								"label": "More Than Meets The Eye"
 							}
+						},
+						{
+							"Bool": {
+								"name": "InHindsight",
+								"state": true,
+								"label": "In Hindsight"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -806,7 +806,7 @@ pub fn lint_group() -> LintGroup {
             ],
             "Use `in hindsight` when reflecting on past events with the benefit of current knowledge.",
             "Corrects incorrect variants of `in hindsight` to the standard phrase.",
-            LintKind::Spelling
+            LintKind::Usage
         ),
         "MakeItSeem" => (
             &[

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -800,6 +800,14 @@ pub fn lint_group() -> LintGroup {
             "Corrects `how ... looks like` to `how ... looks` or `what ... looks like`.",
             LintKind::Grammar
         ),
+        "InHindsight" => (
+            &[
+                (&["in hind sight", "in hind-sight", "on hindsight", "on hind sight", "on hind-sight"], &["in hindsight"]),
+            ],
+            "Use `in hindsight` when reflecting on past events with the benefit of current knowledge.",
+            "Corrects incorrect variants of `in hindsight` to the standard phrase.",
+            LintKind::Spelling
+        ),
         "MakeItSeem" => (
             &[
                 (&["make it seems"], &["make it seem"]),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -2674,6 +2674,53 @@ fn correct_how_it_looks_like_with_apostrophe() {
     );
 }
 
+// InHindsight
+
+#[test]
+fn corrects_on_hindsight() {
+    assert_suggestion_result(
+        "On hindsight, the tip to \"try launching your terminal\" would've been useful",
+        lint_group(),
+        "In hindsight, the tip to \"try launching your terminal\" would've been useful",
+    );
+}
+
+#[test]
+fn corrects_in_hind_sight_hyphenated() {
+    assert_suggestion_result(
+        "It probably could have been better to fake an OSS project name in hind-sight, but anyway we can still fix this.",
+        lint_group(),
+        "It probably could have been better to fake an OSS project name in hindsight, but anyway we can still fix this.",
+    );
+}
+
+#[test]
+fn corrects_in_hind_sight() {
+    assert_suggestion_result(
+        "In hind sight, this is obvious, but the error message led to hours of wasted debugging in the wrong places.",
+        lint_group(),
+        "In hindsight, this is obvious, but the error message led to hours of wasted debugging in the wrong places.",
+    )
+}
+
+#[test]
+fn corrects_on_hind_sight() {
+    assert_suggestion_result(
+        "Yes, on hind sight I've used tasks that don't respond well to kills.",
+        lint_group(),
+        "Yes, in hindsight I've used tasks that don't respond well to kills.",
+    )
+}
+
+#[test]
+fn corrects_on_hind_sight_hyphenated() {
+    assert_suggestion_result(
+        "On hind-sight the likely root cause was not force cleaning helm config.",
+        lint_group(),
+        "In hindsight the likely root cause was not force cleaning helm config.",
+    )
+}
+
 // MakeItSeem
 
 #[test]


### PR DESCRIPTION
# Issues 
N/A

# Description

I heard or read "on hindsight" while dogfooding on YouTube comments and did some Googling.
I found several other common wrong variants of "in hindsight" too:
- in hind sight
- in hind-sight
- on hindsight
- on hind sight
- on hind-sight

Using `phrase_set_corrections` those are all corrected to "in hindsight" now.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Found an example of each variant on GitHub and made unit tests from them.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
