### PR TITLE
refactor: move `dictionary_io` into own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2859,6 +2859,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "harper-dictionary-wordlist"
+version = "2.1.0"
+dependencies = [
+ "harper-core",
+ "itertools 0.14.0",
+ "tokio",
+]
+
+[[package]]
 name = "harper-html"
 version = "2.1.0"
 dependencies = [
@@ -2914,6 +2923,7 @@ dependencies = [
  "harper-asciidoc",
  "harper-comments",
  "harper-core",
+ "harper-dictionary-wordlist",
  "harper-html",
  "harper-ink",
  "harper-jjdescription",
@@ -2922,7 +2932,6 @@ dependencies = [
  "harper-stats",
  "harper-tex",
  "harper-typst",
- "itertools 0.14.0",
  "open",
  "resolve-path",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["harper-cli", "harper-core", "harper-ls", "harper-comments", "harper-wasm", "harper-tree-sitter", "harper-html", "harper-literate-haskell", "harper-typst", "harper-stats", "harper-pos-utils", "harper-brill", "harper-ink", "harper-python", "harper-jjdescription", "harper-thesaurus", "harper-asciidoc", "fuzz", "harper-tex"]
+members = ["harper-cli", "harper-core", "harper-ls", "harper-comments", "harper-wasm", "harper-tree-sitter", "harper-html", "harper-literate-haskell", "harper-typst", "harper-stats", "harper-pos-utils", "harper-brill", "harper-ink", "harper-python", "harper-jjdescription", "harper-thesaurus", "harper-asciidoc", "fuzz", "harper-tex", "harper-dictionary-wordlist"]
 resolver = "2"
 
 [profile.test]

--- a/harper-cli/src/lint.rs
+++ b/harper-cli/src/lint.rs
@@ -24,7 +24,7 @@ use crate::input::{
     single_input::{SingleInput, SingleInputTrait, StdinInput},
 };
 
-/// Sync version of harper-ls/src/dictionary_io@load_dict
+/// Sync version of harper_dictionary_wordlist::load_dict.
 fn load_dict(path: &Path) -> anyhow::Result<MutableDictionary> {
     let str = fs::read_to_string(path)?;
 
@@ -57,7 +57,7 @@ fn load_weirpacks(inputs: &[SingleInput]) -> anyhow::Result<Vec<Weirpack>> {
     Ok(packs)
 }
 
-/// Path version of harper-ls/src/dictionary_io@file_dict_name
+/// Path version of harper-ls file dictionary name rewriting.
 fn file_dict_name(path: &Path) -> PathBuf {
     let mut rewritten = String::new();
 

--- a/harper-dictionary-wordlist/Cargo.toml
+++ b/harper-dictionary-wordlist/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "harper-dictionary-wordlist"
+version = "2.1.0"
+edition = "2024"
+description = "The language checker for developers."
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/automattic/harper"
+
+[dependencies]
+harper-core = { path = "../harper-core", version = "2.0.0", features = ["concurrent"] }
+itertools = "0.14.0"
+tokio = { version = "1.52.1", default-features = false, features = ["fs", "io-util", "macros", "rt"] }

--- a/harper-dictionary-wordlist/src/lib.rs
+++ b/harper-dictionary-wordlist/src/lib.rs
@@ -106,8 +106,7 @@ mod tests {
     fn get_test_unsorted_dict() -> MutableDictionary {
         let mut test_unsorted_dict = MutableDictionary::new();
         test_unsorted_dict.extend_words(
-            TEST_UNSORTED_WORDS
-                .map(|w| (w.chars().collect::<Vec<_>>(), DictWordMetadata::default())),
+            TEST_UNSORTED_WORDS.map(|w| (w.chars().collect::<Vec<_>>(), Default::default())),
         );
         test_unsorted_dict
     }

--- a/harper-ls/Cargo.toml
+++ b/harper-ls/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/automattic/harper"
 
 [dependencies]
 harper-stats = { path = "../harper-stats", version = "2.0.0" }
+harper-dictionary-wordlist = { path = "../harper-dictionary-wordlist", version = "2.0.0" }
 harper-literate-haskell = { path = "../harper-literate-haskell", version = "2.0.0" }
 harper-core = { path = "../harper-core", version = "2.0.0", features = ["concurrent"] }
 harper-comments = { path = "../harper-comments", version = "2.0.0" }
@@ -24,7 +25,6 @@ clap = { version = "4.6.0", default-features = false, features = ["derive", "std
 dirs = "6.0.0"
 anyhow = "1.0.102"
 serde_json = "1.0.149"
-itertools = "0.14.0"
 tracing = { version = "0.1.44", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.23", default-features = false, features = ["fmt", "std"] }
 resolve-path = "0.1.0"

--- a/harper-ls/src/backend.rs
+++ b/harper-ls/src/backend.rs
@@ -5,7 +5,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::config::Config;
-use crate::dictionary_io::{load_dict, save_dict};
 use crate::document_state::DocumentState;
 use crate::git_commit_parser::GitCommitParser;
 use crate::ignored_lints_io::{load_ignored_lints, save_ignored_lints};
@@ -20,6 +19,7 @@ use harper_core::parsers::{
 };
 use harper_core::spell::{Dictionary, FstDictionary, MergedDictionary, MutableDictionary};
 use harper_core::{Dialect, DictWordMetadata, Document, IgnoredLints};
+use harper_dictionary_wordlist::{load_dict, save_dict};
 use harper_html::HtmlParser;
 use harper_ink::InkParser;
 use harper_jjdescription::JJDescriptionParser;

--- a/harper-ls/src/main.rs
+++ b/harper-ls/src/main.rs
@@ -7,7 +7,6 @@ use tokio::net::TcpListener;
 mod backend;
 mod config;
 mod diagnostics;
-mod dictionary_io;
 mod document_state;
 mod git_commit_parser;
 mod ignored_lints_io;


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

While working on Harper Desktop, I ran into a need to serialize and deserialize the user's dictionary to disk. Ideally, it would be human-readable. I then remembered that I wrote a module that does exactly what I need for `harper-ls`. This PR moves that module into its own crate so that it can be consumed by other projects.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
