### PR TITLE
feat(harper.js): make it easier to ignore all lints

### DIFF
--- a/harper-wasm/src/lib.rs
+++ b/harper-wasm/src/lib.rs
@@ -276,18 +276,25 @@ impl Linter {
         Ok(())
     }
 
-    pub fn ignore_lint(&mut self, source_text: String, lint: Lint) {
+    pub fn ignore_lints(&mut self, source_text: String, lints: Vec<Lint>) {
         let source: Lrc<_> = source_text.chars().collect();
 
-        let document =
-            Document::new_from_chars(source, &lint.language.create_parser(), &self.dictionary);
+        for lint in lints {
+            let document = Document::new_from_chars(
+                source.clone(),
+                &lint.language.create_parser(),
+                &self.dictionary,
+            );
 
-        self.ignored_lints.ignore_lint(&lint.inner, &document);
+            self.ignored_lints.ignore_lint(&lint.inner, &document);
+        }
     }
 
     /// Add a specific context hash to the ignored lints list.
-    pub fn ignore_hash(&mut self, hash: u64) {
-        self.ignored_lints.ignore_hash(hash);
+    pub fn ignore_hashes(&mut self, hashes: Vec<u64>) {
+        for hash in hashes {
+            self.ignored_lints.ignore_hash(hash);
+        }
     }
 
     /// Compute the context hash of a given lint.

--- a/harper-wasm/src/lib.rs
+++ b/harper-wasm/src/lib.rs
@@ -310,6 +310,7 @@ impl Linter {
         language: Language,
         all_headings: bool,
         regex_mask: Option<String>,
+        dedup: bool,
     ) -> Vec<OrganizedGroup> {
         let source: Lrc<_> = text.chars().collect();
 
@@ -341,7 +342,9 @@ impl Linter {
             self.ignored_lints.remove_ignored(value, &document);
         }
 
-        remove_overlaps_map(&mut lints);
+        if dedup {
+            remove_overlaps_map(&mut lints);
+        }
 
         lints
             .into_iter()
@@ -369,6 +372,7 @@ impl Linter {
         language: Language,
         all_headings: bool,
         regex_mask: Option<String>,
+        dedup: bool,
     ) -> Vec<Lint> {
         let source: Lrc<_> = text.chars().collect();
 
@@ -397,7 +401,9 @@ impl Linter {
         self.lint_group.config = temp;
 
         self.ignored_lints.remove_ignored(&mut lints, &document);
-        remove_overlaps(&mut lints);
+        if dedup {
+            remove_overlaps(&mut lints);
+        }
 
         lints
             .into_iter()
@@ -782,7 +788,7 @@ mod tests {
         linter.import_words(vec![text.clone()]);
         dbg!(linter.dictionary.get_word_metadata_str(&text));
 
-        let lints = linter.lint(text, Language::Plain, false, None);
+        let lints = linter.lint(text, Language::Plain, false, None, true);
         assert!(lints.is_empty());
     }
 
@@ -803,6 +809,7 @@ mod tests {
                     Language::Plain,
                     false,
                     None,
+                    true,
                 );
 
                 assert!(results.is_empty())

--- a/packages/harper.js/src/Linter.test.ts
+++ b/packages/harper.js/src/Linter.test.ts
@@ -96,6 +96,36 @@ for (const [linterName, Linter] of Object.entries(linters)) {
 		await linter.dispose();
 	});
 
+	test(`${linterName} deduplicates no more lints than raw lint output`, async () => {
+		const linter = new Linter({ binary });
+
+		const source = 'outstandin g';
+		const defaultLints = await linter.lint(source);
+		const explicitLints = await linter.lint(source, { dedup: true });
+		const rawLints = await linter.lint(source, { dedup: false });
+
+		expect(explicitLints.length).toBe(defaultLints.length);
+		expect(defaultLints.length).toBeLessThanOrEqual(rawLints.length);
+
+		await linter.dispose();
+	}, 120000);
+
+	test(`${linterName} deduplicates no more lints than raw organized output`, async () => {
+		const linter = new Linter({ binary });
+
+		const source = 'outstandin g';
+		const defaultLints = Object.values(await linter.organizedLints(source)).flat();
+		const explicitLints = Object.values(
+			await linter.organizedLints(source, { dedup: true }),
+		).flat();
+		const rawLints = Object.values(await linter.organizedLints(source, { dedup: false })).flat();
+
+		expect(explicitLints.length).toBe(defaultLints.length);
+		expect(defaultLints.length).toBeLessThanOrEqual(rawLints.length);
+
+		await linter.dispose();
+	}, 120000);
+
 	test(`${linterName} detects repeated words with multiple synchronous requests`, async () => {
 		const linter = new Linter({ binary });
 

--- a/packages/harper.js/src/Linter.test.ts
+++ b/packages/harper.js/src/Linter.test.ts
@@ -365,6 +365,22 @@ for (const [linterName, Linter] of Object.entries(linters)) {
 		await linter.dispose();
 	});
 
+	test(`${linterName} can ignore multiple lints`, async () => {
+		const linter = new Linter({ binary });
+		const source = 'This is an test of exprting lints.';
+
+		const firstRound = await linter.lint(source);
+
+		expect(firstRound.length).toBeGreaterThanOrEqual(2);
+
+		await linter.ignoreLints(source, firstRound);
+
+		const secondRound = await linter.lint(source);
+
+		expect(secondRound.length).toBe(0);
+		await linter.dispose();
+	});
+
 	test(`${linterName} can ignore lints with hashes`, async () => {
 		const linter = new Linter({ binary });
 		const source = 'This is an test.';

--- a/packages/harper.js/src/Linter.ts
+++ b/packages/harper.js/src/Linter.ts
@@ -88,6 +88,9 @@ export default interface Linter {
 	/** Ignore future instances of a lint from a previous linting run in future invocations. */
 	ignoreLint(source: string, lint: Lint): Promise<void>;
 
+	/** Ignore future instances of lints from a previous linting run in future invocations. */
+	ignoreLints(source: string, lints: Lint[]): Promise<void>;
+
 	/** Ignore future instances of a lint from a previous linting run in future invocations using its hash. */
 	ignoreLintHash(hash: bigint): Promise<void>;
 

--- a/packages/harper.js/src/LocalLinter.ts
+++ b/packages/harper.js/src/LocalLinter.ts
@@ -172,13 +172,17 @@ export default class LocalLinter implements Linter {
 	}
 
 	async ignoreLint(source: string, lint: Lint): Promise<void> {
+		return await this.ignoreLints(source, [lint]);
+	}
+
+	async ignoreLints(source: string, lints: Lint[]): Promise<void> {
 		const inner = await this.inner;
-		inner.ignore_lint(source, lint);
+		inner.ignore_lints(source, lints);
 	}
 
 	async ignoreLintHash(hash: bigint): Promise<void> {
 		const inner = await this.inner;
-		inner.ignore_hash(hash);
+		inner.ignore_hashes(new BigUint64Array([hash]));
 	}
 
 	async exportIgnoredLints(): Promise<string> {

--- a/packages/harper.js/src/LocalLinter.ts
+++ b/packages/harper.js/src/LocalLinter.ts
@@ -54,6 +54,7 @@ export default class LocalLinter implements Linter {
 			language,
 			options?.forceAllHeadings ?? false,
 			options?.regex_mask,
+			options?.dedup ?? true,
 		);
 
 		return lints;
@@ -80,6 +81,7 @@ export default class LocalLinter implements Linter {
 			language,
 			options?.forceAllHeadings ?? false,
 			options?.regex_mask,
+			options?.dedup ?? true,
 		);
 
 		const output: Record<string, Lint[]> = {};

--- a/packages/harper.js/src/WorkerLinter/index.ts
+++ b/packages/harper.js/src/WorkerLinter/index.ts
@@ -155,7 +155,11 @@ export default class WorkerLinter implements Linter {
 	}
 
 	ignoreLint(source: string, lint: Lint): Promise<void> {
-		return this.rpc('ignoreLint', [source, lint]);
+		return this.ignoreLints(source, [lint]);
+	}
+
+	ignoreLints(source: string, lints: Lint[]): Promise<void> {
+		return this.rpc('ignoreLints', [source, lints]);
 	}
 
 	ignoreLintHash(hash: bigint): Promise<void> {

--- a/packages/harper.js/src/main.ts
+++ b/packages/harper.js/src/main.ts
@@ -57,4 +57,7 @@ export interface LintOptions {
 
 	/** Force the entirety of the document to be composed of headings. An undefined value is assumed to be false.*/
 	forceAllHeadings?: boolean;
+
+	/** Remove overlapping lints. An undefined value is assumed to be true. */
+	dedup?: boolean;
 }


### PR DESCRIPTION

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

While working on the Harper editor for Harper Desktop, @jasontheadams and I noticing that the API for ignoring all the lints in a document was pretty clunky.

To remedy this, I've changed two parts of `harper.js`. 

1. The linting functions now accept a `dedup` option. This allows the consumer to change whether overlapping lints are removed (which is often desired for aesthetic reasons). The default behavior remains the same: overlapping lints are removed. This change just allows you to set `dedup = false` so you can get _all_ the problems at once.
2. I've added a batched `ignoreLints` method to the `Linter` interface. This allows you to ignore as many lints as you want, while reusing the same source text. This is helpful for code cleanliness and for performance, since you don't need to shuffle as much data around.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Additional unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
