### PR TITLE
fix(lint-framework): handle soft breaks in contenteditable text extraction

### DIFF
--- a/packages/chrome-plugin/tests/testUtils.ts
+++ b/packages/chrome-plugin/tests/testUtils.ts
@@ -75,16 +75,18 @@ export function getDraftEditor(page: Page): Locator {
 	return page.locator('#rich-example .public-DraftEditor-content');
 }
 
-/** Replace the content of a text editor. Handles newlines by pressing Enter. */
-export async function replaceEditorContent(editorEl: Locator, text: string) {
+/** Replace the content of a text editor. */
+export async function replaceEditorContent(editorEl: Locator, text: string, softBreaks = false) {
 	await editorEl.selectText();
 	await editorEl.press('Backspace');
 
 	const lines = text.split('\n');
+	const breakKey = softBreaks ? 'Shift+Enter' : 'Enter';
+
 	for (let i = 0; i < lines.length; i++) {
 		await editorEl.pressSequentially(lines[i]);
 		if (i < lines.length - 1) {
-			await editorEl.press('Enter');
+			await editorEl.press(breakKey);
 		}
 	}
 }
@@ -372,12 +374,19 @@ export async function testMultipleSuggestionsAndUndo(
 		if (setup) {
 			await setup(page, editor);
 		}
+
+		// Soft breaks: no false positives from concatenation + correct span alignment.
+		await replaceEditorContent(editor, 'Valid words\ntset here.', true);
+		await page.waitForTimeout(4000);
+		await expect(getHarperHighlights(page)).toHaveCount(1);
+		expect(await clickHarperHighlight(page)).toBe(true);
+		await page.getByTitle('Replace with "test"').click();
+		await page.waitForTimeout(500);
+		await assertEditorContains(editor, 'test here');
+
 		await replaceEditorContent(editor, 'The first tset.\nThe second tset.\nThe third tset.');
-
 		await page.waitForTimeout(6000);
-
-		const highlights = getHarperHighlights(page);
-		await expect(highlights).toHaveCount(3);
+		await expect(getHarperHighlights(page)).toHaveCount(3);
 
 		// Get highlights sorted by visual position and click on the middle one
 		const sortedBoxes = await getSortedHighlightBoxes(page);

--- a/packages/lint-framework/src/lint/LintFramework.ts
+++ b/packages/lint-framework/src/lint/LintFramework.ts
@@ -146,7 +146,7 @@ export default class LintFramework {
 					text =
 						target instanceof HTMLTextAreaElement || target instanceof HTMLInputElement
 							? target.value
-							: target.textContent;
+							: (target as HTMLElement).innerText;
 				}
 
 				const newLineIndices = [];

--- a/packages/lint-framework/src/lint/computeLintBoxes/index.ts
+++ b/packages/lint-framework/src/lint/computeLintBoxes/index.ts
@@ -88,7 +88,7 @@ export default function computeLintBoxes(
 				applySuggestion: (sug: UnpackedSuggestion) => {
 					const current = isFormEl(el)
 						? (el as HTMLInputElement | HTMLTextAreaElement).value
-						: (el.textContent ?? '');
+						: el.innerText;
 					replaceValue(el, lint.span, suggestionToReplacementText(sug, lint.span, current));
 				},
 				ignoreLint: opts.ignoreLint ? () => opts.ignoreLint!(lint.context_hash) : undefined,
@@ -335,7 +335,7 @@ function replaceGenericContentEditable(
 	}
 
 	// Fallback: replace entire content
-	el.textContent = applySuggestion(el.textContent, span, {
+	el.textContent = applySuggestion(el.innerText, span, {
 		kind: SuggestionKind.Replace,
 		replacement_text: replacementText,
 	});

--- a/packages/lint-framework/src/lint/domUtils.ts
+++ b/packages/lint-framework/src/lint/domUtils.ts
@@ -79,6 +79,7 @@ export function leafNodes(node: Node): Node[] {
 
 /**
  * Given an element and a Span of text inside it, compute the Range that represents the region of the DOM represented.
+ * Accounts for `<br>` elements which `innerText` converts to newlines.
  * @param target
  * @param span
  */
@@ -92,6 +93,12 @@ export function getRangeForTextSpan(target: Element, span: Span): Range | null {
 
 	for (let i = 0; i < children.length; i++) {
 		const child = children[i] as HTMLElement;
+
+		if (child.nodeName === 'BR') {
+			traversed += 1;
+			continue;
+		}
+
 		const childText = child.textContent ?? '';
 
 		if (traversed + childText.length > span.start && !startFound) {


### PR DESCRIPTION
# Issues
Fixes #3316

# Description
Soft line breaks (`<br>`) caused words at line boundaries to concatenate, triggering false positive typos. Text extraction used `textContent` which ignores `<br>`, switched to `innerText` which converts them to `\n`.

# How Has This Been Tested?
Playwright E2E on Lexical, Slate, ProseMirror, Draft.js, textarea.

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.