### PR TITLE
fix: a some time→some time

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -3643,6 +3643,13 @@
 								"state": true,
 								"label": "Code In Write In"
 							}
+						},
+						{
+							"Bool": {
+								"name": "ASomeTime",
+								"state": true,
+								"label": "A Some Time"
+							}
 						}
 					]
 				}

--- a/harper-core/src/expr/time_unit_expr.rs
+++ b/harper-core/src/expr/time_unit_expr.rs
@@ -12,7 +12,18 @@ use super::Expr;
 /// Matches possessive forms (which are also common misspellings for the plurals).
 /// Matches abbreviations.
 #[derive(Default)]
-pub struct TimeUnitExpr;
+pub struct TimeUnitExpr {
+    include_plurals_only: bool,
+}
+
+impl TimeUnitExpr {
+    /// Creates a TimeUnitExpr that only matches plural time units
+    pub fn plurals_only() -> Self {
+        Self {
+            include_plurals_only: true,
+        }
+    }
+}
 
 impl Expr for TimeUnitExpr {
     fn run(&self, cursor: usize, tokens: &[Token], source: &[char]) -> Option<Span<Token>> {
@@ -66,15 +77,22 @@ impl Expr for TimeUnitExpr {
         let units_other_plural = WordSet::new(&["moments", "nights", "weekends"]);
         let units_other_apos = WordSet::new(&["moment's", "night's", "weekend's"]);
 
-        let units = LongestMatchOf::new(vec![
-            Box::new(units_definite_singular),
-            Box::new(units_definite_plural),
-            Box::new(units_other_singular),
-            Box::new(units_other_plural),
-            Box::new(units_definite_abbrev),
-            Box::new(units_definite_apos),
-            Box::new(units_other_apos),
-        ]);
+        let units = if self.include_plurals_only {
+            LongestMatchOf::new(vec![
+                Box::new(units_definite_plural),
+                Box::new(units_other_plural),
+            ])
+        } else {
+            LongestMatchOf::new(vec![
+                Box::new(units_definite_singular),
+                Box::new(units_definite_plural),
+                Box::new(units_other_singular),
+                Box::new(units_other_plural),
+                Box::new(units_definite_abbrev),
+                Box::new(units_definite_apos),
+                Box::new(units_other_apos),
+            ])
+        };
 
         units.run(cursor, tokens, source)
     }

--- a/harper-core/src/linting/a_some_time.rs
+++ b/harper-core/src/linting/a_some_time.rs
@@ -1,7 +1,8 @@
 use crate::{
     Lint, Token, TokenStringExt,
-    expr::{Expr, SequenceExpr},
+    expr::{Expr, SequenceExpr, TimeUnitExpr},
     linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+    patterns::Word,
 };
 
 pub struct ASomeTime {
@@ -11,18 +12,14 @@ pub struct ASomeTime {
 impl Default for ASomeTime {
     fn default() -> Self {
         Self {
-            expr: SequenceExpr::aco("a").t_ws().t_aco("some").t_ws().t_set(&[
-                "time",
-                "days",
-                "hours",
-                "milliseconds",
-                "minutes",
-                "ms",
-                "months",
-                "seconds",
-                "weeks",
-                "years",
-            ]),
+            expr: SequenceExpr::aco("a")
+                .t_ws()
+                .t_aco("some")
+                .t_ws()
+                .then_any_of(vec![
+                    Box::new(Word::new("time")),
+                    Box::new(TimeUnitExpr::plurals_only()),
+                ]),
         }
     }
 }

--- a/harper-core/src/linting/a_some_time.rs
+++ b/harper-core/src/linting/a_some_time.rs
@@ -1,0 +1,130 @@
+use crate::{
+    Lint, Token, TokenStringExt,
+    expr::{Expr, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+};
+
+pub struct ASomeTime {
+    expr: SequenceExpr,
+}
+
+impl Default for ASomeTime {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::aco("a").t_ws().t_aco("some").t_ws().t_set(&[
+                "time",
+                "days",
+                "hours",
+                "milliseconds",
+                "minutes",
+                "ms",
+                "months",
+                "seconds",
+                "weeks",
+                "years",
+            ]),
+        }
+    }
+}
+
+impl ExprLinter for ASomeTime {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, toks: &[Token], source: &[char]) -> Option<Lint> {
+        let a_some_toks = &toks[0..=2];
+        let a_some_span = a_some_toks.span()?;
+
+        // We use `ReplaceWith` rather than `Remove` because the latter has no case-matching.
+        let suggestions = vec![Suggestion::replace_with_match_case_str(
+            "some",
+            a_some_span.get_content(source),
+        )];
+
+        Some(Lint {
+            span: a_some_span,
+            lint_kind: LintKind::Usage,
+            suggestions,
+            message: "Remove the indefinite article `a` before `some`.".to_string(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Removes the redundant/conflicting indefinite article `a` before `some` when followed by time expressions."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::assert_suggestion_result;
+
+    use super::ASomeTime;
+
+    #[test]
+    fn after_a_some_time() {
+        assert_suggestion_result(
+            "I am connecting to a websocket and I get this error after a some time: SyntaxError: Unexpected end of JSON input",
+            ASomeTime::default(),
+            "I am connecting to a websocket and I get this error after some time: SyntaxError: Unexpected end of JSON input",
+        );
+    }
+
+    #[test]
+    fn for_a_some_months() {
+        assert_suggestion_result(
+            "I haven't upgraded my system for at least a some months.",
+            ASomeTime::default(),
+            "I haven't upgraded my system for at least some months.",
+        );
+    }
+
+    #[test]
+    fn for_a_some_time() {
+        assert_suggestion_result(
+            "The problem with this code is that not receiving images for a some time causes the window to hang",
+            ASomeTime::default(),
+            "The problem with this code is that not receiving images for some time causes the window to hang",
+        );
+    }
+
+    #[test]
+    fn for_a_some_weeks() {
+        assert_suggestion_result(
+            "This problem have been there for a some weeks so does it plans to ve fixed.",
+            ASomeTime::default(),
+            "This problem have been there for some weeks so does it plans to ve fixed.",
+        );
+    }
+
+    #[test]
+    fn a_some_weeks_ago() {
+        assert_suggestion_result(
+            "I reported some warnings from the log a some weeks ago.",
+            ASomeTime::default(),
+            "I reported some warnings from the log some weeks ago.",
+        );
+    }
+
+    // I guess support people is was cheaper than just a some hours of an engineer who can actually fix the platform
+    #[test]
+    fn a_some_hours() {
+        assert_suggestion_result(
+            "I guess support people is was cheaper than just a some hours of an engineer who can actually fix the platform",
+            ASomeTime::default(),
+            "I guess support people is was cheaper than just some hours of an engineer who can actually fix the platform",
+        );
+    }
+
+    #[test]
+    fn a_some_time() {
+        assert_suggestion_result(
+            "Spent a some time not using it, now the problem is back....",
+            ASomeTime::default(),
+            "Spent some time not using it, now the problem is back....",
+        );
+    }
+}

--- a/harper-core/src/linting/few_units_of_time_ago.rs
+++ b/harper-core/src/linting/few_units_of_time_ago.rs
@@ -13,7 +13,7 @@ pub struct FewUnitsOfTimeAgo {
 
 impl Default for FewUnitsOfTimeAgo {
     fn default() -> Self {
-        let units = TimeUnitExpr;
+        let units = TimeUnitExpr::default();
 
         let start = SequenceExpr::default().then_word_except(&["a"]).t_ws();
 

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -11,6 +11,7 @@ use hashbrown::HashMap;
 use lru::LruCache;
 
 use super::a_part::APart;
+use super::a_some_time::ASomeTime;
 use super::a_while::AWhile;
 use super::addicting::Addicting;
 use super::adjective_double_degree::AdjectiveDoubleDegree;
@@ -504,6 +505,7 @@ impl LintGroup {
         // Please maintain alphabetical order.
         // On *nix you can maintain sort order with `sort -t'(' -k2`
         insert_expr_rule!(APart, true);
+        insert_expr_rule!(ASomeTime, true);
         insert_expr_rule!(AWhile, true);
         insert_expr_rule!(Addicting, true);
         insert_expr_rule!(AdjectiveDoubleDegree, true);
@@ -558,7 +560,6 @@ impl LintGroup {
         insert_expr_rule!(DoubleClick, true);
         insert_expr_rule!(DoubleModal, true);
         insert_struct_rule!(EllipsisLength, true);
-        insert_struct_rule!(UseEllipsisCharacter, true);
         insert_expr_rule!(ElsePossessive, true);
         insert_expr_rule!(EverEvery, true);
         insert_expr_rule!(Everyday, true);
@@ -722,6 +723,7 @@ impl LintGroup {
         insert_expr_rule!(TryOnesLuck, true);
         insert_struct_rule!(UnclosedQuotes, true);
         insert_expr_rule!(UpdatePlaceNames, true);
+        insert_struct_rule!(UseEllipsisCharacter, true);
         insert_struct_rule_with_dict!(UseTitleCase, true);
         insert_expr_rule!(VerbToAdjective, true);
         insert_expr_rule!(VeryUnique, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -3,6 +3,7 @@
 //! See the [`Linter`] trait and the [documentation for authoring a rule](https://writewithharper.com/docs/contributors/author-a-rule) for more information.
 
 mod a_part;
+mod a_some_time;
 mod a_while;
 mod addicting;
 mod adjective_double_degree;


### PR DESCRIPTION
# Issues 
N/A

# Description

I heard or read "for a some [units of time]" while dogfooding, dig some Googling, and found it to be quite common.

This linter doesn't rely on a preceding preposition and works with time units from milliseconds to decades or with the word "time".

It's careful not to just remove the "a" as if it's at the beginning of a sentence that will leave the next word lacking a capital. Instead, it replaces "a some" with "some" using case-matching option.

Adds an `include_plurals_only` ctor to `TimeUnitExpr` and uses it here to avoid having different sets of units in different linters.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Half a dozen unit tests used from sentences with different variations.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
