### PR TITLE
fix: restore `CallThem` linter that got unlinked from the project at some point

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -3726,6 +3726,13 @@
 						},
 						{
 							"Bool": {
+								"name": "CallThem",
+								"state": true,
+								"label": "Call Them"
+							}
+						},
+						{
+							"Bool": {
 								"name": "BrandBrandish",
 								"state": true,
 								"label": "Brand Brandish"

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -38,6 +38,7 @@ use super::boring_words::BoringWords;
 use super::bought::Bought;
 use super::brand_brandish::BrandBrandish;
 use super::by_accident::ByAccident;
+use super::call_them::CallThem;
 use super::cant::Cant;
 use super::capitalize_personal_pronouns::CapitalizePersonalPronouns;
 use super::cautionary_tale::CautionaryTale;
@@ -530,6 +531,7 @@ impl LintGroup {
         insert_expr_rule!(Bought, true);
         insert_expr_rule!(BrandBrandish, true);
         insert_expr_rule!(ByAccident, true);
+        insert_expr_rule!(CallThem, true);
         insert_expr_rule!(Cant, true);
         insert_struct_rule!(CapitalizePersonalPronouns, true);
         insert_expr_rule!(CautionaryTale, true);


### PR DESCRIPTION
# Issues 
N/A

I definitely discovered this unlinked `CallThem` module once before. I must've only mentioned on Discord or in another issue or PR, such as the one for checking the curated `LintGroup`.

# Description

There's been a `CallThem` linter for some time but at some point it lost its link in `linting/lint_group.rs`, which has since become `linting/lint_group/mod.rs` but the `call_them.rs` remained as did the link in `linting/mod.rs`

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test` is 100% successful, even the old tests in the `call_them.rs`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
