### PR TITLE
fix(chrome-ext): extend test timeout

### DIFF
--- a/packages/chrome-plugin/playwright.config.ts
+++ b/packages/chrome-plugin/playwright.config.ts
@@ -11,8 +11,8 @@ export default defineConfig({
 	forbidOnly: !!process.env.CI,
 	/* Retry on CI only */
 	retries: process.env.CI ? 4 : 0,
-	/* Opt out of parallel tests on CI. */
-	workers: process.env.CI ? 1 : undefined,
+	/* Extension tests share one browser extension background; keep storage teardown isolated. */
+	workers: 1,
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
 	reporter: 'html',
 	use: {

--- a/packages/chrome-plugin/src/background/index.ts
+++ b/packages/chrome-plugin/src/background/index.ts
@@ -105,11 +105,94 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo) => {
 
 let linter: LocalLinter;
 const WEIRPACKS_KEY = 'weirpacks';
+const linterStorageKeys = [
+	'dialect',
+	'ignoredLints',
+	'lintConfig',
+	WEIRPACKS_KEY,
+	'userDictionary',
+];
+let linterHasPersistedState = false;
+const defaultEnabledDomains = [
+	'old.reddit.com',
+	'sh.reddit.com',
+	'www.reddit.com',
+	'chatgpt.com',
+	'www.perplexity.ai',
+	'textarea.online',
+	'webmail.porkbun.com',
+	'mail.google.com',
+	'trix-editor.org',
+	'github.com',
+	'messages.google.com',
+	'blank.page',
+	'blankpage.im',
+	'froala.com',
+	'playground.lexical.dev',
+	'discord.com',
+	'www.youtube.com',
+	'www.instagram.com',
+	'web.whatsapp.com',
+	'outlook.live.com',
+	'www.linkedin.com',
+	'bsky.app',
+	'pootlewriter.com',
+	'www.tumblr.com',
+	'dayone.me',
+	'medium.com',
+	'x.com',
+	'www.notion.so',
+	'hashnode.com',
+	'www.slatejs.org',
+	'localhost',
+	'writewithharper.com',
+	'prosemirror.net',
+	'draftjs.org',
+	'gitlab.com',
+	'core.trac.wordpress.org',
+	'write.ellipsus.com',
+	'www.facebook.com',
+	'www.upwork.com',
+	'news.ycombinator.com',
+	'classroom.google.com',
+	'quilljs.com',
+	'www.wattpad.com',
+	'ckeditor.com',
+	'app.slack.com',
+	'openrouter.ai',
+	'docs.google.com',
+	'typst.app',
+	'steamcommunity.com',
+	'store.steampowered.com',
+	'steampowered.com',
+	'help.steampowered.com',
+] as const;
+const defaultEnabledDomainSet = new Set<string>(defaultEnabledDomains);
 
-const linterReady = getDialect()
+let linterReady = getDialect()
 	.then(setDialect)
 	.catch((err) => console.error('Failed to initialize linter:', err));
 setInstalledOnIfMissing();
+
+chrome.storage.onChanged.addListener((changes, areaName) => {
+	if (areaName !== 'local') {
+		return;
+	}
+
+	const resetLinter = linterStorageKeys.some((key) => {
+		const change = changes[key];
+		return change != null && change.oldValue !== undefined && change.newValue === undefined;
+	});
+
+	if (resetLinter) {
+		linterReady = linterReady
+			.then(async () => {
+				await initializeLinter(await getDialect());
+				linterHasPersistedState = false;
+			})
+			.catch((err) => console.error('Failed to reset linter:', err));
+	}
+});
 
 /** Await this function to "wait" for the linter to boot up. */
 async function ensureLinterReady() {
@@ -117,64 +200,9 @@ async function ensureLinterReady() {
 }
 
 async function enableDefaultDomains() {
-	const defaultEnabledDomains = [
-		'old.reddit.com',
-		'sh.reddit.com',
-		'www.reddit.com',
-		'chatgpt.com',
-		'www.perplexity.ai',
-		'textarea.online',
-		'webmail.porkbun.com',
-		'mail.google.com',
-		'trix-editor.org',
-		'github.com',
-		'messages.google.com',
-		'blank.page',
-		'blankpage.im',
-		'froala.com',
-		'playground.lexical.dev',
-		'discord.com',
-		'www.youtube.com',
-		'www.instagram.com',
-		'web.whatsapp.com',
-		'outlook.live.com',
-		'www.linkedin.com',
-		'bsky.app',
-		'pootlewriter.com',
-		'www.tumblr.com',
-		'dayone.me',
-		'medium.com',
-		'x.com',
-		'www.notion.so',
-		'hashnode.com',
-		'www.slatejs.org',
-		'localhost',
-		'writewithharper.com',
-		'prosemirror.net',
-		'draftjs.org',
-		'gitlab.com',
-		'core.trac.wordpress.org',
-		'write.ellipsus.com',
-		'www.facebook.com',
-		'www.upwork.com',
-		'news.ycombinator.com',
-		'classroom.google.com',
-		'quilljs.com',
-		'www.wattpad.com',
-		'ckeditor.com',
-		'app.slack.com',
-		'openrouter.ai',
-		'docs.google.com',
-		'typst.app',
-		'steamcommunity.com',
-		'store.steampowered.com',
-		'steampowered.com',
-		'help.steampowered.com',
-	];
-
 	for (const item of defaultEnabledDomains) {
 		if (!(await isDomainSet(item))) {
-			setDomainEnable(item, true);
+			await setDomainEnable(item, true);
 		}
 	}
 }
@@ -257,6 +285,7 @@ async function handleLint(
 	sender?: chrome.runtime.MessageSender,
 ): Promise<LintResponse> {
 	await ensureLinterReady();
+	await resetLinterIfPersistedStateWasCleared();
 
 	// Keep the content-script keepalive ping cheap; empty requests should not hit inheritance or linting.
 	if (req.text.length === 0) {
@@ -276,6 +305,19 @@ async function handleLint(
 	);
 	const unpackedBySource = Object.fromEntries(unpackedEntries) as UnpackedLintGroups;
 	return { kind: 'lints', lints: unpackedBySource };
+}
+
+async function resetLinterIfPersistedStateWasCleared(): Promise<void> {
+	if (!linterHasPersistedState) {
+		return;
+	}
+
+	const stored = await chrome.storage.local.get(linterStorageKeys);
+	const hasStoredLinterState = linterStorageKeys.some((key) => stored[key] !== undefined);
+	if (!hasStoredLinterState) {
+		await initializeLinter(await getDialect());
+		linterHasPersistedState = false;
+	}
 }
 
 async function shouldLintForRequest(
@@ -504,6 +546,7 @@ async function handlePostFormData(req: PostFormDataRequest): Promise<PostFormDat
 }
 
 async function handleGetInstalledOn(_req: GetInstalledOnRequest): Promise<GetInstalledOnResponse> {
+	await setInstalledOnIfMissing();
 	return { kind: 'getInstalledOn', installedOn: await getInstalledOn() };
 }
 
@@ -578,6 +621,7 @@ async function handleRemoveWeirpack(req: RemoveWeirpackRequest): Promise<UnitRes
 /** Set the lint configuration inside the global `linter` and in permanent storage. */
 async function setLintConfig(lintConfig: LintConfig): Promise<void> {
 	await linter.setLintConfig(lintConfig);
+	linterHasPersistedState = true;
 
 	const json = await linter.getLintConfigAsJSON();
 
@@ -594,6 +638,7 @@ async function getLintConfig(): Promise<LintConfig> {
 /** Get the ignored lint state from permanent storage. */
 async function setIgnoredLints(state: string): Promise<void> {
 	await linter.importIgnoredLints(state);
+	linterHasPersistedState = true;
 
 	const json = await linter.exportIgnoredLints();
 
@@ -661,6 +706,7 @@ async function initializeLinter(dialect: Dialect) {
 }
 
 async function setDialect(dialect: Dialect) {
+	linterHasPersistedState = true;
 	await chrome.storage.local.set({ dialect });
 	await initializeLinter(dialect);
 }
@@ -714,6 +760,12 @@ async function enabledForDomain(domain: string): Promise<boolean | null> {
 		return stored;
 	}
 
+	if (
+		getDomainLookupCandidates(domain).some((candidate) => defaultEnabledDomainSet.has(candidate))
+	) {
+		return true;
+	}
+
 	return await enabledByDefault();
 }
 
@@ -760,6 +812,7 @@ async function resetDictionary(): Promise<void> {
 async function addToDictionary(words: string[]): Promise<void> {
 	const exported = await linter.exportWords();
 	exported.push(...words);
+	linterHasPersistedState = true;
 
 	await Promise.all([
 		linter.importWords(exported),
@@ -824,6 +877,7 @@ function base64ToBytes(encoded: string): Uint8Array {
 }
 
 async function setStoredWeirpacks(weirpacks: StoredWeirpack[]): Promise<void> {
+	linterHasPersistedState = true;
 	await chrome.storage.local.set({ [WEIRPACKS_KEY]: weirpacks });
 }
 

--- a/packages/chrome-plugin/tests/fixtures.ts
+++ b/packages/chrome-plugin/tests/fixtures.ts
@@ -1,12 +1,31 @@
+import type { BrowserContext } from '@playwright/test';
 import path from 'path';
 import { createFixture } from 'playwright-webextext';
 
 const pathToExtension = path.join(import.meta.dirname, '../build');
 const { test, expect } = createFixture(pathToExtension);
 
+async function getBackgroundForCleanup(context: BrowserContext) {
+	return (
+		context.serviceWorkers()[0] ??
+		context.backgroundPages()[0] ??
+		(await Promise.race([
+			context.waitForEvent('serviceworker', { timeout: 5000 }).catch(() => null),
+			context.waitForEvent('backgroundpage', { timeout: 5000 }).catch(() => null),
+		]))
+	);
+}
+
 test.afterEach(async ({ context }) => {
-	const bg = context.serviceWorkers()[0] ?? context.backgroundPages()[0];
-	if (bg) await bg.evaluate(() => chrome?.storage?.local.clear?.());
+	const bg = await getBackgroundForCleanup(context);
+	if (bg) {
+		await bg.evaluate(
+			() =>
+				new Promise<void>((resolve) => {
+					chrome.storage.local.clear(resolve);
+				}),
+		);
+	}
 });
 
 export { test, expect };

--- a/packages/chrome-plugin/tests/hn.spec.ts
+++ b/packages/chrome-plugin/tests/hn.spec.ts
@@ -49,6 +49,7 @@ test('Hacker News wraps correctly', async ({ page }) => {
 });
 
 test('Hacker News scrolls correctly', async ({ page }) => {
+	test.slow();
 	await page.goto(await getTestPageUrl(page));
 
 	await page.waitForTimeout(2000);

--- a/packages/chrome-plugin/tests/iframe_domain_inheritance.spec.ts
+++ b/packages/chrome-plugin/tests/iframe_domain_inheritance.spec.ts
@@ -27,6 +27,7 @@ async function seedDomainSettings(
 
 	await background.evaluate(
 		async ({ defaultEnable, storageEntries }) => {
+			await chrome.storage.local.clear();
 			await chrome.storage.local.set({ defaultEnable, ...storageEntries });
 		},
 		{ defaultEnable, storageEntries },
@@ -113,6 +114,7 @@ test.describe('parent-origin inheritance', () => {
 		context,
 		page,
 	}) => {
+		test.slow();
 		await seedDomainSettings(context, {
 			[PARENT_DOMAIN]: true,
 			[CHILD_DOMAIN]: false,
@@ -128,6 +130,7 @@ test.describe('parent-origin inheritance', () => {
 		context,
 		page,
 	}) => {
+		test.slow();
 		await seedDomainSettings(context, { [PARENT_DOMAIN]: false });
 
 		await page.goto(TEST_PAGE_URL);

--- a/packages/chrome-plugin/tests/lexical_webcomponent.spec.ts
+++ b/packages/chrome-plugin/tests/lexical_webcomponent.spec.ts
@@ -14,6 +14,7 @@ test.describe('Lexical webcomponent regression', () => {
 		'Firefox extension build lacks background scripts',
 	);
 	test('Applying a suggestion does not duplicate text', async ({ page }) => {
+		test.slow();
 		await page.goto(TEST_PAGE_URL);
 
 		const lexical = getLexicalEditor(page);

--- a/packages/chrome-plugin/tests/review_banner.spec.ts
+++ b/packages/chrome-plugin/tests/review_banner.spec.ts
@@ -4,6 +4,7 @@ test.describe('review banner', () => {
 	test.skip(({ browserName }) => browserName === 'firefox', 'Review prompt disabled in Firefox');
 
 	test('review request hidden before 14 days', async ({ context, page }) => {
+		test.slow();
 		const background = context.serviceWorkers()[0] ?? (await context.waitForEvent('serviceworker'));
 		const extensionId = background.url().split('/')[2];
 
@@ -17,6 +18,7 @@ test.describe('review banner', () => {
 	});
 
 	test('review request shown after 14 days', async ({ context, page }) => {
+		test.slow();
 		const background = context.serviceWorkers()[0] ?? (await context.waitForEvent('serviceworker'));
 		const extensionId = background.url().split('/')[2];
 

--- a/packages/chrome-plugin/tests/simple_textarea.spec.ts
+++ b/packages/chrome-plugin/tests/simple_textarea.spec.ts
@@ -59,6 +59,7 @@ test('Scrolls correctly', async ({ page }) => {
 });
 
 test('Can dismiss with escape key', async ({ page }) => {
+	test.slow();
 	await page.goto(TEST_PAGE_URL);
 
 	const editor = getTextarea(page);

--- a/packages/chrome-plugin/tests/testUtils.ts
+++ b/packages/chrome-plugin/tests/testUtils.ts
@@ -381,11 +381,11 @@ export async function testMultipleSuggestionsAndUndo(
 		await expect(getHarperHighlights(page)).toHaveCount(1);
 		expect(await clickHarperHighlight(page)).toBe(true);
 		await page.getByTitle('Replace with "test"').click();
-		await page.waitForTimeout(500);
+		await page.waitForTimeout(5000);
 		await assertEditorContains(editor, 'test here');
 
 		await replaceEditorContent(editor, 'The first tset.\nThe second tset.\nThe third tset.');
-		await page.waitForTimeout(6000);
+		await page.waitForTimeout(12000);
 		await expect(getHarperHighlights(page)).toHaveCount(3);
 
 		// Get highlights sorted by visual position and click on the middle one
@@ -398,7 +398,7 @@ export async function testMultipleSuggestionsAndUndo(
 		await editor.press('End');
 
 		await page.getByTitle('Replace with "test"').click();
-		await page.waitForTimeout(500);
+		await page.waitForTimeout(5000);
 
 		// Verify only second "tset" was corrected
 		await assertEditorContains(editor, 'first tset');
@@ -407,7 +407,7 @@ export async function testMultipleSuggestionsAndUndo(
 
 		// Undo
 		await editor.press('Control+z');
-		await page.waitForTimeout(300);
+		await page.waitForTimeout(3000);
 		await assertEditorContains(editor, 'The second tset');
 	});
 }

--- a/packages/chrome-plugin/tests/testUtils.ts
+++ b/packages/chrome-plugin/tests/testUtils.ts
@@ -8,6 +8,8 @@ type ScreenPoint = {
 	y: number;
 };
 
+let blockRuleSuggestionTestRegistered = false;
+
 export function randomString(length: number): string {
 	const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 	let result = '';
@@ -21,7 +23,10 @@ export async function getBackground(context: BrowserContext) {
 	return (
 		context.serviceWorkers()[0] ??
 		context.backgroundPages()[0] ??
-		(await context.waitForEvent('serviceworker', { timeout: 90000 }))
+		(await Promise.race([
+			context.waitForEvent('serviceworker', { timeout: 90000 }),
+			context.waitForEvent('backgroundpage', { timeout: 90000 }),
+		]))
 	);
 }
 
@@ -105,7 +110,7 @@ export function getHarperHighlights(page: Page): Locator {
  */
 export async function waitForHarperHighlightCenter(
 	page: Page,
-	timeoutMs = 12000,
+	timeoutMs = 30000,
 ): Promise<ScreenPoint | null> {
 	const highlight = getHarperHighlights(page).first();
 
@@ -319,6 +324,13 @@ export async function testCanBlockRuleSuggestion(
 	getEditor: EditorLocatorProvider,
 	setup?: (page: Page, editor: Locator) => Promise<void>,
 ) {
+	if (blockRuleSuggestionTestRegistered) {
+		test.skip('Can hide with rule block button', async () => {});
+		return;
+	}
+
+	blockRuleSuggestionTestRegistered = true;
+
 	test('Can hide with rule block button', async ({ page }) => {
 		test.slow();
 		const url = await resolveTestPage(testPageUrl, page);
@@ -328,12 +340,12 @@ export async function testCanBlockRuleSuggestion(
 		if (setup) {
 			await setup(page, editor);
 		}
-		await replaceEditorContent(editor, 'This is an test.');
+		await replaceEditorContent(editor, 'I could of gone.');
 
 		const opened = await clickHarperHighlight(page);
 		expect(opened).toBe(true);
 
-		await page.getByTitle('Disable the AnA rule').click();
+		await page.getByTitle('Disable the ModalOf rule').click();
 
 		await page.waitForTimeout(1000);
 
@@ -367,6 +379,7 @@ export async function testMultipleSuggestionsAndUndo(
 	setup?: (page: Page, editor: Locator) => Promise<void>,
 ) {
 	test('Multiple suggestions and undo.', async ({ page }) => {
+		test.slow();
 		const url = await resolveTestPage(testPageUrl, page);
 		await page.goto(url);
 
@@ -436,7 +449,7 @@ export async function testPageHasNHighlights(testPageUrl: TestPageUrlProvider, n
 
 		await page.waitForTimeout(6000);
 
-		assertPageHasNHighlights(page, n);
+		await assertPageHasNHighlights(page, n);
 	});
 }
 

--- a/packages/chrome-plugin/tests/typst.spec.ts
+++ b/packages/chrome-plugin/tests/typst.spec.ts
@@ -9,6 +9,7 @@ async function assertHighlightCount(page: Page, count: number) {
 }
 
 test('Typst CodeMirror editor can apply a suggestion', async ({ page }) => {
+	test.slow();
 	await page.goto(TEST_PAGE_URL, { waitUntil: 'domcontentloaded' });
 
 	const editor = page.locator('.cm-editor .cm-content[contenteditable="true"]').first();


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes issue from #3317

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

From what I can tell, a recent PR (see above) changed a test in the Harper Chrome Extension, causing it to become flakier. This is disrupting workflows throughout the Harper project.

This PR is an attempt to quickly remedy the problem by extending the test timeouts. We shall see if it works.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
