### PR TITLE
feat: add ThereOwn linter for "there own" → "their own"

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -1989,6 +1989,13 @@
 						},
 						{
 							"Bool": {
+								"name": "ThereOwn",
+								"state": true,
+								"label": "There Own"
+							}
+						},
+						{
+							"Bool": {
 								"name": "Theres",
 								"state": true,
 								"label": "There's"

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -220,6 +220,7 @@ use super::the_point_for::ThePointFor;
 use super::the_proper_noun_possessive::TheProperNounPossessive;
 use super::then_than::ThenThan;
 use super::there_is_agreement::ThereIsAgreement;
+use super::there_own::ThereOwn;
 use super::theres::Theres;
 use super::theses_these::ThesesThese;
 use super::theyre_confusions::TheyreConfusions;
@@ -711,6 +712,7 @@ impl LintGroup {
         insert_expr_rule!(ThePointFor, true);
         insert_expr_rule!(TheProperNounPossessive, true);
         insert_expr_rule!(ThenThan, true);
+        insert_expr_rule!(ThereOwn, true);
         insert_expr_rule!(Theres, true);
         insert_expr_rule!(ThesesThese, true);
         insert_struct_rule!(TheyreConfusions, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -232,6 +232,7 @@ mod the_point_for;
 mod the_proper_noun_possessive;
 mod then_than;
 mod there_is_agreement;
+mod there_own;
 mod theres;
 mod theses_these;
 mod theyre_confusions;

--- a/harper-core/src/linting/there_own.rs
+++ b/harper-core/src/linting/there_own.rs
@@ -1,4 +1,5 @@
-use crate::linting::expr_linter::Chunk;
+use crate::char_string::CharStringExt;
+use crate::linting::expr_linter::{Chunk, followed_by_word, preceded_by_word};
 use crate::{
     Token,
     expr::{Expr, SequenceExpr},
@@ -27,9 +28,26 @@ impl ExprLinter for ThereOwn {
         &self.expr
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint_with_context(
+        &self,
+        matched_tokens: &[Token],
+        source: &[char],
+        ctx: Option<(&[Token], &[Token])>,
+    ) -> Option<Lint> {
         let offender = matched_tokens.first()?;
         let template = offender.span.get_content(source);
+
+        // "there" preceded by a noun/pronoun with "own" followed by a noun/adjective
+        // is likely valid grammar: "people there own nice cars" (people who are there
+        // own nice cars). This does not apply to "they're" or "theyre" variants.
+        let is_there = template.eq_str("there");
+
+        if is_there
+            && preceded_by_word(ctx, |pw| pw.kind.is_nominal())
+            && followed_by_word(ctx, |nw| nw.kind.is_noun() || nw.kind.is_adjective())
+        {
+            return None;
+        }
 
         Some(Lint {
             span: offender.span,
@@ -99,6 +117,15 @@ mod tests {
     fn does_not_flag_there_without_own() {
         assert_lint_count(
             "Put the chairs over there by the window.",
+            ThereOwn::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn does_not_flag_verb_own_after_noun() {
+        assert_lint_count(
+            "People there own nice cars.",
             ThereOwn::default(),
             0,
         );

--- a/harper-core/src/linting/there_own.rs
+++ b/harper-core/src/linting/there_own.rs
@@ -1,0 +1,106 @@
+use crate::linting::expr_linter::Chunk;
+use crate::{
+    Token,
+    expr::{Expr, SequenceExpr},
+    linting::{ExprLinter, Lint, LintKind, Suggestion},
+};
+
+/// Flags "there own", "they're own", and "theyre own" and suggests "their own".
+pub struct ThereOwn {
+    expr: SequenceExpr,
+}
+
+impl Default for ThereOwn {
+    fn default() -> Self {
+        let expr = SequenceExpr::word_set(&["there", "they're", "theyre"])
+            .t_ws()
+            .t_aco("own");
+
+        Self { expr }
+    }
+}
+
+impl ExprLinter for ThereOwn {
+    type Unit = Chunk;
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let offender = matched_tokens.first()?;
+        let template = offender.span.get_content(source);
+
+        Some(Lint {
+            span: offender.span,
+            lint_kind: LintKind::WordChoice,
+            suggestions: vec![Suggestion::replace_with_match_case_str("their", template)],
+            message: "Did you mean the possessive `their`?".to_owned(),
+            priority: 31,
+        })
+    }
+
+    fn description(&self) -> &'static str {
+        "Corrects `there own`, `they're own`, and `theyre own` to `their own`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ThereOwn;
+    use crate::linting::tests::{assert_lint_count, assert_suggestion_result};
+
+    #[test]
+    fn corrects_there_own() {
+        assert_suggestion_result(
+            "Users can split data on there own topics.",
+            ThereOwn::default(),
+            "Users can split data on their own topics.",
+        );
+    }
+
+    #[test]
+    fn corrects_theyre_own() {
+        assert_suggestion_result(
+            "Everybody has they're own preferences.",
+            ThereOwn::default(),
+            "Everybody has their own preferences.",
+        );
+    }
+
+    #[test]
+    fn corrects_theyre_no_apostrophe() {
+        assert_suggestion_result(
+            "It would be helpful for people building theyre own rockets.",
+            ThereOwn::default(),
+            "It would be helpful for people building their own rockets.",
+        );
+    }
+
+    #[test]
+    fn preserves_capitalization() {
+        assert_suggestion_result(
+            "There own connection pool must be configured.",
+            ThereOwn::default(),
+            "Their own connection pool must be configured.",
+        );
+    }
+
+    #[test]
+    fn does_not_flag_correct_their_own() {
+        assert_lint_count(
+            "They manage their own servers.",
+            ThereOwn::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn does_not_flag_there_without_own() {
+        assert_lint_count(
+            "Put the chairs over there by the window.",
+            ThereOwn::default(),
+            0,
+        );
+    }
+}

--- a/harper-core/src/linting/there_own.rs
+++ b/harper-core/src/linting/there_own.rs
@@ -1,5 +1,5 @@
 use crate::char_string::CharStringExt;
-use crate::linting::expr_linter::{Chunk, followed_by_word, preceded_by_word};
+use crate::linting::expr_linter::{Chunk, preceded_by_word};
 use crate::{
     Token,
     expr::{Expr, SequenceExpr},
@@ -37,15 +37,13 @@ impl ExprLinter for ThereOwn {
         let offender = matched_tokens.first()?;
         let template = offender.span.get_content(source);
 
-        // "there" preceded by a noun/pronoun with "own" followed by a noun/adjective
-        // is likely valid grammar: "people there own nice cars" (people who are there
-        // own nice cars). This does not apply to "they're" or "theyre" variants.
-        let is_there = template.eq_str("there");
-
-        if is_there
-            && preceded_by_word(ctx, |pw| pw.kind.is_nominal())
-            && followed_by_word(ctx, |nw| nw.kind.is_noun() || nw.kind.is_adjective())
-        {
+        // When "there" is preceded by a noun or pronoun, it functions as an
+        // adverb ("in that place") and "own" is the main verb:
+        //   "people there own nice cars"
+        //   "companies there own the property"
+        // This does not apply to "they're" or "theyre" variants, which are
+        // always possessive errors before "own".
+        if template.eq_str("there") && preceded_by_word(ctx, |pw| pw.kind.is_nominal()) {
             return None;
         }
 
@@ -126,6 +124,15 @@ mod tests {
     fn does_not_flag_verb_own_after_noun() {
         assert_lint_count(
             "People there own nice cars.",
+            ThereOwn::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn does_not_flag_verb_own_with_determiner() {
+        assert_lint_count(
+            "Companies there own the property.",
             ThereOwn::default(),
             0,
         );

--- a/harper-core/src/linting/there_own.rs
+++ b/harper-core/src/linting/there_own.rs
@@ -104,11 +104,7 @@ mod tests {
 
     #[test]
     fn does_not_flag_correct_their_own() {
-        assert_lint_count(
-            "They manage their own servers.",
-            ThereOwn::default(),
-            0,
-        );
+        assert_lint_count("They manage their own servers.", ThereOwn::default(), 0);
     }
 
     #[test]
@@ -122,19 +118,85 @@ mod tests {
 
     #[test]
     fn does_not_flag_verb_own_after_noun() {
-        assert_lint_count(
-            "People there own nice cars.",
-            ThereOwn::default(),
-            0,
-        );
+        assert_lint_count("People there own nice cars.", ThereOwn::default(), 0);
     }
 
     #[test]
     fn does_not_flag_verb_own_with_determiner() {
-        assert_lint_count(
-            "Companies there own the property.",
+        assert_lint_count("Companies there own the property.", ThereOwn::default(), 0);
+    }
+
+    // Examples from issue #3276 — feature request author's positive cases.
+
+    #[test]
+    fn issue_3276_customise_default_lvl() {
+        assert_suggestion_result(
+            "Provide user the option in setting to customise there own default Effort lvl.",
             ThereOwn::default(),
-            0,
+            "Provide user the option in setting to customise their own default Effort lvl.",
+        );
+    }
+
+    #[test]
+    fn issue_3276_modules_c_files() {
+        assert_suggestion_result(
+            "Allow for modules to provide there own c files.",
+            ThereOwn::default(),
+            "Allow for modules to provide their own c files.",
+        );
+    }
+
+    #[test]
+    fn issue_3276_scripts_create_connection() {
+        assert_suggestion_result(
+            "I have a number of scripts that all create there own connection.",
+            ThereOwn::default(),
+            "I have a number of scripts that all create their own connection.",
+        );
+    }
+
+    #[test]
+    fn issue_3276_silent_appstore_updates() {
+        assert_suggestion_result(
+            "allowing 3rd party appstores to silently update apps installed by theyre own.",
+            ThereOwn::default(),
+            "allowing 3rd party appstores to silently update apps installed by their own.",
+        );
+    }
+
+    #[test]
+    fn issue_3276_theyre_own_command() {
+        assert_suggestion_result(
+            "But because they are they're own command they have their own runtime.",
+            ThereOwn::default(),
+            "But because they are their own command they have their own runtime.",
+        );
+    }
+
+    #[test]
+    fn issue_3276_theyre_own_library() {
+        assert_suggestion_result(
+            "Components I'm working on that will eventually become they're own library.",
+            ThereOwn::default(),
+            "Components I'm working on that will eventually become their own library.",
+        );
+    }
+
+    // Issue #3276's explicit false-positive example.
+
+    #[test]
+    fn issue_3276_false_positive_expensive_cars() {
+        assert_lint_count("People there own expensive cars.", ThereOwn::default(), 0);
+    }
+
+    // Sentence-initial "There own" stays a true positive (no preceding word, so
+    // the adverbial-there guard correctly does not trigger).
+    #[test]
+    fn sentence_initial_there_own_still_flagged() {
+        assert_suggestion_result(
+            "There own employees disagreed with the policy.",
+            ThereOwn::default(),
+            "Their own employees disagreed with the policy.",
         );
     }
 }


### PR DESCRIPTION
# Issues
N/A

# Description

Adds a `ThereOwn` linter that catches "there own", "they're own", and "theyre own" and suggests the possessive "their own". Common mistake in informal writing.

# How Has This Been Tested?

- Corrects "there own" → "their own"
- Corrects "they're own" → "their own"
- Corrects "theyre own" → "their own"
- Does not flag correct "their own"
- Does not flag "there" without "own"

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes