### PR TITLE
feat: add backtick as another wrong-apostrophe mistake

### DIFF
--- a/harper-core/src/expr/sequence_expr.rs
+++ b/harper-core/src/expr/sequence_expr.rs
@@ -613,6 +613,7 @@ impl SequenceExpr {
     gen_then_from_is!(backslash);
     gen_then_from_is!(slash);
     gen_then_from_is!(percent);
+    gen_then_from_is!(backtick);
 
     // Other
 

--- a/harper-core/src/linting/wrong_apostrophe.rs
+++ b/harper-core/src/linting/wrong_apostrophe.rs
@@ -13,18 +13,15 @@ pub struct WrongApostrophe {
 impl Default for WrongApostrophe {
     fn default() -> Self {
         Self {
-            expr: FirstMatchOf::new(vec![
-                Box::new(
-                    SequenceExpr::any_word()
-                        .then_semicolon()
-                        .then_word_set(&CONTRACTION_AND_POSSESSIVE_ENDINGS),
-                ),
-                Box::new(
-                    SequenceExpr::any_word()
-                        .then_acute()
-                        .then_word_set(&CONTRACTION_AND_POSSESSIVE_ENDINGS),
-                ),
-            ]),
+            expr: FirstMatchOf::new(vec![Box::new(
+                SequenceExpr::any_word()
+                    .then_any_of(vec![
+                        Box::new(SequenceExpr::default().then_semicolon()),
+                        Box::new(SequenceExpr::default().then_acute()),
+                        Box::new(SequenceExpr::default().then_backtick()),
+                    ])
+                    .then_word_set(&CONTRACTION_AND_POSSESSIVE_ENDINGS),
+            )]),
         }
     }
 }
@@ -62,7 +59,7 @@ impl ExprLinter for WrongApostrophe {
     }
 
     fn description(&self) -> &str {
-        "Corrects semicolons or acute accents typed instead of apostrophes."
+        "Corrects semicolons, acute accents, and backticks typed instead of apostrophes."
     }
 }
 
@@ -178,6 +175,15 @@ mod tests {
             "You´re looking for clues, but you´re missing all the signs",
             WrongApostrophe::default(),
             "You're looking for clues, but you're missing all the signs",
+        );
+    }
+
+    #[test]
+    fn fix_backticks_used_as_apostrophes() {
+        assert_suggestion_result(
+            "And It Won`T Make One Bit Of Difference If I Answer Right Or Wrong. When You`Re Rich, They Think You Really Know",
+            WrongApostrophe::default(),
+            "And It Won'T Make One Bit Of Difference If I Answer Right Or Wrong. When You'Re Rich, They Think You Really Know",
         );
     }
 }

--- a/harper-core/src/punctuation.rs
+++ b/harper-core/src/punctuation.rs
@@ -80,6 +80,8 @@ pub enum Punctuation {
     Underscore,
     /// `´`
     Acute,
+    /// `\``,
+    Backtick,
 }
 
 impl Punctuation {
@@ -122,6 +124,7 @@ impl Punctuation {
             '|' => Punctuation::Pipe,
             '_' => Punctuation::Underscore,
             '´' => Punctuation::Acute,
+            '`' => Punctuation::Backtick,
             _ => Punctuation::Currency(Currency::from_char(c)?),
         };
 

--- a/harper-core/src/token_kind.rs
+++ b/harper-core/src/token_kind.rs
@@ -289,6 +289,10 @@ impl TokenKind {
         matches!(self, TokenKind::Punctuation(Punctuation::Percent))
     }
 
+    pub fn is_backtick(&self) -> bool {
+        matches!(self, TokenKind::Punctuation(Punctuation::Backtick))
+    }
+
     // Miscellaneous is-methods
 
     /// Checks whether a token is word-like--meaning it is more complex than punctuation and can


### PR DESCRIPTION
# Issues 
N/A

# Description

I was pretty sure people sometimes wrote `` ` `` instead of `'` just as they do with `;` and `´` but didn't want to implement it until I was sure in case it had some hidden side-effects.

Well yesterday I found such a comment on YouTube or somewhere:
> And It Won\`T Make One Bit Of Difference If I Answer Right Or Wrong. When You\`Re Rich, They Think You Really Know

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

A unit test using the sentence above.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
