### PR TITLE
fix: remove debug print statements and related comments

### DIFF
--- a/harper-core/src/linting/not_only_inversion.rs
+++ b/harper-core/src/linting/not_only_inversion.rs
@@ -1,7 +1,7 @@
 use crate::{
     Lint, Token, TokenStringExt,
     expr::{Expr, SequenceExpr},
-    linting::{ExprLinter, LintKind, Suggestion, debug::format_lint_match, expr_linter::Chunk},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
 };
 
 pub struct NotOnlyInversion {
@@ -29,19 +29,12 @@ impl ExprLinter for NotOnlyInversion {
         "Corrects `not only it is` to `not only is it`"
     }
 
-    fn match_to_lint_with_context(
-        &self,
-        toks: &[Token],
-        src: &[char],
-        ctx: Option<(&[Token], &[Token])>,
-    ) -> Option<Lint> {
-        eprintln!("🍭 {}", format_lint_match(toks, ctx, src));
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
         let (prontok, betok) = (toks.get_rel(-3)?, toks.get_rel(-1)?);
         let (pronspan, bespan) = (prontok.span, betok.span);
         let (pronch, bech) = (pronspan.get_content(src), bespan.get_content(src));
 
         let pronbetoks = toks.get_rel_slice(-3, -1)?;
-        eprintln!("🍭🍭 '{}'", pronbetoks.span()?.get_content_string(src));
 
         let inverted = [bech.to_vec(), vec![' '], pronch.to_vec()].concat();
 
@@ -55,7 +48,6 @@ impl ExprLinter for NotOnlyInversion {
             )],
             ..Default::default()
         })
-        // None
     }
 
     fn expr(&self) -> &dyn Expr {

--- a/harper-core/src/linting/plural_decades/mod.rs
+++ b/harper-core/src/linting/plural_decades/mod.rs
@@ -42,7 +42,6 @@ impl ExprLinter for PluralDecades {
         src: &[char],
         ctx: Option<(&[Token], &[Token])>,
     ) -> Option<Lint> {
-        // eprintln!("📅 {}", crate::linting::debug::format_lint_match(toks, ctx, src));
         if toks.len() != 3 {
             return None;
         }

--- a/harper-core/src/linting/rise_the_ranks.rs
+++ b/harper-core/src/linting/rise_the_ranks.rs
@@ -46,7 +46,7 @@ impl ExprLinter for RiseTheRanks {
         &self.expr
     }
 
-    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, toks: &[Token], _src: &[char]) -> Option<Lint> {
         Some(Lint {
             span: toks[0].span,
             lint_kind: LintKind::Usage,

--- a/harper-core/src/linting/rise_the_ranks.rs
+++ b/harper-core/src/linting/rise_the_ranks.rs
@@ -1,7 +1,7 @@
 use crate::{
     Lint, Token,
     expr::{Expr, SequenceExpr},
-    linting::{ExprLinter, LintKind, Suggestion, debug::format_lint_match, expr_linter::Chunk},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
 };
 
 pub struct RiseTheRanks {
@@ -46,14 +46,7 @@ impl ExprLinter for RiseTheRanks {
         &self.expr
     }
 
-    fn match_to_lint_with_context(
-        &self,
-        toks: &[Token],
-        src: &[char],
-        ctx: Option<(&[Token], &[Token])>,
-    ) -> Option<Lint> {
-        eprintln!("🧵 {}", format_lint_match(toks, ctx, src));
-
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
         Some(Lint {
             span: toks[0].span,
             lint_kind: LintKind::Usage,


### PR DESCRIPTION
# Issues 
N/A

# Description

While working on #3339 I stumbled across a debug printf accidentally committed. Some grepping revealed one or two more places the same thing had made it through, and some related comments.

This cleans those up.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
