### PR TITLE
Fix FindFine false positive on 'is find <noun>'

### DIFF
--- a/harper-core/src/linting/find_fine.rs
+++ b/harper-core/src/linting/find_fine.rs
@@ -1,7 +1,10 @@
+use harper_brill::UPOS;
+
 use crate::Token;
 use crate::expr::Expr;
 use crate::expr::SequenceExpr;
 use crate::patterns::InflectionOfBe;
+use crate::patterns::UPOSSet;
 
 use super::expr_linter::Chunk;
 use super::{ExprLinter, Lint, LintKind, Suggestion};
@@ -14,7 +17,15 @@ impl Default for FindFine {
     fn default() -> Self {
         let expr = SequenceExpr::with(InflectionOfBe::default())
             .t_ws()
-            .t_aco("find");
+            .t_aco("find")
+            // Don't flag when `find` is followed by something that could be its
+            // object, e.g. "what you want to do is find someone to replace you".
+            .then_unless(SequenceExpr::default().t_ws().then(UPOSSet::new(&[
+                UPOS::NOUN,
+                UPOS::PROPN,
+                UPOS::PRON,
+                UPOS::DET,
+            ])));
 
         Self { expr }
     }
@@ -49,7 +60,7 @@ impl ExprLinter for FindFine {
 
 #[cfg(test)]
 mod tests {
-    use crate::linting::tests::assert_suggestion_result;
+    use crate::linting::tests::{assert_lint_count, assert_suggestion_result};
 
     use super::FindFine;
 
@@ -69,6 +80,15 @@ mod tests {
             "I am find not using GPU at all for open3d.",
             FindFine::default(),
             "I am fine not using GPU at all for open3d.",
+        );
+    }
+
+    #[test]
+    fn dont_flag_is_find_someone_3255() {
+        assert_lint_count(
+            "Generally speaking what you want to try and do is find someone to replace you before you leave.",
+            FindFine::default(),
+            0,
         );
     }
 }

--- a/harper-core/src/linting/find_fine.rs
+++ b/harper-core/src/linting/find_fine.rs
@@ -20,7 +20,7 @@ impl Default for FindFine {
             .t_aco("find")
             // Don't flag when `find` is followed by something that could be its
             // object, e.g. "what you want to do is find someone to replace you".
-            .then_unless(SequenceExpr::default().t_ws().then(UPOSSet::new(&[
+            .then_unless(SequenceExpr::whitespace().then(UPOSSet::new(&[
                 UPOS::NOUN,
                 UPOS::PROPN,
                 UPOS::PRON,


### PR DESCRIPTION
Fixes #3255

`FindFine` rewrites `is/was/... find` to `fine`, but `find` followed by a noun phrase is a legitimate verb use:

> Generally speaking what you want to try and do is find someone to replace you before you leave.

Added a postfix exception so the lint is suppressed when `find` is followed by a noun, proper noun, pronoun, or determiner (its object). Existing `fine` cases ("everything was fine for me", "I am fine not using ...") are unaffected since they are followed by ADP/PART/ADV or end of sentence.

Added a regression test; full `harper-core` test suite passes.