### PR TITLE
fix(harper-typst): crash

### DIFF
--- a/harper-typst/src/lib.rs
+++ b/harper-typst/src/lib.rs
@@ -86,4 +86,15 @@ mod tests {
         Typst.parse_str("#(.$#$$$. ");
         Typst.parse_str("=#{m\"\".'m\"\"#p#");
     }
+
+    #[test]
+    fn issue_2126_show_rule_preserves_token_order() {
+        let tokens = Typst.parse_str("#show \"a\": \"a\"");
+        let spans = tokens
+            .iter()
+            .map(|token| (token.span.start, token.span.end))
+            .collect_vec();
+
+        assert_eq!(spans, vec![(7, 8), (12, 13)]);
+    }
 }

--- a/harper-typst/src/typst_translator.rs
+++ b/harper-typst/src/typst_translator.rs
@@ -418,8 +418,8 @@ impl<'a> TypstTranslator<'a> {
                 parse_args(&mut set_rule.args().items())
             ],
             Expr::ShowRule(show_rule) => merge![
-                recurse!(show_rule.transform()),
-                show_rule.selector().and_then(|expr| recurse!(expr))
+                show_rule.selector().and_then(|expr| recurse!(expr)),
+                recurse!(show_rule.transform())
             ],
             Expr::Contextual(contextual) => recurse!(contextual.body()),
             Expr::Conditional(conditional) => merge![


### PR DESCRIPTION
# Issues
Fixes #2126

# Description
This fixes a Typst parser crash caused by `#show "a": "a"` emitting show-rule tokens out of source order. The translator now parses the show-rule selector before the transform so downstream linters receive monotonically ordered spans and `RepeatedWords` no longer tries to construct an invalid span.

A regression test covers the reported input and asserts that the emitted token spans preserve source order.

# How Has This Been Tested?

Additional unit tests


# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
