### PR TITLE
fix: allow lowercase mp3 after an

### DIFF
--- a/harper-core/src/indefinite_article.rs
+++ b/harper-core/src/indefinite_article.rs
@@ -68,6 +68,10 @@ pub fn starts_with_vowel(word: &[char], dialect: Dialect) -> Option<InitialSound
         return Some(InitialSound::Either);
     }
 
+    if matches!(word, ['m', 'p', digit, ..] if digit.is_ascii_digit()) {
+        return Some(InitialSound::Vowel);
+    }
+
     if matches!(word, ['e', 'u', 'l', 'e', ..]) {
         return Some(InitialSound::Vowel);
     }

--- a/harper-core/src/indefinite_article.rs
+++ b/harper-core/src/indefinite_article.rs
@@ -68,6 +68,8 @@ pub fn starts_with_vowel(word: &[char], dialect: Dialect) -> Option<InitialSound
         return Some(InitialSound::Either);
     }
 
+    // Treat formats like `mp3` the same as `MP3`: the leading `m` is read as
+    // the letter name “em”, so it takes `an` rather than `a`.
     if matches!(word, ['m', 'p', digit, ..] if digit.is_ascii_digit()) {
         return Some(InitialSound::Vowel);
     }

--- a/harper-core/src/linting/an_a.rs
+++ b/harper-core/src/linting/an_a.rs
@@ -213,8 +213,18 @@ mod tests {
     }
 
     #[test]
+    fn allow_an_lowercase_mp3() {
+        assert_lint_count("an mp3 file", AnA::new(Dialect::American), 0);
+    }
+
+    #[test]
     fn disallow_a_mp_and_a_mp3() {
         assert_lint_count("a MP and a MP3?", AnA::new(Dialect::American), 2);
+    }
+
+    #[test]
+    fn disallow_a_lowercase_mp3() {
+        assert_lint_count("a mp3 file", AnA::new(Dialect::American), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Treat lowercase `mp` followed by a digit (for example, `mp3`) as beginning with the vowel sound "em" for indefinite-article linting.
- Add regression coverage for both `an mp3` and `a mp3`.

Fixes #3289.

## Verification
- `cargo test -p harper-core linting::an_a -- --nocapture`
- `git diff --check`
