### PR TITLE
feat(core): flag way when used for wait

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -2754,6 +2754,13 @@
 						},
 						{
 							"Bool": {
+								"name": "WayWait",
+								"state": true,
+								"label": "Way Wait"
+							}
+						},
+						{
+							"Bool": {
 								"name": "RedundantAcronyms",
 								"state": true,
 								"label": "Redundant Acronyms"

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -247,6 +247,7 @@ use super::vicious_loop::ViciousCircleOrCycle;
 use super::vicious_loop::ViciousCycle;
 use super::was_aloud::WasAloud;
 use super::way_too_adjective::WayTooAdjective;
+use super::way_wait::WayWait;
 use super::web_scraping::WebScraping;
 use super::well_educated::WellEducated;
 use super::were_where::WereWhere;
@@ -737,6 +738,7 @@ impl LintGroup {
         insert_expr_rule!(ViciousCircleOrCycle, false);
         insert_expr_rule!(ViciousCycle, false);
         insert_expr_rule!(WasAloud, true);
+        insert_expr_rule!(WayWait, true);
         insert_expr_rule!(WayTooAdjective, true);
         insert_expr_rule!(WellEducated, true);
         insert_expr_rule!(Whereas, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -258,6 +258,7 @@ mod vice_versa;
 mod vicious_loop;
 mod was_aloud;
 mod way_too_adjective;
+mod way_wait;
 mod web_scraping;
 mod weir_rules;
 mod well_educated;

--- a/harper-core/src/linting/way_wait.rs
+++ b/harper-core/src/linting/way_wait.rs
@@ -1,0 +1,117 @@
+use crate::expr::{Expr, FirstMatchOf, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
+use crate::linting::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::{CharStringExt, Token};
+
+/// Corrects `way` when it is likely a typo for the verb `wait`.
+pub struct WayWait {
+    expr: FirstMatchOf,
+}
+
+impl Default for WayWait {
+    fn default() -> Self {
+        let negative = SequenceExpr::word_set(&[
+            "can't", "cant", "cannot", "couldn't", "couldnt", "doesn't", "doesnt", "don't", "dont",
+            "won't", "wont",
+        ]);
+
+        let can_not = SequenceExpr::fixed_phrase("can not");
+
+        let following = SequenceExpr::word_set(&["for", "to", "until"]);
+
+        Self {
+            expr: FirstMatchOf::new(vec![
+                Box::new(
+                    SequenceExpr::with(negative)
+                        .t_ws()
+                        .t_aco("way")
+                        .t_ws()
+                        .then(following),
+                ),
+                Box::new(
+                    SequenceExpr::with(can_not)
+                        .t_ws()
+                        .t_aco("way")
+                        .t_ws()
+                        .t_set(&["for", "to", "until"]),
+                ),
+            ]),
+        }
+    }
+}
+
+impl ExprLinter for WayWait {
+    type Unit = Chunk;
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        let way_span = toks
+            .iter()
+            .find(|tok| tok.get_ch(src).eq_any_ignore_ascii_case_str(&["way"]))?
+            .span;
+
+        Some(Lint {
+            span: way_span,
+            lint_kind: LintKind::Typo,
+            suggestions: vec![Suggestion::replace_with_match_case(
+                "wait".chars().collect(),
+                way_span.get_content(src),
+            )],
+            message: "‘Way’ might be a typo here. Did you mean ‘wait’?".to_owned(),
+            priority: 31,
+        })
+    }
+
+    fn description(&self) -> &'static str {
+        "Corrects `way` when it appears to be a typo for `wait`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WayWait;
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    #[test]
+    fn fix_cant_way_to() {
+        assert_suggestion_result(
+            "Wow, incredible, can't way to try it.",
+            WayWait::default(),
+            "Wow, incredible, can't wait to try it.",
+        );
+    }
+
+    #[test]
+    fn fix_cannot_way_for() {
+        assert_suggestion_result(
+            "If you cannot way for the next release, downgrade for now.",
+            WayWait::default(),
+            "If you cannot wait for the next release, downgrade for now.",
+        );
+    }
+
+    #[test]
+    fn fix_doesnt_way_until() {
+        assert_suggestion_result(
+            "It doesn't way until completion though.",
+            WayWait::default(),
+            "It doesn't wait until completion though.",
+        );
+    }
+
+    #[test]
+    fn dont_flag_unclear_way_uses() {
+        assert_no_lints(
+            "The RFC doesn't way what resolved value means.",
+            WayWait::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_correct_wait() {
+        assert_no_lints("I can't wait to try it.", WayWait::default());
+    }
+}

--- a/harper-core/src/linting/way_wait.rs
+++ b/harper-core/src/linting/way_wait.rs
@@ -1,41 +1,46 @@
-use crate::expr::{Expr, FirstMatchOf, SequenceExpr};
+use crate::expr::{Expr, SequenceExpr};
 use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::{CharStringExt, Token};
 
 /// Corrects `way` when it is likely a typo for the verb `wait`.
 pub struct WayWait {
-    expr: FirstMatchOf,
+    expr: SequenceExpr,
 }
 
 impl Default for WayWait {
     fn default() -> Self {
-        let negative = SequenceExpr::word_set(&[
-            "can't", "cant", "cannot", "couldn't", "couldnt", "doesn't", "doesnt", "don't", "dont",
-            "won't", "wont",
+        let negative_auxiliary = SequenceExpr::any_of(vec![
+            Box::new(SequenceExpr::word_set(&[
+                "can't",
+                "cant",
+                "cannot",
+                "couldn't",
+                "couldnt",
+                "doesn't",
+                "doesnt",
+                "don't",
+                "dont",
+                "mightn't",
+                "mightnt",
+                "mustn't",
+                "mustnt",
+                "shan't",
+                "shant",
+                "shouldn't",
+                "shouldnt",
+                "won't",
+                "wont",
+            ])),
+            Box::new(SequenceExpr::fixed_phrase("can not")),
         ]);
 
-        let can_not = SequenceExpr::fixed_phrase("can not");
-
-        let following = SequenceExpr::word_set(&["for", "to", "until"]);
-
         Self {
-            expr: FirstMatchOf::new(vec![
-                Box::new(
-                    SequenceExpr::with(negative)
-                        .t_ws()
-                        .t_aco("way")
-                        .t_ws()
-                        .then(following),
-                ),
-                Box::new(
-                    SequenceExpr::with(can_not)
-                        .t_ws()
-                        .t_aco("way")
-                        .t_ws()
-                        .t_set(&["for", "to", "until"]),
-                ),
-            ]),
+            expr: SequenceExpr::with(negative_auxiliary)
+                .t_ws()
+                .t_aco("way")
+                .t_ws()
+                .t_set(&["for", "to", "until"]),
         }
     }
 }
@@ -78,18 +83,18 @@ mod tests {
     #[test]
     fn fix_cant_way_to() {
         assert_suggestion_result(
-            "Wow, incredible, can't way to try it.",
+            "Wow, just seeing this again, incredible, can't way to try it.",
             WayWait::default(),
-            "Wow, incredible, can't wait to try it.",
+            "Wow, just seeing this again, incredible, can't wait to try it.",
         );
     }
 
     #[test]
     fn fix_cannot_way_for() {
         assert_suggestion_result(
-            "If you cannot way for the next release, downgrade for now.",
+            "If it's a real bother and you cannot way for 2.10.16, go back to 2.10.12.",
             WayWait::default(),
-            "If you cannot wait for the next release, downgrade for now.",
+            "If it's a real bother and you cannot wait for 2.10.16, go back to 2.10.12.",
         );
     }
 
@@ -99,6 +104,34 @@ mod tests {
             "It doesn't way until completion though.",
             WayWait::default(),
             "It doesn't wait until completion though.",
+        );
+    }
+
+    #[test]
+    fn fix_can_not_way_for() {
+        assert_suggestion_result(
+            "I can not way for something better to be released.",
+            WayWait::default(),
+            "I can not wait for something better to be released.",
+        );
+    }
+
+    #[test]
+    fn fix_negative_modals() {
+        assert_suggestion_result(
+            "You shouldn't way to tell them.",
+            WayWait::default(),
+            "You shouldn't wait to tell them.",
+        );
+        assert_suggestion_result(
+            "We mustn't way until completion.",
+            WayWait::default(),
+            "We mustn't wait until completion.",
+        );
+        assert_suggestion_result(
+            "I shan't way for another release.",
+            WayWait::default(),
+            "I shan't wait for another release.",
         );
     }
 


### PR DESCRIPTION
## Summary
- add a focused `WayWait` linter for `way` when it appears in clear `wait` contexts
- cover examples from #3345 such as `can't way to`, `cannot way for`, and `doesn't way until`
- keep the rule conservative by not flagging unclear `doesn't way what`-style cases

Fixes #3345.

## Verification
- `cargo fmt --check`
- `cargo test -p harper-core way_wait --lib`
- `cargo test -p harper-core --lib`
- `git diff --check`
