### PR TITLE
fix(core): avoid WereWhere false positive after embedded question

### DIFF
--- a/harper-core/src/linting/were_where.rs
+++ b/harper-core/src/linting/were_where.rs
@@ -67,6 +67,33 @@ impl Default for WereWhere {
     }
 }
 
+fn looks_like_embedded_question_before_think(
+    toks: &[Token],
+    src: &[char],
+    context: Option<(&[Token], &[Token])>,
+) -> bool {
+    if !toks.first().is_some_and(|tok| {
+        matches!(tok.kind, TokenKind::Word(_)) && tok.span.get_content(src).eq_str("think")
+    }) {
+        return false;
+    }
+
+    let Some((before, _)) = context else {
+        return false;
+    };
+
+    let previous_words: Vec<_> = before
+        .iter()
+        .rev()
+        .filter(|tok| matches!(tok.kind, TokenKind::Word(_)))
+        .take(3)
+        .map(|tok| tok.span.get_content(src))
+        .collect();
+
+    matches!(previous_words.as_slice(), [you, do_, what]
+        if you.eq_str("you") && do_.eq_str("do") && what.eq_str("what"))
+}
+
 impl ExprLinter for WereWhere {
     type Unit = Sentence;
 
@@ -108,6 +135,10 @@ impl ExprLinter for WereWhere {
                 ..Default::default()
             })
         } else {
+            if looks_like_embedded_question_before_think(toks, src, context) {
+                return None;
+            }
+
             were_tok.map(|tok| Lint {
                 span: tok.span,
                 lint_kind: LintKind::Typo,
@@ -374,6 +405,14 @@ mod tests {
     fn no_flag_confirmed_they_were() {
         // "they" sits between "confirmed" and "were" — not adjacent, no match
         assert_no_lints("I confirmed they were correct.", WereWhere::default());
+    }
+
+    #[test]
+    fn no_flag_embedded_what_do_you_think_were() {
+        assert_no_lints(
+            "What do you think were the effects the olives had on the pasta's flavor?",
+            WereWhere::default(),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fixes #3214.
- Prevents `WereWhere` from rewriting `were` to `where` in the embedded-question pattern `What do you think were ...`.
- Adds a regression test using the issue sentence.

## Duplicate / spam checks
- Issue #3214 is open, unassigned, and has no comments/reservation.
- Checked open PRs for `3214`, `WereWhere`, `were where`, and `What do you think were`; no active duplicate found.
- Checked recent merged PRs; #3169 touched `WereWhere` but fixed different issues and does not cover #3214.

## Verification
- `rustup run stable cargo fmt --check`
- `rustup run stable cargo test -p harper-core were_where --lib` (35 passed, 3 ignored)
- `rustup run stable cargo test -p harper-core --lib` (5307 passed, 264 ignored)
- `git diff --check`