### PR TITLE
fix(core): avoid InflectedVerbAfterTo false positive after pointed

### DIFF
--- a/harper-core/src/linting/inflected_verb_after_to.rs
+++ b/harper-core/src/linting/inflected_verb_after_to.rs
@@ -79,6 +79,10 @@ impl<T: Dictionary> Linter for InflectedVerbAfterTo<T> {
             let ed_specific_heuristics = || {
                 if let Some(prev) = document.get_next_word_from_offset(pi, -1) {
                     let prev_chars = document.get_span_content(&prev.span);
+                    if prev_chars.eq_str("pointed") {
+                        return ToVerbExpects::ExpectsNominal;
+                    }
+
                     if let Some(metadata) = self.dictionary.get_word_metadata(prev_chars) {
                         // adj: "able to" expects an infinitive verb
                         // verb: "have/had/has/having to" expect an infinitive verb
@@ -107,15 +111,13 @@ impl<T: Dictionary> Linter for InflectedVerbAfterTo<T> {
             }
             if chars.ends_with(&['e', 's']) {
                 let es = check_stem(&chars[..chars.len() - 2]);
-                // Add -es specific heuristics when needed
-                if es {
+                if es && ed_specific_heuristics() == ExpectsInfinitive {
                     lint_from_stem(&chars[..chars.len() - 2]);
                 };
             }
             if chars.ends_with(&['s']) {
                 let s = check_stem(&chars[..chars.len() - 1]);
-                // Add -s specific heuristics when needed
-                if s {
+                if s && ed_specific_heuristics() == ExpectsInfinitive {
                     lint_from_stem(&chars[..chars.len() - 1]);
                 };
             }
@@ -297,6 +299,15 @@ mod tests {
         // Hypothesis: when before "to" is not an adj, assume "to" is a preposition
         assert_lint_count(
             "Comparison to Expected Results",
+            InflectedVerbAfterTo::new(FstDictionary::curated()),
+            0,
+        );
+    }
+
+    #[test]
+    fn issue_2575_dont_flag_pointed_to_outlives() {
+        assert_lint_count(
+            "It is used to verify that the object being pointed to outlives the pointer.",
             InflectedVerbAfterTo::new(FstDictionary::curated()),
             0,
         );

--- a/harper-core/src/linting/inflected_verb_after_to.rs
+++ b/harper-core/src/linting/inflected_verb_after_to.rs
@@ -76,7 +76,7 @@ impl<T: Dictionary> Linter for InflectedVerbAfterTo<T> {
 
             use ToVerbExpects::*;
 
-            let ed_specific_heuristics = || {
+            let expected_form_after_to = || {
                 if let Some(prev) = document.get_next_word_from_offset(pi, -1) {
                     let prev_chars = document.get_span_content(&prev.span);
                     if prev_chars.eq_str("pointed") {
@@ -100,7 +100,7 @@ impl<T: Dictionary> Linter for InflectedVerbAfterTo<T> {
 
             if chars.ends_with(&['e', 'd']) {
                 let ed = check_stem(&chars[..chars.len() - 2]);
-                if ed && ed_specific_heuristics() == ExpectsInfinitive {
+                if ed && expected_form_after_to() == ExpectsInfinitive {
                     lint_from_stem(&chars[..chars.len() - 2]);
                 };
                 let d = check_stem(&chars[..chars.len() - 1]);
@@ -111,13 +111,13 @@ impl<T: Dictionary> Linter for InflectedVerbAfterTo<T> {
             }
             if chars.ends_with(&['e', 's']) {
                 let es = check_stem(&chars[..chars.len() - 2]);
-                if es && ed_specific_heuristics() == ExpectsInfinitive {
+                if es && expected_form_after_to() == ExpectsInfinitive {
                     lint_from_stem(&chars[..chars.len() - 2]);
                 };
             }
             if chars.ends_with(&['s']) {
                 let s = check_stem(&chars[..chars.len() - 1]);
-                if s && ed_specific_heuristics() == ExpectsInfinitive {
+                if s && expected_form_after_to() == ExpectsInfinitive {
                     lint_from_stem(&chars[..chars.len() - 1]);
                 };
             }


### PR DESCRIPTION
## Summary
- Fixes #2575.
- Treats `pointed to` as a prepositional construction for `InflectedVerbAfterTo`, avoiding the false positive in `object being pointed to outlives ...`.
- Applies the existing infinitive-vs-nominal heuristic to `-s`/`-es` stems before linting, instead of unconditionally flagging them.
- Adds the issue sentence as a regression test.

## Duplicate / spam checks
- Issue #2575 is open and unassigned.
- Checked comments: no reservation/claim; only maintainer context explaining the passive-participle construction.
- Checked active PRs for `2575`, `InflectedVerbAfterTo`, `pointed to outlives`, and `outlives`; no duplicate found.
- Checked recent merged PRs with the same terms; no duplicate found.

## Verification
- `rustup run stable cargo fmt --check`
- `rustup run stable cargo test -p harper-core inflected_verb_after_to --lib` (15 passed, 4 ignored)
- `rustup run stable cargo test -p harper-core --lib` (5307 passed, 264 ignored)
- `git diff --check`