### PR TITLE
Add verb past form only helpers

### DIFF
--- a/harper-core/src/dict_word_metadata.rs
+++ b/harper-core/src/dict_word_metadata.rs
@@ -480,6 +480,13 @@ impl DictWordMetadata {
         })
     }
 
+    pub fn is_verb_regular_past_form(&self) -> bool {
+        self.verb.is_some_and(|v| {
+            v.verb_forms
+                .is_some_and(|vf| vf.contains(VerbFormFlags::PAST))
+        })
+    }
+
     pub fn is_verb_simple_past_form(&self) -> bool {
         self.verb.is_some_and(|v| {
             v.verb_forms
@@ -1982,6 +1989,12 @@ pub mod tests {
         }
 
         #[test]
+        fn regular_past_walked() {
+            let md = md("walked");
+            assert!(md.is_verb_regular_past_form())
+        }
+
+        #[test]
         fn simple_past_ate() {
             let md = md("ate");
             assert!(md.is_verb_simple_past_form())
@@ -2019,6 +2032,14 @@ pub mod tests {
             let md = md("walked");
             assert!(!md.is_verb_simple_past_only());
             assert!(!md.is_verb_past_participle_only());
+            assert!(md.is_verb_regular_past_form());
+        }
+
+        #[test]
+        fn irregular_past_forms_are_not_regular_past() {
+            assert!(!md("ate").is_verb_regular_past_form());
+            assert!(!md("eaten").is_verb_regular_past_form());
+            assert!(!md("thought").is_verb_regular_past_form());
         }
 
         #[test]

--- a/harper-core/src/dict_word_metadata.rs
+++ b/harper-core/src/dict_word_metadata.rs
@@ -494,6 +494,24 @@ impl DictWordMetadata {
         })
     }
 
+    pub fn is_verb_simple_past_only(&self) -> bool {
+        self.verb.is_some_and(|v| {
+            v.verb_forms.is_some_and(|vf| {
+                vf.contains(VerbFormFlags::PRETERITE)
+                    && !vf.intersects(VerbFormFlags::PAST | VerbFormFlags::PAST_PARTICIPLE)
+            })
+        })
+    }
+
+    pub fn is_verb_past_participle_only(&self) -> bool {
+        self.verb.is_some_and(|v| {
+            v.verb_forms.is_some_and(|vf| {
+                vf.contains(VerbFormFlags::PAST_PARTICIPLE)
+                    && !vf.intersects(VerbFormFlags::PAST | VerbFormFlags::PRETERITE)
+            })
+        })
+    }
+
     pub fn is_verb_progressive_form(&self) -> bool {
         self.verb.is_some_and(|v| {
             v.verb_forms
@@ -1973,6 +1991,34 @@ pub mod tests {
         fn past_participle_eaten() {
             let md = md("eaten");
             assert!(md.is_verb_past_participle_form())
+        }
+
+        #[test]
+        fn ate_is_simple_past_only() {
+            let md = md("ate");
+            assert!(md.is_verb_simple_past_only());
+            assert!(!md.is_verb_past_participle_only());
+        }
+
+        #[test]
+        fn eaten_is_past_participle_only() {
+            let md = md("eaten");
+            assert!(md.is_verb_past_participle_only());
+            assert!(!md.is_verb_simple_past_only());
+        }
+
+        #[test]
+        fn thought_is_neither_past_form_only() {
+            let md = md("thought");
+            assert!(!md.is_verb_simple_past_only());
+            assert!(!md.is_verb_past_participle_only());
+        }
+
+        #[test]
+        fn regular_past_forms_are_neither_past_form_only() {
+            let md = md("walked");
+            assert!(!md.is_verb_simple_past_only());
+            assert!(!md.is_verb_past_participle_only());
         }
 
         #[test]

--- a/harper-core/src/dict_word_metadata.rs
+++ b/harper-core/src/dict_word_metadata.rs
@@ -482,8 +482,9 @@ impl DictWordMetadata {
 
     pub fn is_verb_regular_past_form(&self) -> bool {
         self.verb.is_some_and(|v| {
-            v.verb_forms
-                .is_some_and(|vf| vf.contains(VerbFormFlags::PAST))
+            v.verb_forms.is_some_and(|vf| {
+                vf.contains(VerbFormFlags::PRETERITE) && vf.contains(VerbFormFlags::PAST_PARTICIPLE)
+            })
         })
     }
 
@@ -1989,8 +1990,8 @@ pub mod tests {
         }
 
         #[test]
-        fn regular_past_walked() {
-            let md = md("walked");
+        fn regular_past_thought() {
+            let md = md("thought");
             assert!(md.is_verb_regular_past_form())
         }
 
@@ -2028,18 +2029,18 @@ pub mod tests {
         }
 
         #[test]
-        fn regular_past_forms_are_neither_past_form_only() {
-            let md = md("walked");
+        fn shared_past_forms_are_neither_past_form_only() {
+            let md = md("thought");
             assert!(!md.is_verb_simple_past_only());
             assert!(!md.is_verb_past_participle_only());
             assert!(md.is_verb_regular_past_form());
         }
 
         #[test]
-        fn irregular_past_forms_are_not_regular_past() {
+        fn distinct_past_forms_are_not_regular_past() {
             assert!(!md("ate").is_verb_regular_past_form());
             assert!(!md("eaten").is_verb_regular_past_form());
-            assert!(!md("thought").is_verb_regular_past_form());
+            assert!(!md("walked").is_verb_regular_past_form());
         }
 
         #[test]

--- a/harper-core/src/token_kind.rs
+++ b/harper-core/src/token_kind.rs
@@ -99,6 +99,7 @@ impl TokenKind {
         is_linking_verb,
         is_verb_lemma,
         is_verb_past_form,
+        is_verb_regular_past_form,
         is_verb_simple_past_form,
         is_verb_past_participle_form,
         is_verb_simple_past_only,
@@ -451,6 +452,13 @@ mod tests {
         let tk = &doc.tokens().next().unwrap().kind;
         assert!(tk.is_verb_past_participle_only());
         assert!(!tk.is_verb_simple_past_only());
+    }
+
+    #[test]
+    fn walked_is_regular_past_form() {
+        let doc = Document::new_plain_english_curated("walked");
+        let tk = &doc.tokens().next().unwrap().kind;
+        assert!(tk.is_verb_regular_past_form());
     }
 
     #[test]

--- a/harper-core/src/token_kind.rs
+++ b/harper-core/src/token_kind.rs
@@ -101,6 +101,8 @@ impl TokenKind {
         is_verb_past_form,
         is_verb_simple_past_form,
         is_verb_past_participle_form,
+        is_verb_simple_past_only,
+        is_verb_past_participle_only,
         is_verb_progressive_form,
         is_verb_third_person_singular_present_form,
 
@@ -433,6 +435,22 @@ mod tests {
         let doc = Document::new_plain_english_curated("equipment");
         let tk = &doc.tokens().next().unwrap().kind;
         assert!(!tk.is_countable_noun());
+    }
+
+    #[test]
+    fn ate_is_simple_past_only() {
+        let doc = Document::new_plain_english_curated("ate");
+        let tk = &doc.tokens().next().unwrap().kind;
+        assert!(tk.is_verb_simple_past_only());
+        assert!(!tk.is_verb_past_participle_only());
+    }
+
+    #[test]
+    fn eaten_is_past_participle_only() {
+        let doc = Document::new_plain_english_curated("eaten");
+        let tk = &doc.tokens().next().unwrap().kind;
+        assert!(tk.is_verb_past_participle_only());
+        assert!(!tk.is_verb_simple_past_only());
     }
 
     #[test]

--- a/harper-core/src/token_kind.rs
+++ b/harper-core/src/token_kind.rs
@@ -455,8 +455,8 @@ mod tests {
     }
 
     #[test]
-    fn walked_is_regular_past_form() {
-        let doc = Document::new_plain_english_curated("walked");
+    fn thought_is_regular_past_form() {
+        let doc = Document::new_plain_english_curated("thought");
         let tk = &doc.tokens().next().unwrap().kind;
         assert!(tk.is_verb_regular_past_form());
     }


### PR DESCRIPTION
## Summary

- add `DictWordMetadata::is_verb_simple_past_only`
- add `DictWordMetadata::is_verb_past_participle_only`
- expose both helpers through `TokenKind`
- cover irregular-only forms (`ate`, `eaten`) and ambiguous/regular forms (`thought`, `walked`)

Fixes #3372.

## Testing

- `cargo fmt --package harper-core`
- `cargo test -p harper-core past_only --lib`
- `cargo test -p harper-core participle_only --lib`
- `cargo test -p harper-core neither_past_form_only --lib`
- `git diff --check`
