### PR TITLE
feat(desktop): fill out setup flow

### DIFF
--- a/harper-desktop/src-tauri/src/lib.rs
+++ b/harper-desktop/src-tauri/src/lib.rs
@@ -10,7 +10,7 @@ use harper_core::{
 };
 use std::{cell::RefCell, rc::Rc, sync::Arc, time::Duration};
 use tauri::{
-    Manager, State, WebviewUrl, WebviewWindowBuilder, WindowEvent,
+    AppHandle, Manager, State, WebviewUrl, WebviewWindowBuilder, WindowEvent,
     image::Image,
     menu::{Menu, MenuItem, PredefinedMenuItem},
     tray::{MouseButton, TrayIconBuilder, TrayIconEvent},
@@ -353,23 +353,72 @@ async fn set_integration_enabled(
 }
 
 #[tauri::command]
-fn get_accessibility_permission_status() -> AccessibilityPermissionStatus {
-    platform_broker().accessibility_permission_status()
+async fn get_accessibility_permission_status(
+    app: AppHandle,
+) -> Result<AccessibilityPermissionStatus, String> {
+    accessibility_permission_status(app).await
 }
 
 #[tauri::command]
-fn request_accessibility_permission() -> AccessibilityPermissionStatus {
-    platform_broker().request_accessibility_permission()
+async fn request_accessibility_permission(
+    app: AppHandle,
+) -> Result<AccessibilityPermissionStatus, String> {
+    request_platform_accessibility_permission(app).await
 }
 
 #[cfg(target_os = "macos")]
-fn platform_broker() -> impl OsBroker {
-    mac_broker::MacBroker::default()
+async fn accessibility_permission_status(
+    app: AppHandle,
+) -> Result<AccessibilityPermissionStatus, String> {
+    run_accessibility_on_main_thread(app, || {
+        mac_broker::MacBroker::default().accessibility_permission_status()
+    })
+    .await
+}
+
+#[cfg(target_os = "macos")]
+async fn request_platform_accessibility_permission(
+    app: AppHandle,
+) -> Result<AccessibilityPermissionStatus, String> {
+    run_accessibility_on_main_thread(app, || {
+        mac_broker::MacBroker::default().request_accessibility_permission()
+    })
+    .await
+}
+
+#[cfg(target_os = "macos")]
+async fn run_accessibility_on_main_thread(
+    app: AppHandle,
+    action: impl FnOnce() -> AccessibilityPermissionStatus + Send + 'static,
+) -> Result<AccessibilityPermissionStatus, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let (sender, receiver) = std::sync::mpsc::channel();
+
+        app.run_on_main_thread(move || {
+            let _ = sender.send(action());
+        })
+        .map_err(|error| error.to_string())?;
+
+        receiver
+            .recv_timeout(Duration::from_secs(5))
+            .map_err(|_| "Accessibility permission check timed out".to_string())
+    })
+    .await
+    .map_err(|error| error.to_string())?
 }
 
 #[cfg(not(target_os = "macos"))]
-fn platform_broker() -> impl OsBroker {
-    os_broker::NoopBroker
+async fn accessibility_permission_status(
+    _app: AppHandle,
+) -> Result<AccessibilityPermissionStatus, String> {
+    Ok(os_broker::NoopBroker.accessibility_permission_status())
+}
+
+#[cfg(not(target_os = "macos"))]
+async fn request_platform_accessibility_permission(
+    _app: AppHandle,
+) -> Result<AccessibilityPermissionStatus, String> {
+    Ok(os_broker::NoopBroker.request_accessibility_permission())
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]

--- a/harper-desktop/src-tauri/src/lib.rs
+++ b/harper-desktop/src-tauri/src/lib.rs
@@ -10,7 +10,7 @@ use harper_core::{
 };
 use std::{cell::RefCell, rc::Rc, sync::Arc, time::Duration};
 use tauri::{
-    AppHandle, Manager, State, WebviewUrl, WebviewWindowBuilder, WindowEvent,
+    Manager, State, WebviewUrl, WebviewWindowBuilder, WindowEvent,
     image::Image,
     menu::{Menu, MenuItem, PredefinedMenuItem},
     tray::{MouseButton, TrayIconBuilder, TrayIconEvent},
@@ -54,6 +54,7 @@ const TOGGLE_SERVICE_MENU_ID: &str = "toggle-service";
 const OPEN_EDITOR_MENU_ID: &str = "open-editor";
 const SETTINGS_MENU_ID: &str = "settings";
 const QUIT_MENU_ID: &str = "quit";
+const ACCESSIBILITY_PERMISSION_DEBUG_MARKER: &str = "accessibility-permission-debug-v1";
 
 struct TrayMenu {
     menu: Menu<tauri::Wry>,
@@ -353,72 +354,34 @@ async fn set_integration_enabled(
 }
 
 #[tauri::command]
-async fn get_accessibility_permission_status(
-    app: AppHandle,
-) -> Result<AccessibilityPermissionStatus, String> {
-    accessibility_permission_status(app).await
+fn get_accessibility_permission_status() -> AccessibilityPermissionStatus {
+    eprintln!("get_accessibility_permission_status: entered");
+    let status = platform_broker().accessibility_permission_status();
+    eprintln!("get_accessibility_permission_status: returning {status:?}");
+    status
 }
 
 #[tauri::command]
-async fn request_accessibility_permission(
-    app: AppHandle,
-) -> Result<AccessibilityPermissionStatus, String> {
-    request_platform_accessibility_permission(app).await
+fn request_accessibility_permission() -> AccessibilityPermissionStatus {
+    eprintln!("request_accessibility_permission: entered");
+    let status = platform_broker().request_accessibility_permission();
+    eprintln!("request_accessibility_permission: returning {status:?}");
+    status
+}
+
+#[tauri::command]
+fn accessibility_permission_debug_marker() -> &'static str {
+    ACCESSIBILITY_PERMISSION_DEBUG_MARKER
 }
 
 #[cfg(target_os = "macos")]
-async fn accessibility_permission_status(
-    app: AppHandle,
-) -> Result<AccessibilityPermissionStatus, String> {
-    run_accessibility_on_main_thread(app, || {
-        mac_broker::MacBroker::default().accessibility_permission_status()
-    })
-    .await
-}
-
-#[cfg(target_os = "macos")]
-async fn request_platform_accessibility_permission(
-    app: AppHandle,
-) -> Result<AccessibilityPermissionStatus, String> {
-    run_accessibility_on_main_thread(app, || {
-        mac_broker::MacBroker::default().request_accessibility_permission()
-    })
-    .await
-}
-
-#[cfg(target_os = "macos")]
-async fn run_accessibility_on_main_thread(
-    app: AppHandle,
-    action: impl FnOnce() -> AccessibilityPermissionStatus + Send + 'static,
-) -> Result<AccessibilityPermissionStatus, String> {
-    tauri::async_runtime::spawn_blocking(move || {
-        let (sender, receiver) = std::sync::mpsc::channel();
-
-        app.run_on_main_thread(move || {
-            let _ = sender.send(action());
-        })
-        .map_err(|error| error.to_string())?;
-
-        receiver
-            .recv_timeout(Duration::from_secs(5))
-            .map_err(|_| "Accessibility permission check timed out".to_string())
-    })
-    .await
-    .map_err(|error| error.to_string())?
+fn platform_broker() -> impl OsBroker {
+    mac_broker::MacBroker::default()
 }
 
 #[cfg(not(target_os = "macos"))]
-async fn accessibility_permission_status(
-    _app: AppHandle,
-) -> Result<AccessibilityPermissionStatus, String> {
-    Ok(os_broker::NoopBroker.accessibility_permission_status())
-}
-
-#[cfg(not(target_os = "macos"))]
-async fn request_platform_accessibility_permission(
-    _app: AppHandle,
-) -> Result<AccessibilityPermissionStatus, String> {
-    Ok(os_broker::NoopBroker.request_accessibility_permission())
+fn platform_broker() -> impl OsBroker {
+    os_broker::NoopBroker
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -473,6 +436,7 @@ pub fn run_tauri() {
             set_integration_enabled,
             get_accessibility_permission_status,
             request_accessibility_permission,
+            accessibility_permission_debug_marker,
         ])
         .on_window_event(|window, event| {
             if should_hide_window_on_close(window.label())

--- a/harper-desktop/src-tauri/src/lib.rs
+++ b/harper-desktop/src-tauri/src/lib.rs
@@ -54,7 +54,6 @@ const TOGGLE_SERVICE_MENU_ID: &str = "toggle-service";
 const OPEN_EDITOR_MENU_ID: &str = "open-editor";
 const SETTINGS_MENU_ID: &str = "settings";
 const QUIT_MENU_ID: &str = "quit";
-const ACCESSIBILITY_PERMISSION_DEBUG_MARKER: &str = "accessibility-permission-debug-v1";
 
 struct TrayMenu {
     menu: Menu<tauri::Wry>,
@@ -355,23 +354,12 @@ async fn set_integration_enabled(
 
 #[tauri::command]
 fn get_accessibility_permission_status() -> AccessibilityPermissionStatus {
-    eprintln!("get_accessibility_permission_status: entered");
-    let status = platform_broker().accessibility_permission_status();
-    eprintln!("get_accessibility_permission_status: returning {status:?}");
-    status
+    platform_broker().accessibility_permission_status()
 }
 
 #[tauri::command]
 fn request_accessibility_permission() -> AccessibilityPermissionStatus {
-    eprintln!("request_accessibility_permission: entered");
-    let status = platform_broker().request_accessibility_permission();
-    eprintln!("request_accessibility_permission: returning {status:?}");
-    status
-}
-
-#[tauri::command]
-fn accessibility_permission_debug_marker() -> &'static str {
-    ACCESSIBILITY_PERMISSION_DEBUG_MARKER
+    platform_broker().request_accessibility_permission()
 }
 
 #[cfg(target_os = "macos")]
@@ -436,7 +424,6 @@ pub fn run_tauri() {
             set_integration_enabled,
             get_accessibility_permission_status,
             request_accessibility_permission,
-            accessibility_permission_debug_marker,
         ])
         .on_window_event(|window, event| {
             if should_hide_window_on_close(window.label())

--- a/harper-desktop/src-tauri/src/lib.rs
+++ b/harper-desktop/src-tauri/src/lib.rs
@@ -15,6 +15,8 @@ use tauri::{
     menu::{Menu, MenuItem, PredefinedMenuItem},
     tray::{MouseButton, TrayIconBuilder, TrayIconEvent},
 };
+
+use crate::os_broker::{AccessibilityPermissionStatus, OsBroker};
 use tokio::{
     io::{Stdin, Stdout},
     runtime::{Builder, Runtime},
@@ -350,6 +352,26 @@ async fn set_integration_enabled(
     Ok(())
 }
 
+#[tauri::command]
+fn get_accessibility_permission_status() -> AccessibilityPermissionStatus {
+    platform_broker().accessibility_permission_status()
+}
+
+#[tauri::command]
+fn request_accessibility_permission() -> AccessibilityPermissionStatus {
+    platform_broker().request_accessibility_permission()
+}
+
+#[cfg(target_os = "macos")]
+fn platform_broker() -> impl OsBroker {
+    mac_broker::MacBroker::default()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn platform_broker() -> impl OsBroker {
+    os_broker::NoopBroker
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let args = Args::parse();
@@ -400,6 +422,8 @@ pub fn run_tauri() {
             add_integration,
             remove_integration,
             set_integration_enabled,
+            get_accessibility_permission_status,
+            request_accessibility_permission,
         ])
         .on_window_event(|window, event| {
             if should_hide_window_on_close(window.label())

--- a/harper-desktop/src-tauri/src/mac_broker.rs
+++ b/harper-desktop/src-tauri/src/mac_broker.rs
@@ -110,7 +110,8 @@ impl OsBroker for MacBroker {
     fn request_accessibility_permission(&self) -> AccessibilityPermissionStatus {
         let prompt_key = unsafe { CFString::wrap_under_get_rule(kAXTrustedCheckOptionPrompt) };
         let prompt_value = CFBoolean::true_value();
-        let options = CFDictionary::from_CFType_pairs(&[(prompt_key, prompt_value)]);
+        let options: CFDictionary<CFString, CFBoolean> =
+            CFDictionary::from_CFType_pairs(&[(prompt_key, prompt_value)]);
 
         if unsafe { AXIsProcessTrustedWithOptions(options.as_concrete_TypeRef()) } {
             AccessibilityPermissionStatus::Granted

--- a/harper-desktop/src-tauri/src/mac_broker.rs
+++ b/harper-desktop/src-tauri/src/mac_broker.rs
@@ -2,15 +2,18 @@ use accessibility::attribute::{AXAttribute, AXUIElementAttributes};
 use accessibility::ui_element::AXUIElement;
 use accessibility::{Error, TreeVisitor, TreeWalker, TreeWalkerFlow};
 use accessibility_sys::{
-    AXUIElementCopyAttributeValue, AXUIElementCopyParameterizedAttributeValue, AXUIElementGetPid,
-    AXValueCreate, AXValueGetType, AXValueGetValue, AXValueRef, error_string,
-    kAXBoundsForRangeParameterizedAttribute, kAXErrorIllegalArgument, kAXErrorNoValue,
-    kAXErrorParameterizedAttributeUnsupported, kAXErrorSuccess, kAXFocusedApplicationAttribute,
-    kAXPositionAttribute, kAXSizeAttribute, kAXValueTypeCFRange, kAXValueTypeCGPoint,
-    kAXValueTypeCGRect, kAXValueTypeCGSize, pid_t,
+    AXIsProcessTrusted, AXIsProcessTrustedWithOptions, AXUIElementCopyAttributeValue,
+    AXUIElementCopyParameterizedAttributeValue, AXUIElementGetPid, AXValueCreate, AXValueGetType,
+    AXValueGetValue, AXValueRef, error_string, kAXBoundsForRangeParameterizedAttribute,
+    kAXErrorIllegalArgument, kAXErrorNoValue, kAXErrorParameterizedAttributeUnsupported,
+    kAXErrorSuccess, kAXFocusedApplicationAttribute, kAXPositionAttribute, kAXSizeAttribute,
+    kAXTrustedCheckOptionPrompt, kAXValueTypeCFRange, kAXValueTypeCGPoint, kAXValueTypeCGRect,
+    kAXValueTypeCGSize, pid_t,
 };
 use core::{ffi::c_void, mem::MaybeUninit};
 use core_foundation::base::{CFRange, CFType, TCFType};
+use core_foundation::boolean::CFBoolean;
+use core_foundation::dictionary::CFDictionary;
 use core_foundation::string::CFString;
 use core_graphics::event::CGEvent;
 use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
@@ -20,7 +23,7 @@ use objc2_foundation::{NSPoint, NSRect, NSSize};
 use std::{cell::RefCell, collections::BTreeMap, error::Error as StdError, ptr, rc::Rc};
 
 use crate::config::{Config, Integration};
-use crate::os_broker::OsBroker;
+use crate::os_broker::{AccessibilityPermissionStatus, OsBroker};
 use crate::rect::{ActionableLint, Rect};
 
 /// macOS implementation of the OS data the highlighter needs.
@@ -94,6 +97,26 @@ impl OsBroker for MacBroker {
         let location = event.location();
 
         Some(egui::pos2(location.x as f32, location.y as f32))
+    }
+
+    fn accessibility_permission_status(&self) -> AccessibilityPermissionStatus {
+        if unsafe { AXIsProcessTrusted() } {
+            AccessibilityPermissionStatus::Granted
+        } else {
+            AccessibilityPermissionStatus::NotGranted
+        }
+    }
+
+    fn request_accessibility_permission(&self) -> AccessibilityPermissionStatus {
+        let prompt_key = unsafe { CFString::wrap_under_get_rule(kAXTrustedCheckOptionPrompt) };
+        let prompt_value = CFBoolean::true_value();
+        let options = CFDictionary::from_CFType_pairs(&[(prompt_key, prompt_value)]);
+
+        if unsafe { AXIsProcessTrustedWithOptions(options.as_concrete_TypeRef()) } {
+            AccessibilityPermissionStatus::Granted
+        } else {
+            AccessibilityPermissionStatus::NotGranted
+        }
     }
 }
 

--- a/harper-desktop/src-tauri/src/os_broker.rs
+++ b/harper-desktop/src-tauri/src/os_broker.rs
@@ -1,9 +1,17 @@
 use harper_core::linting::Lint;
+use serde::Serialize;
 use std::collections::BTreeMap;
 
 use crate::rect::ActionableLint;
 
 pub type LintText = Box<dyn FnMut(&str) -> BTreeMap<String, Vec<Lint>>>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum AccessibilityPermissionStatus {
+    Granted,
+    NotGranted,
+    Unsupported,
+}
 
 /// Provides platform-specific state needed by the highlighter without coupling rendering to an OS.
 ///
@@ -17,6 +25,14 @@ pub trait OsBroker {
     ) -> Vec<ActionableLint>;
 
     fn cursor_position(&self) -> Option<egui::Pos2>;
+
+    fn accessibility_permission_status(&self) -> AccessibilityPermissionStatus {
+        AccessibilityPermissionStatus::Unsupported
+    }
+
+    fn request_accessibility_permission(&self) -> AccessibilityPermissionStatus {
+        self.accessibility_permission_status()
+    }
 }
 
 /// No-op platform broker for targets that do not have an OS implementation yet.

--- a/harper-desktop/src/lib/client.ts
+++ b/harper-desktop/src/lib/client.ts
@@ -143,6 +143,14 @@ export class Client {
 			'Accessibility permission request timed out',
 		);
 	}
+
+	static async getAccessibilityPermissionDebugMarker(): Promise<string> {
+		return await withTimeout(
+			invoke<string>('accessibility_permission_debug_marker'),
+			ACCESSIBILITY_PERMISSION_TIMEOUT_MS,
+			'Accessibility permission debug marker timed out',
+		);
+	}
 }
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {

--- a/harper-desktop/src/lib/client.ts
+++ b/harper-desktop/src/lib/client.ts
@@ -143,14 +143,6 @@ export class Client {
 			'Accessibility permission request timed out',
 		);
 	}
-
-	static async getAccessibilityPermissionDebugMarker(): Promise<string> {
-		return await withTimeout(
-			invoke<string>('accessibility_permission_debug_marker'),
-			ACCESSIBILITY_PERMISSION_TIMEOUT_MS,
-			'Accessibility permission debug marker timed out',
-		);
-	}
 }
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {

--- a/harper-desktop/src/lib/client.ts
+++ b/harper-desktop/src/lib/client.ts
@@ -37,6 +37,8 @@ export interface Integration {
 	enabled: boolean;
 }
 
+export type AccessibilityPermissionStatus = 'Granted' | 'NotGranted' | 'Unsupported';
+
 export class Client {
 	static async getLintConfig(): Promise<LintConfig> {
 		return await invoke<LintConfig>('get_lint_config');
@@ -122,6 +124,14 @@ export class Client {
 
 	static async setIntegrationEnabled(bundleId: string, enabled: boolean): Promise<void> {
 		await invoke('set_integration_enabled', { bundleId, enabled });
+	}
+
+	static async getAccessibilityPermissionStatus(): Promise<AccessibilityPermissionStatus> {
+		return await invoke<AccessibilityPermissionStatus>('get_accessibility_permission_status');
+	}
+
+	static async requestAccessibilityPermission(): Promise<AccessibilityPermissionStatus> {
+		return await invoke<AccessibilityPermissionStatus>('request_accessibility_permission');
 	}
 }
 

--- a/harper-desktop/src/lib/client.ts
+++ b/harper-desktop/src/lib/client.ts
@@ -19,6 +19,8 @@ const DialectValue = {
 	Indian: 4,
 } as const;
 
+const ACCESSIBILITY_PERMISSION_TIMEOUT_MS = 6_000;
+
 let configLinterPromise: Promise<LocalLinterType> | null = null;
 
 function getConfigLinter(): Promise<LocalLinterType> {
@@ -127,12 +129,34 @@ export class Client {
 	}
 
 	static async getAccessibilityPermissionStatus(): Promise<AccessibilityPermissionStatus> {
-		return await invoke<AccessibilityPermissionStatus>('get_accessibility_permission_status');
+		return await withTimeout(
+			invoke<AccessibilityPermissionStatus>('get_accessibility_permission_status'),
+			ACCESSIBILITY_PERMISSION_TIMEOUT_MS,
+			'Accessibility permission check timed out',
+		);
 	}
 
 	static async requestAccessibilityPermission(): Promise<AccessibilityPermissionStatus> {
-		return await invoke<AccessibilityPermissionStatus>('request_accessibility_permission');
+		return await withTimeout(
+			invoke<AccessibilityPermissionStatus>('request_accessibility_permission'),
+			ACCESSIBILITY_PERMISSION_TIMEOUT_MS,
+			'Accessibility permission request timed out',
+		);
 	}
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+	let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+	const timeout = new Promise<never>((_, reject) => {
+		timeoutId = setTimeout(() => reject(new Error(message)), timeoutMs);
+	});
+
+	return Promise.race([promise, timeout]).finally(() => {
+		if (timeoutId) {
+			clearTimeout(timeoutId);
+		}
+	});
 }
 
 function rustDialectToDialect(dialect: RustDialect): Dialect {

--- a/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
+++ b/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
@@ -22,12 +22,14 @@ let accessibilityError = '';
 let isCheckingAccessibility = true;
 let isRequestingAccessibility = false;
 let hasRequestedAccessibility = false;
+let accessibilityDiagnostics: string[] = [];
 
 $: setupSteps = buildSetupSteps();
 $: setupCompletedCount = setupSteps.filter((step) => step.done).length;
 $: setupAllDone = setupSteps.every((step) => step.done);
 
 onMount(() => {
+	recordAccessibilityDiagnostic('settings page mounted');
 	void checkAccessibilityPermission();
 });
 
@@ -46,13 +48,20 @@ function enableTextEditForSetup() {
 async function checkAccessibilityPermission() {
 	isCheckingAccessibility = true;
 	accessibilityError = '';
+	recordAccessibilityDiagnostic('starting backend debug marker check');
 
 	try {
+		const marker = await Client.getAccessibilityPermissionDebugMarker();
+		recordAccessibilityDiagnostic(`backend marker returned: ${marker}`);
+		recordAccessibilityDiagnostic('starting permission status check');
 		accessibilityStatus = await Client.getAccessibilityPermissionStatus();
+		recordAccessibilityDiagnostic(`permission status returned: ${accessibilityStatus}`);
 	} catch (error) {
 		accessibilityError = `Unable to check Accessibility permission: ${error}`;
+		recordAccessibilityDiagnostic(`permission check failed: ${error}`);
 	} finally {
 		isCheckingAccessibility = false;
+		recordAccessibilityDiagnostic('permission check finished');
 	}
 }
 
@@ -64,15 +73,24 @@ async function requestAccessibilityPermission() {
 
 	isRequestingAccessibility = true;
 	accessibilityError = '';
+	recordAccessibilityDiagnostic('starting permission request');
 
 	try {
 		accessibilityStatus = await Client.requestAccessibilityPermission();
 		hasRequestedAccessibility = true;
+		recordAccessibilityDiagnostic(`permission request returned: ${accessibilityStatus}`);
 	} catch (error) {
 		accessibilityError = `Unable to request Accessibility permission: ${error}`;
+		recordAccessibilityDiagnostic(`permission request failed: ${error}`);
 	} finally {
 		isRequestingAccessibility = false;
+		recordAccessibilityDiagnostic('permission request finished');
 	}
+}
+
+function recordAccessibilityDiagnostic(message: string) {
+	const timestamp = new Date().toLocaleTimeString();
+	accessibilityDiagnostics = [...accessibilityDiagnostics.slice(-7), `${timestamp}: ${message}`];
 }
 
 function accessibilityDescription() {
@@ -241,6 +259,22 @@ function buildSetupSteps(): SetupStep[] {
                     <div class="grow">
                       <strong>Waiting for macOS</strong>
                       <p>After granting access in System Settings, return here and recheck permission.</p>
+                    </div>
+                  </div>
+                {/if}
+
+                {#if step.id === "accessibility"}
+                  <div class="detected-app">
+                    <div class="app-tile" style="--app-tint: #2a6bd8">D</div>
+                    <div class="grow">
+                      <strong>Permission diagnostics</strong>
+                      {#if accessibilityDiagnostics.length === 0}
+                        <p>No diagnostics recorded yet.</p>
+                      {:else}
+                        {#each accessibilityDiagnostics as diagnostic}
+                          <p><code>{diagnostic}</code></p>
+                        {/each}
+                      {/if}
                     </div>
                   </div>
                 {/if}

--- a/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
+++ b/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-import { Client, type AccessibilityPermissionStatus } from '$lib/client';
 import { onMount } from 'svelte';
+import { type AccessibilityPermissionStatus, Client } from '$lib/client';
 import { createInitialSettingsState, type SettingsState } from '../settings-data';
 
 type SetupStep = {

--- a/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
+++ b/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
@@ -24,7 +24,13 @@ let isRequestingAccessibility = false;
 let hasRequestedAccessibility = false;
 let accessibilityDiagnostics: string[] = [];
 
-$: setupSteps = buildSetupSteps();
+$: setupSteps = buildSetupSteps(
+	state,
+	accessibilityStatus,
+	isCheckingAccessibility,
+	isRequestingAccessibility,
+	hasRequestedAccessibility,
+);
 $: setupCompletedCount = setupSteps.filter((step) => step.done).length;
 $: setupAllDone = setupSteps.every((step) => step.done);
 
@@ -93,61 +99,77 @@ function recordAccessibilityDiagnostic(message: string) {
 	accessibilityDiagnostics = [...accessibilityDiagnostics.slice(-7), `${timestamp}: ${message}`];
 }
 
-function accessibilityDescription() {
-	if (accessibilityStatus === 'Granted') {
+function accessibilityDescription(status: AccessibilityPermissionStatus | null) {
+	if (status === 'Granted') {
 		return 'Harper can access text through the macOS Accessibility system.';
 	}
 
-	if (accessibilityStatus === 'Unsupported') {
+	if (status === 'Unsupported') {
 		return 'Accessibility setup is only available on macOS right now.';
 	}
 
 	return 'Open system settings and grant Harper access to the Accessibility system.';
 }
 
-function accessibilityActionLabel() {
-	if (isCheckingAccessibility) {
+function accessibilityActionLabel(
+	status: AccessibilityPermissionStatus | null,
+	isChecking: boolean,
+	isRequesting: boolean,
+	hasRequested: boolean,
+) {
+	if (isChecking) {
 		return 'Checking...';
 	}
 
-	if (isRequestingAccessibility) {
+	if (isRequesting) {
 		return 'Opening...';
 	}
 
-	if (accessibilityStatus === 'Granted') {
+	if (status === 'Granted') {
 		return 'Granted';
 	}
 
-	if (accessibilityStatus === 'Unsupported') {
+	if (status === 'Unsupported') {
 		return 'Unsupported';
 	}
 
-	if (hasRequestedAccessibility) {
+	if (hasRequested) {
 		return 'Recheck Permission';
 	}
 
 	return 'Open System Settings';
 }
 
-function buildSetupSteps(): SetupStep[] {
-	const accessibilityDone = accessibilityStatus === 'Granted';
-	const integrationDone = state.setup.integration === 'selected';
-	const testDriveDone = state.setup.testDrive === 'completed';
+function buildSetupSteps(
+	currentState: SettingsState,
+	currentAccessibilityStatus: AccessibilityPermissionStatus | null,
+	currentIsCheckingAccessibility: boolean,
+	currentIsRequestingAccessibility: boolean,
+	currentHasRequestedAccessibility: boolean,
+): SetupStep[] {
+	const accessibilityDone = currentAccessibilityStatus === 'Granted';
+	const integrationDone = currentState.setup.integration === 'selected';
+	const testDriveDone = currentState.setup.testDrive === 'completed';
 	const accessibilityActionDisabled =
-		isCheckingAccessibility ||
-		isRequestingAccessibility ||
-		accessibilityStatus === 'Granted' ||
-		accessibilityStatus === 'Unsupported';
+		currentIsCheckingAccessibility ||
+		currentIsRequestingAccessibility ||
+		currentAccessibilityStatus === 'Granted' ||
+		currentAccessibilityStatus === 'Unsupported';
 
 	return [
 		{
 			id: 'accessibility',
 			title: 'Grant Accessibility permission',
-			desc: accessibilityDescription(),
+			desc: accessibilityDescription(currentAccessibilityStatus),
 			required: true,
 			done: accessibilityDone,
 			locked: false,
-			actionLabel: accessibilityActionLabel(),
+			actionLabel: accessibilityActionLabel(
+				currentAccessibilityStatus,
+				currentIsCheckingAccessibility,
+				currentIsRequestingAccessibility,
+				currentHasRequestedAccessibility,
+			),
 			actionVariant: accessibilityDone ? 'default' : 'primary',
 			action: requestAccessibilityPermission,
 			actionDisabled: accessibilityActionDisabled,

--- a/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
+++ b/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { Client, type AccessibilityPermissionStatus } from '$lib/client';
+import { onMount } from 'svelte';
 import { createInitialSettingsState, type SettingsState } from '../settings-data';
 
 type SetupStep = {
@@ -10,14 +12,24 @@ type SetupStep = {
 	locked: boolean;
 	actionLabel: string;
 	actionVariant: 'default' | 'primary';
-	action: () => void;
+	action: () => void | Promise<void>;
+	actionDisabled?: boolean;
 };
 
 let state: SettingsState = createInitialSettingsState();
+let accessibilityStatus: AccessibilityPermissionStatus | null = null;
+let accessibilityError = '';
+let isCheckingAccessibility = true;
+let isRequestingAccessibility = false;
+let hasRequestedAccessibility = false;
 
 $: setupSteps = buildSetupSteps();
 $: setupCompletedCount = setupSteps.filter((step) => step.done).length;
 $: setupAllDone = setupSteps.every((step) => step.done);
+
+onMount(() => {
+	void checkAccessibilityPermission();
+});
 
 function updateSetup(patch: Partial<SettingsState['setup']>) {
 	state = { ...state, setup: { ...state.setup, ...patch } };
@@ -31,22 +43,96 @@ function enableTextEditForSetup() {
 	};
 }
 
+async function checkAccessibilityPermission() {
+	isCheckingAccessibility = true;
+	accessibilityError = '';
+
+	try {
+		accessibilityStatus = await Client.getAccessibilityPermissionStatus();
+	} catch (error) {
+		accessibilityError = `Unable to check Accessibility permission: ${error}`;
+	} finally {
+		isCheckingAccessibility = false;
+	}
+}
+
+async function requestAccessibilityPermission() {
+	if (hasRequestedAccessibility && accessibilityStatus === 'NotGranted') {
+		await checkAccessibilityPermission();
+		return;
+	}
+
+	isRequestingAccessibility = true;
+	accessibilityError = '';
+
+	try {
+		accessibilityStatus = await Client.requestAccessibilityPermission();
+		hasRequestedAccessibility = true;
+	} catch (error) {
+		accessibilityError = `Unable to request Accessibility permission: ${error}`;
+	} finally {
+		isRequestingAccessibility = false;
+	}
+}
+
+function accessibilityDescription() {
+	if (accessibilityStatus === 'Granted') {
+		return 'Harper can access text through the macOS Accessibility system.';
+	}
+
+	if (accessibilityStatus === 'Unsupported') {
+		return 'Accessibility setup is only available on macOS right now.';
+	}
+
+	return 'Open system settings and grant Harper access to the Accessibility system.';
+}
+
+function accessibilityActionLabel() {
+	if (isCheckingAccessibility) {
+		return 'Checking...';
+	}
+
+	if (isRequestingAccessibility) {
+		return 'Opening...';
+	}
+
+	if (accessibilityStatus === 'Granted') {
+		return 'Granted';
+	}
+
+	if (accessibilityStatus === 'Unsupported') {
+		return 'Unsupported';
+	}
+
+	if (hasRequestedAccessibility) {
+		return 'Recheck Permission';
+	}
+
+	return 'Open System Settings';
+}
+
 function buildSetupSteps(): SetupStep[] {
-	const accessibilityDone = state.setup.accessibility === 'granted';
+	const accessibilityDone = accessibilityStatus === 'Granted';
 	const integrationDone = state.setup.integration === 'selected';
 	const testDriveDone = state.setup.testDrive === 'completed';
+	const accessibilityActionDisabled =
+		isCheckingAccessibility ||
+		isRequestingAccessibility ||
+		accessibilityStatus === 'Granted' ||
+		accessibilityStatus === 'Unsupported';
 
 	return [
 		{
 			id: 'accessibility',
 			title: 'Grant Accessibility permission',
-			desc: 'Open system settings and grant Harper access to the Accessibility system.',
+			desc: accessibilityDescription(),
 			required: true,
 			done: accessibilityDone,
 			locked: false,
-			actionLabel: accessibilityDone ? 'Granted' : 'Open System Settings',
+			actionLabel: accessibilityActionLabel(),
 			actionVariant: accessibilityDone ? 'default' : 'primary',
-			action: () => updateSetup({ accessibility: 'granted' }),
+			action: requestAccessibilityPermission,
+			actionDisabled: accessibilityActionDisabled,
 		},
 		{
 			id: 'integration',
@@ -92,12 +178,20 @@ function buildSetupSteps(): SetupStep[] {
             </button>
           </div>
         {:else}
-          {#if state.setup.accessibility !== "granted"}
+          {#if accessibilityStatus !== "Granted"}
             <div class="warning-banner">
               <div class="big-mark amber">!</div>
               <div>
-                <strong>Harper is not checking anything yet</strong>
-                <p>Grant Accessibility permission so Harper can find text and surface suggestions.</p>
+                {#if isCheckingAccessibility}
+                  <strong>Checking Accessibility permission</strong>
+                  <p>Harper needs macOS Accessibility access before it can check other apps.</p>
+                {:else if accessibilityStatus === "Unsupported"}
+                  <strong>Accessibility setup is unavailable</strong>
+                  <p>Harper Desktop app checking is currently only wired for macOS.</p>
+                {:else}
+                  <strong>Harper is not checking anything yet</strong>
+                  <p>Grant Accessibility permission so Harper can find text and surface suggestions.</p>
+                {/if}
               </div>
             </div>
           {/if}
@@ -133,7 +227,25 @@ function buildSetupSteps(): SetupStep[] {
                 </div>
                 <p>{step.desc}</p>
 
-                {#if step.id === "integration" && state.setup.accessibility === "granted" && state.setup.integration !== "selected"}
+                {#if step.id === "accessibility" && accessibilityError}
+                  <div class="detected-app">
+                    <div class="big-mark amber">!</div>
+                    <div class="grow">
+                      <strong>Permission check failed</strong>
+                      <p>{accessibilityError}</p>
+                    </div>
+                  </div>
+                {:else if step.id === "accessibility" && hasRequestedAccessibility && accessibilityStatus === "NotGranted"}
+                  <div class="detected-app">
+                    <div class="app-tile" style="--app-tint: #b06a1b">A</div>
+                    <div class="grow">
+                      <strong>Waiting for macOS</strong>
+                      <p>After granting access in System Settings, return here and recheck permission.</p>
+                    </div>
+                  </div>
+                {/if}
+
+                {#if step.id === "integration" && accessibilityStatus === "Granted" && state.setup.integration !== "selected"}
                   <div class="detected-app">
                     <div class="app-tile" style="--app-tint: #5a5f68">T</div>
                     <div class="grow">
@@ -149,7 +261,7 @@ function buildSetupSteps(): SetupStep[] {
               <button
                 class={`button ${step.actionVariant === "primary" ? "primary" : ""}`}
                 type="button"
-                disabled={step.locked}
+                disabled={step.locked || step.actionDisabled}
                 on:click={step.action}
               >
                 {step.actionLabel}

--- a/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
+++ b/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
@@ -22,7 +22,6 @@ let accessibilityError = '';
 let isCheckingAccessibility = true;
 let isRequestingAccessibility = false;
 let hasRequestedAccessibility = false;
-let accessibilityDiagnostics: string[] = [];
 
 $: setupSteps = buildSetupSteps(
 	state,
@@ -35,7 +34,6 @@ $: setupCompletedCount = setupSteps.filter((step) => step.done).length;
 $: setupAllDone = setupSteps.every((step) => step.done);
 
 onMount(() => {
-	recordAccessibilityDiagnostic('settings page mounted');
 	void checkAccessibilityPermission();
 });
 
@@ -54,20 +52,13 @@ function enableTextEditForSetup() {
 async function checkAccessibilityPermission() {
 	isCheckingAccessibility = true;
 	accessibilityError = '';
-	recordAccessibilityDiagnostic('starting backend debug marker check');
 
 	try {
-		const marker = await Client.getAccessibilityPermissionDebugMarker();
-		recordAccessibilityDiagnostic(`backend marker returned: ${marker}`);
-		recordAccessibilityDiagnostic('starting permission status check');
 		accessibilityStatus = await Client.getAccessibilityPermissionStatus();
-		recordAccessibilityDiagnostic(`permission status returned: ${accessibilityStatus}`);
 	} catch (error) {
 		accessibilityError = `Unable to check Accessibility permission: ${error}`;
-		recordAccessibilityDiagnostic(`permission check failed: ${error}`);
 	} finally {
 		isCheckingAccessibility = false;
-		recordAccessibilityDiagnostic('permission check finished');
 	}
 }
 
@@ -79,24 +70,15 @@ async function requestAccessibilityPermission() {
 
 	isRequestingAccessibility = true;
 	accessibilityError = '';
-	recordAccessibilityDiagnostic('starting permission request');
 
 	try {
 		accessibilityStatus = await Client.requestAccessibilityPermission();
 		hasRequestedAccessibility = true;
-		recordAccessibilityDiagnostic(`permission request returned: ${accessibilityStatus}`);
 	} catch (error) {
 		accessibilityError = `Unable to request Accessibility permission: ${error}`;
-		recordAccessibilityDiagnostic(`permission request failed: ${error}`);
 	} finally {
 		isRequestingAccessibility = false;
-		recordAccessibilityDiagnostic('permission request finished');
 	}
-}
-
-function recordAccessibilityDiagnostic(message: string) {
-	const timestamp = new Date().toLocaleTimeString();
-	accessibilityDiagnostics = [...accessibilityDiagnostics.slice(-7), `${timestamp}: ${message}`];
 }
 
 function accessibilityDescription(status: AccessibilityPermissionStatus | null) {
@@ -281,22 +263,6 @@ function buildSetupSteps(
                     <div class="grow">
                       <strong>Waiting for macOS</strong>
                       <p>After granting access in System Settings, return here and recheck permission.</p>
-                    </div>
-                  </div>
-                {/if}
-
-                {#if step.id === "accessibility"}
-                  <div class="detected-app">
-                    <div class="app-tile" style="--app-tint: #2a6bd8">D</div>
-                    <div class="grow">
-                      <strong>Permission diagnostics</strong>
-                      {#if accessibilityDiagnostics.length === 0}
-                        <p>No diagnostics recorded yet.</p>
-                      {:else}
-                        {#each accessibilityDiagnostics as diagnostic}
-                          <p><code>{diagnostic}</code></p>
-                        {/each}
-                      {/if}
                     </div>
                   </div>
                 {/if}


### PR DESCRIPTION
# Issues
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

# Description
This fills in the first pieces of the Harper Desktop settings setup flow. The Getting Started page now checks/request macOS Accessibility permission through Tauri, enables TextEdit through the real persisted integrations config, and launches TextEdit for the test-drive step.

Notable changes:
- Add cross-platform broker methods and Tauri/client commands for Accessibility permission status and requests.
- Disable TextEdit in curated desktop integrations by default while preserving existing persisted user config.
- Add a macOS bundle-launch path via `NSWorkspace`, exposed through `Client.launchAppBundle`.
- Replace the Getting Started page's mock TextEdit state with real integration loading, optimistic enablement, error handling, and launch behavior.

# How Has This Been Tested?

Manually.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
