### PR TITLE
feat(core): allow scope config in Weir rules

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -1591,6 +1591,13 @@
 						},
 						{
 							"Bool": {
+								"name": "IncludingButNotLimitedToPunctuation",
+								"state": true,
+								"label": "Including But Not Limited To Punctuation"
+							}
+						},
+						{
+							"Bool": {
 								"name": "MercedesBenzHyphen",
 								"state": true,
 								"label": "Mercedes Benz Hyphen"

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -264,7 +264,7 @@ use super::wrong_apostrophe::WrongApostrophe;
 use super::{ExprLinter, Lint};
 use super::{HtmlDescriptionLinter, Linter};
 use crate::linting::dashes::Dashes;
-use crate::linting::expr_linter::Chunk;
+use crate::linting::expr_linter::{Chunk, Sentence};
 use crate::linting::open_compounds::OpenCompounds;
 use crate::linting::{
     be_adjective_confusions, closed_compounds, initialisms, phrase_set_corrections, weir_rules,
@@ -285,6 +285,8 @@ pub struct LintGroup {
     linters: BTreeMap<String, Box<dyn Linter>>,
     /// We use a binary map here so the ordering is stable.
     chunk_expr_linters: BTreeMap<String, Box<dyn ExprLinter<Unit = Chunk>>>,
+    /// We use a binary map here so the ordering is stable.
+    sentence_expr_linters: BTreeMap<String, Box<dyn ExprLinter<Unit = Sentence>>>,
     /// Since [`ExprLinter`]s operate on a chunk-basis, we can store a
     /// mapping of `Chunk -> Lint` and only rerun the expr linters
     /// when a chunk changes.
@@ -293,6 +295,7 @@ pub struct LintGroup {
     /// of the key.
     #[expect(clippy::complexity)]
     chunk_expr_cache: LruCache<(u64, u64), Lrc<BTreeMap<String, Vec<Lint>>>>,
+    sentence_expr_cache: LruCache<(u64, u64), Lrc<BTreeMap<String, Vec<Lint>>>>,
     hasher_builder: RandomState,
     clashing_linter_names: Option<Vec<String>>,
 }
@@ -305,7 +308,9 @@ impl LintGroup {
             config: FlatConfig::default(),
             linters: BTreeMap::new(),
             chunk_expr_linters: BTreeMap::new(),
+            sentence_expr_linters: BTreeMap::new(),
             chunk_expr_cache: LruCache::new(NonZero::new(1000).unwrap()),
+            sentence_expr_cache: LruCache::new(NonZero::new(1000).unwrap()),
             hasher_builder: RandomState::default(),
             clashing_linter_names: None,
         }
@@ -315,6 +320,7 @@ impl LintGroup {
     pub fn contains_key(&self, name: impl AsRef<str>) -> bool {
         self.linters.contains_key(name.as_ref())
             || self.chunk_expr_linters.contains_key(name.as_ref())
+            || self.sentence_expr_linters.contains_key(name.as_ref())
     }
 
     /// Add a [`Linter`] to the group, returning whether the operation was successful.
@@ -358,6 +364,27 @@ impl LintGroup {
         }
     }
 
+    /// Add a sentence-based [`ExprLinter`] to the group, returning whether the operation was successful.
+    /// If it returns `false`, it is because a linter with that key already existed in the group.
+    pub fn add_sentence_expr_linter(
+        &mut self,
+        name: impl AsRef<str>,
+        linter: impl ExprLinter<Unit = Sentence> + 'static,
+    ) -> bool {
+        if self.contains_key(&name) {
+            if self.clashing_linter_names.is_none() {
+                self.clashing_linter_names = Some(vec![name.as_ref().to_string()]);
+            } else if let Some(clashing_names) = &mut self.clashing_linter_names {
+                clashing_names.push(name.as_ref().to_string());
+            }
+            false
+        } else {
+            self.sentence_expr_linters
+                .insert(name.as_ref().to_string(), Box::new(linter) as _);
+            true
+        }
+    }
+
     /// Merge the contents of another [`LintGroup`] into this one.
     pub fn merge_from(&mut self, other: LintGroup) {
         self.config.merge_from(other.config);
@@ -384,12 +411,27 @@ impl LintGroup {
             }
         }
         self.chunk_expr_linters.extend(other.chunk_expr_linters);
+
+        if let Some((conflicting_key, _)) = other
+            .sentence_expr_linters
+            .iter()
+            .find(|(k, _)| self.contains_key(k))
+        {
+            if self.clashing_linter_names.is_none() {
+                self.clashing_linter_names = Some(vec![conflicting_key.clone()]);
+            } else if let Some(clashing_names) = &mut self.clashing_linter_names {
+                clashing_names.push(conflicting_key.clone());
+            }
+        }
+        self.sentence_expr_linters
+            .extend(other.sentence_expr_linters);
     }
 
     pub fn iter_keys(&self) -> impl Iterator<Item = &str> {
         self.linters
             .keys()
             .chain(self.chunk_expr_linters.keys())
+            .chain(self.sentence_expr_linters.keys())
             .map(|v| v.as_str())
     }
 
@@ -416,6 +458,11 @@ impl LintGroup {
                     .iter()
                     .map(|(key, value)| (key.as_str(), ExprLinter::description(value))),
             )
+            .chain(
+                self.sentence_expr_linters
+                    .iter()
+                    .map(|(key, value)| (key.as_str(), ExprLinter::description(value))),
+            )
             .collect()
     }
 
@@ -426,6 +473,11 @@ impl LintGroup {
             .map(|(key, value)| (key.as_str(), value.description_html()))
             .chain(
                 self.chunk_expr_linters
+                    .iter()
+                    .map(|(key, value)| (key.as_str(), value.description_html())),
+            )
+            .chain(
+                self.sentence_expr_linters
                     .iter()
                     .map(|(key, value)| (key.as_str(), value.description_html())),
             )
@@ -858,6 +910,53 @@ impl LintGroup {
             }
         }
 
+        // Sentence Expr linters
+        for sentence in document.iter_sentences() {
+            let Some(sentence_span) = sentence.span() else {
+                continue;
+            };
+
+            let sentence_chars = document.get_span_content(&sentence_span);
+            let config_hash = self.hasher_builder.hash_one(&self.config);
+            let char_hash = self.hasher_builder.hash_one(sentence_chars);
+            let cache_key = (char_hash, config_hash);
+
+            let sentence_results = if let Some(hit) = self.sentence_expr_cache.get(&cache_key) {
+                hit.clone()
+            } else {
+                let mut pattern_lints = BTreeMap::new();
+
+                for (key, linter) in &mut self.sentence_expr_linters {
+                    if self.config.is_rule_enabled(key) {
+                        let lints =
+                            run_on_chunk(linter, sentence, document.get_source()).map(|mut l| {
+                                l.span.pull_by(sentence_span.start);
+                                l
+                            });
+
+                        pattern_lints.insert(key.clone(), lints.collect());
+                    }
+                }
+
+                let pattern_lints = Lrc::new(pattern_lints);
+
+                self.sentence_expr_cache
+                    .put(cache_key, pattern_lints.clone());
+                pattern_lints
+            };
+
+            for (key, vec) in sentence_results.iter() {
+                results
+                    .entry(key.to_owned())
+                    .or_default()
+                    .extend(vec.iter().cloned().map(|mut lint| {
+                        // Bring the spans back into document-space
+                        lint.span.push_by(sentence_span.start);
+                        lint
+                    }));
+            }
+        }
+
         results
     }
 }
@@ -889,6 +988,7 @@ mod tests {
     use crate::linting::LintKind;
     use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
     use crate::spell::{FstDictionary, MutableDictionary};
+    use crate::weir::WeirLinter;
     use crate::{Dialect, Document, linting::Linter};
 
     fn test_group() -> LintGroup {
@@ -954,6 +1054,31 @@ mod tests {
     #[test]
     fn ok_becomes_okay() {
         assert_suggestion_result("This is ok.", test_group(), "This is okay.");
+    }
+
+    #[test]
+    fn weir_linter_uses_configured_sentence_scope() {
+        let source = r#"
+            expr main one**two
+            let message "Use three."
+            let description "Test sentence-scoped Weir."
+            let kind "Miscellaneous"
+            let becomes "three"
+            let strategy "Exact"
+            let scope "Sentence"
+        "#;
+
+        let mut group = LintGroup::empty();
+        group.add_sentence_expr_linter(
+            "TestSentenceWeir",
+            WeirLinter::new(source)
+                .unwrap()
+                .into_sentence_linter()
+                .unwrap_or_else(|_| unreachable!()),
+        );
+        group.config.set_rule_enabled("TestSentenceWeir", true);
+
+        assert_suggestion_result("one, two.", group, "three.");
     }
 
     #[test]

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -295,6 +295,7 @@ pub struct LintGroup {
     /// of the key.
     #[expect(clippy::complexity)]
     chunk_expr_cache: LruCache<(u64, u64), Lrc<BTreeMap<String, Vec<Lint>>>>,
+    #[expect(clippy::complexity)]
     sentence_expr_cache: LruCache<(u64, u64), Lrc<BTreeMap<String, Vec<Lint>>>>,
     hasher_builder: RandomState,
     clashing_linter_names: Option<Vec<String>>,

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -273,7 +273,7 @@ mod worth_to_do;
 mod would_never_have;
 mod wrong_apostrophe;
 
-pub use expr_linter::{Chunk, ExprLinter};
+pub use expr_linter::{Chunk, ExprLinter, Sentence};
 pub use initialism_linter::InitialismLinter;
 pub use lint::Lint;
 pub use lint_group::{

--- a/harper-core/src/linting/weir_rules/IncludingButNotLimitedToPunctuation.weir
+++ b/harper-core/src/linting/weir_rules/IncludingButNotLimitedToPunctuation.weir
@@ -1,0 +1,36 @@
+expr wordBefore [NOUN, VERB, ADJ, ADV, PRON, PROPN]
+expr phraseMissingAfterIncluding (including but not limited to)
+expr phraseWithAfterIncluding [@phraseMissingAfterIncluding, (including, but not limited to)]
+expr parentheticalMissing [(@wordBefore @phraseMissingAfterIncluding), (, @phraseMissingAfterIncluding)]
+expr parentheticalWithAfterIncluding [(@wordBefore @phraseWithAfterIncluding), (, @phraseWithAfterIncluding)]
+
+expr missingLeading <(@wordBefore @phraseWithAfterIncluding), ( )>
+expr missingAfterIncluding <<(@parentheticalMissing), (including *)>, ( )>
+expr missingAfterTo <<(@parentheticalWithAfterIncluding *), (to *)>, ( )>
+
+expr main [@missingLeading, @missingAfterIncluding, @missingAfterTo]
+
+let message "Add punctuation around `including, but not limited to,`."
+let description "Adds the conventional commas around `including, but not limited to,` when used parenthetically."
+let kind "Punctuation"
+let becomes ", "
+let strategy "Exact"
+let scope "Sentence"
+
+test "There are many activities including but not limited to running, jumping, and swimming." "There are many activities, including, but not limited to, running, jumping, and swimming."
+test "The policy covers services including but not limited to hosting and support." "The policy covers services, including, but not limited to, hosting and support."
+test "We reviewed data including but not limited to logs." "We reviewed data, including, but not limited to, logs."
+test "The package includes tools including but not limited to a formatter." "The package includes tools, including, but not limited to, a formatter."
+test "Eligible expenses including but not limited to meals are reimbursed." "Eligible expenses, including, but not limited to, meals are reimbursed."
+test "There are many activities including, but not limited to, running." "There are many activities, including, but not limited to, running."
+test "The policy covers services, including but not limited to hosting." "The policy covers services, including, but not limited to, hosting."
+test "We reviewed data, including, but not limited to logs." "We reviewed data, including, but not limited to, logs."
+test "The package includes tools including, but not limited to support." "The package includes tools, including, but not limited to, support."
+test "Eligible expenses, including but not limited to meals are reimbursed." "Eligible expenses, including, but not limited to, meals are reimbursed."
+
+allows "There are many activities, including, but not limited to, running, jumping, and swimming."
+allows "The policy covers services, including, but not limited to, hosting and support."
+allows "We reviewed data, including, but not limited to, logs."
+allows "Including but not limited to examples can be awkward at the start of a sentence."
+allows "This sentence is including the phrase but not the parenthetical construction."
+allows "The list is not limited to running."

--- a/harper-core/src/linting/weir_rules/mod.rs
+++ b/harper-core/src/linting/weir_rules/mod.rs
@@ -1,5 +1,5 @@
 use super::LintGroup;
-use crate::weir::WeirLinter;
+use crate::weir::{WeirLinter, WeirScope};
 
 macro_rules! generate_boilerplate {
     ([$($name:ident),+ $(,)?]) => {
@@ -8,7 +8,11 @@ macro_rules! generate_boilerplate {
 
                 {
                     $(
-                        group.add_chunk_expr_linter(stringify!($name), WeirLinter::new(include_str!(concat!(env!("WEIR_RULE_DIR"), "/", stringify!($name), ".weir"))).unwrap());
+                        let linter = WeirLinter::new(include_str!(concat!(env!("WEIR_RULE_DIR"), "/", stringify!($name), ".weir"))).unwrap();
+                        match linter.scope() {
+                            WeirScope::Chunk => group.add_chunk_expr_linter(stringify!($name), linter.into_chunk_linter().unwrap_or_else(|_| unreachable!())),
+                            WeirScope::Sentence => group.add_sentence_expr_linter(stringify!($name), linter.into_sentence_linter().unwrap_or_else(|_| unreachable!())),
+                        };
                     )+
                 }
 

--- a/harper-core/src/linting/weir_rules/mod.rs
+++ b/harper-core/src/linting/weir_rules/mod.rs
@@ -1,5 +1,5 @@
 use super::LintGroup;
-use crate::weir::{WeirLinter, WeirScope};
+use crate::weir::WeirLinter;
 
 macro_rules! generate_boilerplate {
     ([$($name:ident),+ $(,)?]) => {
@@ -9,9 +9,9 @@ macro_rules! generate_boilerplate {
                 {
                     $(
                         let linter = WeirLinter::new(include_str!(concat!(env!("WEIR_RULE_DIR"), "/", stringify!($name), ".weir"))).unwrap();
-                        match linter.scope() {
-                            WeirScope::Chunk => group.add_chunk_expr_linter(stringify!($name), linter.into_chunk_linter().unwrap_or_else(|_| unreachable!())),
-                            WeirScope::Sentence => group.add_sentence_expr_linter(stringify!($name), linter.into_sentence_linter().unwrap_or_else(|_| unreachable!())),
+                        match linter.into_sentence_linter() {
+                            Ok(linter) => group.add_sentence_expr_linter(stringify!($name), linter),
+                            Err(linter) => group.add_chunk_expr_linter(stringify!($name), linter.into_chunk_linter().unwrap_or_else(|_| unreachable!())),
                         };
                     )+
                 }

--- a/harper-core/src/weir/error.rs
+++ b/harper-core/src/weir/error.rs
@@ -18,6 +18,8 @@ pub enum Error {
     InvalidLintKind,
     #[error("Invalid Replacement Strategy")]
     InvalidReplacementStrategy,
+    #[error("Invalid Scope")]
+    InvalidScope,
     #[error("Expected a variable type other than the one provided.")]
     ExpectedDifferentVariableType,
     #[error("Unable to resolve expression reference {0}")]

--- a/harper-core/src/weir/mod.rs
+++ b/harper-core/src/weir/mod.rs
@@ -16,8 +16,8 @@ use is_macro::Is;
 use parsing::{parse_expr_str, parse_str};
 use strum_macros::{AsRefStr, EnumString};
 
-use crate::expr::Expr;
-use crate::linting::{Chunk, ExprLinter, Lint, LintKind, Linter, Suggestion};
+use crate::expr::{Expr, ExprExt};
+use crate::linting::{Chunk, ExprLinter, Lint, LintKind, Linter, Sentence, Suggestion};
 use crate::parsers::Markdown;
 use crate::spell::FstDictionary;
 use crate::{Document, Lrc, Token, TokenStringExt};
@@ -35,6 +35,12 @@ enum ReplacementStrategy {
     Exact,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString)]
+pub enum WeirScope {
+    Chunk,
+    Sentence,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TestResult {
     pub expected: String,
@@ -48,8 +54,13 @@ pub struct WeirLinter {
     strategy: ReplacementStrategy,
     replacements: Vec<String>,
     lint_kind: LintKind,
+    scope: WeirScope,
     ast: Arc<Ast>,
 }
+
+pub struct ChunkWeirLinter(WeirLinter);
+
+pub struct SentenceWeirLinter(WeirLinter);
 
 impl WeirLinter {
     pub fn new(weir_code: &str) -> Result<WeirLinter, Error> {
@@ -61,6 +72,7 @@ impl WeirLinter {
         let lint_kind_name = "kind";
         let replacement_name = "becomes";
         let replacement_strat_name = "strategy";
+        let scope_name = "scope";
 
         let resolved = resolve_exprs(&ast)?;
 
@@ -124,17 +136,74 @@ impl WeirLinter {
             LintKind::Miscellaneous
         };
 
+        let scope_var = ast.get_variable_value(scope_name);
+        let scope = if let Some(scope) = scope_var {
+            let str = scope
+                .as_string()
+                .ok_or(Error::ExpectedDifferentVariableType)?;
+            WeirScope::from_str(str).ok().ok_or(Error::InvalidScope)?
+        } else {
+            WeirScope::Chunk
+        };
+
         let linter = WeirLinter {
             strategy: replacement_strat,
             ast,
             expr: expr.clone(),
             lint_kind,
+            scope,
             description,
             message,
             replacements,
         };
 
         Ok(linter)
+    }
+
+    pub fn scope(&self) -> WeirScope {
+        self.scope
+    }
+
+    pub fn into_chunk_linter(self) -> Result<ChunkWeirLinter, Self> {
+        if self.scope == WeirScope::Chunk {
+            Ok(ChunkWeirLinter(self))
+        } else {
+            Err(self)
+        }
+    }
+
+    pub fn into_sentence_linter(self) -> Result<SentenceWeirLinter, Self> {
+        if self.scope == WeirScope::Sentence {
+            Ok(SentenceWeirLinter(self))
+        } else {
+            Err(self)
+        }
+    }
+
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let span = matched_tokens.span()?;
+        let orig = span.get_content(source);
+
+        let suggestions = match self.strategy {
+            ReplacementStrategy::MatchCase => self
+                .replacements
+                .iter()
+                .map(|s| Suggestion::replace_with_match_case(s.chars().collect(), orig))
+                .collect(),
+            ReplacementStrategy::Exact => self
+                .replacements
+                .iter()
+                .map(|r| Suggestion::ReplaceWith(r.chars().collect()))
+                .collect(),
+        };
+
+        Some(Lint {
+            span,
+            lint_kind: self.lint_kind,
+            suggestions,
+            message: self.message.to_owned(),
+            priority: 31,
+        })
     }
 
     /// Counts the total number of tests defined.
@@ -265,41 +334,62 @@ impl WeirLinter {
     }
 }
 
-impl ExprLinter for WeirLinter {
-    type Unit = Chunk;
-
-    fn expr(&self) -> &dyn Expr {
-        &self.expr
-    }
-
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
-        let span = matched_tokens.span()?;
-        let orig = span.get_content(source);
-
-        let suggestions = match self.strategy {
-            ReplacementStrategy::MatchCase => self
-                .replacements
-                .iter()
-                .map(|s| Suggestion::replace_with_match_case(s.chars().collect(), orig))
-                .collect(),
-            ReplacementStrategy::Exact => self
-                .replacements
-                .iter()
-                .map(|r| Suggestion::ReplaceWith(r.chars().collect()))
-                .collect(),
+impl Linter for WeirLinter {
+    fn lint(&mut self, document: &Document) -> Vec<Lint> {
+        let source = document.get_source();
+        let mut lints = Vec::new();
+        let units: Box<dyn Iterator<Item = &[Token]> + '_> = match self.scope {
+            WeirScope::Chunk => Box::new(document.iter_chunks()),
+            WeirScope::Sentence => Box::new(document.iter_sentences()),
         };
 
-        Some(Lint {
-            span,
-            lint_kind: self.lint_kind,
-            suggestions,
-            message: self.message.to_owned(),
-            priority: 31,
-        })
+        for unit in units {
+            lints.extend(
+                self.expr
+                    .iter_matches(unit, source)
+                    .filter_map(|match_span| {
+                        self.match_to_lint(&unit[match_span.start..match_span.end], source)
+                    }),
+            );
+        }
+
+        lints
     }
 
     fn description(&self) -> &str {
         &self.description
+    }
+}
+
+impl ExprLinter for ChunkWeirLinter {
+    type Unit = Chunk;
+
+    fn expr(&self) -> &dyn Expr {
+        &self.0.expr
+    }
+
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        self.0.match_to_lint(matched_tokens, source)
+    }
+
+    fn description(&self) -> &str {
+        &self.0.description
+    }
+}
+
+impl ExprLinter for SentenceWeirLinter {
+    type Unit = Sentence;
+
+    fn expr(&self) -> &dyn Expr {
+        &self.0.expr
+    }
+
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        self.0.match_to_lint(matched_tokens, source)
+    }
+
+    fn description(&self) -> &str {
+        &self.0.description
     }
 }
 
@@ -320,7 +410,7 @@ pub mod tests {
 
     use crate::weir::Error;
 
-    use super::{TestResult, WeirLinter};
+    use super::{TestResult, WeirLinter, WeirScope};
 
     #[track_caller]
     pub fn assert_passes_all(linter: &mut WeirLinter) {
@@ -401,6 +491,61 @@ pub mod tests {
 
         assert_passes_all(&mut linter);
         assert_eq!(4, linter.count_tests());
+    }
+
+    #[test]
+    fn scope_defaults_to_chunk() {
+        let source = r#"
+            expr main one**two
+            let message "Use three."
+            let description "Test chunk-scoped Weir."
+            let kind "Miscellaneous"
+            let becomes "three"
+            let strategy "Exact"
+
+            allows "one, two."
+        "#;
+
+        let mut linter = WeirLinter::new(source).unwrap();
+
+        assert_eq!(linter.scope(), WeirScope::Chunk);
+        assert_passes_all(&mut linter);
+    }
+
+    #[test]
+    fn sentence_scope_can_match_across_chunks() {
+        let source = r#"
+            expr main one**two
+            let message "Use three."
+            let description "Test sentence-scoped Weir."
+            let kind "Miscellaneous"
+            let becomes "three"
+            let strategy "Exact"
+            let scope "Sentence"
+
+            test "one, two." "three."
+        "#;
+
+        let mut linter = WeirLinter::new(source).unwrap();
+
+        assert_eq!(linter.scope(), WeirScope::Sentence);
+        assert_passes_all(&mut linter);
+    }
+
+    #[test]
+    fn invalid_scope_errors() {
+        let source = r#"
+            expr main one
+            let message ""
+            let description ""
+            let kind "Miscellaneous"
+            let becomes ""
+            let scope "Paragraph"
+        "#;
+
+        let res = WeirLinter::new(source);
+
+        assert_eq!(res.err(), Some(Error::InvalidScope));
     }
 
     #[test]

--- a/harper-core/src/weir/mod.rs
+++ b/harper-core/src/weir/mod.rs
@@ -36,7 +36,7 @@ enum ReplacementStrategy {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString)]
-pub enum WeirScope {
+enum WeirScope {
     Chunk,
     Sentence,
 }
@@ -58,9 +58,9 @@ pub struct WeirLinter {
     ast: Arc<Ast>,
 }
 
-pub struct ChunkWeirLinter(WeirLinter);
+struct ChunkWeirLinter(WeirLinter);
 
-pub struct SentenceWeirLinter(WeirLinter);
+struct SentenceWeirLinter(WeirLinter);
 
 impl WeirLinter {
     pub fn new(weir_code: &str) -> Result<WeirLinter, Error> {
@@ -160,11 +160,7 @@ impl WeirLinter {
         Ok(linter)
     }
 
-    pub fn scope(&self) -> WeirScope {
-        self.scope
-    }
-
-    pub fn into_chunk_linter(self) -> Result<ChunkWeirLinter, Self> {
+    pub fn into_chunk_linter(self) -> Result<impl ExprLinter<Unit = Chunk>, Self> {
         if self.scope == WeirScope::Chunk {
             Ok(ChunkWeirLinter(self))
         } else {
@@ -172,7 +168,7 @@ impl WeirLinter {
         }
     }
 
-    pub fn into_sentence_linter(self) -> Result<SentenceWeirLinter, Self> {
+    pub fn into_sentence_linter(self) -> Result<impl ExprLinter<Unit = Sentence>, Self> {
         if self.scope == WeirScope::Sentence {
             Ok(SentenceWeirLinter(self))
         } else {
@@ -410,7 +406,7 @@ pub mod tests {
 
     use crate::weir::Error;
 
-    use super::{TestResult, WeirLinter, WeirScope};
+    use super::{TestResult, WeirLinter};
 
     #[track_caller]
     pub fn assert_passes_all(linter: &mut WeirLinter) {
@@ -508,8 +504,14 @@ pub mod tests {
 
         let mut linter = WeirLinter::new(source).unwrap();
 
-        assert_eq!(linter.scope(), WeirScope::Chunk);
         assert_passes_all(&mut linter);
+
+        let linter = WeirLinter::new(source).unwrap();
+        let linter = match linter.into_sentence_linter() {
+            Ok(_) => panic!("default-scoped Weir rule should not convert to sentence linter"),
+            Err(linter) => linter,
+        };
+        assert!(linter.into_chunk_linter().is_ok());
     }
 
     #[test]
@@ -528,8 +530,14 @@ pub mod tests {
 
         let mut linter = WeirLinter::new(source).unwrap();
 
-        assert_eq!(linter.scope(), WeirScope::Sentence);
         assert_passes_all(&mut linter);
+
+        assert!(
+            WeirLinter::new(source)
+                .unwrap()
+                .into_sentence_linter()
+                .is_ok()
+        );
     }
 
     #[test]

--- a/harper-core/src/weirpack/mod.rs
+++ b/harper-core/src/weirpack/mod.rs
@@ -9,7 +9,7 @@ use zip::{CompressionMethod, ZipArchive, ZipWriter};
 
 use crate::linting::LintGroup;
 use crate::spell::MutableDictionary;
-use crate::weir::{TestResult, WeirLinter, WeirScope};
+use crate::weir::{TestResult, WeirLinter};
 
 mod error;
 mod manifest;
@@ -72,17 +72,12 @@ impl Weirpack {
 
         for (name, rule) in &self.rules {
             let linter = WeirLinter::new(rule)?;
-            match linter.scope() {
-                WeirScope::Chunk => group.add_chunk_expr_linter(
+            match linter.into_sentence_linter() {
+                Ok(linter) => group.add_sentence_expr_linter(name, linter),
+                Err(linter) => group.add_chunk_expr_linter(
                     name,
                     linter
                         .into_chunk_linter()
-                        .unwrap_or_else(|_| unreachable!()),
-                ),
-                WeirScope::Sentence => group.add_sentence_expr_linter(
-                    name,
-                    linter
-                        .into_sentence_linter()
                         .unwrap_or_else(|_| unreachable!()),
                 ),
             };

--- a/harper-core/src/weirpack/mod.rs
+++ b/harper-core/src/weirpack/mod.rs
@@ -9,7 +9,7 @@ use zip::{CompressionMethod, ZipArchive, ZipWriter};
 
 use crate::linting::LintGroup;
 use crate::spell::MutableDictionary;
-use crate::weir::{TestResult, WeirLinter};
+use crate::weir::{TestResult, WeirLinter, WeirScope};
 
 mod error;
 mod manifest;
@@ -72,7 +72,20 @@ impl Weirpack {
 
         for (name, rule) in &self.rules {
             let linter = WeirLinter::new(rule)?;
-            group.add_chunk_expr_linter(name, linter);
+            match linter.scope() {
+                WeirScope::Chunk => group.add_chunk_expr_linter(
+                    name,
+                    linter
+                        .into_chunk_linter()
+                        .unwrap_or_else(|_| unreachable!()),
+                ),
+                WeirScope::Sentence => group.add_sentence_expr_linter(
+                    name,
+                    linter
+                        .into_sentence_linter()
+                        .unwrap_or_else(|_| unreachable!()),
+                ),
+            };
             group.config.set_rule_enabled(name, true);
         }
 

--- a/packages/web/src/routes/docs/weir/+page.md
+++ b/packages/web/src/routes/docs/weir/+page.md
@@ -247,6 +247,23 @@ let becomes "Google Workspace"
 let strategy "Exact"
 ```
 
+## Matching Scope
+
+By default, Weir rules run on chunks, which are usually clauses split by commas and sentence-ending punctuation.
+If a rule needs to match across a comma within the same sentence, set its scope to `Sentence`.
+
+```plaintext
+expr main one**two
+let message "Use three."
+let description "Replaces a phrase that can span a comma."
+let kind "Miscellaneous"
+let becomes "three"
+let scope "Sentence"
+```
+
+The supported values are `Chunk` and `Sentence`.
+The setting is optional; omitting it is the same as `let scope "Chunk"`.
+
 ## Adding Tests
 
 The Weir language supports the inclusion of tests directly in the file.


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

N/A

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

This PR adds a new setting within a Weir rule: `scope`. It allows rule authors to select which scope the rule runs in. There are two options: "Chunk" (which is the default) and "Sentence". The former only investigate within chunk boundaries while the latter only for sentence boundaries. 

See the edited documentation in the diff for more details.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Additional unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
