### PR TITLE
feat(core): create `CantWay` rule

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -1521,6 +1521,13 @@
 						},
 						{
 							"Bool": {
+								"name": "CantWay",
+								"state": true,
+								"label": "Cant Way"
+							}
+						},
+						{
+							"Bool": {
 								"name": "CaseSensitive",
 								"state": true,
 								"label": "Case Sensitive"

--- a/harper-core/src/linting/modal_be_adjective.rs
+++ b/harper-core/src/linting/modal_be_adjective.rs
@@ -29,6 +29,7 @@ impl Default for ModalBeAdjective {
                     &[
                         "backup", // adjective commonly misused as a verb
                         "likely", // adjective but with special usage
+                        "way",    // typo for "wait" in patterns like "can't way to"
                     ] as &[_],
                 ),
         }
@@ -153,6 +154,14 @@ mod tests {
     fn ignore_soft_fork_3168() {
         assert_no_lints(
             "You should soft-fork the repository.",
+            ModalBeAdjective::default(),
+        );
+    }
+
+    #[test]
+    fn ignore_cant_way() {
+        assert_no_lints(
+            "I can't way for something better to be released.",
             ModalBeAdjective::default(),
         );
     }

--- a/harper-core/src/linting/weir_rules/CantWay.weir
+++ b/harper-core/src/linting/weir_rules/CantWay.weir
@@ -1,0 +1,36 @@
+expr waitToVerb [be, check, come, experience, get, go, have, hear, learn, meet, play, read, see, start, test, try, use, watch, work]
+expr cantAux [can't, cant, cannot, (can not), couldn't]
+expr doesntAux [doesn't, (does not)]
+
+expr main <([(@cantAux way to @waitToVerb), (@cantAux way [for, until]), (@doesntAux way [for, until])]), way>
+
+let message "Did you mean `wait`?"
+let description "Corrects `way` to `wait` in high-confidence contexts such as `can't way to` and `doesn't way for`."
+let kind "Typo"
+let becomes "wait"
+let strategy "MatchCase"
+
+# True positives
+test "I can't way for something better to be released." "I can't wait for something better to be released."
+test "It doesn't way until completion though." "It doesn't wait until completion though."
+test "Wow, incredible, can't way to try it." "Wow, incredible, can't wait to try it."
+test "Can't way to see things like this come into the project." "Can't wait to see things like this come into the project."
+test "saveTransactionToDb doesn't way for transactions to complete." "saveTransactionToDb doesn't wait for transactions to complete."
+test "If you can't way for 2.10.16, go back to 2.10.12." "If you can't wait for 2.10.16, go back to 2.10.12."
+test "Hehe I can't way for a bevel node to be available." "Hehe I can't wait for a bevel node to be available."
+test "I cannot way to hear the announcement." "I cannot wait to hear the announcement."
+test "We can not way until the migration finishes." "We can not wait until the migration finishes."
+test "They cant way to use the new editor." "They cant wait to use the new editor."
+test "She couldn't way for the build to finish." "She couldn't wait for the build to finish."
+test "The runner does not way for child processes." "The runner does not wait for child processes."
+
+# Guardrails / false positives
+allows "The RFC does not say to ignore it."
+allows "The RFC doesn't say what to do with it."
+allows "I tried create+modify below file but that doesn't work."
+allows "I can't say whether this is simply a way to modify the sleep time."
+allows "I cannot find a way to pass login information via a cookie."
+allows "I can't way to proxy the Strapi URL to the URL where Nuxt is running."
+allows "The potential gain doesn't weigh up against the pain."
+allows "The object doesn't weigh half a ton."
+allows "This is a real way to proxy the URL."


### PR DESCRIPTION
# Issues

Fixes #3345

# Description

Adds a new `CantWay` Weir rule that corrects high-confidence uses of `way` where the writer likely meant `wait`, such as:

- `can't way for something better` -> `can't wait for something better`
- `can't way to try it` -> `can't wait to try it`
- `doesn't way for transactions to complete` -> `doesn't wait for transactions to complete`

The rule exists because `way` is a real word, so the spell checker will not catch this typo. The issue examples show it appearing most reliably after negative auxiliaries like `can't`, `cannot`, `couldn't`, `doesn't`, and `does not`, especially before `for`, `until`, or common excited-action verbs after `to`.

The matcher is intentionally conservative. It avoids broad `doesn't way to ...` and unrestricted `can't way to VERB` patterns because several issue examples are ambiguous or likely intended as other corrections, such as `say`, `weigh`, or `find/provide a way`. This should catch the clearest `wait` mistakes without flagging valid or unclear uses of `way`.

This also adds `way` as an exception in `ModalBeAdjective` so Harper does not suggest `can't be way` alongside the new `CantWay` correction.

# Demo

Before this change, Harper did not provide the intended `wait` correction for text like:

```text
I can't way for something better to be released.
```

After this change, Harper reports `Typo::CantWay` with the suggestion:

```text
I can't wait for something better to be released.
```

# How Has This Been Tested?

A fuzz run completed with no `CantWay` hits across the corpus, plus a ton of unit tests.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
