### PR TITLE
fix(core): delegate to correct underlying method

### DIFF
--- a/harper-core/src/spell/merged_dictionary.rs
+++ b/harper-core/src/spell/merged_dictionary.rs
@@ -202,8 +202,8 @@ impl Dictionary for MergedDictionary {
 mod tests {
     use std::sync::Arc;
 
-    use crate::spell::{Dictionary, MergedDictionary, MutableDictionary};
     use crate::DictWordMetadata;
+    use crate::spell::{Dictionary, MergedDictionary, MutableDictionary};
 
     #[test]
     fn merged_contains_exact_word_str_is_case_sensitive() {

--- a/harper-core/src/spell/merged_dictionary.rs
+++ b/harper-core/src/spell/merged_dictionary.rs
@@ -129,7 +129,7 @@ impl Dictionary for MergedDictionary {
 
     fn contains_exact_word_str(&self, word: &str) -> bool {
         let chars: CharString = word.chars().collect();
-        self.contains_word(&chars)
+        self.contains_exact_word(&chars)
     }
 
     fn get_word_metadata_str(&self, word: &str) -> Option<Cow<'_, DictWordMetadata>> {
@@ -195,5 +195,31 @@ impl Dictionary for MergedDictionary {
             .sorted()
             .dedup()
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::spell::{Dictionary, MergedDictionary, MutableDictionary};
+    use crate::DictWordMetadata;
+
+    #[test]
+    fn merged_contains_exact_word_str_is_case_sensitive() {
+        let mut user_dict = MutableDictionary::new();
+        user_dict.append_word_str("Foo", DictWordMetadata::default());
+
+        let mut merged = MergedDictionary::new();
+        merged.add_dictionary(Arc::new(user_dict));
+
+        assert!(merged.contains_word_str("Foo"));
+        assert!(merged.contains_word_str("foo"));
+
+        assert!(merged.contains_exact_word(&['F', 'o', 'o']));
+        assert!(!merged.contains_exact_word(&['f', 'o', 'o']));
+
+        assert!(merged.contains_exact_word_str("Foo"));
+        assert!(!merged.contains_exact_word_str("foo"));
     }
 }


### PR DESCRIPTION
# Issues 

Fixes #3385

# Description

Updates `MergedDictionary::contains_exact_word_str` so it delegates to `contains_exact_word` instead of the case-insensitive `contains_word` path. This makes the `&str` convenience method match the exact, case-sensitive semantics of `contains_exact_word` and the `Dictionary` trait contract.

Adds a focused regression test that constructs a merged dictionary with only `"Foo"` and verifies:

- `contains_word_str` remains case-insensitive.
- `contains_exact_word` remains case-sensitive.
- `contains_exact_word_str` is now case-sensitive.

# Demo

N/A

# How Has This Been Tested?

Regression coverage was added in `harper-core/src/spell/merged_dictionary.rs` for `MergedDictionary::contains_exact_word_str` case sensitivity.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
