### PR TITLE
fix(ci): issue with Rust Cache on new macOS runners

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -119,6 +119,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.7.8
+        with:
+          cache-bin: true
       - name: Build binary
         uses: houseabsolute/actions-rust-cross@v1
         with:

--- a/.github/workflows/vscode_plugin.yml
+++ b/.github/workflows/vscode_plugin.yml
@@ -49,6 +49,10 @@ jobs:
           node-version-file: ".node-version"
       - name: Enable Corepack
         run: corepack enable
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.7.8
+        with:
+          cache-bin: true
       - name: Build harper-ls
         uses: houseabsolute/actions-rust-cross@v1
         with:


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Failing runs of the "Binaries" workflow on `master`.

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

In the attached issue, a previously unknown bug is documented to cause issues when using the Rust cache on the new macOS runners recently released by GitHub. The only known solution is to set `cache-bin: false`.

https://github.com/Swatinem/rust-cache/issues/341
