### PR TITLE
feat: long time ago→a long time ago

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -4906,6 +4906,13 @@
 								"state": true,
 								"label": "In Hindsight"
 							}
+						},
+						{
+							"Bool": {
+								"name": "LongTimeAgo",
+								"state": true,
+								"label": "Long Time Ago"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -119,6 +119,7 @@ use super::let_to_do::LetToDo;
 use super::lets_confusion::LetsConfusion;
 use super::likewise::Likewise;
 use super::long_sentences::LongSentences;
+use super::long_time_ago::LongTimeAgo;
 use super::look_down_ones_nose::LookDownOnesNose;
 use super::looking_forward_to::LookingForwardTo;
 use super::mass_nouns::MassNouns;
@@ -667,6 +668,7 @@ impl LintGroup {
         insert_struct_rule!(LetsConfusion, true);
         insert_expr_rule!(Likewise, true);
         insert_struct_rule!(LongSentences, true);
+        insert_expr_rule!(LongTimeAgo, true);
         insert_expr_rule!(LookDownOnesNose, true);
         insert_expr_rule!(LookingForwardTo, true);
         insert_struct_rule_with_dict!(MassNouns, true);

--- a/harper-core/src/linting/long_time_ago.rs
+++ b/harper-core/src/linting/long_time_ago.rs
@@ -1,0 +1,97 @@
+use crate::{
+    Lint, Token, TokenStringExt,
+    expr::{AnchorStart, Expr, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+};
+
+pub struct LongTimeAgo {
+    expr: SequenceExpr,
+}
+
+impl Default for LongTimeAgo {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::any_of(vec![
+                Box::new(AnchorStart),
+                Box::new(SequenceExpr::default().then_word_except(&["a"]).t_ws()),
+            ])
+            .t_aco("long")
+            .t_ws()
+            .t_aco("time")
+            .t_ws()
+            .t_aco("ago"),
+        }
+    }
+}
+
+impl ExprLinter for LongTimeAgo {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let span = match matched_tokens.len() {
+            5 => matched_tokens.span()?,
+            7 => matched_tokens[2..].span()?,
+            _ => return None,
+        };
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::Usage,
+            suggestions: vec![Suggestion::replace_with_match_case_str(
+                "a long time ago",
+                span.get_content(source),
+            )],
+            message: "The correct phrase is `a long time ago`.".to_string(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects the missing article `a` in the phrase `long time ago`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    use super::LongTimeAgo;
+
+    #[test]
+    fn fix_long_time_ago_mid_sentence() {
+        assert_suggestion_result(
+            "Simple URL redirect handler written long time ago in PHP - yaroslav-ilin/shortener.",
+            LongTimeAgo::default(),
+            "Simple URL redirect handler written a long time ago in PHP - yaroslav-ilin/shortener.",
+        );
+    }
+
+    #[test]
+    fn fix_long_time_ago_start_of_sentence() {
+        assert_suggestion_result(
+            "Long time ago, I wrote this code.",
+            LongTimeAgo::default(),
+            "A long time ago, I wrote this code.",
+        );
+    }
+
+    #[test]
+    fn dont_flag_a_long_time_ago_mid_sentence() {
+        assert_no_lints(
+            "Created a long time ago and now finally saved in this gist as a backup.",
+            LongTimeAgo::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_a_long_time_ago_start_of_sentence() {
+        assert_no_lints(
+            "a long time ago i had random site redirector on my we site that would send visitors to... - sites.txt.",
+            LongTimeAgo::default(),
+        );
+    }
+}

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -124,6 +124,7 @@ mod lint;
 mod lint_group;
 mod lint_kind;
 mod long_sentences;
+mod long_time_ago;
 mod look_down_ones_nose;
 mod looking_forward_to;
 mod map_phrase_linter;


### PR DESCRIPTION
# Issues 
N/A

# Description

I was reminded of this very common one from nonnative speakers while reading Hacker News comments.

Leaving out the "a" from "a long time ago".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
