### PR TITLE
feat(core): new `AvoidContractions` rule

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -2712,6 +2712,13 @@
 					"settings": [
 						{
 							"Bool": {
+								"name": "AvoidContractions",
+								"state": false,
+								"label": "Avoid Contractions"
+							}
+						},
+						{
+							"Bool": {
 								"name": "BoringWords",
 								"state": false,
 								"label": "Boring Words"

--- a/harper-core/src/linting/avoid_contractions.rs
+++ b/harper-core/src/linting/avoid_contractions.rs
@@ -12,38 +12,54 @@ impl Default for AvoidContractions {
     fn default() -> Self {
         Self {
             expr: WordSet::new(&[
-                "isn't",
                 "aren't",
-                "wasn't",
-                "weren't",
-                "don't",
-                "doesn't",
-                "didn't",
                 "can't",
+                "could've",
                 "couldn't",
-                "shouldn't",
-                "wouldn't",
-                "won't",
-                "haven't",
-                "hasn't",
+                "couldn't've",
+                "didn't",
+                "doesn't",
+                "don't",
                 "hadn't",
+                "hasn't",
+                "haven't",
+                "he'll",
+                "how're",
+                "i'll",
+                "i'm",
+                "i've",
+                "isn't",
+                "it'll",
+                "mayn't",
+                "might've",
+                "mightn't",
+                "must've",
                 "mustn't",
                 "needn't",
-                "I'm",
-                "you're",
-                "we're",
-                "they're",
-                "I've",
-                "you've",
-                "we've",
-                "they've",
-                "I'll",
-                "you'll",
-                "we'll",
-                "they'll",
-                "he'll",
+                "oughtn't",
+                "shan't",
                 "she'll",
-                "it'll",
+                "should've",
+                "shouldn't",
+                "that'll",
+                "they'll",
+                "they're",
+                "they've",
+                "wasn't",
+                "we'll",
+                "we're",
+                "we've",
+                "weren't",
+                "what'll",
+                "who'll",
+                "who're",
+                "who've",
+                "won't",
+                "would've",
+                "wouldn't",
+                "you'll",
+                "you're",
+                "you've",
             ]),
         }
     }
@@ -52,38 +68,54 @@ impl Default for AvoidContractions {
 impl AvoidContractions {
     fn expansion(contraction: &str) -> Option<&'static str> {
         match contraction {
-            "isn't" => Some("is not"),
             "aren't" => Some("are not"),
-            "wasn't" => Some("was not"),
-            "weren't" => Some("were not"),
-            "don't" => Some("do not"),
-            "doesn't" => Some("does not"),
-            "didn't" => Some("did not"),
             "can't" => Some("cannot"),
+            "could've" => Some("could have"),
             "couldn't" => Some("could not"),
-            "shouldn't" => Some("should not"),
-            "wouldn't" => Some("would not"),
-            "won't" => Some("will not"),
-            "haven't" => Some("have not"),
-            "hasn't" => Some("has not"),
+            "couldn't've" => Some("could not have"),
+            "didn't" => Some("did not"),
+            "doesn't" => Some("does not"),
+            "don't" => Some("do not"),
             "hadn't" => Some("had not"),
+            "hasn't" => Some("has not"),
+            "haven't" => Some("have not"),
+            "he'll" => Some("he will"),
+            "how're" => Some("how are"),
+            "i'll" => Some("i will"),
+            "i'm" => Some("i am"),
+            "i've" => Some("i have"),
+            "isn't" => Some("is not"),
+            "it'll" => Some("it will"),
+            "mayn't" => Some("may not"),
+            "might've" => Some("might have"),
+            "mightn't" => Some("might not"),
+            "must've" => Some("must have"),
             "mustn't" => Some("must not"),
             "needn't" => Some("need not"),
-            "i'm" => Some("i am"),
-            "you're" => Some("you are"),
-            "we're" => Some("we are"),
-            "they're" => Some("they are"),
-            "i've" => Some("i have"),
-            "you've" => Some("you have"),
-            "we've" => Some("we have"),
-            "they've" => Some("they have"),
-            "i'll" => Some("i will"),
-            "you'll" => Some("you will"),
-            "we'll" => Some("we will"),
-            "they'll" => Some("they will"),
-            "he'll" => Some("he will"),
+            "oughtn't" => Some("ought not"),
+            "shan't" => Some("shall not"),
             "she'll" => Some("she will"),
-            "it'll" => Some("it will"),
+            "should've" => Some("should have"),
+            "shouldn't" => Some("should not"),
+            "that'll" => Some("that will"),
+            "they'll" => Some("they will"),
+            "they're" => Some("they are"),
+            "they've" => Some("they have"),
+            "wasn't" => Some("was not"),
+            "we'll" => Some("we will"),
+            "we're" => Some("we are"),
+            "we've" => Some("we have"),
+            "weren't" => Some("were not"),
+            "what'll" => Some("what will"),
+            "who'll" => Some("who will"),
+            "who're" => Some("who are"),
+            "who've" => Some("who have"),
+            "won't" => Some("will not"),
+            "would've" => Some("would have"),
+            "wouldn't" => Some("would not"),
+            "you'll" => Some("you will"),
+            "you're" => Some("you are"),
+            "you've" => Some("you have"),
             _ => None,
         }
     }
@@ -233,6 +265,60 @@ mod tests {
     }
 
     #[test]
+    fn expands_additional_unambiguous_contractions() {
+        assert_suggestion_result(
+            "We could've waited.",
+            AvoidContractions::default(),
+            "We could have waited.",
+        );
+        assert_suggestion_result(
+            "They couldn't've known.",
+            AvoidContractions::default(),
+            "They could not have known.",
+        );
+        assert_suggestion_result(
+            "How're you doing?",
+            AvoidContractions::default(),
+            "How are you doing?",
+        );
+        assert_suggestion_result(
+            "You mayn't agree.",
+            AvoidContractions::default(),
+            "You may not agree.",
+        );
+        assert_suggestion_result(
+            "I might've helped.",
+            AvoidContractions::default(),
+            "I might have helped.",
+        );
+        assert_suggestion_result(
+            "We must've missed it.",
+            AvoidContractions::default(),
+            "We must have missed it.",
+        );
+        assert_suggestion_result(
+            "She oughtn't leave.",
+            AvoidContractions::default(),
+            "She ought not leave.",
+        );
+        assert_suggestion_result(
+            "That'll work.",
+            AvoidContractions::default(),
+            "That will work.",
+        );
+        assert_suggestion_result(
+            "What'll happen?",
+            AvoidContractions::default(),
+            "What will happen?",
+        );
+        assert_suggestion_result(
+            "Who're they?",
+            AvoidContractions::default(),
+            "Who are they?",
+        );
+    }
+
+    #[test]
     fn preserves_sentence_initial_case() {
         assert_suggestion_result(
             "Isn't this clear?",
@@ -272,7 +358,15 @@ mod tests {
     #[test]
     fn does_not_flag_ambiguous_contractions() {
         assert_no_lints(
-            "It's done. He'd go. She's been there.",
+            "Ain't that odd? It's done. He'd go. She's been there. Who's ready? We'd left.",
+            AvoidContractions::default(),
+        );
+    }
+
+    #[test]
+    fn does_not_flag_non_standard_or_lexicalized_contractions() {
+        assert_no_lints(
+            "We met y'all near the nor'easter exhibit at five o'clock.",
             AvoidContractions::default(),
         );
     }

--- a/harper-core/src/linting/avoid_contractions.rs
+++ b/harper-core/src/linting/avoid_contractions.rs
@@ -1,0 +1,279 @@
+use crate::Token;
+use crate::expr::Expr;
+use crate::linting::expr_linter::Chunk;
+use crate::linting::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::patterns::WordSet;
+
+pub struct AvoidContractions {
+    expr: WordSet,
+}
+
+impl Default for AvoidContractions {
+    fn default() -> Self {
+        Self {
+            expr: WordSet::new(&[
+                "isn't",
+                "aren't",
+                "wasn't",
+                "weren't",
+                "don't",
+                "doesn't",
+                "didn't",
+                "can't",
+                "couldn't",
+                "shouldn't",
+                "wouldn't",
+                "won't",
+                "haven't",
+                "hasn't",
+                "hadn't",
+                "mustn't",
+                "needn't",
+                "I'm",
+                "you're",
+                "we're",
+                "they're",
+                "I've",
+                "you've",
+                "we've",
+                "they've",
+                "I'll",
+                "you'll",
+                "we'll",
+                "they'll",
+                "he'll",
+                "she'll",
+                "it'll",
+            ]),
+        }
+    }
+}
+
+impl AvoidContractions {
+    fn expansion(contraction: &str) -> Option<&'static str> {
+        match contraction {
+            "isn't" => Some("is not"),
+            "aren't" => Some("are not"),
+            "wasn't" => Some("was not"),
+            "weren't" => Some("were not"),
+            "don't" => Some("do not"),
+            "doesn't" => Some("does not"),
+            "didn't" => Some("did not"),
+            "can't" => Some("cannot"),
+            "couldn't" => Some("could not"),
+            "shouldn't" => Some("should not"),
+            "wouldn't" => Some("would not"),
+            "won't" => Some("will not"),
+            "haven't" => Some("have not"),
+            "hasn't" => Some("has not"),
+            "hadn't" => Some("had not"),
+            "mustn't" => Some("must not"),
+            "needn't" => Some("need not"),
+            "i'm" => Some("i am"),
+            "you're" => Some("you are"),
+            "we're" => Some("we are"),
+            "they're" => Some("they are"),
+            "i've" => Some("i have"),
+            "you've" => Some("you have"),
+            "we've" => Some("we have"),
+            "they've" => Some("they have"),
+            "i'll" => Some("i will"),
+            "you'll" => Some("you will"),
+            "we'll" => Some("we will"),
+            "they'll" => Some("they will"),
+            "he'll" => Some("he will"),
+            "she'll" => Some("she will"),
+            "it'll" => Some("it will"),
+            _ => None,
+        }
+    }
+
+    fn normalize(contraction: &str) -> String {
+        contraction.replace('’', "'").to_lowercase()
+    }
+}
+
+impl ExprLinter for AvoidContractions {
+    type Unit = Chunk;
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        let tok = toks.first()?;
+        let contraction = tok.get_str(src);
+        let expansion = Self::expansion(&Self::normalize(&contraction))?;
+
+        Some(Lint {
+            span: tok.span,
+            lint_kind: LintKind::Style,
+            suggestions: vec![Suggestion::replace_with_match_case_str(
+                expansion,
+                tok.get_ch(src),
+            )],
+            message: "Consider expanding this contraction.".to_string(),
+            priority: 63,
+        })
+    }
+
+    fn description(&self) -> &str {
+        "Suggests expanded forms for common contractions, such as `isn't` → `is not` and `we're` → `we are`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    use super::AvoidContractions;
+
+    #[test]
+    fn expands_isnt() {
+        assert_suggestion_result(
+            "This isn't necessary.",
+            AvoidContractions::default(),
+            "This is not necessary.",
+        );
+    }
+
+    #[test]
+    fn expands_wasnt() {
+        assert_suggestion_result(
+            "It wasn't ready.",
+            AvoidContractions::default(),
+            "It was not ready.",
+        );
+    }
+
+    #[test]
+    fn expands_arent() {
+        assert_suggestion_result(
+            "They aren't coming.",
+            AvoidContractions::default(),
+            "They are not coming.",
+        );
+    }
+
+    #[test]
+    fn expands_dont() {
+        assert_suggestion_result(
+            "We don't need it.",
+            AvoidContractions::default(),
+            "We do not need it.",
+        );
+    }
+
+    #[test]
+    fn expands_doesnt() {
+        assert_suggestion_result(
+            "She doesn't agree.",
+            AvoidContractions::default(),
+            "She does not agree.",
+        );
+    }
+
+    #[test]
+    fn expands_didnt() {
+        assert_suggestion_result(
+            "He didn't answer.",
+            AvoidContractions::default(),
+            "He did not answer.",
+        );
+    }
+
+    #[test]
+    fn expands_cant() {
+        assert_suggestion_result(
+            "You can't go.",
+            AvoidContractions::default(),
+            "You cannot go.",
+        );
+    }
+
+    #[test]
+    fn expands_wont() {
+        assert_suggestion_result(
+            "They won't stop.",
+            AvoidContractions::default(),
+            "They will not stop.",
+        );
+    }
+
+    #[test]
+    fn expands_havent() {
+        assert_suggestion_result(
+            "I haven't finished.",
+            AvoidContractions::default(),
+            "I have not finished.",
+        );
+    }
+
+    #[test]
+    fn expands_im() {
+        assert_suggestion_result("I'm ready.", AvoidContractions::default(), "I am ready.");
+    }
+
+    #[test]
+    fn expands_youre() {
+        assert_suggestion_result(
+            "You're right.",
+            AvoidContractions::default(),
+            "You are right.",
+        );
+    }
+
+    #[test]
+    fn expands_theyll() {
+        assert_suggestion_result(
+            "They'll arrive soon.",
+            AvoidContractions::default(),
+            "They will arrive soon.",
+        );
+    }
+
+    #[test]
+    fn preserves_sentence_initial_case() {
+        assert_suggestion_result(
+            "Isn't this clear?",
+            AvoidContractions::default(),
+            "Is not this clear?",
+        );
+    }
+
+    #[test]
+    fn preserves_all_caps() {
+        assert_suggestion_result(
+            "WE DON'T AGREE.",
+            AvoidContractions::default(),
+            "WE DO NOT AGREE.",
+        );
+    }
+
+    #[test]
+    fn handles_typographic_apostrophes() {
+        assert_suggestion_result(
+            "They’re prepared.",
+            AvoidContractions::default(),
+            "They are prepared.",
+        );
+    }
+
+    #[test]
+    fn does_not_flag_possessives() {
+        assert_no_lints("Alice's book is here.", AvoidContractions::default());
+    }
+
+    #[test]
+    fn does_not_flag_names_with_apostrophes() {
+        assert_no_lints("O'Connor arrived.", AvoidContractions::default());
+    }
+
+    #[test]
+    fn does_not_flag_ambiguous_contractions() {
+        assert_no_lints(
+            "It's done. He'd go. She's been there.",
+            AvoidContractions::default(),
+        );
+    }
+}

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -30,6 +30,7 @@ use super::apart_from::ApartFrom;
 use super::arrive_to::ArriveTo;
 use super::ask_no_preposition::AskNoPreposition;
 use super::aspire_to::AspireTo;
+use super::avoid_contractions::AvoidContractions;
 use super::avoid_curses::AvoidCurses;
 use super::back_in_the_day::BackInTheDay;
 use super::be_allowed::BeAllowed;
@@ -579,6 +580,7 @@ impl LintGroup {
         insert_expr_rule!(ApartFrom, true);
         insert_expr_rule!(ArriveTo, true);
         insert_expr_rule!(AskNoPreposition, true);
+        insert_expr_rule!(AvoidContractions, false);
         insert_expr_rule!(AvoidCurses, true);
         insert_expr_rule!(BackInTheDay, true);
         insert_expr_rule!(BeAllowed, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -22,6 +22,7 @@ mod apart_from;
 mod arrive_to;
 mod ask_no_preposition;
 mod aspire_to;
+mod avoid_contractions;
 mod avoid_curses;
 mod back_in_the_day;
 mod be_adjective_confusions;


### PR DESCRIPTION
# Issues 

No linked issue.

# Description

Adds a new opt-in `AvoidContractions` linter that suggests expanded forms for common English contractions.

The rule covers deterministic contraction expansions such as:

- `isn't` → `is not`
- `wasn't` → `was not`
- `don't` → `do not`
- `can't` → `cannot`
- `I'm` → `I am`
- `you're` → `you are`
- `they'll` → `they will`

The rule is registered in the lint group and added to `default_config.json` under Style and Redundancy with `state: false`, so it is available but disabled by default.

Ambiguous contractions such as `it's`, `he'd`, and `she's` are intentionally excluded from this first implementation.

# Demo

N/A

# How Has This Been Tested?

Added unit tests for the new linter covering positive matches, suggestion output, casing behavior, typographic apostrophes, possessives/names, and intentionally excluded ambiguous contractions.

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter

- [x] I made up the sentences in the unit tests.
- [x] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
