### PR TITLE
feat: `AnchorEnd` finally fixed

### DIFF
--- a/harper-core/src/expr/anchor_end.rs
+++ b/harper-core/src/expr/anchor_end.rs
@@ -21,10 +21,10 @@ impl Step for AnchorEnd {
         // Match if cursor is at or past the last non-whitespace token
         // This allows AnchorEnd to work in sequences where the cursor has advanced
         // past the matched content, including when cursor is past the end of the token stream
-        if let Some(last) = last_non_ws {
-            if cursor >= last {
-                return Some(0);
-            }
+        if let Some(last) = last_non_ws
+            && cursor >= last
+        {
+            return Some(0);
         }
 
         None

--- a/harper-core/src/expr/anchor_end.rs
+++ b/harper-core/src/expr/anchor_end.rs
@@ -10,26 +10,31 @@ pub struct AnchorEnd;
 
 impl Step for AnchorEnd {
     fn step(&self, tokens: &[Token], cursor: usize, _source: &[char]) -> Option<isize> {
-        if tokens
+        let last_non_ws = tokens
             .iter()
             .enumerate()
             .rev()
             .filter(|(_, t)| !t.kind.is_whitespace())
             .map(|(i, _)| i)
-            .next()
-            == Some(cursor)
-        {
-            Some(0)
-        } else {
-            None
+            .next();
+
+        // Match if cursor is at or past the last non-whitespace token
+        // This allows AnchorEnd to work in sequences where the cursor has advanced
+        // past the matched content, including when cursor is past the end of the token stream
+        if let Some(last) = last_non_ws {
+            if cursor >= last {
+                return Some(0);
+            }
         }
+
+        None
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::expr::ExprExt;
-    use crate::{Document, Span};
+    use crate::expr::{AnchorStart, ExprExt, SequenceExpr};
+    use crate::{Document, Span, TokenStringExt};
 
     use super::AnchorEnd;
 
@@ -47,5 +52,78 @@ mod tests {
         let matches: Vec<_> = AnchorEnd.iter_matches_in_doc(&document).collect();
 
         assert_eq!(matches, vec![])
+    }
+
+    #[test]
+    fn test_word_at_end_of_document() {
+        // Test matching a specific word at the end of a document
+        let document = Document::new_plain_english_curated("This is the end");
+        let expr = SequenceExpr::default()
+            .then_any_capitalization_of("end")
+            .then(AnchorEnd);
+
+        let matches: Vec<_> = expr.iter_matches_in_doc(&document).collect();
+        // Should match "end" at position 6 (accounting for whitespace tokens)
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].start, 6);
+    }
+
+    #[test]
+    fn test_word_not_at_end_of_doc() {
+        // Test that it doesn't match when word has trailing content
+        let document = Document::new_plain_english_curated("This is the end, really");
+        let expr = SequenceExpr::default()
+            .then_any_capitalization_of("end")
+            .then(AnchorEnd);
+
+        let matches: Vec<_> = expr.iter_matches_in_doc(&document).collect();
+        // Should NOT match because "end" is not at chunk end
+        assert_eq!(matches.len(), 0);
+    }
+
+    #[test]
+    fn test_word_at_end_of_chunk() {
+        // Chunks are split by commas, so "hello, world" becomes two chunks
+        // Test that AnchorEnd works at the end of a chunk
+        let document = Document::new_plain_english_curated("hello, world");
+        let expr = SequenceExpr::default()
+            .then_any_capitalization_of("hello")
+            .then(AnchorEnd);
+
+        // Test on the first chunk which contains just "hello"
+        let first_chunk = document.iter_chunks().next().unwrap();
+        let matches: Vec<_> = expr
+            .iter_matches(first_chunk, document.get_source())
+            .collect();
+        // Should match because "hello" is at the end of its chunk
+        assert_eq!(matches.len(), 1);
+    }
+
+    #[test]
+    fn test_compare_with_anchor_start() {
+        // AnchorStart works as expected
+        let document = Document::new_plain_english_curated("Start here");
+        let expr = SequenceExpr::default()
+            .then(AnchorStart)
+            .then_any_capitalization_of("start");
+
+        let matches: Vec<_> = expr.iter_matches_in_doc(&document).collect();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].start, 0);
+    }
+
+    #[test]
+    fn test_word_with_trailing_whitespace_at_end_of_doc() {
+        // Test AnchorEnd after matching whitespace
+        let document = Document::new_plain_english_curated("foo ");
+        let expr = SequenceExpr::default()
+            .then_any_capitalization_of("foo")
+            .then_whitespace()
+            .then(AnchorEnd);
+
+        let matches: Vec<_> = expr.iter_matches_in_doc(&document).collect();
+        // Should match "foo" at the end (cursor is past the token stream)
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].end, 2);
     }
 }

--- a/harper-core/src/expr/sequence_expr.rs
+++ b/harper-core/src/expr/sequence_expr.rs
@@ -58,19 +58,25 @@ impl Expr for SequenceExpr {
         for cur_expr in &self.exprs {
             let out = cur_expr.run(cursor, tokens, source)?;
 
-            // Only expand the window if the match actually covers some tokens
-            if out.end > out.start {
-                window.expand_to_include(out.start);
-                window.expand_to_include(out.end.checked_sub(1).unwrap_or(out.start));
-            }
+            // Zero-width assertions (like AnchorEnd) validate position without consuming tokens
+            // They should not expand the window or advance the cursor
+            let is_zero_width = out.end == out.start;
 
-            // Only advance cursor if we actually matched something
-            if out.end > cursor {
-                cursor = out.end;
-            } else if out.start < cursor {
-                cursor = out.start;
+            if !is_zero_width {
+                // Only expand the window if the match actually covers some tokens
+                if out.end > out.start {
+                    window.expand_to_include(out.start);
+                    window.expand_to_include(out.end.checked_sub(1).unwrap_or(out.start));
+                }
+
+                // Only advance cursor if we actually matched something
+                if out.end > cursor {
+                    cursor = out.end;
+                } else if out.start < cursor {
+                    cursor = out.start;
+                }
             }
-            // If both start and end are equal to cursor, don't move the cursor
+            // If zero-width, don't expand window or advance cursor - just validate position
         }
 
         Some(window)
@@ -637,7 +643,7 @@ where
 mod tests {
     use crate::{
         Document, TokenKind,
-        expr::{ExprExt, SequenceExpr},
+        expr::{AnchorEnd, ExprExt, SequenceExpr},
         linting::tests::SpanVecExt,
     };
 
@@ -666,5 +672,68 @@ mod tests {
         let doc = Document::new_plain_english_curated("Use a good example.");
         let matches = expr.iter_matches_in_doc(&doc).collect::<Vec<_>>();
         assert_eq!(matches.to_strings(&doc), vec!["Use", "example"]);
+    }
+
+    #[test]
+    fn flag_foo_followed_by_bar_or_at_end_1() {
+        let expr = SequenceExpr::aco("foo").then_any_of(vec![
+            Box::new(SequenceExpr::whitespace().t_aco("bar").then(AnchorEnd)),
+            Box::new(AnchorEnd),
+        ]);
+
+        let doc_with_bar = Document::new_plain_english_curated("foo bar");
+
+        let matches_with_bar = expr.iter_matches_in_doc(&doc_with_bar).collect::<Vec<_>>();
+
+        eprintln!("matches_with_bar: {:#?}", matches_with_bar);
+
+        // "foo bar" matches with span covering both tokens
+        assert_eq!(matches_with_bar.len(), 1);
+        assert_eq!(matches_with_bar[0].start, 0);
+        assert_eq!(matches_with_bar[0].end, 3);
+        assert_eq!(matches_with_bar.to_strings(&doc_with_bar), vec!["foo bar"]);
+    }
+
+    #[test]
+    fn flag_foo_followed_by_bar_or_at_end_2() {
+        let expr = SequenceExpr::aco("foo").then_any_of(vec![
+            Box::new(SequenceExpr::whitespace().t_aco("bar").then(AnchorEnd)),
+            Box::new(AnchorEnd),
+        ]);
+
+        let doc_with_end = Document::new_plain_english_curated("foo");
+
+        let matches_with_end = expr.iter_matches_in_doc(&doc_with_end).collect::<Vec<_>>();
+
+        eprintln!("matches_with_end: {:#?}", matches_with_end);
+
+        // "foo" at end matches with span covering just "foo"
+        assert_eq!(matches_with_end.len(), 1);
+        assert_eq!(matches_with_end[0].start, 0);
+        assert_eq!(matches_with_end[0].end, 1);
+        assert_eq!(matches_with_end.to_strings(&doc_with_end), vec!["foo"]);
+    }
+
+    #[test]
+    fn flag_foo_followed_by_bar_or_at_end_3() {
+        let expr = SequenceExpr::aco("foo").then_any_of(vec![
+            Box::new(SequenceExpr::whitespace().t_aco("bar").then(AnchorEnd)),
+            Box::new(AnchorEnd),
+        ]);
+
+        let doc_with_foo_bar_baz = Document::new_plain_english_curated("foo bar baz");
+
+        let matches_with_foo_bar_baz = expr
+            .iter_matches_in_doc(&doc_with_foo_bar_baz)
+            .collect::<Vec<_>>();
+
+        eprintln!("matches_with_foo_bar_baz: {:#?}", matches_with_foo_bar_baz);
+
+        // "foo bar baz" should NOT match because "bar" is not at the end
+        assert_eq!(matches_with_foo_bar_baz.len(), 0);
+        assert_eq!(
+            matches_with_foo_bar_baz.to_strings(&doc_with_foo_bar_baz),
+            Vec::<String>::new()
+        );
     }
 }

--- a/harper-core/src/linting/addicting.rs
+++ b/harper-core/src/linting/addicting.rs
@@ -1,34 +1,32 @@
 use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
-    expr::{All, AnchorEnd, Expr, FirstMatchOf, LongestMatchOf, ReflexivePronoun, SequenceExpr},
+    expr::{All, AnchorEnd, Expr, FirstMatchOf, ReflexivePronoun, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
 };
 
 pub struct Addicting {
-    expr: LongestMatchOf,
+    expr: SequenceExpr,
 }
 
 impl Default for Addicting {
     fn default() -> Self {
         Self {
-            expr: LongestMatchOf::new(vec![
+            expr: SequenceExpr::aco("addicting").then_longest_of(vec![
                 // matches `addicting` without anything after
-                Box::new(SequenceExpr::aco("addicting").then(AnchorEnd)),
+                Box::new(AnchorEnd),
+                // Semicolon is not handled like comma is for `Chunk` - TODO: remove when #3405 is fixed
+                Box::new(SequenceExpr::default().then_semicolon()),
                 // matches `addicting` <ws> [ any word but not a reflexive pronoun or object pronoun ]
-                Box::new(
-                    SequenceExpr::aco("addicting")
-                        .then_whitespace()
-                        .then(All::new(vec![
-                            // positive - any word
-                            Box::new(SequenceExpr::any_word()),
-                            // negative - reflexive pronoun or object pronoun
-                            Box::new(SequenceExpr::unless(FirstMatchOf::new(vec![
-                                Box::new(ReflexivePronoun::with_common_errors()),
-                                Box::new(SequenceExpr::default().then_object_pronoun()),
-                            ]))),
-                        ])),
-                ),
+                Box::new(SequenceExpr::whitespace().then(All::new(vec![
+                    // positive - any word
+                    Box::new(SequenceExpr::any_word()),
+                    // negative - reflexive pronoun or object pronoun
+                    Box::new(SequenceExpr::unless(FirstMatchOf::new(vec![
+                        Box::new(ReflexivePronoun::with_common_errors()),
+                        Box::new(SequenceExpr::default().then_object_pronoun()),
+                    ]))),
+                ]))),
             ]),
         }
     }
@@ -118,6 +116,56 @@ mod tests {
         assert_no_lints(
             "The British, in another display of gunboat diplomacy, coerced countless innocent people into addicting themselves to opium.",
             Addicting::default(),
+        );
+    }
+
+    #[test]
+    fn fix_at_end() {
+        assert_suggestion_result("It is addicting", Addicting::default(), "It is addictive");
+    }
+
+    #[test]
+    fn fix_before_comma() {
+        assert_suggestion_result(
+            "An addicting, side-scrolling, bouncing platform game - mzmousa/fruit-catcher.",
+            Addicting::default(),
+            "An addictive, side-scrolling, bouncing platform game - mzmousa/fruit-catcher.",
+        );
+    }
+
+    #[test]
+    fn fix_at_end_with_bang() {
+        assert_suggestion_result(
+            "Name of the Game is \"Pappu Pakia\". It is super fun and addicting!",
+            Addicting::default(),
+            "Name of the Game is \"Pappu Pakia\". It is super fun and addictive!",
+        );
+    }
+
+    #[test]
+    fn fix_at_end_with_period() {
+        assert_suggestion_result(
+            "This game is kind of addicting. The fast pace and small initial tail size puts emphasis on control and reaction time.",
+            Addicting::default(),
+            "This game is kind of addictive. The fast pace and small initial tail size puts emphasis on control and reaction time.",
+        );
+    }
+
+    #[test]
+    fn fix_at_end_with_semicolon() {
+        assert_suggestion_result(
+            "Powerful emotionally, Extremely addicting; Best game played in a long time, lost hours of time playing game without realizing",
+            Addicting::default(),
+            "Powerful emotionally, Extremely addictive; Best game played in a long time, lost hours of time playing game without realizing",
+        );
+    }
+
+    #[test]
+    fn fix_at_end_with_semicolon_no_commas_due_to_chunk_mode() {
+        assert_suggestion_result(
+            "Extremely addicting; Best game played in a long time",
+            Addicting::default(),
+            "Extremely addictive; Best game played in a long time",
         );
     }
 }


### PR DESCRIPTION
# Issues 

Fixes #1262
Fixes #1731

# Description

I've tried to get this working twice before, on my own and with LLMs.
I thought I'd give it another shot with an agent with a bigger context window that can look through more source files.

It seems to finally be working but needs a proper review.

I completed an old linter that was supposed to match at the end of a chunk but never worked.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

- Implemented in a linter, `Addicting`, verified that it didn't work without this patch and does work with it.
- Added unit tests to `AnchorEnd`, `SequenceExpr`, and `Addicting`.
- `cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [x] <s>The sentences in the</s> unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

I hunted down real-world sentences for `Addicting` but the AI made 2/3 of the lower-level tests. Some were then hand-tweaked, others were not.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
