### PR TITLE
fix(core): replace Arc with Lrc in call_them and should_contract

### DIFF
--- a/harper-core/src/linting/call_them.rs
+++ b/harper-core/src/linting/call_them.rs
@@ -1,7 +1,8 @@
-use std::{ops::Range, sync::Arc};
+use std::ops::Range;
 
 use crate::expr::{Expr, ExprMap, SequenceExpr};
 use crate::patterns::DerivedFrom;
+use crate::sync::Lrc;
 use crate::{Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
@@ -15,7 +16,7 @@ impl Default for CallThem {
     fn default() -> Self {
         let mut map = ExprMap::default();
 
-        let post_exception = Arc::new(SequenceExpr::default().t_ws().then_word_set(&["if", "it"]));
+        let post_exception = Lrc::new(SequenceExpr::default().t_ws().then_word_set(&["if", "it"]));
 
         map.insert(
             SequenceExpr::with(DerivedFrom::new_from_str("call"))

--- a/harper-core/src/linting/pronoun_contraction/should_contract.rs
+++ b/harper-core/src/linting/pronoun_contraction/should_contract.rs
@@ -1,9 +1,8 @@
-use std::sync::Arc;
-
 use crate::expr::AnchorStart;
 use crate::expr::Expr;
 use crate::expr::OwnedExprExt;
 use crate::expr::SequenceExpr;
+use crate::sync::Lrc;
 use crate::{Token, patterns::WordSet};
 
 use crate::Lint;
@@ -21,7 +20,7 @@ pub struct ShouldContract {
 
 impl Default for ShouldContract {
     fn default() -> Self {
-        let cap = Arc::new(
+        let cap = Lrc::new(
             SequenceExpr::word_set(&["your", "were"])
                 .then_whitespace()
                 .then_non_quantifier_determiner()


### PR DESCRIPTION
# Issues

N/A

# Description

Replaces `std::sync::Arc` with `crate::sync::Lrc` in `call_them.rs` and `should_contract.rs`. `Lrc` is Harper's type alias that selects `Rc` or `Arc` based on the `concurrent` feature, ensuring proper `Send` + `Sync` bounds.

# Testing

- `cargo fmt --check`
- `cargo clippy --package harper-core -- -Dwarnings`