### PR TITLE
chore: unneeded comments, typos in comments

### DIFF
--- a/harper-core/src/linting/a_some_time.rs
+++ b/harper-core/src/linting/a_some_time.rs
@@ -106,7 +106,6 @@ mod tests {
         );
     }
 
-    // I guess support people is was cheaper than just a some hours of an engineer who can actually fix the platform
     #[test]
     fn a_some_hours() {
         assert_suggestion_result(

--- a/harper-core/src/linting/by_accident.rs
+++ b/harper-core/src/linting/by_accident.rs
@@ -1,8 +1,3 @@
-/*
-let message "Did you mean `by accident`?"
-let description "Incorrect preposition: `by accident` is the idiomatic expression."
- */
-
 use crate::{
     Lint, Token,
     expr::{Expr, SequenceExpr},

--- a/harper-core/src/linting/sought_after.rs
+++ b/harper-core/src/linting/sought_after.rs
@@ -19,8 +19,8 @@ impl Default for SoughtAfter {
                 "abit", // Typo for "a bit"
                 "are",  // may cause false positive, but few found so far.
                 "bit",
-                // "is" causes many false postivies and disambiguating looks tricky.
-                // "maybe" causes many false postivies and disambiguating looks tricky.
+                // "is" causes many false positives and disambiguating looks tricky.
+                // "maybe" causes many false positives and disambiguating looks tricky.
                 "of", "quiet", // Common typo for "quite".
             ])),
         ])
@@ -229,7 +229,6 @@ mod tests {
         );
     }
 
-    // This part is occasionally sort after and if they were easily available I reckon you'd sell a few easily enough.
     #[test]
     fn fix_occasionally_sort_after() {
         assert_suggestion_result(
@@ -294,7 +293,6 @@ mod tests {
         );
     }
 
-    // The university that i studied my MBBS from offers the course as well and it is quite sort after for the above said course.
     #[test]
     fn fix_quite_sort_after() {
         assert_suggestion_result(


### PR DESCRIPTION
# Issues 
N/A

# Description

While working on other things I noticed Harper was flagging some things in comments in its own source.
Some comments were not intended to remain in the code and others contained typos.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
