### PR TITLE
feat: for free of charge → for free / free of charge

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -3038,6 +3038,13 @@
 								"state": true,
 								"label": "Side Tangent"
 							}
+						},
+						{
+							"Bool": {
+								"name": "ForFreeOfCharge",
+								"state": true,
+								"label": "For Free of Charge"
+							}
 						}
 					]
 				}

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -13105,7 +13105,7 @@ ardor/NgS
 ardour/NwgS!@_₹
 arduous/~JYp
 arduousness/Ng
-are/~VlS            # 2nd person singular & plural / 1st & 3rd person plural present of 'be'
+are/~Vl             # 2nd person singular & plural / 1st & 3rd person plural present of 'be'
 area/~NwSg
 areal/J
 aren't/V
@@ -25641,7 +25641,7 @@ fop/NSg
 foppery/Nmg
 foppish/Jp
 foppishness/Nmg
-for/~CPRH
+for/~PCRH
 fora/~N9
 forage/~NSgVd>GZ
 forager/NgS
@@ -37402,7 +37402,7 @@ ostracism/Ng
 ostracize/VGdS
 ostrich/~NgS
 other/~JpNgSV
-otherwise/~RJ
+otherwise/~RCJ
 otherworldly/J
 otiose/J
 otter/~NgS

--- a/harper-core/src/expr/sequence_expr.rs
+++ b/harper-core/src/expr/sequence_expr.rs
@@ -496,6 +496,18 @@ impl SequenceExpr {
         })
     }
 
+    /// Match a token where any of the first token kind predicates returns true
+    /// and the second returns false.    
+    pub fn then_kind_any_but_not<F1, F2>(self, preds_is: &'static [F1], pred_not: F2) -> Self
+    where
+        F1: Fn(&TokenKind) -> bool + Send + Sync + 'static,
+        F2: Fn(&TokenKind) -> bool + Send + Sync + 'static,
+    {
+        self.then(move |tok: &Token, _src: &[char]| {
+            preds_is.iter().any(|pred| pred(&tok.kind)) && !pred_not(&tok.kind)
+        })
+    }
+
     /// Match a token where any of the first token kind predicates returns true,
     /// the second returns false, and the token is not in the list of exceptions.    
     pub fn then_kind_any_but_not_except<F1, F2>(

--- a/harper-core/src/linting/for_free_of_charge.rs
+++ b/harper-core/src/linting/for_free_of_charge.rs
@@ -1,0 +1,244 @@
+use crate::{
+    Lint, Token, TokenKind, TokenStringExt,
+    expr::{Expr, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+};
+
+pub struct ForFreeOfCharge {
+    expr: SequenceExpr,
+}
+
+impl Default for ForFreeOfCharge {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::aco("for")
+                .t_ws()
+                .t_aco("free")
+                .t_ws_h()
+                .t_aco("of")
+                .t_ws_h()
+                .t_aco("charge")
+                .then_any_of(vec![
+                    Box::new(SequenceExpr::default().then_kind_any(&[
+                        TokenKind::is_sentence_terminator,
+                        TokenKind::is_comma,
+                        TokenKind::is_quote,
+                    ])),
+                    Box::new(SequenceExpr::whitespace().then_kind_any_but_not(
+                        &[
+                            TokenKind::is_conjunction,
+                            TokenKind::is_preposition,
+                            TokenKind::is_verb,
+                        ],
+                        TokenKind::is_noun,
+                    )),
+                ]),
+        }
+    }
+}
+
+impl ExprLinter for ForFreeOfCharge {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let span = matched_tokens[0..7].span()?;
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::Redundancy,
+            suggestions: vec![
+                Suggestion::replace_with_match_case_str("for free", span.get_content(source)),
+                Suggestion::replace_with_match_case_str("free of charge", span.get_content(source)),
+            ],
+            message: "Use only either `for free` or `free of charge`".to_string(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects `for free of charge` to either `for free` or `free of charge`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_good_and_bad_suggestions, assert_no_lints};
+
+    use super::ForFreeOfCharge;
+
+    // TRUE POSITIVES
+
+    #[test]
+    fn fix_for_foc_question_mark() {
+        // Being followed by a question mark, "for free of charge" is being used as a phrase, not as a modifier
+        assert_good_and_bad_suggestions(
+            "Where to check my paper grammars for free of charge?",
+            ForFreeOfCharge::default(),
+            &[
+                "Where to check my paper grammars for free?",
+                "Where to check my paper grammars free of charge?",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn fix_for_foc_for() {
+        // The following `for` is not a noun so can't be modified by "free of charge"
+        assert_good_and_bad_suggestions(
+            "In Hungary, restaurants are required by law to provide tap water for free of charge for any customers upon request.",
+            ForFreeOfCharge::default(),
+            &[
+                "In Hungary, restaurants are required by law to provide tap water for free for any customers upon request.",
+                "In Hungary, restaurants are required by law to provide tap water free of charge for any customers upon request.",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn fix_for_foc_comma_not() {
+        // Being followed by a comma, "for free of charge" is being used as a phrase, not as a modifier
+        assert_good_and_bad_suggestions(
+            "I provide this software in its entirety for free of charge, and support via GitHub is also free.",
+            ForFreeOfCharge::default(),
+            &[
+                "I provide this software in its entirety for free, and support via GitHub is also free.",
+                "I provide this software in its entirety free of charge, and support via GitHub is also free.",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn fix_for_foc_quote() {
+        // Being within scare quotes, "for free of charge" is being used as a phrase, not as a modifier
+        assert_good_and_bad_suggestions(
+            "Copyright protects copying, not \"giving things away for free of charge\" or anything like that.",
+            ForFreeOfCharge::default(),
+            &[
+                "Copyright protects copying, not \"giving things away for free\" or anything like that.",
+                "Copyright protects copying, not \"giving things away free of charge\" or anything like that.",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn fix_for_foc_otherwise() {
+        // `otherwise` is a conjunction that introduces a contrasting clause
+        // Therefore, not a noun, meaning `free of charge` is not modifying it
+        assert_good_and_bad_suggestions(
+            "For Wizzair, if you have purchased a separate ticket for your infant, then only car seat is allowed for free of charge otherwise its not.",
+            ForFreeOfCharge::default(),
+            &[
+                "For Wizzair, if you have purchased a separate ticket for your infant, then only car seat is allowed for free otherwise its not.",
+                "For Wizzair, if you have purchased a separate ticket for your infant, then only car seat is allowed free of charge otherwise its not.",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn fix_for_foc_comma_but() {
+        assert_good_and_bad_suggestions(
+            "user may use the Software for free of charge, but the Software is basically paid software",
+            ForFreeOfCharge::default(),
+            &[
+                "user may use the Software for free, but the Software is basically paid software",
+                "user may use the Software free of charge, but the Software is basically paid software",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn fix_for_foc_period() {
+        assert_good_and_bad_suggestions(
+            "...giving them away for free of charge. :-) SCNR",
+            ForFreeOfCharge::default(),
+            &[
+                "...giving them away for free. :-) SCNR",
+                "...giving them away free of charge. :-) SCNR",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn fix_for_foc_are() {
+        assert_good_and_bad_suggestions(
+            "Also what they offer for free of charge are very very powerful machines for unlimited amount of time.",
+            ForFreeOfCharge::default(),
+            &[
+                "Also what they offer for free are very very powerful machines for unlimited amount of time.",
+                "Also what they offer free of charge are very very powerful machines for unlimited amount of time.",
+            ],
+            &[],
+        );
+    }
+
+    // FALSE POSITIVES
+
+    #[test]
+    fn allows_foc_as_adj_tier() {
+        // `free of charge` is an adjective phrase modifying `tier` (and should ideally be hyphenated as "free-of-charge tier")
+        assert_no_lints(
+            "We prioritize interactive notebook compute for free of charge tier users.",
+            ForFreeOfCharge::default(),
+        );
+    }
+
+    #[test]
+    fn allows_foc_as_adj_product() {
+        // `free of charge` is an adjective phrase modifying `product` (and should ideally be hyphenated as "free-of-charge product")
+        // NOTE: this is probably bad English trying to say "this is the price we pay for using a free product"
+        assert_no_lints(
+            "This is a cost for free of charge product.",
+            ForFreeOfCharge::default(),
+        );
+    }
+
+    #[test]
+    fn allows_foc_as_adj_feedback() {
+        // `free of charge` is an adjective phrase modifying `feedback` (and should ideally be hyphenated as "free-of-charge feedback")
+        assert_no_lints(
+            "... but if you are not a student in a university I don't know where you should turn for free of charge feedback",
+            ForFreeOfCharge::default(),
+        );
+    }
+
+    #[test]
+    fn allows_foc_as_adj_place() {
+        // `free of charge` is an adjective phrase modifying `place` (and should ideally be hyphenated as "free-of-charge place")
+        assert_no_lints(
+            "you see how many free places are in a particular garage, so you decide either to occupy it or search for free of charge place somewhere else",
+            ForFreeOfCharge::default(),
+        );
+    }
+
+    #[test]
+    fn allows_foc_adj_events() {
+        assert_no_lints(
+            "Create reservation for free-of-charge events should not require any approval of the reservation",
+            ForFreeOfCharge::default(),
+        );
+    }
+
+    // EDGE CASES NOT YET HANDLED
+
+    #[test]
+    fn allows_working_for_free_of_charge() {
+        // The `for` is part of `working for`, not part of `for free`
+        // NOTE: This probably only passes by fluke since `AnchorEnd` is not in the `Expr`, but `AnchorEnd` is probably
+        // NOTE: broken until #3406 is merged
+        assert_no_lints(
+            "I have a client who I’m working for free of charge",
+            ForFreeOfCharge::default(),
+        );
+    }
+}

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -85,6 +85,7 @@ use super::filler_words::FillerWords;
 use super::find_fine::FindFine;
 use super::first_aid_kit::FirstAidKit;
 use super::flesh_out_vs_full_fledged::FleshOutVsFullFledged;
+use super::for_free_of_charge::ForFreeOfCharge;
 use super::for_noun::ForNoun;
 use super::free_predicate::FreePredicate;
 use super::friend_of_me::FriendOfMe;
@@ -635,6 +636,7 @@ impl LintGroup {
         insert_struct_rule!(FindFine, true);
         insert_expr_rule!(FirstAidKit, true);
         insert_expr_rule!(FleshOutVsFullFledged, true);
+        insert_expr_rule!(ForFreeOfCharge, true);
         insert_expr_rule!(ForNoun, true);
         insert_expr_rule!(FreePredicate, true);
         insert_expr_rule!(FriendOfMe, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -81,6 +81,7 @@ mod filler_words;
 mod find_fine;
 mod first_aid_kit;
 mod flesh_out_vs_full_fledged;
+mod for_free_of_charge;
 mod for_noun;
 mod free_predicate;
 mod friend_of_me;

--- a/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
+++ b/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
@@ -2125,7 +2125,7 @@
 > next    , when    suddenly a   footman in        livery   came      running   out          of the wood         — ( she
 # NSg/J/P . NSg/I/C R        D/P NSg     NPr/J/R/P NSg/VB/J NSg/VPt/P Nᴹ/Vg/J/P NSg/VB/J/R/P P  D   NPr🅪Sg/VB/J+ . . ISg+
 > considered him  to be       a   footman because he       was  in        livery   : otherwise , judging by
-# VP/J       ISg+ P  NSg/VLXB D/P NSg     C/P     NPr/ISg+ VLPt NPr/J/R/P NSg/VB/J . J/R       . Nᴹ/Vg/J NSg/P
+# VP/J       ISg+ P  NSg/VLXB D/P NSg     C/P     NPr/ISg+ VLPt NPr/J/R/P NSg/VB/J . J/R/C     . Nᴹ/Vg/J NSg/P
 > his     face    only  , she  would have    called him  a   fish       ) — and  rapped loudly at    the door
 # ISg/D$+ NSg/VB+ J/R/C . ISg+ VXB   NSg/VXB VP/J   ISg+ D/P N🅪SgPl/VB+ . . VB/C VP     R      NSg/P D   NSg/VB+
 > with his     knuckles . It       was  opened by    another footman in        livery   , with a   round
@@ -4045,11 +4045,11 @@
 > you    would seem to be       ’ — or    if    you’d like         it       put     more         simply — ‘          Never imagine
 # ISgPl+ VXB   VB   P  NSg/VLXB . . NPr/C NSg/C K     NSg/VB/J/C/P NPr/ISg+ NSg/VBP NPr/I/J/R/Dq R      . Unlintable R     NSg/VB
 > yourself not     to be       otherwise than what   it       might    appear to others that     what   you
-# ISg+     NSg/R/C P  NSg/VLXB J/R       C/P  NSg/I+ NPr/ISg+ Nᴹ/VXB/J VB     P  NPl/V3 I/C/Ddem NSg/I+ ISgPl+
+# ISg+     NSg/R/C P  NSg/VLXB J/R/C     C/P  NSg/I+ NPr/ISg+ Nᴹ/VXB/J VB     P  NPl/V3 I/C/Ddem NSg/I+ ISgPl+
 > were     or    might    have    been     was  not     otherwise than what   you    had been     would have
-# NSg/VLPt NPr/C Nᴹ/VXB/J NSg/VXB NSg/VLPp VLPt NSg/R/C J/R       C/P  NSg/I+ ISgPl+ VP  NSg/VLPp VXB   NSg/VXB
+# NSg/VLPt NPr/C Nᴹ/VXB/J NSg/VXB NSg/VLPp VLPt NSg/R/C J/R/C     C/P  NSg/I+ ISgPl+ VP  NSg/VLPp VXB   NSg/VXB
 > appeared to them     to be       otherwise . ’ ”
-# VP/J     P  NSg/IPl+ P  NSg/VLXB J/R       . . .
+# VP/J     P  NSg/IPl+ P  NSg/VLXB J/R/C     . . .
 >
 #
 > “ I       think  I       should understand that     better     , ” Alice said very politely , “ if    I       had

--- a/harper-core/tests/text/tagged/The Constitution of the United States.md
+++ b/harper-core/tests/text/tagged/The Constitution of the United States.md
@@ -937,7 +937,7 @@
 > powers   and  duties of his     office  , the Vice        President shall continue to discharge
 # NPrPl/V3 VB/C NPl    P  ISg/D$+ NSg/VB+ . D+  NSg/VB/J/P+ NSg/VB+   VXB   NSg/VB   P  N🅪Sg/VB
 > the same as    Acting  President ; otherwise , the President shall resume the powers
-# D   I/J  R/C/P Nᴹ/Vg/J NSg/VB+   . J/R       . D+  NSg/VB+   VXB   NSg/VB D   NPrPl/V3
+# D   I/J  R/C/P Nᴹ/Vg/J NSg/VB+   . J/R/C     . D+  NSg/VB+   VXB   NSg/VB D   NPrPl/V3
 > and  duties of his     office  .
 # VB/C NPl    P  ISg/D$+ NSg/VB+ .
 >
@@ -1029,7 +1029,7 @@
 > and  all          other    Officers of the United States    , whose Appointments are not     herein
 # VB/C NSg/I/J/C/Dq NSg/VB/J NPl/V3   P  D   VP/J   NPrPl/V3+ . I+    NPl+         VLB NSg/R/C R
 > otherwise provided for   , and  which shall be       established by    Law      : but     the Congress
-# J/R       VP/J/C   R/C/P . VB/C I/C+  VXB   NSg/VLXB VP/J        NSg/P N🅪Sg/VB+ . NSg/C/P D   NPr/VB+
+# J/R/C     VP/J/C   R/C/P . VB/C I/C+  VXB   NSg/VLXB VP/J        NSg/P N🅪Sg/VB+ . NSg/C/P D   NPr/VB+
 > may     by    Law      vest   the Appointment of such  inferior Officers , as    they think
 # NPr/VXB NSg/P N🅪Sg/VB+ NSg/VB D   NSg         P  NSg/I NSg/J    NPl/V3+  . R/C/P IPl+ NSg/VB
 > proper , in        the President alone , in        the Courts of Law      , or    in        the Heads  of
@@ -1193,7 +1193,7 @@
 >
 #
 > No        person  shall be       held to answer for   a    capital , or    otherwise infamous crime    ,
-# NSg/Dq/P+ NSg/VB+ VXB   NSg/VLXB VP   P  NSg/VB R/C/P D/P+ N🅪Sg/J+ . NPr/C J/R       VB/J+    N🅪Sg/VB+ .
+# NSg/Dq/P+ NSg/VB+ VXB   NSg/VLXB VP   P  NSg/VB R/C/P D/P+ N🅪Sg/J+ . NPr/C J/R/C     VB/J+    N🅪Sg/VB+ .
 > unless on  a   presentment or    indictment of a   grand jury      , except in        cases   arising
 # C      J/P D/P NSg         NPr/C NSg        P  D/P NSg/J NSg/VB/J+ . VB/C/P NPr/J/R/P NPl/V3+ Nᴹ/Vg/J
 > in        the land      or    naval forces  , or    in        the militia , when    in        actual service in        time
@@ -1231,7 +1231,7 @@
 > dollars , the right    of trial     by    jury      shall be       preserved , and  no        fact tried by    a
 # NPl+    . D   NPr/VB/J P  NSg/VB/J+ NSg/P NSg/VB/J+ VXB   NSg/VLXB VP/J      . VB/C NSg/Dq/P+ NSg+ VP/J  NSg/P D/P+
 > jury      , shall be       otherwise reexamined in        any    court     of the United States    , than
-# NSg/VB/J+ . VXB   NSg/VLXB J/R       VP/J       NPr/J/R/P I/R/Dq N🅪Sg/VB/J P  D   VP/J   NPrPl/V3+ . C/P
+# NSg/VB/J+ . VXB   NSg/VLXB J/R/C     VP/J       NPr/J/R/P I/R/Dq N🅪Sg/VB/J P  D   VP/J   NPrPl/V3+ . C/P
 > according to the rules  of the common   law      .
 # Nᴹ/Vg/J   P  D   NPl/V3 P  D   NSg/VB/J N🅪Sg/VB+ .
 >

--- a/harper-core/tests/text/tagged/The Great Gatsby.md
+++ b/harper-core/tests/text/tagged/The Great Gatsby.md
@@ -3941,7 +3941,7 @@
 > haunted him  . For   a    moment I       suspected that     he       was  pulling my  leg       , but     a    glance
 # VP/J    ISg+ . R/C/P D/P+ NSg+   ISg/#r+ VP/J      I/C/Ddem NPr/ISg+ VLPt Nᴹ/Vg/J D$+ NSg/VB/J+ . NSg/C/P D/P+ NSg/VB+
 > at    him  convinced me       otherwise .
-# NSg/P ISg+ VP/J      NPr/ISg+ J/R       .
+# NSg/P ISg+ VP/J      NPr/ISg+ J/R/C     .
 >
 #
 > “ After that     I       lived like         a   young    rajah in        all          the capitals of Europe — Paris ,


### PR DESCRIPTION
# Issues 

Fixes #3290

# Description

Fixes redundant "for free of charge" suggesting both "for free" and "free of charge"

- Adds a `then_kind_any_but_not` method to `SequenceExpr`.
- Includes a couple of tweaks to `dictionary.dict` to not generate "ares" from "are", add the conjunction POS to "otherwise", and reorder the POS flags on "for".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test --package harper-core --lib -- linting::for_free_of_charge::tests --nocapture`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
