### PR TITLE
fix(desktop): hide highlights while windows move

### DIFF
--- a/harper-desktop/src-tauri/src/mac_broker.rs
+++ b/harper-desktop/src-tauri/src/mac_broker.rs
@@ -6,8 +6,9 @@ use accessibility_sys::{
     AXUIElementCopyParameterizedAttributeValue, AXUIElementGetPid, AXValueCreate, AXValueGetType,
     AXValueGetValue, AXValueRef, error_string, kAXBoundsForRangeParameterizedAttribute,
     kAXErrorIllegalArgument, kAXErrorNoValue, kAXErrorParameterizedAttributeUnsupported,
-    kAXErrorSuccess, kAXFocusedApplicationAttribute, kAXTrustedCheckOptionPrompt,
-    kAXValueTypeCFRange, kAXValueTypeCGRect, pid_t,
+    kAXErrorSuccess, kAXFocusedApplicationAttribute, kAXPositionAttribute, kAXSizeAttribute,
+    kAXTrustedCheckOptionPrompt, kAXValueTypeCFRange, kAXValueTypeCGPoint, kAXValueTypeCGRect,
+    kAXValueTypeCGSize, pid_t,
 };
 use core::{ffi::c_void, mem::MaybeUninit};
 use core_foundation::base::{CFRange, CFType, TCFType};
@@ -16,6 +17,7 @@ use core_foundation::dictionary::CFDictionary;
 use core_foundation::string::CFString;
 use core_graphics::event::CGEvent;
 use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
+use core_graphics::geometry::{CGPoint, CGSize};
 use harper_core::linting::{Lint, Suggestion};
 use objc2_app_kit::NSRunningApplication;
 use objc2_foundation::NSRect;
@@ -33,6 +35,23 @@ use crate::rect::{ActionableLint, Rect};
 pub struct MacBroker {
     last_focused: Option<pid_t>,
     integrations: Rc<RefCell<Vec<Integration>>>,
+    last_geometry: Option<GeometrySnapshot>,
+}
+
+#[derive(Debug, Clone)]
+struct GeometrySnapshot {
+    pid: pid_t,
+    window_frame: Rect,
+    lints: Vec<LintSnapshot>,
+}
+
+#[derive(Debug, Clone)]
+struct LintSnapshot {
+    rect: Rect,
+    rule_name: String,
+    span_start: usize,
+    span_len: usize,
+    source_text: String,
 }
 
 impl MacBroker {
@@ -40,6 +59,7 @@ impl MacBroker {
         Self {
             last_focused: None,
             integrations,
+            last_geometry: None,
         }
     }
 
@@ -53,6 +73,32 @@ impl MacBroker {
             self.last_focused = Some(focused_pid);
             Ok(Some(focused_pid))
         }
+    }
+
+    fn correct_for_window_movement(
+        &mut self,
+        pid: pid_t,
+        window_frame: Rect,
+        rects: &mut [ActionableLint],
+    ) {
+        let lints = lint_snapshots(rects);
+
+        if let Some(last_geometry) = &self.last_geometry
+            && should_translate_geometry(last_geometry, pid, window_frame, &lints)
+        {
+            let dx = window_frame.x - last_geometry.window_frame.x;
+            let dy = window_frame.y - last_geometry.window_frame.y;
+
+            for (positioned_lint, last_lint) in rects.iter_mut().zip(&last_geometry.lints) {
+                positioned_lint.rect = last_lint.rect.translated(dx, dy);
+            }
+        }
+
+        self.last_geometry = Some(GeometrySnapshot {
+            pid,
+            window_frame,
+            lints: lint_snapshots(rects),
+        });
     }
 }
 
@@ -69,25 +115,39 @@ impl OsBroker for MacBroker {
     ) -> Vec<ActionableLint> {
         let pid = match self.target_pid() {
             Ok(Some(pid)) => pid,
-            Ok(None) => return Vec::new(),
+            Ok(None) => {
+                self.last_geometry = None;
+                return Vec::new();
+            }
             Err(err) => {
+                self.last_geometry = None;
                 eprintln!("Unable to identify focused window: {err}");
                 return Vec::new();
             }
         };
 
         if !is_pid_approved(pid, &self.integrations.borrow()) {
+            self.last_geometry = None;
             return Vec::new();
         }
 
         let el = AXUIElement::application(pid);
+        let window_frame = focused_window_frame(&el).ok();
 
         let walker = TreeWalker::new();
         let collector = RectCollector::new(lint_text);
 
         walker.walk(&el, &collector);
 
-        collector.unwrap_rects()
+        let mut rects = collector.unwrap_rects();
+
+        if let Some(window_frame) = window_frame {
+            self.correct_for_window_movement(pid, window_frame, &mut rects);
+        } else {
+            self.last_geometry = None;
+        }
+
+        rects
     }
 
     fn cursor_position(&self) -> Option<egui::Pos2> {
@@ -118,6 +178,138 @@ impl OsBroker for MacBroker {
             AccessibilityPermissionStatus::NotGranted
         }
     }
+}
+
+fn lint_snapshots(rects: &[ActionableLint]) -> Vec<LintSnapshot> {
+    rects
+        .iter()
+        .map(|positioned_lint| LintSnapshot {
+            rect: positioned_lint.rect,
+            rule_name: positioned_lint.rule_name.clone(),
+            span_start: positioned_lint.lint.span.start,
+            span_len: positioned_lint.lint.span.len(),
+            source_text: positioned_lint.source_text.clone(),
+        })
+        .collect()
+}
+
+fn should_translate_geometry(
+    last_geometry: &GeometrySnapshot,
+    pid: pid_t,
+    window_frame: Rect,
+    lints: &[LintSnapshot],
+) -> bool {
+    last_geometry.pid == pid
+        && window_frame.same_size_as(last_geometry.window_frame)
+        && window_frame_has_moved(last_geometry.window_frame, window_frame)
+        && same_lint_identity(&last_geometry.lints, lints)
+}
+
+fn window_frame_has_moved(previous: Rect, current: Rect) -> bool {
+    (previous.x - current.x).abs() > 0.5 || (previous.y - current.y).abs() > 0.5
+}
+
+fn same_lint_identity(left: &[LintSnapshot], right: &[LintSnapshot]) -> bool {
+    left.len() == right.len()
+        && left.iter().zip(right).all(|(left, right)| {
+            left.rule_name == right.rule_name
+                && left.span_start == right.span_start
+                && left.span_len == right.span_len
+                && left.source_text == right.source_text
+        })
+}
+
+fn focused_window_frame(app: &AXUIElement) -> Result<Rect, Box<dyn StdError>> {
+    let window = app.focused_window()?;
+    let position = ax_point_attribute(&window, kAXPositionAttribute)?;
+    let size = ax_size_attribute(&window, kAXSizeAttribute)?;
+
+    Ok(Rect {
+        x: position.x,
+        y: position.y,
+        width: size.width,
+        height: size.height,
+    })
+}
+
+fn ax_point_attribute(element: &AXUIElement, name: &str) -> Result<CGPoint, Box<dyn StdError>> {
+    let value = ax_value_attribute(element, name, kAXValueTypeCGPoint)?;
+    let ax_value = value.as_CFTypeRef() as AXValueRef;
+    let mut point = MaybeUninit::<CGPoint>::uninit();
+
+    let ok = unsafe {
+        AXValueGetValue(
+            ax_value,
+            kAXValueTypeCGPoint,
+            point.as_mut_ptr() as *mut c_void,
+        )
+    };
+
+    if !ok {
+        return Err(format!("AXValueGetValue failed for {name}").into());
+    }
+
+    Ok(unsafe { point.assume_init() })
+}
+
+fn ax_size_attribute(element: &AXUIElement, name: &str) -> Result<CGSize, Box<dyn StdError>> {
+    let value = ax_value_attribute(element, name, kAXValueTypeCGSize)?;
+    let ax_value = value.as_CFTypeRef() as AXValueRef;
+    let mut size = MaybeUninit::<CGSize>::uninit();
+
+    let ok = unsafe {
+        AXValueGetValue(
+            ax_value,
+            kAXValueTypeCGSize,
+            size.as_mut_ptr() as *mut c_void,
+        )
+    };
+
+    if !ok {
+        return Err(format!("AXValueGetValue failed for {name}").into());
+    }
+
+    Ok(unsafe { size.assume_init() })
+}
+
+fn ax_value_attribute(
+    element: &AXUIElement,
+    name: &str,
+    expected_type: u32,
+) -> Result<CFType, Box<dyn StdError>> {
+    let attr = CFString::new(name);
+    let mut value = ptr::null();
+
+    let err = unsafe {
+        AXUIElementCopyAttributeValue(
+            element.as_concrete_TypeRef(),
+            attr.as_concrete_TypeRef(),
+            &mut value,
+        )
+    };
+
+    if err != kAXErrorSuccess {
+        return Err(format!(
+            "AXUIElementCopyAttributeValue failed for {name}: {}",
+            error_string(err)
+        )
+        .into());
+    }
+
+    if value.is_null() {
+        return Err(format!("AXUIElementCopyAttributeValue returned null for {name}").into());
+    }
+
+    let value = unsafe { CFType::wrap_under_create_rule(value) };
+    let ax_value = value.as_CFTypeRef() as AXValueRef;
+
+    if unsafe { AXValueGetType(ax_value) } != expected_type {
+        return Err(
+            format!("AXUIElementCopyAttributeValue returned unexpected type for {name}").into(),
+        );
+    }
+
+    Ok(value)
 }
 
 fn focused_window_pid() -> Result<pid_t, Box<dyn StdError>> {

--- a/harper-desktop/src-tauri/src/mac_broker.rs
+++ b/harper-desktop/src-tauri/src/mac_broker.rs
@@ -6,18 +6,22 @@ use accessibility_sys::{
     AXUIElementCopyParameterizedAttributeValue, AXUIElementGetPid, AXValueCreate, AXValueGetType,
     AXValueGetValue, AXValueRef, error_string, kAXBoundsForRangeParameterizedAttribute,
     kAXErrorIllegalArgument, kAXErrorNoValue, kAXErrorParameterizedAttributeUnsupported,
-    kAXErrorSuccess, kAXFocusedApplicationAttribute, kAXPositionAttribute, kAXSizeAttribute,
-    kAXTrustedCheckOptionPrompt, kAXValueTypeCFRange, kAXValueTypeCGPoint, kAXValueTypeCGRect,
-    kAXValueTypeCGSize, pid_t,
+    kAXErrorSuccess, kAXFocusedApplicationAttribute, kAXTrustedCheckOptionPrompt,
+    kAXValueTypeCFRange, kAXValueTypeCGRect, pid_t,
 };
 use core::{ffi::c_void, mem::MaybeUninit};
+use core_foundation::array::CFArray;
 use core_foundation::base::{CFRange, CFType, TCFType};
 use core_foundation::boolean::CFBoolean;
 use core_foundation::dictionary::CFDictionary;
-use core_foundation::string::CFString;
+use core_foundation::number::CFNumber;
+use core_foundation::string::{CFString, CFStringRef};
 use core_graphics::event::CGEvent;
 use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
-use core_graphics::geometry::{CGPoint, CGSize};
+use core_graphics::window::{
+    kCGNullWindowID, kCGWindowAlpha, kCGWindowBounds, kCGWindowLayer,
+    kCGWindowListExcludeDesktopElements, kCGWindowListOptionOnScreenOnly, kCGWindowOwnerPID,
+};
 use harper_core::linting::{Lint, Suggestion};
 use objc2_app_kit::NSRunningApplication;
 use objc2_foundation::NSRect;
@@ -89,15 +93,17 @@ impl MacBroker {
             let dx = window_frame.x - last_geometry.window_frame.x;
             let dy = window_frame.y - last_geometry.window_frame.y;
 
-            for (positioned_lint, last_lint) in rects.iter_mut().zip(&last_geometry.lints) {
-                positioned_lint.rect = last_lint.rect.translated(dx, dy);
+            for positioned_lint in rects {
+                positioned_lint.rect = positioned_lint.rect.translated(dx, dy);
             }
+
+            return;
         }
 
         self.last_geometry = Some(GeometrySnapshot {
             pid,
             window_frame,
-            lints: lint_snapshots(rects),
+            lints,
         });
     }
 }
@@ -132,7 +138,6 @@ impl OsBroker for MacBroker {
         }
 
         let el = AXUIElement::application(pid);
-        let window_frame = focused_window_frame(&el).ok();
 
         let walker = TreeWalker::new();
         let collector = RectCollector::new(lint_text);
@@ -141,7 +146,7 @@ impl OsBroker for MacBroker {
 
         let mut rects = collector.unwrap_rects();
 
-        if let Some(window_frame) = window_frame {
+        if let Some(window_frame) = frontmost_window_frame_for_pid(pid) {
             self.correct_for_window_movement(pid, window_frame, &mut rects);
         } else {
             self.last_geometry = None;
@@ -180,138 +185,6 @@ impl OsBroker for MacBroker {
     }
 }
 
-fn lint_snapshots(rects: &[ActionableLint]) -> Vec<LintSnapshot> {
-    rects
-        .iter()
-        .map(|positioned_lint| LintSnapshot {
-            rect: positioned_lint.rect,
-            rule_name: positioned_lint.rule_name.clone(),
-            span_start: positioned_lint.lint.span.start,
-            span_len: positioned_lint.lint.span.len(),
-            source_text: positioned_lint.source_text.clone(),
-        })
-        .collect()
-}
-
-fn should_translate_geometry(
-    last_geometry: &GeometrySnapshot,
-    pid: pid_t,
-    window_frame: Rect,
-    lints: &[LintSnapshot],
-) -> bool {
-    last_geometry.pid == pid
-        && window_frame.same_size_as(last_geometry.window_frame)
-        && window_frame_has_moved(last_geometry.window_frame, window_frame)
-        && same_lint_identity(&last_geometry.lints, lints)
-}
-
-fn window_frame_has_moved(previous: Rect, current: Rect) -> bool {
-    (previous.x - current.x).abs() > 0.5 || (previous.y - current.y).abs() > 0.5
-}
-
-fn same_lint_identity(left: &[LintSnapshot], right: &[LintSnapshot]) -> bool {
-    left.len() == right.len()
-        && left.iter().zip(right).all(|(left, right)| {
-            left.rule_name == right.rule_name
-                && left.span_start == right.span_start
-                && left.span_len == right.span_len
-                && left.source_text == right.source_text
-        })
-}
-
-fn focused_window_frame(app: &AXUIElement) -> Result<Rect, Box<dyn StdError>> {
-    let window = app.focused_window()?;
-    let position = ax_point_attribute(&window, kAXPositionAttribute)?;
-    let size = ax_size_attribute(&window, kAXSizeAttribute)?;
-
-    Ok(Rect {
-        x: position.x,
-        y: position.y,
-        width: size.width,
-        height: size.height,
-    })
-}
-
-fn ax_point_attribute(element: &AXUIElement, name: &str) -> Result<CGPoint, Box<dyn StdError>> {
-    let value = ax_value_attribute(element, name, kAXValueTypeCGPoint)?;
-    let ax_value = value.as_CFTypeRef() as AXValueRef;
-    let mut point = MaybeUninit::<CGPoint>::uninit();
-
-    let ok = unsafe {
-        AXValueGetValue(
-            ax_value,
-            kAXValueTypeCGPoint,
-            point.as_mut_ptr() as *mut c_void,
-        )
-    };
-
-    if !ok {
-        return Err(format!("AXValueGetValue failed for {name}").into());
-    }
-
-    Ok(unsafe { point.assume_init() })
-}
-
-fn ax_size_attribute(element: &AXUIElement, name: &str) -> Result<CGSize, Box<dyn StdError>> {
-    let value = ax_value_attribute(element, name, kAXValueTypeCGSize)?;
-    let ax_value = value.as_CFTypeRef() as AXValueRef;
-    let mut size = MaybeUninit::<CGSize>::uninit();
-
-    let ok = unsafe {
-        AXValueGetValue(
-            ax_value,
-            kAXValueTypeCGSize,
-            size.as_mut_ptr() as *mut c_void,
-        )
-    };
-
-    if !ok {
-        return Err(format!("AXValueGetValue failed for {name}").into());
-    }
-
-    Ok(unsafe { size.assume_init() })
-}
-
-fn ax_value_attribute(
-    element: &AXUIElement,
-    name: &str,
-    expected_type: u32,
-) -> Result<CFType, Box<dyn StdError>> {
-    let attr = CFString::new(name);
-    let mut value = ptr::null();
-
-    let err = unsafe {
-        AXUIElementCopyAttributeValue(
-            element.as_concrete_TypeRef(),
-            attr.as_concrete_TypeRef(),
-            &mut value,
-        )
-    };
-
-    if err != kAXErrorSuccess {
-        return Err(format!(
-            "AXUIElementCopyAttributeValue failed for {name}: {}",
-            error_string(err)
-        )
-        .into());
-    }
-
-    if value.is_null() {
-        return Err(format!("AXUIElementCopyAttributeValue returned null for {name}").into());
-    }
-
-    let value = unsafe { CFType::wrap_under_create_rule(value) };
-    let ax_value = value.as_CFTypeRef() as AXValueRef;
-
-    if unsafe { AXValueGetType(ax_value) } != expected_type {
-        return Err(
-            format!("AXUIElementCopyAttributeValue returned unexpected type for {name}").into(),
-        );
-    }
-
-    Ok(value)
-}
-
 fn focused_window_pid() -> Result<pid_t, Box<dyn StdError>> {
     let system = AXUIElement::system_wide();
     let app = ax_element_attribute(&system, kAXFocusedApplicationAttribute)?;
@@ -348,6 +221,128 @@ fn bundle_identifier_for_pid(pid: pid_t) -> Result<Option<String>, Box<dyn StdEr
     };
 
     Ok(Some(bundle_identifier.to_string()))
+}
+
+fn lint_snapshots(rects: &[ActionableLint]) -> Vec<LintSnapshot> {
+    rects
+        .iter()
+        .map(|positioned_lint| LintSnapshot {
+            rect: positioned_lint.rect,
+            rule_name: positioned_lint.rule_name.clone(),
+            span_start: positioned_lint.lint.span.start,
+            span_len: positioned_lint.lint.span.len(),
+            source_text: positioned_lint.source_text.clone(),
+        })
+        .collect()
+}
+
+fn should_translate_geometry(
+    last_geometry: &GeometrySnapshot,
+    pid: pid_t,
+    window_frame: Rect,
+    lints: &[LintSnapshot],
+) -> bool {
+    last_geometry.pid == pid
+        && window_frame.same_size_as(last_geometry.window_frame)
+        && window_frame_has_moved(last_geometry.window_frame, window_frame)
+        && same_lints(&last_geometry.lints, lints)
+}
+
+fn window_frame_has_moved(previous: Rect, current: Rect) -> bool {
+    (previous.x - current.x).abs() > 0.5 || (previous.y - current.y).abs() > 0.5
+}
+
+fn same_lints(left: &[LintSnapshot], right: &[LintSnapshot]) -> bool {
+    left.len() == right.len()
+        && left.iter().zip(right).all(|(left, right)| {
+            left.rect.nearly_equal_to(right.rect)
+                && left.rule_name == right.rule_name
+                && left.span_start == right.span_start
+                && left.span_len == right.span_len
+                && left.source_text == right.source_text
+        })
+}
+
+fn frontmost_window_frame_for_pid(pid: pid_t) -> Option<Rect> {
+    let window_infos = core_graphics::window::copy_window_info(
+        kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements,
+        kCGNullWindowID,
+    )?;
+    let window_infos = unsafe {
+        CFArray::<CFDictionary<CFString, CFType>>::wrap_under_get_rule(
+            window_infos.as_concrete_TypeRef(),
+        )
+    };
+
+    window_infos
+        .iter()
+        .filter(|window_info| window_pid(window_info) == Some(pid))
+        .filter(|window_info| window_layer(window_info) == Some(0))
+        .filter(|window_info| window_alpha(window_info).is_some_and(|alpha| alpha > 0.0))
+        .find_map(|window_info| window_bounds(&window_info))
+}
+
+fn window_pid(window_info: &CFDictionary<CFString, CFType>) -> Option<pid_t> {
+    dictionary_i64(window_info, unsafe { kCGWindowOwnerPID }).map(|value| value as pid_t)
+}
+
+fn window_layer(window_info: &CFDictionary<CFString, CFType>) -> Option<i64> {
+    dictionary_i64(window_info, unsafe { kCGWindowLayer })
+}
+
+fn window_alpha(window_info: &CFDictionary<CFString, CFType>) -> Option<f64> {
+    dictionary_f64(window_info, unsafe { kCGWindowAlpha })
+}
+
+fn window_bounds(window_info: &CFDictionary<CFString, CFType>) -> Option<Rect> {
+    let bounds = dictionary_dictionary(window_info, unsafe { kCGWindowBounds })?;
+
+    Some(Rect {
+        x: dictionary_f64(
+            &bounds,
+            CFString::from_static_string("X").as_concrete_TypeRef(),
+        )?,
+        y: dictionary_f64(
+            &bounds,
+            CFString::from_static_string("Y").as_concrete_TypeRef(),
+        )?,
+        width: dictionary_f64(
+            &bounds,
+            CFString::from_static_string("Width").as_concrete_TypeRef(),
+        )?,
+        height: dictionary_f64(
+            &bounds,
+            CFString::from_static_string("Height").as_concrete_TypeRef(),
+        )?,
+    })
+}
+
+fn dictionary_i64(dictionary: &CFDictionary<CFString, CFType>, key: CFStringRef) -> Option<i64> {
+    dictionary_number(dictionary, key)?.to_i64()
+}
+
+fn dictionary_f64(dictionary: &CFDictionary<CFString, CFType>, key: CFStringRef) -> Option<f64> {
+    dictionary_number(dictionary, key)?.to_f64()
+}
+
+fn dictionary_number(
+    dictionary: &CFDictionary<CFString, CFType>,
+    key: CFStringRef,
+) -> Option<CFNumber> {
+    let key = unsafe { CFString::wrap_under_get_rule(key) };
+    let value = dictionary.find(&key)?;
+
+    Some(unsafe { CFNumber::wrap_under_get_rule(value.as_CFTypeRef() as _) })
+}
+
+fn dictionary_dictionary(
+    dictionary: &CFDictionary<CFString, CFType>,
+    key: CFStringRef,
+) -> Option<CFDictionary<CFString, CFType>> {
+    let key = unsafe { CFString::wrap_under_get_rule(key) };
+    let value = dictionary.find(&key)?;
+
+    Some(unsafe { CFDictionary::wrap_under_get_rule(value.as_CFTypeRef() as _) })
 }
 
 fn ax_element_attribute(

--- a/harper-desktop/src-tauri/src/mac_broker.rs
+++ b/harper-desktop/src-tauri/src/mac_broker.rs
@@ -25,11 +25,21 @@ use core_graphics::window::{
 use harper_core::linting::{Lint, Suggestion};
 use objc2_app_kit::NSRunningApplication;
 use objc2_foundation::NSRect;
-use std::{cell::RefCell, collections::BTreeMap, error::Error as StdError, ptr, rc::Rc};
+use std::{
+    cell::RefCell,
+    collections::BTreeMap,
+    error::Error as StdError,
+    ptr,
+    rc::Rc,
+    time::{Duration, Instant},
+};
 
 use crate::config::{Config, Integration};
 use crate::os_broker::{AccessibilityPermissionStatus, OsBroker};
 use crate::rect::{ActionableLint, Rect};
+
+const WINDOW_MOVEMENT_SETTLE_DURATION: Duration = Duration::from_millis(150);
+const WINDOW_FRAME_TOLERANCE: f64 = 0.5;
 
 /// macOS implementation of the OS data the highlighter needs.
 ///
@@ -39,23 +49,14 @@ use crate::rect::{ActionableLint, Rect};
 pub struct MacBroker {
     last_focused: Option<pid_t>,
     integrations: Rc<RefCell<Vec<Integration>>>,
-    last_geometry: Option<GeometrySnapshot>,
+    window_movement: Option<WindowMovementState>,
 }
 
 #[derive(Debug, Clone)]
-struct GeometrySnapshot {
+struct WindowMovementState {
     pid: pid_t,
-    window_frame: Rect,
-    lints: Vec<LintSnapshot>,
-}
-
-#[derive(Debug, Clone)]
-struct LintSnapshot {
-    rect: Rect,
-    rule_name: String,
-    span_start: usize,
-    span_len: usize,
-    source_text: String,
+    frame: Rect,
+    last_changed_at: Instant,
 }
 
 impl MacBroker {
@@ -63,7 +64,7 @@ impl MacBroker {
         Self {
             last_focused: None,
             integrations,
-            last_geometry: None,
+            window_movement: None,
         }
     }
 
@@ -79,32 +80,38 @@ impl MacBroker {
         }
     }
 
-    fn correct_for_window_movement(
-        &mut self,
-        pid: pid_t,
-        window_frame: Rect,
-        rects: &mut [ActionableLint],
-    ) {
-        let lints = lint_snapshots(rects);
+    fn window_is_moving(&mut self, pid: pid_t) -> bool {
+        let Some(frame) = frontmost_window_frame_for_pid(pid) else {
+            self.window_movement = None;
+            return true;
+        };
 
-        if let Some(last_geometry) = &self.last_geometry
-            && should_translate_geometry(last_geometry, pid, window_frame, &lints)
-        {
-            let dx = window_frame.x - last_geometry.window_frame.x;
-            let dy = window_frame.y - last_geometry.window_frame.y;
+        let now = Instant::now();
+        let Some(state) = &mut self.window_movement else {
+            self.window_movement = Some(WindowMovementState {
+                pid,
+                frame,
+                last_changed_at: settled_instant(now),
+            });
+            return false;
+        };
 
-            for positioned_lint in rects {
-                positioned_lint.rect = positioned_lint.rect.translated(dx, dy);
-            }
-
-            return;
+        if state.pid != pid {
+            *state = WindowMovementState {
+                pid,
+                frame,
+                last_changed_at: settled_instant(now),
+            };
+            return false;
         }
 
-        self.last_geometry = Some(GeometrySnapshot {
-            pid,
-            window_frame,
-            lints,
-        });
+        if window_frame_changed(state.frame, frame) {
+            state.frame = frame;
+            state.last_changed_at = now;
+            return true;
+        }
+
+        now.duration_since(state.last_changed_at) < WINDOW_MOVEMENT_SETTLE_DURATION
     }
 }
 
@@ -122,18 +129,22 @@ impl OsBroker for MacBroker {
         let pid = match self.target_pid() {
             Ok(Some(pid)) => pid,
             Ok(None) => {
-                self.last_geometry = None;
+                self.window_movement = None;
                 return Vec::new();
             }
             Err(err) => {
-                self.last_geometry = None;
+                self.window_movement = None;
                 eprintln!("Unable to identify focused window: {err}");
                 return Vec::new();
             }
         };
 
         if !is_pid_approved(pid, &self.integrations.borrow()) {
-            self.last_geometry = None;
+            self.window_movement = None;
+            return Vec::new();
+        }
+
+        if self.window_is_moving(pid) {
             return Vec::new();
         }
 
@@ -144,15 +155,7 @@ impl OsBroker for MacBroker {
 
         walker.walk(&el, &collector);
 
-        let mut rects = collector.unwrap_rects();
-
-        if let Some(window_frame) = frontmost_window_frame_for_pid(pid) {
-            self.correct_for_window_movement(pid, window_frame, &mut rects);
-        } else {
-            self.last_geometry = None;
-        }
-
-        rects
+        collector.unwrap_rects()
     }
 
     fn cursor_position(&self) -> Option<egui::Pos2> {
@@ -223,44 +226,20 @@ fn bundle_identifier_for_pid(pid: pid_t) -> Result<Option<String>, Box<dyn StdEr
     Ok(Some(bundle_identifier.to_string()))
 }
 
-fn lint_snapshots(rects: &[ActionableLint]) -> Vec<LintSnapshot> {
-    rects
-        .iter()
-        .map(|positioned_lint| LintSnapshot {
-            rect: positioned_lint.rect,
-            rule_name: positioned_lint.rule_name.clone(),
-            span_start: positioned_lint.lint.span.start,
-            span_len: positioned_lint.lint.span.len(),
-            source_text: positioned_lint.source_text.clone(),
-        })
-        .collect()
+fn window_frame_changed(previous: Rect, current: Rect) -> bool {
+    !nearly_equal(previous.x, current.x)
+        || !nearly_equal(previous.y, current.y)
+        || !nearly_equal(previous.width, current.width)
+        || !nearly_equal(previous.height, current.height)
 }
 
-fn should_translate_geometry(
-    last_geometry: &GeometrySnapshot,
-    pid: pid_t,
-    window_frame: Rect,
-    lints: &[LintSnapshot],
-) -> bool {
-    last_geometry.pid == pid
-        && window_frame.same_size_as(last_geometry.window_frame)
-        && window_frame_has_moved(last_geometry.window_frame, window_frame)
-        && same_lints(&last_geometry.lints, lints)
+fn settled_instant(now: Instant) -> Instant {
+    now.checked_sub(WINDOW_MOVEMENT_SETTLE_DURATION)
+        .unwrap_or(now)
 }
 
-fn window_frame_has_moved(previous: Rect, current: Rect) -> bool {
-    (previous.x - current.x).abs() > 0.5 || (previous.y - current.y).abs() > 0.5
-}
-
-fn same_lints(left: &[LintSnapshot], right: &[LintSnapshot]) -> bool {
-    left.len() == right.len()
-        && left.iter().zip(right).all(|(left, right)| {
-            left.rect.nearly_equal_to(right.rect)
-                && left.rule_name == right.rule_name
-                && left.span_start == right.span_start
-                && left.span_len == right.span_len
-                && left.source_text == right.source_text
-        })
+fn nearly_equal(left: f64, right: f64) -> bool {
+    (left - right).abs() <= WINDOW_FRAME_TOLERANCE
 }
 
 fn frontmost_window_frame_for_pid(pid: pid_t) -> Option<Rect> {

--- a/harper-desktop/src-tauri/src/mac_broker.rs
+++ b/harper-desktop/src-tauri/src/mac_broker.rs
@@ -314,7 +314,7 @@ fn dictionary_dictionary(dictionary: &WindowInfo, key: CFStringRef) -> Option<Wi
 fn dictionary_value(dictionary: &WindowInfo, key: CFStringRef) -> Option<CFType> {
     let key = unsafe { CFString::wrap_under_get_rule(key) };
 
-    dictionary.find(&key).map(|value| value.to_untyped())
+    dictionary.find(&key).map(|value| value.clone())
 }
 
 fn ax_element_attribute(

--- a/harper-desktop/src-tauri/src/mac_broker.rs
+++ b/harper-desktop/src-tauri/src/mac_broker.rs
@@ -40,6 +40,7 @@ use crate::rect::{ActionableLint, Rect};
 
 const WINDOW_MOVEMENT_SETTLE_DURATION: Duration = Duration::from_millis(150);
 const WINDOW_FRAME_TOLERANCE: f64 = 0.5;
+type WindowInfo = CFDictionary<CFString, CFType>;
 
 /// macOS implementation of the OS data the highlighter needs.
 ///
@@ -88,20 +89,12 @@ impl MacBroker {
 
         let now = Instant::now();
         let Some(state) = &mut self.window_movement else {
-            self.window_movement = Some(WindowMovementState {
-                pid,
-                frame,
-                last_changed_at: settled_instant(now),
-            });
+            self.window_movement = Some(settled_window_state(pid, frame, now));
             return false;
         };
 
         if state.pid != pid {
-            *state = WindowMovementState {
-                pid,
-                frame,
-                last_changed_at: settled_instant(now),
-            };
+            *state = settled_window_state(pid, frame, now);
             return false;
         }
 
@@ -233,9 +226,14 @@ fn window_frame_changed(previous: Rect, current: Rect) -> bool {
         || !nearly_equal(previous.height, current.height)
 }
 
-fn settled_instant(now: Instant) -> Instant {
-    now.checked_sub(WINDOW_MOVEMENT_SETTLE_DURATION)
-        .unwrap_or(now)
+fn settled_window_state(pid: pid_t, frame: Rect, now: Instant) -> WindowMovementState {
+    WindowMovementState {
+        pid,
+        frame,
+        last_changed_at: now
+            .checked_sub(WINDOW_MOVEMENT_SETTLE_DURATION)
+            .unwrap_or(now),
+    }
 }
 
 fn nearly_equal(left: f64, right: f64) -> bool {
@@ -247,11 +245,8 @@ fn frontmost_window_frame_for_pid(pid: pid_t) -> Option<Rect> {
         kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements,
         kCGNullWindowID,
     )?;
-    let window_infos = unsafe {
-        CFArray::<CFDictionary<CFString, CFType>>::wrap_under_get_rule(
-            window_infos.as_concrete_TypeRef(),
-        )
-    };
+    let window_infos =
+        unsafe { CFArray::<WindowInfo>::wrap_under_get_rule(window_infos.as_concrete_TypeRef()) };
 
     window_infos
         .iter()
@@ -261,19 +256,19 @@ fn frontmost_window_frame_for_pid(pid: pid_t) -> Option<Rect> {
         .find_map(|window_info| window_bounds(&window_info))
 }
 
-fn window_pid(window_info: &CFDictionary<CFString, CFType>) -> Option<pid_t> {
+fn window_pid(window_info: &WindowInfo) -> Option<pid_t> {
     dictionary_i64(window_info, unsafe { kCGWindowOwnerPID }).map(|value| value as pid_t)
 }
 
-fn window_layer(window_info: &CFDictionary<CFString, CFType>) -> Option<i64> {
+fn window_layer(window_info: &WindowInfo) -> Option<i64> {
     dictionary_i64(window_info, unsafe { kCGWindowLayer })
 }
 
-fn window_alpha(window_info: &CFDictionary<CFString, CFType>) -> Option<f64> {
+fn window_alpha(window_info: &WindowInfo) -> Option<f64> {
     dictionary_f64(window_info, unsafe { kCGWindowAlpha })
 }
 
-fn window_bounds(window_info: &CFDictionary<CFString, CFType>) -> Option<Rect> {
+fn window_bounds(window_info: &WindowInfo) -> Option<Rect> {
     let bounds = dictionary_dictionary(window_info, unsafe { kCGWindowBounds })?;
 
     Some(Rect {
@@ -296,32 +291,30 @@ fn window_bounds(window_info: &CFDictionary<CFString, CFType>) -> Option<Rect> {
     })
 }
 
-fn dictionary_i64(dictionary: &CFDictionary<CFString, CFType>, key: CFStringRef) -> Option<i64> {
+fn dictionary_i64(dictionary: &WindowInfo, key: CFStringRef) -> Option<i64> {
     dictionary_number(dictionary, key)?.to_i64()
 }
 
-fn dictionary_f64(dictionary: &CFDictionary<CFString, CFType>, key: CFStringRef) -> Option<f64> {
+fn dictionary_f64(dictionary: &WindowInfo, key: CFStringRef) -> Option<f64> {
     dictionary_number(dictionary, key)?.to_f64()
 }
 
-fn dictionary_number(
-    dictionary: &CFDictionary<CFString, CFType>,
-    key: CFStringRef,
-) -> Option<CFNumber> {
-    let key = unsafe { CFString::wrap_under_get_rule(key) };
-    let value = dictionary.find(&key)?;
+fn dictionary_number(dictionary: &WindowInfo, key: CFStringRef) -> Option<CFNumber> {
+    let value = dictionary_value(dictionary, key)?;
 
     Some(unsafe { CFNumber::wrap_under_get_rule(value.as_CFTypeRef() as _) })
 }
 
-fn dictionary_dictionary(
-    dictionary: &CFDictionary<CFString, CFType>,
-    key: CFStringRef,
-) -> Option<CFDictionary<CFString, CFType>> {
-    let key = unsafe { CFString::wrap_under_get_rule(key) };
-    let value = dictionary.find(&key)?;
+fn dictionary_dictionary(dictionary: &WindowInfo, key: CFStringRef) -> Option<WindowInfo> {
+    let value = dictionary_value(dictionary, key)?;
 
-    Some(unsafe { CFDictionary::wrap_under_get_rule(value.as_CFTypeRef() as _) })
+    Some(unsafe { WindowInfo::wrap_under_get_rule(value.as_CFTypeRef() as _) })
+}
+
+fn dictionary_value(dictionary: &WindowInfo, key: CFStringRef) -> Option<CFType> {
+    let key = unsafe { CFString::wrap_under_get_rule(key) };
+
+    dictionary.find(&key).map(|value| value.to_untyped())
 }
 
 fn ax_element_attribute(

--- a/harper-desktop/src-tauri/src/rect.rs
+++ b/harper-desktop/src-tauri/src/rect.rs
@@ -18,6 +18,22 @@ impl Rect {
             height,
         }
     }
+
+    pub fn translated(self, dx: f64, dy: f64) -> Self {
+        Self {
+            x: self.x + dx,
+            y: self.y + dy,
+            ..self
+        }
+    }
+
+    pub fn same_size_as(self, other: Self) -> bool {
+        nearly_equal(self.width, other.width) && nearly_equal(self.height, other.height)
+    }
+}
+
+fn nearly_equal(left: f64, right: f64) -> bool {
+    (left - right).abs() <= 0.5
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -91,5 +107,29 @@ impl ColoredRect {
             height,
             color,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Rect;
+
+    #[test]
+    fn translated_moves_origin_without_changing_size() {
+        let rect = Rect::new(10.0, 20.0, 30.0, 40.0).translated(5.0, -7.0);
+
+        assert_eq!(rect, Rect::new(15.0, 13.0, 30.0, 40.0));
+    }
+
+    #[test]
+    fn same_size_allows_subpixel_accessibility_noise() {
+        assert!(Rect::new(0.0, 0.0, 100.0, 50.0).same_size_as(Rect::new(10.0, 10.0, 100.4, 49.6,)));
+    }
+
+    #[test]
+    fn same_size_rejects_meaningful_resize() {
+        assert!(
+            !Rect::new(0.0, 0.0, 100.0, 50.0).same_size_as(Rect::new(10.0, 10.0, 101.0, 50.0,))
+        );
     }
 }

--- a/harper-desktop/src-tauri/src/rect.rs
+++ b/harper-desktop/src-tauri/src/rect.rs
@@ -30,6 +30,10 @@ impl Rect {
     pub fn same_size_as(self, other: Self) -> bool {
         nearly_equal(self.width, other.width) && nearly_equal(self.height, other.height)
     }
+
+    pub fn nearly_equal_to(self, other: Self) -> bool {
+        nearly_equal(self.x, other.x) && nearly_equal(self.y, other.y) && self.same_size_as(other)
+    }
 }
 
 fn nearly_equal(left: f64, right: f64) -> bool {
@@ -122,7 +126,7 @@ mod tests {
     }
 
     #[test]
-    fn same_size_allows_subpixel_accessibility_noise() {
+    fn same_size_allows_subpixel_noise() {
         assert!(Rect::new(0.0, 0.0, 100.0, 50.0).same_size_as(Rect::new(10.0, 10.0, 100.4, 49.6,)));
     }
 
@@ -130,6 +134,16 @@ mod tests {
     fn same_size_rejects_meaningful_resize() {
         assert!(
             !Rect::new(0.0, 0.0, 100.0, 50.0).same_size_as(Rect::new(10.0, 10.0, 101.0, 50.0,))
+        );
+    }
+
+    #[test]
+    fn nearly_equal_to_compares_origin_and_size_with_tolerance() {
+        assert!(
+            Rect::new(10.0, 20.0, 30.0, 40.0).nearly_equal_to(Rect::new(10.4, 19.6, 30.4, 39.6,))
+        );
+        assert!(
+            !Rect::new(10.0, 20.0, 30.0, 40.0).nearly_equal_to(Rect::new(10.6, 20.0, 30.0, 40.0,))
         );
     }
 }

--- a/harper-desktop/src-tauri/src/rect.rs
+++ b/harper-desktop/src-tauri/src/rect.rs
@@ -18,26 +18,6 @@ impl Rect {
             height,
         }
     }
-
-    pub fn translated(self, dx: f64, dy: f64) -> Self {
-        Self {
-            x: self.x + dx,
-            y: self.y + dy,
-            ..self
-        }
-    }
-
-    pub fn same_size_as(self, other: Self) -> bool {
-        nearly_equal(self.width, other.width) && nearly_equal(self.height, other.height)
-    }
-
-    pub fn nearly_equal_to(self, other: Self) -> bool {
-        nearly_equal(self.x, other.x) && nearly_equal(self.y, other.y) && self.same_size_as(other)
-    }
-}
-
-fn nearly_equal(left: f64, right: f64) -> bool {
-    (left - right).abs() <= 0.5
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -111,39 +91,5 @@ impl ColoredRect {
             height,
             color,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::Rect;
-
-    #[test]
-    fn translated_moves_origin_without_changing_size() {
-        let rect = Rect::new(10.0, 20.0, 30.0, 40.0).translated(5.0, -7.0);
-
-        assert_eq!(rect, Rect::new(15.0, 13.0, 30.0, 40.0));
-    }
-
-    #[test]
-    fn same_size_allows_subpixel_noise() {
-        assert!(Rect::new(0.0, 0.0, 100.0, 50.0).same_size_as(Rect::new(10.0, 10.0, 100.4, 49.6,)));
-    }
-
-    #[test]
-    fn same_size_rejects_meaningful_resize() {
-        assert!(
-            !Rect::new(0.0, 0.0, 100.0, 50.0).same_size_as(Rect::new(10.0, 10.0, 101.0, 50.0,))
-        );
-    }
-
-    #[test]
-    fn nearly_equal_to_compares_origin_and_size_with_tolerance() {
-        assert!(
-            Rect::new(10.0, 20.0, 30.0, 40.0).nearly_equal_to(Rect::new(10.4, 19.6, 30.4, 39.6,))
-        );
-        assert!(
-            !Rect::new(10.0, 20.0, 30.0, 40.0).nearly_equal_to(Rect::new(10.6, 20.0, 30.0, 40.0,))
-        );
     }
 }

--- a/harper-desktop/src/lib/settings/pages/GeneralPage.svelte
+++ b/harper-desktop/src/lib/settings/pages/GeneralPage.svelte
@@ -13,7 +13,6 @@ const DialectValue = {
 } as const;
 
 let menuBar = true;
-let menuBarClick = 'open-settings';
 let launchAtStartup = false;
 let autoUpdate = true;
 let dialect = 'american';
@@ -156,22 +155,6 @@ function settingsValueToDialect(value: string): Dialect {
               >
                 {#if menuBar}<span class="settings-icon icon-check" aria-hidden="true"></span>{/if}
               </button>
-            </div>
-
-            <div class="inline-row">
-              <label for="menu-bar-click">Click the icon to:</label>
-              <select
-                id="menu-bar-click"
-                class="select"
-                disabled
-                title="Not wired yet"
-                bind:value={menuBarClick}
-              >
-                <option value="open-settings">Open settings</option>
-                <option value="show-menu">Show a menu</option>
-                <option value="toggle-pause">Pause or resume</option>
-                <option value="quick-review">Open quick review</option>
-              </select>
             </div>
 
             <div class="row">

--- a/harper-desktop/src/lib/settings/pages/IntegrationsPage.svelte
+++ b/harper-desktop/src/lib/settings/pages/IntegrationsPage.svelte
@@ -116,29 +116,6 @@ function closeAppPicker() {
 
 <section>
   <div class="stanza">
-    <div class="eyebrow">App integrations</div>
-    <div class="row top">
-      <div>
-        <strong>Watch everywhere</strong>
-        <p>Harper checks writing in any app that supports text input.</p>
-      </div>
-      <button
-        class="toggle"
-        type="button"
-        role="switch"
-        aria-checked="false"
-        aria-label="Toggle watch everywhere"
-        disabled
-        title="Not wired yet"
-      >
-        <span></span>
-      </button>
-    </div>
-  </div>
-
-  <div class="divider"></div>
-
-  <div class="stanza">
     <div class="eyebrow">Selected apps</div>
     <p class="section-copy">Harper will only watch the apps you enable here.</p>
 

--- a/harper-desktop/src/lib/settings/pages/RulesPage.svelte
+++ b/harper-desktop/src/lib/settings/pages/RulesPage.svelte
@@ -296,10 +296,9 @@ async function resetRules() {
 }
 
 async function disableRules() {
-	const ruleIds = allKnownRuleIds();
 	const nextLintConfig = { ...(lintConfig ?? defaultLintConfig ?? {}) };
 
-	for (const ruleId of ruleIds) {
+	for (const ruleId of allKnownRuleIds()) {
 		nextLintConfig[ruleId] = false;
 	}
 

--- a/harper-desktop/src/lib/settings/pages/RulesPage.svelte
+++ b/harper-desktop/src/lib/settings/pages/RulesPage.svelte
@@ -228,6 +228,14 @@ function isRuleEnabled(rule: RuleItem) {
 	return lintConfig?.[rule.id] ?? defaultLintConfig?.[rule.id] ?? false;
 }
 
+function allKnownRuleIds() {
+	return new Set([
+		...Object.keys(defaultLintConfig ?? {}),
+		...Object.keys(lintConfig ?? {}),
+		...displayedRules.map((rule) => rule.id),
+	]);
+}
+
 async function setRuleOverride(ruleId: string, value: RuleOverride) {
 	const nextRules = { ...rules };
 
@@ -288,19 +296,18 @@ async function resetRules() {
 }
 
 async function disableRules() {
-	const nextRules = Object.fromEntries(
-		displayedRules.map((rule) => [rule.id, 'off' as RuleOverride]),
-	);
+	const ruleIds = allKnownRuleIds();
+	const nextLintConfig = { ...(lintConfig ?? defaultLintConfig ?? {}) };
+
+	for (const ruleId of ruleIds) {
+		nextLintConfig[ruleId] = false;
+	}
+
+	const nextRules = rulesFromLintConfig(nextLintConfig, defaultLintConfig ?? {});
 
 	if (!lintConfig) {
 		rules = nextRules;
 		return;
-	}
-
-	const nextLintConfig = { ...lintConfig };
-
-	for (const rule of displayedRules) {
-		nextLintConfig[rule.id] = false;
 	}
 
 	await saveLintConfig(nextLintConfig, nextRules);


### PR DESCRIPTION
# Issues 

No linked issue.

# Description

- Hide desktop highlights while the active macOS window is moving or has not yet settled.
- Detect active-window movement using CoreGraphics window bounds instead of Accessibility window geometry.
- Keep Accessibility usage limited to focused-app/text-range interactions needed for lint collection and suggestions.
- Avoid walking the Accessibility tree while the active window is moving, preventing stale text-range bounds from being rendered.
- Hide disabled/unwired desktop settings:
  - **Watch everywhere** on the integrations page.
  - **Click the icon to:** on the general settings page.
- Fix the Rules page **Disable all** action so it disables the full known rule set, including rules from the current config, default config, and structured rule list.
- Update the `tree-sitter-c-sharp` dependency from `0.23.1` to `0.23.5`.

# Demo

N/A

# How Has This Been Tested?

Manually.

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
