### PR TITLE
fix(desktop): broken buttons on setup page

### DIFF
--- a/harper-desktop/src-tauri/src/lib.rs
+++ b/harper-desktop/src-tauri/src/lib.rs
@@ -362,6 +362,11 @@ fn request_accessibility_permission() -> AccessibilityPermissionStatus {
     platform_broker().request_accessibility_permission()
 }
 
+#[tauri::command]
+fn launch_app(bundle_id: String) -> Result<(), String> {
+    platform_broker().launch_app_bundle(&bundle_id)
+}
+
 #[cfg(target_os = "macos")]
 fn platform_broker() -> impl OsBroker {
     mac_broker::MacBroker::default()
@@ -424,6 +429,7 @@ pub fn run_tauri() {
             set_integration_enabled,
             get_accessibility_permission_status,
             request_accessibility_permission,
+            launch_app,
         ])
         .on_window_event(|window, event| {
             if should_hide_window_on_close(window.label())

--- a/harper-desktop/src-tauri/src/mac_broker.rs
+++ b/harper-desktop/src-tauri/src/mac_broker.rs
@@ -118,6 +118,22 @@ impl OsBroker for MacBroker {
             AccessibilityPermissionStatus::NotGranted
         }
     }
+
+    fn launch_app_bundle(&self, bundle_id: &str) -> Result<(), String> {
+        let bundle_id = bundle_id.trim();
+
+        if bundle_id.is_empty() {
+            return Err("Bundle ID cannot be empty.".to_string());
+        }
+
+        std::process::Command::new("open")
+            .arg("-b")
+            .arg(bundle_id)
+            .spawn()
+            .map_err(|error| format!("Failed to launch {bundle_id}: {error}"))?;
+
+        Ok(())
+    }
 }
 
 fn focused_window_pid() -> Result<pid_t, Box<dyn StdError>> {

--- a/harper-desktop/src-tauri/src/os_broker.rs
+++ b/harper-desktop/src-tauri/src/os_broker.rs
@@ -33,6 +33,10 @@ pub trait OsBroker {
     fn request_accessibility_permission(&self) -> AccessibilityPermissionStatus {
         self.accessibility_permission_status()
     }
+
+    fn launch_app_bundle(&self, _bundle_id: &str) -> Result<(), String> {
+        Err("Launching apps by bundle ID is only supported on macOS.".to_string())
+    }
 }
 
 /// No-op platform broker for targets that do not have an OS implementation yet.

--- a/harper-desktop/src/lib/client.ts
+++ b/harper-desktop/src/lib/client.ts
@@ -128,6 +128,10 @@ export class Client {
 		await invoke('set_integration_enabled', { bundleId, enabled });
 	}
 
+	static async launchApp(bundleId: string): Promise<void> {
+		await invoke('launch_app', { bundleId });
+	}
+
 	static async getAccessibilityPermissionStatus(): Promise<AccessibilityPermissionStatus> {
 		return await withTimeout(
 			invoke<AccessibilityPermissionStatus>('get_accessibility_permission_status'),

--- a/harper-desktop/src/lib/settings/SettingsApp.svelte
+++ b/harper-desktop/src/lib/settings/SettingsApp.svelte
@@ -39,7 +39,7 @@ $: if (contentEl && active) {
 
   <main bind:this={contentEl} class="content" aria-label={title}>
     {#if active === "getting-started"}
-      <GettingStartedPage />
+      <GettingStartedPage navigateToSection={(section) => (active = section)} />
     {:else if active === "general"}
       <GeneralPage />
     {:else if active === "writing"}

--- a/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
+++ b/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { onMount } from 'svelte';
-import { type AccessibilityPermissionStatus, Client } from '$lib/client';
+import { type AccessibilityPermissionStatus, Client, type Integration } from '$lib/client';
 import { createInitialSettingsState, type SectionId, type SettingsState } from '../settings-data';
 
 type SetupStep = {
@@ -24,8 +24,15 @@ let accessibilityError = '';
 let isCheckingAccessibility = true;
 let isRequestingAccessibility = false;
 let hasRequestedAccessibility = false;
+let integrations: Integration[] = [];
+let integrationsError = '';
+let isLoadingIntegrations = true;
+let isEnablingTextEdit = false;
 let isLaunchingTextEdit = false;
 let testDriveError = '';
+
+$: textEditIntegration = integrations.find((item) => item.bundle_id === 'com.apple.TextEdit');
+$: isTextEditEnabled = textEditIntegration?.enabled === true;
 
 $: setupSteps = buildSetupSteps(
 	state,
@@ -33,24 +40,62 @@ $: setupSteps = buildSetupSteps(
 	isCheckingAccessibility,
 	isRequestingAccessibility,
 	hasRequestedAccessibility,
+	isTextEditEnabled,
+	isLoadingIntegrations,
+	isEnablingTextEdit,
 );
 $: setupCompletedCount = setupSteps.filter((step) => step.done).length;
 $: setupAllDone = setupSteps.every((step) => step.done);
 
 onMount(() => {
 	void checkAccessibilityPermission();
+	void loadIntegrations();
 });
 
 function updateSetup(patch: Partial<SettingsState['setup']>) {
 	state = { ...state, setup: { ...state.setup, ...patch } };
 }
 
-function enableTextEditForSetup() {
-	state = {
-		...state,
-		integrations: { ...state.integrations, textedit: true },
-		setup: { ...state.setup, integration: 'selected' },
-	};
+async function loadIntegrations() {
+	isLoadingIntegrations = true;
+	integrationsError = '';
+
+	try {
+		integrations = await Client.getIntegrations();
+	} catch (error) {
+		integrationsError = `Unable to load integrations: ${error}`;
+	} finally {
+		isLoadingIntegrations = false;
+	}
+}
+
+async function enableTextEditForSetup() {
+	isEnablingTextEdit = true;
+	integrationsError = '';
+
+	try {
+		if (textEditIntegration) {
+			await Client.setIntegrationEnabled('com.apple.TextEdit', true);
+			integrations = integrations.map((integration) =>
+				integration.bundle_id === 'com.apple.TextEdit'
+					? { ...integration, enabled: true }
+					: integration,
+			);
+		} else {
+			await Client.addIntegration('com.apple.TextEdit');
+			integrations = [...integrations, { bundle_id: 'com.apple.TextEdit', enabled: true }];
+		}
+
+		state = {
+			...state,
+			integrations: { ...state.integrations, textedit: true },
+			setup: { ...state.setup, integration: 'selected' },
+		};
+	} catch (error) {
+		integrationsError = `Unable to enable TextEdit: ${error}`;
+	} finally {
+		isEnablingTextEdit = false;
+	}
 }
 
 async function launchTextEditForTestDrive() {
@@ -146,9 +191,12 @@ function buildSetupSteps(
 	currentIsCheckingAccessibility: boolean,
 	currentIsRequestingAccessibility: boolean,
 	currentHasRequestedAccessibility: boolean,
+	currentIsTextEditEnabled: boolean,
+	currentIsLoadingIntegrations: boolean,
+	currentIsEnablingTextEdit: boolean,
 ): SetupStep[] {
 	const accessibilityDone = currentAccessibilityStatus === 'Granted';
-	const integrationDone = currentState.setup.integration === 'selected';
+	const integrationDone = currentIsTextEditEnabled;
 	const testDriveDone = currentState.setup.testDrive === 'completed';
 	const accessibilityActionDisabled =
 		currentIsCheckingAccessibility ||
@@ -184,6 +232,7 @@ function buildSetupSteps(
 			actionLabel: integrationDone ? 'Manage' : 'Browse apps',
 			actionVariant: 'default',
 			action: () => navigateToSection('integrations'),
+			actionDisabled: currentIsLoadingIntegrations || currentIsEnablingTextEdit,
 		},
 		{
 			id: 'test-drive',
@@ -300,15 +349,39 @@ function buildSetupSteps(
                   </div>
                 {/if}
 
-                {#if step.id === "integration" && accessibilityStatus === "Granted" && state.setup.integration !== "selected"}
+                {#if step.id === "integration" && integrationsError}
+                  <div class="detected-app">
+                    <div class="big-mark amber">!</div>
+                    <div class="grow">
+                      <strong>Integration update failed</strong>
+                      <p>{integrationsError}</p>
+                    </div>
+                  </div>
+                {:else if step.id === "integration" && accessibilityStatus === "Granted" && isLoadingIntegrations}
+                  <div class="detected-app">
+                    <div class="app-tile" style="--app-tint: #5a5f68">T</div>
+                    <div class="grow">
+                      <strong>Checking TextEdit</strong>
+                      <p>Loading integration state...</p>
+                    </div>
+                  </div>
+                {:else if step.id === "integration" && accessibilityStatus === "Granted" && isTextEditEnabled}
+                  <div class="detected-app">
+                    <div class="app-tile" style="--app-tint: #5a5f68">T</div>
+                    <div class="grow">
+                      <strong>TextEdit enabled</strong>
+                      <p>Harper is configured to check TextEdit.</p>
+                    </div>
+                  </div>
+                {:else if step.id === "integration" && accessibilityStatus === "Granted"}
                   <div class="detected-app">
                     <div class="app-tile" style="--app-tint: #5a5f68">T</div>
                     <div class="grow">
                       <strong>TextEdit detected</strong>
                       <p>A good starter app for trying Harper.</p>
                     </div>
-                    <button class="button primary" type="button" on:click={enableTextEditForSetup}>
-                      Enable
+                    <button class="button primary" type="button" disabled={isEnablingTextEdit} on:click={enableTextEditForSetup}>
+                      {isEnablingTextEdit ? "Enabling..." : "Enable"}
                     </button>
                   </div>
                 {/if}

--- a/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
+++ b/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { onMount } from 'svelte';
 import { type AccessibilityPermissionStatus, Client } from '$lib/client';
-import { createInitialSettingsState, type SettingsState } from '../settings-data';
+import { createInitialSettingsState, type SectionId, type SettingsState } from '../settings-data';
 
 type SetupStep = {
 	id: 'accessibility' | 'integration' | 'test-drive';
@@ -16,12 +16,16 @@ type SetupStep = {
 	actionDisabled?: boolean;
 };
 
+export let navigateToSection: (section: SectionId) => void;
+
 let state: SettingsState = createInitialSettingsState();
 let accessibilityStatus: AccessibilityPermissionStatus | null = null;
 let accessibilityError = '';
 let isCheckingAccessibility = true;
 let isRequestingAccessibility = false;
 let hasRequestedAccessibility = false;
+let isLaunchingTextEdit = false;
+let testDriveError = '';
 
 $: setupSteps = buildSetupSteps(
 	state,
@@ -47,6 +51,20 @@ function enableTextEditForSetup() {
 		integrations: { ...state.integrations, textedit: true },
 		setup: { ...state.setup, integration: 'selected' },
 	};
+}
+
+async function launchTextEditForTestDrive() {
+	isLaunchingTextEdit = true;
+	testDriveError = '';
+
+	try {
+		await Client.launchApp('com.apple.TextEdit');
+		updateSetup({ testDrive: 'completed' });
+	} catch (error) {
+		testDriveError = `Unable to launch TextEdit: ${error}`;
+	} finally {
+		isLaunchingTextEdit = false;
+	}
 }
 
 async function checkAccessibilityPermission() {
@@ -165,7 +183,7 @@ function buildSetupSteps(
 			locked: !accessibilityDone,
 			actionLabel: integrationDone ? 'Manage' : 'Browse apps',
 			actionVariant: 'default',
-			action: enableTextEditForSetup,
+			action: () => navigateToSection('integrations'),
 		},
 		{
 			id: 'test-drive',
@@ -174,9 +192,14 @@ function buildSetupSteps(
 			required: false,
 			done: testDriveDone,
 			locked: !accessibilityDone || !integrationDone,
-			actionLabel: testDriveDone ? 'Run again' : 'Launch TextEdit',
+			actionLabel: isLaunchingTextEdit
+				? 'Launching...'
+				: testDriveDone
+					? 'Run again'
+					: 'Launch TextEdit',
 			actionVariant: testDriveDone ? 'default' : 'primary',
-			action: () => updateSetup({ testDrive: 'completed' }),
+			action: launchTextEditForTestDrive,
+			actionDisabled: isLaunchingTextEdit,
 		},
 	];
 }
@@ -263,6 +286,16 @@ function buildSetupSteps(
                     <div class="grow">
                       <strong>Waiting for macOS</strong>
                       <p>After granting access in System Settings, return here and recheck permission.</p>
+                    </div>
+                  </div>
+                {/if}
+
+                {#if step.id === "test-drive" && testDriveError}
+                  <div class="detected-app">
+                    <div class="big-mark amber">!</div>
+                    <div class="grow">
+                      <strong>TextEdit launch failed</strong>
+                      <p>{testDriveError}</p>
                     </div>
                   </div>
                 {/if}


### PR DESCRIPTION
# Issues 

N/A

# Description

This updates the Harper Desktop getting-started setup flow so the setup buttons perform real actions instead of only mutating local UI state.

- Adds a general `launch_app` Tauri command for launching macOS apps by bundle ID.
- Routes app launching through the OS broker layer, with macOS implemented in `MacBroker` and other platforms returning an unsupported error.
- Adds `Client.launchApp(bundleId)` for frontend access to the command.
- Wires the setup flow's “Launch TextEdit” action to launch `com.apple.TextEdit`.
- Makes the setup flow's “Manage” / “Browse apps” action navigate to the Integrations settings page.
- Loads real integration state in the Getting Started page so TextEdit does not show an “Enable” button when it is already enabled.
- Updates the TextEdit enable action to add or enable the real `com.apple.TextEdit` integration.

# Demo

N/A

# How Has This Been Tested?

N/A

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter

N/A

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
