### PR TITLE
feat: lint or generate config `label`s, lint `description`

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -1,5306 +1,4577 @@
 {
-	"settings": [
-		{
-			"Group": {
-				"label": "Proper Nouns",
-				"description": "Checks names of places, organizations, products, and other proper nouns that should keep their standard capitalization.",
-				"child": {
-					"settings": [
-						{
-							"Bool": {
-								"name": "Americas",
-								"state": true,
-								"label": "Americas"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Australia",
-								"state": true,
-								"label": "Australia"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OceansAndSeas",
-								"state": true,
-								"label": "Oceans And Seas"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Canada",
-								"state": true,
-								"label": "Canada"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Laos",
-								"state": true,
-								"label": "Laos"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Malaysia",
-								"state": true,
-								"label": "Malaysia"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Countries",
-								"state": true,
-								"label": "Countries"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NationalCapitals",
-								"state": true,
-								"label": "National Capitals"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ChineseCommunistParty",
-								"state": true,
-								"label": "Chinese Communist Party"
-							}
-						},
-						{
-							"Bool": {
-								"name": "UnitedOrganizations",
-								"state": true,
-								"label": "United Organizations"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Holidays",
-								"state": true,
-								"label": "Holidays"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Koreas",
-								"state": true,
-								"label": "Koreas"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AmazonNames",
-								"state": true,
-								"label": "Amazon Names"
-							}
-						},
-						{
-							"Bool": {
-								"name": "GoogleNames",
-								"state": true,
-								"label": "Google Names"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AzureNames",
-								"state": true,
-								"label": "Azure Names"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MicrosoftNames",
-								"state": true,
-								"label": "Microsoft Names"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AppleNames",
-								"state": true,
-								"label": "Apple Names"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MetaNames",
-								"state": true,
-								"label": "Meta Names"
-							}
-						},
-						{
-							"Bool": {
-								"name": "JetpackNames",
-								"state": true,
-								"label": "Jetpack Names"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TumblrNames",
-								"state": true,
-								"label": "Tumblr Names"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PocketCastsNames",
-								"state": true,
-								"label": "Pocket Casts Names"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DayOneNames",
-								"state": true,
-								"label": "Day One Names"
-							}
-						},
-						{
-							"Bool": {
-								"name": "USUniversities",
-								"state": true,
-								"label": "US Universities"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NotablePlaces",
-								"state": true,
-								"label": "Notable Places"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ProperNouns",
-								"state": true,
-								"label": "Proper Nouns"
-							}
-						},
-						{
-							"Bool": {
-								"name": "CompaniesProductsAndTrademarks",
-								"state": true,
-								"label": "Companies Products And Trademarks"
-							}
-						}
-					]
-				}
-			}
-		},
-		{
-			"Group": {
-				"label": "Initialisms",
-				"description": "Covers abbreviated forms and initialisms that should use the expected letter casing or punctuation.",
-				"child": {
-					"settings": [
-						{
-							"Bool": {
-								"name": "AsFarAsIKnow",
-								"state": true,
-								"label": "As Far As I Know"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AsSoonAsPossible",
-								"state": true,
-								"label": "As Soon As Possible"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BeRightBack",
-								"state": true,
-								"label": "Be Right Back"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ByTheWay",
-								"state": true,
-								"label": "By The Way"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExplainLikeImFive",
-								"state": true,
-								"label": "Explain Like Im Five"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ForWhatItsWorth",
-								"state": true,
-								"label": "For What Its Worth"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ForYourInformation",
-								"state": true,
-								"label": "For Your Information"
-							}
-						},
-						{
-							"Bool": {
-								"name": "IDontKnow",
-								"state": true,
-								"label": "I Dont Know"
-							}
-						},
-						{
-							"Bool": {
-								"name": "IfIRecallCorrectly",
-								"state": true,
-								"label": "If I Recall Correctly"
-							}
-						},
-						{
-							"Bool": {
-								"name": "IfIUnderstandCorrectly",
-								"state": true,
-								"label": "If I Understand Correctly"
-							}
-						},
-						{
-							"Bool": {
-								"name": "IfYouKnowYouKnow",
-								"state": true,
-								"label": "If You Know You Know"
-							}
-						},
-						{
-							"Bool": {
-								"name": "InCaseYouMissedIt",
-								"state": true,
-								"label": "In Case You Missed It"
-							}
-						},
-						{
-							"Bool": {
-								"name": "InMyHumbleOpinion",
-								"state": true,
-								"label": "In My Humble Opinion"
-							}
-						},
-						{
-							"Bool": {
-								"name": "InMyOpinion",
-								"state": true,
-								"label": "In My Opinion"
-							}
-						},
-						{
-							"Bool": {
-								"name": "InRealLife",
-								"state": true,
-								"label": "In Real Life"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NeverMind",
-								"state": true,
-								"label": "Never Mind"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OhMyGod",
-								"state": true,
-								"label": "Oh My God"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PleaseTakeALook",
-								"state": true,
-								"label": "Please Take A Look"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Really",
-								"state": true,
-								"label": "Really"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TalkToYouLater",
-								"state": true,
-								"label": "Talk To You Later"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ToBeHonest",
-								"state": true,
-								"label": "To Be Honest"
-							}
-						}
-					]
-				}
-			}
-		},
-		{
-			"Group": {
-				"label": "Closed Compounds",
-				"description": "Flags compound words that should be written as a single closed form instead of split apart.",
-				"child": {
-					"settings": [
-						{
-							"Bool": {
-								"name": "Anybody",
-								"state": true,
-								"label": "Anybody"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Anyhow",
-								"state": true,
-								"label": "Anyhow"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Anywhere",
-								"state": true,
-								"label": "Anywhere"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Backplane",
-								"state": true,
-								"label": "Backplane"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Bypass",
-								"state": true,
-								"label": "Bypass"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Chalkboard",
-								"state": true,
-								"label": "Chalkboard"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Deadlift",
-								"state": true,
-								"label": "Deadlift"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Desktop",
-								"state": true,
-								"label": "Desktop"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Devops",
-								"state": true,
-								"label": "Devops"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Everybody",
-								"state": true,
-								"label": "Everybody"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Everyone",
-								"state": true,
-								"label": "Everyone"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Everywhere",
-								"state": true,
-								"label": "Everywhere"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Furthermore",
-								"state": true,
-								"label": "Furthermore"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Henceforth",
-								"state": true,
-								"label": "Henceforth"
-							}
-						},
-						{
-							"Bool": {
-								"name": "However",
-								"state": true,
-								"label": "However"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Insofar",
-								"state": true,
-								"label": "Insofar"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Instead",
-								"state": true,
-								"label": "Instead"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Intact",
-								"state": true,
-								"label": "Intact"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Itself",
-								"state": true,
-								"label": "Itself"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Keystroke",
-								"state": true,
-								"label": "Keystroke"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Keystrokes",
-								"state": true,
-								"label": "Keystrokes"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Laptop",
-								"state": true,
-								"label": "Laptop"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Meanwhile",
-								"state": true,
-								"label": "Meanwhile"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Middleware",
-								"state": true,
-								"label": "Middleware"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Misunderstand",
-								"state": true,
-								"label": "Misunderstand"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Misunderstood",
-								"state": true,
-								"label": "Misunderstood"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Misuse",
-								"state": true,
-								"label": "Misuse"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Misused",
-								"state": true,
-								"label": "Misused"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Multicore",
-								"state": true,
-								"label": "Multicore"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Multimedia",
-								"state": true,
-								"label": "Multimedia"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Multithreading",
-								"state": true,
-								"label": "Multithreading"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Myself",
-								"state": true,
-								"label": "Myself"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Nonetheless",
-								"state": true,
-								"label": "Nonetheless"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Nothing",
-								"state": true,
-								"label": "Nothing"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Notwithstanding",
-								"state": true,
-								"label": "Notwithstanding"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Nowhere",
-								"state": true,
-								"label": "Nowhere"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Overall",
-								"state": true,
-								"label": "Overall"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Overclocking",
-								"state": true,
-								"label": "Overclocking"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Overload",
-								"state": true,
-								"label": "Overload"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Overnight",
-								"state": true,
-								"label": "Overnight"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Postpone",
-								"state": true,
-								"label": "Postpone"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Proofread",
-								"state": true,
-								"label": "Proofread"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Regardless",
-								"state": true,
-								"label": "Regardless"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Shortcoming",
-								"state": true,
-								"label": "Shortcoming"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Shortcomings",
-								"state": true,
-								"label": "Shortcomings"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Somebody",
-								"state": true,
-								"label": "Somebody"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Somehow",
-								"state": true,
-								"label": "Somehow"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Someone",
-								"state": true,
-								"label": "Someone"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Somewhere",
-								"state": true,
-								"label": "Somewhere"
-							}
-						},
-						{
-							"Bool": {
-								"name": "There",
-								"state": true,
-								"label": "There"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Therefore",
-								"state": true,
-								"label": "Therefore"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Thereupon",
-								"state": true,
-								"label": "Thereupon"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Underclock",
-								"state": true,
-								"label": "Underclock"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Upset",
-								"state": true,
-								"label": "Upset"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Upward",
-								"state": true,
-								"label": "Upward"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Whereupon",
-								"state": true,
-								"label": "Whereupon"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Widespread",
-								"state": true,
-								"label": "Widespread"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Without",
-								"state": true,
-								"label": "Without"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Worldwide",
-								"state": true,
-								"label": "Worldwide"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Worthwhile",
-								"state": true,
-								"label": "Worthwhile"
-							}
-						}
-					]
-				}
-			}
-		},
-		{
-			"Group": {
-				"label": "Phrase Corrections",
-				"description": "Collects common phrase-level fixes where a standard expression is preferred over a mistaken variant.",
-				"child": {
-					"settings": [
-						{
-							"Bool": {
-								"name": "Ado",
-								"state": true,
-								"label": "Ado"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AtAllCosts",
-								"state": true,
-								"label": "At All Costs"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ArgumentToBeMade",
-								"state": true,
-								"label": "Argument To Be Made"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Bollocks",
-								"state": true,
-								"label": "Bollocks"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ChampAtTheBit",
-								"state": true,
-								"label": "Champ At The Bit"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ClientOrServerSide",
-								"state": true,
-								"label": "Client Or Server Side"
-							}
-						},
-						{
-							"Bool": {
-								"name": "CompulseToCompel",
-								"state": true,
-								"label": "Compulse To Compel"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ConfirmThat",
-								"state": true,
-								"label": "Confirm That"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DefiniteArticle",
-								"state": true,
-								"label": "Definite Article"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DigestiveTract",
-								"state": true,
-								"label": "Digestive Tract"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Discuss",
-								"state": true,
-								"label": "Discuss"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DoesOrDose",
-								"state": true,
-								"label": "Does Or Dose"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandArgument",
-								"state": true,
-								"label": "Expand Argument"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandDependencies",
-								"state": true,
-								"label": "Expand Dependencies"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandDeref",
-								"state": true,
-								"label": "Expand Deref"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandParameter",
-								"state": true,
-								"label": "Expand Parameter"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandPointer",
-								"state": true,
-								"label": "Expand Pointer"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandStandardInputAndOutput",
-								"state": true,
-								"label": "Expand Standard Input And Output"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExplanationMark",
-								"state": true,
-								"label": "Explanation Mark"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExtendOrExtent",
-								"state": true,
-								"label": "Extend Or Extent"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FlauntForFlout",
-								"state": true,
-								"label": "Flaunt For Flout"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FoamAtTheMouth",
-								"state": true,
-								"label": "Foam At The Mouth"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FootTheBill",
-								"state": true,
-								"label": "Foot The Bill"
-							}
-						},
-						{
-							"Bool": {
-								"name": "GetUsedTo",
-								"state": true,
-								"label": "Get Used To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "GrindToAHalt",
-								"state": true,
-								"label": "Grind To A Halt"
-							}
-						},
-						{
-							"Bool": {
-								"name": "HavePassed",
-								"state": true,
-								"label": "Have Passed"
-							}
-						},
-						{
-							"Bool": {
-								"name": "HitTheNailOnTheHead",
-								"state": true,
-								"label": "Hit The Nail On The Head"
-							}
-						},
-						{
-							"Bool": {
-								"name": "HomeInOn",
-								"state": true,
-								"label": "Home In On"
-							}
-						},
-						{
-							"Bool": {
-								"name": "InDetail",
-								"state": true,
-								"label": "In Detail"
-							}
-						},
-						{
-							"Bool": {
-								"name": "InvestIn",
-								"state": true,
-								"label": "Invest In"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LayoutVerb",
-								"state": true,
-								"label": "Layout Verb"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LitotesDirectPositive",
-								"state": true,
-								"label": "Litotes Direct Positive"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MakeDoWith",
-								"state": true,
-								"label": "Make Do With"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MakeSense",
-								"state": true,
-								"label": "Make Sense"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MootPoint",
-								"state": true,
-								"label": "Moot Point"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OperatingSystem",
-								"state": true,
-								"label": "Operating System"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PassersBy",
-								"state": true,
-								"label": "Passers By"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PeekBehindTheCurtain",
-								"state": true,
-								"label": "Peek Behind The Curtain"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Piggyback",
-								"state": true,
-								"label": "Piggyback"
-							}
-						},
-						{
-							"Bool": {
-								"name": "RedundantSuperlatives",
-								"state": true,
-								"label": "Redundant Superlatives"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ResponsibilityFor",
-								"state": true,
-								"label": "Responsibility For"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ScapeGoat",
-								"state": true,
-								"label": "Scape Goat"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SeamToSeem",
-								"state": true,
-								"label": "Seam To Seem"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SubjunctiveWasToWere",
-								"state": true,
-								"label": "Subjunctive Was To Were"
-							}
-						},
-						{
-							"Bool": {
-								"name": "UseToUsedTo",
-								"state": true,
-								"label": "Use To Used To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WreakHavoc",
-								"state": true,
-								"label": "Wreak Havoc"
-							}
-						},
-						{
-							"Bool": {
-								"name": "VerseAsVerb",
-								"state": true,
-								"label": "Verse As Verb"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WroteToRote",
-								"state": true,
-								"label": "Wrote To Rote"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AwaitFor",
-								"state": true,
-								"label": "Await For"
-							}
-						},
-						{
-							"Bool": {
-								"name": "CommitmentTo",
-								"state": true,
-								"label": "Commitment To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Copyright",
-								"state": true,
-								"label": "Copyright"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DateBackFrom",
-								"state": true,
-								"label": "Date Back From"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DoubleEdgedSword",
-								"state": true,
-								"label": "Double Edged Sword"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandAlloc",
-								"state": true,
-								"label": "Expand Alloc"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandDecl",
-								"state": true,
-								"label": "Expand Decl"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Expat",
-								"state": true,
-								"label": "Expat"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Expatriate",
-								"state": true,
-								"label": "Expatriate"
-							}
-						},
-						{
-							"Bool": {
-								"name": "GetRidOf",
-								"state": true,
-								"label": "Get Rid Of"
-							}
-						},
-						{
-							"Bool": {
-								"name": "HolyWar",
-								"state": true,
-								"label": "Holy War"
-							}
-						},
-						{
-							"Bool": {
-								"name": "HowItLooksLike",
-								"state": true,
-								"label": "How It Looks Like"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MakeItSeem",
-								"state": true,
-								"label": "Make It Seem"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NervousWreck",
-								"state": true,
-								"label": "Nervous Wreck"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NotOnly",
-								"state": true,
-								"label": "Not Only"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Payed",
-								"state": true,
-								"label": "Payed"
-							}
-						},
-						{
-							"Bool": {
-								"name": "RiseTheQuestion",
-								"state": true,
-								"label": "Rise The Question"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ToTooIdioms",
-								"state": true,
-								"label": "To Too Idioms"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TooTo",
-								"state": true,
-								"label": "Too To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WholeEntire",
-								"state": true,
-								"label": "Whole Entire"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WorseOrWorst",
-								"state": true,
-								"label": "Worse Or Worst"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandGovt",
-								"state": true,
-								"label": "Expand Govt"
-							}
-						},
-						{
-							"Bool": {
-								"name": "InflectionPoint",
-								"state": true,
-								"label": "Inflection Point"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FormativeYears",
-								"state": true,
-								"label": "Formative Years"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandAlgorithm",
-								"state": true,
-								"label": "Expand Algorithm"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandCoordinate",
-								"state": true,
-								"label": "Expand Coordinate"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandNotification",
-								"state": true,
-								"label": "Expand Notification"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandVulnerability",
-								"state": true,
-								"label": "Expand Vulnerability"
-							}
-						}
-					]
-				}
-			}
-		},
-		{
-			"Group": {
-				"label": "Capitalization and Case",
-				"description": "Catches capitalization and casing issues in titles, sentences, brands, and other case-sensitive text.",
-				"child": {
-					"settings": [
-						{
-							"Bool": {
-								"name": "CapitalizePersonalPronouns",
-								"state": true,
-								"label": "Capitalize Personal Pronouns"
-							}
-						},
-						{
-							"Bool": {
-								"name": "JohnsHopkins",
-								"state": true,
-								"label": "Johns Hopkins"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NumberSuffixCapitalization",
-								"state": true,
-								"label": "Number Suffix Capitalization"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SentenceCapitalization",
-								"state": true,
-								"label": "Sentence Capitalization"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TheProperNounPossessive",
-								"state": true,
-								"label": "The Proper Noun Possessive"
-							}
-						},
-						{
-							"Bool": {
-								"name": "UseTitleCase",
-								"state": true,
-								"label": "Use Title Case"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WordPressDotcom",
-								"state": true,
-								"label": "WordPress Dotcom"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ColdModalTypo",
-								"state": true,
-								"label": "Cold Modal Typo"
-							}
-						},
-						{
-							"Bool": {
-								"name": "GoggleBrand",
-								"state": true,
-								"label": "Goggle Brand"
-							}
-						},
-						{
-							"Bool": {
-								"name": "YeaToYeah",
-								"state": true,
-								"label": "Yea To Yeah"
-							}
-						},
-						{
-							"Bool": {
-								"name": "YehToYeah",
-								"state": true,
-								"label": "Yeh To Yeah"
-							}
-						}
-					]
-				}
-			}
-		},
-		{
-			"Group": {
-				"label": "Punctuation and Spacing",
-				"description": "Handles punctuation marks, apostrophes, quotation marks, commas, and spacing conventions.",
-				"child": {
-					"settings": [
-						{
-							"Bool": {
-								"name": "CommaFixes",
-								"state": true,
-								"label": "Comma Fixes"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Dashes",
-								"state": true,
-								"label": "Dashes"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DotInitialisms",
-								"state": true,
-								"label": "Dot Initialisms"
-							}
-						},
-						{
-							"Bool": {
-								"name": "EllipsisLength",
-								"state": true,
-								"label": "Ellipsis Length"
-							}
-						},
-						{
-							"Bool": {
-								"name": "UseEllipsisCharacter",
-								"state": true,
-								"label": "Use Ellipsis Character"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NoFrenchSpaces",
-								"state": true,
-								"label": "No French Spaces"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NoOxfordComma",
-								"state": false,
-								"label": "No Oxford Comma"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OxfordComma",
-								"state": true,
-								"label": "Oxford Comma"
-							}
-						},
-						{
-							"Bool": {
-								"name": "QuoteSpacing",
-								"state": true,
-								"label": "Quote Spacing"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Spaces",
-								"state": true,
-								"label": "Spaces"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TransposedSpace",
-								"state": true,
-								"label": "Transposed Space"
-							}
-						},
-						{
-							"Bool": {
-								"name": "UnclosedQuotes",
-								"state": true,
-								"label": "Unclosed Quotes"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WrongApostrophe",
-								"state": true,
-								"label": "Wrong Apostrophe"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AOkHyphen",
-								"state": true,
-								"label": "A Ok Hyphen"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BluRayHyphen",
-								"state": true,
-								"label": "Blu Ray Hyphen"
-							}
-						},
-						{
-							"Bool": {
-								"name": "CantWay",
-								"state": true,
-								"label": "Cant Way"
-							}
-						},
-						{
-							"Bool": {
-								"name": "CaseSensitive",
-								"state": true,
-								"label": "Case Sensitive"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ClickThroughRate",
-								"state": true,
-								"label": "Click Through Rate"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DoubleCheckHyphen",
-								"state": true,
-								"label": "Double Check Hyphen"
-							}
-						},
-						{
-							"Bool": {
-								"name": "EagleEyed",
-								"state": true,
-								"label": "Eagle Eyed"
-							}
-						},
-						{
-							"Bool": {
-								"name": "EverPresent",
-								"state": true,
-								"label": "Ever Present"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FaceFirst",
-								"state": true,
-								"label": "Face First"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FirstPersonModifierHyphen",
-								"state": true,
-								"label": "First Person Modifier Hyphen"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FromTheGetGo",
-								"state": true,
-								"label": "From The Get Go"
-							}
-						},
-						{
-							"Bool": {
-								"name": "GuineaBissau",
-								"state": true,
-								"label": "Guinea Bissau"
-							}
-						},
-						{
-							"Bool": {
-								"name": "IntroCueCommaBeforeThanks",
-								"state": true,
-								"label": "Intro Cue Comma Before Thanks"
-							}
-						},
-						{
-							"Bool": {
-								"name": "IncludingButNotLimitedToPunctuation",
-								"state": true,
-								"label": "Including But Not Limited To Punctuation"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MercedesBenzHyphen",
-								"state": true,
-								"label": "Mercedes Benz Hyphen"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OffTheCuff",
-								"state": true,
-								"label": "Off The Cuff"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OneHanded",
-								"state": true,
-								"label": "One Handed"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PasswordProtectedHyphen",
-								"state": true,
-								"label": "Password Protected Hyphen"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PortAuPrince",
-								"state": true,
-								"label": "Port Au Prince"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PortoNovo",
-								"state": true,
-								"label": "Porto Novo"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PostItNoteHyphen",
-								"state": true,
-								"label": "Post It Note Hyphen"
-							}
-						},
-						{
-							"Bool": {
-								"name": "RainbowColoredHyphen",
-								"state": true,
-								"label": "Rainbow Colored Hyphen"
-							}
-						},
-						{
-							"Bool": {
-								"name": "RapidFire",
-								"state": true,
-								"label": "Rapid Fire"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ToDoHyphen",
-								"state": true,
-								"label": "To Do Hyphen"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WellBeing",
-								"state": true,
-								"label": "Well Being"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WorstCaseScenario",
-								"state": true,
-								"label": "Worst Case Scenario"
-							}
-						}
-					]
-				}
-			}
-		},
-		{
-			"Group": {
-				"label": "Numbers and Units",
-				"description": "Checks how numbers, dates, times, decades, and measurement units are written.",
-				"child": {
-					"settings": [
-						{
-							"Bool": {
-								"name": "BestOfAllTime",
-								"state": true,
-								"label": "Best Of All Time"
-							}
-						},
-						{
-							"Bool": {
-								"name": "CorrectNumberSuffix",
-								"state": true,
-								"label": "Correct Number Suffix"
-							}
-						},
-						{
-							"Bool": {
-								"name": "CurrencyPlacement",
-								"state": true,
-								"label": "Currency Placement"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DayAndAge",
-								"state": true,
-								"label": "Day And Age"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandMemoryShorthands",
-								"state": true,
-								"label": "Expand Memory Shorthands"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandPeople",
-								"state": true,
-								"label": "Expand People"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandTimeShorthands",
-								"state": true,
-								"label": "Expand Time Shorthands"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FewUnitsOfTimeAgo",
-								"state": true,
-								"label": "Few Units Of Time Ago"
-							}
-						},
-						{
-							"Bool": {
-								"name": "HyphenateNumberDay",
-								"state": true,
-								"label": "Hyphenate Number Day"
-							}
-						},
-						{
-							"Bool": {
-								"name": "InTimeFromNow",
-								"state": true,
-								"label": "In Time From Now"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Months",
-								"state": true,
-								"label": "Months"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MostNumber",
-								"state": true,
-								"label": "Most Number"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MostOfTheTimes",
-								"state": true,
-								"label": "Most Of The Times"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SinceDuration",
-								"state": true,
-								"label": "Since Duration"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SpelledNumbers",
-								"state": false,
-								"label": "Spelled Numbers"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PluralDecades",
-								"state": true,
-								"label": "Plural Decades"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ALongTime",
-								"state": true,
-								"label": "A Long Time"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DegreesKelvin",
-								"state": true,
-								"label": "Degrees Kelvin"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DegreesKelvinSymbol",
-								"state": true,
-								"label": "Degrees Kelvin Symbol"
-							}
-						},
-						{
-							"Bool": {
-								"name": "EveryTime",
-								"state": true,
-								"label": "Every Time"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ForALongTime",
-								"state": true,
-								"label": "For A Long Time"
-							}
-						},
-						{
-							"Bool": {
-								"name": "HalfAnHour",
-								"state": true,
-								"label": "Half An Hour"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ItTimeAuxiliary",
-								"state": true,
-								"label": "It Time Auxiliary"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LinesOfCode",
-								"state": true,
-								"label": "Lines Of Code"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OnSecondThought",
-								"state": true,
-								"label": "On Second Thought"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TickingTimeClock",
-								"state": true,
-								"label": "Ticking Time Clock"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ToSomeDegree",
-								"state": true,
-								"label": "To Some Degree"
-							}
-						}
-					]
-				}
-			}
-		},
-		{
-			"Group": {
-				"label": "Pronouns and Possession",
-				"description": "Focuses on pronouns, contractions, possessives, and related agreement problems.",
-				"child": {
-					"settings": [
-						{
-							"Bool": {
-								"name": "ElsePossessive",
-								"state": true,
-								"label": "Else Possessive"
-							}
-						},
-						{
-							"Bool": {
-								"name": "HavePronoun",
-								"state": true,
-								"label": "Have Pronoun"
-							}
-						},
-						{
-							"Bool": {
-								"name": "IAmAgreement",
-								"state": true,
-								"label": "I Am Agreement"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ItsContraction",
-								"state": true,
-								"label": "Its Contraction"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ItsPossessive",
-								"state": true,
-								"label": "Its Possessive"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MultipleSequentialPronouns",
-								"state": true,
-								"label": "Multiple Sequential Pronouns"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NorModalPronoun",
-								"state": true,
-								"label": "Nor Modal Pronoun"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PossessiveNoun",
-								"state": false,
-								"label": "Possessive Noun"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PossessiveYour",
-								"state": true,
-								"label": "Possessive Your"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PronounAre",
-								"state": true,
-								"label": "Pronoun Are"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PronounContraction",
-								"state": true,
-								"label": "Pronoun Contraction"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PronounInflectionBe",
-								"state": true,
-								"label": "Pronoun Inflection Be"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PronounKnew",
-								"state": true,
-								"label": "Pronoun Knew"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PronounVerbAgreement",
-								"state": true,
-								"label": "Pronoun Verb Agreement"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SubjectPronoun",
-								"state": true,
-								"label": "Subject Pronoun"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TheMy",
-								"state": true,
-								"label": "The My"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThereOwn",
-								"state": true,
-								"label": "There Own"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Theres",
-								"state": true,
-								"label": "There's"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TheyreConfusions",
-								"state": true,
-								"label": "They're Confusions"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WereWhere",
-								"state": true,
-								"label": "Were Where"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WhomSubjectOfVerb",
-								"state": true,
-								"label": "Whom Subject Of Verb"
-							}
-						},
-						{
-							"Bool": {
-								"name": "EachOthersPossessive",
-								"state": true,
-								"label": "Each Others Possessive"
-							}
-						},
-						{
-							"Bool": {
-								"name": "HeDos",
-								"state": true,
-								"label": "He Dos"
-							}
-						},
-						{
-							"Bool": {
-								"name": "HeartToHeard",
-								"state": true,
-								"label": "Heart To Heard"
-							}
-						},
-						{
-							"Bool": {
-								"name": "IAm",
-								"state": true,
-								"label": "I Am"
-							}
-						},
-						{
-							"Bool": {
-								"name": "IDo",
-								"state": true,
-								"label": "I Do"
-							}
-						},
-						{
-							"Bool": {
-								"name": "InOfItself",
-								"state": true,
-								"label": "In Of Itself"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MyHouse",
-								"state": true,
-								"label": "My House"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NeedHelp",
-								"state": true,
-								"label": "Need Help"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TheirToThere",
-								"state": true,
-								"label": "Their To There"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TheirToTheyre",
-								"state": true,
-								"label": "Their To Theyre"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThereToTheir",
-								"state": true,
-								"label": "There To Their"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TheyToThem",
-								"state": true,
-								"label": "They To Them"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TheyreToTheir",
-								"state": true,
-								"label": "Theyre To Their"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WhetYourAppetite",
-								"state": true,
-								"label": "Whet Your Appetite"
-							}
-						},
-						{
-							"Bool": {
-								"name": "YourOutClauseAgreement",
-								"state": true,
-								"label": "Your Out Clause Agreement"
-							}
-						},
-						{
-							"Bool": {
-								"name": "YourPredicateAdjective",
-								"state": true,
-								"label": "Your Predicate Adjective"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Yourself",
-								"state": true,
-								"label": "Yourself"
-							}
-						}
-					]
-				}
-			}
-		},
-		{
-			"Group": {
-				"label": "Compounds and Hyphenation",
-				"description": "Covers hyphenation and multi-word compounds that should be open, closed, or hyphenated.",
-				"child": {
-					"settings": [
-						{
-							"Bool": {
-								"name": "CompoundNouns",
-								"state": true,
-								"label": "Compound Nouns"
-							}
-						},
-						{
-							"Bool": {
-								"name": "CompoundSubjectI",
-								"state": true,
-								"label": "Compound Subject I"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DoubleClick",
-								"state": true,
-								"label": "Double Click"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MergeWords",
-								"state": true,
-								"label": "Merge Words"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OpenCompounds",
-								"state": true,
-								"label": "Open Compounds"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OpenTheLight",
-								"state": true,
-								"label": "Open The Light"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PhrasalVerbAsCompoundNoun",
-								"state": true,
-								"label": "Phrasal Verb As Compound Noun"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SplitWords",
-								"state": true,
-								"label": "Split Words"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BuiltIn",
-								"state": true,
-								"label": "Built In"
-							}
-						},
-						{
-							"Bool": {
-								"name": "EasyGoingCompoundAdjective",
-								"state": true,
-								"label": "Easy Going Compound Adjective"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LastDitch",
-								"state": true,
-								"label": "Last Ditch"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MakeupCompoundNoun",
-								"state": true,
-								"label": "Makeup Compound Noun"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OvertimeCompoundNoun",
-								"state": true,
-								"label": "Overtime Compound Noun"
-							}
-						},
-						{
-							"Bool": {
-								"name": "RoadMap",
-								"state": true,
-								"label": "Road Map"
-							}
-						},
-						{
-							"Bool": {
-								"name": "StateOfTheArt",
-								"state": true,
-								"label": "State Of The Art"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThereAfterCompound",
-								"state": true,
-								"label": "There After Compound"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WokVerbTypo",
-								"state": true,
-								"label": "Wok Verb Typo"
-							}
-						}
-					]
-				}
-			}
-		},
-		{
-			"Group": {
-				"label": "Spelling and Orthography",
-				"description": "Flags misspellings, orthographic inconsistencies, and word forms that are spelled the wrong way.",
-				"child": {
-					"settings": [
-						{
-							"Bool": {
-								"name": "Misspell",
-								"state": true,
-								"label": "Misspell"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OrthographicConsistency",
-								"state": true,
-								"label": "Orthographic Consistency"
-							}
-						},
-						{
-							"Bool": {
-								"name": "RegularIrregulars",
-								"state": true,
-								"label": "Regular Irregulars"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SneakedSnuck",
-								"state": true,
-								"label": "Sneaked Snuck"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OkToOkay",
-								"state": true,
-								"label": "Ok To Okay"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SpellCheck",
-								"state": true,
-								"label": "Spell Check"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AdNauseam",
-								"state": true,
-								"label": "Ad Nauseam"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Albeit",
-								"state": true,
-								"label": "Albeit"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AllThough",
-								"state": true,
-								"label": "All Though"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AtLeasToLeast",
-								"state": true,
-								"label": "At Leas To Least"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AtLestToLeast",
-								"state": true,
-								"label": "At Lest To Least"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BeenThere",
-								"state": true,
-								"label": "Been There"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BestRegards",
-								"state": true,
-								"label": "Best Regards"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BetterOffWith",
-								"state": true,
-								"label": "Better Off With"
-							}
-						},
-						{
-							"Bool": {
-								"name": "CanBeSeen",
-								"state": true,
-								"label": "Can Be Seen"
-							}
-						},
-						{
-							"Bool": {
-								"name": "CaseInPoint",
-								"state": true,
-								"label": "Case In Point"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DoNotWant",
-								"state": true,
-								"label": "Do Not Want"
-							}
-						},
-						{
-							"Bool": {
-								"name": "EludedTo",
-								"state": true,
-								"label": "Eluded To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "EverSince",
-								"state": true,
-								"label": "Ever Since"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExitedExcitedContext",
-								"state": true,
-								"label": "Exited Excited Context"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FetalPosition",
-								"state": true,
-								"label": "Fetal Position"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ForAWhile",
-								"state": true,
-								"label": "For A While"
-							}
-						},
-						{
-							"Bool": {
-								"name": "GoingTo",
-								"state": true,
-								"label": "Going To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "HowMach",
-								"state": true,
-								"label": "How Mach"
-							}
-						},
-						{
-							"Bool": {
-								"name": "HumanLife",
-								"state": true,
-								"label": "Human Life"
-							}
-						},
-						{
-							"Bool": {
-								"name": "InLieuOf",
-								"state": true,
-								"label": "In Lieu Of"
-							}
-						},
-						{
-							"Bool": {
-								"name": "InThe",
-								"state": true,
-								"label": "In The"
-							}
-						},
-						{
-							"Bool": {
-								"name": "IsKnownFor",
-								"state": true,
-								"label": "Is Known For"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ItCan",
-								"state": true,
-								"label": "It Can"
-							}
-						},
-						{
-							"Bool": {
-								"name": "IveGotTo",
-								"state": true,
-								"label": "Ive Got To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "JustDeserts",
-								"state": true,
-								"label": "Just Deserts"
-							}
-						},
-						{
-							"Bool": {
-								"name": "KindRegards",
-								"state": true,
-								"label": "Kind Regards"
-							}
-						},
-						{
-							"Bool": {
-								"name": "KindSortOf",
-								"state": true,
-								"label": "Kind Sort Of"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LetAlone",
-								"state": true,
-								"label": "Let Alone"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LooksLikes",
-								"state": true,
-								"label": "Looks Likes"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MoreThatLikely",
-								"state": true,
-								"label": "More That Likely"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NobelPeacePrize",
-								"state": true,
-								"label": "Nobel Peace Prize"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NotIn",
-								"state": true,
-								"label": "Not In"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NotTo",
-								"state": true,
-								"label": "Not To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NowWay",
-								"state": true,
-								"label": "Now Way"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OutOfSync",
-								"state": true,
-								"label": "Out Of Sync"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PedalToTheMetal",
-								"state": true,
-								"label": "Pedal To The Metal"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PerSe",
-								"state": true,
-								"label": "Per Se"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PleasRequestVerb",
-								"state": true,
-								"label": "Pleas Request Verb"
-							}
-						},
-						{
-							"Bool": {
-								"name": "RallyToReally",
-								"state": true,
-								"label": "Rally To Really"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SomeOfThe",
-								"state": true,
-								"label": "Some Of The"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SpecialAttention",
-								"state": true,
-								"label": "Special Attention"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SpinalChord",
-								"state": true,
-								"label": "Spinal Chord"
-							}
-						},
-						{
-							"Bool": {
-								"name": "StrikeChord",
-								"state": true,
-								"label": "Strike Chord"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThatThis",
-								"state": true,
-								"label": "That This"
-							}
-						},
-						{
-							"Bool": {
-								"name": "The",
-								"state": true,
-								"label": "The"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThieveNoun",
-								"state": true,
-								"label": "Thieve Noun"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThoughtProcess",
-								"state": true,
-								"label": "Thought Process"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ToLoseTooLoose",
-								"state": true,
-								"label": "To Lose Too Loose"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TrialAndError",
-								"state": true,
-								"label": "Trial And Error"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TuffEnough",
-								"state": true,
-								"label": "Tuff Enough"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TurnItOff",
-								"state": true,
-								"label": "Turn It Off"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WithoutOut",
-								"state": true,
-								"label": "Without Out"
-							}
-						},
-						{
-							"Bool": {
-								"name": "CloseTightKnit",
-								"state": true,
-								"label": "Close Tight Knit"
-							}
-						}
-					]
-				}
-			}
-		},
-		{
-			"Group": {
-				"label": "Style and Redundancy",
-				"description": "Highlights wordy, repetitive, or overly weak phrasing that can usually be tightened up.",
-				"child": {
-					"settings": [
-						{
-							"Bool": {
-								"name": "BoringWords",
-								"state": false,
-								"label": "Boring Words"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DiscourseMarkers",
-								"state": true,
-								"label": "Discourse Markers"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FillerWords",
-								"state": true,
-								"label": "Filler Words"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Hedging",
-								"state": true,
-								"label": "Hedging"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LongSentences",
-								"state": true,
-								"label": "Long Sentences"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MoreBetter",
-								"state": true,
-								"label": "More Better"
-							}
-						},
-						{
-							"Bool": {
-								"name": "QuiteQuiet",
-								"state": true,
-								"label": "Quite Quiet"
-							}
-						},
-						{
-							"Bool": {
-								"name": "RedundantAcronyms",
-								"state": true,
-								"label": "Redundant Acronyms"
-							}
-						},
-						{
-							"Bool": {
-								"name": "RedundantAdditiveAdverbs",
-								"state": true,
-								"label": "Redundant Additive Adverbs"
-							}
-						},
-						{
-							"Bool": {
-								"name": "RedundantProgressiveComparative",
-								"state": true,
-								"label": "Redundant Progressive Comparative"
-							}
-						},
-						{
-							"Bool": {
-								"name": "RepeatedWords",
-								"state": true,
-								"label": "Repeated Words"
-							}
-						},
-						{
-							"Bool": {
-								"name": "VeryUnique",
-								"state": true,
-								"label": "Very Unique"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WayTooAdjective",
-								"state": true,
-								"label": "Way Too Adjective"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WidelyAccepted",
-								"state": true,
-								"label": "Widely Accepted"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MultipleFrequencyAdverbs",
-								"state": true,
-								"label": "Multiple Frequency Adverbs"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ACoupleMore",
-								"state": true,
-								"label": "A Couple More"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AnAnother",
-								"state": true,
-								"label": "An Another"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AnotherAn",
-								"state": true,
-								"label": "Another An"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ArriveOnWeekday",
-								"state": true,
-								"label": "Arrive On Weekday"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AsIfThough",
-								"state": true,
-								"label": "As If Though"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AvoidAndAlso",
-								"state": true,
-								"label": "Avoid And Also"
-							}
-						},
-						{
-							"Bool": {
-								"name": "CauseItIsBecause",
-								"state": true,
-								"label": "Cause It Is Because"
-							}
-						},
-						{
-							"Bool": {
-								"name": "CondenseAllThe",
-								"state": true,
-								"label": "Condense All The"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Cybersec",
-								"state": true,
-								"label": "Cybersec"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Excellent",
-								"state": true,
-								"label": "Excellent"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandBecause",
-								"state": true,
-								"label": "Expand Because"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandControl",
-								"state": true,
-								"label": "Expand Control"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandForward",
-								"state": true,
-								"label": "Expand Forward"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandMinimum",
-								"state": true,
-								"label": "Expand Minimum"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandPrevious",
-								"state": true,
-								"label": "Expand Previous"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandThrough",
-								"state": true,
-								"label": "Expand Through"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandWith",
-								"state": true,
-								"label": "Expand With"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExpandWithout",
-								"state": true,
-								"label": "Expand Without"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FatalOutcome",
-								"state": true,
-								"label": "Fatal Outcome"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Freezing",
-								"state": true,
-								"label": "Freezing"
-							}
-						},
-						{
-							"Bool": {
-								"name": "KindOf",
-								"state": true,
-								"label": "Kind Of"
-							}
-						},
-						{
-							"Bool": {
-								"name": "RedundantIIRC",
-								"state": true,
-								"label": "Redundant IIRC"
-							}
-						},
-						{
-							"Bool": {
-								"name": "RedundantPretty",
-								"state": true,
-								"label": "Redundant Pretty"
-							}
-						},
-						{
-							"Bool": {
-								"name": "RedundantThat",
-								"state": true,
-								"label": "Redundant That"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SendAnEmailTo",
-								"state": true,
-								"label": "Send An Email To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Starving",
-								"state": true,
-								"label": "Starving"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Towards",
-								"state": true,
-								"label": "Towards"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TrueToWord",
-								"state": true,
-								"label": "True To Word"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WasComprisedOf",
-								"state": true,
-								"label": "Was Comprised Of"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SideTangent",
-								"state": true,
-								"label": "Side Tangent"
-							}
-						}
-					]
-				}
-			}
-		},
-		{
-			"Group": {
-				"label": "Grammar and Agreement",
-				"description": "Catches grammar issues involving agreement, articles, prepositions, verb forms, and sentence structure.",
-				"child": {
-					"settings": [
-						{
-							"Bool": {
-								"name": "AdjectiveDoubleDegree",
-								"state": true,
-								"label": "Adjective Double Degree"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AdjectiveOfA",
-								"state": true,
-								"label": "Adjective Of A"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AskNoPreposition",
-								"state": true,
-								"label": "Ask No Preposition"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DoubleModal",
-								"state": true,
-								"label": "Double Modal"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ForNoun",
-								"state": true,
-								"label": "For Noun"
-							}
-						},
-						{
-							"Bool": {
-								"name": "HowTo",
-								"state": true,
-								"label": "How To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "IfWouldve",
-								"state": true,
-								"label": "If Wouldve"
-							}
-						},
-						{
-							"Bool": {
-								"name": "InflectedVerbAfterTo",
-								"state": true,
-								"label": "Inflected Verb After To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LetToDo",
-								"state": true,
-								"label": "Let To Do"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MassNouns",
-								"state": true,
-								"label": "Mass Nouns"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MissingPreposition",
-								"state": true,
-								"label": "Missing Preposition"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MissingTo",
-								"state": true,
-								"label": "Missing To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ModalBeAdjective",
-								"state": true,
-								"label": "Modal Be Adjective"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ModalOf",
-								"state": true,
-								"label": "Modal Of"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ModalSeem",
-								"state": true,
-								"label": "Modal Seem"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MoreAdjective",
-								"state": true,
-								"label": "More Adjective"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NeedToNoun",
-								"state": true,
-								"label": "Need To Noun"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NominalWants",
-								"state": true,
-								"label": "Nominal Wants"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NounVerbConfusion",
-								"state": true,
-								"label": "Noun Verb Confusion"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ObsessPreposition",
-								"state": true,
-								"label": "Obsess Preposition"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OneAndTheSame",
-								"state": true,
-								"label": "One And The Same"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OneOfTheSingular",
-								"state": true,
-								"label": "One Of The Singular"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OughtToBe",
-								"state": true,
-								"label": "Ought To Be"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PluralWrongWordOfPhrase",
-								"state": true,
-								"label": "Plural Wrong Word Of Phrase"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ProgressiveNeedsBe",
-								"state": true,
-								"label": "Progressive Needs Be"
-							}
-						},
-						{
-							"Bool": {
-								"name": "QuantifierNeedsOf",
-								"state": true,
-								"label": "Quantifier Needs Of"
-							}
-						},
-						{
-							"Bool": {
-								"name": "QuantifierNumeralConflict",
-								"state": true,
-								"label": "Quantifier Numeral Conflict"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ReasonForDoing",
-								"state": true,
-								"label": "Reason For Doing"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SimplePastToPastParticiple",
-								"state": true,
-								"label": "Simple Past To Past Participle"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SingleBe",
-								"state": true,
-								"label": "Single Be"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SomeWithoutArticle",
-								"state": true,
-								"label": "Some Without Article"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TakeALookTo",
-								"state": true,
-								"label": "Take A Look To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TakeMedicine",
-								"state": true,
-								"label": "Take Medicine"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThatThan",
-								"state": true,
-								"label": "That Than"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThatWhich",
-								"state": true,
-								"label": "That Which"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThenThan",
-								"state": true,
-								"label": "Then Than"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThriveOn",
-								"state": true,
-								"label": "Thrive On"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TryOnesHandAt",
-								"state": true,
-								"label": "Try Ones Hand At"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TryOnesLuck",
-								"state": true,
-								"label": "Try Ones Luck"
-							}
-						},
-						{
-							"Bool": {
-								"name": "VerbToAdjective",
-								"state": true,
-								"label": "Verb To Adjective"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WouldNeverHave",
-								"state": true,
-								"label": "Would Never Have"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AfterAWhile",
-								"state": true,
-								"label": "After A While"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AfterAll",
-								"state": true,
-								"label": "After All"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AllReady",
-								"state": true,
-								"label": "All Ready"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AnotherOnes",
-								"state": true,
-								"label": "Another Ones"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AnotherThings",
-								"state": true,
-								"label": "Another Things"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AsEvidentBy",
-								"state": true,
-								"label": "As Evident By"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AsFollows",
-								"state": true,
-								"label": "As Follows"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AsLongAs",
-								"state": true,
-								"label": "As Long As"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Beforehand",
-								"state": true,
-								"label": "Beforehand"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BetterOffPhrase",
-								"state": true,
-								"label": "Better Off Phrase"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DoIAdjective",
-								"state": true,
-								"label": "Do I Adjective"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DontCan",
-								"state": true,
-								"label": "Don't Can"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DoubleNegative",
-								"state": true,
-								"label": "Double Negative"
-							}
-						},
-						{
-							"Bool": {
-								"name": "EachAndEveryOne",
-								"state": true,
-								"label": "Each And Every One"
-							}
-						},
-						{
-							"Bool": {
-								"name": "HadOf",
-								"state": true,
-								"label": "Had Of"
-							}
-						},
-						{
-							"Bool": {
-								"name": "HaveNegNoAny",
-								"state": true,
-								"label": "Have Neg No Any"
-							}
-						},
-						{
-							"Bool": {
-								"name": "HumanBeings",
-								"state": true,
-								"label": "Human Beings"
-							}
-						},
-						{
-							"Bool": {
-								"name": "InAWhile",
-								"state": true,
-								"label": "In A While"
-							}
-						},
-						{
-							"Bool": {
-								"name": "InAnyWay",
-								"state": true,
-								"label": "In Any Way"
-							}
-						},
-						{
-							"Bool": {
-								"name": "InsteadOf",
-								"state": true,
-								"label": "Instead Of"
-							}
-						},
-						{
-							"Bool": {
-								"name": "IsBeenAuxSequence",
-								"state": true,
-								"label": "Is Been Aux Sequence"
-							}
-						},
-						{
-							"Bool": {
-								"name": "KnowNothingVerb",
-								"state": true,
-								"label": "Know Nothing Verb"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LikeAsIf",
-								"state": true,
-								"label": "Like As If"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LookInto",
-								"state": true,
-								"label": "Look Into"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MissingDeterminer",
-								"state": true,
-								"label": "Missing Determiner"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NotBeAfterNot",
-								"state": true,
-								"label": "Not Be After Not"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PartsOfSpeech",
-								"state": true,
-								"label": "Parts Of Speech"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PointsOfView",
-								"state": true,
-								"label": "Points Of View"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PrincipleToPrincipalRoleNoun",
-								"state": true,
-								"label": "Principle To Principal Role Noun"
-							}
-						},
-						{
-							"Bool": {
-								"name": "RelayOnForRely",
-								"state": true,
-								"label": "Relay On For Rely"
-							}
-						},
-						{
-							"Bool": {
-								"name": "RulesOfThumb",
-								"state": true,
-								"label": "Rules Of Thumb"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SameAs",
-								"state": true,
-								"label": "Same As"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ShutdownVerb",
-								"state": true,
-								"label": "Shutdown Verb"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SomebodyElses",
-								"state": true,
-								"label": "Somebody Elses"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThanksALot",
-								"state": true,
-								"label": "Thanks A Lot"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TheAnother",
-								"state": true,
-								"label": "The Another"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThereMissingIsClause",
-								"state": true,
-								"label": "There Missing Is Clause"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThinkKnowOff",
-								"state": true,
-								"label": "Think Know Off"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThreatenVerb",
-								"state": true,
-								"label": "Threaten Verb"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ToGreatLengths",
-								"state": true,
-								"label": "To Great Lengths"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ToWorryAbout",
-								"state": true,
-								"label": "To Worry About"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TomorrowPossessiveModifier",
-								"state": true,
-								"label": "Tomorrow Possessive Modifier"
-							}
-						},
-						{
-							"Bool": {
-								"name": "VeryLess",
-								"state": true,
-								"label": "Very Less"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WantBe",
-								"state": true,
-								"label": "Want Be"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WillContain",
-								"state": true,
-								"label": "Will Contain"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WillNonLemma",
-								"state": true,
-								"label": "Will Non Lemma"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AspireTo",
-								"state": true,
-								"label": "Aspire To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "CodeInWriteIn",
-								"state": true,
-								"label": "Code In Write In"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThereIsAgreement",
-								"state": true,
-								"label": "There Is Agreement"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ASomeTime",
-								"state": true,
-								"label": "A Some Time"
-							}
-						}
-					]
-				}
-			}
-		},
-		{
-			"Group": {
-				"label": "Word Choice and Usage",
-				"description": "Suggests more standard or idiomatic wording when a phrase is technically understandable but poorly chosen.",
-				"child": {
-					"settings": [
-						{
-							"Bool": {
-								"name": "AllowTo",
-								"state": true,
-								"label": "Allow To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ArriveTo",
-								"state": true,
-								"label": "Arrive To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AvoidCurses",
-								"state": true,
-								"label": "Avoid Curses"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BeAllowed",
-								"state": true,
-								"label": "Be Allowed"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BeBiased",
-								"state": true,
-								"label": "Be Biased"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BeConcerned",
-								"state": true,
-								"label": "Be Concerned"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BePrejudiced",
-								"state": true,
-								"label": "Be Prejudiced"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BeShocked",
-								"state": true,
-								"label": "Be Shocked"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BeWorried",
-								"state": true,
-								"label": "Be Worried"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Bought",
-								"state": true,
-								"label": "Bought"
-							}
-						},
-						{
-							"Bool": {
-								"name": "CallThem",
-								"state": true,
-								"label": "Call Them"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BrandBrandish",
-								"state": true,
-								"label": "Brand Brandish"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ByAccident",
-								"state": true,
-								"label": "By Accident"
-							}
-						},
-						{
-							"Bool": {
-								"name": "CautionaryTale",
-								"state": true,
-								"label": "Cautionary Tale"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ChangeTack",
-								"state": true,
-								"label": "Change Tack"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ChockFull",
-								"state": true,
-								"label": "Chock Full"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Confident",
-								"state": true,
-								"label": "Confident"
-							}
-						},
-						{
-							"Bool": {
-								"name": "CureFor",
-								"state": true,
-								"label": "Cure For"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DoMistake",
-								"state": true,
-								"label": "Do Mistake"
-							}
-						},
-						{
-							"Bool": {
-								"name": "EverEvery",
-								"state": true,
-								"label": "Ever Every"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Everyday",
-								"state": true,
-								"label": "Everyday"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ExceptOf",
-								"state": true,
-								"label": "Except Of"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FarBeIt",
-								"state": true,
-								"label": "Far Be It"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FascinatedBy",
-								"state": true,
-								"label": "Fascinated By"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FeelFell",
-								"state": true,
-								"label": "Feel Fell"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FirstAidKit",
-								"state": true,
-								"label": "First Aid Kit"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FleshOutVsFullFledged",
-								"state": true,
-								"label": "Flesh Out Vs Full Fledged"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FreePredicate",
-								"state": true,
-								"label": "Free Predicate"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FriendOfMe",
-								"state": true,
-								"label": "Friend Of Me"
-							}
-						},
-						{
-							"Bool": {
-								"name": "GoodAt",
-								"state": true,
-								"label": "Good At"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Handful",
-								"state": true,
-								"label": "Handful"
-							}
-						},
-						{
-							"Bool": {
-								"name": "HelloGreeting",
-								"state": true,
-								"label": "Hello Greeting"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Hereby",
-								"state": true,
-								"label": "Hereby"
-							}
-						},
-						{
-							"Bool": {
-								"name": "HopHope",
-								"state": true,
-								"label": "Hop Hope"
-							}
-						},
-						{
-							"Bool": {
-								"name": "InterestedIn",
-								"state": true,
-								"label": "Interested In"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ItLooksLikeThat",
-								"state": true,
-								"label": "It Looks Like That"
-							}
-						},
-						{
-							"Bool": {
-								"name": "JealousOf",
-								"state": true,
-								"label": "Jealous Of"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LeadRiseTo",
-								"state": true,
-								"label": "Lead Rise To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LeftRightHand",
-								"state": true,
-								"label": "Left Right Hand"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LessWorse",
-								"state": true,
-								"label": "Less Worse"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Likewise",
-								"state": true,
-								"label": "Likewise"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LookDownOnesNose",
-								"state": true,
-								"label": "Look Down Ones Nose"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LookingForwardTo",
-								"state": true,
-								"label": "Looking Forward To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LookForwardTo",
-								"state": true,
-								"label": "Look Forward To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MeansALotTo",
-								"state": true,
-								"label": "Means A Lot To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MixedBag",
-								"state": true,
-								"label": "Mixed Bag"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NoLonger",
-								"state": true,
-								"label": "No Longer"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NoMatchFor",
-								"state": true,
-								"label": "No Match For"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NumericRangeEnDash",
-								"state": true,
-								"label": "Numeric Range En Dash"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Nobody",
-								"state": true,
-								"label": "Nobody"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OfCourse",
-								"state": true,
-								"label": "Of Course"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OldestInTheBook",
-								"state": true,
-								"label": "Oldest In The Book"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OnFloor",
-								"state": true,
-								"label": "On Floor"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OnceOrTwice",
-								"state": true,
-								"label": "Once Or Twice"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OutOfDate",
-								"state": true,
-								"label": "Out Of Date"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Oxymorons",
-								"state": true,
-								"label": "Oxymorons"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PiqueInterest",
-								"state": true,
-								"label": "Pique Interest"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Respond",
-								"state": true,
-								"label": "Respond"
-							}
-						},
-						{
-							"Bool": {
-								"name": "RightClick",
-								"state": true,
-								"label": "Right Click"
-							}
-						},
-						{
-							"Bool": {
-								"name": "RiseTheRanks",
-								"state": true,
-								"label": "Rise The Ranks"
-							}
-						},
-						{
-							"Bool": {
-								"name": "RollerSkated",
-								"state": true,
-								"label": "Roller Skated"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SafeToSave",
-								"state": true,
-								"label": "Safe To Save"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SaveToSafe",
-								"state": true,
-								"label": "Save To Safe"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SomethingIs",
-								"state": true,
-								"label": "Something Is"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SomewhatSomething",
-								"state": true,
-								"label": "Somewhat Something"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SoonToBe",
-								"state": true,
-								"label": "Soon To Be"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SoughtAfter",
-								"state": true,
-								"label": "Sought After"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ToAdverb",
-								"state": true,
-								"label": "To Adverb"
-							}
-						},
-						{
-							"Bool": {
-								"name": "UpdatePlaceNames",
-								"state": true,
-								"label": "Update Place Names"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ViceVersa",
-								"state": true,
-								"label": "Vice Versa"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WasAloud",
-								"state": true,
-								"label": "Was Aloud"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WellEducated",
-								"state": true,
-								"label": "Well Educated"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WinPrize",
-								"state": true,
-								"label": "Win Prize"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WishCould",
-								"state": true,
-								"label": "Wish Could"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WorthToDo",
-								"state": true,
-								"label": "Worth To Do"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AheadAnd",
-								"state": true,
-								"label": "Ahead And"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AllOfASudden",
-								"state": true,
-								"label": "All Of A Sudden"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Alongside",
-								"state": true,
-								"label": "Alongside"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AlzheimersDisease",
-								"state": true,
-								"label": "Alzheimers Disease"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AsFarBackAs",
-								"state": true,
-								"label": "As Far Back As"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AsItHappens",
-								"state": true,
-								"label": "As It Happens"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AsOfCurrently",
-								"state": true,
-								"label": "As Of Currently"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AsOfLately",
-								"state": true,
-								"label": "As Of Lately"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AsOpposedTo",
-								"state": true,
-								"label": "As Opposed To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AtFaceValue",
-								"state": true,
-								"label": "At Face Value"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AtTheBestOfTimes",
-								"state": true,
-								"label": "At The Best Of Times"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AtTheEndOfTheDay",
-								"state": true,
-								"label": "At The End Of The Day"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AtTheExpenseOf",
-								"state": true,
-								"label": "At The Expense Of"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AwareOf",
-								"state": true,
-								"label": "Aware Of"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BadRap",
-								"state": true,
-								"label": "Bad Rap"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BanTogether",
-								"state": true,
-								"label": "Ban Together"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BareInMind",
-								"state": true,
-								"label": "Bare In Mind"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BatedBreath",
-								"state": true,
-								"label": "Bated Breath"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BeckAndCall",
-								"state": true,
-								"label": "Beck And Call"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BesideThePoint",
-								"state": true,
-								"label": "Beside The Point"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BewareOf",
-								"state": true,
-								"label": "Beware Of"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BlacklistWhitelist",
-								"state": true,
-								"label": "Blacklist Whitelist"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BlanketStatement",
-								"state": true,
-								"label": "Blanket Statement"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Brutality",
-								"state": true,
-								"label": "Brutality"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ComprisesOf",
-								"state": true,
-								"label": "Comprises Of"
-							}
-						},
-						{
-							"Bool": {
-								"name": "CoursingThroughVeins",
-								"state": true,
-								"label": "Coursing Through Veins"
-							}
-						},
-						{
-							"Bool": {
-								"name": "CuttingAgeEggcorn",
-								"state": true,
-								"label": "Cutting Age Eggcorn"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DampSquib",
-								"state": true,
-								"label": "Damp Squib"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DoToDueTo",
-								"state": true,
-								"label": "Do To Due To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DueDiligence",
-								"state": true,
-								"label": "Due Diligence"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DuringAges",
-								"state": true,
-								"label": "During Ages"
-							}
-						},
-						{
-							"Bool": {
-								"name": "EggYolk",
-								"state": true,
-								"label": "Egg Yolk"
-							}
-						},
-						{
-							"Bool": {
-								"name": "EnMasse",
-								"state": true,
-								"label": "En Masse"
-							}
-						},
-						{
-							"Bool": {
-								"name": "EnRoute",
-								"state": true,
-								"label": "En Route"
-							}
-						},
-						{
-							"Bool": {
-								"name": "EveryOnceAndAgain",
-								"state": true,
-								"label": "Every Once And Again"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FairBit",
-								"state": true,
-								"label": "Fair Bit"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FarAndFewBetween",
-								"state": true,
-								"label": "Far And Few Between"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FastPaste",
-								"state": true,
-								"label": "Fast Paste"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ForArgumentsSake",
-								"state": true,
-								"label": "For Arguments Sake"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ForTheMostPart",
-								"state": true,
-								"label": "For The Most Part"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FreeRein",
-								"state": true,
-								"label": "Free Rein"
-							}
-						},
-						{
-							"Bool": {
-								"name": "GildedAge",
-								"state": true,
-								"label": "Gilded Age"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Haphazard",
-								"state": true,
-								"label": "Haphazard"
-							}
-						},
-						{
-							"Bool": {
-								"name": "HiddenIn",
-								"state": true,
-								"label": "Hidden In"
-							}
-						},
-						{
-							"Bool": {
-								"name": "HungerPang",
-								"state": true,
-								"label": "Hunger Pang"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ImitateFrom",
-								"state": true,
-								"label": "Imitate From"
-							}
-						},
-						{
-							"Bool": {
-								"name": "InAHurry",
-								"state": true,
-								"label": "In A Hurry"
-							}
-						},
-						{
-							"Bool": {
-								"name": "InNeedOf",
-								"state": true,
-								"label": "In Need Of"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Initiatively",
-								"state": true,
-								"label": "Initiatively"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Insensitive",
-								"state": true,
-								"label": "Insensitive"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Insurmountable",
-								"state": true,
-								"label": "Insurmountable"
-							}
-						},
-						{
-							"Bool": {
-								"name": "JawDropping",
-								"state": true,
-								"label": "Jaw Dropping"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LastButNotLeast",
-								"state": true,
-								"label": "Last But Not Least"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LastNight",
-								"state": true,
-								"label": "Last Night"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LaughOfAt",
-								"state": true,
-								"label": "Laugh Of At"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LeaveToFor",
-								"state": true,
-								"label": "Leave To For"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LikeThePlague",
-								"state": true,
-								"label": "Like The Plague"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LikeTheresNoTomorrow",
-								"state": true,
-								"label": "Like Theres No Tomorrow"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LikelyHood",
-								"state": true,
-								"label": "Likely Hood"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LowHangingFruit",
-								"state": true,
-								"label": "Low Hanging Fruit"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ManagerialReins",
-								"state": true,
-								"label": "Managerial Reins"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Monumentous",
-								"state": true,
-								"label": "Monumentous"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NerveRacking",
-								"state": true,
-								"label": "Nerve Racking"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OldWivesTale",
-								"state": true,
-								"label": "Old Wives Tale"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OnFirstGlance",
-								"state": true,
-								"label": "On First Glance"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OnTheSpurOfTheMoment",
-								"state": true,
-								"label": "On The Spur Of The Moment"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OnTopOf",
-								"state": true,
-								"label": "On Top Of"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OnceInAWhile",
-								"state": true,
-								"label": "Once In A While"
-							}
-						},
-						{
-							"Bool": {
-								"name": "OneFellSwoop",
-								"state": true,
-								"label": "One Fell Swoop"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PeaceOfMind",
-								"state": true,
-								"label": "Peace Of Mind"
-							}
-						},
-						{
-							"Bool": {
-								"name": "PrayingMantis",
-								"state": true,
-								"label": "Praying Mantis"
-							}
-						},
-						{
-							"Bool": {
-								"name": "QuiteMany",
-								"state": true,
-								"label": "Quite Many"
-							}
-						},
-						{
-							"Bool": {
-								"name": "RealTrouper",
-								"state": true,
-								"label": "Real Trouper"
-							}
-						},
-						{
-							"Bool": {
-								"name": "RifeWith",
-								"state": true,
-								"label": "Rife With"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ScantilyClad",
-								"state": true,
-								"label": "Scantily Clad"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SimilarLike",
-								"state": true,
-								"label": "Similar Like"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SimpleGrammatical",
-								"state": true,
-								"label": "Simple Grammatical"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SneakPeekPreview",
-								"state": true,
-								"label": "Sneak Peek Preview"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SneakingSuspicion",
-								"state": true,
-								"label": "Sneaking Suspicion"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SoonerOrLater",
-								"state": true,
-								"label": "Sooner Or Later"
-							}
-						},
-						{
-							"Bool": {
-								"name": "StatuteOfLimitations",
-								"state": true,
-								"label": "Statute Of Limitations"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SufficeItToSay",
-								"state": true,
-								"label": "Suffice It To Say"
-							}
-						},
-						{
-							"Bool": {
-								"name": "SupposedTo",
-								"state": true,
-								"label": "Supposed To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TakeItPersonally",
-								"state": true,
-								"label": "Take It Personally"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThatChallenged",
-								"state": true,
-								"label": "That Challenged"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TheDifferenceBetween",
-								"state": true,
-								"label": "The Difference Between"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TheWhetherWeather",
-								"state": true,
-								"label": "The Whether Weather"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ToBackOut",
-								"state": true,
-								"label": "To Back Out"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ToTheMannerBorn",
-								"state": true,
-								"label": "To The Manner Born"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TongueInCheek",
-								"state": true,
-								"label": "Tongue In Cheek"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Unless",
-								"state": true,
-								"label": "Unless"
-							}
-						},
-						{
-							"Bool": {
-								"name": "VeryKnown",
-								"state": true,
-								"label": "Very Known"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WaveFunction",
-								"state": true,
-								"label": "Wave Function"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WellKept",
-								"state": true,
-								"label": "Well Kept"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WroughtIron",
-								"state": true,
-								"label": "Wrought Iron"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Damages",
-								"state": true,
-								"label": "Damages"
-							}
-						},
-						{
-							"Bool": {
-								"name": "WebScraping",
-								"state": true,
-								"label": "Web Scraping"
-							}
-						},
-						{
-							"Bool": {
-								"name": "MoreThanMeetsTheEye",
-								"state": true,
-								"label": "More Than Meets The Eye"
-							}
-						},
-						{
-							"Bool": {
-								"name": "InFavourOfDoing",
-								"state": true,
-								"label": "In Favour Of Doing"
-							}
-						},
-						{
-							"Bool": {
-								"name": "InHindsight",
-								"state": true,
-								"label": "In Hindsight"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LongTimeAgo",
-								"state": true,
-								"label": "Long Time Ago"
-							}
-						}
-					]
-				}
-			}
-		},
-		{
-			"Group": {
-				"label": "Regionalisms and Dialect",
-				"description": "Groups dialect-sensitive wording and regional usage that may not fit the selected audience.",
-				"child": {
-					"settings": [
-						{
-							"Bool": {
-								"name": "Regionalisms",
-								"state": true,
-								"label": "Regionalisms"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Touristic",
-								"state": true,
-								"label": "Touristic"
-							}
-						}
-					]
-				}
-			}
-		},
-		{
-			"Group": {
-				"label": "Miscellaneous",
-				"description": "A catch-all for rules that do not fit neatly into the other categories but are still useful to surface.",
-				"child": {
-					"settings": [
-						{
-							"Bool": {
-								"name": "APart",
-								"state": true,
-								"label": "A Part"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AWhile",
-								"state": true,
-								"label": "A While"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Addicting",
-								"state": true,
-								"label": "Addicting"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AfterLater",
-								"state": true,
-								"label": "After Later"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AllHellBreakLoose",
-								"state": true,
-								"label": "All Hell Break Loose"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AllIntentsAndPurposes",
-								"state": true,
-								"label": "All Intents And Purposes"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AmInTheMorning",
-								"state": true,
-								"label": "Am In The Morning"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AmountsFor",
-								"state": true,
-								"label": "Amounts For"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AnA",
-								"state": true,
-								"label": "An A"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AndIn",
-								"state": true,
-								"label": "And In"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AndTheLike",
-								"state": true,
-								"label": "And The Like"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AnotherThingComing",
-								"state": true,
-								"label": "Another Thing Coming"
-							}
-						},
-						{
-							"Bool": {
-								"name": "AnotherThinkComing",
-								"state": false,
-								"label": "Another Think Coming"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ApartFrom",
-								"state": true,
-								"label": "Apart From"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BackInTheDay",
-								"state": true,
-								"label": "Back In The Day"
-							}
-						},
-						{
-							"Bool": {
-								"name": "BehindTheScenes",
-								"state": true,
-								"label": "Behind The Scenes"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Cant",
-								"state": true,
-								"label": "Can't"
-							}
-						},
-						{
-							"Bool": {
-								"name": "CriteriaPhenomena",
-								"state": true,
-								"label": "Criteria Phenomena"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DespiteItIs",
-								"state": true,
-								"label": "Despite It Is"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DespiteOf",
-								"state": true,
-								"label": "Despite Of"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DidPast",
-								"state": true,
-								"label": "Did Past"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Didnt",
-								"state": true,
-								"label": "Didn't"
-							}
-						},
-						{
-							"Bool": {
-								"name": "DisjointPrefixes",
-								"state": true,
-								"label": "Disjoint Prefixes"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FedUpWith",
-								"state": true,
-								"label": "Fed Up With"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FindFine",
-								"state": true,
-								"label": "Find Fine"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FindOut",
-								"state": true,
-								"label": "Find Out"
-							}
-						},
-						{
-							"Bool": {
-								"name": "GoSoFarAsTo",
-								"state": true,
-								"label": "Go So Far As To"
-							}
-						},
-						{
-							"Bool": {
-								"name": "GoToWar",
-								"state": true,
-								"label": "Go To War"
-							}
-						},
-						{
-							"Bool": {
-								"name": "HaveTakeALook",
-								"state": true,
-								"label": "Have Take A Look"
-							}
-						},
-						{
-							"Bool": {
-								"name": "InOnTheCards",
-								"state": true,
-								"label": "In On The Cards"
-							}
-						},
-						{
-							"Bool": {
-								"name": "LetsConfusion",
-								"state": true,
-								"label": "Lets Confusion"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NailOnTheHead",
-								"state": true,
-								"label": "Nail On The Head"
-							}
-						},
-						{
-							"Bool": {
-								"name": "NotOnlyInversion",
-								"state": true,
-								"label": "Not Only Inversion"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ShootOneselfInTheFoot",
-								"state": true,
-								"label": "Shoot Oneself In The Foot"
-							}
-						},
-						{
-							"Bool": {
-								"name": "TheHowWhy",
-								"state": true,
-								"label": "The How Why"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThePointFor",
-								"state": true,
-								"label": "The Point For"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThesesThese",
-								"state": true,
-								"label": "Theses These"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThingThink",
-								"state": true,
-								"label": "Thing Think"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThisTypeOfThing",
-								"state": true,
-								"label": "This Type Of Thing"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThoughThought",
-								"state": true,
-								"label": "Though Thought"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThrowAway",
-								"state": true,
-								"label": "Throw Away"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ThrowRubbish",
-								"state": true,
-								"label": "Throw Rubbish"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ToTwoToo",
-								"state": true,
-								"label": "To Two Too"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ViciousCircle",
-								"state": true,
-								"label": "Vicious Circle"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ViciousCircleOrCycle",
-								"state": false,
-								"label": "Vicious Circle Or Cycle"
-							}
-						},
-						{
-							"Bool": {
-								"name": "ViciousCycle",
-								"state": false,
-								"label": "Vicious Cycle"
-							}
-						},
-						{
-							"Bool": {
-								"name": "Whereas",
-								"state": true,
-								"label": "Whereas"
-							}
-						},
-						{
-							"Bool": {
-								"name": "FondOn",
-								"state": true,
-								"label": "Fond On"
-							}
-						}
-					]
-				}
-			}
-		}
-	]
+  "settings": [
+    {
+      "Group": {
+        "label": "Proper Nouns",
+        "description": "Checks names of places, organizations, products, and other proper nouns that should keep their standard capitalization.",
+        "child": {
+          "settings": [
+            {
+              "Bool": {
+                "name": "Americas",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Australia",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OceansAndSeas",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Canada",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Laos",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Malaysia",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Countries",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NationalCapitals",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ChineseCommunistParty",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "UnitedOrganizations",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Holidays",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Koreas",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AmazonNames",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "GoogleNames",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AzureNames",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MicrosoftNames",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AppleNames",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MetaNames",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "JetpackNames",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TumblrNames",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PocketCastsNames",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DayOneNames",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "USUniversities",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NotablePlaces",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ProperNouns",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "CompaniesProductsAndTrademarks",
+                "state": true
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "Group": {
+        "label": "Initialisms",
+        "description": "Covers abbreviated forms and initialisms that should use the expected letter casing or punctuation.",
+        "child": {
+          "settings": [
+            {
+              "Bool": {
+                "name": "AsFarAsIKnow",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AsSoonAsPossible",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BeRightBack",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ByTheWay",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExplainLikeImFive",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ForWhatItsWorth",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ForYourInformation",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "IDontKnow",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "IfIRecallCorrectly",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "IfIUnderstandCorrectly",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "IfYouKnowYouKnow",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "InCaseYouMissedIt",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "InMyHumbleOpinion",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "InMyOpinion",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "InRealLife",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NeverMind",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OhMyGod",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PleaseTakeALook",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Really",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TalkToYouLater",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ToBeHonest",
+                "state": true
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "Group": {
+        "label": "Closed Compounds",
+        "description": "Flags compound words that should be written as a single closed form instead of split apart.",
+        "child": {
+          "settings": [
+            {
+              "Bool": {
+                "name": "Anybody",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Anyhow",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Anywhere",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Backplane",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Bypass",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Chalkboard",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Deadlift",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Desktop",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Devops",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Everybody",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Everyone",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Everywhere",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Furthermore",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Henceforth",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "However",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Insofar",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Instead",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Intact",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Itself",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Keystroke",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Keystrokes",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Laptop",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Meanwhile",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Middleware",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Misunderstand",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Misunderstood",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Misuse",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Misused",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Multicore",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Multimedia",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Multithreading",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Myself",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Nonetheless",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Nothing",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Notwithstanding",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Nowhere",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Overall",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Overclocking",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Overload",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Overnight",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Postpone",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Proofread",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Regardless",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Shortcoming",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Shortcomings",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Somebody",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Somehow",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Someone",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Somewhere",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "There",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Therefore",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Thereupon",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Underclock",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Upset",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Upward",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Whereupon",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Widespread",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Without",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Worldwide",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Worthwhile",
+                "state": true
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "Group": {
+        "label": "Phrase Corrections",
+        "description": "Collects common phrase-level fixes where a standard expression is preferred over a mistaken variant.",
+        "child": {
+          "settings": [
+            {
+              "Bool": {
+                "name": "Ado",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AtAllCosts",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ArgumentToBeMade",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Bollocks",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ChampAtTheBit",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ClientOrServerSide",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "CompulseToCompel",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ConfirmThat",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DefiniteArticle",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DigestiveTract",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Discuss",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DoesOrDose",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandArgument",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandDependencies",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandDeref",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandParameter",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandPointer",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandStandardInputAndOutput",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExplanationMark",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExtendOrExtent",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FlauntForFlout",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FoamAtTheMouth",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FootTheBill",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "GetUsedTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "GrindToAHalt",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "HavePassed",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "HitTheNailOnTheHead",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "HomeInOn",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "InDetail",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "InvestIn",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LayoutVerb",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LitotesDirectPositive",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MakeDoWith",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MakeSense",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MootPoint",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OperatingSystem",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PassersBy",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PeekBehindTheCurtain",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Piggyback",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "RedundantSuperlatives",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ResponsibilityFor",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ScapeGoat",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SeamToSeem",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SubjunctiveWasToWere",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "UseToUsedTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WreakHavoc",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "VerseAsVerb",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WroteToRote",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AwaitFor",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "CommitmentTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Copyright",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DateBackFrom",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DoubleEdgedSword",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandAlloc",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandDecl",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Expat",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Expatriate",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "GetRidOf",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "HolyWar",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "HowItLooksLike",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MakeItSeem",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NervousWreck",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NotOnly",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Payed",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "RiseTheQuestion",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ToTooIdioms",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TooTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WholeEntire",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WorseOrWorst",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandGovt",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "InflectionPoint",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FormativeYears",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandAlgorithm",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandCoordinate",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandNotification",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandVulnerability",
+                "state": true
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "Group": {
+        "label": "Capitalization and Case",
+        "description": "Catches capitalization and casing issues in titles, sentences, brands, and other case-sensitive text.",
+        "child": {
+          "settings": [
+            {
+              "Bool": {
+                "name": "CapitalizePersonalPronouns",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "JohnsHopkins",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NumberSuffixCapitalization",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SentenceCapitalization",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TheProperNounPossessive",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "UseTitleCase",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WordPressDotcom",
+                "state": true,
+                "label": "WordPress Dotcom"
+              }
+            },
+            {
+              "Bool": {
+                "name": "ColdModalTypo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "GoggleBrand",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "YeaToYeah",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "YehToYeah",
+                "state": true
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "Group": {
+        "label": "Punctuation and Spacing",
+        "description": "Handles punctuation marks, apostrophes, quotation marks, commas, and spacing conventions.",
+        "child": {
+          "settings": [
+            {
+              "Bool": {
+                "name": "CommaFixes",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Dashes",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DotInitialisms",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "EllipsisLength",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "UseEllipsisCharacter",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NoFrenchSpaces",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NoOxfordComma",
+                "state": false
+              }
+            },
+            {
+              "Bool": {
+                "name": "OxfordComma",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "QuoteSpacing",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Spaces",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TransposedSpace",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "UnclosedQuotes",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WrongApostrophe",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AOkHyphen",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BluRayHyphen",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "CantWay",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "CaseSensitive",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ClickThroughRate",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DoubleCheckHyphen",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "EagleEyed",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "EverPresent",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FaceFirst",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FirstPersonModifierHyphen",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FromTheGetGo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "GuineaBissau",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "IntroCueCommaBeforeThanks",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "IncludingButNotLimitedToPunctuation",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MercedesBenzHyphen",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OffTheCuff",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OneHanded",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PasswordProtectedHyphen",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PortAuPrince",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PortoNovo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PostItNoteHyphen",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "RainbowColoredHyphen",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "RapidFire",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ToDoHyphen",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WellBeing",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WorstCaseScenario",
+                "state": true
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "Group": {
+        "label": "Numbers and Units",
+        "description": "Checks how numbers, dates, times, decades, and measurement units are written.",
+        "child": {
+          "settings": [
+            {
+              "Bool": {
+                "name": "BestOfAllTime",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "CorrectNumberSuffix",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "CurrencyPlacement",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DayAndAge",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandMemoryShorthands",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandPeople",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandTimeShorthands",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FewUnitsOfTimeAgo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "HyphenateNumberDay",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "InTimeFromNow",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Months",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MostNumber",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MostOfTheTimes",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SinceDuration",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SpelledNumbers",
+                "state": false
+              }
+            },
+            {
+              "Bool": {
+                "name": "PluralDecades",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ALongTime",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DegreesKelvin",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DegreesKelvinSymbol",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "EveryTime",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ForALongTime",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "HalfAnHour",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ItTimeAuxiliary",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LinesOfCode",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OnSecondThought",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TickingTimeClock",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ToSomeDegree",
+                "state": true
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "Group": {
+        "label": "Pronouns and Possession",
+        "description": "Focuses on pronouns, contractions, possessives, and related agreement problems.",
+        "child": {
+          "settings": [
+            {
+              "Bool": {
+                "name": "ElsePossessive",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "HavePronoun",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "IAmAgreement",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ItsContraction",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ItsPossessive",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MultipleSequentialPronouns",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NorModalPronoun",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PossessiveNoun",
+                "state": false
+              }
+            },
+            {
+              "Bool": {
+                "name": "PossessiveYour",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PronounAre",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PronounContraction",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PronounInflectionBe",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PronounKnew",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PronounVerbAgreement",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SubjectPronoun",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TheMy",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThereOwn",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Theres",
+                "state": true,
+                "label": "There's"
+              }
+            },
+            {
+              "Bool": {
+                "name": "TheyreConfusions",
+                "state": true,
+                "label": "They're Confusions"
+              }
+            },
+            {
+              "Bool": {
+                "name": "WereWhere",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WhomSubjectOfVerb",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "EachOthersPossessive",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "HeDos",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "HeartToHeard",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "IAm",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "IDo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "InOfItself",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MyHouse",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NeedHelp",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TheirToThere",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TheirToTheyre",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThereToTheir",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TheyToThem",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TheyreToTheir",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WhetYourAppetite",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "YourOutClauseAgreement",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "YourPredicateAdjective",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Yourself",
+                "state": true
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "Group": {
+        "label": "Compounds and Hyphenation",
+        "description": "Covers hyphenation and multi-word compounds that should be open, closed, or hyphenated.",
+        "child": {
+          "settings": [
+            {
+              "Bool": {
+                "name": "CompoundNouns",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "CompoundSubjectI",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DoubleClick",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MergeWords",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OpenCompounds",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OpenTheLight",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PhrasalVerbAsCompoundNoun",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SplitWords",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BuiltIn",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "EasyGoingCompoundAdjective",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LastDitch",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MakeupCompoundNoun",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OvertimeCompoundNoun",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "RoadMap",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "StateOfTheArt",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThereAfterCompound",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WokVerbTypo",
+                "state": true
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "Group": {
+        "label": "Spelling and Orthography",
+        "description": "Flags misspellings, orthographic inconsistencies, and word forms that are spelled the wrong way.",
+        "child": {
+          "settings": [
+            {
+              "Bool": {
+                "name": "Misspell",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OrthographicConsistency",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "RegularIrregulars",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SneakedSnuck",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OkToOkay",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SpellCheck",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AdNauseam",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Albeit",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AllThough",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AtLeasToLeast",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AtLestToLeast",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BeenThere",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BestRegards",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BetterOffWith",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "CanBeSeen",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "CaseInPoint",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DoNotWant",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "EludedTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "EverSince",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExitedExcitedContext",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FetalPosition",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ForAWhile",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "GoingTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "HowMach",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "HumanLife",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "InLieuOf",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "InThe",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "IsKnownFor",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ItCan",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "IveGotTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "JustDeserts",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "KindRegards",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "KindSortOf",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LetAlone",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LooksLikes",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MoreThatLikely",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NobelPeacePrize",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NotIn",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NotTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NowWay",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OutOfSync",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PedalToTheMetal",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PerSe",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PleasRequestVerb",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "RallyToReally",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SomeOfThe",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SpecialAttention",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SpinalChord",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "StrikeChord",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThatThis",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "The",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThieveNoun",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThoughtProcess",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ToLoseTooLoose",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TrialAndError",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TuffEnough",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TurnItOff",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WithoutOut",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "CloseTightKnit",
+                "state": true
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "Group": {
+        "label": "Style and Redundancy",
+        "description": "Highlights wordy, repetitive, or overly weak phrasing that can usually be tightened up.",
+        "child": {
+          "settings": [
+            {
+              "Bool": {
+                "name": "BoringWords",
+                "state": false
+              }
+            },
+            {
+              "Bool": {
+                "name": "DiscourseMarkers",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FillerWords",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Hedging",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LongSentences",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MoreBetter",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "QuiteQuiet",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "RedundantAcronyms",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "RedundantAdditiveAdverbs",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "RedundantProgressiveComparative",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "RepeatedWords",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "VeryUnique",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WayTooAdjective",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WidelyAccepted",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MultipleFrequencyAdverbs",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ACoupleMore",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AnAnother",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AnotherAn",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ArriveOnWeekday",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AsIfThough",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AvoidAndAlso",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "CauseItIsBecause",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "CondenseAllThe",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Cybersec",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Excellent",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandBecause",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandControl",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandForward",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandMinimum",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandPrevious",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandThrough",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandWith",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExpandWithout",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FatalOutcome",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Freezing",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "KindOf",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "RedundantIIRC",
+                "state": true,
+                "label": "Redundant IIRC"
+              }
+            },
+            {
+              "Bool": {
+                "name": "RedundantPretty",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "RedundantThat",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SendAnEmailTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Starving",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Towards",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TrueToWord",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WasComprisedOf",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SideTangent",
+                "state": true
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "Group": {
+        "label": "Grammar and Agreement",
+        "description": "Catches grammar issues involving agreement, articles, prepositions, verb forms, and sentence structure.",
+        "child": {
+          "settings": [
+            {
+              "Bool": {
+                "name": "AdjectiveDoubleDegree",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AdjectiveOfA",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AskNoPreposition",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DoubleModal",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ForNoun",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "HowTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "IfWouldve",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "InflectedVerbAfterTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LetToDo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MassNouns",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MissingPreposition",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MissingTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ModalBeAdjective",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ModalOf",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ModalSeem",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MoreAdjective",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NeedToNoun",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NominalWants",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NounVerbConfusion",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ObsessPreposition",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OneAndTheSame",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OneOfTheSingular",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OughtToBe",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PluralWrongWordOfPhrase",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ProgressiveNeedsBe",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "QuantifierNeedsOf",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "QuantifierNumeralConflict",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ReasonForDoing",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SimplePastToPastParticiple",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SingleBe",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SomeWithoutArticle",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TakeALookTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TakeMedicine",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThatThan",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThatWhich",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThenThan",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThriveOn",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TryOnesHandAt",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TryOnesLuck",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "VerbToAdjective",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WouldNeverHave",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AfterAWhile",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AfterAll",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AllReady",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AnotherOnes",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AnotherThings",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AsEvidentBy",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AsFollows",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AsLongAs",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Beforehand",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BetterOffPhrase",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DoIAdjective",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DontCan",
+                "state": true,
+                "label": "Don't Can"
+              }
+            },
+            {
+              "Bool": {
+                "name": "DoubleNegative",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "EachAndEveryOne",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "HadOf",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "HaveNegNoAny",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "HumanBeings",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "InAWhile",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "InAnyWay",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "InsteadOf",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "IsBeenAuxSequence",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "KnowNothingVerb",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LikeAsIf",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LookInto",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MissingDeterminer",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NotBeAfterNot",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PartsOfSpeech",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PointsOfView",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PrincipleToPrincipalRoleNoun",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "RelayOnForRely",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "RulesOfThumb",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SameAs",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ShutdownVerb",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SomebodyElses",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThanksALot",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TheAnother",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThereMissingIsClause",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThinkKnowOff",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThreatenVerb",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ToGreatLengths",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ToWorryAbout",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TomorrowPossessiveModifier",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "VeryLess",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WantBe",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WillContain",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WillNonLemma",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AspireTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "CodeInWriteIn",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThereIsAgreement",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ASomeTime",
+                "state": true
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "Group": {
+        "label": "Word Choice and Usage",
+        "description": "Suggests more standard or idiomatic wording when a phrase is technically understandable but poorly chosen.",
+        "child": {
+          "settings": [
+            {
+              "Bool": {
+                "name": "AllowTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ArriveTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AvoidCurses",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BeAllowed",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BeBiased",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BeConcerned",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BePrejudiced",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BeShocked",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BeWorried",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Bought",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "CallThem",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BrandBrandish",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ByAccident",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "CautionaryTale",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ChangeTack",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ChockFull",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Confident",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "CureFor",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DoMistake",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "EverEvery",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Everyday",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ExceptOf",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FarBeIt",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FascinatedBy",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FeelFell",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FirstAidKit",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FleshOutVsFullFledged",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FreePredicate",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FriendOfMe",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "GoodAt",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Handful",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "HelloGreeting",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Hereby",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "HopHope",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "InterestedIn",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ItLooksLikeThat",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "JealousOf",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LeadRiseTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LeftRightHand",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LessWorse",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Likewise",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LookDownOnesNose",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LookingForwardTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LookForwardTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MeansALotTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MixedBag",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NoLonger",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NoMatchFor",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NumericRangeEnDash",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Nobody",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OfCourse",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OldestInTheBook",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OnFloor",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OnceOrTwice",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OutOfDate",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Oxymorons",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PiqueInterest",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Respond",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "RightClick",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "RiseTheRanks",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "RollerSkated",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SafeToSave",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SaveToSafe",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SomethingIs",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SomewhatSomething",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SoonToBe",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SoughtAfter",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ToAdverb",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "UpdatePlaceNames",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ViceVersa",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WasAloud",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WellEducated",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WinPrize",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WishCould",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WorthToDo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AheadAnd",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AllOfASudden",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Alongside",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AlzheimersDisease",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AsFarBackAs",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AsItHappens",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AsOfCurrently",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AsOfLately",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AsOpposedTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AtFaceValue",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AtTheBestOfTimes",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AtTheEndOfTheDay",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AtTheExpenseOf",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AwareOf",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BadRap",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BanTogether",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BareInMind",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BatedBreath",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BeckAndCall",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BesideThePoint",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BewareOf",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BlacklistWhitelist",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BlanketStatement",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Brutality",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ComprisesOf",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "CoursingThroughVeins",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "CuttingAgeEggcorn",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DampSquib",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DoToDueTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DueDiligence",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DuringAges",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "EggYolk",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "EnMasse",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "EnRoute",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "EveryOnceAndAgain",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FairBit",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FarAndFewBetween",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FastPaste",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ForArgumentsSake",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ForTheMostPart",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FreeRein",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "GildedAge",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Haphazard",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "HiddenIn",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "HungerPang",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ImitateFrom",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "InAHurry",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "InNeedOf",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Initiatively",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Insensitive",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Insurmountable",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "JawDropping",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LastButNotLeast",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LastNight",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LaughOfAt",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LeaveToFor",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LikeThePlague",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LikeTheresNoTomorrow",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LikelyHood",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LowHangingFruit",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ManagerialReins",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Monumentous",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NerveRacking",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OldWivesTale",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OnFirstGlance",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OnTheSpurOfTheMoment",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OnTopOf",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OnceInAWhile",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "OneFellSwoop",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PeaceOfMind",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "PrayingMantis",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "QuiteMany",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "RealTrouper",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "RifeWith",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ScantilyClad",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SimilarLike",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SimpleGrammatical",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SneakPeekPreview",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SneakingSuspicion",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SoonerOrLater",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "StatuteOfLimitations",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SufficeItToSay",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "SupposedTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TakeItPersonally",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThatChallenged",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TheDifferenceBetween",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TheWhetherWeather",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ToBackOut",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ToTheMannerBorn",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TongueInCheek",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Unless",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "VeryKnown",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WaveFunction",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WellKept",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WroughtIron",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Damages",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "WebScraping",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "MoreThanMeetsTheEye",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "InFavourOfDoing",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "InHindsight",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LongTimeAgo",
+                "state": true
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "Group": {
+        "label": "Regionalisms and Dialect",
+        "description": "Groups dialect-sensitive wording and regional usage that may not fit the selected audience.",
+        "child": {
+          "settings": [
+            {
+              "Bool": {
+                "name": "Regionalisms",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Touristic",
+                "state": true
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "Group": {
+        "label": "Miscellaneous",
+        "description": "A catch-all for rules that do not fit neatly into the other categories but are still useful to surface.",
+        "child": {
+          "settings": [
+            {
+              "Bool": {
+                "name": "APart",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AWhile",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Addicting",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AfterLater",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AllHellBreakLoose",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AllIntentsAndPurposes",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AmInTheMorning",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AmountsFor",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AnA",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AndIn",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AndTheLike",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AnotherThingComing",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "AnotherThinkComing",
+                "state": false
+              }
+            },
+            {
+              "Bool": {
+                "name": "ApartFrom",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BackInTheDay",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "BehindTheScenes",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Cant",
+                "state": true,
+                "label": "Can't"
+              }
+            },
+            {
+              "Bool": {
+                "name": "CriteriaPhenomena",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DespiteItIs",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DespiteOf",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "DidPast",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "Didnt",
+                "state": true,
+                "label": "Didn't"
+              }
+            },
+            {
+              "Bool": {
+                "name": "DisjointPrefixes",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FedUpWith",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FindFine",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FindOut",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "GoSoFarAsTo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "GoToWar",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "HaveTakeALook",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "InOnTheCards",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "LetsConfusion",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NailOnTheHead",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "NotOnlyInversion",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ShootOneselfInTheFoot",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "TheHowWhy",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThePointFor",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThesesThese",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThingThink",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThisTypeOfThing",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThoughThought",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThrowAway",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ThrowRubbish",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ToTwoToo",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ViciousCircle",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "ViciousCircleOrCycle",
+                "state": false
+              }
+            },
+            {
+              "Bool": {
+                "name": "ViciousCycle",
+                "state": false
+              }
+            },
+            {
+              "Bool": {
+                "name": "Whereas",
+                "state": true
+              }
+            },
+            {
+              "Bool": {
+                "name": "FondOn",
+                "state": true
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
 }

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -1160,6 +1160,174 @@ mod tests {
         }
     }
 
+    /// Tests that literal descriptions and labels in the config JSON don't contain errors.
+    ///
+    /// This validates the manually-written descriptions and labels in default_config.json
+    /// (Group descriptions, Bool labels, OneOfMany labels, etc.) to ensure they don't trigger
+    /// linter rules.
+    ///
+    /// Labels emit warnings (since they often show incorrect forms they're catching),
+    /// while descriptions cause test failures if they contain errors.
+    ///
+    /// Excludes Style, Miscellaneous, and Grammar lint kinds (labels often show incorrect forms).
+    ///
+    /// TODO: Also check auto-generated labels/descriptions to identify when manual descriptions
+    /// should be added for clarity.
+    #[test]
+    fn config_descriptions_are_clean() {
+        check_config_text(false);
+    }
+
+    /// Tests that literal descriptions and labels in the config JSON don't contain errors.
+    ///
+    /// Same as config_descriptions_are_clean but does NOT exclude any lint kinds.
+    /// Use this to catch all potential issues, including grammar/style in labels.
+    #[test]
+    fn config_descriptions_are_clean_strict() {
+        check_config_text(true);
+    }
+
+    fn check_config_text(strict: bool) {
+        let enforcer_config = FlatConfig::new_curated();
+        let mut lints_to_enforce =
+            LintGroup::new_curated(FstDictionary::curated(), Dialect::American)
+                .with_lint_config(enforcer_config);
+
+        // Load the default config JSON
+        let config_json = include_str!("../../../default_config.json");
+        let config: serde_json::Value = serde_json::from_str(config_json).expect("Invalid JSON");
+
+        let mut warning_count = 0;
+
+        fn check_text(
+            lints_to_enforce: &mut LintGroup,
+            context: &str,
+            text: &str,
+            is_label: bool,
+            strict: bool,
+            warning_count: &mut usize,
+        ) {
+            let doc = Document::new_markdown_default_curated(text);
+            eprintln!("{context}: {text}");
+
+            let mut lints = lints_to_enforce.lint(&doc);
+
+            if !strict {
+                // Remove ones related to style, miscellaneous, and grammar
+                // Labels often show incorrect forms they're catching, so we exclude these
+                lints.retain(|l| {
+                    l.lint_kind != LintKind::Style
+                        && l.lint_kind != LintKind::Miscellaneous
+                        && l.lint_kind != LintKind::Grammar
+                });
+            }
+
+            if !lints.is_empty() {
+                if is_label {
+                    eprintln!("⚠️  Warning: {context} has lints:");
+                    for lint in &lints {
+                        eprintln!("   - {}", lint.message);
+                    }
+                    *warning_count += 1;
+                } else {
+                    dbg!(lints);
+                    panic!();
+                }
+            }
+        }
+
+        // Extract all literal descriptions and labels from the config
+        if let Some(settings) = config.get("settings").and_then(|v| v.as_array()) {
+            for (i, setting) in settings.iter().enumerate() {
+                if let Some(group) = setting.get("Group").and_then(|v| v.as_object()) {
+                    if let Some(label) = group.get("label").and_then(|v| v.as_str()) {
+                        check_text(
+                            &mut lints_to_enforce,
+                            &format!("Group[{i}] label"),
+                            label,
+                            true,
+                            strict,
+                            &mut warning_count,
+                        );
+
+                        if let Some(description) = group.get("description").and_then(|v| v.as_str())
+                        {
+                            check_text(
+                                &mut lints_to_enforce,
+                                &format!("Group[{i}] {label} description"),
+                                description,
+                                false,
+                                strict,
+                                &mut warning_count,
+                            );
+                        }
+
+                        // Check child settings
+                        if let Some(child) = group.get("child").and_then(|v| v.as_object()) {
+                            if let Some(child_settings) =
+                                child.get("settings").and_then(|v| v.as_array())
+                            {
+                                for (j, child_setting) in child_settings.iter().enumerate() {
+                                    if let Some(obj) = child_setting.as_object() {
+                                        let context = format!("Group[{i}] {label} setting[{j}]");
+
+                                        // Check Bool labels
+                                        if let Some(bool_obj) =
+                                            obj.get("Bool").and_then(|v| v.as_object())
+                                        {
+                                            if let Some(label) =
+                                                bool_obj.get("label").and_then(|v| v.as_str())
+                                            {
+                                                check_text(
+                                                    &mut lints_to_enforce,
+                                                    &format!("{context} Bool label"),
+                                                    label,
+                                                    true,
+                                                    strict,
+                                                    &mut warning_count,
+                                                );
+                                            }
+                                        }
+
+                                        // Check OneOfMany labels
+                                        if let Some(one_of_many) =
+                                            obj.get("OneOfMany").and_then(|v| v.as_object())
+                                        {
+                                            if let Some(labels) =
+                                                one_of_many.get("labels").and_then(|v| v.as_array())
+                                            {
+                                                for (k, label) in labels.iter().enumerate() {
+                                                    if let Some(label_str) = label.as_str() {
+                                                        check_text(
+                                                            &mut lints_to_enforce,
+                                                            &format!(
+                                                                "{context} OneOfMany label[{k}]"
+                                                            ),
+                                                            label_str,
+                                                            true,
+                                                            strict,
+                                                            &mut warning_count,
+                                                        );
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if warning_count > 0 {
+            eprintln!(
+                "\n⚠️  Found {warning_count} label(s) with lints (warnings only, test passed)"
+            );
+        }
+    }
+
     #[test]
     fn no_linter_names_clash() {
         let group =

--- a/harper-core/src/linting/lint_group/structured_config/human_readable_structured_config.rs
+++ b/harper-core/src/linting/lint_group/structured_config/human_readable_structured_config.rs
@@ -2,6 +2,29 @@ use serde::{Deserialize, Serialize};
 
 use super::{Setting, StructuredConfig};
 
+fn pascal_case_to_label(name: &str) -> String {
+    let mut result = String::new();
+    let chars: Vec<char> = name.chars().collect();
+
+    for (i, &c) in chars.iter().enumerate() {
+        if c.is_uppercase() {
+            let prev_is_lower = i > 0 && chars[i - 1].is_lowercase();
+            let next_is_lower = i + 1 < chars.len() && chars[i + 1].is_lowercase();
+            let prev_is_upper = i > 0 && chars[i - 1].is_uppercase();
+
+            if i > 0 && prev_is_lower
+                || prev_is_upper && !next_is_lower
+                || !prev_is_upper && next_is_lower
+            {
+                result.push(' ');
+            }
+        }
+        result.push(c);
+    }
+
+    result
+}
+
 /// A human-readable mirror of [`super::StructuredConfig`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HumanReadableStructuredConfig {
@@ -94,10 +117,13 @@ impl HumanReadableSetting {
 
     fn to_setting(&self) -> Option<Setting> {
         match self {
-            Self::Bool { name, state, .. } => Some(Setting::Bool {
-                name: name.clone(),
-                state: *state,
-            }),
+            Self::Bool { name, state, label } => {
+                let _computed_label = label.clone().unwrap_or_else(|| pascal_case_to_label(name));
+                Some(Setting::Bool {
+                    name: name.clone(),
+                    state: *state,
+                })
+            }
             Self::OneOfMany {
                 names,
                 name,
@@ -109,9 +135,13 @@ impl HumanReadableSetting {
                     None => None,
                 };
 
+                let computed_labels = labels
+                    .clone()
+                    .unwrap_or_else(|| names.iter().map(|n| pascal_case_to_label(n)).collect());
+
                 Some(Setting::OneOfMany {
                     names: names.clone(),
-                    labels: labels.clone().unwrap_or_else(|| names.clone()),
+                    labels: computed_labels,
                     choice,
                 })
             }


### PR DESCRIPTION
# Issues 
N/A

# Description

- `label` fields of rules are now optional.
- Automatically generate the `label`s that are identical to the `name` fields.
- Lint the remaining ones plus the `label` and `description`s of the `Group`s.

I haven't fully reviewed the code yet.
Some labels have intentional grammar mistakes, so we can either turn off the rules or lint kinds involved, or print warnings for `label`s but fail for `description`.

Currently it does both but also runs a "strict" mode, which causes a build failure.

It could also lint the generated labels, which would cue us that those ones should instead have hand-written ones.

# Demo
```
Group[10] label: Style and Redundancy
Group[10] Style and Redundancy description: Highlights wordy, repetitive, or overly weak phrasing that can usually be tightened up.
Group[10] Style and Redundancy setting[36] Bool label: Redundant IIRC
⚠️  Warning: Group[10] Style and Redundancy setting[36] Bool label has lints:
   - Try expanding this initialism.
Group[11] label: Grammar and Agreement
Group[11] Grammar and Agreement description: Catches grammar issues involving agreement, articles, prepositions, verb forms, and sentence structure.
Group[11] Grammar and Agreement setting[52] Bool label: Don't Can
⚠️  Warning: Group[11] Grammar and Agreement setting[52] Bool label has lints:
   - The grammatically correct form is `can't` or `cannot`.
Group[12] label: Word Choice and Usage
Group[12] Word Choice and Usage description: Suggests more standard or idiomatic wording when a phrase is technically understandable but poorly chosen.
```

# How Has This Been Tested?

Manually

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
