### PR TITLE
fix: treat semicolons as chunk separators

### DIFF
--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -809,7 +809,9 @@ impl LintGroup {
         insert_struct_rule!(WordPressDotcom, true);
         insert_expr_rule_with_dict!(WorthToDo, true);
         insert_expr_rule!(WouldNeverHave, true);
-        insert_expr_rule!(WrongApostrophe, true);
+        // Uses Sentence rather than Chunk
+        out.add("WrongApostrophe", WrongApostrophe::default());
+        out.config.set_rule_enabled("WrongApostrophe", true);
 
         // Uses Sentence rather than Chunk
         out.add("AspireTo", AspireTo::default());

--- a/harper-core/src/linting/wrong_apostrophe.rs
+++ b/harper-core/src/linting/wrong_apostrophe.rs
@@ -1,7 +1,7 @@
 use crate::{
     Token, TokenStringExt,
     expr::{Expr, FirstMatchOf, SequenceExpr},
-    linting::{ExprLinter, Lint, LintKind, Suggestion, expr_linter::Chunk},
+    linting::{ExprLinter, Lint, LintKind, Suggestion, expr_linter::Sentence},
 };
 
 const CONTRACTION_AND_POSSESSIVE_ENDINGS: [&str; 7] = ["d", "ll", "m", "re", "s", "t", "ve"];
@@ -27,7 +27,7 @@ impl Default for WrongApostrophe {
 }
 
 impl ExprLinter for WrongApostrophe {
-    type Unit = Chunk;
+    type Unit = Sentence;
 
     fn expr(&self) -> &dyn Expr {
         &self.expr

--- a/harper-core/src/token_kind.rs
+++ b/harper-core/src/token_kind.rs
@@ -320,7 +320,10 @@ impl TokenKind {
             TokenKind::Punctuation(punct) => {
                 matches!(
                     punct,
-                    Punctuation::Comma | Punctuation::Quote { .. } | Punctuation::Colon
+                    Punctuation::Comma
+                        | Punctuation::Semicolon
+                        | Punctuation::Quote { .. }
+                        | Punctuation::Colon
                 )
             }
             _ => false,

--- a/harper-core/src/token_string_ext.rs
+++ b/harper-core/src/token_string_ext.rs
@@ -302,3 +302,28 @@ impl TokenStringExt for [Token] {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{Document, TokenStringExt};
+
+    fn chunk_strings(source: &str) -> Vec<String> {
+        let source_chars = source.chars().collect::<Vec<_>>();
+        let document = Document::new_markdown_default_curated(source);
+
+        document
+            .iter_chunks()
+            .map(|chunk| chunk.span().unwrap().get_content_string(&source_chars))
+            .collect()
+    }
+
+    #[test]
+    fn comma_separates_chunks() {
+        assert_eq!(chunk_strings("foo bar, baz"), vec!["foo bar,", " baz"]);
+    }
+
+    #[test]
+    fn semicolon_separates_chunks() {
+        assert_eq!(chunk_strings("foo bar; baz"), vec!["foo bar;", " baz"]);
+    }
+}


### PR DESCRIPTION
# Issues
Fixes #3405

# Description
Treat semicolons as chunk terminators so end-of-chunk expression behavior is consistent with commas and similar punctuation.

This patch:
- adds `Punctuation::Semicolon` to `TokenKind::is_chunk_terminator()`
- adds chunk-splitting tests for comma and semicolon in `token_string_ext.rs`
- switches `WrongApostrophe` from `Chunk` to `Sentence` scope to preserve context after chunk boundary changes

# Demo
N/A

# How Has This Been Tested?
- `just test`
    - All relevant Rust/core tests passed.
    - One local Chrome extension options UI test failed:
      `[chromium] tests/options_structured_rules.spec.ts › structured rule settings › rule dropdown updates only the targeted flat rule`

# AI Disclosure
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
- [x] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
