### PR TITLE
feat: nought→zero for US english

### DIFF
--- a/harper-core/src/linting/regionalisms.rs
+++ b/harper-core/src/linting/regionalisms.rs
@@ -60,6 +60,7 @@ enum Concept {
     LightBulbLightGlobe,
     LorryTruck,
     MotorhomeRv,
+    NoughtZero,
     PhotocopierXerox,
     PhotocopyXerox,
     PickupUte,
@@ -409,6 +410,12 @@ const REGIONAL_TERMS: &[Term<'_>] = &[
         concept: BloodNoseNosebleed,
     },
     Term {
+        term: "nought",
+        flag: Flag,
+        dialects: &[Australian, British, Canadian, Indian],
+        concept: NoughtZero,
+    },
+    Term {
         term: "pacifier",
         flag: Flag,
         dialects: &[American],
@@ -600,6 +607,12 @@ const REGIONAL_TERMS: &[Term<'_>] = &[
         flag: Flag,
         dialects: &[American, Canadian],
         concept: WindscreenWindshield,
+    },
+    Term {
+        term: "zero",
+        flag: UniversalTerm,
+        dialects: &[American, Australian, British, Canadian, Indian],
+        concept: NoughtZero,
     },
 ];
 
@@ -850,5 +863,10 @@ mod tests {
             Regionalisms::new(Dialect::Australian),
             "Is eggplant used in curries or chutneys?",
         );
+    }
+
+    #[test]
+    fn americans_dont_say_nought() {
+        assert_suggestion_result("nought", Regionalisms::new(Dialect::American), "zero");
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

Was reading something about numbers and there it said that Americans don't use the word "nought". But every English speaking country uses "zero" whether or not they also use "nought".

I couldn't really find any useful examples though as full sentences, so not sure how useful this would be.

# How Has This Been Tested?

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [x] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
