### PR TITLE
fix(core): avoid PronounKnew false positive after anyone

### DIFF
--- a/harper-core/src/linting/pronoun_knew.rs
+++ b/harper-core/src/linting/pronoun_knew.rs
@@ -20,20 +20,14 @@ trait PronounKnewExt {
 impl Default for PronounKnew {
     fn default() -> Self {
         // The pronoun that would occur before a verb would be a subject pronoun.
-        // But "its" commonly occurs before "new" and is a possessive pronoun. (Much more commonly a determiner)
-        // Since "his" and "her" are possessive and object pronouns respectively, we ignore them too.
-        let pronoun_pattern = |tok: &Token, source: &[char]| {
+        // Indefinite pronouns commonly appear in noun phrases like "anyone new",
+        // so only subject personal pronouns should match this rule.
+        let pronoun_pattern = |tok: &Token, _source: &[char]| {
             if !tok.kind.is_upos(UPOS::PRON) {
                 return false;
             }
 
-            if tok.kind.is_possessive_determiner() || !tok.kind.is_pronoun() {
-                return false;
-            }
-
-            let pronorm = tok.get_str(source).to_lowercase();
-            let excluded = ["every", "something", "nothing"];
-            !excluded.contains(&&*pronorm)
+            tok.kind.is_personal_pronoun() && tok.kind.is_subject_pronoun()
         };
 
         let pronoun_then_new = SequenceExpr::with(pronoun_pattern)
@@ -141,6 +135,25 @@ mod tests {
     #[test]
     fn does_not_flag_with_nothing_1298() {
         assert_lint_count("This is nothing new.", PronounKnew::default(), 0);
+    }
+
+    #[test]
+    fn does_not_flag_with_anyone_new_3257() {
+        assert_lint_count("before inviting anyone new in.", PronounKnew::default(), 0);
+    }
+
+    #[test]
+    fn does_not_flag_with_indefinite_pronouns_before_new() {
+        assert_lint_count(
+            "We need someone new for the role.",
+            PronounKnew::default(),
+            0,
+        );
+        assert_lint_count(
+            "Everyone new should read the guide.",
+            PronounKnew::default(),
+            0,
+        );
     }
 
     #[test]


### PR DESCRIPTION
Note: I am an AI agent and implemented this PR autonomously. I inspected the relevant code path, kept the diff scoped to the linter, and ran the verification commands listed below locally.

# Issues
Fixes #3257

# Description
`PronounKnew` currently accepts any dictionary pronoun before `new`, with a small exclusion list for known false positives. That makes noun phrases such as `anyone new` look like a typo for `anyone knew`.

This narrows the rule to subject personal pronouns, which are the pronouns that can plausibly precede the verb `knew`. Indefinite pronouns such as `anyone`, `someone`, and `everyone` no longer trigger this rule, while existing cases like `I new what to do.` and `She often new the answer.` continue to be covered by the existing tests.

# Demo
N/A; this is a core linter behavior change covered by unit tests.

# How Has This Been Tested?
- `cargo test -p harper-core pronoun_knew::tests::does_not_flag_with_anyone_new_3257` failed before the fix with `Expected "before inviting anyone new in." to create 0 lints, but it created 1.`
- `cargo test -p harper-core pronoun_knew`
- `cargo test -p harper-core`
- `cargo fmt -- --check`
- `cargo clippy -p harper-core -- -Dwarnings -D clippy::dbg_macro -D clippy::needless_raw_string_hashes`

I also tried the workspace clippy command from `check-rust`:

- `cargo clippy -- -Dwarnings -D clippy::dbg_macro -D clippy::needless_raw_string_hashes`

That failed in an untouched desktop file with an existing `clippy::type_complexity` warning at `harper-desktop/src-tauri/src/mac_broker.rs:368`. I did not change that unrelated code path.

`just check-rust` was not run because this local PATH does not currently have `just` or `cargo-hack` available.

# AI Disclosure
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [x] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
- [x] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.