### PR TITLE
fix(core): avoid overall false positive after over all

### DIFF
--- a/harper-core/src/linting/closed_compounds.rs
+++ b/harper-core/src/linting/closed_compounds.rs
@@ -1,6 +1,73 @@
-use crate::linting::LintGroup;
+use crate::expr::{Expr, FixedPhrase};
+use crate::linting::expr_linter::Chunk;
+use crate::linting::{ExprLinter, Lint, LintGroup, LintKind, Suggestion};
+use crate::{Token, TokenStringExt};
 
 use super::MapPhraseLinter;
+
+struct Overall {
+    expr: FixedPhrase,
+}
+
+impl Default for Overall {
+    fn default() -> Self {
+        Self {
+            expr: FixedPhrase::from_phrase("over all"),
+        }
+    }
+}
+
+impl ExprLinter for Overall {
+    type Unit = Chunk;
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn match_to_lint_with_context(
+        &self,
+        matched_tokens: &[Token],
+        source: &[char],
+        context: Option<(&[Token], &[Token])>,
+    ) -> Option<Lint> {
+        if followed_by_quantifier_complement(context, source) {
+            return None;
+        }
+
+        let span = matched_tokens.span()?;
+        let matched_text = span.get_content(source);
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::Miscellaneous,
+            suggestions: vec![Suggestion::replace_with_match_case(
+                "overall".chars().collect(),
+                matched_text,
+            )],
+            message: "Did you mean the closed compound `overall`?".to_string(),
+            priority: 31,
+        })
+    }
+
+    fn description(&self) -> &str {
+        "Looks for incorrect spacing inside the closed compound `overall`."
+    }
+}
+
+fn followed_by_quantifier_complement(
+    context: Option<(&[Token], &[Token])>,
+    source: &[char],
+) -> bool {
+    if let Some((_, after)) = context
+        && let [ws, word, ..] = after
+        && ws.kind.is_whitespace()
+    {
+        let word = word.get_str(source);
+        return word.eq_ignore_ascii_case("the") || word.eq_ignore_ascii_case("of");
+    }
+
+    false
+}
 
 pub fn lint_group() -> LintGroup {
     let mut group = LintGroup::empty();
@@ -57,7 +124,6 @@ pub fn lint_group() -> LintGroup {
         "Nothing"         => (&["no thing"][..], "nothing"),
         "Notwithstanding" => (&["not with standing"][..], "notwithstanding"),
         "Nowhere"         => (&["no where"][..], "nowhere"),
-        "Overall"         => (&["over all"][..], "overall"),
         "Overclocking"    => (&["over clocking"][..], "overclocking"),
         "Overload"        => (&["over load"][..], "overload"),
         "Overnight"       => (&["over night"][..], "overnight"),
@@ -82,6 +148,8 @@ pub fn lint_group() -> LintGroup {
         "Worldwide"       => (&["world wide"][..], "worldwide"),
         "Worthwhile"      => (&["worth while", "worth-while"][..], "worthwhile"),
     });
+
+    group.add("Overall", Box::new(Overall::default()));
 
     group.set_all_rules_to(Some(true));
 
@@ -155,6 +223,19 @@ mod tests {
         let test_sentence = "The over all performance was good.";
         let expected = "The overall performance was good.";
         assert_suggestion_result(test_sentence, lint_group(), expected);
+    }
+
+    #[test]
+    fn over_all_the_is_allowed() {
+        assert_no_lints("Iterate over all the save data in the slot.", lint_group());
+    }
+
+    #[test]
+    fn over_all_of_the_is_allowed() {
+        assert_no_lints(
+            "Iterate over all of the save data in the slot.",
+            lint_group(),
+        );
     }
 
     #[test]

--- a/harper-core/src/linting/closed_compounds.rs
+++ b/harper-core/src/linting/closed_compounds.rs
@@ -1,7 +1,7 @@
 use crate::expr::{Expr, FixedPhrase};
-use crate::linting::expr_linter::Chunk;
+use crate::linting::expr_linter::{Chunk, followed_by_word};
 use crate::linting::{ExprLinter, Lint, LintGroup, LintKind, Suggestion};
-use crate::{Token, TokenStringExt};
+use crate::{CharStringExt, Token, TokenStringExt};
 
 use super::MapPhraseLinter;
 
@@ -30,7 +30,10 @@ impl ExprLinter for Overall {
         source: &[char],
         context: Option<(&[Token], &[Token])>,
     ) -> Option<Lint> {
-        if followed_by_quantifier_complement(context, source) {
+        if followed_by_word(context, |word| {
+            word.get_ch(source)
+                .eq_any_ignore_ascii_case_str(&["the", "of"])
+        }) {
             return None;
         }
 
@@ -52,21 +55,6 @@ impl ExprLinter for Overall {
     fn description(&self) -> &str {
         "Looks for incorrect spacing inside the closed compound `overall`."
     }
-}
-
-fn followed_by_quantifier_complement(
-    context: Option<(&[Token], &[Token])>,
-    source: &[char],
-) -> bool {
-    if let Some((_, after)) = context
-        && let [ws, word, ..] = after
-        && ws.kind.is_whitespace()
-    {
-        let word = word.get_str(source);
-        return word.eq_ignore_ascii_case("the") || word.eq_ignore_ascii_case("of");
-    }
-
-    false
 }
 
 pub fn lint_group() -> LintGroup {

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -472,15 +472,6 @@ Suggest:
 
 
 
-Lint:    Miscellaneous (31 priority)
-Message: |
-     238 | puzzle!” And she began thinking over all the children she knew that were of the
-         |                                 ^~~~~~~~ Did you mean the closed compound `overall`?
-Suggest:
-  - Replace with: “overall”
-
-
-
 Lint:    Capitalization (31 priority)
 Message: |
      243 | all sorts of things, and she, oh! she knows such a very little! Besides, she’s

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -1549,15 +1549,6 @@ Suggest:
 
 
 
-Lint:    Miscellaneous (31 priority)
-Message: |
-    1307 | A thrill passed over all of us. The three Mr. Mumbles bent forward and listened
-         |                 ^~~~~~~~ Did you mean the closed compound `overall`?
-Suggest:
-  - Replace with: “overall”
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
     1310 | “I don’t think it’s so much that,” argued Lucille sceptically; “it’s more that


### PR DESCRIPTION
# Issues

Fixes #1249

# Description

This keeps the `Overall` closed-compound correction for cases like `over all performance`, but skips it when `over all` is followed by `the` or `of`, where `all` is acting as a quantifier in phrases such as `over all the save data` and `over all of the save data`.

The change is scoped to the `Overall` closed-compound rule. Other closed compound mappings still use the shared `MapPhraseLinter` path.

# Demo

Not visual.

# How Has This Been Tested?

- `cargo test -p harper-core linting::closed_compounds::tests::over_all -- --nocapture`
- `cargo test -p harper-core linting::closed_compounds -- --nocapture`
- `cargo check -p harper-core`
- `cargo fmt --check`
- `git diff --check`

# AI Disclosure
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [x] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.