### PR TITLE
Avoid mass noun lints for ing modifiers

### DIFF
--- a/harper-core/src/linting/mass_nouns/noun_countability.rs
+++ b/harper-core/src/linting/mass_nouns/noun_countability.rs
@@ -64,6 +64,7 @@ impl ExprLinter for NounCountability {
             || followed_by_word(ctx, |t| {
                 t.kind.is_noun() || t.kind.is_oov() || t.get_ch(src).eq_str("and")
             })
+            || (is_ing_word(&toks[2], src) && followed_by_nominal_head(ctx, src))
         {
             return None;
         }
@@ -184,10 +185,86 @@ impl ExprLinter for NounCountability {
     }
 }
 
+fn is_ing_word(tok: &Token, src: &[char]) -> bool {
+    tok.get_ch(src).ends_with_ignore_ascii_case_str("ing")
+}
+
+fn followed_by_nominal_head(ctx: Option<(&[Token], &[Token])>, src: &[char]) -> bool {
+    let Some((_, after)) = ctx else {
+        return false;
+    };
+
+    follows_modifiers_then_noun(after, src)
+        || follows_slash_separated_ing_modifiers_then_noun(after, src)
+}
+
+fn follows_modifiers_then_noun(tokens: &[Token], src: &[char]) -> bool {
+    let mut cursor = 0;
+
+    loop {
+        let Some([ws, word, rest @ ..]) = tokens.get(cursor..) else {
+            return false;
+        };
+
+        if !ws.kind.is_whitespace() {
+            return false;
+        }
+
+        if is_nominal_chain_boundary(word, src) {
+            return false;
+        }
+
+        if is_likely_nominal_head(word, src) {
+            return true;
+        }
+
+        if word.kind.is_adjective()
+            || word.kind.is_adverb()
+            || word.kind.is_verb_progressive_form()
+            || word.kind.is_verb_past_participle_form()
+        {
+            cursor = tokens.len() - rest.len();
+            continue;
+        }
+
+        return false;
+    }
+}
+
+fn is_nominal_chain_boundary(tok: &Token, src: &[char]) -> bool {
+    tok.kind.is_preposition()
+        || tok.kind.is_determiner()
+        || tok.kind.is_conjunction()
+        || tok.get_ch(src).eq_any_ignore_ascii_case_str(&[
+            "about", "after", "as", "at", "before", "by", "for", "from", "in", "into", "of", "on",
+            "through", "to", "under", "with",
+        ])
+}
+
+fn is_likely_nominal_head(tok: &Token, src: &[char]) -> bool {
+    (tok.kind.is_noun() || tok.kind.is_oov()) && !is_nominal_chain_boundary(tok, src)
+}
+
+fn follows_slash_separated_ing_modifiers_then_noun(tokens: &[Token], src: &[char]) -> bool {
+    let mut cursor = 0;
+    let mut saw_slash_modifier = false;
+
+    while let Some([slash, word, rest @ ..]) = tokens.get(cursor..) {
+        if !slash.kind.is_slash() || !is_ing_word(word, src) {
+            break;
+        }
+
+        saw_slash_modifier = true;
+        cursor = tokens.len() - rest.len();
+    }
+
+    saw_slash_modifier && follows_modifiers_then_noun(&tokens[cursor..], src)
+}
+
 #[cfg(test)]
 mod tests {
     use super::NounCountability;
-    use crate::linting::tests::{assert_lint_count, assert_suggestion_result};
+    use crate::linting::tests::{assert_lint_count, assert_no_lints, assert_suggestion_result};
 
     #[test]
     fn corrects_a() {
@@ -307,6 +384,30 @@ mod tests {
             "Additionally, many software development platforms also provide access to a community of developers.",
             NounCountability::default(),
             0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_ing_modifier_before_adjective_noun() {
+        assert_no_lints(
+            "They succeeded by receiving a working direct link in return.",
+            NounCountability::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_slash_separated_ing_modifiers_before_noun() {
+        assert_no_lints(
+            "MockAPI is meant to be a prototyping/testing/learning tool.",
+            NounCountability::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_coordinate_predicate_ing_adjective() {
+        assert_no_lints(
+            "They're both confusing and tedious to use.",
+            NounCountability::default(),
         );
     }
 


### PR DESCRIPTION
# Issues
Fixes #1994

# Description
This updates the mass noun countability rule to avoid treating `-ing` words as countability errors when they are acting as present-participle modifiers before a noun head.

It covers adjective chains such as `a working direct link` and slash-separated modifier chains such as `a prototyping/testing/learning tool`, while preserving existing mass-noun corrections like `one clothing based on weather conditions`.

# Demo
N/A; linter behavior is covered by unit tests.

# How Has This Been Tested?
- `CARGO_HOME=$PWD/.cargo-home CARGO_TARGET_DIR=$PWD/target cargo test -p harper-core linting::mass_nouns::noun_countability::tests:: -- --nocapture`
- `CARGO_HOME=$PWD/.cargo-home CARGO_TARGET_DIR=$PWD/target cargo fmt --check`
- `CARGO_HOME=$PWD/.cargo-home CARGO_TARGET_DIR=$PWD/target cargo test -p harper-core`
- `git diff --check`

# AI Disclosure
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [x] I am an agent or I got an agent to do the work autonomously.

OpenAI GPT-5 assisted with the implementation and validation.

# If Your PR Implements or Enhances a Linter
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
