### PR TITLE
fix(ci): produce universal desktop binaries

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -18,28 +18,17 @@ jobs:
     strategy:
       matrix:
         platform:
-          - name: macOS x64
-            artifact_name: harper-desktop-macos-x64
-            os: macos-26-intel
-            command: just build-desktop-macos
-            unsigned_command: just build-desktop-macos-unsigned
-            artifact_paths: |
-              target/release/bundle/dmg/*.dmg
-              target/release/bundle/macos/*.app.tar.gz
-              target/release/bundle/macos/*.app.tar.gz.sig
-            unsigned_artifact_paths: |
-              target/release/bundle/dmg/*.dmg
           - name: macOS arm64
-            artifact_name: harper-desktop-macos-arm64
+            artifact_name: harper-desktop-macos-universal
             os: macos-14
             command: just build-desktop-macos
             unsigned_command: just build-desktop-macos-unsigned
             artifact_paths: |
-              target/release/bundle/dmg/*.dmg
-              target/release/bundle/macos/*.app.tar.gz
-              target/release/bundle/macos/*.app.tar.gz.sig
+              target/universal-apple-darwin/release/bundle/dmg/*.dmg
+              target/universal-apple-darwin/release/bundle/macos/*.app.tar.gz
+              target/universal-apple-darwin/release/bundle/macos/*.app.tar.gz.sig
             unsigned_artifact_paths: |
-              target/release/bundle/dmg/*.dmg
+              target/universal-apple-darwin/release/bundle/dmg/*.dmg
 
     steps:
       - name: Checkout
@@ -50,6 +39,9 @@ jobs:
         uses: pnpm/action-setup@v4
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install macOS Rust targets
+        if: runner.os == 'macOS'
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:

--- a/justfile
+++ b/justfile
@@ -205,7 +205,7 @@ build-desktop-macos: build-harperjs build-lint-framework build-components build-
 
   cd "{{justfile_directory()}}/harper-desktop"
   pnpm install
-  cargo tauri build -b app,dmg
+  cargo tauri build -b app,dmg --target universal-apple-darwin
 
 # Build Harper Desktop macOS bundles without updater artifacts.
 build-desktop-macos-unsigned: build-harperjs build-lint-framework build-components build-harper-editor
@@ -214,7 +214,7 @@ build-desktop-macos-unsigned: build-harperjs build-lint-framework build-componen
 
   cd "{{justfile_directory()}}/harper-desktop"
   pnpm install
-  cargo tauri build -b app,dmg --config '{"bundle":{"createUpdaterArtifacts":false}}'
+  cargo tauri build -b app,dmg --config '{"bundle":{"createUpdaterArtifacts":false}}' --target universal-apple-darwin
 
 # Build the Harper Obsidian plugin.
 build-obsidian: build-harperjs


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

Instead of producing separate x86 and ARM app bundles for macOS, this PR sets up our CI to produce universal binaries, whose updates and installers can be used on any platform.

