### PR TITLE
feat: USD dollars→USD/US dollars

### DIFF
--- a/harper-core/src/linting/redundant_acronyms.rs
+++ b/harper-core/src/linting/redundant_acronyms.rs
@@ -82,7 +82,7 @@ impl ExprLinter for RedundantAcronyms {
             .find(|(a, _, _, _)| (*a).eq_ignore_ascii_case(&acronym_str))?;
 
         // Skip if AllCapsOnly flag is set and acronym is not all caps
-        if matches!(flag, Flag::AllCapsOnly) && acronym_str != acronym_str.to_uppercase() {
+        if matches!(flag, AllCapsOnly) && !acronym_str.chars().all(|c| c.is_ascii_uppercase()) {
             return Option::None;
         }
 
@@ -90,7 +90,7 @@ impl ExprLinter for RedundantAcronyms {
             .iter()
             .all(|c| c.is_ascii_alphabetic() && c.is_ascii_uppercase());
 
-        let plural_ending = if matches!(flag, Flag::DontPluralizeAcronym) {
+        let plural_ending = if matches!(flag, DontPluralizeAcronym) {
             String::new()
         } else {
             last_word_chars

--- a/harper-core/src/linting/redundant_acronyms.rs
+++ b/harper-core/src/linting/redundant_acronyms.rs
@@ -6,17 +6,38 @@ use crate::{
     token_string_ext::TokenStringExt,
 };
 
+enum Flag {
+    /// Some acronyms should only be matched when all caps, like "PIN"
+    AllCapsOnly,
+    /// Some acronyms should not be pluralized, like "USD"
+    DontPluralizeAcronym,
+    /// No special flags
+    None,
+}
+use Flag::*;
+
 // (acronym, first_words, last_word)
-const ACRONYMS: &[(&str, &[&str], &str)] = &[
-    ("ATM", &["automated teller", "automatic teller"], "machine"),
-    ("GUI", &["graphical user"], "interface"),
-    ("LCD", &["liquid crystal"], "display"),
-    ("LLM", &["large language"], "model"),
+const ACRONYMS: &[(&str, &[&str], &str, Flag)] = &[
+    (
+        "ATM",
+        &["automated teller", "automatic teller"],
+        "machine",
+        None,
+    ),
+    ("GUI", &["graphical user"], "interface", None),
+    ("LCD", &["liquid crystal"], "display", None),
+    ("LLM", &["large language"], "model", None),
     // Note: "pin number" (not capitalized) is used to refer to GPIO pins etc.
-    ("PIN", &["personal identification"], "number"),
-    ("TUI", &["text-based user", "terminal user"], "interface"),
-    ("UI", &["user"], "interface"),
-    ("VIN", &["vehicle identification"], "number"),
+    ("PIN", &["personal identification"], "number", AllCapsOnly),
+    (
+        "TUI",
+        &["text-based user", "terminal user"],
+        "interface",
+        None,
+    ),
+    ("UI", &["user"], "interface", None),
+    ("USD", &["US"], "dollars", DontPluralizeAcronym),
+    ("VIN", &["vehicle identification"], "number", None),
 ];
 
 pub struct RedundantAcronyms {
@@ -27,7 +48,7 @@ impl Default for RedundantAcronyms {
     fn default() -> Self {
         let exprs: Vec<Box<dyn Expr>> = ACRONYMS
             .iter()
-            .map(|&(acronym, _, last_str)| {
+            .map(|&(acronym, _, last_str, _)| {
                 let last_string = last_str.to_string();
                 Box::new(SequenceExpr::aco(acronym).t_ws().then_any_of(vec![
                     Box::new(Word::new(last_str)),
@@ -56,24 +77,28 @@ impl ExprLinter for RedundantAcronyms {
         let last_word_chars = last_word_span.get_content(src);
         let acronym_str = toks.first()?.get_str(src);
 
-        // "pin number" (lowercase) is used to refer to the pins on microchips, etc.
-        if acronym_str.eq_ignore_ascii_case("PIN") && acronym_str != "PIN" {
-            return None;
-        }
-
-        let (_, middle_words, _) = ACRONYMS
+        let (_, middle_words, _, flag) = ACRONYMS
             .iter()
-            .find(|(a, _, _)| (*a).eq_ignore_ascii_case(&acronym_str))?;
+            .find(|(a, _, _, _)| (*a).eq_ignore_ascii_case(&acronym_str))?;
+
+        // Skip if AllCapsOnly flag is set and acronym is not all caps
+        if matches!(flag, Flag::AllCapsOnly) && acronym_str != acronym_str.to_uppercase() {
+            return Option::None;
+        }
 
         let is_all_caps = last_word_chars
             .iter()
             .all(|c| c.is_ascii_alphabetic() && c.is_ascii_uppercase());
 
-        let plural_ending = last_word_chars
-            .last()
-            .filter(|&&c| c.eq_ignore_ascii_case(&'s'))
-            .map(|c| c.to_string())
-            .unwrap_or_default();
+        let plural_ending = if matches!(flag, Flag::DontPluralizeAcronym) {
+            String::new()
+        } else {
+            last_word_chars
+                .last()
+                .filter(|&&c| c.eq_ignore_ascii_case(&'s'))
+                .map(|c| c.to_string())
+                .unwrap_or_default()
+        };
 
         let suggestions: Vec<Suggestion> = std::iter::once(Suggestion::ReplaceWith(
             format!("{acronym_str}{plural_ending}").chars().collect(),
@@ -372,6 +397,19 @@ mod tests {
             &[
                 "Ollama is an open-source tool for running LLMs locally.",
                 "Ollama is an open-source tool for running large language models locally.",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn correct_usd() {
+        assert_good_and_bad_suggestions(
+            "And because I didn't have USD dollars, I used zip ties [music] instead of a proper microonal bass.",
+            RedundantAcronyms::default(),
+            &[
+                "And because I didn't have US dollars, I used zip ties [music] instead of a proper microonal bass.",
+                "And because I didn't have USD, I used zip ties [music] instead of a proper microonal bass.",
             ],
             &[],
         );


### PR DESCRIPTION
# Issues 
N/A

# Description

Recently I heard people redundantly say the redundant "USD dollars" recently.

This PR enhances the `RedundantAcronyms` linter to fix this. Since "USD" is treated as an invariant plural like "sheep", new logic was needed to handle it. Since "PIN" also needed special logic, I added a `Flag` `enum` that can indicate either.

The Windsurf AI agent worked for a few seconds and I liked the logic it implemented to support the `enum`.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
