### PR TITLE
feat: add check vs cheque, tire vs tyre

### DIFF
--- a/harper-core/src/linting/regionalisms.rs
+++ b/harper-core/src/linting/regionalisms.rs
@@ -39,9 +39,11 @@ enum Concept {
     CaravanTrailer,
     CatsupKetchupTomatoSauce,
     CellPhoneMobilePhone,
-    CoolboxCoolerEsky,
+    CheckCheque,
+    CheckbookChequebook,
     ChipsCrisps,
     CilantroCoriander,
+    CoolboxCoolerEsky,
     Crore,
     Crores,
     DiaperNappy,
@@ -68,8 +70,9 @@ enum Concept {
     Prepone,
     SpannerWrench,
     StationWagonEstate,
-    UpdateUpdation,
+    TireTyre,
     UpdatesUpdations,
+    UpdateUpdation,
     WindscreenWindshield,
 }
 
@@ -192,6 +195,30 @@ const REGIONAL_TERMS: &[Term<'_>] = &[
         flag: Flag,
         dialects: &[American],
         concept: CellPhoneMobilePhone,
+    },
+    Term {
+        term: "check",
+        flag: UniversalTerm,
+        dialects: &[American],
+        concept: CheckCheque,
+    },
+    Term {
+        term: "checkbook",
+        flag: Flag,
+        dialects: &[American],
+        concept: CheckbookChequebook,
+    },
+    Term {
+        term: "cheque",
+        flag: Flag,
+        dialects: &[Australian, British, Canadian, Indian],
+        concept: CheckCheque,
+    },
+    Term {
+        term: "chequebook",
+        flag: Flag,
+        dialects: &[Australian, British, Canadian, Indian],
+        concept: CheckbookChequebook,
     },
     Term {
         term: "chips",
@@ -523,6 +550,18 @@ const REGIONAL_TERMS: &[Term<'_>] = &[
         flag: HasOtherMeanings,
         dialects: &[Australian, British],
         concept: FaucetTap,
+    },
+    Term {
+        term: "tire",
+        flag: HasOtherMeanings,
+        dialects: &[American],
+        concept: TireTyre,
+    },
+    Term {
+        term: "tyre",
+        flag: Flag,
+        dialects: &[Australian, British, Canadian, Indian],
+        concept: TireTyre,
     },
     Term {
         term: "tomato sauce",

--- a/harper-core/src/linting/regionalisms.rs
+++ b/harper-core/src/linting/regionalisms.rs
@@ -554,13 +554,13 @@ const REGIONAL_TERMS: &[Term<'_>] = &[
     Term {
         term: "tire",
         flag: HasOtherMeanings,
-        dialects: &[American],
+        dialects: &[American, Canadian],
         concept: TireTyre,
     },
     Term {
         term: "tyre",
         flag: Flag,
-        dialects: &[Australian, British, Canadian, Indian],
+        dialects: &[Australian, British, Indian],
         concept: TireTyre,
     },
     Term {


### PR DESCRIPTION
# Issues 
N/A

# Description

For some reason these words popped into my head as examples of words which exist in different dialects but where one covers the meanings of two spellings in another:

- tire / tyre
- check / cheque

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
