### PR TITLE
fix(dependabot): change pnpm engine constraint to valid semver range

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	},
 	"engines": {
 		"node": ">=22",
-		"pnpm": "^10.6.3"
+		"pnpm": ">=10.6.3"
 	},
 	"devDependencies": {
 		"@babel/runtime": "catalog:",


### PR DESCRIPTION
Dependabot fails to parse ^10.6.3 when expanded to >=10.6.3 <11.0.0. Using >=10.6.3 instead.