### PR TITLE
feat: every single of→every single one of

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -4955,6 +4955,13 @@
 								"state": true,
 								"label": "Crave For"
 							}
+						},
+						{
+							"Bool": {
+								"name": "EverySingleOneOf",
+								"state": true,
+								"label": "Every Single One Of"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/weir_rules/EverySingleOneOf.weir
+++ b/harper-core/src/linting/weir_rules/EverySingleOneOf.weir
@@ -1,0 +1,10 @@
+expr main (every single of)
+
+let message "This phrase is missing the word `one`."
+let description "Detects missing `one` in the phrase 'every single one of'."
+let kind "Usage"
+let becomes "every single one of"
+
+test "There is at least 1 example coded in Java for every single of their 23 design patterns for Object-oriented programming." "There is at least 1 example coded in Java for every single one of their 23 design patterns for Object-oriented programming."
+test "Codex should be able to run commands on my current repo without asking me to approve every single of it" "Codex should be able to run commands on my current repo without asking me to approve every single one of it"
+test "Which is why it's very likely that you won't need every single of these plugins." "Which is why it's very likely that you won't need every single one of these plugins."


### PR DESCRIPTION
# Issues 
N/A

# Description

I read this somewhere and didn't expect it to be a common mistake, but Googling for it proved otherwise.
I think it comes from two sources: 1. Speakers of other languages without a good grasp of English grammar. 2. English speakers thinking faster than they can type.

It comes up in a couple of English grammar & usage forums:
- https://www.italki.com/en/post/question-335321
- https://forum.wordreference.com/threads/every-single-of-them.3168696/

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
