### PR TITLE
fix(desktop): change name in dock from `harper-desktop` to `Harper`

### DIFF
--- a/harper-desktop/src-tauri/src/lib.rs
+++ b/harper-desktop/src-tauri/src/lib.rs
@@ -111,7 +111,7 @@ fn show_editor_window(app: &tauri::AppHandle) -> tauri::Result<()> {
         EDITOR_WINDOW_LABEL,
         WebviewUrl::App("index.html".into()),
     )
-    .title("harper-desktop")
+    .title("Harper")
     .inner_size(800.0, 600.0)
     .build()?;
     window.set_focus()?;

--- a/harper-desktop/src-tauri/tauri.conf.json
+++ b/harper-desktop/src-tauri/tauri.conf.json
@@ -25,7 +25,10 @@
 			"icons/icon.icns",
 			"icons/icon.ico"
 		],
-		"createUpdaterArtifacts": true
+		"createUpdaterArtifacts": true,
+		"macOS": {
+			"bundleName": "Harper"
+		}
 	},
 	"plugins": {
 		"updater": {


### PR DESCRIPTION
# Issues 

Fixes #3477
# Description

Updates Harper Desktop's user-facing macOS app name from `harper-desktop` to `Harper` without changing the underlying product/package identity used for generated artifacts.

- Adds `bundle.macOS.bundleName` in `harper-desktop/src-tauri/tauri.conf.json` so the macOS bundle/Dock display name is `Harper`.
- Updates the main editor window title in `harper-desktop/src-tauri/src/lib.rs` from `harper-desktop` to `Harper`.
- Leaves `productName`, bundle identifier, updater endpoint, package names, and config paths unchanged to avoid renaming CI artifacts or changing app identity.

# Demo

N/A

# How Has This Been Tested?

N/A; this PR only changes Tauri display metadata and the main window title.

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
