### PR TITLE
fix(desktop): open settings by default

### DIFF
--- a/harper-desktop/src-tauri/src/config.rs
+++ b/harper-desktop/src-tauri/src/config.rs
@@ -124,6 +124,16 @@ impl Config {
         Ok(())
     }
 
+    pub fn main_config_exists() -> Result<bool, ConfigError> {
+        let main_path = Self::main_path().ok_or(ConfigError::ConfigDirUnavailable)?;
+
+        match fs::metadata(main_path) {
+            Ok(_) => Ok(true),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+            Err(error) => Err(error.into()),
+        }
+    }
+
     pub async fn load_from_system() -> Result<Self, ConfigError> {
         let main_path = Self::main_path().ok_or(ConfigError::ConfigDirUnavailable)?;
         let dictionary_path = Self::dictionary_path().ok_or(ConfigError::ConfigDirUnavailable)?;
@@ -397,6 +407,14 @@ mod tests {
             path.parent().unwrap().file_name().unwrap(),
             "harper-desktop"
         );
+    }
+
+    #[test]
+    fn main_config_exists_reports_missing_file() {
+        let exists = Config::main_config_exists().unwrap();
+        let expected = Config::main_path().unwrap().exists();
+
+        assert_eq!(exists, expected);
     }
 
     #[test]

--- a/harper-desktop/src-tauri/src/lib.rs
+++ b/harper-desktop/src-tauri/src/lib.rs
@@ -456,11 +456,29 @@ pub fn run_tauri() {
         .enable_all()
         .build()
         .expect("failed to build config runtime");
-    let config = match config_runtime.block_on(Config::load_from_system()) {
-        Ok(config) => config,
+    let is_first_launch = match Config::main_config_exists() {
+        Ok(exists) => !exists,
         Err(error) => {
-            eprintln!("failed to load config, using defaults: {error}");
-            Config::new()
+            eprintln!("failed to check config existence: {error}");
+            false
+        }
+    };
+
+    let config = if is_first_launch {
+        let config = Config::new();
+
+        if let Err(error) = config_runtime.block_on(config.save_to_system()) {
+            eprintln!("failed to save initial config: {error}");
+        }
+
+        config
+    } else {
+        match config_runtime.block_on(Config::load_from_system()) {
+            Ok(config) => config,
+            Err(error) => {
+                eprintln!("failed to load config, using defaults: {error}");
+                Config::new()
+            }
         }
     };
     let config = Arc::new(Mutex::new(config));
@@ -512,7 +530,7 @@ pub fn run_tauri() {
                 }
             }
         })
-        .setup(|app| {
+        .setup(move |app| {
             let is_service_running = app.state::<HighlighterService>().is_running();
             let menu = tray_menu(app, is_service_running)?;
             let service_toggle = menu.service_toggle.clone();
@@ -573,6 +591,10 @@ pub fn run_tauri() {
                 });
 
             tray.build(app)?;
+
+            if is_first_launch {
+                show_settings_window(app.handle())?;
+            }
 
             Ok(())
         })


### PR DESCRIPTION
# Issues 

N/A

# Description

Open Harper Desktop settings automatically on first launch only.

- Added a persisted-config existence check in `Config::main_config_exists()`.
- Updated desktop startup to treat a missing config file as first launch.
- Save the default config during first launch so subsequent launches do not reopen settings automatically.
- Open the settings window from Tauri setup only when first-launch detection succeeds.

The goal is to make it more obvious that the settings must be accessed to go through the setup process, and thereby give Harper accessibility permissions.

# Demo

N/A

# How Has This Been Tested?

- Added unit coverage for the config-existence helper.

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter

N/A

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
