### PR TITLE
feat(desktop): avoid starting service until perms are granted

### DIFF
--- a/harper-desktop/src-tauri/src/config.rs
+++ b/harper-desktop/src-tauri/src/config.rs
@@ -31,6 +31,7 @@ pub struct Config {
     pub debounce_ms: u64,
     pub auto_update: bool,
     pub last_update_check: Option<u64>,
+    pub highlighter_service_enabled: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -50,6 +51,7 @@ impl Config {
             debounce_ms: 0,
             auto_update: true,
             last_update_check: None,
+            highlighter_service_enabled: true,
         }
     }
 
@@ -189,6 +191,7 @@ impl Config {
             "debounce_ms": self.debounce_ms,
             "auto_update": self.auto_update,
             "last_update_check": self.last_update_check,
+            "highlighter_service_enabled": self.highlighter_service_enabled,
         }))
     }
 
@@ -213,6 +216,11 @@ impl Config {
                 "last_update_check",
             )?
             .flatten(),
+            highlighter_service_enabled: deserialize_optional_field(
+                object,
+                "highlighter_service_enabled",
+            )?
+            .unwrap_or(true),
         })
     }
 }
@@ -276,6 +284,7 @@ mod tests {
         assert!(serialized.contains("debounce_ms"));
         assert!(serialized.contains("auto_update"));
         assert!(serialized.contains("last_update_check"));
+        assert!(serialized.contains("highlighter_service_enabled"));
     }
 
     #[test]
@@ -294,6 +303,10 @@ mod tests {
         assert_eq!(deserialized.debounce_ms, config.debounce_ms);
         assert_eq!(deserialized.auto_update, config.auto_update);
         assert_eq!(deserialized.last_update_check, config.last_update_check);
+        assert_eq!(
+            deserialized.highlighter_service_enabled,
+            config.highlighter_service_enabled
+        );
         assert_eq!(
             serde_json::from_str::<serde_json::Value>(&deserialized.serialize_main().unwrap())
                 .unwrap(),
@@ -348,6 +361,21 @@ mod tests {
 
         assert!(deserialized.auto_update);
         assert_eq!(deserialized.last_update_check, None);
+    }
+
+    #[test]
+    fn deserialize_main_enables_highlighter_service_when_missing() {
+        let config = Config::new();
+        let mut value =
+            serde_json::from_str::<serde_json::Value>(&config.serialize_main().unwrap()).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .remove("highlighter_service_enabled");
+
+        let deserialized = Config::deserialize_main(&value.to_string()).unwrap();
+
+        assert!(deserialized.highlighter_service_enabled);
     }
 
     #[test]

--- a/harper-desktop/src-tauri/src/lib.rs
+++ b/harper-desktop/src-tauri/src/lib.rs
@@ -183,6 +183,23 @@ fn should_hide_window_on_close(label: &str) -> bool {
     label == EDITOR_WINDOW_LABEL || label == SETTINGS_WINDOW_LABEL
 }
 
+fn accessibility_allows_highlighter_start() -> bool {
+    platform_broker().accessibility_permission_status() == AccessibilityPermissionStatus::Granted
+}
+
+fn start_highlighter_service_if_enabled_and_permitted(
+    highlighter_service: &HighlighterService,
+    highlighter_service_enabled: bool,
+) {
+    if !highlighter_service_enabled || !accessibility_allows_highlighter_start() {
+        return;
+    }
+
+    if let Err(error) = highlighter_service.start() {
+        eprintln!("failed to start highlighter service: {error}");
+    }
+}
+
 #[tauri::command]
 async fn get_lint_config(config: State<'_, Arc<Mutex<Config>>>) -> Result<FlatConfig, String> {
     let mut lint_config = config.lock().await.lint_config.clone();
@@ -427,6 +444,46 @@ fn request_accessibility_permission() -> AccessibilityPermissionStatus {
 }
 
 #[tauri::command]
+async fn start_highlighter_service(
+    config: State<'_, Arc<Mutex<Config>>>,
+    highlighter_service: State<'_, HighlighterService>,
+) -> Result<bool, String> {
+    {
+        let mut config = config.lock().await;
+        config.highlighter_service_enabled = true;
+        config
+            .save_to_system()
+            .await
+            .map_err(|error| error.to_string())?;
+    }
+
+    if accessibility_allows_highlighter_start() {
+        highlighter_service
+            .start()
+            .map_err(|error| error.to_string())?;
+    }
+
+    Ok(highlighter_service.is_running())
+}
+
+#[tauri::command]
+async fn stop_highlighter_service(
+    config: State<'_, Arc<Mutex<Config>>>,
+    highlighter_service: State<'_, HighlighterService>,
+) -> Result<bool, String> {
+    {
+        let mut config = config.lock().await;
+        config.highlighter_service_enabled = false;
+        config
+            .save_to_system()
+            .await
+            .map_err(|error| error.to_string())?;
+    }
+
+    Ok(highlighter_service.stop())
+}
+
+#[tauri::command]
 fn launch_app(bundle_id: String) -> Result<(), String> {
     platform_broker().launch_app_bundle(&bundle_id)
 }
@@ -481,12 +538,13 @@ pub fn run_tauri() {
             }
         }
     };
+    let highlighter_service_enabled = config.highlighter_service_enabled;
     let config = Arc::new(Mutex::new(config));
     let highlighter_service = HighlighterService::new(config.clone());
-
-    if let Err(error) = highlighter_service.start() {
-        eprintln!("failed to start highlighter service: {error}");
-    }
+    start_highlighter_service_if_enabled_and_permitted(
+        &highlighter_service,
+        highlighter_service_enabled,
+    );
 
     tauri::Builder::default()
         .manage(config)
@@ -517,6 +575,8 @@ pub fn run_tauri() {
             set_integration_enabled,
             get_accessibility_permission_status,
             request_accessibility_permission,
+            start_highlighter_service,
+            stop_highlighter_service,
             launch_app,
         ])
         .on_window_event(|window, event| {
@@ -544,25 +604,50 @@ pub fn run_tauri() {
                 .tooltip("Harper Desktop")
                 .show_menu_on_left_click(false)
                 .on_menu_event(move |app, event| match event.id().as_ref() {
-                    TOGGLE_SERVICE_MENU_ID => match app.state::<HighlighterService>().toggle() {
-                        Ok(status) => {
-                            if let Err(error) =
-                                update_service_tray_state(app, &service_toggle, status)
-                            {
-                                eprintln!("failed to update service tray state: {error}");
-                            }
-                        }
-                        Err(error) => {
-                            eprintln!("failed to toggle highlighter service: {error}");
+                    TOGGLE_SERVICE_MENU_ID => {
+                        let highlighter_service = app.state::<HighlighterService>();
 
-                            let is_running = app.state::<HighlighterService>().is_running();
-                            if let Err(error) =
-                                update_service_tray_state(app, &service_toggle, is_running)
+                        let toggle_result = if highlighter_service.is_running() {
+                            tauri::async_runtime::block_on(stop_highlighter_service(
+                                app.state::<Arc<Mutex<Config>>>(),
+                                highlighter_service,
+                            ))
+                        } else {
+                            let result = tauri::async_runtime::block_on(start_highlighter_service(
+                                app.state::<Arc<Mutex<Config>>>(),
+                                highlighter_service,
+                            ));
+
+                            if matches!(result, Ok(false))
+                                && !accessibility_allows_highlighter_start()
+                                && let Err(error) = show_settings_window(app)
                             {
-                                eprintln!("failed to update service tray state: {error}");
+                                eprintln!("failed to show settings window: {error}");
+                            }
+
+                            result
+                        };
+
+                        match toggle_result {
+                            Ok(status) => {
+                                if let Err(error) =
+                                    update_service_tray_state(app, &service_toggle, status)
+                                {
+                                    eprintln!("failed to update service tray state: {error}");
+                                }
+                            }
+                            Err(error) => {
+                                eprintln!("failed to toggle highlighter service: {error}");
+
+                                let is_running = app.state::<HighlighterService>().is_running();
+                                if let Err(error) =
+                                    update_service_tray_state(app, &service_toggle, is_running)
+                                {
+                                    eprintln!("failed to update service tray state: {error}");
+                                }
                             }
                         }
-                    },
+                    }
                     OPEN_EDITOR_MENU_ID => {
                         if let Err(error) = show_editor_window(app) {
                             eprintln!("failed to show editor window: {error}");
@@ -712,6 +797,7 @@ pub fn run_highlighter() {
             debounce_ms: *dictionary_debounce_ms.borrow(),
             auto_update: true,
             last_update_check: None,
+            highlighter_service_enabled: true,
         };
         *dictionary_linter.borrow_mut() = config.create_linter();
 
@@ -787,6 +873,7 @@ fn fetch_highlighter_config(
             debounce_ms,
             auto_update: true,
             last_update_check: None,
+            highlighter_service_enabled: true,
         })
     })
 }

--- a/harper-desktop/src/lib/client.ts
+++ b/harper-desktop/src/lib/client.ts
@@ -171,6 +171,14 @@ export class Client {
 			'Accessibility permission request timed out',
 		);
 	}
+
+	static async startHighlighterService(): Promise<boolean> {
+		return await invoke<boolean>('start_highlighter_service');
+	}
+
+	static async stopHighlighterService(): Promise<boolean> {
+		return await invoke<boolean>('stop_highlighter_service');
+	}
 }
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {

--- a/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
+++ b/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
@@ -118,6 +118,10 @@ async function checkAccessibilityPermission() {
 
 	try {
 		accessibilityStatus = await Client.getAccessibilityPermissionStatus();
+
+		if (accessibilityStatus === 'Granted') {
+			await Client.startHighlighterService();
+		}
 	} catch (error) {
 		accessibilityError = `Unable to check Accessibility permission: ${error}`;
 	} finally {
@@ -137,6 +141,10 @@ async function requestAccessibilityPermission() {
 	try {
 		accessibilityStatus = await Client.requestAccessibilityPermission();
 		hasRequestedAccessibility = true;
+
+		if (accessibilityStatus === 'Granted') {
+			await Client.startHighlighterService();
+		}
 	} catch (error) {
 		accessibilityError = `Unable to request Accessibility permission: ${error}`;
 	} finally {


### PR DESCRIPTION
# Issues 

None.

# Description

This PR delays starting the Harper Desktop highlighter service until Accessibility permission is available and the persisted service setting allows it.

Key changes:
- Adds `highlighter_service_enabled` to the desktop config, defaulting to be enabled for new and existing configs.
- Starts the highlighter on app startup only when `highlighter_service_enabled` is true and Accessibility permission is granted.
- Adds Tauri commands to explicitly start and stop the highlighter service while updating the persisted config value.
- Updates the tray service toggle to use the persisted service setting.
- Keeps Accessibility permission check/request commands read-only.
- Starts the service from the onboarding flow after the frontend confirms Accessibility permission is granted.

# Demo

Not applicable.

# How Has This Been Tested?

- Added config serialization/deserialization coverage for `highlighter_service_enabled`, including the default value used when loading older configs.

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [x] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter

- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist

- [ ] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
