### PR TITLE
feat: desktop get locale/dialect from Tauri

### DIFF
--- a/harper-core/src/dict_word_metadata.rs
+++ b/harper-core/src/dict_word_metadata.rs
@@ -1088,6 +1088,11 @@ impl Dialect {
             _ => None,
         }
     }
+    // BCP-47 https://www.rfc-editor.org/rfc/rfc5646
+    #[must_use]
+    pub fn try_from_bcp47(bcp47: &str) -> Option<Self> {
+        bcp47.strip_prefix("en-").and_then(Self::try_from_abbr)
+    }
 }
 impl TryFrom<DialectFlags> for Dialect {
     type Error = ();

--- a/harper-core/src/dict_word_metadata.rs
+++ b/harper-core/src/dict_word_metadata.rs
@@ -1089,7 +1089,6 @@ impl Dialect {
         }
     }
     // BCP-47 https://www.rfc-editor.org/rfc/rfc5646
-    #[must_use]
     pub fn try_from_bcp47(bcp47: &str) -> Option<Self> {
         bcp47.strip_prefix("en-").and_then(Self::try_from_abbr)
     }

--- a/harper-desktop/src-tauri/Cargo.toml
+++ b/harper-desktop/src-tauri/Cargo.toml
@@ -34,6 +34,7 @@ harper-core = { path = "../../harper-core" }
 harper-dictionary-wordlist = { path = "../../harper-dictionary-wordlist" }
 egui_commonmark = "0.23.0"
 tokio = { version = "1.52.2", features = ["full"] }
+tauri-plugin-os = "2.3.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 accessibility = "0.2.0"

--- a/harper-desktop/src-tauri/src/config.rs
+++ b/harper-desktop/src-tauri/src/config.rs
@@ -43,7 +43,7 @@ impl Config {
     pub fn new() -> Self {
         Self {
             mutable_dictionary: MutableDictionary::new(),
-            dialect: Dialect::American,
+            dialect: Self::detect_system_dialect(),
             ignored_lints: IgnoredLints::new(),
             lint_config: FlatConfig::new_curated(),
             integrations: Self::curated_integrations(),
@@ -51,6 +51,12 @@ impl Config {
             auto_update: true,
             last_update_check: None,
         }
+    }
+
+    pub fn detect_system_dialect() -> Dialect {
+        tauri_plugin_os::locale()
+            .and_then(|bcp47| Dialect::try_from_bcp47(&bcp47))
+            .unwrap_or(Dialect::American)
     }
 
     pub fn curated_integrations() -> Vec<Integration> {

--- a/harper-desktop/src-tauri/src/lib.rs
+++ b/harper-desktop/src-tauri/src/lib.rs
@@ -496,6 +496,7 @@ pub fn run_tauri() {
             None,
         ))
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_os::init())
         .invoke_handler(tauri::generate_handler![
             get_lint_config,
             get_dialect,


### PR DESCRIPTION
# Issues 
Closes #3501

# Description

Sets the `Dialect` for Harper Desktop from the system using the official Tauri method.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

- Manually - let me know if you can think of a way to make any unit test(s) or integration test(s)
- `cargo test`
- `just build-desktop-macos` then installing the newly build app, running it, going into prefs, and seeing this: <img width="892" height="636" alt="Screenshot 2026-05-26 at 1 33 57 pm" src="https://github.com/user-attachments/assets/d795989d-ff3a-4895-9c7e-67ae5faee1c7" />

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

Actually I used Google AI to help choose which method to use and to finesse the code to something tiny and Rusty.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
