### PR TITLE
fix: closure checking apostrophe confusingly named `is_tack`

### DIFF
--- a/harper-core/src/lexing/mod.rs
+++ b/harper-core/src/lexing/mod.rs
@@ -84,14 +84,14 @@ pub fn lex_english_token(source: &[char]) -> FoundToken {
 }
 
 fn lex_word(source: &[char]) -> Option<FoundToken> {
-    let is_tack = |c: char| lex_punctuation(&[c]).is_some_and(|t| t.token.is_apostrophe());
+    let is_apostrophe = |c: char| lex_punctuation(&[c]).is_some_and(|t| t.token.is_apostrophe());
 
     let mut end = source
         .iter()
-        .position(|c| !c.is_english_lingual() && !c.is_ascii_digit() && !is_tack(*c))
+        .position(|c| !c.is_english_lingual() && !c.is_ascii_digit() && !is_apostrophe(*c))
         .unwrap_or(source.len());
 
-    while end >= 1 && is_tack(source[end - 1]) {
+    while end >= 1 && is_apostrophe(source[end - 1]) {
         end -= 1;
     }
 


### PR DESCRIPTION
# Issues 
N/A

# Description

I was going to work on some more mixups between "tack" and "tact" but while grepping for existing logic doing this I happened across a closure named `is_tack()` inside `lex_word()` in `lexing/mod.rs` Apparently this came about in one of the commits that made up the Weir PR: https://github.com/Automattic/harper/commit/46f4547f73968850d14df91fc13c1899fbb38b05

The closure actually checks for presence of an apostrophe. I'm guessing this was a typo for "tick" given that `` ` `` is often called "backtick" though Googling for whether anyone also calls `'` "tick" I couldn't find any evidence of that. So I've just changed it to the most vanilla / least confusing name `is_apostrophe()`

The only benefit of this bikeshedding change is that it won't be a red herring again for anyone else working on "tact" vs "tack" in the future (-:

# Demo
N/A

# How Has This Been Tested?
`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
