### PR TITLE
refactor: tweak two phrase set corrections

### DIFF
--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -64,6 +64,7 @@ pub fn lint_group() -> LintGroup {
         "ArgumentToBeMade" => (
             &[
                 ("argument to be said", "argument to be made"),
+                ("arguments to be said", "arguments to be made"),
             ],
             "The phrase `argument to be made` is correct.",
             "Corrects `argument to be said` to `argument to be made`.",
@@ -854,14 +855,6 @@ pub fn lint_group() -> LintGroup {
             "Don't use both `how` and `like` together to express similarity.",
             "Corrects `how ... looks like` to `how ... looks` or `what ... looks like`.",
             LintKind::Grammar
-        ),
-        "InHindsight" => (
-            &[
-                (&["in hind sight", "in hind-sight", "on hindsight", "on hind sight", "on hind-sight"], &["in hindsight"]),
-            ],
-            "Use `in hindsight` when reflecting on past events with the benefit of current knowledge.",
-            "Corrects incorrect variants of `in hindsight` to the standard phrase.",
-            LintKind::Usage
         ),
         "MakeItSeem" => (
             &[

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -46,6 +46,15 @@ fn corrects_there_is_an_argument_to_be_said() {
     );
 }
 
+#[test]
+fn corrects_theres_theres_arguments_to_be_said() {
+    assert_suggestion_result(
+        "there's there's arguments to be said for all of it.",
+        lint_group(),
+        "there's there's arguments to be made for all of it.",
+    );
+}
+
 // Bollocks
 
 #[test]
@@ -2834,53 +2843,6 @@ fn correct_how_it_looks_like_with_apostrophe() {
         lint_group(),
         "In the picture we can see how It looks on worker desktop.",
     );
-}
-
-// InHindsight
-
-#[test]
-fn corrects_on_hindsight() {
-    assert_suggestion_result(
-        "On hindsight, the tip to \"try launching your terminal\" would've been useful",
-        lint_group(),
-        "In hindsight, the tip to \"try launching your terminal\" would've been useful",
-    );
-}
-
-#[test]
-fn corrects_in_hind_sight_hyphenated() {
-    assert_suggestion_result(
-        "It probably could have been better to fake an OSS project name in hind-sight, but anyway we can still fix this.",
-        lint_group(),
-        "It probably could have been better to fake an OSS project name in hindsight, but anyway we can still fix this.",
-    );
-}
-
-#[test]
-fn corrects_in_hind_sight() {
-    assert_suggestion_result(
-        "In hind sight, this is obvious, but the error message led to hours of wasted debugging in the wrong places.",
-        lint_group(),
-        "In hindsight, this is obvious, but the error message led to hours of wasted debugging in the wrong places.",
-    )
-}
-
-#[test]
-fn corrects_on_hind_sight() {
-    assert_suggestion_result(
-        "Yes, on hind sight I've used tasks that don't respond well to kills.",
-        lint_group(),
-        "Yes, in hindsight I've used tasks that don't respond well to kills.",
-    )
-}
-
-#[test]
-fn corrects_on_hind_sight_hyphenated() {
-    assert_suggestion_result(
-        "On hind-sight the likely root cause was not force cleaning helm config.",
-        lint_group(),
-        "In hindsight the likely root cause was not force cleaning helm config.",
-    )
 }
 
 // MakeItSeem

--- a/harper-core/src/linting/weir_rules/InHindsight.weir
+++ b/harper-core/src/linting/weir_rules/InHindsight.weir
@@ -1,0 +1,12 @@
+expr main [(in hind sight), (in hind-sight), (on hindsight), (on hind sight), (on hind-sight)]
+
+let message "Use `in hindsight` when reflecting on past events with the benefit of current knowledge."
+let description "Corrects incorrect variants of `in hindsight` to the standard phrase."
+let kind "Usage"
+let becomes "in hindsight"
+
+test "On hindsight, the tip to \"try launching your terminal\" would've been useful" "In hindsight, the tip to \"try launching your terminal\" would've been useful"
+test "It probably could have been better to fake an OSS project name in hind-sight, but anyway we can still fix this." "It probably could have been better to fake an OSS project name in hindsight, but anyway we can still fix this."
+test "In hind sight, this is obvious, but the error message led to hours of wasted debugging in the wrong places." "In hindsight, this is obvious, but the error message led to hours of wasted debugging in the wrong places."
+test "Yes, on hind sight I've used tasks that don't respond well to kills." "Yes, in hindsight I've used tasks that don't respond well to kills."
+test "On hind-sight the likely root cause was not force cleaning helm config." "In hindsight the likely root cause was not force cleaning helm config."


### PR DESCRIPTION
# Issues 
N/A

# Description

While looking into a new phrase set correction I noticed two ones I recently added that weren't quite right. Both just had single corrections rather than sets.
- One, `InHindsight ` was moved to a Weir rule.
- The other, `ArgumentToBeMade ` was extended to cover plural as well as singular.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
