### PR TITLE
Fix issue #3502

### DIFF
--- a/harper-desktop/src/lib/settings/pages/IntegrationsPage.svelte
+++ b/harper-desktop/src/lib/settings/pages/IntegrationsPage.svelte
@@ -42,7 +42,10 @@ function toIntegrationRow(integration: Integration): IntegrationRow {
 }
 
 function integrationName(bundleId: string) {
-	return bundleId.split('.').at(-1) || bundleId;
+	// Capitalize the first letter so that e.g. "com.apple.mail" → "Mail" instead of "mail".
+	// Apps with already title-case suffixes (e.g. "TextEdit") are unaffected.
+	const raw = bundleId.split('.').at(-1) || bundleId;
+	return raw.charAt(0).toUpperCase() + raw.slice(1);
 }
 
 async function setIntegrationEnabled(bundleId: string, enabled: boolean) {


### PR DESCRIPTION
This PR fixes issue #3502.

---

**Summary of changes:**

The fix has been applied and pushed to the `fix-issue-3502` branch. Here's a summary:

**Problem:** In the Integrations settings page, Apple Mail was displayed as "mail" (lowercase) because the `integrationName()` function extracted the raw last segment of the bundle ID (`com.apple.mail` → `mail`). All other apps happened to already have title-case suffixes.

**Fix:** Modified the `integrationName()` function in `IntegrationsPage.svelte` to capitalize the first character of the extracted name:

```typescript
// Before:
return bundleId.split('.').at(-1) || bundleId;

// After:
const raw = bundleId.split('.').at(-1) || bundleId;
return raw.charAt(0).toUpperCase() + raw.slice(1);
```

**Effect on all integrations:**
| Bundle ID | Before | After |
|---|---|---|
| `com.apple.mail` | mail | **Mail** ✅ |
| `com.apple.TextEdit` | TextEdit | TextEdit ✅ |
| `com.apple.MobileSMS` | MobileSMS | MobileSMS ✅ |
| `com.apple.Notes` | Notes | Notes ✅ |

The fix is minimal (2 lines changed) and also benefits any user-added apps with lowercase suffixes.