### PR TITLE
feat(desktop): get display name for bundles from system

### DIFF
--- a/harper-desktop/src-tauri/src/lib.rs
+++ b/harper-desktop/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ use harper_core::{
     linting::{FlatConfig, Lint, LintGroup},
     spell::{Dictionary, MutableDictionary},
 };
+use serde::Serialize;
 use std::{cell::RefCell, rc::Rc, sync::Arc, time::Duration};
 use tauri::{
     Manager, State, WebviewUrl, WebviewWindowBuilder, WindowEvent,
@@ -56,6 +57,13 @@ const TOGGLE_SERVICE_MENU_ID: &str = "toggle-service";
 const OPEN_EDITOR_MENU_ID: &str = "open-editor";
 const SETTINGS_MENU_ID: &str = "settings";
 const QUIT_MENU_ID: &str = "quit";
+
+#[derive(Debug, Clone, Serialize)]
+struct IntegrationView {
+    bundle_id: String,
+    enabled: bool,
+    display_name: String,
+}
 
 struct TrayMenu {
     menu: Menu<tauri::Wry>,
@@ -366,8 +374,18 @@ async fn add_to_dictionary(
 #[tauri::command]
 async fn get_integrations(
     config: State<'_, Arc<Mutex<Config>>>,
-) -> Result<Vec<Integration>, String> {
-    Ok(config.lock().await.integrations.clone())
+) -> Result<Vec<IntegrationView>, String> {
+    let integrations = config.lock().await.integrations.clone();
+    let broker = platform_broker();
+
+    Ok(integrations
+        .into_iter()
+        .map(|integration| IntegrationView {
+            display_name: broker.integration_display_name(&integration.bundle_id),
+            bundle_id: integration.bundle_id,
+            enabled: integration.enabled,
+        })
+        .collect())
 }
 
 #[tauri::command]

--- a/harper-desktop/src-tauri/src/mac_broker.rs
+++ b/harper-desktop/src-tauri/src/mac_broker.rs
@@ -29,6 +29,8 @@ use std::{
     cell::RefCell,
     collections::BTreeMap,
     error::Error as StdError,
+    path::Path,
+    process::Command,
     ptr,
     rc::Rc,
     time::{Duration, Instant},
@@ -180,6 +182,10 @@ impl OsBroker for MacBroker {
         }
     }
 
+    fn system_integration_display_name(&self, bundle_id: &str) -> Option<String> {
+        system_integration_display_name(bundle_id)
+    }
+
     fn launch_app_bundle(&self, bundle_id: &str) -> Result<(), String> {
         let bundle_id = bundle_id.trim();
 
@@ -187,13 +193,49 @@ impl OsBroker for MacBroker {
             return Err("Bundle ID cannot be empty.".to_string());
         }
 
-        std::process::Command::new("open")
+        Command::new("open")
             .arg("-b")
             .arg(bundle_id)
             .spawn()
             .map_err(|error| format!("Failed to launch {bundle_id}: {error}"))?;
 
         Ok(())
+    }
+}
+
+fn system_integration_display_name(bundle_id: &str) -> Option<String> {
+    let bundle_id = bundle_id.trim();
+
+    if bundle_id.is_empty() {
+        return None;
+    }
+
+    let predicate_bundle_id = bundle_id.replace('\\', "\\\\").replace('"', "\\\"");
+    let output = Command::new("mdfind")
+        .arg(format!(
+            "kMDItemCFBundleIdentifier == \"{predicate_bundle_id}\""
+        ))
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| display_name_from_app_path(line.trim()))
+        .next()
+}
+
+fn display_name_from_app_path(path: &str) -> Option<String> {
+    let file_name = Path::new(path).file_name()?.to_str()?;
+    let display_name = file_name.strip_suffix(".app").unwrap_or(file_name).trim();
+
+    if display_name.is_empty() {
+        None
+    } else {
+        Some(display_name.to_string())
     }
 }
 

--- a/harper-desktop/src-tauri/src/os_broker.rs
+++ b/harper-desktop/src-tauri/src/os_broker.rs
@@ -34,9 +34,33 @@ pub trait OsBroker {
         self.accessibility_permission_status()
     }
 
+    fn system_integration_display_name(&self, _bundle_id: &str) -> Option<String> {
+        None
+    }
+
+    fn integration_display_name(&self, bundle_id: &str) -> String {
+        self.system_integration_display_name(bundle_id)
+            .unwrap_or_else(|| fallback_integration_display_name(bundle_id))
+    }
+
     fn launch_app_bundle(&self, _bundle_id: &str) -> Result<(), String> {
         Err("Launching apps by bundle ID is only supported on macOS.".to_string())
     }
+}
+
+fn fallback_integration_display_name(bundle_id: &str) -> String {
+    let trimmed = bundle_id.trim();
+
+    if trimmed.is_empty() {
+        return "Unknown app".to_string();
+    }
+
+    trimmed
+        .split('.')
+        .rev()
+        .find(|segment| !segment.is_empty())
+        .unwrap_or(trimmed)
+        .to_string()
 }
 
 /// No-op platform broker for targets that do not have an OS implementation yet.
@@ -57,5 +81,29 @@ impl OsBroker for NoopBroker {
 
     fn cursor_position(&self) -> Option<egui::Pos2> {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fallback_integration_display_name;
+
+    #[test]
+    fn fallback_handles_empty_bundle_ids() {
+        assert_eq!(fallback_integration_display_name(""), "Unknown app");
+        assert_eq!(fallback_integration_display_name("   "), "Unknown app");
+    }
+
+    #[test]
+    fn fallback_uses_last_non_empty_segment_without_changing_case() {
+        assert_eq!(
+            fallback_integration_display_name("com.microsoft.VSCode"),
+            "VSCode"
+        );
+        assert_eq!(
+            fallback_integration_display_name("com.googlecode.iterm2"),
+            "iterm2"
+        );
+        assert_eq!(fallback_integration_display_name("com.example."), "example");
     }
 }

--- a/harper-desktop/src/lib/client.ts
+++ b/harper-desktop/src/lib/client.ts
@@ -37,6 +37,7 @@ function getConfigLinter(): Promise<LocalLinterType> {
 export interface Integration {
 	bundle_id: string;
 	enabled: boolean;
+	display_name: string;
 }
 
 export type AccessibilityPermissionStatus = 'Granted' | 'NotGranted' | 'Unsupported';

--- a/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
+++ b/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
@@ -83,7 +83,10 @@ async function enableTextEditForSetup() {
 			);
 		} else {
 			await Client.addIntegration('com.apple.TextEdit');
-			integrations = [...integrations, { bundle_id: 'com.apple.TextEdit', enabled: true }];
+			integrations = [
+				...integrations,
+				{ bundle_id: 'com.apple.TextEdit', enabled: true, display_name: 'TextEdit' },
+			];
 		}
 
 		state = {

--- a/harper-desktop/src/lib/settings/pages/IntegrationsPage.svelte
+++ b/harper-desktop/src/lib/settings/pages/IntegrationsPage.svelte
@@ -37,12 +37,8 @@ async function loadIntegrations() {
 function toIntegrationRow(integration: Integration): IntegrationRow {
 	return {
 		...integration,
-		name: integrationName(integration.bundle_id),
+		name: integration.display_name,
 	};
-}
-
-function integrationName(bundleId: string) {
-	return bundleId.split('.').at(-1) || bundleId;
 }
 
 async function setIntegrationEnabled(bundleId: string, enabled: boolean) {
@@ -93,12 +89,16 @@ async function addIntegration(bundleId: string) {
 
 	const previousIntegrations = integrations;
 
-	integrations = [...integrations, { bundle_id: trimmedBundleId, enabled: true }];
+	integrations = [
+		...integrations,
+		{ bundle_id: trimmedBundleId, enabled: true, display_name: trimmedBundleId },
+	];
 	isIntegrationsSaving = true;
 	integrationsError = '';
 
 	try {
 		await Client.addIntegration(trimmedBundleId);
+		await loadIntegrations();
 		closeAppPicker();
 	} catch (error) {
 		integrations = previousIntegrations;


### PR DESCRIPTION
# Issues 

Fixes #3502

# Description

This PR changes Harper Desktop integrations to display app names resolved by the Rust OS broker instead of deriving labels in the frontend from bundle ID suffixes.

Implements macOS system lookup in `MacBroker` for bundle IDs, falling back to a private safe suffix-based display name.

# Demo

N/A

# How Has This Been Tested?

Added Rust unit tests for private fallback display-name behavior.

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
