### PR TITLE
feat: from the naked eye→by/to/with the naked eye

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -3713,6 +3713,13 @@
 								"state": true,
 								"label": "A Some Time"
 							}
+						},
+						{
+							"Bool": {
+								"name": "NakedEye",
+								"state": true,
+								"label": "Naked Eye"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -144,6 +144,7 @@ use super::most_of_the_times::MostOfTheTimes;
 use super::multiple_frequency_adverbs::MultipleFrequencyAdverbs;
 use super::multiple_sequential_pronouns::MultipleSequentialPronouns;
 use super::nail_on_the_head::NailOnTheHead;
+use super::naked_eye::NakedEye;
 use super::need_to_noun::NeedToNoun;
 use super::no_french_spaces::NoFrenchSpaces;
 use super::no_longer::NoLonger;
@@ -697,6 +698,7 @@ impl LintGroup {
         insert_expr_rule!(MostOfTheTimes, true);
         insert_expr_rule!(MultipleSequentialPronouns, true);
         insert_expr_rule!(NailOnTheHead, true);
+        insert_expr_rule!(NakedEye, true);
         insert_expr_rule!(NeedToNoun, true);
         insert_struct_rule!(NoFrenchSpaces, true);
         insert_expr_rule!(NoLonger, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -153,6 +153,7 @@ mod most_of_the_times;
 mod multiple_frequency_adverbs;
 mod multiple_sequential_pronouns;
 mod nail_on_the_head;
+mod naked_eye;
 mod need_to_noun;
 mod no_french_spaces;
 mod no_longer;

--- a/harper-core/src/linting/naked_eye.rs
+++ b/harper-core/src/linting/naked_eye.rs
@@ -1,0 +1,199 @@
+use crate::{
+    CharStringExt, Lint, Token, TokenKind, TokenStringExt,
+    expr::{Expr, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+};
+
+pub struct NakedEye {
+    expr: SequenceExpr,
+}
+
+impl Default for NakedEye {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::optional(
+                SequenceExpr::word_set(&[
+                    "hide", "hides", "hid", "hidden", "hiding", "keep", "keeps", "kept", "keeping",
+                ])
+                .t_ws()
+                .then_optional(
+                    SequenceExpr::optional(
+                        SequenceExpr::default()
+                            .then_kind_any(&[
+                                TokenKind::is_determiner,
+                                TokenKind::is_adjective,
+                                TokenKind::is_oov,
+                            ])
+                            .t_ws(),
+                    )
+                    .then_noun()
+                    .t_ws(),
+                ),
+            )
+            .then_preposition()
+            .t_ws()
+            .t_aco("the")
+            .t_ws()
+            .t_aco("naked")
+            .t_ws()
+            .t_set(&["eye", "eyes"]),
+        }
+    }
+}
+
+impl ExprLinter for NakedEye {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        let (verb, _adj, _noun, prep, _idiom) = match toks.len() {
+            7 => (None, None, None, &toks[0], &toks[2..]),
+            9 => (Some(&toks[0]), None, None, &toks[2], &toks[4..]),
+            11 => (Some(&toks[0]), None, Some(&toks[2]), &toks[4], &toks[6..]),
+            13 => (
+                Some(&toks[0]),
+                Some(&toks[2]),
+                Some(&toks[4]),
+                &toks[6],
+                &toks[8..],
+            ),
+            _ => return None,
+        };
+
+        let prep = prep.span;
+        let prepch = prep.get_content(src);
+
+        match (
+            verb.is_some(),
+            prepch.eq_ch(&['f', 'r', 'o', 'm']),
+            prepch.eq_any_ignore_ascii_case_str(&["to", "with", "by"]),
+        ) {
+            (_, _, true) => return None,    // known good preposition
+            (true, true, _) => return None, // hide from
+            (_, false, _) => return None,   // any other preposition
+            (_, true, _) => (),             // from
+        };
+
+        let suggestions = ["to", "with", "by"]
+            .into_iter()
+            .map(|p| Suggestion::replace_with_match_case_str(p, prep.get_content(src)))
+            .collect();
+
+        Some(Lint {
+            span: prep,
+            lint_kind: LintKind::Miscellaneous,
+            suggestions,
+            message: "This idiom usually requires a different preposition.".to_string(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects the wrong preposition used instead of `to`, `with`, or `by` the naked eye."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    use super::NakedEye;
+
+    #[test]
+    #[ignore = "Underscores are not parts of words"]
+    fn dont_flag_hiding_adj_noun_from() {
+        assert_no_lints(
+            "Once the opt-in is complete, the obtained lock() and unlock() utilities enable hiding __experimental APIs from the naked eye:",
+            NakedEye::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_easily_hide_noun_from() {
+        assert_no_lints(
+            "But there is something we forgot about, something that allows one to easily hide things from the naked eye ... macros!",
+            NakedEye::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_well_hidden_from() {
+        assert_no_lints(
+            "We successfully tampered with the release, well hidden from the naked eye.",
+            NakedEye::default(),
+        );
+    }
+
+    #[test]
+    fn but_from_the_naked_eye() {
+        assert_suggestion_result(
+            "As you can see from the pic the pedestrian is being detected but from the naked eye it can't be seen due to the slope.",
+            NakedEye::default(),
+            "As you can see from the pic the pedestrian is being detected but to the naked eye it can't be seen due to the slope.",
+        );
+    }
+
+    #[test]
+    fn even_from_the_naked_eye() {
+        assert_suggestion_result(
+            "the Photoshop one when even from the naked eye you can tell that if you were to zoom into",
+            NakedEye::default(),
+            "the Photoshop one when even with the naked eye you can tell that if you were to zoom into",
+        );
+    }
+
+    #[test]
+    fn looks_legit_to_the_naked_eye() {
+        assert_suggestion_result(
+            "In fact, it looks like legit 1080p from the naked eye I guess... 😭",
+            NakedEye::default(),
+            "In fact, it looks like legit 1080p to the naked eye I guess... 😭",
+        );
+    }
+
+    #[test]
+    fn observed_from_the_naked_eye() {
+        assert_suggestion_result(
+            "... when observed from the naked eye for the bone micro-architecture of the osteoporotic and healthy cases ...",
+            NakedEye::default(),
+            "... when observed with the naked eye for the bone micro-architecture of the osteoporotic and healthy cases ...",
+        );
+    }
+
+    #[test]
+    fn being_private_hidden_from() {
+        assert_no_lints(
+            "... which makes the entire concept of it being private hidden from the naked eye.",
+            NakedEye::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_keep_det_noun_from() {
+        assert_no_lints(
+            "... but how can I keep this key from the naked eyes?",
+            NakedEye::default(),
+        );
+    }
+
+    #[test]
+    fn just_from_the_naked_eye() {
+        assert_suggestion_result(
+            "What I want is, just from the naked eye, I think there are only 5 colors on this picture",
+            NakedEye::default(),
+            "What I want is, just with the naked eye, I think there are only 5 colors on this picture",
+        );
+    }
+
+    #[test]
+    fn invisibility_from_the_naked_eye() {
+        assert_suggestion_result(
+            "Considering the real security implications of true invisibility from the naked eye",
+            NakedEye::default(),
+            "Considering the real security implications of true invisibility to the naked eye",
+        );
+    }
+}

--- a/harper-core/src/linting/naked_eye.rs
+++ b/harper-core/src/linting/naked_eye.rs
@@ -1,5 +1,5 @@
 use crate::{
-    CharStringExt, Lint, Token, TokenKind, TokenStringExt,
+    CharStringExt, Lint, Token, TokenKind,
     expr::{Expr, SequenceExpr},
     linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
 };


### PR DESCRIPTION
# Issues 
N/A

# Description

I heard somebody say "from the naked eye" in a YouTube video, did some research to confirm that it's wrong and common.

Specifically allows the prepositions "to", "with", and "by", but only "from" is flagged.
Unless the verb before "from" is an inflection of "hide" or "keep".

For now, the same logic applies also to "the naked eyes" plural, but not to variants without "the". File issues if these or other variants should be handled.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
