### PR TITLE
docs: tips for faster iteration

### DIFF
--- a/packages/web/src/routes/docs/contributors/author-a-rule/+page.md
+++ b/packages/web/src/routes/docs/contributors/author-a-rule/+page.md
@@ -263,6 +263,15 @@ From there, you can run `just lint <test filename>`.
 It should emit a readable report of the grammatical errors in the document.
 If the error your rule looks for does _not_ appear in this list, something is wrong.
 
+Once you have unit tests for your rule, use `cargo test -- <REGEX>` from `harper-core` to run only the tests whose names match a pattern:
+
+```bash
+cd harper-core
+cargo test -- <REGEX>
+```
+
+This keeps the edit-test loop fast while you iterate on one rule and skips tests from other workspace crates.
+
 If you need any help writing or debugging rules, don't be afraid to contact the Harper team in your draft pull request.
 
 > **Note:** if two lints (or suggestions) overlap or address the same problem, this command will only display the first one.

--- a/packages/web/src/routes/docs/contributors/tests/+page.md
+++ b/packages/web/src/routes/docs/contributors/tests/+page.md
@@ -12,10 +12,22 @@ While we do take advantage of snapshot and integration tests, we tend to focus o
 ## Performance
 
 In the interest of maintaining fast iteration cycles, we run our tests with `opt-level = 1`.
-These optimizations are known to cause issues with debuggers. 
+These optimizations are known to cause issues with debuggers.
 If you plan to use one, you may want to comment them out.
 
 @code(../../../../../../../Cargo.toml)
+
+## Filtering Tests
+
+Use `cargo test -- <REGEX>` to run only tests whose names match a pattern.
+When iterating on core rules, it is usually fastest to run this from `harper-core`:
+
+```bash
+cd harper-core
+cargo test -- <REGEX>
+```
+
+This repeatedly runs the rule's focused tests while skipping tests from other workspace crates.
 
 ## Other Reading
 


### PR DESCRIPTION
# Description

Documented how you can use `cargo test -- <REGEX>` to filter tests and that you can solely run tests inside of `harper-core`. Both tips can improve iteration speed on new rules.
