### PR TITLE
fix(core): Weir options should resolve independent of order

### DIFF
--- a/harper-core/src/expr/longest_match_of.rs
+++ b/harper-core/src/expr/longest_match_of.rs
@@ -14,6 +14,10 @@ impl LongestMatchOf {
     pub fn add(&mut self, expr: impl Expr + 'static) {
         self.exprs.push(Box::new(expr));
     }
+
+    pub fn add_boxed(&mut self, expr: Box<dyn Expr>) {
+        self.exprs.push(expr);
+    }
 }
 
 impl Expr for LongestMatchOf {

--- a/harper-core/src/weir/ast.rs
+++ b/harper-core/src/weir/ast.rs
@@ -3,7 +3,7 @@ use hashbrown::HashMap;
 use is_macro::Is;
 use itertools::Itertools;
 
-use crate::expr::{Expr, Filter, FirstMatchOf, SequenceExpr, UnlessStep};
+use crate::expr::{Expr, Filter, LongestMatchOf, SequenceExpr, UnlessStep};
 use crate::patterns::{AnyPattern, DerivedFrom, UPOSSet, WhitespacePattern, Word};
 use crate::{CharString, CharStringExt, Lrc, Punctuation, Token};
 
@@ -128,7 +128,7 @@ impl AstExprNode {
                 Ok(Box::new(expr))
             }
             AstExprNode::Arr(children) => {
-                let mut expr = FirstMatchOf::default();
+                let mut expr = LongestMatchOf::default();
 
                 for node in children {
                     expr.add_boxed(node.to_expr(ctx_exprs)?);

--- a/harper-core/src/weir/mod.rs
+++ b/harper-core/src/weir/mod.rs
@@ -464,6 +464,30 @@ pub mod tests {
     }
 
     #[test]
+    fn array_prefers_longest_match_over_first_match() {
+        for main in [
+            "[(capitalized off of), (capitalized off)]",
+            "[(capitalized off), (capitalized off of)]",
+        ] {
+            let source = format!(
+                r#"
+            expr main {main}
+            let message "Use the replacement."
+            let description "Regression test for overlapping Weir array options."
+            let kind "Miscellaneous"
+            let becomes "replacement"
+            let strategy "Exact"
+
+            test "capitalized off of" "replacement"
+            "#
+            );
+
+            let mut linter = WeirLinter::new(&source).unwrap();
+            assert_passes_all(&mut linter);
+        }
+    }
+
+    #[test]
     fn g_suite_with_refs() {
         let source = r#"
             expr a (G [Suite, Suit])


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

This fixes an issue mentioned to me in [Discord](https://discord.com/channels/1335035237213671495/1461079667367739472/1509217447104876684).

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

If two expressions existed in a Weir option (denoted with the `[]` syntax), a shorter branch might stop a longer branch from matching.

As it turnes out, this was pretty easy to fix. I just swapped out `FirstMatchof` for `LongestMatchOf`. 

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Additional unit test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
