### PR TITLE
fix: initialize default grammar rules in WorkerLinter setup

### DIFF
--- a/packages/harper.js/src/LocalLinter.ts
+++ b/packages/harper.js/src/LocalLinter.ts
@@ -28,6 +28,8 @@ export default class LocalLinter implements Linter {
 
 	async setup(): Promise<void> {
 		await this.lint('', { language: 'plaintext' });
+		// Workaround for Issue 3490: ensure default rule state is materialized
+		await this.getDefaultLintConfigAsJSON();
 
 		const exported = await this.exportIgnoredLints();
 		await this.importIgnoredLints(exported);


### PR DESCRIPTION
Bug: WorkerLinter's default-enabled grammar rules are silently inactive until getDefaultLintConfig() is called.

Root Cause: The curated rules are conditionally initialized in the Rust WASM layer via FlatConfig's curated lazy lock, but under certain conditions in a Web Worker environment, the rule set initialization isn't correctly populated when setup merely triggers linting an empty string. The getter explicitly requests materialization of the rules, breaking the dependency cycle.

Why fix is correct: Calling getDefaultLintConfigAsJSON inside LocalLinter's setup explicitly materializes the default rule state via the Wasm-bindgen exported get_default_lint_config_as_json. This ensures the rules are armed and cached before the first proper lint is dispatched, effectively fixing the bug while preserving backwards-compatibility.