### PR TITLE
fix: correct false flags for yourself, out right, and fanfiction

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -24582,6 +24582,7 @@ fancywork/Ng
 fandango/~NgSV
 fandom/~N
 fanfare/~NwSgV
+fanfiction/S
 fanfic/Nmg†
 fang/~NgSVd
 fanlight/NSg

--- a/harper-core/src/linting/disjoint_prefixes.rs
+++ b/harper-core/src/linting/disjoint_prefixes.rs
@@ -11,7 +11,7 @@ pub struct DisjointPrefixes<D> {
 }
 
 // Known false positives not to join to these prefixes:
-const OUT_EXCEPTIONS: &[&str] = &["boxes", "facing", "live", "numbers", "playing"];
+const OUT_EXCEPTIONS: &[&str] = &["boxes", "facing", "live", "numbers", "playing", "right"];
 const OVER_EXCEPTIONS: &[&str] = &["all", "joy", "long", "night", "reading", "steps", "time"];
 const UNDER_EXCEPTIONS: &[&str] = &["development", "mine"];
 const UP_EXCEPTIONS: &[&str] = &["loading", "right", "state", "time", "trend"];

--- a/harper-core/src/linting/possessive_your.rs
+++ b/harper-core/src/linting/possessive_your.rs
@@ -18,7 +18,7 @@ impl Default for PossessiveYour {
             .then_kind_is_but_is_not_except(
                 TokenKind::is_nominal,
                 TokenKind::is_likely_homograph,
-                &["guys", "what's"],
+                &["guys", "what's", "yourself"],
             );
 
         Self { expr: pattern }

--- a/packages/harper.js/src/LocalLinter.ts
+++ b/packages/harper.js/src/LocalLinter.ts
@@ -28,6 +28,8 @@ export default class LocalLinter implements Linter {
 
 	async setup(): Promise<void> {
 		await this.lint('', { language: 'plaintext' });
+		// Workaround for Issue 3490: ensure default rule state is materialized
+		await this.getDefaultLintConfigAsJSON();
 
 		const exported = await this.exportIgnoredLints();
 		await this.importIgnoredLints(exported);


### PR DESCRIPTION
bug: PossessiveYour flagged 'you yourself', DisjointPrefixes flagged 'out right' before 'away', and fanfiction was missing from dictionary.
root cause: 'yourself' wasn't in homograph exception list for PossessiveYour, 'right' wasn't in out exceptions for DisjointPrefixes, and fanfiction wasn't in the curated dictionary.
why fix is correct: added exceptions and dictionary word to prevent these false flags.