### PR TITLE
fix: false positive 'an mp3' wrongly flagged to change to 'a mp3'

### DIFF
--- a/harper-core/src/indefinite_article.rs
+++ b/harper-core/src/indefinite_article.rs
@@ -138,6 +138,7 @@ pub fn starts_with_vowel(word: &[char], dialect: Dialect) -> Option<InitialSound
             | ['n', 'g', ..]
             | ['n', 'v', ..]
             | ['x', 'b', 'o', 'x']
+            | ['m', 'p', '3' | '4', ..]
             | ['h', 'e', 'i', 'r', ..]
             | ['h', 'o', 'n', 'o', 'r', ..]
             | ['h', 'o', 'n', 'e', 's', ..]

--- a/harper-core/src/linting/an_a.rs
+++ b/harper-core/src/linting/an_a.rs
@@ -210,6 +210,7 @@ mod tests {
     #[test]
     fn allow_an_mp_and_an_mp3() {
         assert_lint_count("an MP and an MP3?", AnA::new(Dialect::American), 0);
+        assert_lint_count("an mp3", AnA::new(Dialect::American), 0);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #3289.

### Root Cause
Lowercase 'mp3' and 'mp4' were falling back to being treated as consonants because they aren't parsed as likely initialisms (since they contain lower-case and numbers).

### Fix
Added 'mp3' and 'mp4' as explicit exceptions in the vowel-sound checker for indefinite articles.