### PR TITLE
fix: upgrade Playwright to working version

### DIFF
--- a/packages/chrome-plugin/package.json
+++ b/packages/chrome-plugin/package.json
@@ -26,7 +26,7 @@
 	},
 	"devDependencies": {
 		"@crxjs/vite-plugin": "^2.3.0",
-		"@playwright/test": "^1.58.0",
+		"@playwright/test": "1.60.0",
 		"@sveltejs/vite-plugin-svelte": "^4.0.0",
 		"@types/chrome": "^0.0.246",
 		"@types/lodash-es": "^4.17.12",

--- a/packages/harper.js/package.json
+++ b/packages/harper.js/package.json
@@ -33,7 +33,7 @@
 		"marked": "^16.4.1",
 		"p-lazy": "^5.0.0",
 		"p-memoize": "^7.1.1",
-		"playwright": "^1.58.0",
+		"playwright": "1.60.0",
 		"type-fest": "^4.37.0",
 		"typescript": "catalog:",
 		"vite": "^6.1.0",

--- a/packages/obsidian-plugin/package.json
+++ b/packages/obsidian-plugin/package.json
@@ -4,7 +4,7 @@
 	"version": "2.2.1",
 	"main": "main.js",
 	"devDependencies": {
-		"@playwright/test": "^1.58.0",
+		"@playwright/test": "1.60.0",
 		"@rollup/plugin-node-resolve": "^16.0.0",
 		"@types/lodash-es": "^4.17.12",
 		"@vitest/browser": "^4.0.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,8 +127,8 @@ importers:
         specifier: ^2.3.0
         version: 2.3.0
       '@playwright/test':
-        specifier: ^1.58.0
-        version: 1.58.0
+        specifier: 1.60.0
+        version: 1.60.0
       '@sveltejs/vite-plugin-svelte':
         specifier: ^4.0.0
         version: 4.0.4(svelte@5.43.12)(vite@5.4.17(@types/node@22.13.10)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0))
@@ -158,7 +158,7 @@ importers:
         version: 14.1.1
       playwright-webextext:
         specifier: ^0.0.4
-        version: 0.0.4(@playwright/test@1.58.0)(playwright@1.58.0)
+        version: 0.0.4(@playwright/test@1.60.0)(playwright@1.60.0)
       prettier:
         specifier: ^3.1.0
         version: 3.5.3
@@ -304,7 +304,7 @@ importers:
         version: 4.0.16(msw@2.7.3(@types/node@22.13.10)(typescript@5.9.3))(vite@6.3.5(@types/node@22.13.10)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))(vitest@4.0.16)
       '@vitest/browser-playwright':
         specifier: ^4.0.16
-        version: 4.0.16(msw@2.7.3(@types/node@22.13.10)(typescript@5.9.3))(playwright@1.58.0)(vite@6.3.5(@types/node@22.13.10)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))(vitest@4.0.16)
+        version: 4.0.16(msw@2.7.3(@types/node@22.13.10)(typescript@5.9.3))(playwright@1.60.0)(vite@6.3.5(@types/node@22.13.10)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))(vitest@4.0.16)
       '@vitest/ui':
         specifier: 4.0.16
         version: 4.0.16(vitest@4.0.16)
@@ -321,8 +321,8 @@ importers:
         specifier: ^7.1.1
         version: 7.1.1
       playwright:
-        specifier: ^1.58.0
-        version: 1.58.0
+        specifier: 1.60.0
+        version: 1.60.0
       type-fest:
         specifier: ^4.37.0
         version: 4.37.0
@@ -437,8 +437,8 @@ importers:
         version: 2.8.1
     devDependencies:
       '@playwright/test':
-        specifier: ^1.58.0
-        version: 1.58.0
+        specifier: 1.60.0
+        version: 1.60.0
       '@rollup/plugin-node-resolve':
         specifier: ^16.0.0
         version: 16.0.1(rollup@4.53.3)
@@ -450,7 +450,7 @@ importers:
         version: 4.0.16(msw@2.7.3(@types/node@22.13.10)(typescript@5.9.3))(vite@6.3.5(@types/node@22.13.10)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))(vitest@4.0.16)
       '@vitest/browser-playwright':
         specifier: ^4.0.16
-        version: 4.0.16(msw@2.7.3(@types/node@22.13.10)(typescript@5.9.3))(playwright@1.58.0)(vite@6.3.5(@types/node@22.13.10)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))(vitest@4.0.16)
+        version: 4.0.16(msw@2.7.3(@types/node@22.13.10)(typescript@5.9.3))(playwright@1.60.0)(vite@6.3.5(@types/node@22.13.10)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))(vitest@4.0.16)
       obsidian:
         specifier: ^1.7.2
         version: 1.8.7(@codemirror/state@6.5.2)(@codemirror/view@6.36.4)
@@ -645,7 +645,7 @@ importers:
     devDependencies:
       '@wordpress/scripts':
         specifier: ^30.9.0
-        version: 30.13.0(@playwright/test@1.58.0)(@types/eslint@9.6.1)(@types/node@22.13.10)(@types/webpack@4.41.40)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.37.0)(typescript@5.9.3)
+        version: 30.13.0(@playwright/test@1.60.0)(@types/eslint@9.6.1)(@types/node@22.13.10)(@types/webpack@4.41.40)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.37.0)(typescript@5.9.3)
       '@wp-now/wp-now':
         specifier: ^0.1.74
         version: 0.1.74
@@ -2895,8 +2895,8 @@ packages:
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.58.0':
-    resolution: {integrity: sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -9931,8 +9931,8 @@ packages:
   pkg-types@2.1.0:
     resolution: {integrity: sha512-wmJwA+8ihJixSoHKxZJRBQG1oY8Yr9pGLzRmSsNms0iNWyHHAlZCa7mmKiFR10YPZuz/2k169JiS/inOjBCZ2A==}
 
-  playwright-core@1.58.0:
-    resolution: {integrity: sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -9948,8 +9948,8 @@ packages:
       playwright:
         optional: true
 
-  playwright@1.58.0:
-    resolution: {integrity: sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -15682,9 +15682,9 @@ snapshots:
 
   '@pkgr/core@0.1.1': {}
 
-  '@playwright/test@1.58.0':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.58.0
+      playwright: 1.60.0
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.15(@types/webpack@4.41.40)(react-refresh@0.14.2)(type-fest@4.37.0)(webpack-dev-server@4.15.2)(webpack@5.98.0)':
     dependencies:
@@ -17554,11 +17554,11 @@ snapshots:
       tinyglobby: 0.2.15
       vite-plugin-pwa: 0.21.1(vite@6.3.5(@types/node@22.13.10)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0)
 
-  '@vitest/browser-playwright@4.0.16(msw@2.7.3(@types/node@22.13.10)(typescript@5.9.3))(playwright@1.58.0)(vite@6.3.5(@types/node@22.13.10)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))(vitest@4.0.16)':
+  '@vitest/browser-playwright@4.0.16(msw@2.7.3(@types/node@22.13.10)(typescript@5.9.3))(playwright@1.60.0)(vite@6.3.5(@types/node@22.13.10)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))(vitest@4.0.16)':
     dependencies:
       '@vitest/browser': 4.0.16(msw@2.7.3(@types/node@22.13.10)(typescript@5.9.3))(vite@6.3.5(@types/node@22.13.10)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))(vitest@4.0.16)
       '@vitest/mocker': 4.0.16(msw@2.7.3(@types/node@22.13.10)(typescript@5.9.3))(vite@6.3.5(@types/node@22.13.10)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))
-      playwright: 1.58.0
+      playwright: 1.60.0
       tinyrainbow: 3.0.3
       vitest: 4.0.16(@types/node@22.13.10)(@vitest/browser-playwright@4.0.16)(@vitest/ui@4.0.16)(jiti@2.6.1)(jsdom@20.0.3)(lightningcss@1.32.0)(msw@2.7.3(@types/node@22.13.10)(typescript@5.9.3))(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)
     transitivePeerDependencies:
@@ -18277,9 +18277,9 @@ snapshots:
       '@babel/runtime': 7.25.7
       '@wordpress/deprecated': 4.20.0
 
-  '@wordpress/e2e-test-utils-playwright@1.20.0(@playwright/test@1.58.0)':
+  '@wordpress/e2e-test-utils-playwright@1.20.0(@playwright/test@1.60.0)':
     dependencies:
-      '@playwright/test': 1.58.0
+      '@playwright/test': 1.60.0
       change-case: 4.1.2
       form-data: 4.0.2
       get-port: 5.1.1
@@ -18758,16 +18758,16 @@ snapshots:
       react: 18.3.1
       route-recognizer: 0.3.4
 
-  '@wordpress/scripts@30.13.0(@playwright/test@1.58.0)(@types/eslint@9.6.1)(@types/node@22.13.10)(@types/webpack@4.41.40)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.37.0)(typescript@5.9.3)':
+  '@wordpress/scripts@30.13.0(@playwright/test@1.60.0)(@types/eslint@9.6.1)(@types/node@22.13.10)(@types/webpack@4.41.40)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.37.0)(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.25.7
-      '@playwright/test': 1.58.0
+      '@playwright/test': 1.60.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(@types/webpack@4.41.40)(react-refresh@0.14.2)(type-fest@4.37.0)(webpack-dev-server@4.15.2)(webpack@5.98.0)
       '@svgr/webpack': 8.1.0(typescript@5.9.3)
       '@wordpress/babel-preset-default': 8.20.0
       '@wordpress/browserslist-config': 6.20.0
       '@wordpress/dependency-extraction-webpack-plugin': 6.20.0(webpack@5.98.0)
-      '@wordpress/e2e-test-utils-playwright': 1.20.0(@playwright/test@1.58.0)
+      '@wordpress/e2e-test-utils-playwright': 1.20.0(@playwright/test@1.60.0)
       '@wordpress/eslint-plugin': 22.6.0(@babel/core@7.25.7)(@types/eslint@9.6.1)(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.10)(babel-plugin-macros@3.1.0))(typescript@5.9.3)(wp-prettier@3.0.3)
       '@wordpress/jest-preset-default': 12.20.0(@babel/core@7.25.7)(jest@29.7.0(@types/node@22.13.10)(babel-plugin-macros@3.1.0))
       '@wordpress/npm-package-json-lint-config': 5.20.0(npm-package-json-lint@6.4.0(typescript@5.9.3))
@@ -24594,16 +24594,16 @@ snapshots:
       exsolve: 1.0.4
       pathe: 2.0.3
 
-  playwright-core@1.58.0: {}
+  playwright-core@1.60.0: {}
 
-  playwright-webextext@0.0.4(@playwright/test@1.58.0)(playwright@1.58.0):
+  playwright-webextext@0.0.4(@playwright/test@1.60.0)(playwright@1.60.0):
     optionalDependencies:
-      '@playwright/test': 1.58.0
-      playwright: 1.58.0
+      '@playwright/test': 1.60.0
+      playwright: 1.60.0
 
-  playwright@1.58.0:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.58.0
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -27130,7 +27130,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.13.10
-      '@vitest/browser-playwright': 4.0.16(msw@2.7.3(@types/node@22.13.10)(typescript@5.9.3))(playwright@1.58.0)(vite@6.3.5(@types/node@22.13.10)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))(vitest@4.0.16)
+      '@vitest/browser-playwright': 4.0.16(msw@2.7.3(@types/node@22.13.10)(typescript@5.9.3))(playwright@1.60.0)(vite@6.3.5(@types/node@22.13.10)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0))(vitest@4.0.16)
       '@vitest/ui': 4.0.16(vitest@4.0.16)
       jsdom: 20.0.3
     transitivePeerDependencies:


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

This fixes an issue caused by https://github.com/microsoft/playwright/issues/40724

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

In some versions of Playwright, when combined with some versions of Node.js, the browser install step can hang. This is currently stopping CI from completing.

I have updated Playwright to a version that does not have this issue.
