### PR TITLE
fix(desktop): rename to `Harper`

### DIFF
--- a/harper-desktop/src-tauri/tauri.conf.json
+++ b/harper-desktop/src-tauri/tauri.conf.json
@@ -25,10 +25,7 @@
 			"icons/icon.icns",
 			"icons/icon.ico"
 		],
-		"createUpdaterArtifacts": true,
-		"macOS": {
-			"bundleName": "Harper"
-		}
+		"createUpdaterArtifacts": true
 	},
 	"plugins": {
 		"updater": {

--- a/harper-desktop/src-tauri/tauri.conf.json
+++ b/harper-desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
-	"productName": "harper-desktop",
+	"productName": "Harper",
 	"version": "2.3.0",
 	"identifier": "com.elijahpotter.harper-desktop",
 	"build": {

--- a/packages/web/src/routes/desktop/download/+server.ts
+++ b/packages/web/src/routes/desktop/download/+server.ts
@@ -3,7 +3,7 @@ import { GithubClient } from '$lib/GitHubClient';
 import type { RequestHandler } from './$types';
 
 const latestReleaseUrl = 'https://github.com/Automattic/harper/releases/latest';
-const desktopDmgPattern = /^harper-desktop_.*_universal\.dmg$/;
+const desktopDmgPattern = /^(?:Harper|harper-desktop)_.*_universal\.dmg$/;
 
 export const GET: RequestHandler = async () => {
 	let downloadUrl: string | null = null;

--- a/packages/web/src/routes/download-harper-desktop/[target]/[arch]/[current_version]/+server.ts
+++ b/packages/web/src/routes/download-harper-desktop/[target]/[arch]/[current_version]/+server.ts
@@ -42,36 +42,40 @@ const compareVersions = (left: string, right: string) => {
 const isCurrentVersionUpToDate = (currentVersion: string, latestVersion: string) =>
 	compareVersions(currentVersion, latestVersion) >= 0;
 
-const getAssetPrefix = (target: string, arch: string) => {
+const supportsTarget = (target: string, arch: string) => {
 	const normalizedTarget = target.toLowerCase();
 	const normalizedArch = arch.toLowerCase();
 	const isMacOs = ['darwin', 'macos', 'macos-universal', 'apple-darwin'].some((targetName) =>
 		normalizedTarget.includes(targetName),
 	);
 
-	if (!isMacOs) {
-		return null;
-	}
+	return isMacOs && ['aarch64', 'arm64', 'x86_64', 'x64', 'amd64'].includes(normalizedArch);
+};
 
-	if (['aarch64', 'arm64'].includes(normalizedArch)) {
-		return 'harper-desktop-macos-arm64';
-	}
+const updateAssetBasenames = [
+	'Harper',
+	// Pre-rename artifacts used the old product name. Keep this fallback so users can still update
+	// from releases published before the app bundle was renamed to `Harper.app`.
+	'harper-desktop',
+	// Older server logic expected these names, so tolerate them if any draft/retry release used them.
+	'harper-desktop-macos-arm64',
+	'harper-desktop-macos-x64',
+];
 
-	if (['x86_64', 'x64', 'amd64'].includes(normalizedArch)) {
-		return 'harper-desktop-macos-x64';
+const findAssetByName = (assets: GitHubReleaseAsset[], name: string) =>
+	assets.find((asset) => asset.name === name);
+
+const findUpdateAssets = (release: GitHubRelease) => {
+	for (const basename of updateAssetBasenames) {
+		const archiveAsset = findAssetByName(release.assets, `${basename}.app.tar.gz`);
+		const signatureAsset = findAssetByName(release.assets, `${basename}.app.tar.gz.sig`);
+
+		if (archiveAsset != null && signatureAsset != null) {
+			return { archiveAsset, signatureAsset };
+		}
 	}
 
 	return null;
-};
-
-const findAssetByPrefixAndSuffix = (assets: GitHubReleaseAsset[], prefix: string, suffix: string) =>
-	assets.find((asset) => asset.name.startsWith(prefix) && asset.name.endsWith(suffix));
-
-const findUpdateAssets = (release: GitHubRelease, assetPrefix: string) => {
-	const archiveAsset = findAssetByPrefixAndSuffix(release.assets, assetPrefix, '.app.tar.gz');
-	const signatureAsset = findAssetByPrefixAndSuffix(release.assets, assetPrefix, '.app.tar.gz.sig');
-
-	return archiveAsset == null || signatureAsset == null ? null : { archiveAsset, signatureAsset };
 };
 
 const getSignatureFromCache = async (asset: GitHubReleaseAsset) => {
@@ -114,9 +118,7 @@ export const GET = async ({ params }: RequestEvent) => {
 		return noUpdate();
 	}
 
-	const assetPrefix = getAssetPrefix(target, arch);
-
-	if (assetPrefix == null) {
+	if (!supportsTarget(target, arch)) {
 		console.log(`No Harper Desktop update available for unsupported platform ${target}/${arch}.`);
 		return noUpdate();
 	}
@@ -131,10 +133,9 @@ export const GET = async ({ params }: RequestEvent) => {
 		return noUpdate();
 	}
 
-	const updateAssets = findUpdateAssets(latestRelease, assetPrefix);
-
+	const updateAssets = findUpdateAssets(latestRelease);
 	if (updateAssets == null) {
-		console.log(`No Harper Desktop updater assets found for ${assetPrefix} in ${latestVersion}.`);
+		console.log(`No Harper Desktop updater assets found in ${latestVersion}.`);
 		return noUpdate();
 	}
 

--- a/packages/web/src/routes/download-harper-desktop/[target]/[arch]/[current_version]/+server.ts
+++ b/packages/web/src/routes/download-harper-desktop/[target]/[arch]/[current_version]/+server.ts
@@ -52,23 +52,19 @@ const supportsTarget = (target: string, arch: string) => {
 	return isMacOs && ['aarch64', 'arm64', 'x86_64', 'x64', 'amd64'].includes(normalizedArch);
 };
 
-const updateAssetBasenames = [
+const appBundleBasenames = [
 	'Harper',
-	// Pre-rename artifacts used the old product name. Keep this fallback so users can still update
-	// from releases published before the app bundle was renamed to `Harper.app`.
 	'harper-desktop',
-	// Older server logic expected these names, so tolerate them if any draft/retry release used them.
 	'harper-desktop-macos-arm64',
 	'harper-desktop-macos-x64',
 ];
 
-const findAssetByName = (assets: GitHubReleaseAsset[], name: string) =>
-	assets.find((asset) => asset.name === name);
-
 const findUpdateAssets = (release: GitHubRelease) => {
-	for (const basename of updateAssetBasenames) {
-		const archiveAsset = findAssetByName(release.assets, `${basename}.app.tar.gz`);
-		const signatureAsset = findAssetByName(release.assets, `${basename}.app.tar.gz.sig`);
+	const assetsByName = new Map(release.assets.map((asset) => [asset.name, asset]));
+
+	for (const basename of appBundleBasenames) {
+		const archiveAsset = assetsByName.get(`${basename}.app.tar.gz`);
+		const signatureAsset = assetsByName.get(`${basename}.app.tar.gz.sig`);
 
 		if (archiveAsset != null && signatureAsset != null) {
 			return { archiveAsset, signatureAsset };


### PR DESCRIPTION
# Issues 

N/A

# Description

Renames the Tauri desktop product from `harper-desktop` to `Harper` so future macOS DMGs contain `Harper.app` instead of `harper-desktop.app`.

Also updates the website download and desktop updater asset lookup logic to handle the new artifact names while preserving compatibility with previously published `harper-desktop` artifacts.

# Demo

N/A

# How Has This Been Tested?

N/A

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter

- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
