### PR TITLE
feat(desktop): add report issue buttons to menus

### DIFF
--- a/harper-desktop/src-tauri/src/lib.rs
+++ b/harper-desktop/src-tauri/src/lib.rs
@@ -14,9 +14,10 @@ use std::{cell::RefCell, rc::Rc, sync::Arc, time::Duration};
 use tauri::{
     Manager, State, WebviewUrl, WebviewWindowBuilder, WindowEvent,
     image::Image,
-    menu::{Menu, MenuItem, PredefinedMenuItem},
+    menu::{HELP_SUBMENU_ID, Menu, MenuItem, PredefinedMenuItem},
     tray::{MouseButton, TrayIconBuilder, TrayIconEvent},
 };
+use tauri_plugin_opener::OpenerExt;
 
 use crate::os_broker::{AccessibilityPermissionStatus, OsBroker};
 use tokio::{
@@ -56,6 +57,7 @@ const TRAY_MENU_BAR_ID: &str = "harper-menu-bar";
 const TOGGLE_SERVICE_MENU_ID: &str = "toggle-service";
 const OPEN_EDITOR_MENU_ID: &str = "open-editor";
 const SETTINGS_MENU_ID: &str = "settings";
+const REPORT_ISSUE_MENU_ID: &str = "report-issue";
 const QUIT_MENU_ID: &str = "quit";
 
 #[derive(Debug, Clone, Serialize)]
@@ -148,6 +150,38 @@ fn show_settings_window(app: &tauri::AppHandle) -> tauri::Result<()> {
     Ok(())
 }
 
+fn open_issue_report(app: &tauri::AppHandle) {
+    if let Err(error) = app.opener().open_url(
+        "https://github.com/Automattic/harper/issues/new/choose",
+        None::<&str>,
+    ) {
+        eprintln!("failed to open issue report URL: {error}");
+    }
+}
+
+fn desktop_app_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
+    let menu = Menu::default(app)?;
+
+    if let Some(help_menu) = menu
+        .get(HELP_SUBMENU_ID)
+        .and_then(|item| item.as_submenu().cloned())
+    {
+        if !help_menu.items()?.is_empty() {
+            help_menu.append(&PredefinedMenuItem::separator(app)?)?;
+        }
+
+        help_menu.append(&MenuItem::with_id(
+            app,
+            REPORT_ISSUE_MENU_ID,
+            "Report an Issue",
+            true,
+            None::<&str>,
+        )?)?;
+    }
+
+    Ok(menu)
+}
+
 fn tray_menu(app: &tauri::App, is_running: bool) -> tauri::Result<TrayMenu> {
     let service_toggle = MenuItem::with_id(
         app,
@@ -160,11 +194,25 @@ fn tray_menu(app: &tauri::App, is_running: bool) -> tauri::Result<TrayMenu> {
         MenuItem::with_id(app, OPEN_EDITOR_MENU_ID, "Open Editor", true, None::<&str>)?;
     let separator = PredefinedMenuItem::separator(app)?;
     let settings = MenuItem::with_id(app, SETTINGS_MENU_ID, "Settings", true, None::<&str>)?;
+    let report_issue = MenuItem::with_id(
+        app,
+        REPORT_ISSUE_MENU_ID,
+        "Report an Issue",
+        true,
+        None::<&str>,
+    )?;
     let quit = MenuItem::with_id(app, QUIT_MENU_ID, "Quit", true, None::<&str>)?;
 
     let menu = Menu::with_items(
         app,
-        &[&service_toggle, &open_editor, &separator, &settings, &quit],
+        &[
+            &service_toggle,
+            &open_editor,
+            &separator,
+            &settings,
+            &report_issue,
+            &quit,
+        ],
     )?;
 
     Ok(TrayMenu {
@@ -598,6 +646,12 @@ pub fn run_tauri() {
             stop_highlighter_service,
             launch_app,
         ])
+        .menu(desktop_app_menu)
+        .on_menu_event(|app, event| {
+            if event.id().as_ref() == REPORT_ISSUE_MENU_ID {
+                open_issue_report(app);
+            }
+        })
         .on_window_event(|window, event| {
             if should_hide_window_on_close(window.label())
                 && let WindowEvent::CloseRequested { api, .. } = event
@@ -677,6 +731,7 @@ pub fn run_tauri() {
                             eprintln!("failed to show settings window: {error}");
                         }
                     }
+                    REPORT_ISSUE_MENU_ID => open_issue_report(app),
                     QUIT_MENU_ID => app.exit(0),
                     _ => {}
                 })


### PR DESCRIPTION
# Issues 

None.

# Description

Adds a native "Report an Issue" entry to Harper Desktop menus:

- Adds the item to the tray/menu-bar menu alongside Settings and Quit.
- Adds the item to the native Help menu.
- Wires both entries to open Harper's GitHub issue-report URL in the default browser.

# Demo

Not included.

# How Has This Been Tested?

Not applicable; this change only adds menu items and URL-opening wiring.

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter

Not applicable.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
