### PR TITLE
fix(desktop): exit child when parent stops

### DIFF
--- a/harper-desktop/src-tauri/src/communication/client.rs
+++ b/harper-desktop/src-tauri/src/communication/client.rs
@@ -1,7 +1,11 @@
 use harper_core::{
     Dialect, DictWordMetadata, IgnoredLints, linting::FlatConfig, spell::MutableDictionary,
 };
-use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, BufReader, Stdin, Stdout};
+use std::time::Duration;
+use tokio::{
+    io::{AsyncBufReadExt, AsyncRead, AsyncWrite, BufReader, Stdin, Stdout},
+    time::timeout,
+};
 
 use super::error::ProtocolError;
 use super::framing::write_message;
@@ -157,7 +161,16 @@ where
         write_message(&mut self.writer, &request).await?;
 
         let mut line = String::new();
-        if self.reader.read_line(&mut line).await? == 0 {
+        let response = timeout(Duration::from_secs(5), self.reader.read_line(&mut line)).await;
+        let bytes_read = match response {
+            Ok(bytes_read) => bytes_read?,
+            Err(_) => {
+                eprintln!("parent process did not respond within 5 seconds; exiting highlighter");
+                std::process::exit(1);
+            }
+        };
+
+        if bytes_read == 0 {
             return Err(ProtocolError::UnexpectedEof);
         }
 


### PR DESCRIPTION
# Issues 

None.

# Description

Adds a 5-second timeout to highlighter IPC requests sent to the parent Tauri process.

If the parent does not respond in time, the highlighter logs a diagnostic and exits instead of continuing to run independently.

This solves an issue where the highlighter process can be difficult to stop because it is not tied to the parent and its window does not appear in the dock.

# Demo

Not applicable.

# How Has This Been Tested?

The existing desktop communication tests cover highlighter IPC request/response behavior.

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter

Not applicable.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
