### PR TITLE
fix(web): make correct font "important"

### DIFF
--- a/packages/web/src/app.css
+++ b/packages/web/src/app.css
@@ -5,6 +5,8 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
+	--font-serif: Domine, serif;
+
 	--color-primary-50: #fef4e7; /* honey bronze */
 	--color-primary-100: #fce9cf;
 	--color-primary-200: #f9d49f;

--- a/packages/web/src/routes/+page.svelte
+++ b/packages/web/src/routes/+page.svelte
@@ -163,14 +163,14 @@ onMount(() => {
 	<section class="bg-[#fbfaf6] px-10 pt-[4.4rem] pb-20 text-center dark:bg-black max-[880px]:px-4">
 		<div class="mx-auto flex max-w-[44rem] flex-col items-center">
 			<HarperMark size={108} />
-			<h1 class="!mt-7 !mb-0 py-0 font-serif text-[clamp(3.4rem,8vw,4rem)] font-[650] leading-[1.02] tracking-normal text-inherit">
+			<h1 class="!mt-7 !mb-0 py-0 !font-serif text-[clamp(3.4rem,8vw,4rem)] font-[650] leading-[1.02] tracking-normal text-inherit">
 				Hi. I’m Harper.
 			</h1>
-			<p class="!mt-[1.35rem] !mb-0 font-serif text-[1.38rem] leading-[1.35]">
+			<p class="!mt-[1.35rem] !mb-0 !font-serif text-[1.38rem] leading-[1.35]">
 				The <strong class="inline-block -rotate-1 bg-primary-100 p-1 text-black">Free</strong> Grammar Checker
 				That Respects Your Privacy
 			</p>
-			<p class="!mt-3 !mb-0 font-serif text-[1.12rem] leading-[1.35] text-[#807a6e] italic dark:text-white/55">
+			<p class="!mt-3 !mb-0 !font-serif text-[1.12rem] leading-[1.35] text-[#807a6e] italic dark:text-white/55">
 				I make you look like a grammar genius.
 			</p>
 			<div class="mt-7 flex flex-wrap gap-[0.65rem] max-[620px]:flex-col max-[620px]:items-stretch">
@@ -183,7 +183,7 @@ onMount(() => {
 	<section class="bg-[#fbfaf6] pt-2 pb-[5.6rem] dark:bg-black" aria-labelledby="try-editor-title">
 		<div class="mx-auto max-w-[73.75rem] px-10 max-[880px]:px-4">
 			<div class="mb-[1.1rem] flex items-baseline justify-between gap-4 max-[620px]:flex-col max-[620px]:items-stretch">
-				<h2 id="try-editor-title" class="!m-0 py-0 font-serif text-[1.38rem] font-semibold leading-[1.3] tracking-normal text-inherit">
+				<h2 id="try-editor-title" class="!m-0 py-0 !font-serif text-[1.38rem] font-semibold leading-[1.3] tracking-normal text-inherit">
 					Try Harper
 				</h2>
 				<a
@@ -205,7 +205,7 @@ onMount(() => {
 
 	<section id="about" class="border-t-[0.5px] border-[rgba(28,26,22,0.1)] bg-[#fdfbf5] py-[4.8rem] dark:border-white/10 dark:bg-black">
 		<div class="mx-auto max-w-[45rem] px-10 max-[880px]:px-4">
-			<p class="!m-0 font-serif text-[clamp(1.6rem,4vw,1.75rem)] font-[550] leading-[1.35] text-[#1c1a16] dark:text-white">
+			<p class="!m-0 !font-serif text-[clamp(1.6rem,4vw,1.75rem)] font-[550] leading-[1.35] text-[#1c1a16] dark:text-white">
 				Harper is a free, open-source grammar checker designed to be just right. Think of it as
 				the private alternative to Grammarly, built after years of dealing with the shortcomings
 				of the competition.
@@ -220,7 +220,7 @@ onMount(() => {
 	<section class="border-t-[0.5px] border-[rgba(28,26,22,0.1)] bg-[#fdfbf5] py-[4.8rem] dark:border-white/10 dark:bg-black">
 		<div class="mx-auto grid max-w-[68.75rem] grid-cols-[minmax(0,1fr)_minmax(20rem,1fr)] items-center gap-14 px-10 max-[880px]:grid-cols-1 max-[880px]:px-4">
 			<div>
-				<h2 class="!mt-3 !mb-0 py-0 font-serif text-[clamp(2.2rem,5vw,2.5rem)] font-[650] leading-[1.08] tracking-normal text-inherit">
+				<h2 class="!mt-3 !mb-0 py-0 !font-serif text-[clamp(2.2rem,5vw,2.5rem)] font-[650] leading-[1.08] tracking-normal text-inherit">
 					One grammar checker.<br />Every place you write.
 				</h2>
 				<p class="!mt-6 !mb-0 text-base leading-[1.65] text-[#4a463e] dark:text-white/70">
@@ -265,7 +265,7 @@ onMount(() => {
 	<section class="border-t-[0.5px] border-[rgba(28,26,22,0.1)] bg-[#fbfaf6] py-[4.5rem] dark:border-white/10 dark:bg-black">
 		<div class="mx-auto max-w-[73.75rem] px-10 max-[880px]:px-4">
 			<div class="mb-11 text-center">
-				<h2 class="!mt-3 !mb-0 py-0 font-serif text-[clamp(2.2rem,5vw,2.5rem)] font-[650] leading-[1.08] tracking-normal text-inherit">
+				<h2 class="!mt-3 !mb-0 py-0 !font-serif text-[clamp(2.2rem,5vw,2.5rem)] font-[650] leading-[1.08] tracking-normal text-inherit">
 					Loved by writers, journalists, and devs.
 				</h2>
 			</div>
@@ -286,7 +286,7 @@ onMount(() => {
 	<section class="border-t-[0.5px] border-[rgba(28,26,22,0.1)] bg-[#1c1a16] py-[5.6rem] pb-[6.25rem] text-center text-[#fbfaf6] dark:border-white/10">
 		<div class="mx-auto max-w-[45rem] px-10 max-[880px]:px-4 [&_.harper-mark]:mx-auto [&_.harper-mark]:mb-[1.4rem] [&_.harper-mark]:text-[#fbe8c2]">
 			<HarperMark size={56} />
-			<h2 class="!mt-3 !mb-0 py-0 font-serif text-[clamp(2.5rem,6vw,3.25rem)] font-[650] leading-[1.05] tracking-normal text-inherit">
+			<h2 class="!mt-3 !mb-0 py-0 !font-serif text-[clamp(2.5rem,6vw,3.25rem)] font-[650] leading-[1.05] tracking-normal text-inherit">
 				Pay us a visit on GitHub.
 			</h2>
 			<p class="!mt-6 !mb-0 text-base leading-[1.65] text-[#fbfaf6]/70">

--- a/packages/web/src/routes/desktop/+page.svelte
+++ b/packages/web/src/routes/desktop/+page.svelte
@@ -43,7 +43,7 @@ const faqs = [
 	<section class="relative overflow-hidden px-14 pt-3 pb-14 after:pointer-events-none after:absolute after:inset-[-20%_-10%] after:content-[''] after:bg-[radial-gradient(ellipse_at_70%_20%,#fbf3e6_0%,transparent_60%)] dark:after:opacity-10 max-[700px]:px-4">
 		<div class="relative z-[1] mx-auto grid max-w-[77.5rem] grid-cols-[minmax(0,1fr)_minmax(32rem,1.2fr)] items-center gap-8 pt-[1.9rem] max-[1040px]:grid-cols-1">
 			<div>
-				<h1 class="!mt-[0.85rem] !mb-0 py-0 font-serif text-[clamp(3.2rem,6vw,3.9rem)] font-[650] leading-[1.02] tracking-normal text-inherit">
+				<h1 class="!mt-[0.85rem] !mb-0 py-0 !font-serif text-[clamp(3.2rem,6vw,3.9rem)] font-[650] leading-[1.02] tracking-normal text-inherit">
 					Works in every app.
 				</h1>
 				<p class="!mt-5 !mb-0 max-w-[28.75rem] text-base leading-[1.6] text-[#4a463e] dark:text-white/70">
@@ -71,7 +71,7 @@ const faqs = [
 	<section class="border-t-[0.5px] border-[rgba(28,26,22,0.1)] bg-[#fdfbf5] py-[4.5rem] pb-20 dark:border-white/10 dark:bg-black">
 		<div class="mx-auto max-w-[68.75rem] px-14 max-[700px]:px-4">
 			<div class="mx-auto max-w-[40rem] text-center">
-				<h2 class="!mt-3 !mb-0 py-0 font-serif text-[clamp(2.1rem,5vw,2.45rem)] font-[650] leading-[1.1] tracking-normal text-inherit">
+				<h2 class="!mt-3 !mb-0 py-0 !font-serif text-[clamp(2.1rem,5vw,2.45rem)] font-[650] leading-[1.1] tracking-normal text-inherit">
 					Every text field. Same Harper.
 				</h2>
 				<p class="!mt-6 !mb-0 text-base leading-[1.6] text-[#4a463e] dark:text-white/70">
@@ -100,7 +100,7 @@ const faqs = [
 	<section class="border-t-[0.5px] border-[rgba(28,26,22,0.1)] bg-[#fdfbf5] py-[4.5rem] pb-20 dark:border-white/10 dark:bg-black">
 		<div class="mx-auto grid max-w-[68.75rem] grid-cols-[minmax(0,1fr)_minmax(22rem,1.1fr)] items-center gap-14 px-14 max-[1040px]:grid-cols-1 max-[700px]:px-4">
 			<div>
-				<h2 class="!mt-3 !mb-0 py-0 font-serif text-[clamp(2.1rem,5vw,2.45rem)] font-[650] leading-[1.1] tracking-normal text-inherit">
+				<h2 class="!mt-3 !mb-0 py-0 !font-serif text-[clamp(2.1rem,5vw,2.45rem)] font-[650] leading-[1.1] tracking-normal text-inherit">
 					Tune the rules. Build your own dictionary.
 				</h2>
 				<p class="!mt-6 !mb-0 text-base leading-[1.6] text-[#4a463e] dark:text-white/70">
@@ -126,7 +126,7 @@ const faqs = [
 	<section class="relative overflow-hidden border-t-[0.5px] border-[rgba(28,26,22,0.1)] bg-[#fbfaf6] py-[4.5rem] after:pointer-events-none after:absolute after:inset-[-20%_-10%] after:content-[''] after:bg-[radial-gradient(ellipse_at_70%_20%,#fbf3e6_0%,transparent_60%)] dark:border-white/10 dark:bg-black dark:after:opacity-10">
 		<div class="relative z-[1] mx-auto max-w-[45rem] px-14 text-center max-[700px]:px-4 [&_.harper-mark]:mx-auto">
 			<HarperMark size={64} />
-			<h2 class="!mt-3 !mb-0 py-0 font-serif text-[clamp(2.1rem,5vw,2.45rem)] font-[650] leading-[1.1] tracking-normal text-inherit">
+			<h2 class="!mt-3 !mb-0 py-0 !font-serif text-[clamp(2.1rem,5vw,2.45rem)] font-[650] leading-[1.1] tracking-normal text-inherit">
 				Free. Forever. Yours.
 			</h2>
 			<p class="!mt-6 !mb-[1.6rem] text-base leading-[1.6] text-[#4a463e] dark:text-white/70">

--- a/packages/web/src/routes/get/+page.svelte
+++ b/packages/web/src/routes/get/+page.svelte
@@ -61,10 +61,10 @@ function clearFilters() {
 
 	<section class="border-b-[0.5px] border-[rgba(28,26,22,0.1)] bg-[#fdfbf5] px-10 py-16 pb-[4.25rem] text-center dark:border-white/10 dark:bg-black max-[860px]:px-4">
 		<div class="mx-auto max-w-[58rem]">
-			<h1 class="!mt-[0.85rem] !mb-0 py-0 font-serif text-[clamp(3.2rem,7vw,3.5rem)] font-[650] leading-[1.02] tracking-normal text-inherit">
+			<h1 class="!mt-[0.85rem] !mb-0 py-0 !font-serif text-[clamp(3.2rem,7vw,3.5rem)] font-[650] leading-[1.02] tracking-normal text-inherit">
 				Take Harper with you.
 			</h1>
-			<p class="mx-auto !mt-3 !mb-[2.2rem] max-w-[35rem] font-serif text-[1.2rem] leading-[1.45] text-[#4a463e] dark:text-white/70">
+			<p class="mx-auto !mt-3 !mb-[2.2rem] max-w-[35rem] !font-serif text-[1.2rem] leading-[1.45] text-[#4a463e] dark:text-white/70">
 				Use Harper in your favorite apps and browsers. Good grammar goes where you are.
 			</p>
 			<div class="mx-auto grid max-w-[47.5rem] grid-cols-2 gap-[0.85rem] text-left max-[640px]:grid-cols-1">
@@ -157,7 +157,7 @@ function clearFilters() {
 			<div class="grid grid-cols-[repeat(auto-fill,minmax(20rem,1fr))] gap-3 max-[640px]:grid-cols-1">
 				{#if filtered.length === 0}
 					<div class="col-span-full rounded-[0.9rem] border-[0.5px] border-dashed border-[rgba(28,26,22,0.16)] bg-white px-6 py-[3.75rem] text-center dark:border-white/15 dark:bg-white/5">
-						<h2 class="!mt-0 !mb-1.5 py-0 font-serif text-[1.4rem]">No match for "{query}"</h2>
+						<h2 class="!mt-0 !mb-1.5 py-0 !font-serif text-[1.4rem]">No match for "{query}"</h2>
 						<p class="!m-0 text-[#807a6e] dark:text-white/55">
 							Don’t see your editor? <a class="font-extrabold !text-[#b06a1b] no-underline hover:no-underline dark:!text-primary-300" href={marketingLinks.github}>Help us build it →</a>
 						</p>


### PR DESCRIPTION
# Issues

None.

# Description

This PR fixes the fact the the `/` page and some of the other new pages are reverting to the browser font, rather than the cool and stylized "Domine" font that is Harper's brand.

- Configures Tailwind’s `font-serif` theme token to use Domine.
- Marks the homepage’s serif font utilities as important so they are not overridden by UnoCSS-generated styles.

# Demo

Not included.

# How Has This Been Tested?

Not applicable; CSS/class changes only.

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
