### PR TITLE
feat: proof-of-concepts→proofs-of-concept

### DIFF
--- a/harper-core/src/linting/plural_wrong_word_of_phrase.rs
+++ b/harper-core/src/linting/plural_wrong_word_of_phrase.rs
@@ -16,6 +16,7 @@ const PATTERNS: &[(&[&str], &str, &[&str])] = &[
     (&["line"], "of", &["code"]),
     (&["part"], "of", &["speech", "speeches"]),
     (&["point"], "of", &["view"]),
+    (&["proof"], "of", &["concept"]),
     (&["rule"], "of", &["thumb"]),
 ];
 
@@ -95,11 +96,14 @@ impl ExprLinter for PluralWrongWordOfPhrase {
             format!("{}s", main_noun[0])
         };
 
+        // NOTE: We depend only on the first space or hyphen to determine the separator
+        let sep = [' ', '-'][toks[1].kind.is_hyphen() as usize];
+
         Some(Lint {
             lint_kind: LintKind::Usage,
             span: toks.span()?,
             suggestions: vec![Suggestion::replace_with_match_case(
-                format!("{} {} {}", main_noun_pl, mid, last_noun[0])
+                format!("{}{}{}{}{}", main_noun_pl, sep, mid, sep, last_noun[0])
                     .chars()
                     .collect::<Vec<char>>(),
                 toks.span()?.get_content(src),
@@ -211,7 +215,7 @@ mod tests {
         assert_suggestion_result(
             "Add rule-of-thumbs for basic metrics, like \"Spill more than 1GB is a red flag\".",
             PluralWrongWordOfPhrase::default(),
-            "Add rules of thumb for basic metrics, like \"Spill more than 1GB is a red flag\".",
+            "Add rules-of-thumb for basic metrics, like \"Spill more than 1GB is a red flag\".",
         );
     }
 
@@ -251,7 +255,7 @@ mod tests {
         assert_suggestion_result(
             "what makes 'Super Hexagon' rise above other nostalgic flash-in-the-pans is that there is a game to be learned here",
             PluralWrongWordOfPhrase::default(),
-            "what makes 'Super Hexagon' rise above other nostalgic flashes in the pan is that there is a game to be learned here",
+            "what makes 'Super Hexagon' rise above other nostalgic flashes-in-the-pan is that there is a game to be learned here",
         );
     }
 
@@ -261,6 +265,17 @@ mod tests {
             "Who are some of the biggest flashes in the pans in wrestling history?",
             PluralWrongWordOfPhrase::default(),
             "Who are some of the biggest flashes in the pan in wrestling history?",
+        );
+    }
+
+    // ProofOfConcept
+
+    #[test]
+    fn correct_proof_of_concepts() {
+        assert_suggestion_result(
+            "I wrote about my love of throwaway prototypes; those little proof-of-concepts that exist purely to get an idea out of your head",
+            PluralWrongWordOfPhrase::default(),
+            "I wrote about my love of throwaway prototypes; those little proofs-of-concept that exist purely to get an idea out of your head",
         );
     }
 }

--- a/harper-core/src/linting/plural_wrong_word_of_phrase.rs
+++ b/harper-core/src/linting/plural_wrong_word_of_phrase.rs
@@ -99,6 +99,13 @@ impl ExprLinter for PluralWrongWordOfPhrase {
         // NOTE: We depend only on the first space or hyphen to determine the separator
         let sep = [' ', '-'][toks[1].kind.is_hyphen() as usize];
 
+        // If `mid` contains a hyphen or space, it must also use the matching separator
+        let mid = match sep {
+            ' ' => mid.replace('-', " "),
+            '-' => mid.replace(' ', "-"),
+            _ => mid.to_string(),
+        };
+
         Some(Lint {
             lint_kind: LintKind::Usage,
             span: toks.span()?,


### PR DESCRIPTION
# Issues 
N/A

# Description

I was reading a blog post where the writer used "proof-of-concepts" and knew straight away that it belong in the `PluralWrongWordOfPhrase` linter.

What I didn't remember was that the linter accepted spaces or hyphens between words but always suggested only with spaces. I've changed this to suggest either spaces or hyphens, based on what's between the first two words. If the separator between the last two words doesn't match, it will be ignored.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
