### PR TITLE
feat: pay for check/fee/price→pay check/fee/price

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -4990,6 +4990,12 @@
 								"state": true,
 								"label": "Every Single One Of"
 							}
+						},{
+							"Bool": {
+								"name": "PayForPrice",
+								"state": true,
+								"label": "Pay For Price"
+							}
 						}
 					]
 				}

--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -4990,7 +4990,8 @@
 								"state": true,
 								"label": "Every Single One Of"
 							}
-						},{
+						},
+						{
 							"Bool": {
 								"name": "PayForPrice",
 								"state": true,

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -171,6 +171,7 @@ use super::ought_to_be::OughtToBe;
 use super::out_of_date::OutOfDate;
 use super::oxford_comma::OxfordComma;
 use super::oxymorons::Oxymorons;
+use super::pay_for_price::PayForPrice;
 use super::phrasal_verb_as_compound_noun::PhrasalVerbAsCompoundNoun;
 use super::pique_interest::PiqueInterest;
 use super::plural_decades::PluralDecades;
@@ -727,6 +728,7 @@ impl LintGroup {
         insert_expr_rule!(OutOfDate, true);
         insert_struct_rule!(OxfordComma, true);
         insert_expr_rule!(Oxymorons, true);
+        insert_expr_rule!(PayForPrice, true);
         insert_struct_rule!(PhrasalVerbAsCompoundNoun, true);
         insert_expr_rule!(PiqueInterest, true);
         insert_expr_rule!(PluralWrongWordOfPhrase, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -181,6 +181,7 @@ mod ought_to_be;
 mod out_of_date;
 mod oxford_comma;
 mod oxymorons;
+mod pay_for_price;
 mod phrasal_verb_as_compound_noun;
 mod phrase_set_corrections;
 mod pique_interest;

--- a/harper-core/src/linting/pay_for_price.rs
+++ b/harper-core/src/linting/pay_for_price.rs
@@ -1,7 +1,7 @@
 use crate::{
     Lint, Token, TokenStringExt,
     expr::{Expr, OwnedExprExt, SequenceExpr},
-    linting::{ExprLinter, LintKind, Suggestion, debug::format_lint_match, expr_linter::Chunk},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
 };
 
 pub struct PayForPrice {
@@ -33,13 +33,7 @@ impl Default for PayForPrice {
 impl ExprLinter for PayForPrice {
     type Unit = Chunk;
 
-    fn match_to_lint_with_context(
-        &self,
-        matched_tokens: &[Token],
-        source: &[char],
-        context: Option<(&[Token], &[Token])>,
-    ) -> Option<Lint> {
-        eprintln!("🚨 {}", format_lint_match(matched_tokens, context, source));
+    fn match_to_lint(&self, matched_tokens: &[Token], _source: &[char]) -> Option<Lint> {
         let span = matched_tokens[2..4].span()?;
         let lint_kind = LintKind::Usage;
         let suggestions = vec![Suggestion::Remove];

--- a/harper-core/src/linting/pay_for_price.rs
+++ b/harper-core/src/linting/pay_for_price.rs
@@ -1,0 +1,195 @@
+use crate::{
+    Lint, Token, TokenStringExt,
+    expr::{Expr, OwnedExprExt, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, debug::format_lint_match, expr_linter::Chunk},
+};
+
+pub struct PayForPrice {
+    expr: SequenceExpr,
+}
+
+impl Default for PayForPrice {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::word_set(&["pay", "paid", "pays", "paying"])
+                .t_ws()
+                .t_aco("for")
+                .t_ws()
+                .then_optional(SequenceExpr::default().then_determiner().t_ws())
+                .then(
+                    SequenceExpr::word_set(&[
+                        "bill", "bills", "check", "checks", "cheque", "cheques", "charge",
+                        "charges", "cost", "costs", "fee", "fees", "price", "prices",
+                    ])
+                    .but_not(SequenceExpr::any_of(vec![
+                        Box::new(SequenceExpr::aco("check").t_ws_h().t_set(&["in", "out"])),
+                        Box::new(SequenceExpr::aco("price").t_ws_h().t_aco("increase")),
+                    ])),
+                ),
+        }
+    }
+}
+
+impl ExprLinter for PayForPrice {
+    type Unit = Chunk;
+
+    fn match_to_lint_with_context(
+        &self,
+        matched_tokens: &[Token],
+        source: &[char],
+        context: Option<(&[Token], &[Token])>,
+    ) -> Option<Lint> {
+        eprintln!("🚨 {}", format_lint_match(matched_tokens, context, source));
+        let span = matched_tokens[2..4].span()?;
+        let lint_kind = LintKind::Usage;
+        let suggestions = vec![Suggestion::Remove];
+        let message = "You `pay for` things or services, but just `pay prices/fees`, etc with no preposition.".to_string();
+        Some(Lint {
+            span,
+            lint_kind,
+            suggestions,
+            message,
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects extraneous `for` when used of charges, fees, prices, etc."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    use super::PayForPrice;
+
+    #[test]
+    fn pay_for_fees() {
+        assert_suggestion_result(
+            "Accounts having BNB accounts use this to pay for fees",
+            PayForPrice::default(),
+            "Accounts having BNB accounts use this to pay fees",
+        );
+    }
+
+    #[test]
+    fn pay_for_a_bill() {
+        assert_suggestion_result(
+            "being instructed to either pay for a bill, an expense, or a gift",
+            PayForPrice::default(),
+            "being instructed to either pay a bill, an expense, or a gift",
+        );
+    }
+
+    #[test]
+    fn pay_for_a_check() {
+        assert_suggestion_result(
+            "Having to pay for a check is 'paying for what you use'.",
+            PayForPrice::default(),
+            "Having to pay a check is 'paying for what you use'.",
+        );
+    }
+
+    #[test]
+    fn pay_for_a_fee() {
+        assert_suggestion_result(
+            "then the account needs to pay for a fee of X",
+            PayForPrice::default(),
+            "then the account needs to pay a fee of X",
+        );
+    }
+
+    #[test]
+    fn pay_for_the_bill() {
+        assert_suggestion_result(
+            "Cannot pay for the bill and cannot delete the bill",
+            PayForPrice::default(),
+            "Cannot pay the bill and cannot delete the bill",
+        );
+    }
+
+    #[test]
+    fn pay_for_the_check() {
+        assert_suggestion_result(
+            "should be able to ascertain if he will pay for the check or not",
+            PayForPrice::default(),
+            "should be able to ascertain if he will pay the check or not",
+        );
+    }
+
+    #[test]
+    fn paying_for_the_bill() {
+        assert_suggestion_result(
+            "Maybe some people in his family weren't paying for the bill out of their own account",
+            PayForPrice::default(),
+            "Maybe some people in his family weren't paying the bill out of their own account",
+        );
+    }
+
+    #[test]
+    fn paying_for_the_check() {
+        assert_suggestion_result(
+            "how does everyone deal with paying for the check or the bill of any activity",
+            PayForPrice::default(),
+            "how does everyone deal with paying the check or the bill of any activity",
+        );
+    }
+
+    #[test]
+    fn pays_for_the_bill() {
+        assert_suggestion_result(
+            "I now understand that when a man pays for the bill, he has clear intentions",
+            PayForPrice::default(),
+            "I now understand that when a man pays the bill, he has clear intentions",
+        );
+    }
+
+    // Edge cases / False positives / Not yet handlec
+
+    #[test]
+    #[ignore = "Detecting this pattery will require more thought"]
+    fn dont_flag_paying_for_fees() {
+        assert_no_lints(
+            "it will specify how much you need and how much you're paying for fees",
+            PayForPrice::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_pay_for_rate_limit_increase() {
+        // Here 'rate' is part of a compound noun 'rate limit increase'
+        assert_no_lints(
+            "Can we pay for a rate limit increase?",
+            PayForPrice::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_pay_for_check_in_or_out() {
+        assert_no_lints(
+            "Most normally, tenants pay for a check-in and landlords pay for the check-out.",
+            PayForPrice::default(),
+        )
+    }
+
+    #[test]
+    fn dont_flag_pay_for_the_price_increase() {
+        assert_no_lints(
+            "Unless you want to pay for the price increase and have no issue with the owner, then go for signing up for a sourcehut account.",
+            PayForPrice::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_paying_for_comma_prices() {
+        assert_no_lints(
+            "If everyone used all of the tokens they thought they were paying for, prices would explode.",
+            PayForPrice::default(),
+        );
+    }
+}


### PR DESCRIPTION
# Issues 
N/A

# Description

This is one I've been hearing and reading around the place and keep thinking about making a rule for.
It catches a bunch of variations on the theme of "pay for" a "fee/price/bill/check" etc.

Works for all inflections of "pay", and with or without an article before the noun.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
