### PR TITLE
refactor: avoid complex type warning

### DIFF
--- a/harper-desktop/src-tauri/src/mac_broker.rs
+++ b/harper-desktop/src-tauri/src/mac_broker.rs
@@ -405,9 +405,11 @@ fn ax_element_attribute(
     Ok(unsafe { AXUIElement::wrap_under_create_rule(value as _) })
 }
 
+type LintCallback<'a> = dyn FnMut(&str) -> BTreeMap<String, Vec<Lint>> + 'a;
+
 struct RectCollector<'a> {
     rects: RefCell<Vec<ActionableLint>>,
-    lint_text: RefCell<&'a mut dyn FnMut(&str) -> BTreeMap<String, Vec<Lint>>>,
+    lint_text: RefCell<&'a mut LintCallback<'a>>,
 }
 
 impl TreeVisitor for RectCollector<'_> {


### PR DESCRIPTION
# Issues 
N/A

# Description

I've been noticing this warning in builds for a week or two:
```
warning: very complex type used. Consider factoring parts into `type` definitions
   --> harper-desktop/src-tauri/src/mac_broker.rs:368:16
    |
368 |     lint_text: RefCell<&'a mut dyn FnMut(&str) -> BTreeMap<String, Vec<Lint>>>,
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#type_complexity
    = note: `#[warn(clippy::type_complexity)]` on by default

warning: `harper-desktop` (lib) generated 1 warning
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 36.46s
warning: the following packages contain code that will be rejected by a future version of Rust: block v0.1.6
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
    Blocking waiting for file lock on build directory
```

I've just introduced a type alias `LintCallback`.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

I used Google Search's AI.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
