### PR TITLE
fix: don't flag more low-hanging fruit→lower-hanging

### DIFF
--- a/harper-core/src/linting/more_adjective.rs
+++ b/harper-core/src/linting/more_adjective.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 
 use crate::{
     char_ext::CharExt,
-    expr::{Expr, SequenceExpr},
+    expr::{Expr, FirstMatchOf, SequenceExpr},
     linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
     spell::Dictionary,
     {CharStringExt, Lint, Token, TokenStringExt},
@@ -23,12 +23,16 @@ where
                 .t_ws()
                 .then_positive_adjective()
                 // Include a following "than adjective" which we'll use to identify a false positive #2925
-                .then_optional(
-                    SequenceExpr::whitespace()
-                        .t_aco("than")
-                        .t_ws()
-                        .then_positive_adjective(),
-                ),
+                // Or a following hyphen which we'll use to identify a false positive #3568
+                .then_optional(FirstMatchOf::new(vec![
+                    Box::new(
+                        SequenceExpr::whitespace()
+                            .t_aco("than")
+                            .t_ws()
+                            .then_positive_adjective(),
+                    ),
+                    Box::new(|tok: &Token, _source: &[char]| tok.kind.is_hyphen()),
+                ])),
             dict,
         }
     }


### PR DESCRIPTION
# Issues 
Fixes #3568

# Description

Check for a hyphen immediately after the adjective and don't flag if present.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
