### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,24 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -118,11 +118,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-bin: "true"
       - name: Build binary
-        uses: houseabsolute/actions-rust-cross@v1
+        uses: houseabsolute/actions-rust-cross@f481cb5e0110765615313e2177ce12a99bf26bbd # v1
         with:
           command: ${{ matrix.platform.command }}
           target: ${{ matrix.platform.target }}
@@ -147,7 +147,7 @@ jobs:
 
       - name: Release artifacts
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           artifacts: ${{ matrix.platform.name }}
           allowUpdates: true

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           cache-bin: "true"
       - name: Build binary
-        uses: houseabsolute/actions-rust-cross@f481cb5e0110765615313e2177ce12a99bf26bbd # v1
+        uses: houseabsolute/actions-rust-cross@fe6ede73c7f0a50412ec05994e2aa5a7bf635eac # v1.0.7
         with:
           command: ${{ matrix.platform.command }}
           target: ${{ matrix.platform.target }}

--- a/.github/workflows/build_web.yml
+++ b/.github/workflows/build_web.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Retrieve version after install
         id: nodenv
         run: echo "node-version=$(node -v | sed 's/^v//')" >> $GITHUB_OUTPUT
-      - uses: redhat-actions/buildah-build@v2
+      - uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
         with:
           image: web
           containerfiles: |

--- a/.github/workflows/chrome_plugin.yml
+++ b/.github/workflows/chrome_plugin.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".node-version"
       - name: Enable Corepack
         run: corepack enable
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: cargo-bins/cargo-binstall@f8810ffa11196f23afb38e6fb64716fbf814ad8f # main
       - name: Install `wasm-pack`
         run: cargo binstall wasm-pack --force --no-confirm
       - name: Build Chrome Plugin
@@ -40,7 +40,7 @@ jobs:
           name: harper-firefox-plugin.zip
           path: "packages/chrome-plugin/package/harper-firefox-plugin.zip"
       - name: Release artifacts
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           artifacts: "packages/chrome-plugin/package/*.zip"

--- a/.github/workflows/chrome_plugin.yml
+++ b/.github/workflows/chrome_plugin.yml
@@ -22,7 +22,7 @@ jobs:
           node-version-file: ".node-version"
       - name: Enable Corepack
         run: corepack enable
-      - uses: cargo-bins/cargo-binstall@f8810ffa11196f23afb38e6fb64716fbf814ad8f # main
+      - uses: cargo-bins/cargo-binstall@main
       - name: Install `wasm-pack`
         run: cargo binstall wasm-pack --force --no-confirm
       - name: Build Chrome Plugin

--- a/.github/workflows/chrome_plugin.yml
+++ b/.github/workflows/chrome_plugin.yml
@@ -22,7 +22,7 @@ jobs:
           node-version-file: ".node-version"
       - name: Enable Corepack
         run: corepack enable
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: cargo-bins/cargo-binstall@f8810ffa11196f23afb38e6fb64716fbf814ad8f # main
       - name: Install `wasm-pack`
         run: cargo binstall wasm-pack --force --no-confirm
       - name: Build Chrome Plugin

--- a/.github/workflows/just_checks.yml
+++ b/.github/workflows/just_checks.yml
@@ -53,7 +53,7 @@ jobs:
           sudo apt-get install -y libappindicator3-dev || true
       - name: Rust Cache
         uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: cargo-bins/cargo-binstall@f8810ffa11196f23afb38e6fb64716fbf814ad8f # main
       - name: Install `wasm-pack`
         run: cargo binstall wasm-pack --force --no-confirm
       - name: Install `cargo hack`

--- a/.github/workflows/just_checks.yml
+++ b/.github/workflows/just_checks.yml
@@ -53,7 +53,7 @@ jobs:
           sudo apt-get install -y libappindicator3-dev || true
       - name: Rust Cache
         uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
-      - uses: cargo-bins/cargo-binstall@f8810ffa11196f23afb38e6fb64716fbf814ad8f # main
+      - uses: cargo-bins/cargo-binstall@main
       - name: Install `wasm-pack`
         run: cargo binstall wasm-pack --force --no-confirm
       - name: Install `cargo hack`

--- a/.github/workflows/just_checks.yml
+++ b/.github/workflows/just_checks.yml
@@ -30,10 +30,10 @@ jobs:
           ]
     steps:
       - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           components: rustfmt,clippy
       - name: Install Node.js
@@ -52,8 +52,8 @@ jobs:
             libxdo-dev
           sudo apt-get install -y libappindicator3-dev || true
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2.7.8
-      - uses: cargo-bins/cargo-binstall@main
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+      - uses: cargo-bins/cargo-binstall@f8810ffa11196f23afb38e6fb64716fbf814ad8f # main
       - name: Install `wasm-pack`
         run: cargo binstall wasm-pack --force --no-confirm
       - name: Install `cargo hack`

--- a/.github/workflows/vscode_plugin.yml
+++ b/.github/workflows/vscode_plugin.yml
@@ -43,18 +43,18 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".node-version"
       - name: Enable Corepack
         run: corepack enable
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-bin: "true"
       - name: Build harper-ls
-        uses: houseabsolute/actions-rust-cross@v1
+        uses: houseabsolute/actions-rust-cross@f481cb5e0110765615313e2177ce12a99bf26bbd # v1
         with:
           target: ${{ matrix.platform.rust_target }}
           args: "--locked --release --bin harper-ls"
@@ -79,14 +79,14 @@ jobs:
           echo artifact=$(echo packages/vscode-plugin/*.vsix) >> $GITHUB_OUTPUT
       - name: Release artifacts
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           artifacts: "./packages/vscode-plugin/*.vsix"
           allowUpdates: true
           draft: true
       - name: Publish to OpenVSX
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: HaaLeo/publish-vscode-extension@v1
+        uses: HaaLeo/publish-vscode-extension@f4ece70f329f66686bd71c54b1671353fe320e49 # v1.7.0
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
           packagePath: "./packages/vscode-plugin/"
@@ -94,7 +94,7 @@ jobs:
           skipDuplicate: true
       - name: Publish to the Visual Studio Marketplace
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: HaaLeo/publish-vscode-extension@v1
+        uses: HaaLeo/publish-vscode-extension@f4ece70f329f66686bd71c54b1671353fe320e49 # v1.7.0
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           packagePath: "./packages/vscode-plugin/"

--- a/.github/workflows/vscode_plugin.yml
+++ b/.github/workflows/vscode_plugin.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           cache-bin: "true"
       - name: Build harper-ls
-        uses: houseabsolute/actions-rust-cross@f481cb5e0110765615313e2177ce12a99bf26bbd # v1
+        uses: houseabsolute/actions-rust-cross@fe6ede73c7f0a50412ec05994e2aa5a7bf635eac # v1.0.7
         with:
           target: ${{ matrix.platform.rust_target }}
           args: "--locked --release --bin harper-ls"

--- a/.github/workflows/wp_plugin.yml
+++ b/.github/workflows/wp_plugin.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".node-version"
       - name: Enable Corepack
         run: corepack enable
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: cargo-bins/cargo-binstall@f8810ffa11196f23afb38e6fb64716fbf814ad8f # main
       - name: Install wasm-pack
         run: cargo binstall wasm-pack --force --no-confirm
       - name: Build
@@ -34,7 +34,7 @@ jobs:
           path: packages/wordpress-plugin/harper.zip
       - name: Draft GitHub release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           artifacts: packages/wordpress-plugin/harper.zip
           allowUpdates: true

--- a/.github/workflows/wp_plugin.yml
+++ b/.github/workflows/wp_plugin.yml
@@ -22,7 +22,7 @@ jobs:
           node-version-file: ".node-version"
       - name: Enable Corepack
         run: corepack enable
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: cargo-bins/cargo-binstall@f8810ffa11196f23afb38e6fb64716fbf814ad8f # main
       - name: Install wasm-pack
         run: cargo binstall wasm-pack --force --no-confirm
       - name: Build

--- a/.github/workflows/wp_plugin.yml
+++ b/.github/workflows/wp_plugin.yml
@@ -22,7 +22,7 @@ jobs:
           node-version-file: ".node-version"
       - name: Enable Corepack
         run: corepack enable
-      - uses: cargo-bins/cargo-binstall@f8810ffa11196f23afb38e6fb64716fbf814ad8f # main
+      - uses: cargo-bins/cargo-binstall@main
       - name: Install wasm-pack
         run: cargo binstall wasm-pack --force --no-confirm
       - name: Build

--- a/harper-desktop/.github/workflows/build_artifacts.yml
+++ b/harper-desktop/.github/workflows/build_artifacts.yml
@@ -48,7 +48,7 @@ jobs:
         run: corepack enable
       - name: Rust Cache
         uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: cargo-bins/cargo-binstall@f8810ffa11196f23afb38e6fb64716fbf814ad8f # main
       - name: Install APT packages
         if: matrix.platform == 'ubuntu-latest'
         run: sudo apt update && sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev nsis lld llvm -y

--- a/harper-desktop/.github/workflows/build_artifacts.yml
+++ b/harper-desktop/.github/workflows/build_artifacts.yml
@@ -36,10 +36,10 @@ jobs:
               src-tauri/target/release/bundle/dmg
     steps:
       - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           components: rustfmt,clippy
       - name: Install Node.js
@@ -47,8 +47,8 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2.7.8
-      - uses: cargo-bins/cargo-binstall@main
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+      - uses: cargo-bins/cargo-binstall@f8810ffa11196f23afb38e6fb64716fbf814ad8f # main
       - name: Install APT packages
         if: matrix.platform == 'ubuntu-latest'
         run: sudo apt update && sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev nsis lld llvm -y

--- a/harper-desktop/.github/workflows/build_artifacts.yml
+++ b/harper-desktop/.github/workflows/build_artifacts.yml
@@ -48,7 +48,7 @@ jobs:
         run: corepack enable
       - name: Rust Cache
         uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
-      - uses: cargo-bins/cargo-binstall@f8810ffa11196f23afb38e6fb64716fbf814ad8f # main
+      - uses: cargo-bins/cargo-binstall@main
       - name: Install APT packages
         if: matrix.platform == 'ubuntu-latest'
         run: sudo apt update && sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev nsis lld llvm -y


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs. This was generated by agents but checked and verified by a human (me).

Tracking: DEVPROD-1072

Repo-level summary:
- Pinned distinct third-party action refs in this PR: 10
- Repo-level unpinned usage count from the trunk recheck: 21
- Dependabot GitHub Actions coverage: appended (.github/dependabot.yml)

Note: `cargo-bins/cargo-binstall@main` is branch-like rather than version-tagged, so this PR freezes the current `main` commit and labels it as `# main`.

Verification commands:

```bash
# actions-rust-lang/setup-rust-toolchain # v1.16.1 -> 46268bd060767258de96ed93c1251119784f2ab6
gh api repos/actions-rust-lang/setup-rust-toolchain/commits/v1.16.1 --jq '.sha'
# expected: 46268bd060767258de96ed93c1251119784f2ab6

# cargo-bins/cargo-binstall # main -> f8810ffa11196f23afb38e6fb64716fbf814ad8f
gh api repos/cargo-bins/cargo-binstall/commits/main --jq '.sha'
# expected: f8810ffa11196f23afb38e6fb64716fbf814ad8f

# extractions/setup-just # v2.0.0 -> dd310ad5a97d8e7b41793f8ef055398d51ad4de6
gh api repos/extractions/setup-just/commits/v2.0.0 --jq '.sha'
# expected: dd310ad5a97d8e7b41793f8ef055398d51ad4de6

# HaaLeo/publish-vscode-extension # v1.7.0 -> f4ece70f329f66686bd71c54b1671353fe320e49
gh api repos/HaaLeo/publish-vscode-extension/commits/v1.7.0 --jq '.sha'
# expected: f4ece70f329f66686bd71c54b1671353fe320e49

# houseabsolute/actions-rust-cross # v1.0.7 -> fe6ede73c7f0a50412ec05994e2aa5a7bf635eac
gh api repos/houseabsolute/actions-rust-cross/commits/v1.0.7 --jq '.sha'
# expected: fe6ede73c7f0a50412ec05994e2aa5a7bf635eac

# ncipollo/release-action # v1.21.0 -> 339a81892b84b4eeb0f6e744e4574d79d0d9b8dd
gh api repos/ncipollo/release-action/commits/v1.21.0 --jq '.sha'
# expected: 339a81892b84b4eeb0f6e744e4574d79d0d9b8dd

# pnpm/action-setup # v4.3.0 -> b906affcce14559ad1aafd4ab0e942779e9f58b1
gh api repos/pnpm/action-setup/commits/v4.3.0 --jq '.sha'
# expected: b906affcce14559ad1aafd4ab0e942779e9f58b1

# redhat-actions/buildah-build # v2.13 -> 7a95fa7ee0f02d552a32753e7414641a04307056
gh api repos/redhat-actions/buildah-build/commits/v2.13 --jq '.sha'
# expected: 7a95fa7ee0f02d552a32753e7414641a04307056

# Swatinem/rust-cache # v2.7.8 -> 9d47c6ad4b02e050fd481d890b2ea34778fd09d6
gh api repos/Swatinem/rust-cache/commits/v2.7.8 --jq '.sha'
# expected: 9d47c6ad4b02e050fd481d890b2ea34778fd09d6

# Swatinem/rust-cache # v2.9.1 -> c19371144df3bb44fab255c43d04cbc2ab54d1c4
gh api repos/Swatinem/rust-cache/commits/v2.9.1 --jq '.sha'
# expected: c19371144df3bb44fab255c43d04cbc2ab54d1c4
```
