### PR TITLE
feat: at face values→at face value

### DIFF
--- a/harper-core/src/linting/weir_rules/AtFaceValue.weir
+++ b/harper-core/src/linting/weir_rules/AtFaceValue.weir
@@ -1,8 +1,10 @@
-expr main (on face value)
+expr main [(at face values), (on face value), (on face values)]
 
-let message "`at face value is more idiomatic and more common."
-let description "Corrects `on face value` to the more usual `at face value`."
+let message "`at face value` is more idiomatic and more common."
+let description "Corrects nonstandard variants of `at face value`."
 let kind "WordChoice"
 let becomes "at face value"
 
 test "Obviously what you want is possible and on face value it's a trivial change on our end." "Obviously what you want is possible and at face value it's a trivial change on our end."
+test "their own work should of course not always be taken at face values" "their own work should of course not always be taken at face value"
+test "Sounds like you havent experienced all that Go can offer, and disposed it on face values." "Sounds like you havent experienced all that Go can offer, and disposed it at face value."


### PR DESCRIPTION
# Issues 
N/A

# Description

I read "at face values" on some forum, verified that it's not an accepted variant of "at face value", and that it's relatively common.

We already had a Weir rule to correct "on face value" so I added both "at face values" and "on face values" to it.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

- `hippietrail@Andrews-M1-MacBook-Air harper % cargo run --bin harper-cli test harper-core/src/linting/weir_rules/AtFaceValue.weir`
- `cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
