### PR TITLE
fix: don't flag CVEs

### DIFF
--- a/harper-core/src/linting/numeric_range_en_dash.rs
+++ b/harper-core/src/linting/numeric_range_en_dash.rs
@@ -1,7 +1,10 @@
-use crate::Token;
-use crate::expr::{Expr, SequenceExpr};
-use crate::linting::expr_linter::Chunk;
-use crate::punctuation::Punctuation;
+use crate::{
+    Token,
+    char_string::CharStringExt,
+    expr::{Expr, SequenceExpr},
+    linting::expr_linter::Chunk,
+    punctuation::Punctuation,
+};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -40,6 +43,14 @@ fn is_chained_numeric_form(context: Option<(&[Token], &[Token])>) -> bool {
     preceded_by_numeric_dash || followed_by_dash_numeric
 }
 
+fn is_cve(context: Option<(&[Token], &[Token])>, source: &[char]) -> bool {
+    context.is_some_and(|(before, _)| {
+        matches!(before, [.., word, hy]
+            if hy.kind.is_hyphen() && word.kind.is_word() && word.get_ch(source).eq_ch(&['c', 'v', 'e'])
+        )
+    })
+}
+
 pub struct NumericRangeEnDash {
     expr: SequenceExpr,
 }
@@ -68,10 +79,14 @@ impl ExprLinter for NumericRangeEnDash {
     fn match_to_lint_with_context(
         &self,
         matched_tokens: &[Token],
-        _source: &[char],
+        source: &[char],
         context: Option<(&[Token], &[Token])>,
     ) -> Option<Lint> {
         if is_chained_numeric_form(context) {
+            return None;
+        }
+
+        if is_cve(context, source) {
             return None;
         }
 
@@ -217,5 +232,10 @@ mod tests {
             "The code spans 12-14-16 in the export.",
             NumericRangeEnDash::default(),
         );
+    }
+
+    #[test]
+    fn dont_flag_cve_3580() {
+        assert_no_lints("CVE-2017-5753", NumericRangeEnDash::default());
     }
 }


### PR DESCRIPTION
# Issues 
Fixes #3580

# Description

Harper was flagging things like `CVE-2017-5753`

Now checks for "cve-" to the left of apparent number ranges.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

I used Google Search's AI for some ideas and making my solution more Rusty at the end.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
