### PR TITLE
fix(harper.js): slow message passing from slow cache lookups

### DIFF
--- a/packages/harper.js/src/BinaryModule.ts
+++ b/packages/harper.js/src/BinaryModule.ts
@@ -112,7 +112,7 @@ export function createBinaryModuleFromUrl(url: string, glueFlavor?: WasmGlueFlav
 export class BinaryModuleImpl {
 	public url: string | URL = '';
 	public glueFlavor: WasmGlueFlavor = 'full';
-	private inner: Promise<WasmModule> | null = null;
+	protected inner: Promise<WasmModule> | null = null;
 
 	/** Load a binary from a specified URL. This is the only recommended way to construct this type. */
 	public static create(url: string | URL, glueFlavor?: WasmGlueFlavor): BinaryModuleImpl {
@@ -155,8 +155,6 @@ export class SuperBinaryModule extends BinaryModuleImpl {
 	}
 
 	async getBinaryModule(): Promise<any> {
-		return await LazyPromise.from(() =>
-			loadBinary(typeof this.url === 'string' ? this.url : this.url.href, this.glueFlavor),
-		);
+		return await this.inner!;
 	}
 }

--- a/packages/harper.js/src/BinaryModule.ts
+++ b/packages/harper.js/src/BinaryModule.ts
@@ -66,29 +66,32 @@ function getInitInput(binary: string): InitInput {
 	return binary;
 }
 
-const loadBinaryWithKey = pMemoize(
-	async (_cacheKey: string, binary: string, glueFlavor: WasmGlueFlavor) => {
-		const exports = loadGlue(glueFlavor);
+async function loadBinaryUncached(binary: string, glueFlavor: WasmGlueFlavor): Promise<WasmModule> {
+	const exports = loadGlue(glueFlavor);
 
-		const defaultGlueBinary = getDefaultGlueBinary(binary, glueFlavor);
-		if (defaultGlueBinary != null) {
-			try {
-				await defaultGlue.default({ module_or_path: getInitInput(defaultGlueBinary) });
-			} catch (err) {
-				if (glueFlavor === 'slim') {
-					throw err;
-				}
+	const defaultGlueBinary = getDefaultGlueBinary(binary, glueFlavor);
+	if (defaultGlueBinary != null) {
+		try {
+			await defaultGlue.default({ module_or_path: getInitInput(defaultGlueBinary) });
+		} catch (err) {
+			if (glueFlavor === 'slim') {
+				throw err;
 			}
 		}
+	}
 
-		await exports.default({ module_or_path: getInitInput(binary) });
+	await exports.default({ module_or_path: getInitInput(binary) });
 
-		return exports;
-	},
-);
+	return exports;
+}
+
+const loadBinaryByFlavor: Record<WasmGlueFlavor, (binary: string) => Promise<WasmModule>> = {
+	full: pMemoize((binary: string) => loadBinaryUncached(binary, 'full')),
+	slim: pMemoize((binary: string) => loadBinaryUncached(binary, 'slim')),
+};
 
 function loadBinary(binary: string, glueFlavor: WasmGlueFlavor) {
-	return loadBinaryWithKey(`${glueFlavor}:${binary}`, binary, glueFlavor);
+	return loadBinaryByFlavor[glueFlavor](binary);
 }
 
 export interface BinaryModule {
@@ -112,7 +115,7 @@ export function createBinaryModuleFromUrl(url: string, glueFlavor?: WasmGlueFlav
 export class BinaryModuleImpl {
 	public url: string | URL = '';
 	public glueFlavor: WasmGlueFlavor = 'full';
-	protected inner: Promise<WasmModule> | null = null;
+	private inner: Promise<WasmModule> | null = null;
 
 	/** Load a binary from a specified URL. This is the only recommended way to construct this type. */
 	public static create(url: string | URL, glueFlavor?: WasmGlueFlavor): BinaryModuleImpl {
@@ -155,6 +158,8 @@ export class SuperBinaryModule extends BinaryModuleImpl {
 	}
 
 	async getBinaryModule(): Promise<any> {
-		return await this.inner!;
+		return await LazyPromise.from(() =>
+			loadBinary(typeof this.url === 'string' ? this.url : this.url.href, this.glueFlavor),
+		);
 	}
 }


### PR DESCRIPTION
# Issues 

Fixes #3577

# Description
This PR fixes a `WorkerLinter` performance regression that affected integrations using inlined WASM binaries, including the Obsidian plugin.

`SuperBinaryModule.getBinaryModule()` now reuses the existing lazy `BinaryModuleImpl.inner` promise instead of calling back into `loadBinary(...)` on every access. This avoids repeatedly constructing a new cache key from the full inlined WASM data URL, which is very large for `slimBinaryInlined`.

This construction and subsequent comparison was really slow and it was happening every time a message was passed between the `WorkerLinter` and the main thread. This resulted in large, noticeable, and persistent lag.

# How Has This Been Tested?

Manually

# AI Disclosure
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
N/A

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
