### PR TITLE
feat: incidence report→incident report

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -4997,6 +4997,13 @@
 								"state": true,
 								"label": "Pay For Price"
 							}
+						},
+						{
+							"Bool": {
+								"name": "IncidentReport",
+								"state": true,
+								"label": "Incident Report"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/weir_rules/IncidentReport/Plural.weir
+++ b/harper-core/src/linting/weir_rules/IncidentReport/Plural.weir
@@ -1,0 +1,8 @@
+expr main incidence reports
+
+let message "Did you mean `incident reports`?"
+let description "Corrects `incidence reports` to `incident reports`."
+let kind "WordChoice"
+let becomes "incident reports"
+
+test "We calibrate this pool of models to incidence reports using Hamiltonian Monte Carlo." "We calibrate this pool of models to incident reports using Hamiltonian Monte Carlo."

--- a/harper-core/src/linting/weir_rules/IncidentReport/Singular.weir
+++ b/harper-core/src/linting/weir_rules/IncidentReport/Singular.weir
@@ -1,0 +1,8 @@
+expr main incidence report
+
+let message "Did you mean `incident report`?"
+let description "Corrects `incidence report` to `incident report`."
+let kind "WordChoice"
+let becomes "incident report"
+
+test "Create rough draft of incidence report form." "Create rough draft of incident report form."


### PR DESCRIPTION
# Issues 
N/A

# Description

I've noticed many people on YouTube these days are saying "incidences" when they mean "incidents". This is a small part of that where the context is clear:

<img width="673" height="220" alt="image" src="https://github.com/user-attachments/assets/10cf68a8-f67a-493e-85ce-941456837c8d" />

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
