### PR TITLE
fix(core): false-positive after contraction

### DIFF
--- a/harper-core/src/linting/disjoint_prefixes.rs
+++ b/harper-core/src/linting/disjoint_prefixes.rs
@@ -77,7 +77,10 @@ where
         let (pre, _) = ctx?;
 
         // Cloud Native Pub-Sub System at Pinterest -> subsystem
-        if pre.last().is_some_and(|p| p.kind.is_hyphen()) {
+        if pre
+            .last()
+            .is_some_and(|p| p.kind.is_hyphen() || p.kind.is_apostrophe())
+        {
             return None;
         }
 
@@ -166,6 +169,22 @@ mod tests {
             "Advanced Nginx configuration available for super users",
             DisjointPrefixes::new(FstDictionary::curated()),
             "Advanced Nginx configuration available for superusers",
+        );
+    }
+
+    #[test]
+    fn dont_join_contraction_suffix_after_ascii_apostrophe() {
+        assert_no_lints(
+            "you 're fresh so you don't neglect them",
+            DisjointPrefixes::new(FstDictionary::curated()),
+        );
+    }
+
+    #[test]
+    fn dont_join_contraction_suffix_after_typographic_apostrophe() {
+        assert_no_lints(
+            "you ’re fresh so you don’t neglect them",
+            DisjointPrefixes::new(FstDictionary::curated()),
         );
     }
 


### PR DESCRIPTION
# Issues 

I found this issue while browsing Bluesky.

# Description

Prevents `DisjointPrefixes` from treating contraction suffixes as standalone prefixes when they are preceded by an apostrophe. This avoids false positives such as interpreting split `you 're fresh` / `you ’re fresh` as `re fresh` -> `refresh`.

# Demo

N/A

# How Has This Been Tested?

Added regression coverage in `harper-core/src/linting/disjoint_prefixes.rs` for ASCII and typographic apostrophe contraction suffixes.

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter

- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
