### PR TITLE
fix(core): ignore the letter `s` when found in a parenthesis after a word

### DIFF
--- a/harper-core/src/lib.rs
+++ b/harper-core/src/lib.rs
@@ -99,6 +99,45 @@ pub fn remove_overlaps(lints: &mut Vec<Lint>) {
     lints.remove_indices(remove_indices);
 }
 
+/// Remove lints whose character spans overlap any nonempty match of an expression.
+///
+/// This is useful for letting higher-level token patterns mark text ranges where otherwise valid
+/// lower-level lints should be suppressed. Expression matches are checked from every token index,
+/// including overlapping matches, and zero-width expression matches are ignored.
+pub fn remove_lints_overlapping_expr<E: expr::Expr + ?Sized>(
+    expr: &E,
+    document: &Document,
+    lints: &mut Vec<Lint>,
+) {
+    if lints.is_empty() {
+        return;
+    }
+
+    let tokens = document.get_tokens();
+    let source = document.get_source();
+    let matched_spans: Vec<Span<char>> = (0..tokens.len())
+        .filter_map(|cursor| {
+            let token_span = expr.run(cursor, tokens, source)?;
+
+            if token_span.is_empty() {
+                None
+            } else {
+                Some(token_span.to_char_span(tokens))
+            }
+        })
+        .collect();
+
+    if matched_spans.is_empty() {
+        return;
+    }
+
+    lints.retain(|lint| {
+        !matched_spans
+            .iter()
+            .any(|matched_span| lint.span.overlaps_with(*matched_span))
+    });
+}
+
 /// Remove overlapping lints from a map keyed by rule name, similar to [`remove_overlaps`].
 ///
 /// The map is treated as if all contained lints were in a single flat collection, ensuring the
@@ -173,9 +212,10 @@ mod tests {
     use crate::remove_overlaps_map;
     use crate::spell::FstDictionary;
     use crate::{
-        Dialect, Document,
+        Dialect, Document, Span,
+        expr::{AnchorStart, SequenceExpr},
         linting::{LintGroup, Linter},
-        remove_overlaps,
+        remove_lints_overlapping_expr, remove_overlaps,
     };
 
     #[test]
@@ -191,6 +231,45 @@ mod tests {
         dbg!(&lints);
 
         assert_eq!(lints.len(), 3);
+    }
+
+    #[test]
+    fn remove_lints_overlapping_expr_removes_overlapping_lints() {
+        let doc = Document::new_plain_english_curated("keep bad keep");
+        let mut lints = vec![Lint {
+            span: Span::new(5, 8),
+            ..Default::default()
+        }];
+
+        remove_lints_overlapping_expr(&SequenceExpr::aco("bad"), &doc, &mut lints);
+
+        assert!(lints.is_empty());
+    }
+
+    #[test]
+    fn remove_lints_overlapping_expr_keeps_non_overlapping_lints() {
+        let doc = Document::new_plain_english_curated("keep bad keep");
+        let mut lints = vec![Lint {
+            span: Span::new(0, 4),
+            ..Default::default()
+        }];
+
+        remove_lints_overlapping_expr(&SequenceExpr::aco("bad"), &doc, &mut lints);
+
+        assert_eq!(lints.len(), 1);
+    }
+
+    #[test]
+    fn remove_lints_overlapping_expr_ignores_zero_width_matches() {
+        let doc = Document::new_plain_english_curated("bad");
+        let mut lints = vec![Lint {
+            span: Span::new(0, 3),
+            ..Default::default()
+        }];
+
+        remove_lints_overlapping_expr(&AnchorStart, &doc, &mut lints);
+
+        assert_eq!(lints.len(), 1);
     }
 
     #[quickcheck]

--- a/harper-core/src/linting/spell_check.rs
+++ b/harper-core/src/linting/spell_check.rs
@@ -6,8 +6,9 @@ use smallvec::ToSmallVec;
 use super::{Lint, LintKind, Linter};
 use super::{Suggestion, informal_laughter::is_informal_laughter};
 use crate::document::Document;
+use crate::expr::{Filter, SequenceExpr};
 use crate::spell::{Dictionary, suggest_correct_spelling};
-use crate::{CharString, CharStringExt, Dialect, TokenStringExt};
+use crate::{CharString, CharStringExt, Dialect, TokenStringExt, remove_lints_overlapping_expr};
 
 pub struct SpellCheck<T>
 where
@@ -64,6 +65,25 @@ impl<T: Dictionary> SpellCheck<T> {
         // no suggestions found
         Vec::new()
     }
+}
+
+fn parenthetical_plural_s_expr() -> Filter {
+    Filter::new(vec![
+        Box::new(
+            SequenceExpr::default()
+                .then_any_word()
+                .then_kind_where(|kind| kind.is_open_round())
+                .t_aco("s")
+                .then_kind_where(|kind| kind.is_close_round()),
+        ),
+        Box::new(
+            SequenceExpr::default()
+                .then_kind_where(|kind| kind.is_open_round())
+                .t_aco("s")
+                .then_kind_where(|kind| kind.is_close_round()),
+        ),
+        Box::new(SequenceExpr::aco("s")),
+    ])
 }
 
 impl<T: Dictionary> Linter for SpellCheck<T> {
@@ -130,6 +150,8 @@ impl<T: Dictionary> Linter for SpellCheck<T> {
                 priority: 63,
             })
         }
+
+        remove_lints_overlapping_expr(&parenthetical_plural_s_expr(), document, &mut lints);
 
         lints
     }
@@ -531,6 +553,66 @@ mod tests {
             SpellCheck::new(FstDictionary::curated(), Dialect::American),
             &["macOS"],
             &["MacOS"],
+        );
+    }
+
+    #[test]
+    fn allows_parenthetical_plural_s() {
+        assert_no_lints(
+            "Please ask each person(s) to sign.",
+            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+        );
+    }
+
+    #[test]
+    fn allows_multiple_parenthetical_plural_s_markers() {
+        assert_no_lints(
+            "Review the person(s) and document(s).",
+            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+        );
+    }
+
+    #[test]
+    fn allows_uppercase_parenthetical_plural_s() {
+        assert_no_lints(
+            "CONTACT THE PERSON(S).",
+            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+        );
+    }
+
+    #[test]
+    fn still_flags_misspelled_word_before_parenthetical_plural_s() {
+        assert_lint_count(
+            "Please ask each persson(s) to sign.",
+            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            1,
+        );
+    }
+
+    #[test]
+    fn still_flags_parenthetical_s_without_preceding_word() {
+        assert_lint_count(
+            "Please mark (s) on the form.",
+            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            1,
+        );
+    }
+
+    #[test]
+    fn still_flags_spaced_parenthetical_s() {
+        assert_lint_count(
+            "Please ask each person (s) to sign.",
+            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            1,
+        );
+    }
+
+    #[test]
+    fn still_flags_longer_parenthetical_marker() {
+        assert_lint_count(
+            "Please ask each person(ss) to sign.",
+            SpellCheck::new(FstDictionary::curated(), Dialect::American),
+            1,
         );
     }
 


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #476

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

The spellcheck rule didn't like it when someone would place an optional pluralization at the end of a word (as in "person(s)"). To fix this, I added a utility function that allows one to filter a lint list with an expression. If a lint overlaps any item in the document that matches the expression, it is thrown out.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Additional unit tests.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
