### PR TITLE
fix(desktop): make macOS accessibility activation work when AXEnhancedUserInterface is rejected

### DIFF
--- a/harper-desktop/src-tauri/src/mac_broker.rs
+++ b/harper-desktop/src-tauri/src/mac_broker.rs
@@ -6,9 +6,9 @@ use accessibility_sys::{
     AXUIElementCopyParameterizedAttributeValue, AXUIElementGetPid, AXUIElementSetAttributeValue,
     AXValueCreate, AXValueGetType, AXValueGetValue, AXValueRef, error_string,
     kAXBoundsForRangeParameterizedAttribute, kAXErrorAttributeUnsupported, kAXErrorIllegalArgument,
-    kAXErrorNoValue, kAXErrorParameterizedAttributeUnsupported, kAXErrorSuccess,
-    kAXFocusedApplicationAttribute, kAXTrustedCheckOptionPrompt, kAXValueTypeCFRange,
-    kAXValueTypeCGRect, pid_t,
+    kAXErrorNoValue, kAXErrorNotImplemented, kAXErrorParameterizedAttributeUnsupported,
+    kAXErrorSuccess, kAXFocusedApplicationAttribute, kAXTrustedCheckOptionPrompt,
+    kAXValueTypeCFRange, kAXValueTypeCGRect, pid_t,
 };
 use core::{ffi::c_void, mem::MaybeUninit};
 use core_foundation::array::CFArray;
@@ -251,8 +251,7 @@ impl MacBroker {
         match set_enhanced_user_interface_preserving_previous(app, true) {
             Ok(enhanced_user_interface_restore_value) => {
                 eprintln!(
-                    "Requested AXEnhancedUserInterface for {bundle_id} pid {pid}; waiting for {} debounce",
-                    "Chromium"
+                    "Requested AXEnhancedUserInterface for {bundle_id} pid {pid}; waiting for Chromium debounce"
                 );
                 self.accessibility_activation = Some(AccessibilityActivationState {
                     pid,
@@ -268,13 +267,16 @@ impl MacBroker {
             }
             Err(error) if is_unsupported_accessibility_activation_error(error) => {
                 eprintln!(
-                    "AXEnhancedUserInterface unsupported for {bundle_id} pid {pid}: {}",
+                    "AXEnhancedUserInterface unsupported for {bundle_id} pid {pid}: {}; proceeding to verification",
                     error_string(error)
                 );
                 self.accessibility_activation = Some(AccessibilityActivationState {
                     pid,
                     bundle_id: bundle_id.to_string(),
-                    status: AccessibilityActivationStatus::RetryLater,
+                    status: AccessibilityActivationStatus::Pending {
+                        ready_at: now,
+                        verification_attempts: 0,
+                    },
                     last_attempted_at: now,
                     enhanced_user_interface_restore_value: None,
                 });
@@ -529,7 +531,9 @@ fn release_accessibility_activation(state: &AccessibilityActivationState) {
 
 /// Returns whether an AX error means the target does not support this attribute.
 fn is_unsupported_accessibility_activation_error(error: i32) -> bool {
-    error == kAXErrorAttributeUnsupported || error == kAXErrorNoValue
+    error == kAXErrorAttributeUnsupported
+        || error == kAXErrorNoValue
+        || error == kAXErrorNotImplemented
 }
 
 /// Sets `AXEnhancedUserInterface` while returning its old value when readable.
@@ -537,7 +541,23 @@ fn set_enhanced_user_interface_preserving_previous(
     app: &AXUIElement,
     enabled: bool,
 ) -> Result<Option<bool>, i32> {
-    set_boolean_attribute_preserving_previous(app, "AXEnhancedUserInterface", enabled)
+    match set_boolean_attribute_preserving_previous(app, "AXEnhancedUserInterface", enabled) {
+        Ok(previous) => Ok(previous),
+        Err(error) => {
+            // Some apps (notably Electron/Chromium ones such as Slack) reject
+            // `AXEnhancedUserInterface` (e.g. with kAXErrorNotImplemented) but
+            // support the Electron-specific `AXManualAccessibility` attribute to
+            // enable their accessibility tree. Fall back to it. No restore value
+            // is preserved because restoration targets `AXEnhancedUserInterface`.
+            match set_boolean_attribute(app, "AXManualAccessibility", enabled) {
+                Ok(()) => {
+                    eprintln!("Activated accessibility via AXManualAccessibility fallback");
+                    Ok(None)
+                }
+                Err(_) => Err(error),
+            }
+        }
+    }
 }
 
 /// Restores a boolean AX attribute if a previous value was captured.
@@ -905,13 +925,14 @@ impl TreeVisitor for AccessibilityActivationProbe {
             self.found_supported_text_element.set(true);
 
             let string = cf_type_to_string(&value).unwrap_or_default();
-            let bounds = if string.is_empty() {
-                TextRangeBoundsProbe::Unavailable
+            let bounds_usable = if string.is_empty() {
+                false
             } else {
-                probe_element_rect_for_text_range(element, 0, 1)
+                probe_element_rect_for_text_range(element, 0, 1).has_usable_text_metrics()
+                    || element_rect_for_text_range_with_fallback(element, &string, 0, 1).is_some()
             };
 
-            if bounds.has_usable_text_metrics() {
+            if bounds_usable {
                 self.found_text_range_bounds.set(true);
                 return TreeWalkerFlow::Exit;
             }
@@ -941,10 +962,11 @@ impl TreeVisitor for RectCollector<'_> {
 
             for (rule_name, lints) in organized_lints {
                 for lint in lints {
-                    if let Ok(Some(rect)) = element_rect_for_text_range(
+                    if let Some(rect) = element_rect_for_text_range_with_fallback(
                         element,
-                        lint.span.start as isize,
-                        lint.span.len() as isize,
+                        &string,
+                        lint.span.start,
+                        lint.span.len(),
                     ) {
                         let element = element.clone();
                         let source_text = string.clone();
@@ -1018,6 +1040,101 @@ fn is_supported_text_role(role: &str) -> bool {
     matches!(role, "AXTextArea" | "AXTextField")
 }
 
+/// Collects `AXStaticText` descendants with their string values.
+///
+/// Chromium-based apps (e.g. Slack) report degenerate `AXBoundsForRange`
+/// rects on the editable `AXTextArea` wrapper but expose usable bounds on the
+/// `AXStaticText` leaf nodes inside it.
+struct StaticTextCollector {
+    texts: RefCell<Vec<(AXUIElement, String)>>,
+}
+
+impl StaticTextCollector {
+    fn new() -> Self {
+        Self {
+            texts: RefCell::new(Vec::new()),
+        }
+    }
+
+    fn into_texts(self) -> Vec<(AXUIElement, String)> {
+        self.texts.into_inner()
+    }
+}
+
+impl TreeVisitor for StaticTextCollector {
+    fn enter_element(&self, element: &AXUIElement) -> TreeWalkerFlow {
+        if let Ok(role) = element.role()
+            && role == "AXStaticText"
+            && let Ok(value) = element.value()
+            && let Some(string) = cf_type_to_string(&value)
+            && !string.is_empty()
+        {
+            self.texts.borrow_mut().push((element.clone(), string));
+        }
+
+        TreeWalkerFlow::Continue
+    }
+
+    fn exit_element(&self, _element: &AXUIElement) {}
+}
+
+/// Finds `needle` within `haystack` starting at char offset `from`.
+fn find_char_subslice(haystack: &[char], needle: &[char], from: usize) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+
+    let end = haystack.len() - needle.len();
+    (from..=end).find(|&i| haystack[i..i + needle.len()] == *needle)
+}
+
+/// Resolves text-range bounds, falling back to `AXStaticText` descendants
+/// when the element itself reports unusable bounds (Chromium-based apps).
+fn element_rect_for_text_range_with_fallback(
+    element: &AXUIElement,
+    full_text: &str,
+    start_index: usize,
+    length: usize,
+) -> Option<Rect> {
+    if let Ok(Some(rect)) =
+        element_rect_for_text_range(element, start_index as isize, length as isize)
+    {
+        return Some(rect);
+    }
+
+    let walker = TreeWalker::new();
+    let collector = StaticTextCollector::new();
+    walker.walk(element, &collector);
+
+    let full_chars: Vec<char> = full_text.chars().collect();
+    let mut cursor = 0usize;
+
+    for (child, child_text) in collector.into_texts() {
+        let child_chars: Vec<char> = child_text.chars().collect();
+        // Locate this child's text within the parent value, starting at the
+        // cursor, to absorb any separators the parent inserts between children.
+        let Some(child_start) = find_char_subslice(&full_chars, &child_chars, cursor) else {
+            continue;
+        };
+        let child_end = child_start + child_chars.len();
+
+        if start_index >= child_start
+            && start_index + length <= child_end
+            && let Ok(Some(rect)) = element_rect_for_text_range(
+                &child,
+                (start_index - child_start) as isize,
+                length as isize,
+            )
+        {
+            return Some(rect);
+        }
+
+        cursor = child_end;
+    }
+
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1033,6 +1150,18 @@ mod tests {
         assert!(!is_supported_text_role("AXButton"));
         assert!(!is_supported_text_role("AXStaticText"));
         assert!(!is_supported_text_role(""));
+    }
+
+    #[test]
+    fn finds_char_subslice_respecting_offset() {
+        let haystack: Vec<char> = "one\ntwo two".chars().collect();
+        let needle: Vec<char> = "two".chars().collect();
+
+        assert_eq!(find_char_subslice(&haystack, &needle, 0), Some(4));
+        assert_eq!(find_char_subslice(&haystack, &needle, 5), Some(8));
+        assert_eq!(find_char_subslice(&haystack, &needle, 9), None);
+        assert_eq!(find_char_subslice(&haystack, &[], 0), None);
+        assert_eq!(find_char_subslice(&[], &needle, 0), None);
     }
 
     #[test]


### PR DESCRIPTION
On recent macOS 15.7.x, setting AXEnhancedUserInterface on another app's AX element fails with kAXErrorNotImplemented (-25208) for every target app (observed for AppKit apps like TextEdit and Electron apps like Slack, on macOS 15.7.7 / 24G720). Harper treated this error as retryable, so activation stayed in RetryLater forever, get_boxes() always returned no lints, and the desktop app silently did nothing.

Fix, in four parts:

- Treat kAXErrorNotImplemented as an unsupported-attribute error.
- When the attribute is unsupported, proceed to text-metrics verification instead of retrying forever: native AppKit text views expose usable AXBoundsForRange without any activation.
- Fall back to the Electron-specific AXManualAccessibility attribute when AXEnhancedUserInterface cannot be set, so Chromium-based apps (e.g. Slack) still enable their accessibility tree.
- Chromium reports degenerate zero-size AXBoundsForRange rects on the editable AXTextArea wrapper but real ones on the AXStaticText leaf nodes inside it. Add a fallback that maps lint spans onto those leaves by char-offset text matching, used by both the activation verification probe and RectCollector.

Verified on macOS 15.7.7: underlines and suggestions now appear in both TextEdit (AppKit) and Slack (Electron); previously neither worked.

Fixes #3500

# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
