### PR TITLE
feat: the entire of→the entirety of

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5039,6 +5039,13 @@
 								"state": true,
 								"label": "Incident Report"
 							}
+						},
+						{
+							"Bool": {
+								"name": "TheEntiretyOf",
+								"state": true,
+								"label": "The Entirety Of"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/weir_rules/TheEntiretyOf.weir
+++ b/harper-core/src/linting/weir_rules/TheEntiretyOf.weir
@@ -1,0 +1,9 @@
+expr main (the entire of)
+
+let message "Use `the entirety of` instead of `the entire of`."
+let description "Corrects `the entire of` to `the entirety of`."
+let kind "Usage"
+let becomes "the entirety of"
+
+test "I'm certain that is not the entire of your traceback" "I'm certain that is not the entirety of your traceback"
+test "I think there's still value in sharp emitting the metadata event when the entire of the input is available" "I think there's still value in sharp emitting the metadata event when the entirety of the input is available"


### PR DESCRIPTION
# Issues 
N/A

# Description

Just heard "the entire of" in a Tsoding video and thought it sounded common. Verified that it is and that there's no common false positives.

For now only handles the safe variant with "the" so a Weir rule suffices. It could support variants without "the" but a Rust implementation would be better as there are edge cases and different suggestions to offer depending on the context.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo run --bin harper-cli test harper-core/src/linting/weir_rules/TheEntiretyOf.weir`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
