### PR TITLE
fix(core): support multiple brackets in rune matcher

### DIFF
--- a/harper-core/src/spell/rune/matcher.rs
+++ b/harper-core/src/spell/rune/matcher.rs
@@ -23,9 +23,10 @@ impl Matcher {
 
             match c {
                 '[' => {
-                    let close_idx = source[idx..]
-                        .find(']')
-                        .ok_or(Error::UnmatchedBracket { index: idx })?;
+                    let close_idx = idx
+                        + source[idx..]
+                            .find(']')
+                            .ok_or(Error::UnmatchedBracket { index: idx })?;
 
                     let bracket_contents = &source[idx + 1..close_idx];
 
@@ -145,6 +146,20 @@ mod tests {
     }
 
     #[test]
+    fn parses_multi_brackets() {
+        let matcher = Matcher::parse("u[xy]a[^z]").unwrap();
+        assert_eq!(
+            matcher.operators,
+            vec![
+                Operator::Literal('u'),
+                Operator::MatchOne(vec!['x', 'y']),
+                Operator::Literal('a'),
+                Operator::MatchNone(vec!['z']),
+            ]
+        );
+    }
+
+    #[test]
     fn matches_vowels() {
         let matcher = Matcher::parse("[aeiou]").unwrap();
 
@@ -156,10 +171,27 @@ mod tests {
     }
 
     #[test]
+    fn matches_multiple_bracket_vowels() {
+        let matcher = Matcher::parse("u[xy]a[^z]").unwrap();
+
+        assert!(matcher.matches(&['u', 'x', 'a', 'q']));
+        assert!(matcher.matches(&['u', 'y', 'a', 'y']));
+        assert!(!matcher.matches(&['u', 'e', 'a', 'e']));
+        assert!(!matcher.matches(&['u', 'x', 'a', 'z']));
+    }
+
+    #[test]
     fn round_trip() {
         let source = "[^aeiou]a.s";
         let matcher = Matcher::parse(source).unwrap();
 
+        assert_eq!(matcher.to_string(), source);
+    }
+
+    #[test]
+    fn round_trip_multiple_brackets() {
+        let source = "über[^e]gegen[^eü]";
+        let matcher = Matcher::parse(source).unwrap();
         assert_eq!(matcher.to_string(), source);
     }
 }


### PR DESCRIPTION
# Description
Fixes a bug in `harper-core`'s rune `Matcher::parse` where `close_idx` was computed as a relative offset from `idx` but treated as an absolute index into `source`. This produced wrong slices (and, in many cases, panics or `UnmatchedBracket` errors) whenever a pattern contained more than one bracket group, which broke replacements in `annotations.json` that use patterns like `u[xy]a[^z]`.

# How Has This Been Tested?
I was building my own dictionary where I needed multiple conditions. With that fix it's working properly.

# AI Disclosure
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively. (claude code, but that's not an agent)
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
