### PR TITLE
refactor: centralize suggestion transformation depth limit #3597

### DIFF
--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -298,6 +298,13 @@ pub use suggestion::{Suggestion, SuggestionCollectionExt};
 
 use crate::{Document, LSend, render_markdown};
 
+/// Maximum number of sequential lint suggestions explored when searching for a
+/// transformation path (for example in Weir rule tests or linting test helpers).
+///
+/// This is a compile-time limit that prevents unbounded search when suggestion
+/// application cycles or deep multi-step fixes are involved.
+pub const MAX_SUGGESTION_TRANSFORMATION_DEPTH: usize = 100;
+
 /// A __stateless__ rule that searches documents for grammatical errors.
 ///
 /// Commonly implemented via [`ExprLinter`].
@@ -585,7 +592,8 @@ pub mod tests {
     /// Applies suggestions iteratively until any combination produces the expected result.
     ///
     /// Explores all possible suggestion branches (depth-first search) until finding a path
-    /// that produces the expected result. Stops after 100 iterations to prevent infinite loops.
+    /// that produces the expected result. Stops after
+    /// [`MAX_SUGGESTION_TRANSFORMATION_DEPTH`] iterations to prevent infinite loops.
     ///
     /// Use this when you want to verify that *some* suggestion sequence produces the
     /// expected result, without caring which specific suggestions are used.
@@ -621,8 +629,11 @@ pub mod tests {
         depth: usize,
     ) -> bool {
         // Prevent infinite recursion (e.g. cycles in suggestions)
-        if depth > 100 {
-            eprintln!("⚠️  Reached depth limit (100)");
+        if depth > super::MAX_SUGGESTION_TRANSFORMATION_DEPTH {
+            eprintln!(
+                "⚠️  Reached depth limit ({})",
+                super::MAX_SUGGESTION_TRANSFORMATION_DEPTH
+            );
             return false;
         }
 

--- a/harper-core/src/weir/mod.rs
+++ b/harper-core/src/weir/mod.rs
@@ -17,7 +17,10 @@ use parsing::{parse_expr_str, parse_str};
 use strum_macros::{AsRefStr, EnumString};
 
 use crate::expr::{Expr, ExprExt};
-use crate::linting::{Chunk, ExprLinter, Lint, LintKind, Linter, Sentence, Suggestion};
+use crate::linting::{
+    Chunk, ExprLinter, Lint, LintKind, Linter, MAX_SUGGESTION_TRANSFORMATION_DEPTH, Sentence,
+    Suggestion,
+};
 use crate::parsers::Markdown;
 use crate::spell::FstDictionary;
 use crate::{Document, Lrc, Token, TokenStringExt};
@@ -232,7 +235,7 @@ impl WeirLinter {
                     return Some(current);
                 }
 
-                if depth >= 100 {
+                if depth >= MAX_SUGGESTION_TRANSFORMATION_DEPTH {
                     continue;
                 }
 
@@ -280,7 +283,7 @@ impl WeirLinter {
                 }
 
                 iter_count += 1;
-                if iter_count == 100 {
+                if iter_count == MAX_SUGGESTION_TRANSFORMATION_DEPTH {
                     break;
                 }
             }


### PR DESCRIPTION
# Issues
Fixes #3597

# Description
This is a refactor that centralizes the hardcoded transformation depth limits into a single compile-time constant. Currently, the depth limit for suggestion transformations is duplicated across the codebase, making it difficult to adjust this value globally. This change introduces `MAX_SUGGESTION_TRANSFORMATION_DEPTH` as a single source of truth.

The PR updates:
- Lint suggestion search logic depth limits
- Weir transformation logic depth limits
- Related documentation comments

The behavior remains unchanged; this refactor makes future adjustments easier and eliminates duplicate constants.

# Demo
No visual changes — this is a code refactor only.

# How Has This Been Tested?
- `cargo check -p harper-core` ✓
- `cargo test -p harper-core` ✓

All tests pass, confirming the refactor maintains the existing behavior.

# AI Disclosure
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
- [ ] I made up the sentences in the unit tests.
- [x] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.