### PR TITLE
fix: digged→dug

### DIFF
--- a/harper-core/irregular_verbs.json
+++ b/harper-core/irregular_verbs.json
@@ -26,6 +26,7 @@
 	["come", "came", "come"],
 	["cost", "cost", "cost"],
 	["cut", "cut", "cut"],
+	["dig", "dug", "dug"],
 	["dive", "dove", "dove"],
 	["do", "did", "done"],
 	["drink", "drank", "drunk"],

--- a/harper-core/src/linting/regular_irregulars.rs
+++ b/harper-core/src/linting/regular_irregulars.rs
@@ -348,6 +348,15 @@ mod tests {
                 "I ate and drank too much but I slept good.",
             );
         }
+
+        #[test]
+        fn fix_digged() {
+            assert_suggestion_result(
+                "I digged a bit deeper.",
+                RegularIrregulars::new(FstDictionary::curated()),
+                "I dug a bit deeper.",
+            );
+        }
     }
 
     mod adjectives {


### PR DESCRIPTION
# Issues 
Fixes #3617

# Description

"digged" was not getting corrected to "dug". It turned out just to not be included in our list of irregular verbs.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test` with a new test using the sentence from the bug report.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
