### PR TITLE
feat: indian english "godown" is "warehouse" elsewhere

### DIFF
--- a/harper-core/src/linting/regionalisms.rs
+++ b/harper-core/src/linting/regionalisms.rs
@@ -55,6 +55,7 @@ enum Concept {
     FootpathPavementSidewalk,
     GasolinePetrol,
     GasStationPetrolStationServiceStation,
+    GodownWarehouse,
     // HooverVacuumCleaner - Hoover is also a surname and vacuum cleaner is universal.
     JumperSweater,
     Lakh,
@@ -365,6 +366,12 @@ const REGIONAL_TERMS: &[Term<'_>] = &[
         concept: GasolinePetrol,
     },
     Term {
+        term: "godown",
+        flag: Flag,
+        dialects: &[Indian],
+        concept: GodownWarehouse,
+    },
+    Term {
         term: "India",
         flag: UniversalTerm,
         dialects: &[American, Australian, British, Canadian, Indian],
@@ -628,6 +635,12 @@ const REGIONAL_TERMS: &[Term<'_>] = &[
         flag: Flag,
         dialects: &[American],
         concept: PhotocopyXerox,
+    },
+    Term {
+        term: "warehouse",
+        flag: UniversalTerm,
+        dialects: &[American, Australian, British, Canadian],
+        concept: GodownWarehouse,
     },
     Term {
         term: "wrench",
@@ -907,5 +920,10 @@ mod tests {
     #[test]
     fn americans_dont_say_nought() {
         assert_suggestion_result("nought", Regionalisms::new(Dialect::American), "zero");
+    }
+
+    #[test]
+    fn godown_isnt_used_outside_asia() {
+        assert_suggestion_result("godown", Regionalisms::new(Dialect::American), "warehouse");
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

I saw a "godown" walking to my usual cafe here in Penang and realized that's the Indian English word for "warehouse" and I didn't think it was in our `Regionalisms` module yet.

This PR adds it.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
