### PR TITLE
feat: out (of) the window variant matching dialect

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5063,6 +5063,13 @@
 								"state": true,
 								"label": "Touristic"
 							}
+						},
+						{
+							"Bool": {
+								"name": "OutOfTheWindow",
+								"state": true,
+								"label": "Out (of) the Window"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -171,6 +171,7 @@ use super::open_the_light::OpenTheLight;
 use super::orthographic_consistency::OrthographicConsistency;
 use super::ought_to_be::OughtToBe;
 use super::out_of_date::OutOfDate;
+use super::out_of_the_window::OutOfTheWindow;
 use super::oxford_comma::OxfordComma;
 use super::oxymorons::Oxymorons;
 use super::pay_for_price::PayForPrice;
@@ -731,6 +732,7 @@ impl LintGroup {
         insert_expr_rule!(OrthographicConsistency, true);
         insert_expr_rule!(OughtToBe, true);
         insert_expr_rule!(OutOfDate, true);
+        insert_expr_rule_with_dialect!(OutOfTheWindow, true);
         insert_struct_rule!(OxfordComma, true);
         insert_expr_rule!(Oxymorons, true);
         insert_expr_rule!(PayForPrice, true);
@@ -825,9 +827,6 @@ impl LintGroup {
         insert_struct_rule!(WordPressDotcom, true);
         insert_expr_rule_with_dict!(WorthToDo, true);
         insert_expr_rule!(WouldNeverHave, true);
-        // Uses Sentence rather than Chunk
-        out.add("WrongApostrophe", WrongApostrophe::default());
-        out.config.set_rule_enabled("WrongApostrophe", true);
 
         // Uses Sentence rather than Chunk
         out.add("AspireTo", AspireTo::default());
@@ -849,10 +848,6 @@ impl LintGroup {
         out.add("PluralDecades", PluralDecades::default());
         out.config.set_rule_enabled("PluralDecades", true);
 
-        // Uses Sentence rather than Chunk
-        out.add("WereWhere", WereWhere::default());
-        out.config.set_rule_enabled("WereWhere", true);
-
         // Uses Dictionary and Dialect
         out.add("SpellCheck", SpellCheck::new(dictionary.clone(), dialect));
         out.config.set_rule_enabled("SpellCheck", true);
@@ -867,6 +862,14 @@ impl LintGroup {
         // Uses Sentence rather than Chunk
         out.add("WebScraping", WebScraping::default());
         out.config.set_rule_enabled("WebScraping", true);
+
+        // Uses Sentence rather than Chunk
+        out.add("WereWhere", WereWhere::default());
+        out.config.set_rule_enabled("WereWhere", true);
+
+        // Uses Sentence rather than Chunk
+        out.add("WrongApostrophe", WrongApostrophe::default());
+        out.config.set_rule_enabled("WrongApostrophe", true);
 
         out
     }

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -181,6 +181,7 @@ mod open_the_light;
 mod orthographic_consistency;
 mod ought_to_be;
 mod out_of_date;
+mod out_of_the_window;
 mod oxford_comma;
 mod oxymorons;
 mod pay_for_price;

--- a/harper-core/src/linting/out_of_the_window.rs
+++ b/harper-core/src/linting/out_of_the_window.rs
@@ -1,0 +1,117 @@
+use crate::{
+    Dialect, Lint, Token, TokenStringExt,
+    expr::{Expr, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+};
+
+pub struct OutOfTheWindow {
+    expr: SequenceExpr,
+    dialect: Dialect,
+}
+
+impl OutOfTheWindow {
+    pub fn new(dialect: Dialect) -> Self {
+        Self {
+            expr: SequenceExpr::aco("out")
+                .then_optional(SequenceExpr::whitespace().t_aco("of"))
+                .t_ws()
+                .t_aco("the")
+                .t_ws()
+                .t_aco("window"),
+            dialect,
+        }
+    }
+}
+
+impl ExprLinter for OutOfTheWindow {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, toks: &[Token], _src: &[char]) -> Option<Lint> {
+        let (span, sugg, msg) = match (toks.len(), self.dialect) {
+            (7, Dialect::American | Dialect::Australian | Dialect::Canadian) => {
+                (
+                    toks[1..=2].span()?,
+                    Suggestion::Remove,
+                    format!("If this is the idiom about abandoning a plan, it's more usual to leave out `of` in {} English", self.dialect),
+                )
+            }
+            (5, Dialect::British) => {
+                (
+                    toks[0].span,
+                    Suggestion::InsertAfter(vec![' ', 'o', 'f']),
+                    "If this is the idiom about abandoning a plan, consider using `of` in British English".to_string(),
+                )
+            }
+            _ => return None,
+        };
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::Regionalism,
+            suggestions: vec![sugg],
+            message: msg,
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "A linter for the idiom `out (of) the window`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        Dialect,
+        linting::tests::{assert_lint_message, assert_no_lints, assert_suggestion_result},
+    };
+
+    use super::OutOfTheWindow;
+
+    #[test]
+    fn us_english() {
+        assert_suggestion_result(
+            "The whole Gnome session goes out of the window instantly, both upon explicit screen locking and upon automatic locking after a timeout.",
+            OutOfTheWindow::new(Dialect::American),
+            "The whole Gnome session goes out the window instantly, both upon explicit screen locking and upon automatic locking after a timeout.",
+        );
+    }
+
+    #[test]
+    fn uk_english() {
+        assert_suggestion_result(
+            "determinism went out the window, everything is terrible",
+            OutOfTheWindow::new(Dialect::British),
+            "determinism went out of the window, everything is terrible",
+        );
+    }
+
+    #[test]
+    fn in_english_doesnt_flag_with_of() {
+        assert_no_lints(
+            "errors and orchestration in general all go out of the window",
+            OutOfTheWindow::new(Dialect::Indian),
+        );
+    }
+
+    #[test]
+    fn in_english_doesnt_flag_without_of() {
+        assert_no_lints(
+            "I was so excited to develop my new app in .NET MAUI but then all this excitement went out the window due to two things stability and tooling.",
+            OutOfTheWindow::new(Dialect::Indian),
+        );
+    }
+
+    #[test]
+    fn gives_the_right_message_for_canadian_english() {
+        assert_lint_message(
+            "This all works great unless I use middlware and then it all goes out the window.",
+            OutOfTheWindow::new(Dialect::Canadian),
+            "If this is the idiom about abandoning a plan, it's more usual to leave out `of` in Canadian English",
+        );
+    }
+}

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -1011,6 +1011,17 @@ Message: |
 
 
 
+Lint:    Regionalism (127 priority)
+Message: |
+     610 | door, and the other arm curled round her head. Still she went on growing, and,
+     611 | as a last resource, she put one arm out of the window, and one foot up the
+         |                                        ^~~ If this is the idiom about abandoning a plan, it's more usual to leave out `of` in Australian English
+     612 | chimney, and said to herself “Now I can do no more, whatever happens. What will
+Suggest:
+  - Remove error
+
+
+
 Lint:    Readability (127 priority)
 Message: |
      615 | Luckily for Alice, the little magic bottle had now had its full effect, and she
@@ -1065,6 +1076,16 @@ Message: |
          |                                                     ^~~~~ `arrum` should probably be written as `arr um`.
 Suggest:
   - Replace with: “arr um”
+
+
+
+Lint:    Regionalism (127 priority)
+Message: |
+     681 | thought Alice. “I wonder what they’ll do next! As for pulling me out of the
+         |                                                                     ^~~ If this is the idiom about abandoning a plan, it's more usual to leave out `of` in Australian English
+     682 | window, I only wish they could! I’m sure I don’t want to stay in here any
+Suggest:
+  - Remove error
 
 
 


### PR DESCRIPTION
# Issues 
Fixes #3615

# Description

I heard or read "gone out of the window" somewhere and thought it shouldn't have that "of".
But I did some research and found out that both variants are accepted though the one with "of" is prevalent in the UK while the variant without is preferred in US, Canada, and Australia. Indian English seems the least clear so it accepts both without flagging any error.

If we get false positives for literal uses we might have to do more context checking.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
