### PR TITLE
feat: acclimize→acclimate/acclimatize

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5039,6 +5039,13 @@
 								"state": true,
 								"label": "Incident Report"
 							}
+						},
+						{
+							"Bool": {
+								"name": "Acclimize",
+								"state": true,
+								"label": "Acclimize"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/acclimize.rs
+++ b/harper-core/src/linting/acclimize.rs
@@ -1,0 +1,174 @@
+use crate::{
+    Lint, Token,
+    expr::Expr,
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+    patterns::WordSet,
+};
+
+pub struct Acclimize {
+    expr: WordSet,
+}
+
+impl Default for Acclimize {
+    fn default() -> Self {
+        Self {
+            expr: WordSet::new(&[
+                "acclimise",
+                "acclimised",
+                "acclimises",
+                "acclimising",
+                "acclimize",
+                "acclimized",
+                "acclimizes",
+                "acclimizing",
+            ]),
+        }
+    }
+}
+
+impl ExprLinter for Acclimize {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        let (ize, ate) = (
+            match (toks[0].get_ch(src)[7], toks[0].get_ch(src).last()?) {
+                ('s', 'e') => "acclimatise",
+                ('z', 'e') => "acclimatize",
+                ('s', 'd') => "acclimatised",
+                ('z', 'd') => "acclimatized",
+                ('s', 's') => "acclimatises",
+                ('z', 's') => "acclimatizes",
+                ('s', 'g') => "acclimatising",
+                ('z', 'g') => "acclimatizing",
+                _ => return None,
+            },
+            match toks[0].get_ch(src).last()? {
+                'e' => "acclimate",
+                'd' => "acclimated",
+                's' => "acclimates",
+                'g' => "acclimating",
+                _ => return None,
+            },
+        );
+
+        let suggestions = [ize, ate]
+            .iter()
+            .map(|&s| Suggestion::replace_with_match_case(s.chars().collect(), toks[0].get_ch(src)))
+            .collect();
+        let message = "Did you mean `acclimate` or `acclimatize`/`acclimise`?".to_string();
+
+        Some(Lint {
+            span: toks[0].span,
+            lint_kind: LintKind::WordChoice,
+            suggestions,
+            message,
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects `acclitize`/`acclimise` to `acclimate` and `acclimatise`/`acclimatize`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::assert_good_and_bad_suggestions;
+
+    use super::Acclimize;
+
+    #[test]
+    fn acclimize() {
+        assert_good_and_bad_suggestions(
+            "It takes about 2 weeks for your body to fully acclimize.",
+            Acclimize::default(),
+            &[
+                "It takes about 2 weeks for your body to fully acclimatize.",
+                "It takes about 2 weeks for your body to fully acclimate.",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn acclimise() {
+        assert_good_and_bad_suggestions(
+            "he's reached his accessibility limit and must wait a week to acclimise",
+            Acclimize::default(),
+            &[
+                "he's reached his accessibility limit and must wait a week to acclimatise",
+                "he's reached his accessibility limit and must wait a week to acclimate",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn acclimized() {
+        assert_good_and_bad_suggestions(
+            "You acclimized to flip and slide phones, no wonder modern phones are so foreign.",
+            Acclimize::default(),
+            &[
+                "You acclimated to flip and slide phones, no wonder modern phones are so foreign.",
+                "You acclimatized to flip and slide phones, no wonder modern phones are so foreign.",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn acclimised() {
+        assert_good_and_bad_suggestions(
+            "Anything less than this and you'll risk not being properly acclimised.",
+            Acclimize::default(),
+            &[
+                "Anything less than this and you'll risk not being properly acclimated.",
+                "Anything less than this and you'll risk not being properly acclimatised.",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn acclimises() {
+        assert_good_and_bad_suggestions(
+            "as if my body acclimises to the drug before the 20mg or so hits the stomach",
+            Acclimize::default(),
+            &[
+                "as if my body acclimates to the drug before the 20mg or so hits the stomach",
+                "as if my body acclimatises to the drug before the 20mg or so hits the stomach",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn acclimizing() {
+        assert_good_and_bad_suggestions(
+            "I can't afford to spend a week acclimizing in Ecuador beforehand",
+            Acclimize::default(),
+            &[
+                "I can't afford to spend a week acclimating in Ecuador beforehand",
+                "I can't afford to spend a week acclimatizing in Ecuador beforehand",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn acclimising() {
+        assert_good_and_bad_suggestions(
+            "So, some leaders are acclimising to uncertainty but much of their workforce are not feeling the same sense of optimism.",
+            Acclimize::default(),
+            &[
+                "So, some leaders are acclimating to uncertainty but much of their workforce are not feeling the same sense of optimism.",
+                "So, some leaders are acclimatising to uncertainty but much of their workforce are not feeling the same sense of optimism.",
+            ],
+            &[],
+        );
+    }
+}

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -13,6 +13,7 @@ use lru::LruCache;
 use super::a_part::APart;
 use super::a_some_time::ASomeTime;
 use super::a_while::AWhile;
+use super::acclimize::Acclimize;
 use super::addicting::Addicting;
 use super::adjective_double_degree::AdjectiveDoubleDegree;
 use super::adjective_of_a::AdjectiveOfA;
@@ -575,6 +576,7 @@ impl LintGroup {
         insert_expr_rule!(APart, true);
         insert_expr_rule!(ASomeTime, true);
         insert_expr_rule!(AWhile, true);
+        insert_expr_rule!(Acclimize, true);
         insert_expr_rule!(Addicting, true);
         insert_expr_rule!(AdjectiveDoubleDegree, true);
         insert_struct_rule!(AdjectiveOfA, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -5,6 +5,7 @@
 mod a_part;
 mod a_some_time;
 mod a_while;
+mod acclimize;
 mod addicting;
 mod adjective_double_degree;
 mod adjective_of_a;


### PR DESCRIPTION
# Issues 
N/A

# Description

I heard a YouTube use the word "acclimize" and thought he must be mixing up "acclimate" and "acclimatize". Some Googling confirmed this.

`SpellCheck` does flag it and does suggest both correct words, but it seemed worth the trouble to have a specific linter anyway.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
