### PR TITLE
docs: add Indian English to web `meta`/`description`

### DIFF
--- a/packages/web/src/app.html
+++ b/packages/web/src/app.html
@@ -10,7 +10,7 @@
   <title>Harper | Privacy-First Offline Grammar Checker for Developers & Writers</title>
 
   <meta name="description"
-    content="Harper is a blazing-fast, open-source grammar & spell checker that runs entirely on your device, covering US, UK, Canadian & Australian English—no data ever leaves your machine. Harper is the only grammar checker that doesn't use AI." />
+    content="Harper is a blazing-fast, open-source grammar & spell checker that runs entirely on your device, covering US, UK, Canadian, Australian & Indian English—no data ever leaves your machine. Harper is the only grammar checker that doesn't use AI." />
 
   <meta name="keywords"
     content="Harper, grammar checker, spell checker, privacy-first, offline, open source, fast grammar tool, developer writing, markdown checker" />


### PR DESCRIPTION
# Issues 
N/A

# Description

I noticed that in Google searches Harper does not include Indian English in its supported dialects:
<img width="1051" height="687" alt="image" src="https://github.com/user-attachments/assets/276482c4-5d5d-4249-bfee-2aabbaa4aa4b" />

This was due to the `<meta name="description"/>` field in `packages/web/src/app.html`

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
N/A

