### PR TITLE
feat: as how→as to how

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5039,6 +5039,13 @@
 								"state": true,
 								"label": "Incident Report"
 							}
+						},
+						{
+							"Bool": {
+								"name": "AsHow",
+								"state": true,
+								"label": "As How"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/as_how.rs
+++ b/harper-core/src/linting/as_how.rs
@@ -1,0 +1,197 @@
+use crate::{
+    Lint, Token, TokenStringExt,
+    char_string::CharStringExt,
+    expr::{Expr, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+};
+
+pub struct AsHow {
+    expr: SequenceExpr,
+}
+
+impl Default for AsHow {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::any_capitalization_of("as")
+                .t_ws()
+                .t_aco("how"),
+        }
+    }
+}
+
+impl ExprLinter for AsHow {
+    type Unit = Chunk;
+
+    fn match_to_lint_with_context(
+        &self,
+        toks: &[Token],
+        src: &[char],
+        ctx: Option<(&[Token], &[Token])>,
+    ) -> Option<Lint> {
+        if let Some((before, _)) = ctx
+            && let [left @ .., last_word, last_ws] = before
+            && last_ws.kind.is_whitespace()
+        {
+            if last_word.get_ch(src).eq_str("same") {
+                return None;
+            }
+
+            if let [.., prev_word, prev_ws] = left
+                && last_word.kind.is_adjective()
+                && prev_ws.kind.is_whitespace()
+                && prev_word.get_ch(src).eq_ch(&['a', 's'])
+            {
+                return None;
+            }
+        }
+
+        let span = toks.span()?;
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::Usage,
+            suggestions: vec![Suggestion::replace_with_match_case_str(
+                "as to how",
+                span.get_content(src),
+            )],
+            message: "Consider rephrasing to 'as to how'".to_owned(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects `as how` to `as to how`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    use super::AsHow;
+
+    #[test]
+    fn advise() {
+        assert_suggestion_result(
+            "[BUG] Advise as how to debug error messages.",
+            AsHow::default(),
+            "[BUG] Advise as to how to debug error messages.",
+        );
+    }
+
+    #[test]
+    fn puzzled() {
+        assert_suggestion_result(
+            "Since I'm using OpenAPI to describe my API I'm puzzled as how to describe this response.",
+            AsHow::default(),
+            "Since I'm using OpenAPI to describe my API I'm puzzled as to how to describe this response.",
+        );
+    }
+
+    #[test]
+    fn example() {
+        assert_suggestion_result(
+            "A sample/example as how to use Summaries",
+            AsHow::default(),
+            "A sample/example as to how to use Summaries",
+        );
+    }
+
+    #[test]
+    fn clueless() {
+        assert_suggestion_result(
+            "searched the issues/questions but I'm still clueless as how to set the body of the HTTP request",
+            AsHow::default(),
+            "searched the issues/questions but I'm still clueless as to how to set the body of the HTTP request",
+        );
+    }
+
+    #[test]
+    fn examples() {
+        assert_suggestion_result(
+            "We would need a more concrete specification together with examples as how this would be supposed to work.",
+            AsHow::default(),
+            "We would need a more concrete specification together with examples as to how this would be supposed to work.",
+        );
+    }
+
+    #[test]
+    fn confused() {
+        assert_suggestion_result(
+            "Hi! I'm confused as how to save the brain bytes model",
+            AsHow::default(),
+            "Hi! I'm confused as to how to save the brain bytes model",
+        );
+    }
+
+    #[test]
+    fn tackle() {
+        assert_suggestion_result(
+            "it's more of a design document/me laying my thoughts out as how to tackle this problem",
+            AsHow::default(),
+            "it's more of a design document/me laying my thoughts out as to how to tackle this problem",
+        );
+    }
+
+    // Avoid false positives
+
+    #[test]
+    fn avoid_as_well_as_how() {
+        assert_no_lints("When to do Git things (as well as how)", AsHow::default());
+    }
+
+    #[test]
+    fn avoid_as_well_as_they() {
+        assert_no_lints(
+            "Some questions on configuring capsules, as well as how they are (or are not) weighted.",
+            AsHow::default(),
+        );
+    }
+
+    #[test]
+    fn avoid_as_well_as_how_to() {
+        assert_no_lints(
+            "how to contribute a feature to PolyScope as well as how to modify and remove it",
+            AsHow::default(),
+        );
+    }
+
+    #[test]
+    fn avoid_as_much_as() {
+        assert_no_lints(
+            "It recognizes that how code looks matters just as much as how it works.",
+            AsHow::default(),
+        );
+    }
+
+    #[test]
+    fn avoid_as_far_as() {
+        assert_no_lints(
+            "Although the renderer will be opinionated as far as how it will structure the submission data out-of-the-box",
+            AsHow::default(),
+        );
+    }
+
+    #[test]
+    fn avoid_the_same_as() {
+        assert_no_lints(
+            "FILE_ALL_ACCESS is not defined the same as how Windows defines it",
+            AsHow::default(),
+        );
+    }
+
+    // Edge cases
+
+    #[test]
+    #[ignore = "we probably can't handle this case no matter what"]
+    fn hard_to_parse() {
+        assert_no_lints(
+            "As how many requests is a request with a list of coordinates counted?",
+            AsHow::default(),
+        );
+    }
+}

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -28,6 +28,7 @@ use super::another_thing_coming::AnotherThingComing;
 use super::another_think_coming::AnotherThinkComing;
 use super::apart_from::ApartFrom;
 use super::arrive_to::ArriveTo;
+use super::as_how::AsHow;
 use super::as_to_interrogative::AsToInterrogative;
 use super::ask_no_preposition::AskNoPreposition;
 use super::aspire_to::AspireTo;
@@ -590,6 +591,7 @@ impl LintGroup {
         insert_expr_rule!(AnotherThinkComing, false);
         insert_expr_rule!(ApartFrom, true);
         insert_expr_rule!(ArriveTo, true);
+        insert_expr_rule!(AsHow, true);
         insert_expr_rule!(AsToInterrogative, true);
         insert_expr_rule!(AskNoPreposition, true);
         insert_expr_rule!(AvoidContractions, false);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -20,6 +20,7 @@ mod another_thing_coming;
 mod another_think_coming;
 mod apart_from;
 mod arrive_to;
+mod as_how;
 mod as_to_interrogative;
 mod ask_no_preposition;
 mod aspire_to;


### PR DESCRIPTION
# Issues 
N/A

# Description

I read somewhere in the past couple of days "as how" when it clearly was supposed to be "as to how".
I'm pretty sure this done by nonnative speakers who don't know how English works rather than being a typo.
I've chosen `LintKind::Usage` which should also cover the case of native speakers thinking "as how" is the normal way to use it.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

I also used the AI in Google Search for some ideas, such as the `@` in the array destructing which I had never seen before!

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
