### PR TITLE
docs: add harper.js Chrome extension example

### DIFF
--- a/packages/harper.js/README.md
+++ b/packages/harper.js/README.md
@@ -5,4 +5,10 @@ Harper is a grammar checker designed to be easy to consume and integrate into yo
 
 [Read the documentation to learn more.](https://writewithharper.com/docs/harperjs/introduction)
 
+Examples:
+
+- [Node.js/CommonJS](./examples/commonjs-simple)
+- [Raw browser page](./examples/raw-web)
+- [Chrome extension popup](./examples/chrome-extension)
+
 Wondering how good our algorithm is? [Give it a whirl.](https://writewithharper.com)

--- a/packages/harper.js/examples/chrome-extension/README.md
+++ b/packages/harper.js/examples/chrome-extension/README.md
@@ -1,0 +1,64 @@
+# Chrome extension popup
+
+Chrome extensions cannot load executable code from a CDN, so bundle `harper.js`
+with your extension instead of importing it from `unpkg` at runtime. This
+minimal Manifest V3 popup shows the pieces you need.
+
+Install the package in your extension project:
+
+```sh
+npm install harper.js
+```
+
+Use a popup page that loads your bundled script:
+
+```json
+{
+  "manifest_version": 3,
+  "name": "Harper popup example",
+  "version": "0.0.1",
+  "action": {
+    "default_popup": "popup.html"
+  }
+}
+```
+
+```html
+<textarea id="source">This is an test.</textarea>
+<pre id="output">Loading Harper...</pre>
+<script type="module" src="./popup.js"></script>
+```
+
+Then import Harper from npm in the source file that your bundler emits as
+`popup.js`:
+
+```ts
+import { WorkerLinter } from 'harper.js';
+import { binaryInlined } from 'harper.js/binaryInlined';
+
+const linter = new WorkerLinter({ binary: binaryInlined });
+
+const source = document.querySelector<HTMLTextAreaElement>('#source');
+const output = document.querySelector<HTMLElement>('#output');
+
+async function update() {
+  if (!source || !output) {
+    return;
+  }
+
+  const lints = await linter.lint(source.value, { language: 'plaintext' });
+  output.textContent =
+    lints.length === 0
+      ? 'No suggestions.'
+      : lints.map((lint) => lint.message()).join('\n');
+}
+
+source?.addEventListener('input', update);
+void update();
+```
+
+The `binaryInlined` entry point embeds the WebAssembly binary in the bundled
+JavaScript, which avoids extra extension asset paths while you are getting
+started. If you prefer to ship the Wasm file separately, import `binary` from
+`harper.js/binary` and make sure your bundler copies the generated Wasm asset
+into the extension package.

--- a/packages/harper.js/examples/raw-web/index.html
+++ b/packages/harper.js/examples/raw-web/index.html
@@ -5,8 +5,8 @@
   <meta charset="utf-8" />
   <script type="module">
     // We can import `harper.js` using native ECMAScript syntax.
-    // TODO: Update to the latest version.
-    import {binaryInlined, WorkerLinter } from 'https://unpkg.com/harper.js@1.12.0/dist/harper.js';
+    import { binaryInlined } from 'https://unpkg.com/harper.js@2.4.0/dist/binaryInlined.js';
+    import { WorkerLinter } from 'https://unpkg.com/harper.js@2.4.0/dist/index.js';
 
     // Since we are working in the browser, we can use either `WorkerLinter`, which doesn't block the event loop, or `LocalLinter`, which does.
     const linter = new WorkerLinter({binary: binaryInlined});


### PR DESCRIPTION
Summary:
- document how to bundle harper.js in a Manifest V3 popup
- add the example to the harper.js README
- update the raw browser CDN imports to the current 2.4 dist entry points

Closes #3628

Checks:
- pnpm dlx @biomejs/biome@2.3.3 check packages/harper.js/README.md packages/harper.js/examples/raw-web/index.html packages/harper.js/examples/chrome-extension/README.md
- git diff --check