### PR TITLE
feat: leaving in drones→leaving in droves

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5095,6 +5095,13 @@
 								"state": true,
 								"label": "As How"
 							}
+						},
+						{
+							"Bool": {
+								"name": "LeavingInDroves",
+								"state": true,
+								"label": "Leaving In Droves"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/leaving_in_droves.rs
+++ b/harper-core/src/linting/leaving_in_droves.rs
@@ -1,0 +1,100 @@
+use crate::{
+    Lint, Token,
+    expr::{Expr, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+};
+
+pub struct LeavingInDroves {
+    expr: SequenceExpr,
+}
+
+impl Default for LeavingInDroves {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::word_set(&["leave", "leaves", "leaving", "left"])
+                .t_ws()
+                .t_aco("in")
+                .t_ws()
+                .t_aco("drones"),
+        }
+    }
+}
+
+impl ExprLinter for LeavingInDroves {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, toks: &[Token], _src: &[char]) -> Option<Lint> {
+        let span = toks.last()?.span;
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::Eggcorn,
+            suggestions: vec![Suggestion::replace_with_match_case_str(
+                "droves",
+                span.get_content(_src),
+            )],
+            message: "`Drones` is an eggcorn. The correct word is `droves`.".to_owned(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects `leaving in drones` to `leaving in droves`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::assert_suggestion_result;
+
+    use super::LeavingInDroves;
+
+    #[test]
+    fn jobs() {
+        assert_suggestion_result(
+            "Jobs are leaving in drones out of the country.",
+            LeavingInDroves::default(),
+            "Jobs are leaving in droves out of the country.",
+        );
+    }
+
+    #[test]
+    fn wealthy() {
+        assert_suggestion_result(
+            "Yet they are amongst some of the loudest promoters of the notion that the wealthy will leave in drones.",
+            LeavingInDroves::default(),
+            "Yet they are amongst some of the loudest promoters of the notion that the wealthy will leave in droves.",
+        );
+    }
+
+    #[test]
+    fn employees() {
+        assert_suggestion_result(
+            "consider the damage that will be caused when employees start leaving in drones as if we didn't have enough people leave already in the past 2 years.",
+            LeavingInDroves::default(),
+            "consider the damage that will be caused when employees start leaving in droves as if we didn't have enough people leave already in the past 2 years.",
+        );
+    }
+
+    #[test]
+    fn pastors() {
+        assert_suggestion_result(
+            "Why Are Nigerian Pastors Leaving In Drones?",
+            LeavingInDroves::default(),
+            "Why Are Nigerian Pastors Leaving In Droves?",
+        );
+    }
+
+    #[test]
+    fn left() {
+        assert_suggestion_result(
+            "I have remained at the place while my coworkers have left in drones.",
+            LeavingInDroves::default(),
+            "I have remained at the place while my coworkers have left in droves.",
+        );
+    }
+}

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -122,6 +122,7 @@ use super::its_possessive::ItsPossessive;
 use super::jealous_of::JealousOf;
 use super::johns_hopkins::JohnsHopkins;
 use super::lead_rise_to::LeadRiseTo;
+use super::leaving_in_droves::LeavingInDroves;
 use super::left_right_hand::LeftRightHand;
 use super::less_worse::LessWorse;
 use super::let_to_do::LetToDo;
@@ -685,6 +686,7 @@ impl LintGroup {
         insert_expr_rule!(JealousOf, true);
         insert_expr_rule!(JohnsHopkins, true);
         insert_expr_rule!(LeadRiseTo, true);
+        insert_expr_rule!(LeavingInDroves, true);
         insert_expr_rule!(LeftRightHand, true);
         insert_expr_rule!(LessWorse, true);
         insert_expr_rule!(LetToDo, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -124,6 +124,7 @@ mod its_possessive;
 mod jealous_of;
 mod johns_hopkins;
 mod lead_rise_to;
+mod leaving_in_droves;
 mod left_right_hand;
 mod less_worse;
 mod let_to_do;


### PR DESCRIPTION
# Issues 
N/A

# Description

This one made me laugh out loud when I stumbled across it while working on another linter.
I had no idea drones were already carrying human passengers.

This covers all inflections of "to leave in drones" to the lower-tech "leave in droves".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
