### PR TITLE
feat: max exodus→mass exodus

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5095,6 +5095,13 @@
 								"state": true,
 								"label": "As How"
 							}
+						},
+						{
+							"Bool": {
+								"name": "MassExodus",
+								"state": true,
+								"label": "Mass Exodus"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/weir_rules/MassExodus.weir
+++ b/harper-core/src/linting/weir_rules/MassExodus.weir
@@ -1,0 +1,9 @@
+expr main (max exodus)
+
+let message "Corrects `max exodues` to `mass exodus`."
+let description "Corrects the eggcorn `max exodues` to the idiomatic `mass exodus`."
+let kind "Eggcorn"
+let becomes "mass exodus"
+
+test "If we simplified the tax code it would help curb the max exodus of that money" "If we simplified the tax code it would help curb the mass exodus of that money"
+test "This triggers a max exodus as everyone wants out before their home values are underwater" "This triggers a mass exodus as everyone wants out before their home values are underwater"


### PR DESCRIPTION
# Issues 
N/A

# Description

Ran into this one yesterday. Seems to be a pretty straightforward eggcorn.
So far it only handles the singular.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
