### PR TITLE
feat(desktop): mark support for Slack and Discord

### DIFF
--- a/harper-desktop/src-tauri/src/config.rs
+++ b/harper-desktop/src-tauri/src/config.rs
@@ -67,6 +67,8 @@ impl Config {
             "com.apple.mail",
             "com.apple.MobileSMS",
             "com.apple.Notes",
+            "com.tinyspeck.slackmacgap",
+            "com.hnc.Discord",
         ]
         .into_iter()
         .map(|bundle_id| Integration {
@@ -329,6 +331,8 @@ mod tests {
         assert!(config.is_integration_enabled("com.apple.mail"));
         assert!(config.is_integration_enabled("com.apple.MobileSMS"));
         assert!(config.is_integration_enabled("com.apple.Notes"));
+        assert!(config.is_integration_enabled("com.tinyspeck.slackmacgap"));
+        assert!(config.is_integration_enabled("com.hnc.Discord"));
     }
 
     #[test]
@@ -341,6 +345,8 @@ mod tests {
         let deserialized = Config::deserialize_main(&value.to_string()).unwrap();
 
         assert_eq!(deserialized.integrations, Config::curated_integrations());
+        assert!(deserialized.is_integration_enabled("com.tinyspeck.slackmacgap"));
+        assert!(deserialized.is_integration_enabled("com.hnc.Discord"));
     }
 
     #[test]


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

N/A

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

I have tested the latest version of Harper Desktop and have manually enabled both Slack and Discord. It works great! So, I am enabling them by default in future versions of the app.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
