### PR TITLE
feat: as compare to→as compared to

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -4377,6 +4377,13 @@
 						},
 						{
 							"Bool": {
+								"name": "AsComparedTo",
+								"state": true,
+								"label": "As Compared To"
+							}
+						},
+						{
+							"Bool": {
 								"name": "AsOpposedTo",
 								"state": true,
 								"label": "As Opposed To"

--- a/harper-core/src/linting/weir_rules/AsComparedTo.weir
+++ b/harper-core/src/linting/weir_rules/AsComparedTo.weir
@@ -1,0 +1,9 @@
+expr main (as compare to)
+
+let message "Did you mean `as compared to`?"
+let description "Corrects `as compare to` to `as compared to`."
+let kind "Usage"
+let becomes "as compared to"
+
+test "Latency in the live media as compare to Shaka Player" "Latency in the live media as compared to Shaka Player"
+test "facet_nested have a different behaviour as compare to facet_grid when combining character and numeric" "facet_nested have a different behaviour as compared to facet_grid when combining character and numeric"


### PR DESCRIPTION
# Issues 
N/A

# Description

Exactly like the `AsOpposedTo` weir rule I recently made. This is a particularly common mistake in Southeast Asian English: "As compare to" will be flagged to become "as compared to".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
