### PR TITLE
fix: don't flag missing "to" between "want" and a noun+verb word

### DIFF
--- a/harper-core/src/linting/missing_to.rs
+++ b/harper-core/src/linting/missing_to.rs
@@ -372,7 +372,18 @@ impl ExprLinter for MissingTo {
 
         if matches!(
             controller_text,
-            "learn" | "learned" | "learning" | "learns" | "learnt" | "mean" | "means" | "meant"
+            "learn"
+                | "learned"
+                | "learning"
+                | "learns"
+                | "learnt"
+                | "mean"
+                | "means"
+                | "meant"
+                | "want"
+                | "wanted"
+                | "wanting"
+                | "wants"
         ) && next_is_noun_but_not_verb
         {
             return None;
@@ -420,7 +431,7 @@ impl ExprLinter for MissingTo {
 #[cfg(test)]
 mod tests {
     use super::MissingTo;
-    use crate::linting::tests::{assert_lint_count, assert_suggestion_result};
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
 
     #[test]
     fn inserts_to_after_meant() {
@@ -523,219 +534,203 @@ mod tests {
 
     #[test]
     fn no_lint_when_to_present() {
-        assert_lint_count("She wants to finish early.", MissingTo::default(), 0);
+        assert_no_lints("She wants to finish early.", MissingTo::default());
     }
 
     #[test]
     fn no_lint_with_noun_after_controller() {
-        assert_lint_count("They arranged a meeting at noon.", MissingTo::default(), 0);
+        assert_no_lints("They arranged a meeting at noon.", MissingTo::default());
     }
 
     #[test]
     fn no_lint_needs_follow_up_appointments() {
-        assert_lint_count(
+        assert_no_lints(
             "Gus is recovering well, though he needs follow-up appointments.",
             MissingTo::default(),
-            0,
         );
     }
 
     #[test]
     fn no_lint_delays_meant_decisions() {
-        assert_lint_count(
+        assert_no_lints(
             "The delays meant decisions were often made on outdated information, hindering agility and potentially impacting return on investment.",
             MissingTo::default(),
-            0,
         );
     }
 
     #[test]
     fn no_lint_reduced_relative_clause_after_participle() {
-        assert_lint_count(
+        assert_no_lints(
             "The techniques learned would probably not change much with resolution so 480i would seem almost as usable for educational use as 8K video.",
             MissingTo::default(),
-            0,
         );
     }
 
     #[test]
     fn no_lint_bouquet_of_roses() {
-        assert_lint_count(
+        assert_no_lints(
             "I made a note to request a small bouquet of roses for his room, a simple gesture that I hoped would bring a moment of solace.",
             MissingTo::default(),
-            0,
         );
     }
 
     #[test]
     fn no_lint_for_intended_word_phrase() {
-        assert_lint_count(
+        assert_no_lints(
             "Detects incorrect usage of `peak` when the intended word is `pique`.",
             MissingTo::default(),
-            0,
         );
     }
 
     #[test]
     fn no_lint_long_passage() {
-        assert_lint_count(
+        assert_no_lints(
             "Before her was another long passage illuminated by lamps.",
             MissingTo::default(),
-            0,
         );
     }
 
     #[test]
     fn no_lint_long_island_sound() {
-        assert_lint_count(
+        assert_no_lints(
             "The sailboat drifted along Long Island Sound at sunrise.",
             MissingTo::default(),
-            0,
         );
     }
 
     #[test]
     fn no_lint_learn_tag_probabilities() {
-        assert_lint_count(
+        assert_no_lints(
             "These models learn tag probabilities from annotated corpora.",
             MissingTo::default(),
-            0,
         );
     }
 
     #[test]
     fn no_lint_standard_feature_nominal_phrase() {
-        assert_lint_count(
+        assert_no_lints(
             "This is a standard and expected feature for any e-commerce site selling visually-driven products.",
             MissingTo::default(),
-            0,
         );
     }
 
     #[test]
     fn no_lint_mixing_bowl_nominal_phrase() {
-        assert_lint_count(
+        assert_no_lints(
             "This is a 2-quart mixing bowl, ideal for everything from whipping cream to preparing cake batter.",
             MissingTo::default(),
-            0,
         );
     }
 
     #[test]
     fn no_lint_try_and_say() {
-        assert_lint_count(
+        assert_no_lints(
             "I'll try and say hello before I leave.",
             MissingTo::default(),
-            0,
         );
     }
 
     #[test]
     fn no_lint_failed_edit_attempts() {
-        assert_lint_count("failed edit attempts", MissingTo::default(), 0);
+        assert_no_lints("failed edit attempts", MissingTo::default());
     }
 
     #[test]
     fn no_lint_ready_work() {
-        assert_lint_count("ready work", MissingTo::default(), 0);
+        assert_no_lints("ready work", MissingTo::default());
     }
 
     #[test]
     fn no_lint_bad_at_managing_side_effects() {
-        assert_lint_count("Bad at managing side-effects", MissingTo::default(), 0);
+        assert_no_lints("Bad at managing side-effects", MissingTo::default());
     }
 
     #[test]
     fn no_lint_a_fully_resolved_conflict() {
-        assert_lint_count("a fully resolved conflict", MissingTo::default(), 0);
+        assert_no_lints("a fully resolved conflict", MissingTo::default());
     }
 
     #[test]
     fn no_lint_a_resolved_configuration() {
-        assert_lint_count("A resolved configuration", MissingTo::default(), 0);
+        assert_no_lints("A resolved configuration", MissingTo::default());
     }
 
     #[test]
     fn no_lint_a_fully_resolved_configuration() {
-        assert_lint_count("A fully resolved configuration", MissingTo::default(), 0);
+        assert_no_lints("A fully resolved configuration", MissingTo::default());
     }
 
     #[test]
     fn no_lint_a_resolved_set_of_configuration() {
-        assert_lint_count("A resolved set of configuration", MissingTo::default(), 0);
+        assert_no_lints("A resolved set of configuration", MissingTo::default());
     }
 
     #[test]
     fn no_lint_a_fully_resolved_set_of_configuration() {
-        assert_lint_count(
+        assert_no_lints(
             "A fully resolved set of configuration",
             MissingTo::default(),
-            0,
         );
     }
 
     #[test]
     fn no_lint_system_produced_a_fully_resolved_set_of_dependencies() {
-        assert_lint_count(
+        assert_no_lints(
             "System produced a fully resolved set of dependencies",
             MissingTo::default(),
-            0,
         );
     }
 
     #[test]
     fn no_lint_a_resolved_list_of_parameters() {
-        assert_lint_count("A resolved list of parameters", MissingTo::default(), 0);
+        assert_no_lints("A resolved list of parameters", MissingTo::default());
     }
 
     #[test]
     fn no_lint_a_fully_resolved_list_of_parameters() {
-        assert_lint_count(
-            "A fully resolved list of parameters",
-            MissingTo::default(),
-            0,
-        );
+        assert_no_lints("A fully resolved list of parameters", MissingTo::default());
     }
 
     #[test]
     fn no_lint_a_prepared_stranger() {
-        assert_lint_count("A prepared stranger", MissingTo::default(), 0);
+        assert_no_lints("A prepared stranger", MissingTo::default());
     }
 
     #[test]
     fn no_lint_a_fully_prepared_stranger() {
-        assert_lint_count("A fully prepared stranger", MissingTo::default(), 0);
+        assert_no_lints("A fully prepared stranger", MissingTo::default());
     }
 
     #[test]
     fn no_lint_a_prepared_group_of_strangers() {
-        assert_lint_count("A prepared group of strangers", MissingTo::default(), 0);
+        assert_no_lints("A prepared group of strangers", MissingTo::default());
     }
 
     #[test]
     fn no_lint_a_fully_prepared_group_of_strangers() {
-        assert_lint_count(
-            "A fully prepared group of strangers",
-            MissingTo::default(),
-            0,
-        );
+        assert_no_lints("A fully prepared group of strangers", MissingTo::default());
     }
 
     #[test]
     fn no_lint_a_nicely_arranged_set_of_flowers() {
-        assert_lint_count(
-            "A nicely arranged bunch of flowers",
-            MissingTo::default(),
-            0,
-        );
+        assert_no_lints("A nicely arranged bunch of flowers", MissingTo::default());
     }
 
     #[test]
     fn no_lint_a_recently_forgotten_list_of_names() {
-        assert_lint_count(
-            "A recently forgotten list of names",
+        assert_no_lints("A recently forgotten list of names", MissingTo::default());
+    }
+
+    #[test]
+    fn april_16_3188() {
+        assert_no_lints("I want people like you in my life.", MissingTo::default());
+    }
+
+    #[test]
+    fn june_13_3188() {
+        assert_no_lints(
+            "Sometimes too much or too little to do. If too much, might be serious about wanting distance from others.",
             MissingTo::default(),
-            0,
         );
     }
 }


### PR DESCRIPTION
# Issues 
Fixes #3188

# Description

The `MissingTo` linter wanted "to" added after "want" when the next word is annotated as both noun and verb.
The code already had a special category for a similar pattern with "learn" and "mean", so it was added there.

I also changed all the `assert_lint_count()` tests to `assert_no_lints()` tests.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
