### PR TITLE
feat: add "standard option" to `Oxymorons`

### DIFF
--- a/harper-core/src/linting/oxymorons.rs
+++ b/harper-core/src/linting/oxymorons.rs
@@ -14,23 +14,24 @@ impl Oxymorons {
     pub fn new() -> Self {
         // List of phrases that are considered oxymoronic.
         let phrases = vec![
-            "amateur expert",
-            "increasingly less",
-            "advancing backwards?",
+            "advancing backwards",
             "alludes explicitly to",
-            "explicitly alludes to",
-            "totally obsolescent",
-            "completely obsolescent",
-            "generally always",
-            "usually always",
+            "amateur expert",
             "build down",
+            "completely obsolescent",
             "conspicuous absence",
             "exact estimate",
+            "explicitly alludes to",
             "found missing",
+            "generally always",
+            "increasingly less",
             "intense apathy",
             "mandatory choice",
             "nonworking mother",
             "organized mess",
+            "standard Option",
+            "totally obsolescent",
+            "usually always",
         ];
 
         // Build a vector of exact-match patterns for each oxymoron.
@@ -141,6 +142,15 @@ mod tests {
     fn phrase_split_by_line_break() {
         assert_lint_count(
             "nonworking\nmother is not a term to be used.",
+            Oxymorons::new(),
+            1,
+        );
+    }
+
+    #[test]
+    fn detects_standard_option() {
+        assert_lint_count(
+            "and that probably correlates with CD players becoming a standard option in cars",
             Oxymorons::new(),
             1,
         );


### PR DESCRIPTION
# Issues 
N/A

# Description

Flags "standard option" as an `Oxymoron` after seeing it in an article I was reading. Used that sentence as a unit test.

I also alphasoerted the list of oxymoronic phrases.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
