### PR TITLE
feat: app picker bundle ID lookup

### DIFF
--- a/harper-desktop/src-tauri/src/commands.rs
+++ b/harper-desktop/src-tauri/src/commands.rs
@@ -3,7 +3,7 @@
 
 use crate::config::Config;
 use crate::highlighter_service::HighlighterService;
-use crate::os_broker::{AccessibilityPermissionStatus, OsBroker};
+use crate::os_broker::{AccessibilityPermissionStatus, AppSearchResult, OsBroker};
 use crate::{IntegrationView, accessibility_allows_highlighter_start, platform_broker};
 use harper_core::{
     Dialect, DictWordMetadata, IgnoredLints,
@@ -40,6 +40,7 @@ pub fn application_message_handler<R: Runtime>() -> impl Fn(Invoke<R>) -> bool {
         start_highlighter_service,
         stop_highlighter_service,
         launch_app,
+        search_apps,
     ]
 }
 
@@ -339,4 +340,9 @@ pub(crate) async fn stop_highlighter_service(
 #[tauri::command]
 fn launch_app(bundle_id: String) -> Result<(), String> {
     platform_broker().launch_app_bundle(&bundle_id)
+}
+
+#[tauri::command]
+fn search_apps(query: String) -> Result<Vec<AppSearchResult>, String> {
+    platform_broker().search_apps(&query)
 }

--- a/harper-desktop/src-tauri/src/mac_broker.rs
+++ b/harper-desktop/src-tauri/src/mac_broker.rs
@@ -38,7 +38,7 @@ use std::{
 };
 
 use crate::config::{Config, Integration};
-use crate::os_broker::{AccessibilityPermissionStatus, OsBroker};
+use crate::os_broker::{AccessibilityPermissionStatus, AppSearchResult, OsBroker};
 use crate::rect::{ActionableLint, Rect};
 
 const WINDOW_MOVEMENT_SETTLE_DURATION: Duration = Duration::from_millis(150);
@@ -417,6 +417,70 @@ impl OsBroker for MacBroker {
 
         Ok(())
     }
+
+    fn search_apps(&self, query: &str) -> Result<Vec<AppSearchResult>, String> {
+        let query = query.trim();
+
+        if query.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Search for apps by display name using mdfind
+        let escaped_query = query.replace('\\', "\\\\").replace('"', "\\\"");
+        let output = Command::new("mdfind")
+            .arg(format!("kMDItemContentType == 'com.apple.application-bundle' && kMDItemDisplayName == '*{escaped_query}*'cd"))
+            .output()
+            .map_err(|error| format!("Failed to execute mdfind: {error}"))?;
+
+        if !output.status.success() {
+            return Err(format!(
+                "mdfind failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+
+        let mut results = Vec::new();
+
+        for line in String::from_utf8_lossy(&output.stdout).lines() {
+            let line = line.trim();
+            if let Some(display_name) = display_name_from_app_path(line) {
+                if let Some(bundle_id) = bundle_id_from_app_path(line) {
+                    results.push(AppSearchResult {
+                        name: display_name,
+                        bundle_id,
+                    });
+                }
+            }
+        }
+
+        Ok(results)
+    }
+}
+
+fn bundle_id_from_app_path(path: &str) -> Option<String> {
+    let output = Command::new("mdls")
+        .arg("-name")
+        .arg("kMDItemCFBundleIdentifier")
+        .arg(path)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let output = String::from_utf8_lossy(&output.stdout);
+
+    // Parse the output from mdls which looks like:
+    // kMDItemCFBundleIdentifier = "com.example.app"
+    output
+        .lines()
+        .find(|line| line.contains("kMDItemCFBundleIdentifier"))
+        .and_then(|line| {
+            line.split('=')
+                .nth(1)
+                .map(|s| s.trim().trim_matches('"').to_string())
+        })
 }
 
 fn system_integration_display_name(bundle_id: &str) -> Option<String> {

--- a/harper-desktop/src-tauri/src/mac_broker.rs
+++ b/harper-desktop/src-tauri/src/mac_broker.rs
@@ -426,9 +426,12 @@ impl OsBroker for MacBroker {
         }
 
         // Search for apps by display name using mdfind
+        // Use case-insensitive search and ensure we only get .app bundles
         let escaped_query = query.replace('\\', "\\\\").replace('"', "\\\"");
         let output = Command::new("mdfind")
-            .arg(format!("kMDItemContentType == 'com.apple.application-bundle' && kMDItemDisplayName == '*{escaped_query}*'cd"))
+            .arg(format!(
+                "kMDItemContentType == 'com.apple.application-bundle' && kMDItemDisplayName == '*{escaped_query}*'cd"
+            ))
             .output()
             .map_err(|error| format!("Failed to execute mdfind: {error}"))?;
 
@@ -440,11 +443,34 @@ impl OsBroker for MacBroker {
         }
 
         let mut results = Vec::new();
+        let mut seen_bundle_ids = std::collections::HashSet::new();
 
         for line in String::from_utf8_lossy(&output.stdout).lines() {
             let line = line.trim();
+
+            // Skip if not an .app bundle
+            if !line.ends_with(".app") {
+                continue;
+            }
+
             if let Some(display_name) = display_name_from_app_path(line) {
+                // Skip if display name looks like a bundle ID (contains dots)
+                if display_name.contains('.') {
+                    continue;
+                }
+
                 if let Some(bundle_id) = bundle_id_from_app_path(line) {
+                    // Skip if we've already seen this bundle ID (deduplication)
+                    if seen_bundle_ids.contains(&bundle_id) {
+                        continue;
+                    }
+
+                    // Skip if bundle ID looks like a path or is invalid
+                    if bundle_id.contains('/') || bundle_id.is_empty() {
+                        continue;
+                    }
+
+                    seen_bundle_ids.insert(bundle_id.clone());
                     results.push(AppSearchResult {
                         name: display_name,
                         bundle_id,

--- a/harper-desktop/src-tauri/src/mac_broker.rs
+++ b/harper-desktop/src-tauri/src/mac_broker.rs
@@ -499,14 +499,21 @@ fn bundle_id_from_app_path(path: &str) -> Option<String> {
 
     // Parse the output from mdls which looks like:
     // kMDItemCFBundleIdentifier = "com.example.app"
-    output
+    let bundle_id = output
         .lines()
         .find(|line| line.contains("kMDItemCFBundleIdentifier"))
         .and_then(|line| {
             line.split('=')
                 .nth(1)
                 .map(|s| s.trim().trim_matches('"').to_string())
-        })
+        })?;
+
+    // Filter out null or empty bundle IDs
+    if bundle_id.is_empty() || bundle_id == "(null)" || bundle_id == "null" {
+        return None;
+    }
+
+    Some(bundle_id)
 }
 
 fn system_integration_display_name(bundle_id: &str) -> Option<String> {

--- a/harper-desktop/src-tauri/src/os_broker.rs
+++ b/harper-desktop/src-tauri/src/os_broker.rs
@@ -46,6 +46,16 @@ pub trait OsBroker {
     fn launch_app_bundle(&self, _bundle_id: &str) -> Result<(), String> {
         Err("Launching apps by bundle ID is only supported on macOS.".to_string())
     }
+
+    fn search_apps(&self, _query: &str) -> Result<Vec<AppSearchResult>, String> {
+        Err("App search is only supported on macOS.".to_string())
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AppSearchResult {
+    pub name: String,
+    pub bundle_id: String,
 }
 
 fn fallback_integration_display_name(bundle_id: &str) -> String {

--- a/harper-desktop/src/lib/settings/components/AppPickerModal.svelte
+++ b/harper-desktop/src/lib/settings/components/AppPickerModal.svelte
@@ -1,13 +1,57 @@
 <script lang="ts">
+import { invoke } from '@tauri-apps/api/core';
+
 export let bundleId = '';
 export let existingBundleIds: string[];
 export let isSaving = false;
 export let close: () => void;
 export let add: (bundleId: string) => void;
 
+let searchResults: Array<{ name: string; bundle_id: string }> = [];
+let isSearching = false;
+let debounceTimeout: number | null = null;
+
 $: trimmedBundleId = bundleId.trim();
 $: isDuplicate = existingBundleIds.includes(trimmedBundleId);
 $: canAdd = Boolean(trimmedBundleId) && !isDuplicate && !isSaving;
+
+async function performSearch(query: string) {
+	if (!query.trim()) {
+		searchResults = [];
+		return;
+	}
+
+	isSearching = true;
+	try {
+		const results = await invoke<Array<{ name: string; bundle_id: string }>>('search_apps', {
+			query,
+		});
+		searchResults = results;
+	} catch (error) {
+		console.error('Search failed:', error);
+		searchResults = [];
+	} finally {
+		isSearching = false;
+	}
+}
+
+function handleInput(event: Event) {
+	const target = event.target as HTMLInputElement;
+	bundleId = target.value;
+
+	if (debounceTimeout) {
+		clearTimeout(debounceTimeout);
+	}
+
+	debounceTimeout = window.setTimeout(() => {
+		performSearch(bundleId);
+	}, 300);
+}
+
+function selectApp(selectedBundleId: string) {
+	bundleId = selectedBundleId;
+	searchResults = [];
+}
 
 function submit() {
 	if (canAdd) {
@@ -48,9 +92,10 @@ function submit() {
       <span class="settings-icon icon-search" aria-hidden="true"></span>
       <input
         type="text"
-        placeholder="com.apple.TextEdit"
-        bind:value={bundleId}
+        placeholder="Search for an app..."
+        value={bundleId}
         disabled={isSaving}
+        on:input={handleInput}
         on:keydown={(event) => {
           if (event.key === "Enter") {
             submit();
@@ -59,10 +104,33 @@ function submit() {
       />
     </div>
     <div class="modal-list">
-      {#if isDuplicate}
-        <div class="empty">That application is already configured.</div>
+      {#if isSearching}
+        <div class="empty">Searching...</div>
+      {:else if searchResults.length > 0}
+        {#each searchResults as result}
+          <div
+            class="app-result"
+            role="button"
+            tabindex="0"
+            on:click={() => selectApp(result.bundle_id)}
+            on:keydown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                selectApp(result.bundle_id);
+              }
+            }}
+          >
+            <div class="app-result-name">{result.name}</div>
+            <div class="app-result-bundle-id">{result.bundle_id}</div>
+          </div>
+        {/each}
+      {:else if trimmedBundleId}
+        {#if isDuplicate}
+          <div class="empty">That application is already configured.</div>
+        {:else}
+          <div class="empty">No matching apps found. Try typing the bundle ID directly (e.g., com.apple.TextEdit)</div>
+        {/if}
       {:else}
-        <div class="empty">Use the app's macOS bundle identifier. Example: com.apple.TextEdit</div>
+        <div class="empty">Search for an app by name, or enter the bundle ID directly.</div>
       {/if}
     </div>
     <div class="modal-actions">

--- a/harper-desktop/src/lib/settings/settings.css
+++ b/harper-desktop/src/lib/settings/settings.css
@@ -919,6 +919,35 @@ em,
 	padding: 6px;
 }
 
+.app-result {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	padding: 10px 12px;
+	border-radius: 6px;
+	cursor: pointer;
+}
+
+.app-result:hover {
+	background: rgba(0, 0, 0, 0.04);
+}
+
+.app-result:focus {
+	outline: 2px solid var(--settings-accent);
+	outline-offset: -2px;
+}
+
+.app-result-name {
+	font-weight: 600;
+	color: var(--settings-ink);
+}
+
+.app-result-bundle-id {
+	font-size: 11.5px;
+	color: var(--settings-ink-3);
+	font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
 .picker-row {
 	width: 100%;
 	display: flex;


### PR DESCRIPTION
# Issues 
Fixes #3643

# Description

Changes the `AppPickerModal` to allow the user to type the name of an app and find the bundle ID itself rather than expecting the user to find the bundle ID somehow.

My editor is letting me use the built-in coding AI for the first time in weeks.
I vibe-coded the original version in rawdog macOS API calls from Rust without using any objc crate or such.
I then took that code and vibe-coded a standalone Taui PoC app that populated a listview while the user enters app name.
Then today I showed the AI the files in Harper Desktop I thought were relevant, and the previous Tauri PoC and asked it to integrate them.

I asked it to use the objc2 crate or whatever Harper was already using for other macOS calls instead of rawdogging, but it failed to find the needed API `NSMetadataQuery` support via objc2 and decided to instead shell out to the macOS CLI tool `mdfind`.

I'll keep iterating on this but `NSMetadataQuery` requires a runloop, which the AI says will be a problem. It might be whining though since that didn't stop the previous Tauri PoC and was part of the reason I wanted to get it working in Tauri before trying to bring it into Harper.

# Demo
<img width="534" height="307" alt="image" src="https://github.com/user-attachments/assets/3f40017a-9f35-4bea-a157-98db560582ba" />

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
