### PR TITLE
test(core): regression coverage for rollback false negative (#3239)

### DIFF
--- a/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
+++ b/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
@@ -813,4 +813,33 @@ mod tests {
             "How to properly set up a backup link (and have it act like a backup again after stop/start of master link)",
         );
     }
+
+    // Only the verb misuse ("going to rollback again") is flagged; the correct
+    // noun usage ("did a rollback") is left alone.
+    #[test]
+    fn issue_3239_flag_rollback_again() {
+        assert_lint_count(
+            "I already did a rollback. I'm not going to rollback again.",
+            PhrasalVerbAsCompoundNoun::default(),
+            1,
+        );
+    }
+
+    #[test]
+    fn issue_3239_correct_rollback_again() {
+        assert_suggestion_result(
+            "I already did a rollback. I'm not going to rollback again.",
+            PhrasalVerbAsCompoundNoun::default(),
+            "I already did a rollback. I'm not going to roll back again.",
+        );
+    }
+
+    #[test]
+    fn issue_3239_correct_rollback_the_update() {
+        assert_suggestion_result(
+            "I'm going to rollback the update.",
+            PhrasalVerbAsCompoundNoun::default(),
+            "I'm going to roll back the update.",
+        );
+    }
 }


### PR DESCRIPTION
## What & why

#3239 reports a false negative: *"I'm going to rollback the update"* isn't flagged, while the analogous *"workout"* misuse is.

While reproducing it, I found this **no longer happens on `master`**:

- `rollback` and `comeback` are already noun-only in `harper-core/dictionary.dict` (`rollback/~NSg`, `comeback/~NgS`) — no stray `/V` flag.
- The default-enabled `PhrasalVerbAsCompoundNoun` rule already catches the misuse through its particle heuristics (it doesn't depend on a dictionary `/V` flag).

End-to-end with the curated `LintGroup`, *"I'm going to rollback the update."* is flagged and suggests **roll back**.

There were no regression tests pinning this behavior, so this PR adds them.

## What's in here

Three tests in `phrasal_verb_as_compound_noun.rs`, using the exact sentences from the issue:

- `issue_3239_flag_rollback_again` — only the verb misuse (*"going to rollback again"*) is flagged; the correct noun usage (*"did a rollback"*) is left alone (1 lint total).
- `issue_3239_correct_rollback_again` / `issue_3239_correct_rollback_the_update` — the suggestion rewrites `rollback` → `roll back`.

No production code is changed.

## How to test

```
cargo test -p harper-core --lib issue_3239
```

Local checks matching CI all pass: `cargo fmt -- --check`, `cargo clippy -- -Dwarnings -D clippy::dbg_macro -D clippy::needless_raw_string_hashes`, and `cargo test -p harper-core --lib` (5278 passed).

## Note

Since the underlying behavior is already correct, I left the issue open rather than auto-closing it — happy to close it if you agree, or to extend the tests (e.g. add a `comeback` case) if that's useful.
