### PR TITLE
chore(harper.js): update examples to latest API

### DIFF
--- a/packages/harper.js/examples/commonjs-simple/README.md
+++ b/packages/harper.js/examples/commonjs-simple/README.md
@@ -1,7 +1,7 @@
 # `commonjs-simple`
 
-An example of using `harper.js` in a Node.js application.
-Read the source code in `index.cjs` to see what's going on.
+An example of using `harper.js@2.4.0` in a Node.js application.
+Read the source code in `index.js` to see what's going on.
 
 You can run it using pnpm:
 

--- a/packages/harper.js/examples/commonjs-simple/index.js
+++ b/packages/harper.js/examples/commonjs-simple/index.js
@@ -1,6 +1,7 @@
 async function main() {
 	const harper = await import('harper.js');
 	const { binary } = await import('harper.js/binary');
+
 	// We cannot use `WorkerLinter` on Node.js since it relies on web-specific APIs.
 	// This constructs the linter to consume American English.
 	const linter = new harper.LocalLinter({
@@ -8,24 +9,28 @@ async function main() {
 		dialect: harper.Dialect.American,
 	});
 
-	const lints = await linter.lint('This is a example of how to use `harper.js`.');
+	try {
+		const lints = await linter.lint('This is a example of how to use `harper.js`.');
 
-	console.log('Here are the results of linting the above text:');
+		console.log('Here are the results of linting the above text:');
 
-	for (const lint of lints) {
-		console.log(' - ', lint.span().start, ':', lint.span().end, lint.message());
+		for (const lint of lints) {
+			console.log(' - ', lint.span().start, ':', lint.span().end, lint.message());
 
-		if (lint.suggestion_count() !== 0) {
-			console.log('Suggestions:');
+			if (lint.suggestion_count() !== 0) {
+				console.log('Suggestions:');
 
-			for (const sug of lint.suggestions()) {
-				console.log(
-					'\t - ',
-					sug.kind() === 1 ? 'Remove' : 'Replace with',
-					sug.get_replacement_text(),
-				);
+				for (const sug of lint.suggestions()) {
+					console.log(
+						'\t - ',
+						sug.kind() === harper.SuggestionKind.Remove ? 'Remove' : 'Replace with',
+						sug.get_replacement_text(),
+					);
+				}
 			}
 		}
+	} finally {
+		await linter.dispose();
 	}
 }
 

--- a/packages/harper.js/examples/raw-web/index.html
+++ b/packages/harper.js/examples/raw-web/index.html
@@ -5,11 +5,11 @@
   <meta charset="utf-8" />
   <script type="module">
     // We can import `harper.js` using native ECMAScript syntax.
-    // TODO: Update to the latest version.
-    import {binaryInlined, WorkerLinter } from 'https://unpkg.com/harper.js@1.12.0/dist/harper.js';
+    import { binaryInlined } from 'https://unpkg.com/harper.js@2.4.0/dist/binaryInlined.js';
+    import { WorkerLinter } from 'https://unpkg.com/harper.js@2.4.0/dist/index.js';
 
     // Since we are working in the browser, we can use either `WorkerLinter`, which doesn't block the event loop, or `LocalLinter`, which does.
-    const linter = new WorkerLinter({binary: binaryInlined});
+    const linter = new WorkerLinter({ binary: binaryInlined });
 
     // Every time the `<textarea/>` received an input, we process it and update our list.
     async function onInput(e) {
@@ -29,7 +29,7 @@
 
     const inputField = document.getElementById('maininput');
     inputField.addEventListener('input', onInput);
-    onInput({target: inputField});
+    onInput({ target: inputField });
   </script>
 
   <!--Make the page look good using SimpleCSS-->

--- a/packages/web/src/routes/docs/harperjs/configurerules/+page.md
+++ b/packages/web/src/routes/docs/harperjs/configurerules/+page.md
@@ -8,14 +8,18 @@ Further, consumers should allow space (in their UI, database, etc.) for addition
 
 To make this easier, `harper.js` exposes a [`LintConfig`](/docs/harperjs/ref/harper.js.lintconfig.html) type, which can be obtained via `Linter.getLintConfig` and written using `Linter.setLintConfig`.
 
-Each key refers to a specific rule. Each rule can be disabled (set the value to `false`), enabled (set the value to `true`), or to the default (set the value to `undefined`).
+Each key refers to a specific rule. Each rule can be disabled (set the value to `false`), enabled (set the value to `true`), or reset to the default (set the value to `null`).
 For example, the following code disables `SpellCheck`, enables `ExplanationMarks`, and sets `SameAs` to assume the default value.
 
 ```javascript
-let linter = new WorkerLinter();
+import { WorkerLinter } from 'harper.js';
+import { binary } from 'harper.js/binary';
+
+let linter = new WorkerLinter({ binary });
 
 await linter.setLintConfig({
     SpellCheck: false,
     ExplanationMarks: true,
+    SameAs: null,
 });
 ```


### PR DESCRIPTION
# Issues 

Related to #3628

# Description

Updates harper.js examples and related documentation to match the latest published `harper.js@2.4.0` API.

- Updates the `raw-web` CDN example to import `WorkerLinter` and `binaryInlined` from their current package export paths.
- Updates the Node example to use `SuggestionKind.Remove` instead of a magic numeric value and dispose of the linter after use.
- Corrects the `commonjs-simple` README to reference `index.js` and the current harper.js version.
- Updates the rule-configuration docs to use `new WorkerLinter({ binary })` and `null` when resetting a rule to its default config.

# Demo

Not applicable.

# How Has This Been Tested?

Not applicable for this documentation and example update.

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
