### PR TITLE
Expose English isolation in harper.js and browser extension

### DIFF
--- a/harper-wasm/src/lib.rs
+++ b/harper-wasm/src/lib.rs
@@ -311,6 +311,45 @@ impl Linter {
         ctx.default_hash()
     }
 
+    fn create_lint_parser(
+        &self,
+        language: Language,
+        all_headings: bool,
+        regex_mask: Option<String>,
+        isolate_english: bool,
+    ) -> Option<Box<dyn Parser>> {
+        let mut parser = language.create_parser();
+
+        if let Some(regex) = regex_mask {
+            let Some(masker) = RegexMasker::new(regex.as_str(), true) else {
+                tracing::warn!("Ignoring lint request because the regex mask is invalid: {regex}");
+                return None;
+            };
+
+            parser = Box::new(Mask::new(masker, parser));
+        }
+
+        if all_headings {
+            parser = Box::new(OopsAllHeadings::new(parser));
+        }
+
+        if isolate_english {
+            parser = Box::new(IsolateEnglish::new(parser, self.dictionary.clone()));
+        }
+
+        Some(parser)
+    }
+
+    fn with_curated_config<T>(&mut self, lint: impl FnOnce(&mut LintGroup) -> T) -> T {
+        let config = self.lint_group.config.clone();
+        self.lint_group.config.fill_with_curated();
+
+        let output = lint(&mut self.lint_group);
+
+        self.lint_group.config = config;
+        output
+    }
+
     pub fn organized_lints(
         &mut self,
         text: String,
@@ -318,32 +357,19 @@ impl Linter {
         all_headings: bool,
         regex_mask: Option<String>,
         dedup: bool,
+        isolate_english: bool,
     ) -> Vec<OrganizedGroup> {
         let source: Lrc<_> = text.chars().collect();
-
-        let mut parser = language.create_parser();
-
-        if let Some(regex) = regex_mask {
-            let masker_maybe = RegexMasker::new(regex.as_str(), true);
-            if let Some(masker) = masker_maybe {
-                parser = Box::new(Mask::new(masker, parser));
-            } else {
-                return vec![];
-            }
-        }
-
-        if all_headings {
-            parser = Box::new(OopsAllHeadings::new(parser));
-        }
+        let Some(parser) =
+            self.create_lint_parser(language, all_headings, regex_mask, isolate_english)
+        else {
+            return vec![];
+        };
 
         let document = Document::new_from_chars(source.clone(), &parser, &self.dictionary);
 
-        let temp = self.lint_group.config.clone();
-        self.lint_group.config.fill_with_curated();
-
-        let mut lints = self.lint_group.organized_lints(&document);
-
-        self.lint_group.config = temp;
+        let mut lints =
+            self.with_curated_config(|lint_group| lint_group.organized_lints(&document));
 
         for value in lints.values_mut() {
             self.ignored_lints.remove_ignored(value, &document);
@@ -359,12 +385,7 @@ impl Linter {
                 group: s,
                 lints: ls
                     .into_iter()
-                    .map(|l| {
-                        let problem_text = l.get_str(&source);
-                        let span = Into::<Span>::into(l.span).to_js_indices(&source);
-
-                        Lint::new(l, span, problem_text, language)
-                    })
+                    .map(|l| create_lint(l, &source, language))
                     .collect(),
             })
             .collect()
@@ -380,32 +401,18 @@ impl Linter {
         all_headings: bool,
         regex_mask: Option<String>,
         dedup: bool,
+        isolate_english: bool,
     ) -> Vec<Lint> {
         let source: Lrc<_> = text.chars().collect();
-
-        let mut parser = language.create_parser();
-
-        if let Some(regex) = regex_mask {
-            let masker_maybe = RegexMasker::new(regex.as_str(), true);
-            if let Some(masker) = masker_maybe {
-                parser = Box::new(Mask::new(masker, parser));
-            } else {
-                return vec![];
-            }
-        }
-
-        if all_headings {
-            parser = Box::new(OopsAllHeadings::new(parser));
-        }
+        let Some(parser) =
+            self.create_lint_parser(language, all_headings, regex_mask, isolate_english)
+        else {
+            return vec![];
+        };
 
         let document = Document::new_from_chars(source.clone(), &parser, &self.dictionary);
 
-        let temp = self.lint_group.config.clone();
-        self.lint_group.config.fill_with_curated();
-
-        let mut lints = self.lint_group.lint(&document);
-
-        self.lint_group.config = temp;
+        let mut lints = self.with_curated_config(|lint_group| lint_group.lint(&document));
 
         self.ignored_lints.remove_ignored(&mut lints, &document);
         if dedup {
@@ -414,11 +421,7 @@ impl Linter {
 
         lints
             .into_iter()
-            .map(|l| {
-                let problem_text = l.get_str(&source);
-                let span = Into::<Span>::into(l.span).to_js_indices(&source);
-                Lint::new(l, span, problem_text, language)
-            })
+            .map(|l| create_lint(l, &source, language))
             .collect()
     }
 
@@ -560,6 +563,13 @@ impl Linter {
         self.lint_group.merge_from(group);
         Ok(JsValue::UNDEFINED)
     }
+}
+
+fn create_lint(lint: harper_core::linting::Lint, source: &[char], language: Language) -> Lint {
+    let problem_text = lint.get_str(source);
+    let span = Into::<Span>::into(lint.span).to_js_indices(source);
+
+    Lint::new(lint, span, problem_text, language)
 }
 
 #[wasm_bindgen]
@@ -795,7 +805,7 @@ mod tests {
         linter.import_words(vec![text.clone()]);
         dbg!(linter.dictionary.get_word_metadata_str(&text));
 
-        let lints = linter.lint(text, Language::Plain, false, None, true);
+        let lints = linter.lint(text, Language::Plain, false, None, true, false);
         assert!(lints.is_empty());
     }
 
@@ -817,6 +827,7 @@ mod tests {
                     false,
                     None,
                     true,
+                    false,
                 );
 
                 assert!(results.is_empty())

--- a/packages/chrome-plugin/src/ProtocolClient.ts
+++ b/packages/chrome-plugin/src/ProtocolClient.ts
@@ -10,7 +10,15 @@ export default class ProtocolClient {
 	});
 
 	private static cacheKey(text: string, domain: string, options?: LintOptions): string {
-		return `${domain}:${text}:${options?.forceAllHeadings ?? ''}:${options?.language ?? ''}`;
+		return JSON.stringify([
+			domain,
+			text,
+			options?.language ?? 'markdown',
+			options?.forceAllHeadings ?? false,
+			options?.regex_mask ?? null,
+			options?.dedup ?? true,
+			options?.isolateEnglish ?? false,
+		]);
 	}
 
 	public static async lint(
@@ -58,6 +66,15 @@ export default class ProtocolClient {
 
 	public static async setDialect(dialect: Dialect): Promise<void> {
 		await chrome.runtime.sendMessage({ kind: 'setDialect', dialect });
+	}
+
+	public static async getIsolateEnglish(): Promise<boolean> {
+		return (await chrome.runtime.sendMessage({ kind: 'getIsolateEnglish' })).isolateEnglish;
+	}
+
+	public static async setIsolateEnglish(isolateEnglish: boolean): Promise<void> {
+		this.lintCache.clear();
+		await chrome.runtime.sendMessage({ kind: 'setIsolateEnglish', isolateEnglish });
 	}
 
 	public static async getDelay(): Promise<number> {

--- a/packages/chrome-plugin/src/background/index.ts
+++ b/packages/chrome-plugin/src/background/index.ts
@@ -26,6 +26,7 @@ import {
 	type GetHotkeyResponse,
 	type GetInstalledOnRequest,
 	type GetInstalledOnResponse,
+	type GetIsolateEnglishResponse,
 	type GetLintDescriptionsRequest,
 	type GetLintDescriptionsResponse,
 	type GetReviewedRequest,
@@ -50,6 +51,7 @@ import {
 	type SetDialectRequest,
 	type SetDomainStatusRequest,
 	type SetHotkeyRequest,
+	type SetIsolateEnglishRequest,
 	type SetReviewedRequest,
 	type SetUserDictionaryRequest,
 	type UnitResponse,
@@ -228,6 +230,10 @@ function handleRequest(message: Request, sender?: chrome.runtime.MessageSender):
 			return handleSetDialect(message);
 		case 'getDialect':
 			return handleGetDialect(message);
+		case 'getIsolateEnglish':
+			return handleGetIsolateEnglish();
+		case 'setIsolateEnglish':
+			return handleSetIsolateEnglish(message);
 		case 'getDelay':
 			return handleGetDelay(message);
 		case 'setDelay':
@@ -297,7 +303,8 @@ async function handleLint(
 		return { kind: 'lints', lints: {} };
 	}
 
-	const grouped = await linter.organizedLints(req.text, req.options);
+	const isolateEnglish = req.options?.isolateEnglish === true || (await getIsolateEnglish());
+	const grouped = await linter.organizedLints(req.text, { ...req.options, isolateEnglish });
 	const unpackedEntries = await Promise.all(
 		Object.entries(grouped).map(async ([source, lints]) => {
 			const unpacked = await Promise.all(lints.map((lint) => unpackLint(req.text, lint, linter)));
@@ -382,6 +389,16 @@ async function handleSetDialect(req: SetDialectRequest): Promise<UnitResponse> {
 
 async function handleGetDialect(_req: GetDialectRequest): Promise<GetDialectResponse> {
 	return { kind: 'getDialect', dialect: await getDialect() };
+}
+
+async function handleGetIsolateEnglish(): Promise<GetIsolateEnglishResponse> {
+	return { kind: 'getIsolateEnglish', isolateEnglish: await getIsolateEnglish() };
+}
+
+async function handleSetIsolateEnglish(req: SetIsolateEnglishRequest): Promise<UnitResponse> {
+	await setIsolateEnglish(req.isolateEnglish);
+
+	return createUnitResponse();
 }
 
 async function handleGetDelay(_req: GetDelayRequest): Promise<GetDelayResponse> {
@@ -662,6 +679,15 @@ async function getDialect(): Promise<Dialect> {
 	}
 
 	return resp.dialect;
+}
+
+async function getIsolateEnglish(): Promise<boolean> {
+	const resp = await chrome.storage.local.get({ isolateEnglish: false });
+	return resp.isolateEnglish === true;
+}
+
+async function setIsolateEnglish(isolateEnglish: boolean): Promise<void> {
+	await chrome.storage.local.set({ isolateEnglish });
 }
 
 async function getActivationKey(): Promise<ActivationKey> {

--- a/packages/chrome-plugin/src/options/Options.svelte
+++ b/packages/chrome-plugin/src/options/Options.svelte
@@ -19,6 +19,7 @@ let searchQuery = $state('');
 let searchQueryLower = $derived(searchQuery.toLowerCase());
 let expandedGroups: Record<string, boolean> = $state({});
 let dialect = $state(Dialect.American);
+let isolateEnglish = $state(false);
 let delay = $state(0);
 let delayLoaded = $state(false);
 let defaultEnabled = $state(false);
@@ -69,6 +70,10 @@ Promise.all([
 
 ProtocolClient.getDialect().then((d) => {
 	dialect = d;
+});
+
+ProtocolClient.getIsolateEnglish().then((value) => {
+	isolateEnglish = value;
 });
 
 ProtocolClient.getDelay().then((value) => {
@@ -205,6 +210,17 @@ $effect(() => {
 
 function updateLintConfig(nextConfig: LintConfig) {
 	lintConfig = nextConfig;
+}
+
+function setIsolateEnglishFromCheckbox(event: Event): void {
+	const input = event.currentTarget;
+	if (!(input instanceof HTMLInputElement)) {
+		console.warn('Could not update isolate English setting: missing checkbox input.');
+		return;
+	}
+
+	isolateEnglish = input.checked;
+	ProtocolClient.setIsolateEnglish(input.checked);
 }
 
 function toggleGroup(groupKey: string) {
@@ -349,6 +365,23 @@ async function removeWeirpack(id: string) {
             <option value={Dialect.Canadian}>🇨🇦 Canadian</option>
             <option value={Dialect.Indian}>🇮🇳 Indian</option>
           </Select>
+        </div>
+      </div>
+
+      <div class="space-y-5">
+        <div class="flex items-center justify-between">
+          <div class="flex flex-col">
+            <h3 class="text-sm">Ignore Non-English Text</h3>
+            <p class="text-xs text-gray-600 dark:text-gray-400">
+              Skip text that Harper detects as not English.
+            </p>
+          </div>
+          <input
+            type="checkbox"
+            checked={isolateEnglish}
+            onchange={setIsolateEnglishFromCheckbox}
+            class="h-5 w-5"
+          />
         </div>
       </div>
 

--- a/packages/chrome-plugin/src/protocol.ts
+++ b/packages/chrome-plugin/src/protocol.ts
@@ -9,6 +9,8 @@ export type Request =
 	| GetLintDescriptionsRequest
 	| SetDialectRequest
 	| GetDialectRequest
+	| GetIsolateEnglishRequest
+	| SetIsolateEnglishRequest
 	| GetDelayRequest
 	| SetDelayRequest
 	| SetDomainStatusRequest
@@ -41,6 +43,7 @@ export type Response =
 	| UnitResponse
 	| GetLintDescriptionsResponse
 	| GetDialectResponse
+	| GetIsolateEnglishResponse
 	| GetDelayResponse
 	| GetDomainStatusResponse
 	| GetDefaultStatusResponse
@@ -57,7 +60,7 @@ export type LintRequest = {
 	kind: 'lint';
 	domain: string;
 	text: string;
-	options: LintOptions;
+	options?: LintOptions;
 };
 
 export type LintResponse = {
@@ -123,6 +126,20 @@ export type GetDialectRequest = {
 export type GetDialectResponse = {
 	kind: 'getDialect';
 	dialect: Dialect;
+};
+
+export type GetIsolateEnglishRequest = {
+	kind: 'getIsolateEnglish';
+};
+
+export type GetIsolateEnglishResponse = {
+	kind: 'getIsolateEnglish';
+	isolateEnglish: boolean;
+};
+
+export type SetIsolateEnglishRequest = {
+	kind: 'setIsolateEnglish';
+	isolateEnglish: boolean;
 };
 
 export type GetDomainStatusRequest = {

--- a/packages/harper.js/src/Linter.test.ts
+++ b/packages/harper.js/src/Linter.test.ts
@@ -177,6 +177,34 @@ for (const [linterName, Linter] of Object.entries(linters)) {
 		await linter.dispose();
 	});
 
+	test(`${linterName} can ignore non-English text in lint outputs`, async () => {
+		const linter = new Linter({ binary });
+		const source =
+			'En la mañana, como a dish de los huevos, un poquito of tocino, y a lot of leche.';
+
+		const defaultLints = await linter.lint(source, { language: 'plaintext' });
+		const englishOnlyLints = await linter.lint(source, {
+			language: 'plaintext',
+			isolateEnglish: true,
+		});
+		const defaultOrganizedLints = Object.values(
+			await linter.organizedLints(source, { language: 'plaintext' }),
+		).flat();
+		const englishOnlyOrganizedLints = Object.values(
+			await linter.organizedLints(source, {
+				language: 'plaintext',
+				isolateEnglish: true,
+			}),
+		).flat();
+
+		expect(defaultLints.length).toBeGreaterThan(0);
+		expect(defaultOrganizedLints.length).toBeGreaterThan(0);
+		expect(englishOnlyLints).toHaveLength(0);
+		expect(englishOnlyOrganizedLints).toHaveLength(0);
+
+		await linter.dispose();
+	});
+
 	test(`${linterName} can run setup without issues`, async () => {
 		const linter = new Linter({ binary });
 

--- a/packages/harper.js/src/LocalLinter.ts
+++ b/packages/harper.js/src/LocalLinter.ts
@@ -6,6 +6,34 @@ import type Linter from './Linter';
 import type { LinterInit, WeirpackTestFailures } from './Linter';
 import type { LintConfig, LintOptions, StructuredLintConfig } from './main';
 
+type WasmLintArgs = [string, Language, boolean, string | undefined, boolean, boolean];
+
+function toWasmLanguage(language: LintOptions['language']): Language {
+	switch (language) {
+		case 'plaintext':
+			return Language.Plain;
+		case 'typst':
+			return Language.Typst;
+		case 'markdown':
+		case undefined:
+			return Language.Markdown;
+		default:
+			console.warn(`Unknown Harper language '${String(language)}'; using markdown.`);
+			return Language.Markdown;
+	}
+}
+
+function toWasmLintArgs(text: string, options?: LintOptions): WasmLintArgs {
+	return [
+		text,
+		toWasmLanguage(options?.language),
+		options?.forceAllHeadings ?? false,
+		options?.regex_mask,
+		options?.dedup ?? true,
+		options?.isolateEnglish ?? false,
+	];
+}
+
 /** A Linter that runs in the current JavaScript context (meaning it is allowed to block the event loop).
  * See the interface definition for more details. */
 export default class LocalLinter implements Linter {
@@ -35,54 +63,12 @@ export default class LocalLinter implements Linter {
 
 	async lint(text: string, options?: LintOptions): Promise<Lint[]> {
 		const inner = await this.inner;
-
-		let language = Language.Markdown;
-
-		switch (options?.language) {
-			case 'plaintext':
-				language = Language.Plain;
-				break;
-			case 'markdown':
-				language = Language.Markdown;
-				break;
-			case 'typst':
-				language = Language.Typst;
-		}
-
-		const lints = inner.lint(
-			text,
-			language,
-			options?.forceAllHeadings ?? false,
-			options?.regex_mask,
-			options?.dedup ?? true,
-		);
-
-		return lints;
+		return inner.lint(...toWasmLintArgs(text, options));
 	}
 
 	async organizedLints(text: string, options?: LintOptions): Promise<Record<string, Lint[]>> {
 		const inner = await this.inner;
-		let language = Language.Markdown;
-
-		switch (options?.language) {
-			case 'plaintext':
-				language = Language.Plain;
-				break;
-			case 'markdown':
-				language = Language.Markdown;
-				break;
-			case 'typst':
-				language = Language.Typst;
-				break;
-		}
-
-		const lintGroups = inner.organized_lints(
-			text,
-			language,
-			options?.forceAllHeadings ?? false,
-			options?.regex_mask,
-			options?.dedup ?? true,
-		);
+		const lintGroups = inner.organized_lints(...toWasmLintArgs(text, options));
 
 		const output: Record<string, Lint[]> = {};
 

--- a/packages/harper.js/src/main.ts
+++ b/packages/harper.js/src/main.ts
@@ -82,4 +82,7 @@ export interface LintOptions {
 
 	/** Remove overlapping lints. An undefined value is assumed to be true. */
 	dedup?: boolean;
+
+	/** Ignore text that is unlikely to be English. An undefined value is assumed to be false. */
+	isolateEnglish?: boolean;
 }


### PR DESCRIPTION
# Issues

Closes #3364

# Description

This exposes Harper's existing English-isolation/language-detection behavior to `harper.js` and the browser extension.

It adds an `isolateEnglish` lint option, wires it through the wasm lint paths, and adds a browser extension setting so users can skip text Harper detects as non-English. The extension also includes the option in lint caching so toggling the setting produces fresh results.

# Demo

No demo attached. The UI change is a small checkbox in the extension options page.

# How Has This Been Tested?

- Ran the wasm tests.
- Rebuilt the wasm package and ran the `harper.js` linter tests: 200 tests passed.
- Built `harper.js`, `components`, `lint-framework`, and the Chrome extension.
- `just format` still fails on pre-existing Chrome fixture a11y issues unrelated to this change.

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter

N/A; this exposes an existing language-isolation behavior rather than adding or changing a linter.

- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.