### PR TITLE
feat: in depth→in-depth

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -1728,6 +1728,13 @@
 								"state": true,
 								"label": "Worst Case Scenario"
 							}
+						},
+						{
+							"Bool": {
+								"name": "InDemandInDepth",
+								"state": true,
+								"label": "In Demand / In Depth"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/in_demand_in_depth.rs
+++ b/harper-core/src/linting/in_demand_in_depth.rs
@@ -41,12 +41,8 @@ impl ExprLinter for InDemandInDepth {
     type Unit = Chunk;
 
     fn match_to_lint(&self, toks: &[Token], _src: &[char]) -> Option<Lint> {
-        let Some(tok) = toks.get(3) else {
-            return None;
-        };
-
         Some(Lint {
-            span: tok.span,
+            span: toks.get(3)?.span,
             lint_kind: LintKind::Punctuation,
             suggestions: vec![Suggestion::ReplaceWith(vec!['-'])],
             message: "When used as adjectives, `in-demand` and `in-depth` should be hyphenated."

--- a/harper-core/src/linting/in_demand_in_depth.rs
+++ b/harper-core/src/linting/in_demand_in_depth.rs
@@ -1,0 +1,135 @@
+use crate::{
+    Lint, Token, TokenKind,
+    expr::{Expr, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+};
+
+pub struct InDemandInDepth {
+    expr: SequenceExpr,
+}
+
+impl Default for InDemandInDepth {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::default()
+                .then_kind_any_but_not(
+                    // To flag:
+                    // ✔ [Get] in depth answers                            - verb lemma
+                    // ✔ consisting [of] in depth technical discussion     - preposition
+                    // ✔ [more]/[most]                                     - determiner/quantifier? adverb?
+                    // Not to flag:
+                    // ✘ explore these [concepts] in depth                 - plural noun
+                    // ✘ [Defense] in Depth                                - abstract/mass noun
+                    // ✘ and [MCP] in depth                                - mass noun
+                    &[
+                        TokenKind::is_verb_lemma,
+                        TokenKind::is_preposition,
+                        TokenKind::is_quantifier,
+                        TokenKind::is_degree_adverb,
+                    ],
+                    TokenKind::is_mass_noun,
+                )
+                .t_ws()
+                .t_aco("in")
+                .t_ws()
+                .t_set(&["demand", "demands", "depth", "depths"]),
+        }
+    }
+}
+
+impl ExprLinter for InDemandInDepth {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, toks: &[Token], _src: &[char]) -> Option<Lint> {
+        let Some(tok) = toks.get(3) else {
+            return None;
+        };
+
+        Some(Lint {
+            span: tok.span,
+            lint_kind: LintKind::Punctuation,
+            suggestions: vec![Suggestion::ReplaceWith(vec!['-'])],
+            message: "When used as adjectives, `in-demand` and `in-depth` should be hyphenated."
+                .to_owned(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Checks for `in-demand` and `in-depth` used as adjectives but not hyphenated."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::assert_suggestion_result;
+
+    use super::InDemandInDepth;
+
+    #[test]
+    fn of_in_depth_technical_discussion() {
+        assert_suggestion_result(
+            "One hour video call consisting of in depth technical discussion with lead developers",
+            InDemandInDepth::default(),
+            "One hour video call consisting of in-depth technical discussion with lead developers",
+        );
+    }
+
+    #[test]
+    fn a_more_in_depth_documentation() {
+        assert_suggestion_result(
+            "I have added a more in depth documentation for each concept",
+            InDemandInDepth::default(),
+            "I have added a more in-depth documentation for each concept",
+        );
+    }
+
+    #[test]
+    fn most_in_demand_job_technologies() {
+        assert_suggestion_result(
+            "Jupyter notebook for scraping and analysis of most in demand job technologies skills for data scientists",
+            InDemandInDepth::default(),
+            "Jupyter notebook for scraping and analysis of most in-demand job technologies skills for data scientists",
+        );
+    }
+
+    #[test]
+    fn invited_engineer_to_explain_more_in_depth() {
+        assert_suggestion_result(
+            "invited one of their engineers to the next meeting to explain this more in depth",
+            InDemandInDepth::default(),
+            "invited one of their engineers to the next meeting to explain this more in-depth",
+        );
+    }
+
+    #[test]
+    fn very_in_depth_explination() {
+        assert_suggestion_result(
+            "This is a very in depth explination of naive bayes w.r.t implementation in python",
+            InDemandInDepth::default(),
+            "This is a very in-depth explination of naive bayes w.r.t implementation in python",
+        );
+    }
+
+    #[test]
+    fn pretty_in_depth_comparison() {
+        assert_suggestion_result(
+            "there should be a pretty in depth comparison of all of the options in the wiki",
+            InDemandInDepth::default(),
+            "there should be a pretty in-depth comparison of all of the options in the wiki",
+        );
+    }
+
+    #[test]
+    fn quite_in_depth_analysis() {
+        assert_suggestion_result(
+            "There was already a quite in depth analysis for Tasmota here",
+            InDemandInDepth::default(),
+            "There was already a quite in-depth analysis for Tasmota here",
+        );
+    }
+}

--- a/harper-core/src/linting/in_demand_in_depth.rs
+++ b/harper-core/src/linting/in_demand_in_depth.rs
@@ -32,7 +32,7 @@ impl Default for InDemandInDepth {
                 .t_ws()
                 .t_aco("in")
                 .t_ws()
-                .t_set(&["demand", "demands", "depth", "depths"]),
+                .t_set(&["demand", "depth"]),
         }
     }
 }

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -114,6 +114,7 @@ use super::how_to::HowTo;
 use super::hyphenate_number_day::HyphenateNumberDay;
 use super::i_am_agreement::IAmAgreement;
 use super::if_wouldve::IfWouldve;
+use super::in_demand_in_depth::InDemandInDepth;
 use super::in_favour_of_doing::InFavourOfDoing;
 use super::in_on_the_cards::InOnTheCards;
 use super::in_time_from_now::InTimeFromNow;
@@ -681,6 +682,7 @@ impl LintGroup {
         insert_expr_rule!(HyphenateNumberDay, true);
         insert_expr_rule!(IAmAgreement, true);
         insert_expr_rule!(IfWouldve, true);
+        insert_expr_rule!(InDemandInDepth, true);
         insert_expr_rule!(InFavourOfDoing, true);
         insert_struct_rule_with_dialect!(InOnTheCards, true);
         insert_expr_rule!(InTimeFromNow, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -111,6 +111,7 @@ mod how_to;
 mod hyphenate_number_day;
 mod i_am_agreement;
 mod if_wouldve;
+mod in_demand_in_depth;
 mod in_favour_of_doing;
 mod in_on_the_cards;
 mod in_time_from_now;


### PR DESCRIPTION
# Issues 
N/A

# Description

Many compounds can act as an adjective or an adverb and should be hyphenated only when used as an adjective. This is a good rule but not 100% reliable. This linter only covers "in demand" and "in depth".

There are surely cases it doesn't yet catch. If it catches anything it should not, that is a bug. Either way, please report.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
