### PR TITLE
feat: cross platform→cross-platform

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -2339,6 +2339,13 @@
 								"state": true,
 								"label": "Wok Verb Typo"
 							}
+						},
+						{
+							"Bool": {
+								"name": "CrossPlatform",
+								"state": true,
+								"label": "Cross Platform"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/weir_rules/CrossPlatform.weir
+++ b/harper-core/src/linting/weir_rules/CrossPlatform.weir
@@ -1,0 +1,10 @@
+expr main (cross platform)
+
+let message "`Cross-platform` should always be hyphenated in all positions."
+let description "Unlike some compound modifiers, `cross-platform` should always be hyphenated."
+let kind "Punctuation"
+let becomes "cross-platform"
+
+test "A C++11 single-file header-only cross platform HTTP/HTTPS library." "A C++11 single-file header-only cross-platform HTTP/HTTPS library."
+test "Cross Platform Tutorial." "Cross-Platform Tutorial."
+test "Cross platform / architecture install option" "Cross-platform / architecture install option"


### PR DESCRIPTION
# Issues 
N/A

# Description

I was 2/3 of the way through writing a Rust linter for this that detected whether it was used attributively or predicatively. But at some point an AI I was consulting told me it's in the category of permanently-hyphenated terms so I did some research: The OED, which lists hyphenated and open compounds separately as you can see here for "built-in": 
<img width="662" height="370" alt="image" src="https://github.com/user-attachments/assets/aa0d2f89-f154-4fd1-98e1-c78add21e579" />

Only includes the hyphenated version when it comes to "open-source"
<img width="733" height="254" alt="image" src="https://github.com/user-attachments/assets/932f5cb7-95af-4a22-bfd6-765d20c0fc30" />

Likewise, [Cambridge](https://dictionary.cambridge.org/dictionary/english/cross-platform) and [Oxford Learner's](https://www.oxfordlearnersdictionaries.com/definition/english/cross-platform?q=cross-platform) only include hyphenated entries. (None of the other professional online dictionaries include an entry)

So I ditched the Rust version and made a very simple Weir rule instead.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo run --bin harper-cli test harper-core/src/linting/weir_rules/CrossPlatform.w
eir` and then `harper % just format && cargo clippy && cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

I used Google Search's AI for researching but not for coding.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
