### PR TITLE
feat: hazzle→hassle

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -2783,6 +2783,13 @@
 								"state": true,
 								"label": "The The To That The"
 							}
+						},
+						{
+							"Bool": {
+								"name": "Hazzle",
+								"state": true,
+								"label": "Hazzle"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/weir_rules/Hazzle/Hazzle.weir
+++ b/harper-core/src/linting/weir_rules/Hazzle/Hazzle.weir
@@ -1,0 +1,10 @@
+
+expr main hazzle
+
+let message "Did you mean `hassle`?"
+let description "Corrects `hazzle` to `hassle`."
+let kind "Spelling"
+let becomes "hassle"
+
+test "Also, it is a hazzle that these 3 pics remain in the burst folder" "Also, it is a hassle that these 3 pics remain in the burst folder"
+test "A bare minimum set of tools to get your Transformice script started hazzle-free." "A bare minimum set of tools to get your Transformice script started hassle-free."

--- a/harper-core/src/linting/weir_rules/Hazzle/Hazzled.weir
+++ b/harper-core/src/linting/weir_rules/Hazzle/Hazzled.weir
@@ -1,0 +1,9 @@
+expr main hazzled
+
+let message "Did you mean `hassled`?"
+let description "Corrects `hazzled` to `hassled`."
+let kind "Spelling"
+let becomes "hassled"
+
+test "I've hazzled with syncthing before and i'd use that solution on my portable folders too." "I've hassled with syncthing before and i'd use that solution on my portable folders too."
+test "This lift and shift approach ensures, the developers and the end user community do not get hazzled by new ways of doing things." "This lift and shift approach ensures, the developers and the end user community do not get hassled by new ways of doing things."

--- a/harper-core/src/linting/weir_rules/Hazzle/Hazzles.weir
+++ b/harper-core/src/linting/weir_rules/Hazzle/Hazzles.weir
@@ -1,0 +1,9 @@
+expr main hazzles
+
+let message "Did you mean `hassles`?"
+let description "Corrects `hazzles` to `hassles`."
+let kind "Spelling"
+let becomes "hassles"
+
+test "No more hazzles with configuration files." "No more hassles with configuration files."
+test "For your logistics and delivery hazzles ." "For your logistics and delivery hassles ."

--- a/harper-core/src/linting/weir_rules/Hazzle/Hazzling.weir
+++ b/harper-core/src/linting/weir_rules/Hazzle/Hazzling.weir
@@ -1,0 +1,9 @@
+expr main hazzling
+
+let message "Did you mean `hassling`?"
+let description "Corrects `hazzling` to `hassling`."
+let kind "Spelling"
+let becomes "hassling"
+
+test "need to be exclusive from states so there is no hazzling with communtativity of the xor operator of hashing functions." "need to be exclusive from states so there is no hassling with communtativity of the xor operator of hashing functions."
+test "Due to some server hazzling I have to forward this stuff to my new server" "Due to some server hassling I have to forward this stuff to my new server"


### PR DESCRIPTION
# Issues 
N/A

# Description

In an issue on another GitHub repo somebody used the word "hazzle", which I'd come across before as an obvious nonnative misspelling of "hassle":
> I'm gonna close this because I don't really want to fix it, as I know it's gonna be a bit of a **hazzle** for me.

This linter corrects all noun and verb inflections of it, though it's by far most common as a noun.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
