### PR TITLE
chore(dict): add 'Juneteenth' to dictionary

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -5303,6 +5303,7 @@ July/OgS
 Jun/Og
 June/OgS
 Juneau/Og
+Juneteenth/gO
 Jung/Og
 Jungfrau/Og         # mountain
 Jungian/JNg
@@ -54702,4 +54703,3 @@ vicontiel/J         # As above, alternative version
 viscomital/J        # As above, alternative version
 WordCamp/Og
 worldbuild/V>G
-Juneteenth/gO

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -54702,3 +54702,4 @@ vicontiel/J         # As above, alternative version
 viscomital/J        # As above, alternative version
 WordCamp/Og
 worldbuild/V>G
+Juneteenth/gO


### PR DESCRIPTION
# Issues
None.

# Description
Harper currently flags 'Juneteenth' as a spelling error. However, major dictionaries—including the [Oxford English Dictionary](https://www.oed.com/dictionary/juneteenth_n) and [Merriam-Webster](https://www.merriam-webster.com/dictionary/juneteenth)—recognize it as a proper noun. This PR adds 'Juneteenth' to Harper's dictionary.

_Following the [guidelines](https://writewithharper.com/docs/contributors/dictionary#Adding-Nouns), I have only run `just addnoun Juneteenth`._

# Demo
<img width="762" height="428" alt="image" src="https://github.com/user-attachments/assets/2a3ba84a-3438-4823-bf26-efa151bd7746" />

# How Has This Been Tested?
I ran `just build-web && cd ./packages/web && npm run preview` and locally verified that 'Juneteenth' no longer reports a spelling error.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
