### PR TITLE
feat: in do course→in due course

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5179,6 +5179,13 @@
 								"state": true,
 								"label": "Run Into Problems / Trouble"
 							}
+						},
+						{
+							"Bool": {
+								"name": "InDueCourse",
+								"state": true,
+								"label": "In Due Course"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/weir_rules/InDueCourse.weir
+++ b/harper-core/src/linting/weir_rules/InDueCourse.weir
@@ -1,0 +1,9 @@
+expr main (in do course)
+
+let message "Use `in due course` instead of `in do course`."
+let description "Corrects `do` to `due` in the eggcorn `in do course`."
+let kind "Eggcorn"
+let becomes "in due course"
+
+test "We will menage everything in do course of time." "We will menage everything in due course of time."
+test "What might not come in do course of the game if you don't play it smart is the uber loot." "What might not come in due course of the game if you don't play it smart is the uber loot."


### PR DESCRIPTION
# Issues 

Part of #499

# Description

People often mix up "do" and "due" in writing. I believe we already flag some contexts, but didn't already handle this one. A Weir rule fixes it.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
