### PR TITLE
feat: read and write→reads and writes/read and write

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -3825,6 +3825,13 @@
 								"state": true,
 								"label": "Complain As Noun"
 							}
+						},
+						{
+							"Bool": {
+								"name": "ReadsAndWrites",
+								"state": true,
+								"label": "Reads and Writes"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/weir_rules/ReadsAndWrites.weir
+++ b/harper-core/src/linting/weir_rules/ReadsAndWrites.weir
@@ -1,0 +1,9 @@
+expr main (read and writes)
+
+let message "Did you mean `reads and writes` or `read and write`? If they are main nouns they should probably both be plural (disk reads and writes). If they describe another noun, they should probably both be singular (read and write permissions)."
+let description "Corrects inconsistent noun or verb forms when `read` and `write` are paired."
+let kind "Grammar"
+let becomes ["reads and writes", "read and write"]
+
+test "And it appears what that means is any read and writes to memory on the 2GS when you first power it up are always going to just go to bank zero." "And it appears what that means is any reads and writes to memory on the 2GS when you first power it up are always going to just go to bank zero."
+test "AppWrite puts the read and writes permissions of the database on the client-side." "AppWrite puts the read and write permissions of the database on the client-side."


### PR DESCRIPTION
# Issues 
N/A

# Description

I was listening to Adrian's Digital Basement and heard it say "read and writes" instead of "reads and writes". I did some Googling and this turns out not to be rare.

It seems to happen only when the words are used as nouns, almost never when used as verbs.
But there are two ways they are used as nouns:
- main nouns: As disk **read and writes** are always slower ...
- attributive nouns (like adjectives): ... the existing **read and writes** streams

The former should be "reads and writes" and the latter should be "read and write". This implementation does not try to analyse the context and offers both corrections with advice on how to choose.

"Reads and write" also happens but has a much greater ratio of false positives, so is not addressed.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

I did use Google Search's AI to check if any examples were false positives among 3 pages of snippets.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
