### PR TITLE
fix(chrome-ext): work within Gutenberg `<iframe />`s

### DIFF
--- a/packages/chrome-plugin/src/contentScript/index.ts
+++ b/packages/chrome-plugin/src/contentScript/index.ts
@@ -113,27 +113,29 @@ function scan() {
 			fw.addTarget(element);
 		});
 
-	document.querySelectorAll('[data-testid="gutenberg-editor"]').forEach((element) => {
-		const leafs = leafNodes(element);
+	document
+		.querySelectorAll('[data-testid="gutenberg-editor"], .block-editor-iframe__body')
+		.forEach((element) => {
+			const leafs = leafNodes(element);
 
-		const seenBlockContainers = new Set<Element>();
+			const seenBlockContainers = new Set<Element>();
 
-		for (const leaf of leafs) {
-			const blockContainer = getClosestBlockAncestor(leaf, element);
+			for (const leaf of leafs) {
+				const blockContainer = getClosestBlockAncestor(leaf, element);
 
-			if (!blockContainer || seenBlockContainers.has(blockContainer)) {
-				continue;
+				if (!blockContainer || seenBlockContainers.has(blockContainer)) {
+					continue;
+				}
+
+				seenBlockContainers.add(blockContainer);
+
+				if (!isVisible(blockContainer)) {
+					continue;
+				}
+
+				fw.addTarget(blockContainer);
 			}
-
-			seenBlockContainers.add(blockContainer);
-
-			if (!isVisible(blockContainer)) {
-				continue;
-			}
-
-			fw.addTarget(blockContainer);
-		}
-	});
+		});
 
 	document
 		.querySelectorAll<HTMLElement>('.cm-editor .cm-content[contenteditable="true"]')

--- a/packages/chrome-plugin/src/manifest.ts
+++ b/packages/chrome-plugin/src/manifest.ts
@@ -70,6 +70,7 @@ export default defineManifest({
 			matches: ['<all_urls>'],
 			all_frames: true,
 			match_about_blank: true,
+			match_origin_as_fallback: true,
 			js: ['src/contentScript/index.ts'],
 			run_at: 'document_idle',
 		},


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #3158

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

In WordPress 7.0 and on WordPress.com, the Gutenberg editor's behavior has changed. It is now far more likely to place the editor contents inside an `<iframe />` element. With Harper's Chrome Extension manifest, it would miss lints within that `<iframe />`. I've updated the manifest to allow Harper to fix errors within the new Gutenberg editor.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
