### PR TITLE
fix(obsidian): stale data on the Settings page

### DIFF
--- a/packages/obsidian-plugin/src/HarperSettingTab.ts
+++ b/packages/obsidian-plugin/src/HarperSettingTab.ts
@@ -37,15 +37,11 @@ export class HarperSettingTab extends PluginSettingTab {
 	}
 
 	updateSettings() {
+		this.settings = undefined;
 		this.state.getSettings().then((v) => {
-			const shouldRedrawWholeTab = this.settings == null;
 			this.settings = v;
 			this.updateToggleAllRulesButton();
-			if (shouldRedrawWholeTab) {
-				this.display(false);
-				return;
-			}
-			this.rerenderLintSettings();
+			this.display(false);
 		});
 	}
 
@@ -74,7 +70,6 @@ export class HarperSettingTab extends PluginSettingTab {
 	display(update = true) {
 		if (update) {
 			this.update();
-			this.display(false);
 		}
 
 		const { containerEl } = this;


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Fixes #2438

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

The values within the setting page were not updating when they needed to be. This resulted in stale or incorrect data being filled in where it shouldn't have been.

I've updated the page's logic to more greedily obtain up-to-date values from disk.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.


# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
