### PR TITLE
refactor: more vec ctors and builders converted to iterators per #3670

### DIFF
--- a/harper-core/src/expr/all.rs
+++ b/harper-core/src/expr/all.rs
@@ -1,4 +1,7 @@
-use crate::{Span, Token, expr::Expr};
+use crate::{
+    Span, Token,
+    expr::{AsBoxedExpr, Expr},
+};
 
 /// An [`Expr`] that matches against tokens if and only if all of its children do.
 /// This can be useful for situations where you have multiple expressions that represent a grammatical
@@ -11,8 +14,10 @@ pub struct All {
 }
 
 impl All {
-    pub fn new(children: Vec<Box<dyn Expr>>) -> Self {
-        Self { children }
+    pub fn new(children: impl IntoIterator<Item = impl AsBoxedExpr>) -> Self {
+        Self {
+            children: children.into_iter().map(|e| e.into_boxed_expr()).collect(),
+        }
     }
 
     pub fn add(&mut self, e: impl Expr + 'static) {

--- a/harper-core/src/expr/duration_expr.rs
+++ b/harper-core/src/expr/duration_expr.rs
@@ -29,8 +29,8 @@ impl Expr for DurationExpr {
         // positive "a few" and negative "few"
         let a_few = SequenceExpr::optional(SequenceExpr::aco("a").t_ws()).t_aco("few");
 
-        let expr = SequenceExpr::longest_of(vec![
-            Box::new(SpelledNumberExpr),
+        let expr = SequenceExpr::longest_of([
+            Box::new(SpelledNumberExpr) as Box<dyn Expr>,
             Box::new(SequenceExpr::default().then_number()),
             Box::new(IndefiniteArticle::default()),
             Box::new(a_couple_of),

--- a/harper-core/src/expr/filter.rs
+++ b/harper-core/src/expr/filter.rs
@@ -1,6 +1,6 @@
 use crate::{Span, Token};
 
-use super::Expr;
+use super::{AsBoxedExpr, Expr};
 
 /// An expression that wraps other expressions to build a filter-line pipeline.
 ///
@@ -14,13 +14,13 @@ use super::Expr;
 ///
 /// ``` rust
 /// use harper_core::patterns::WhitespacePattern;
-/// use harper_core::expr::{SequenceExpr, Filter, ExprExt};
+/// use harper_core::expr::{AsBoxedExpr, Expr, SequenceExpr, Filter, ExprExt};
 /// use harper_core::{Span, Document};
 ///
 /// let a = SequenceExpr::word_seq(&["chock", "full"]);
 /// let b = WhitespacePattern;
 ///
-/// let filter = Filter::new(vec![Box::new(a), Box::new(b)]);
+/// let filter = Filter::new([Box::new(a) as Box<dyn Expr>, Box::new(b)]);
 /// let doc = Document::new_markdown_default_curated("This test is chock full of insights.");
 ///
 /// let matches: Vec<_> = filter.iter_matches_in_doc(&doc).collect();
@@ -31,8 +31,10 @@ pub struct Filter {
 }
 
 impl Filter {
-    pub fn new(steps: Vec<Box<dyn Expr>>) -> Self {
-        Self { steps }
+    pub fn new(steps: impl IntoIterator<Item = impl AsBoxedExpr>) -> Self {
+        Self {
+            steps: steps.into_iter().map(|s| s.into_boxed_expr()).collect(),
+        }
     }
 }
 

--- a/harper-core/src/expr/pronoun_be.rs
+++ b/harper-core/src/expr/pronoun_be.rs
@@ -9,13 +9,13 @@ pub struct PronounBe {
 impl Default for PronounBe {
     fn default() -> Self {
         Self {
-            expr: SequenceExpr::default().then_any_of(vec![
+            expr: SequenceExpr::default().then_any_of([
                 Box::new(
                     SequenceExpr::default()
                         .then_subject_pronoun()
                         .t_ws()
                         .t_set(&["am", "are", "is", "was", "were"]),
-                ),
+                ) as Box<dyn Expr>,
                 Box::new(WordSet::new(&[
                     "i'm", "we're", "you're", "he's", "she's", "it's", "they're",
                 ])),

--- a/harper-core/src/expr/sequence_expr.rs
+++ b/harper-core/src/expr/sequence_expr.rs
@@ -2,7 +2,7 @@ use paste::paste;
 
 use crate::{
     CharStringExt, Lrc, Span, Token, TokenKind,
-    expr::{FirstMatchOf, FixedPhrase, LongestMatchOf},
+    expr::{AsBoxedExpr, FirstMatchOf, FixedPhrase, LongestMatchOf},
     patterns::{AnyPattern, IndefiniteArticle, WhitespacePattern, Word, WordSet},
 };
 
@@ -140,12 +140,12 @@ impl SequenceExpr {
     // Multiple expressions
 
     /// Match the first of multiple expressions.
-    pub fn any_of(exprs: Vec<Box<dyn Expr>>) -> Self {
+    pub fn any_of(exprs: impl IntoIterator<Item = impl AsBoxedExpr>) -> Self {
         Self::default().then_any_of(exprs)
     }
 
     /// Match the longest of multiple expressions.
-    pub fn longest_of(exprs: Vec<Box<dyn Expr>>) -> Self {
+    pub fn longest_of(exprs: impl IntoIterator<Item = impl AsBoxedExpr>) -> Self {
         Self::default().then_longest_of(exprs)
     }
 
@@ -183,7 +183,7 @@ impl SequenceExpr {
     /// If more than one of the provided expressions match, this function provides no guarantee
     /// as to which match will end up being used. If you need to get the longest of multiple
     /// matches, use [`Self::then_longest_of()`] instead.
-    pub fn then_any_of(mut self, exprs: Vec<Box<dyn Expr>>) -> Self {
+    pub fn then_any_of(mut self, exprs: impl IntoIterator<Item = impl AsBoxedExpr>) -> Self {
         self.exprs.push(Box::new(FirstMatchOf::new(exprs)));
         self
     }
@@ -192,7 +192,7 @@ impl SequenceExpr {
     ///
     /// If you don't need the longest match, prefer using the short-circuiting
     /// [`Self::then_any_of()`] instead.
-    pub fn then_longest_of(mut self, exprs: Vec<Box<dyn Expr>>) -> Self {
+    pub fn then_longest_of(mut self, exprs: impl IntoIterator<Item = impl AsBoxedExpr>) -> Self {
         self.exprs.push(Box::new(LongestMatchOf::new(exprs)));
         self
     }
@@ -687,7 +687,7 @@ where
 mod tests {
     use crate::{
         Document, TokenKind,
-        expr::{AnchorEnd, ExprExt, SequenceExpr},
+        expr::{AnchorEnd, Expr, ExprExt, SequenceExpr},
         linting::tests::SpanVecExt,
     };
 
@@ -720,8 +720,8 @@ mod tests {
 
     #[test]
     fn flag_foo_followed_by_bar_or_at_end_1() {
-        let expr = SequenceExpr::aco("foo").then_any_of(vec![
-            Box::new(SequenceExpr::whitespace().t_aco("bar").then(AnchorEnd)),
+        let expr = SequenceExpr::aco("foo").then_any_of([
+            Box::new(SequenceExpr::whitespace().t_aco("bar").then(AnchorEnd)) as Box<dyn Expr>,
             Box::new(AnchorEnd),
         ]);
 
@@ -740,8 +740,8 @@ mod tests {
 
     #[test]
     fn flag_foo_followed_by_bar_or_at_end_2() {
-        let expr = SequenceExpr::aco("foo").then_any_of(vec![
-            Box::new(SequenceExpr::whitespace().t_aco("bar").then(AnchorEnd)),
+        let expr = SequenceExpr::aco("foo").then_any_of([
+            Box::new(SequenceExpr::whitespace().t_aco("bar").then(AnchorEnd)) as Box<dyn Expr>,
             Box::new(AnchorEnd),
         ]);
 
@@ -760,8 +760,8 @@ mod tests {
 
     #[test]
     fn flag_foo_followed_by_bar_or_at_end_3() {
-        let expr = SequenceExpr::aco("foo").then_any_of(vec![
-            Box::new(SequenceExpr::whitespace().t_aco("bar").then(AnchorEnd)),
+        let expr = SequenceExpr::aco("foo").then_any_of([
+            Box::new(SequenceExpr::whitespace().t_aco("bar").then(AnchorEnd)) as Box<dyn Expr>,
             Box::new(AnchorEnd),
         ]);
 

--- a/harper-core/src/expr/spelled_number_expr.rs
+++ b/harper-core/src/expr/spelled_number_expr.rs
@@ -52,13 +52,13 @@ impl Expr for SpelledNumberExpr {
         );
 
         let tens_units_compounds = SequenceExpr::word_set(tens)
-            .then_any_of(vec![
-                Box::new(|t: &Token, _s: &[char]| t.kind.is_hyphen()),
+            .then_any_of([
+                Box::new(|t: &Token, _s: &[char]| t.kind.is_hyphen()) as Box<dyn Expr>,
                 Box::new(WhitespacePattern),
             ])
             .then_word_set(units);
 
-        let expr = LongestMatchOf::new(vec![
+        let expr = LongestMatchOf::new([
             Box::new(single_words) as Box<dyn Expr>,
             Box::new(tens_units_compounds),
         ]);

--- a/harper-core/src/expr/time_unit_expr.rs
+++ b/harper-core/src/expr/time_unit_expr.rs
@@ -78,13 +78,13 @@ impl Expr for TimeUnitExpr {
         let units_other_apos = WordSet::new(&["moment's", "night's", "weekend's"]);
 
         let units = if self.include_plurals_only {
-            LongestMatchOf::new(vec![
-                Box::new(units_definite_plural),
+            LongestMatchOf::new([
+                Box::new(units_definite_plural) as Box<dyn Expr>,
                 Box::new(units_other_plural),
             ])
         } else {
-            LongestMatchOf::new(vec![
-                Box::new(units_definite_singular),
+            LongestMatchOf::new([
+                Box::new(units_definite_singular) as Box<dyn Expr>,
                 Box::new(units_definite_plural),
                 Box::new(units_other_singular),
                 Box::new(units_other_plural),

--- a/harper-core/src/linting/a_some_time.rs
+++ b/harper-core/src/linting/a_some_time.rs
@@ -12,12 +12,10 @@ pub struct ASomeTime {
 impl Default for ASomeTime {
     fn default() -> Self {
         Self {
-            expr: SequenceExpr::word_seq(&["a", "some"])
-                .t_ws()
-                .then_any_of(vec![
-                    Box::new(Word::new("time")),
-                    Box::new(TimeUnitExpr::plurals_only()),
-                ]),
+            expr: SequenceExpr::word_seq(&["a", "some"]).t_ws().then_any_of([
+                Box::new(Word::new("time")) as Box<dyn Expr>,
+                Box::new(TimeUnitExpr::plurals_only()),
+            ]),
         }
     }
 }

--- a/harper-core/src/linting/addicting.rs
+++ b/harper-core/src/linting/addicting.rs
@@ -12,9 +12,9 @@ pub struct Addicting {
 impl Default for Addicting {
     fn default() -> Self {
         Self {
-            expr: SequenceExpr::aco("addicting").then_longest_of(vec![
+            expr: SequenceExpr::aco("addicting").then_longest_of([
                 // matches `addicting` without anything after
-                Box::new(AnchorEnd),
+                Box::new(AnchorEnd) as Box<dyn Expr>,
                 // Semicolon is not handled like comma is for `Chunk` - TODO: remove when #3405 is fixed
                 Box::new(SequenceExpr::default().then_semicolon()),
                 // matches `addicting` <ws> [ any word but not a reflexive pronoun or object pronoun ]

--- a/harper-core/src/linting/am_in_the_morning.rs
+++ b/harper-core/src/linting/am_in_the_morning.rs
@@ -33,8 +33,14 @@ impl Default for AmInTheMorning {
 
         let ws_at_periods = FixedPhrase::from_phrase(" at night");
 
-        let expr = SequenceExpr::any_of(vec![Box::new(maybe_ws_am), Box::new(maybe_ws_pm)])
-            .then_any_of(vec![Box::new(ws_in_periods), Box::new(ws_at_periods)]);
+        let expr = SequenceExpr::any_of([
+            Box::new(maybe_ws_am) as Box<dyn Expr>,
+            Box::new(maybe_ws_pm),
+        ])
+        .then_any_of([
+            Box::new(ws_in_periods) as Box<dyn Expr>,
+            Box::new(ws_at_periods),
+        ]);
 
         Self { expr }
     }

--- a/harper-core/src/linting/and_the_like.rs
+++ b/harper-core/src/linting/and_the_like.rs
@@ -21,14 +21,12 @@ impl Default for AndTheLike {
                         .then_word_set(&["alike", "alikes", "like", "likes"]),
                 ),
                 Box::new(SequenceExpr::unless(
-                    SequenceExpr::word_set(&["and", "or"])
-                        .t_ws()
-                        .then_any_of(vec![
-                            // But not the correct variants
-                            Box::new(FixedPhrase::from_phrase("the like")),
-                            // And not the phrases that were coincidentally caught in the net
-                            Box::new(WordSet::new(&["like", "likes"])),
-                        ]),
+                    SequenceExpr::word_set(&["and", "or"]).t_ws().then_any_of([
+                        // But not the correct variants
+                        Box::new(FixedPhrase::from_phrase("the like")) as Box<dyn Expr>,
+                        // And not the phrases that were coincidentally caught in the net
+                        Box::new(WordSet::new(&["like", "likes"])),
+                    ]),
                 )),
             ]),
         }

--- a/harper-core/src/linting/be_adjective_confusions.rs
+++ b/harper-core/src/linting/be_adjective_confusions.rs
@@ -26,13 +26,13 @@ impl BeAdjectiveLinter {
     ) -> Self {
         Self {
             expr: SequenceExpr::default()
-                .then_any_of(vec![
+                .then_any_of([
                     Box::new(
                         SequenceExpr::default()
                             .then_subject_pronoun()
                             .t_ws()
                             .t_set(&["am", "are", "is", "was", "were"]),
-                    ),
+                    ) as Box<dyn Expr>,
                     Box::new(WordSet::new(&[
                         // Correct contractions
                         "i'm", "we're", "you're", "he's", "she's", "they're",

--- a/harper-core/src/linting/by_the_book.rs
+++ b/harper-core/src/linting/by_the_book.rs
@@ -30,8 +30,8 @@ impl Default for ByTheBook {
             .t_aco("the")
             .t_ws()
             .t_aco("books")
-            .then_any_of(vec![
-                Box::new(AnchorEnd),
+            .then_any_of([
+                Box::new(AnchorEnd) as Box<dyn Expr>,
                 Box::new(SequenceExpr::whitespace().then_conjunction()),
             ]),
         }

--- a/harper-core/src/linting/change_tack.rs
+++ b/harper-core/src/linting/change_tack.rs
@@ -20,8 +20,9 @@ impl Default for ChangeTack {
                 Box::new(
                     SequenceExpr::longest_of(vec![
                         Box::new(SequenceExpr::word_set(verb_forms).then_optional(
-                            SequenceExpr::default().t_ws().then_any_of(vec![
-                                Box::new(SequenceExpr::default().then_possessive_determiner()),
+                            SequenceExpr::default().t_ws().then_any_of([
+                                Box::new(SequenceExpr::default().then_possessive_determiner())
+                                    as Box<dyn Expr>,
                                 Box::new(Word::new("it's")),
                             ]),
                         )),

--- a/harper-core/src/linting/crave_for.rs
+++ b/harper-core/src/linting/crave_for.rs
@@ -19,8 +19,8 @@ impl Default for CraveFor {
                         .t_aco("for"),
                 ) as Box<dyn Expr>,
                 Box::new(
-                    SequenceExpr::any_of(vec![
-                        Box::new(InflectionOfBe::default()),
+                    SequenceExpr::any_of([
+                        Box::new(InflectionOfBe::default()) as Box<dyn Expr>,
                         Box::new(WordSet::new(&[
                             "i'm", "we're", "you're", "he's", "she's", "it's", "they're",
                         ])),

--- a/harper-core/src/linting/did_past.rs
+++ b/harper-core/src/linting/did_past.rs
@@ -19,8 +19,8 @@ where
 {
     pub fn new(dict: D) -> Self {
         Self {
-            expr: SequenceExpr::longest_of(vec![
-                Box::new(WordSet::new(&["did", "didn't", "didnt"])),
+            expr: SequenceExpr::longest_of([
+                Box::new(WordSet::new(&["did", "didn't", "didnt"])) as Box<dyn Expr>,
                 Box::new(FixedPhrase::from_phrase("did not")),
             ])
             .then_optional(SequenceExpr::default().t_ws().then_subject_pronoun())

--- a/harper-core/src/linting/do_mistake.rs
+++ b/harper-core/src/linting/do_mistake.rs
@@ -18,11 +18,11 @@ impl Default for DoMistake {
             expr: Box::new(
                 SequenceExpr::word_set(&["do", "did", "does", "doing", "done"])
                     .t_ws()
-                    .then_longest_of(vec![
+                    .then_longest_of([
                         Box::new(WordSet::new(&[
                             "a", "an", "the", "that", "these", "this", "those", "another", "many",
                             "several", "some", "my", "our", "your", "his", "her", "its", "their",
-                        ])),
+                        ])) as Box<dyn Expr>,
                         Box::new(FixedPhrase::from_phrase("a lot of")),
                         Box::new(FixedPhrase::from_phrase("lots of")),
                         Box::new(FixedPhrase::from_phrase("that kind of")),

--- a/harper-core/src/linting/ever_every.rs
+++ b/harper-core/src/linting/ever_every.rs
@@ -12,13 +12,13 @@ pub struct EverEvery {
 impl Default for EverEvery {
     fn default() -> Self {
         Self {
-            expr: SequenceExpr::any_of(vec![
+            expr: SequenceExpr::any_of([
                 Box::new(WordSet::new(&[
                     "are", "aren't", "arent", "did", "didn't", "didnt", "do", "does", "doesn't",
                     "doesnt", "dont", "don't", "had", "hadn't", "hadnt", "has", "hasn't", "hasnt",
                     "have", "haven't", "havent", "is", "isn't", "isnt", "was", "wasn't", "wasnt",
                     "were", "weren't", "werent",
-                ])),
+                ])) as Box<dyn Expr>,
                 Box::new(ModalVerb::with_common_errors()),
             ])
             .t_ws()

--- a/harper-core/src/linting/everyday.rs
+++ b/harper-core/src/linting/everyday.rs
@@ -23,7 +23,7 @@ impl Default for Everyday {
         ]);
 
         let bad_before_every_day = All::new(vec![
-            Box::new(SequenceExpr::any_word().t_ws().then(every_day.clone())),
+            Box::new(SequenceExpr::any_word().t_ws().then(every_day.clone())) as Box<dyn Expr>,
             Box::new(|tok: &Token, _src: &[char]| {
                 // "this" and "that" are both determiners and pronouns
                 tok.kind.is_determiner() && !tok.kind.is_pronoun()

--- a/harper-core/src/linting/good_at.rs
+++ b/harper-core/src/linting/good_at.rs
@@ -11,8 +11,8 @@ pub struct GoodAt {
 
 impl Default for GoodAt {
     fn default() -> Self {
-        let we_re_not_always_very_good_in_sth = SequenceExpr::any_of(vec![
-            Box::new(InflectionOfBe::default()),
+        let we_re_not_always_very_good_in_sth = SequenceExpr::any_of([
+            Box::new(InflectionOfBe::default()) as Box<dyn Expr>,
             Box::new(WordSet::new(&[
                 "I'm", "we're", "you're", "he's", "she's", "it's", "they're", "Im", "were",
                 "youre", "your", "hes", "shes", "its", "theyre",

--- a/harper-core/src/linting/if_wouldve.rs
+++ b/harper-core/src/linting/if_wouldve.rs
@@ -16,12 +16,12 @@ impl Default for IfWouldve {
                 .t_ws()
                 .then(NominalPhrase)
                 .t_ws()
-                .then_any_of(vec![
+                .then_any_of([
                     Box::new(
                         SequenceExpr::word_set(&["would", "had"])
                             .t_ws()
                             .then_word_set(&["have", "of"]),
-                    ),
+                    ) as Box<dyn Expr>,
                     Box::new(WordSet::new(&["would've", "wouldve", "had've", "hadve"])),
                 ])
                 .t_ws()

--- a/harper-core/src/linting/long_time_ago.rs
+++ b/harper-core/src/linting/long_time_ago.rs
@@ -11,8 +11,8 @@ pub struct LongTimeAgo {
 impl Default for LongTimeAgo {
     fn default() -> Self {
         Self {
-            expr: SequenceExpr::any_of(vec![
-                Box::new(AnchorStart),
+            expr: SequenceExpr::any_of([
+                Box::new(AnchorStart) as Box<dyn Expr>,
                 Box::new(SequenceExpr::default().then_word_except(&["a"]).t_ws()),
             ])
             .t_aco("long")

--- a/harper-core/src/linting/means_a_lot_to.rs
+++ b/harper-core/src/linting/means_a_lot_to.rs
@@ -16,8 +16,8 @@ impl Default for MeansALotTo {
                 // Note that "meaning a lot to" is not used.
                 .t_set(&["mean", "means", "meant"])
                 .t_ws()
-                .then_any_of(vec![
-                    Box::new(FixedPhrase::from_phrase("a lot")),
+                .then_any_of([
+                    Box::new(FixedPhrase::from_phrase("a lot")) as Box<dyn Expr>,
                     Box::new(WordSet::new(&["alot", "lot"])),
                 ])
                 .t_ws()

--- a/harper-core/src/linting/most_of_the_times.rs
+++ b/harper-core/src/linting/most_of_the_times.rs
@@ -11,8 +11,8 @@ pub struct MostOfTheTimes {
 impl Default for MostOfTheTimes {
     fn default() -> Self {
         Self {
-            expr: SequenceExpr::any_of(vec![
-                Box::new(FixedPhrase::from_phrase("a lot")),
+            expr: SequenceExpr::any_of([
+                Box::new(FixedPhrase::from_phrase("a lot")) as Box<dyn Expr>,
                 Box::new(Word::new("most")),
             ])
             .t_ws()

--- a/harper-core/src/linting/quantifier_numeral_conflict.rs
+++ b/harper-core/src/linting/quantifier_numeral_conflict.rs
@@ -17,13 +17,13 @@ impl Default for QuantifierNumeralConflict {
                     SequenceExpr::default()
                         .then_quantifier()
                         .t_ws()
-                        .then_longest_of(vec![
-                            Box::new(SpelledNumberExpr),
+                        .then_longest_of([
+                            Box::new(SpelledNumberExpr) as Box<dyn Expr>,
                             Box::new(SequenceExpr::default().then_cardinal_number()),
                         ]),
                 ),
-                Box::new(SequenceExpr::unless(SequenceExpr::any_of(vec![
-                    Box::new(WordSet::new(&["all", "any", "every", "no"])),
+                Box::new(SequenceExpr::unless(SequenceExpr::any_of([
+                    Box::new(WordSet::new(&["all", "any", "every", "no"])) as Box<dyn Expr>,
                     Box::new(
                         SequenceExpr::word_set(&["each", "some"])
                             .t_ws()

--- a/harper-core/src/linting/redundant_acronyms.rs
+++ b/harper-core/src/linting/redundant_acronyms.rs
@@ -51,8 +51,8 @@ impl Default for RedundantAcronyms {
             .iter()
             .map(|&(acronym, _, last_str, _)| {
                 let last_string = last_str.to_string();
-                Box::new(SequenceExpr::aco(acronym).t_ws().then_any_of(vec![
-                    Box::new(Word::new(last_str)),
+                Box::new(SequenceExpr::aco(acronym).t_ws().then_any_of([
+                    Box::new(Word::new(last_str)) as Box<dyn Expr>,
                     Box::new(move |t: &Token, src: &[char]| {
                         t.get_ch(src).eq_str(&format!("{last_string}s"))
                     }),

--- a/harper-core/src/linting/run_into_problems_or_trouble.rs
+++ b/harper-core/src/linting/run_into_problems_or_trouble.rs
@@ -16,8 +16,8 @@ impl Default for RunIntoProblemsOrTrouble {
                 .t_ws()
                 .t_aco("into")
                 .t_ws()
-                .then_any_of(vec![
-                    Box::new(WordSet::new(&["problem", "troubles"])),
+                .then_any_of([
+                    Box::new(WordSet::new(&["problem", "troubles"])) as Box<dyn Expr>,
                     Box::new(SequenceExpr::word_seq(&["a", "trouble"])),
                 ]),
         }

--- a/harper-core/src/linting/simple_past_to_past_participle.rs
+++ b/harper-core/src/linting/simple_past_to_past_participle.rs
@@ -18,9 +18,9 @@ impl Default for SimplePastToPastParticiple {
             expr: All::new(vec![
                 // positive: the general case
                 Box::new(
-                    SequenceExpr::any_of(vec![
+                    SequenceExpr::any_of([
                         // for perfect tenses
-                        Box::new(WordSet::new(&["have", "had", "has", "having"])),
+                        Box::new(WordSet::new(&["have", "had", "has", "having"])) as Box<dyn Expr>,
                         // for passive voice
                         Box::new(InflectionOfBe::default()),
                         // pronoun + have contractions

--- a/harper-core/src/linting/single_be.rs
+++ b/harper-core/src/linting/single_be.rs
@@ -62,15 +62,15 @@ pub struct SingleBe {
 impl Default for SingleBe {
     fn default() -> Self {
         fn be_like_expr() -> SequenceExpr {
-            SequenceExpr::any_of(vec![
-                Box::new(InflectionOfBe::new()),
+            SequenceExpr::any_of([
+                Box::new(InflectionOfBe::new()) as Box<dyn Expr>,
                 Box::new(DerivedFrom::new_from_str("be")),
             ])
         }
 
         fn be_like_or_contraction() -> SequenceExpr {
-            SequenceExpr::any_of(vec![
-                Box::new(be_like_expr()),
+            SequenceExpr::any_of([
+                Box::new(be_like_expr()) as Box<dyn Expr>,
                 Box::new(looks_like_be_contraction),
             ])
         }

--- a/harper-core/src/linting/then_than.rs
+++ b/harper-core/src/linting/then_than.rs
@@ -34,7 +34,7 @@ impl ThenThan {
                         .t_ws()
                         .then_unless(Word::new("that")),
                 ),
-            ])),
+            ])) as Box<dyn Expr>,
             // Exceptions to the rule.
             Box::new(Invert::new(WordSet::new(&["back", "this", "so", "but"]))),
         ]);

--- a/harper-core/src/linting/this_type_of_thing.rs
+++ b/harper-core/src/linting/this_type_of_thing.rs
@@ -20,9 +20,9 @@ impl Default for ThisTypeOfThing {
                 )
                 .t_aco("of")
                 .t_ws()
-                .then_any_of(vec![
+                .then_any_of([
                     // "thing" is common in this construction and won't be part of a compound noun.
-                    Box::new(WordSet::new(&["thing", "things"])),
+                    Box::new(WordSet::new(&["thing", "things"])) as Box<dyn Expr>,
                     // Other singular nouns may be part of hard-to-determine compound nouns, but plural nouns won't.
                     Box::new(
                         SequenceExpr::default()

--- a/harper-core/src/linting/to_two_too/to_too_adverb.rs
+++ b/harper-core/src/linting/to_two_too/to_too_adverb.rs
@@ -22,12 +22,12 @@ impl Default for ToTooAdverb {
                 &["as", "only"],
             )
             .then_optional_whitespace()
-            .then_any_of(vec![
+            .then_any_of([
                 Box::new(SequenceExpr::default().then_kind_is_but_is_not_except(
                     TokenKind::is_punctuation,
                     |_| false,
                     &["`", "\"", "'", "“", "”", "‘", "’", "-", "–", "—"],
-                )),
+                )) as Box<dyn Expr>,
                 Box::new(AnchorEnd),
             ]);
 

--- a/harper-core/src/linting/to_two_too/to_too_degree_words.rs
+++ b/harper-core/src/linting/to_two_too/to_too_degree_words.rs
@@ -19,12 +19,12 @@ impl Default for ToTooDegreeWords {
             .t_aco("to")
             .t_ws()
             .then_word_set(&["many", "much", "few"])
-            .then_any_of(vec![
+            .then_any_of([
                 Box::new(SequenceExpr::default().then_kind_is_but_is_not_except(
                     TokenKind::is_punctuation,
                     |_| false,
                     &["`", "\"", "'", "“", "”", "‘", "’", "-", "–", "—"],
-                )),
+                )) as Box<dyn Expr>,
                 Box::new(AnchorEnd),
             ]);
 

--- a/harper-core/src/linting/to_two_too/to_too_pronoun_end.rs
+++ b/harper-core/src/linting/to_two_too/to_too_pronoun_end.rs
@@ -30,12 +30,12 @@ impl Default for ToTooPronounEnd {
         .then_pronoun()
         .t_ws()
         .t_aco("to")
-        .then_any_of(vec![
+        .then_any_of([
             Box::new(SequenceExpr::default().then_kind_is_but_is_not_except(
                 TokenKind::is_punctuation,
                 |_| false,
                 &["`", "\"", "'", "“", "”", "‘", "’"],
-            )),
+            )) as Box<dyn Expr>,
             Box::new(AnchorEnd),
         ]);
 

--- a/harper-core/src/linting/well_educated.rs
+++ b/harper-core/src/linting/well_educated.rs
@@ -22,7 +22,7 @@ impl Default for WellEducated {
             .then_optional_whitespace()
             .t_aco("educated");
 
-        let expr = SequenceExpr::any_of(vec![Box::new(combined), Box::new(separated)]);
+        let expr = SequenceExpr::any_of([Box::new(combined) as Box<dyn Expr>, Box::new(separated)]);
 
         Self { expr }
     }

--- a/harper-core/src/linting/whom_subject_of_verb.rs
+++ b/harper-core/src/linting/whom_subject_of_verb.rs
@@ -14,11 +14,11 @@ impl Default for WhomSubjectOfVerb {
         Self {
             expr: SequenceExpr::word_set(&["whom", "whomever", "whomsoever"])
                 .t_ws()
-                .then_any_of(vec![
+                .then_any_of([
                     Box::new(SequenceExpr::default().then_kind_where(|k| {
                         k.is_verb_third_person_singular_present_form()
                             || k.is_verb_simple_past_form()
-                    })),
+                    })) as Box<dyn Expr>,
                     Box::new(ModalVerb::with_common_errors()),
                 ]),
         }

--- a/harper-core/src/weir/ast.rs
+++ b/harper-core/src/weir/ast.rs
@@ -136,12 +136,14 @@ impl AstExprNode {
 
                 Ok(Box::new(expr))
             }
-            AstExprNode::Filter(children) => Ok(Box::new(Filter::new(
-                children
+            AstExprNode::Filter(children) => {
+                let steps: Vec<Box<dyn Expr>> = children
                     .iter()
                     .map(|n| n.to_expr(ctx_exprs))
-                    .process_results(|iter| iter.collect())?,
-            ))),
+                    .process_results(|iter| iter.collect())?;
+
+                Ok(Box::new(Filter::new(steps)))
+            }
             AstExprNode::Punctuation(punct) => {
                 let punct = *punct;
 


### PR DESCRIPTION
# Issues 

Continuing the work of #3670

# Description

Following the success of converting the constructors of `FirstMatchOf` and `LongestMatchOf` from using `Vec`s to using iterators, this PR does the same for the builder functions and the remaining `Expr`s constructors and builders that were using `Vec`s.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
