### PR TITLE
docs: add inline-scribe to Projects Using Harper

### DIFF
--- a/packages/web/src/routes/docs/about/+page.md
+++ b/packages/web/src/routes/docs/about/+page.md
@@ -71,6 +71,7 @@ Some of the open-source projects using Harper include:
 - [QOwnNotes](https://www.qownnotes.org/)
 - [Grammate](https://grammate.goodishlab.com/)
 - [PhrAIse](https://github.com/hqrrr/Phraise)
+- [inline-scribe](https://github.com/mk668a/inline-scribe)
 
 Are you using Harper in your open source work and want to be included in this list?
 If so, please open a PR. 


### PR DESCRIPTION
Following the invitation at the bottom of the "Projects Using Harper" page — adding **inline-scribe** to the list.

inline-scribe is a Chrome extension (MIT) that proofreads text in any browser field with an on-device LLM (Ollama, or Chrome's built-in Gemini Nano) and shows a Word-style, per-fix accept/reject diff. As of v1.1.0 it integrates Harper as an **optional local pre-pass**: Harper makes the deterministic, mechanical fixes (capitalization, punctuation, formatting, repetition, agreement) instantly and offline, and the LLM only handles fluency / word choice. Lexical guesses (spelling, typos) are deliberately left to the LLM. It uses `LocalLinter` + the WASM binary, so the pre-pass stays fully on-device.

- Repo: https://github.com/mk668a/inline-scribe
- Harper integration (the pre-pass): https://github.com/mk668a/inline-scribe/blob/main/src/core/harper.ts

Thanks for Harper — the rule-based, fully-local core is exactly what made it a great pre-pass to build on. Happy to tweak the entry if you'd prefer a different format or placement.
