### PR TITLE
feat: a mean to an end→a means to an end

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5312,6 +5312,13 @@
 								"state": true,
 								"label": "In Due Course"
 							}
+						},
+						{
+							"Bool": {
+								"name": "AMeansToAnEnd",
+								"state": true,
+								"label": "A Means To An End"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/weir_rules/AMeansToAnEnd.weir
+++ b/harper-core/src/linting/weir_rules/AMeansToAnEnd.weir
@@ -1,0 +1,9 @@
+expr main (a mean to an end)
+
+let message "The correct idiom is `a means to an end`."
+let description "Corrects `a mean to an end` to `a means to an end`"
+let kind "Usage"
+let becomes "a means to an end"
+
+test "coding, programming, anything really is a mean to an end, to get money" "coding, programming, anything really is a means to an end, to get money"
+test "It's a mean to an end, not the end itself." "It's a means to an end, not the end itself."


### PR DESCRIPTION
# Issues 
N/A

# Description

Read this one in a YouTube comment thread, verified that it's not considered a legit variant, verified that it's common in the wild.

"A mean to an end" will be changed to use "means".

I checked for other variants like "an mean" or "a end" or "ends" and none were found.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
