### PR TITLE
feat: lint the Source Control commit message box

### DIFF
--- a/harper-ls/src/backend.rs
+++ b/harper-ls/src/backend.rs
@@ -361,7 +361,9 @@ impl Backend {
                     Some(Box::new(ts_parser))
                 }
             }
-            "git-commit" | "gitcommit" | "octo" => Some(Box::new(GitCommitParser::default())),
+            "git-commit" | "gitcommit" | "octo" | "scminput" => {
+                Some(Box::new(GitCommitParser::default()))
+            }
             "html" => Some(Box::new(HtmlParser::default())),
             "asciidoc" => Some(Box::new(AsciidocParser::default())),
             "ink" => Some(Box::new(InkParser::default())),

--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -62,6 +62,7 @@
 		"onLanguage:ruby",
 		"onLanguage:rust",
 		"onLanguage:scala",
+		"onLanguage:scminput",
 		"onLanguage:shellscript",
 		"onLanguage:solidity",
 		"onLanguage:swift",

--- a/packages/vscode-plugin/src/extension.ts
+++ b/packages/vscode-plugin/src/extension.ts
@@ -70,16 +70,19 @@ export async function activate(context: ExtensionContext): Promise<void> {
 		.filter((e) => e.startsWith('onLanguage:'))
 		.flatMap((e) => {
 			const language = e.split(':')[1];
+
+			// The Source Control commit message box is a document with the
+			// `scminput` language id. It is not backed by a file on disk, so it is
+			// matched by language alone rather than by scheme.
+			if (language === 'scminput') {
+				return [{ language: 'scminput' }];
+			}
+
 			return [
 				{ language, scheme: 'file' },
 				{ language, scheme: 'untitled' },
 			];
 		});
-
-	// The Source Control commit message box is a document with the `scminput`
-	// language id. It is not backed by a file on disk, so it is matched by
-	// language alone rather than by scheme.
-	clientOptions.documentSelector.push({ language: 'scminput' });
 
 	clientOptions.outputChannel = window.createOutputChannel('Harper');
 	context.subscriptions.push(clientOptions.outputChannel);

--- a/packages/vscode-plugin/src/extension.ts
+++ b/packages/vscode-plugin/src/extension.ts
@@ -76,6 +76,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
 			];
 		});
 
+	// The Source Control commit message box is a document with the `scminput`
+	// language id. It is not backed by a file on disk, so it is matched by
+	// language alone rather than by scheme.
+	clientOptions.documentSelector.push({ language: 'scminput' });
+
 	clientOptions.outputChannel = window.createOutputChannel('Harper');
 	context.subscriptions.push(clientOptions.outputChannel);
 

--- a/packages/vscode-plugin/src/tests/suite/integration.test.ts
+++ b/packages/vscode-plugin/src/tests/suite/integration.test.ts
@@ -108,6 +108,26 @@ describe('Integration >', () => {
 		);
 	});
 
+	it('gives correct diagnostics for the Source Control commit message box', async () => {
+		// The Source Control commit box uses the `scminput` language id. Harper
+		// should lint it like a git commit message, so the subject line is checked
+		// while lines starting with `#` (comments) are ignored.
+		const untitledUri = await openUntitled('Errorz\n# Errorz');
+
+		compareActualVsExpectedDiagnostics(
+			await waitForDiagnosticsChange(
+				untitledUri,
+				async () => await setTextDocumentLanguage(untitledUri, 'scminput'),
+			),
+			createExpectedDiagnostics({
+				message: 'Did you mean to spell `Errorz` this way?',
+				range: createRange(0, 0, 0, 6),
+				source: 'Harper',
+				code: 'SpellCheck',
+			}),
+		);
+	});
+
 	it('updates diagnostics on configuration change', async () => {
 		const config = workspace.getConfiguration('harper.linters');
 


### PR DESCRIPTION
# Issues 
Closes [#2988](https://github.com/Automattic/harper/issues/2988)

# Description
The VS Code extension now lints the commit message input in the Source Control panel. Those documents carry the `scminput` language id and a non-file URI, so the language client matches them by language alone, and harper-ls parses their contents with the git commit parser.

# Demo
Typing a commit message with spelling errors into the Source Control box
now surfaces Harper diagnostics and quick-fixes inline:

<img width="623" height="442" alt="Screenshot 2026-06-29 at 08 07 43" src="https://github.com/user-attachments/assets/8d19b32c-70c9-4d2d-a0f0-fd379e4e32dc" />
<img width="669" height="455" alt="Screenshot 2026-06-29 at 08 07 58" src="https://github.com/user-attachments/assets/a257f772-3e7a-4127-8079-4223809c9cc1" />
<img width="627" height="470" alt="Screenshot 2026-06-29 at 08 08 32" src="https://github.com/user-attachments/assets/9e0bb735-2b02-4a58-be4e-5c46e375947a" />


# How Has This Been Tested?

**Automated:** Added an integration test in `packages/vscode-plugin/src/tests/suite/integration.test.ts` that opens an in-memory document, sets its language to `scminput` (the same language id VS Code gives the Source Control commit box), and asserts Harper's diagnostics. With `Errorz\n# Errorz`, the subject line is flagged while the `#` comment line is ignored — confirming the input is parsed as a git commit message. It runs in the existing `test-vscode` CI job.

**Manual:** Built `harper-ls` from this branch, ran the extension in an Extension Development Host, and typed `Fix detritis in teh code` into the Source Control commit box. Harper flags "detritis" and "teh" with suggestions, as shown in the demo.

> Note for reviewers: the linting lives in `harper-ls`, so the server must be rebuilt from this branch to see the effect — testing only the extension against a released `harper-ls` will show nothing. This mirrors the `just test-vscode` flow.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
