### PR TITLE
refactor(core): introduce `SequenceExpr::number()` constructor

### DIFF
--- a/harper-core/src/expr/duration_expr.rs
+++ b/harper-core/src/expr/duration_expr.rs
@@ -31,7 +31,7 @@ impl Expr for DurationExpr {
 
         let expr = SequenceExpr::longest_of([
             Box::new(SpelledNumberExpr) as Box<dyn Expr>,
-            Box::new(SequenceExpr::default().then_number()),
+            Box::new(SequenceExpr::number()),
             Box::new(IndefiniteArticle::default()),
             Box::new(a_couple_of),
             Box::new(a_few),

--- a/harper-core/src/expr/sequence_expr.rs
+++ b/harper-core/src/expr/sequence_expr.rs
@@ -120,6 +120,11 @@ impl SequenceExpr {
         Self::default().then_any_word()
     }
 
+    /// Match any number.
+    pub fn number() -> Self {
+        Self::default().then_number()
+    }
+
     // Expressions of more than one token
 
     /// Optionally match an expression.

--- a/harper-core/src/linting/hyphenate_number_day.rs
+++ b/harper-core/src/linting/hyphenate_number_day.rs
@@ -11,8 +11,7 @@ pub struct HyphenateNumberDay {
 
 impl Default for HyphenateNumberDay {
     fn default() -> Self {
-        let pattern = SequenceExpr::default()
-            .then_number()
+        let pattern = SequenceExpr::number()
             .then_whitespace()
             .t_aco("day")
             .then_longest_of(vec![

--- a/harper-core/src/linting/numeric_range_en_dash.rs
+++ b/harper-core/src/linting/numeric_range_en_dash.rs
@@ -60,10 +60,7 @@ impl Default for NumericRangeEnDash {
         // Match isolated numeric ranges like `12-14` or `3—5`.
         // The context check below skips dates, version chains, and similar
         // multipart numeric forms that should keep their existing separators.
-        let pattern = SequenceExpr::default()
-            .then_number()
-            .then(is_target_dash)
-            .then_number();
+        let pattern = SequenceExpr::number().then(is_target_dash).then_number();
 
         Self { expr: pattern }
     }

--- a/harper-core/src/linting/soon_to_be.rs
+++ b/harper-core/src/linting/soon_to_be.rs
@@ -31,8 +31,7 @@ impl Default for SoonToBe {
         };
 
         let hyphenated_number_modifier = || {
-            SequenceExpr::default()
-                .then_number()
+            SequenceExpr::number()
                 .then_hyphen()
                 .then_nominal()
                 .then_optional(SequenceExpr::default().then_hyphen().then_adjective())


### PR DESCRIPTION
# Issues 
N/A

# Description

Just introduces a `number()` constructor to `SequenceExpr` and uses it in the four places that already used `SequenceExpr::default().then_number()`

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
