### PR TITLE
feat: call it quit→call it quits

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5319,6 +5319,13 @@
 								"state": true,
 								"label": "A Means To An End"
 							}
+						},
+						{
+							"Bool": {
+								"name": "CallItQuits",
+								"state": true,
+								"label": "Call It Quits"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/call_it_quits.rs
+++ b/harper-core/src/linting/call_it_quits.rs
@@ -1,0 +1,163 @@
+use crate::{
+    Lint, Token,
+    expr::{Expr, SequenceExpr},
+    linting::{
+        ExprLinter, LintKind, Suggestion,
+        expr_linter::{Chunk, followed_by_token},
+    },
+};
+
+pub struct CallItQuits {
+    expr: SequenceExpr,
+}
+
+impl Default for CallItQuits {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::word_set(&["call", "calls", "called", "calling"])
+                .t_ws()
+                .t_aco("it")
+                .t_ws()
+                // "Quit" and "QUIT" would result in many false positives.
+                .then_exact_word("quit"),
+        }
+    }
+}
+
+impl ExprLinter for CallItQuits {
+    type Unit = Chunk;
+
+    fn match_to_lint_with_context(
+        &self,
+        matched_tokens: &[Token],
+        _source: &[char],
+        context: Option<(&[Token], &[Token])>,
+    ) -> Option<Lint> {
+        // Watch out for calling a funciton `quit()`
+        if followed_by_token(context, |t| t.kind.is_open_round()) {
+            return None;
+        }
+
+        Some(Lint {
+            span: matched_tokens.last()?.span,
+            lint_kind: LintKind::Usage,
+            suggestions: vec![Suggestion::ReplaceWith("quits".chars().collect())],
+            message: "This idiom uses the plural 'quits' to mean 'gives up' or 'stops'.".to_owned(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects wrong variants of the idiom 'call it quits'."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    use super::CallItQuits;
+
+    #[test]
+    fn fix_cant_now() {
+        assert_suggestion_result(
+            "You can't call it quit now, you need to see it through !!",
+            CallItQuits::default(),
+            "You can't call it quits now, you need to see it through !!",
+        );
+    }
+
+    #[test]
+    fn fix_for_the_evening() {
+        assert_suggestion_result(
+            "do some maintenance and logistics before you call it quit for the evening",
+            CallItQuits::default(),
+            "do some maintenance and logistics before you call it quits for the evening",
+        );
+    }
+
+    #[test]
+    fn fix_before_calling() {
+        assert_suggestion_result(
+            "you may like to put a large number for TIMEOUT, so that before calling it quit, xstress will wait to see",
+            CallItQuits::default(),
+            "you may like to put a large number for TIMEOUT, so that before calling it quits, xstress will wait to see",
+        );
+    }
+
+    #[test]
+    fn fix_might_need_to() {
+        assert_suggestion_result(
+            "But I feel like I might need to call it quit and calibrate/find parameters myself and ignore the data provided/used inside OpenVR.",
+            CallItQuits::default(),
+            "But I feel like I might need to call it quits and calibrate/find parameters myself and ignore the data provided/used inside OpenVR.",
+        );
+    }
+
+    #[test]
+    fn fix_finally() {
+        assert_suggestion_result(
+            "I was about to call it quit but I tried a second time this way and it finally worked",
+            CallItQuits::default(),
+            "I was about to call it quits but I tried a second time this way and it finally worked",
+        );
+    }
+
+    #[test]
+    fn fix_ctf() {
+        assert_suggestion_result(
+            "everyone got tired, we called it quit and the CTF ended",
+            CallItQuits::default(),
+            "everyone got tired, we called it quits and the CTF ended",
+        );
+    }
+
+    #[test]
+    fn avoid_some_call_it() {
+        assert_no_lints(
+            "Some call it Quit, some Exit and some Close, There's no issue to fix.",
+            CallItQuits::default(),
+        );
+    }
+
+    #[test]
+    fn avoid_lets_call_it() {
+        assert_no_lints(
+            "and i need a new UiMode variant let's call it Quit.",
+            CallItQuits::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flg_wither_intervenin_punctuation() {
+        assert_no_lints(
+            "I try it, but I can't find function of dispose called. it quit immediately.",
+            CallItQuits::default(),
+        );
+    }
+
+    #[test]
+    fn avoid_flagging_all_caps_possible_false_positives() {
+        assert_no_lints("Just call it QUIT and you're done.", CallItQuits::default());
+    }
+
+    #[test]
+    fn avoid_flagging_function_names() {
+        assert_no_lints(
+            "call it soloSplit() , call it quit() or whatever else would be nice",
+            CallItQuits::default(),
+        );
+    }
+
+    #[test]
+    fn avoid_flagging_stop_button() {
+        assert_no_lints(
+            "The Stop button (or maybe call it Quit) should stop just like the Pause button does",
+            CallItQuits::default(),
+        );
+    }
+}

--- a/harper-core/src/linting/expr_linter.rs
+++ b/harper-core/src/linting/expr_linter.rs
@@ -152,10 +152,23 @@ pub fn followed_by_word(
     false
 }
 
-pub fn followed_by_hyphen(context: Option<(&[Token], &[Token])>) -> bool {
+/// Check for a specific token type after a matched span.
+///
+/// Validates that the "after" context starts with a token that matches the predicate.
+/// This is useful for checking for specific punctuation or other token types.
+///
+/// Returns `false` if context is `None`, missing tokens, or the structure is malformed.
+pub fn followed_by_token(
+    context: Option<(&[Token], &[Token])>,
+    predicate: impl Fn(&Token) -> bool,
+) -> bool {
     context
         .and_then(|(_, after)| after.first())
-        .is_some_and(|hy| hy.kind.is_hyphen())
+        .is_some_and(predicate)
+}
+
+pub fn followed_by_hyphen(context: Option<(&[Token], &[Token])>) -> bool {
+    followed_by_token(context, |hy| hy.kind.is_hyphen())
 }
 
 /// Counterintuitively, a sentence includes the whitespace after

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -44,6 +44,7 @@ use super::brand_brandish::BrandBrandish;
 use super::by_accident::ByAccident;
 use super::by_ones_own::ByOnesOwn;
 use super::by_the_book::ByTheBook;
+use super::call_it_quits::CallItQuits;
 use super::call_them::CallThem;
 use super::cant::Cant;
 use super::capitalize_personal_pronouns::CapitalizePersonalPronouns;
@@ -620,6 +621,7 @@ impl LintGroup {
         insert_expr_rule!(ByAccident, true);
         insert_expr_rule!(ByOnesOwn, true);
         insert_expr_rule!(ByTheBook, true);
+        insert_expr_rule!(CallItQuits, true);
         insert_expr_rule!(CallThem, true);
         insert_expr_rule!(Cant, true);
         insert_struct_rule!(CapitalizePersonalPronouns, true);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -37,6 +37,7 @@ mod brand_brandish;
 mod by_accident;
 mod by_ones_own;
 mod by_the_book;
+mod call_it_quits;
 mod call_them;
 mod cant;
 mod capitalize_personal_pronouns;


### PR DESCRIPTION
# Issues 
N/A

# Description

Yesterday in a comment thread I found somebody using "call it quit" instead of the idiomatic "call it quits".
I verified that it's not a legitimate variant and that it's common.
I found potential false positives when "quit" refers to a button, control, function, etc.
I therefore discard matches where "quit" is not all-lowercase or is followed by `(`.

To enable checking for the following `(` I added a new `followed_by_token()` method and modified the existing `followed_by_hyphen()` method to also call it.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
