### PR TITLE
feat: link list→linked list

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5319,6 +5319,13 @@
 								"state": true,
 								"label": "A Means To An End"
 							}
+						},
+						{
+							"Bool": {
+								"name": "LinkedList",
+								"state": true,
+								"label": "Linked List"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/weir_rules/LinkedList/Plural.weir
+++ b/harper-core/src/linting/weir_rules/LinkedList/Plural.weir
@@ -1,0 +1,10 @@
+expr main link lists
+
+let message "If you mean the low-level data structure, use `linked lists` instead of `link lists`."
+let description "Corrects `link lists` to `linked lists`."
+let kind "Usage"
+let becomes "linked lists"
+
+test "Tree data structure was used for the implementation of buddy system where as two separate doubly link lists have been used to keep the record of the holes and the memory allocated to the processes" "Tree data structure was used for the implementation of buddy system where as two separate doubly linked lists have been used to keep the record of the holes and the memory allocated to the processes"
+test "Link lists are self organizing to keep the nodes close to each other to benefit from cache locality." "Linked lists are self organizing to keep the nodes close to each other to benefit from cache locality."
+test "Link lists are composed of nodes. Each node contains a value and points to a single child node: Visualization of 4 nodes in a linked list." "Linked lists are composed of nodes. Each node contains a value and points to a single child node: Visualization of 4 nodes in a linked list."

--- a/harper-core/src/linting/weir_rules/LinkedList/Singular.weir
+++ b/harper-core/src/linting/weir_rules/LinkedList/Singular.weir
@@ -1,0 +1,14 @@
+expr main link list
+
+let message "If you mean the low-level data structure, use `linked list` instead of `link list`."
+let description "Corrects `link list` to `linked list`."
+let kind "Usage"
+let becomes "linked list"
+
+#TODO broken due to #3741 - replace_with_match_case works by index
+#test "Backtracking/Examples/Reverse Link List Recursion.java" "Backtracking/Examples/Reverse Linked List Recursion.java"
+#test "006 Link List/       → More linked list practice" "006 Linked List/       → More linked list practice"
+#test "LIST OF DATA STRUCTURES · Link List. Singly linked list; Doubly linked list; Circular linked list · Stacks. Array based; Link List based · Queues." "LIST OF DATA STRUCTURES · Linked List. Singly linked list; Doubly linked list; Circular linked list · Stacks. Array based; Linked List based · Queues."
+test "Doubly link list with header circular." "Doubly linked list with header circular."
+test "link list implementation in c language." "linked list implementation in c language."
+test "use one pointer to construct double-link list." "use one pointer to construct double-linked list."


### PR DESCRIPTION
# Issues 
N/A

# Description

It's not uncommon for some nonnative English speakers to use "link list" when referring to a "linked list". It's occasionally probably also done as a typo by native speakers.

It's also commonly used legitimately for things like an HTML `ol` or `ul` or a ListView in a UI offering a selection of URLs etc.

Due to this it offers guidance in its `message` about when to use a suggestion.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
