### PR TITLE
docs(harper-ls): declare that we only support the latest stable Rust version

### DIFF
--- a/packages/web/src/routes/docs/integrations/language-server/+page.md
+++ b/packages/web/src/routes/docs/integrations/language-server/+page.md
@@ -68,7 +68,7 @@ If you have Rust installed, `harper-ls` is on [crates.io](https://crates.io/crat
 cargo install harper-ls --locked
 ```
 
-For this to work, make sure that `~/.cargo/bin` is in your system `$PATH`. If you are on a Debian-based Linux distribution, you may need to install `build-essential`.
+For this to work, make sure that `~/.cargo/bin` is in your system `$PATH`. If you are on a Debian-based Linux distribution, you may need to install `build-essential`. We only support the latest stable version of Rust. If you are not sure if you have the latest version already, you may compare the output of `rustc --version` to the content of [this page.](https://blog.rust-lang.org/releases/latest)
 
 ### GitHub Releases
 


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Related to #3730.

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

Adds a statement on the bit of the website where we explain how to install `harper-ls` with `cargo` declaring that we only support the latest version of Rust.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
