### PR TITLE
refactor: missed lint message `.to_string()` change to `.to_owned()`

### DIFF
--- a/harper-core/expr_linter_skeleton.rs
+++ b/harper-core/expr_linter_skeleton.rs
@@ -32,7 +32,7 @@ impl ExprLinter for ExprLinterSkeleton {
             "correction",
             span.get_content(source),
         )];
-        let message = "Fix this erorr".to_string();
+        let message = "Fix this erorr".to_owned();
         Some(Lint {
             span,
             lint_kind,

--- a/harper-core/expr_linter_skeleton_commented.rs
+++ b/harper-core/expr_linter_skeleton_commented.rs
@@ -91,7 +91,7 @@ impl ExprLinter for ExprLinterSkeleton {
         // EDIT   your message should allow for both possibilities.
         // EDIT Likewise, if two or more suggestions are very different, as happens with
         // EDIT   confusable words, it's a good idea to guide the user with concise definitions.
-        let message = "Fix this erorr".to_string();
+        let message = "Fix this erorr".to_owned();
 
         // EDIT You can return different `Lint`s from different places in your logic.
         Some(Lint {

--- a/harper-core/src/linting/adjective_double_degree.rs
+++ b/harper-core/src/linting/adjective_double_degree.rs
@@ -42,7 +42,7 @@ impl ExprLinter for AdjectiveDoubleDegree {
             (['m', 'o', 'r', 'e'], true, false) => (
                 LintKind::Redundancy,
                 "Using `more` and the comparative form of the adjective together is redundant."
-                    .to_string(),
+                    .to_owned(),
                 vec![Suggestion::replace_with_match_case(
                     adj_chars.to_vec(),
                     phrase_chars,
@@ -51,7 +51,7 @@ impl ExprLinter for AdjectiveDoubleDegree {
             (['m', 'o', 's', 't'], false, true) => (
                 LintKind::Redundancy,
                 "Using `most` and the superlative form of the adjective together is redundant."
-                    .to_string(),
+                    .to_owned(),
                 vec![Suggestion::replace_with_match_case(
                     adj_chars.to_vec(),
                     phrase_chars,
@@ -84,7 +84,7 @@ impl ExprLinter for AdjectiveDoubleDegree {
                 (
                     LintKind::WordChoice,
                     "The degree of the adverb conflicts with the degree of the adjective."
-                        .to_string(),
+                        .to_owned(),
                     vec![
                         Suggestion::replace_with_match_case(adj_chars.to_vec(), phrase_chars),
                         Suggestion::replace_with_match_case(other_adj_degree, phrase_chars),

--- a/harper-core/src/linting/as_to_interrogative.rs
+++ b/harper-core/src/linting/as_to_interrogative.rs
@@ -48,7 +48,7 @@ impl ExprLinter for AsToInterrogative {
                 "as to",
                 matched_tokens[2].get_ch(source),
             )],
-            message: "This construction requires `as to` instead of just `to`.".to_string(),
+            message: "This construction requires `as to` instead of just `to`.".to_owned(),
             ..Default::default()
         })
     }

--- a/harper-core/src/linting/be_adjective_confusions.rs
+++ b/harper-core/src/linting/be_adjective_confusions.rs
@@ -90,7 +90,7 @@ impl ExprLinter for BeAdjectiveLinter {
                 self.adjective,
                 wtok.span.get_content(src),
             )],
-            message: self.message.to_string(),
+            message: self.message.to_owned(),
             ..Default::default()
         })
     }

--- a/harper-core/src/linting/by_ones_own.rs
+++ b/harper-core/src/linting/by_ones_own.rs
@@ -88,7 +88,7 @@ impl ExprLinter for ByOnesOwn {
             suggestions,
             message:
                 "`By one's own` is not idiomatic. Consider either `on one's own` or `by oneself`."
-                    .to_string(),
+                    .to_owned(),
             ..Default::default()
         })
     }

--- a/harper-core/src/linting/capitalize_personal_pronouns.rs
+++ b/harper-core/src/linting/capitalize_personal_pronouns.rs
@@ -30,7 +30,7 @@ impl Linter for CapitalizePersonalPronouns {
                         lint_kind: LintKind::Capitalization,
                         suggestions: vec![Suggestion::ReplaceWith(replacement)],
                         message: "The first-person singular subject pronoun must be capitalized."
-                            .to_string(),
+                            .to_owned(),
                         priority: 31,
                     })
                 } else {

--- a/harper-core/src/linting/catch_22.rs
+++ b/harper-core/src/linting/catch_22.rs
@@ -43,7 +43,7 @@ impl ExprLinter for Catch22 {
                 "catch",
                 toks[0].span.get_content(src),
             )],
-            message: "This idiom uses 'catch' instead of 'cache' or 'cash'.".to_string(),
+            message: "This idiom uses 'catch' instead of 'cache' or 'cash'.".to_owned(),
             ..Default::default()
         })
     }

--- a/harper-core/src/linting/code_in_write_in.rs
+++ b/harper-core/src/linting/code_in_write_in.rs
@@ -91,7 +91,7 @@ impl ExprLinter for CodeInWriteIn {
                 span.get_content(source),
             )],
             message: "For writing code, the preposition should be `in` rather than `on`."
-                .to_string(),
+                .to_owned(),
             ..Default::default()
         })
     }

--- a/harper-core/src/linting/complain_as_noun.rs
+++ b/harper-core/src/linting/complain_as_noun.rs
@@ -47,7 +47,7 @@ impl ExprLinter for ComplainAsNoun {
                 noun.to_vec(),
                 matched_tokens[idx].get_ch(source),
             )],
-            message: "The noun form is `complaint`.".to_string(),
+            message: "The noun form is `complaint`.".to_owned(),
             ..Default::default()
         })
     }

--- a/harper-core/src/linting/convenient_store.rs
+++ b/harper-core/src/linting/convenient_store.rs
@@ -145,7 +145,7 @@ impl ExprLinter for ConvenientStore {
             "convenience",
             span.get_content(src),
         )];
-        let message = "Did you mean `convenience store`?".to_string();
+        let message = "Did you mean `convenience store`?".to_owned();
         Some(Lint {
             span,
             lint_kind,

--- a/harper-core/src/linting/determiner_without_noun.rs
+++ b/harper-core/src/linting/determiner_without_noun.rs
@@ -33,8 +33,7 @@ impl ExprLinter for DeterminerWithoutNoun {
             span,
             lint_kind: LintKind::Miscellaneous,
             suggestions: Vec::<Suggestion>::new(),
-            message: "A determiner should not be immediately followed by a conjunction."
-                .to_string(),
+            message: "A determiner should not be immediately followed by a conjunction.".to_owned(),
             priority: 32,
         })
     }

--- a/harper-core/src/linting/disjoint_prefixes.rs
+++ b/harper-core/src/linting/disjoint_prefixes.rs
@@ -130,7 +130,7 @@ impl<D: Dictionary> ExprLinter for DisjointPrefixes<D> {
             lint_kind: LintKind::Spelling,
             suggestions,
             message: "This looks like a prefix that can be joined with the rest of the word."
-                .to_string(),
+                .to_owned(),
             ..Default::default()
         })
     }

--- a/harper-core/src/linting/except_of.rs
+++ b/harper-core/src/linting/except_of.rs
@@ -56,7 +56,7 @@ impl ExprLinter for ExceptOf {
                 replacement,
                 span.get_content(src),
             )],
-            message: msg.to_string(),
+            message: msg.to_owned(),
             ..Default::default()
         })
     }

--- a/harper-core/src/linting/fascinated_by.rs
+++ b/harper-core/src/linting/fascinated_by.rs
@@ -38,7 +38,7 @@ impl ExprLinter for FascinatedBy {
                 Suggestion::replace_with_match_case_str("with", prep_chars),
             ],
             message: "The correct prepositions to use with `fascinated` are `by` or `with`."
-                .to_string(),
+                .to_owned(),
             ..Default::default()
         })
     }

--- a/harper-core/src/linting/few_units_of_time_ago.rs
+++ b/harper-core/src/linting/few_units_of_time_ago.rs
@@ -50,7 +50,7 @@ impl ExprLinter for FewUnitsOfTimeAgo {
         Some(Lint {
             span: span.unwrap(),
             message: "In this construction you need to use `a few` instead of just `few`."
-                .to_string(),
+                .to_owned(),
             suggestions: vec![Suggestion::replace_with_match_case_str(
                 "a few",
                 span.unwrap().get_content(src),

--- a/harper-core/src/linting/handful_of_more.rs
+++ b/harper-core/src/linting/handful_of_more.rs
@@ -32,7 +32,7 @@ impl ExprLinter for HandfulOfMore {
             span: matched_tokens[first_ws_idx..=of_idx].span()?,
             lint_kind: LintKind::Nonstandard,
             suggestions: vec![Suggestion::Remove],
-            message: "Using `of` in this construction is not standard.".to_string(),
+            message: "Using `of` in this construction is not standard.".to_owned(),
             ..Default::default()
         })
     }

--- a/harper-core/src/linting/it_is.rs
+++ b/harper-core/src/linting/it_is.rs
@@ -67,8 +67,7 @@ impl ExprLinter for ItIs {
                 "it's".chars().collect(),
                 text,
             )],
-            message: "Consider using 'it's' (it is) instead of 'its' (possessive form)."
-                .to_string(),
+            message: "Consider using 'it's' (it is) instead of 'its' (possessive form).".to_owned(),
             priority: 31,
         })
     }

--- a/harper-core/src/linting/jump_the_gun.rs
+++ b/harper-core/src/linting/jump_the_gun.rs
@@ -40,7 +40,7 @@ impl ExprLinter for JumpTheGun {
                 "the gun",
                 det_ws_gun_span.get_content(source),
             )],
-            message: "The correct idiom is `jump the gun`".to_string(),
+            message: "The correct idiom is `jump the gun`".to_owned(),
             ..Default::default()
         })
     }

--- a/harper-core/src/linting/less_worse.rs
+++ b/harper-core/src/linting/less_worse.rs
@@ -88,7 +88,7 @@ impl ExprLinter for LessWorse {
                 .iter()
                 .map(|s| Suggestion::replace_with_match_case(s.to_vec(), template))
                 .collect::<Vec<_>>(),
-            message: message.to_string(),
+            message: message.to_owned(),
             priority: 126,
         })
     }

--- a/harper-core/src/linting/map_phrase_linter.rs
+++ b/harper-core/src/linting/map_phrase_linter.rs
@@ -128,7 +128,7 @@ impl ExprLinter for MapPhraseLinter {
                     )
                 })
                 .collect(),
-            message: self.message.to_string(),
+            message: self.message.to_owned(),
             priority: 31,
         })
     }

--- a/harper-core/src/linting/map_phrase_set_linter.rs
+++ b/harper-core/src/linting/map_phrase_set_linter.rs
@@ -113,7 +113,7 @@ impl<'a> ExprLinter for MapPhraseSetLinter<'a> {
             span,
             lint_kind: self.lint_kind,
             suggestions,
-            message: self.message.to_string(),
+            message: self.message.to_owned(),
             priority: 31,
         })
     }

--- a/harper-core/src/linting/means_a_lot_to.rs
+++ b/harper-core/src/linting/means_a_lot_to.rs
@@ -54,7 +54,7 @@ impl ExprLinter for MeansALotTo {
                 sug.chars().collect(),
                 span.get_content(src),
             )],
-            message: msg.to_string(),
+            message: msg.to_owned(),
             ..Default::default()
         })
     }

--- a/harper-core/src/linting/modal_be_adjective.rs
+++ b/harper-core/src/linting/modal_be_adjective.rs
@@ -64,7 +64,7 @@ impl ExprLinter for ModalBeAdjective {
             span: toks[0].span,
             suggestions: vec![Suggestion::InsertAfter(" be".chars().collect())],
             message: "You may be missing the word `be` between this modal verb and adjective."
-                .to_string(),
+                .to_owned(),
             ..Default::default()
         })
     }

--- a/harper-core/src/linting/more_adjective.rs
+++ b/harper-core/src/linting/more_adjective.rs
@@ -170,7 +170,7 @@ impl<D: Dictionary> ExprLinter for MoreAdjective<D> {
             lint_kind: LintKind::Style,
             suggestions,
             message: "This is not an error, but an inflected form of this adjective also exists"
-                .to_string(),
+                .to_owned(),
             ..Default::default()
         })
     }

--- a/harper-core/src/linting/oldest_in_the_book.rs
+++ b/harper-core/src/linting/oldest_in_the_book.rs
@@ -66,7 +66,7 @@ impl ExprLinter for OldestInTheBook {
         } else {
             "If this is a play on the idiom `oldest trick in the book`, it should use singular `book` instead of plural `books`."
         }
-        .to_string();
+        .to_owned();
 
         Some(Lint {
             span: toks.last()?.span,

--- a/harper-core/src/linting/on_floor.rs
+++ b/harper-core/src/linting/on_floor.rs
@@ -78,7 +78,7 @@ impl ExprLinter for OnFloor {
             message: format!(
                 "Corrects `{incorrect_preposition}` to `on` when talking about position inside a building",
             )
-            .to_string(),
+            .to_owned(),
             priority: 63,
         })
     }

--- a/harper-core/src/linting/ought_to_be.rs
+++ b/harper-core/src/linting/ought_to_be.rs
@@ -72,7 +72,7 @@ impl ExprLinter for OughtToBe {
                 original,
             )],
             message: "Did you mean `ought to be` (expressing expectation or obligation)?"
-                .to_string(),
+                .to_owned(),
             priority: 31,
         })
     }

--- a/harper-core/src/linting/pay_for_price.rs
+++ b/harper-core/src/linting/pay_for_price.rs
@@ -37,7 +37,7 @@ impl ExprLinter for PayForPrice {
         let span = matched_tokens[2..4].span()?;
         let lint_kind = LintKind::Usage;
         let suggestions = vec![Suggestion::Remove];
-        let message = "You `pay for` things or services, but just `pay prices/fees`, etc with no preposition.".to_string();
+        let message = "You `pay for` things or services, but just `pay prices/fees`, etc with no preposition.".to_owned();
         Some(Lint {
             span,
             lint_kind,

--- a/harper-core/src/linting/plural_wrong_word_of_phrase.rs
+++ b/harper-core/src/linting/plural_wrong_word_of_phrase.rs
@@ -115,8 +115,7 @@ impl ExprLinter for PluralWrongWordOfPhrase {
                     .collect::<Vec<char>>(),
                 toks.span()?.get_content(src),
             )],
-            message: "This phrase is pluralized on the main noun, not on the last noun."
-                .to_string(),
+            message: "This phrase is pluralized on the main noun, not on the last noun.".to_owned(),
             ..Default::default()
         })
     }

--- a/harper-core/src/linting/possessive_noun.rs
+++ b/harper-core/src/linting/possessive_noun.rs
@@ -75,7 +75,7 @@ impl<D: Dictionary> ExprLinter for PossessiveNoun<D> {
             span,
             lint_kind: LintKind::Miscellaneous,
             suggestions: vec![Suggestion::ReplaceWith(replacement.chars().collect())],
-            message: self.description().to_string(),
+            message: self.description().to_owned(),
             priority: 10,
         })
     }

--- a/harper-core/src/linting/pronoun_verb_agreement.rs
+++ b/harper-core/src/linting/pronoun_verb_agreement.rs
@@ -231,7 +231,7 @@ impl<D: Dictionary> ExprLinter for PronounVerbAgreement<D> {
             lint_kind: LintKind::Agreement,
             suggestions,
             message: "The form of the verb must agree in grammatical number with the pronoun."
-                .to_string(),
+                .to_owned(),
             ..Default::default()
         })
     }

--- a/harper-core/src/linting/proper_noun_capitalization_linters.rs
+++ b/harper-core/src/linting/proper_noun_capitalization_linters.rs
@@ -71,7 +71,7 @@ impl ExprLinter for ProperNounCapitalizationLinter {
             suggestions: vec![Suggestion::ReplaceWith(
                 canonical_case.get_source().to_vec(),
             )],
-            message: self.description.to_string(),
+            message: self.description.to_owned(),
             priority: 31,
         })
     }

--- a/harper-core/src/linting/redundant_progressive_comparative.rs
+++ b/harper-core/src/linting/redundant_progressive_comparative.rs
@@ -56,7 +56,7 @@ impl ExprLinter for RedundantProgressiveComparative {
                 replacement,
                 span.get_content(src),
             )],
-            message: message.to_string(),
+            message: message.to_owned(),
             priority: 31,
         })
     }

--- a/harper-core/src/linting/sentence_capitalization.rs
+++ b/harper-core/src/linting/sentence_capitalization.rs
@@ -83,7 +83,7 @@ impl<T: Dictionary> Linter for SentenceCapitalization<T> {
                             suggestions: vec![Suggestion::ReplaceWith(replacement_chars)],
                             priority: 31,
                             message: "This sentence does not start with a capital letter"
-                                .to_string(),
+                                .to_owned(),
                         });
                     }
                 }

--- a/harper-core/src/linting/take_medicine.rs
+++ b/harper-core/src/linting/take_medicine.rs
@@ -98,7 +98,7 @@ impl ExprLinter for TakeMedicine {
             lint_kind: LintKind::Usage,
             suggestions,
             message: "Use a verb like `take` or `swallow` with medicine instead of `eat`."
-                .to_string(),
+                .to_owned(),
             priority: 63,
         })
     }

--- a/harper-core/src/linting/that_than.rs
+++ b/harper-core/src/linting/that_than.rs
@@ -49,7 +49,7 @@ impl ExprLinter for ThatThan {
                 that_tok.get_ch(src),
             )],
             message: "This looks like a comparison that should use `than` rather than `that`."
-                .to_string(),
+                .to_owned(),
             priority: 31,
         })
     }

--- a/harper-core/src/linting/the_last_days.rs
+++ b/harper-core/src/linting/the_last_days.rs
@@ -43,8 +43,8 @@ impl ExprLinter for TheLastDays {
         let last_idx = 4;
 
         let suggestions = vec![Suggestion::InsertAfter(" few".chars().collect())];
-        let message = "To speak about recent time use `the last few` rather than just `the last`."
-            .to_string();
+        let message =
+            "To speak about recent time use `the last few` rather than just `the last`.".to_owned();
 
         Some(Lint {
             span: toks[last_idx].span,

--- a/harper-core/src/linting/the_proper_noun_possessive.rs
+++ b/harper-core/src/linting/the_proper_noun_possessive.rs
@@ -41,7 +41,7 @@ impl ExprLinter for TheProperNounPossessive {
             suggestions: vec![Suggestion::Remove],
             message:
                 "The definite article `the` is redundant before a proper noun in the possessive."
-                    .to_string(),
+                    .to_owned(),
             ..Default::default()
         })
     }

--- a/harper-core/src/linting/the_the_to_that_the.rs
+++ b/harper-core/src/linting/the_the_to_that_the.rs
@@ -39,7 +39,7 @@ impl ExprLinter for TheTheToThatThe {
                 .iter()
                 .map(|s| Suggestion::replace_with_match_case_str(s, ch))
                 .collect(),
-            message: "Did you mean `that the` or just `the`?".to_string(),
+            message: "Did you mean `that the` or just `the`?".to_owned(),
             priority: 126, // Higher priority than `RepeatedWords`
         })
     }

--- a/harper-core/src/linting/this_type_of_thing.rs
+++ b/harper-core/src/linting/this_type_of_thing.rs
@@ -143,7 +143,7 @@ impl ExprLinter for ThisTypeOfThing {
                 bad_tok.get_ch(src),
             )],
             message: "The grammatical number of the determiner and the two nouns must agree."
-                .to_string(),
+                .to_owned(),
             ..Default::default()
         })
     }

--- a/harper-core/src/linting/thrive_on.rs
+++ b/harper-core/src/linting/thrive_on.rs
@@ -40,7 +40,7 @@ impl ExprLinter for ThriveOn {
                 span.get_content(src),
             )],
             message: "Consider using `thrive on` instead of `thrive off` or `thrive off of`."
-                .to_string(),
+                .to_owned(),
             ..Default::default()
         })
     }

--- a/harper-core/src/linting/throw_away.rs
+++ b/harper-core/src/linting/throw_away.rs
@@ -39,7 +39,7 @@ impl ExprLinter for ThrowAway {
                 Suggestion::replace_with_match_case_str("threw", original),
             ],
             message: "Use `throw away` or `threw away`, depending on the tense you need."
-                .to_string(),
+                .to_owned(),
             priority: 60,
         })
     }

--- a/harper-core/src/linting/throw_rubbish.rs
+++ b/harper-core/src/linting/throw_rubbish.rs
@@ -100,7 +100,7 @@ impl Linter for ThrowRubbish {
                         lint_kind: LintKind::Miscellaneous,
                         suggestions,
                         message: "To dispose of rubbish we don't just throw it, we throw it away"
-                            .to_string(),
+                            .to_owned(),
                         priority: 63,
                     });
                 }

--- a/harper-core/src/linting/vicious_loop/mod.rs
+++ b/harper-core/src/linting/vicious_loop/mod.rs
@@ -139,7 +139,7 @@ fn to_lint(toks: &[Token], src: &[char], pref: Prefer) -> Option<Lint> {
             )],
             message:
                 "The idiom uses the word `vicious`, not `viscous`, which describes thick liquids."
-                    .to_string(),
+                    .to_owned(),
             ..Default::default()
         });
     }

--- a/harper-core/src/linting/web_scraping.rs
+++ b/harper-core/src/linting/web_scraping.rs
@@ -120,7 +120,7 @@ fn match_web_then_scrap(toks: &[Token], src: &[char]) -> Option<Lint> {
         )],
         message:
             "`Scrap` means `discard`. The word for gathering information from websites is `scrape`."
-                .to_string(),
+                .to_owned(),
         ..Default::default()
     })
 }
@@ -154,7 +154,7 @@ fn match_scrap_then_web(toks: &[Token], src: &[char]) -> Option<Lint> {
         )],
         message:
             "`Scrap` means `discard`. The word for gathering information from websites is `scrape`."
-                .to_string(),
+                .to_owned(),
         ..Default::default()
     })
 }

--- a/harper-core/src/linting/will_non_lemma.rs
+++ b/harper-core/src/linting/will_non_lemma.rs
@@ -159,8 +159,7 @@ impl<D: Dictionary> ExprLinter for WillNonLemma<D> {
             span: toks.span()?,
             lint_kind: LintKind::Grammar,
             suggestions,
-            message: "`Will` and `shall` should be followed by a verb in its base form."
-                .to_string(),
+            message: "`Will` and `shall` should be followed by a verb in its base form.".to_owned(),
             ..Default::default()
         })
     }


### PR DESCRIPTION
# Issues 

Continues on from what was missed in https://github.com/Automattic/harper/pull/3569

# Description

Back in #3569 I thought I changed all the `message` fields of `Lint`s that were using `.to_string()` to standardize on `.to_owned()` after looking into why both were used and finding reasons that `.to_owned()` was probably the better one after all, despite my using `.to_string()` in most of my linters.

Before searching the repo I expected only the skeleton linters were still using `.to_string()` but there was a lot I was missing!

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
