### PR TITLE
feat: clearly state that the desktop app is in beta

### DIFF
--- a/packages/web/src/routes/desktop/+page.svelte
+++ b/packages/web/src/routes/desktop/+page.svelte
@@ -50,6 +50,9 @@ const faqs = [
 					Use Harper Desktop in the apps you use every day such as Mail, Slack, Notes, Pages,
 					and Discord.
 				</p>
+				<p class="!mt-5 !mb-0 max-w-[28.75rem] text-base leading-[1.6] text-[#4a463e] dark:text-white/70">
+          Currently in beta.
+				</p>
 				<div class="mt-6 flex flex-col items-start gap-[0.6rem] [&_svg]:size-[0.95rem] [&_svg]:fill-current">
 					<PillButton href="/desktop/download" size="lg">
 						<svg slot="icon" viewBox="0 0 24 24" aria-hidden="true">
@@ -130,7 +133,7 @@ const faqs = [
 				Free. Forever. Yours.
 			</h2>
 			<p class="!mt-6 !mb-[1.6rem] text-base leading-[1.6] text-[#4a463e] dark:text-white/70">
-				Harper Desktop is free, like the rest of Harper. No account or credit card necessary.
+				Harper Desktop is free, like the rest of Harper. No account or credit card necessary. Download the beta today.
 			</p>
 			<PillButton href="/desktop/download" size="lg">Download for macOS</PillButton>
 			<div class='mt-4 text-xs text-[#807a6e] dark:text-white/55 [font-family:"JetBrains_Mono",monospace]'>macOS 14 Sonoma or later · Apple Silicon &amp; Intel</div>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

Taking a look at the desktop app's download page today, I saw that it did NOT clearly state that it was in beta.
I have done so.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
