### PR TITLE
fix: 2 unused imports and 1 nested if

### DIFF
--- a/harper-desktop/src-tauri/src/mac_broker/app_search_index.rs
+++ b/harper-desktop/src-tauri/src/mac_broker/app_search_index.rs
@@ -2,9 +2,7 @@ use std::collections::BTreeSet;
 
 use crate::os_broker::AppSearchResult;
 
-use super::app_catalog::{
-    self, app_search_result_from_bundle_id, installed_application_bundle_ids,
-};
+use super::app_catalog::{app_search_result_from_bundle_id, installed_application_bundle_ids};
 
 pub struct AppSearchIndex {
     index: Vec<AppSearchResult>,

--- a/harper-desktop/src-tauri/src/mac_broker/focused_window_pid.rs
+++ b/harper-desktop/src-tauri/src/mac_broker/focused_window_pid.rs
@@ -3,7 +3,7 @@ use accessibility_sys::{
     AXUIElementGetPid, error_string, kAXErrorSuccess, kAXFocusedApplicationAttribute, pid_t,
 };
 use core_foundation::base::TCFType;
-use objc2_app_kit::{NSRunningApplication, NSWorkspace};
+use objc2_app_kit::NSWorkspace;
 use std::error::Error as StdError;
 
 use super::core_foundation_utilities::ax_element_attribute;

--- a/harper-desktop/src-tauri/src/mac_broker/mod.rs
+++ b/harper-desktop/src-tauri/src/mac_broker/mod.rs
@@ -79,10 +79,10 @@ impl MacBroker {
     /// The process ID of the currently focused window.
     /// In the interest of performance, the returned value may be slightly stale.
     fn target_pid(&mut self) -> Result<Option<pid_t>, Box<dyn StdError>> {
-        if let Some((last_focused, measurement_time)) = self.last_focused {
-            if Instant::now().duration_since(measurement_time).as_secs() < 3 {
-                return Ok(Some(last_focused));
-            }
+        if let Some((last_focused, measurement_time)) = self.last_focused
+            && Instant::now().duration_since(measurement_time).as_secs() < 3
+        {
+            return Ok(Some(last_focused));
         }
 
         let focused_pid = focused_window_pid::focused_window_pid()?;


### PR DESCRIPTION
# Issues 
N/A

# Description

I keep seeing a couple of minor warnings when building, in the macOS broker code for Desktop. Since we have no warnings anywhere else I thought I'd fix those. In doing so I also found a Clippy warning for an `if` inside an `if let` that was just as trivially fixed.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
