### PR TITLE
feat: may of us/you/them→many of ...

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -2818,6 +2818,13 @@
 								"state": true,
 								"label": "Hazzle"
 							}
+						},
+						{
+							"Bool": {
+								"name": "MayOfPronoun",
+								"state": true,
+								"label": "May Of Pronoun"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/weir_rules/MayOfPronoun/Them.weir
+++ b/harper-core/src/linting/weir_rules/MayOfPronoun/Them.weir
@@ -1,0 +1,8 @@
+expr main (may of them)
+let message "Did you mean `many of them`?"
+let description "Corrects the typo `may of them` to `many of them`"
+let kind "Typo"
+let becomes "many of them"
+
+test "For may of them they don't follow proper semver." "For many of them they don't follow proper semver."
+test "Sorting keys in a group may be controversial though, as it seems may of them are ordered by important" "Sorting keys in a group may be controversial though, as it seems many of them are ordered by important"

--- a/harper-core/src/linting/weir_rules/MayOfPronoun/Us.weir
+++ b/harper-core/src/linting/weir_rules/MayOfPronoun/Us.weir
@@ -1,0 +1,8 @@
+expr main (may of us)
+let message "Did you mean `many of us`?"
+let description "Corrects the typo `may of us` to `many of us`"
+let kind "Typo"
+let becomes "many of us"
+
+test "It's really a great work, maybe may of us want to use this to generate a 3D model for 2D real images" "It's really a great work, maybe many of us want to use this to generate a 3D model for 2D real images"
+test "great, you don't know how so may of us are looking forward to this" "great, you don't know how so many of us are looking forward to this"

--- a/harper-core/src/linting/weir_rules/MayOfPronoun/You.weir
+++ b/harper-core/src/linting/weir_rules/MayOfPronoun/You.weir
@@ -1,0 +1,8 @@
+expr main (may of you)
+let message "Did you mean `many of you`?"
+let description "Corrects the typo `may of you` to `many of you`"
+let kind "Typo"
+let becomes "many of you"
+
+test "I, like may of you guys, have followed this thing for years, for many others, decades." "I, like many of you guys, have followed this thing for years, for many others, decades."
+test "How may of you are going? I will be there for sure!" "How many of you are going? I will be there for sure!"


### PR DESCRIPTION
# Issues 
N/A

# Description

In a comment thread somewhere I spotted the typo "may of us" or "may of them" and recognized it as a pretty common typo.

This linter fixes those and "may of you" to "many of us/you/them".

I couldn't find any false positives.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
