### PR TITLE
feat: not along after/afterward/afterwards→not long ...

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -2818,6 +2818,13 @@
 								"state": true,
 								"label": "Hazzle"
 							}
+						},
+						{
+							"Bool": {
+								"name": "NotLongAfter",
+								"state": true,
+								"label": "Not Long After"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/weir_rules/NotLongAfter/After.weir
+++ b/harper-core/src/linting/weir_rules/NotLongAfter/After.weir
@@ -1,0 +1,9 @@
+expr main (not along after)
+
+let message "Did you mean `not long after`?"
+let description "Corrects `not along after` to `not long after`."
+let kind "Typo"
+let becomes "not long after"
+
+test "Not along after the incident, one Islamic militant group called the strike a \"jihadi operation\"" "Not long after the incident, one Islamic militant group called the strike a \"jihadi operation\""
+test "Not along after the final vote, a Wikipedia admin deleted the article." "Not long after the final vote, a Wikipedia admin deleted the article."

--- a/harper-core/src/linting/weir_rules/NotLongAfter/Afterward.weir
+++ b/harper-core/src/linting/weir_rules/NotLongAfter/Afterward.weir
@@ -1,0 +1,9 @@
+expr main (not along afterward)
+
+let message "Did you mean `not long afterward`?"
+let description "Corrects `not along afterward` to `not long afterward`."
+let kind "Typo"
+let becomes "not long afterward"
+
+test "Camp Bucca closed not along afterward." "Camp Bucca closed not long afterward."
+test "Not along afterward, the cat was successfully rescued by an expressway traffic officer" "Not long afterward, the cat was successfully rescued by an expressway traffic officer"

--- a/harper-core/src/linting/weir_rules/NotLongAfter/Afterwards.weir
+++ b/harper-core/src/linting/weir_rules/NotLongAfter/Afterwards.weir
@@ -1,0 +1,9 @@
+expr main (not along afterwards)
+
+let message "Did you mean `not long afterwards`?"
+let description "Corrects `not along afterwards` to `not long afterwards`."
+let kind "Typo"
+let becomes "not long afterwards"
+
+test "Not along afterwards, the young Artemis began seeing news reports that his father had disappeared while traveling on his yacht." "Not long afterwards, the young Artemis began seeing news reports that his father had disappeared while traveling on his yacht."
+test "a younger, \“modern\” couple with three children moved in a couple houses down, and not along afterwards began to build a patio." "a younger, \“modern\” couple with three children moved in a couple houses down, and not long afterwards began to build a patio."


### PR DESCRIPTION
# Issues 
N/A

# Description

Read "not along after" somewhere while working on other stuff and realized it was either a typo or ESL English for "not long after".
While working on it I discovered the variants "not along afterward" and "not along afterwards" exist too.

I've implemented the three of them under a single Weir rule as a directory with three files.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
