### PR TITLE
fix(core): catch less common that comparisons

### DIFF
--- a/harper-core/src/linting/that_than.rs
+++ b/harper-core/src/linting/that_than.rs
@@ -1,12 +1,12 @@
 use crate::linting::expr_linter::Chunk;
 use crate::{
-    Token, TokenKind,
-    expr::{Expr, SequenceExpr},
+    CharStringExt, Token, TokenKind,
+    expr::{AnchorEnd, Expr, FirstMatchOf, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
 };
 
 pub struct ThatThan {
-    expr: SequenceExpr,
+    expr: FirstMatchOf,
 }
 
 impl Default for ThatThan {
@@ -21,8 +21,21 @@ impl Default for ThatThan {
             .t_ws()
             .then_word_except(&["way"]);
 
+        let more_less_common_that_digit_word = SequenceExpr::word_set(&["more", "less"])
+            .t_ws()
+            .t_aco("common")
+            .t_ws()
+            .t_aco("that")
+            .t_ws()
+            .then(|tok: &Token, src: &[char]| tok.get_ch(src).iter().any(|ch| ch.is_ascii_digit()))
+            .then_optional(SequenceExpr::default().then_punctuation())
+            .then(AnchorEnd);
+
         Self {
-            expr: adjective_er_that_nextword,
+            expr: FirstMatchOf::new([
+                Box::new(adjective_er_that_nextword) as Box<dyn Expr>,
+                Box::new(more_less_common_that_digit_word),
+            ]),
         }
     }
 }
@@ -35,11 +48,7 @@ impl ExprLinter for ThatThan {
     }
 
     fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
-        if toks.len() != 5 {
-            return None;
-        }
-
-        let that_tok = &toks[2];
+        let that_tok = toks.iter().find(|tok| tok.get_ch(src).eq_str("that"))?;
 
         Some(Lint {
             span: that_tok.span,
@@ -202,6 +211,42 @@ mod tests {
     fn dont_flag_more_clear_that() {
         assert_lint_count(
             "Make it more clear that users need to download the VS tooling installer for .NET Core in VS.",
+            ThatThan::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn fix_way_less_common_that_mp3() {
+        assert_suggestion_result(
+            "This format is way less common that mp3.",
+            ThatThan::default(),
+            "This format is way less common than mp3.",
+        );
+    }
+
+    #[test]
+    fn dont_flag_less_common_that_people_clause() {
+        assert_lint_count(
+            "It is less common that people configure this manually.",
+            ThatThan::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_more_common_that_users_clause() {
+        assert_lint_count(
+            "It is more common that users choose the default option.",
+            ThatThan::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn dont_flag_less_common_that_mp3_players_break() {
+        assert_lint_count(
+            "It's less common that mp3 players break than CD players.",
             ThatThan::default(),
             0,
         );


### PR DESCRIPTION
AI/agent assistance was used to prepare this patch.

This fixes #3736 by extending the existing `ThatThan` linter to catch the reported `less common that mp3` comparison shape without enabling the broader `more/less adjective that` pattern that already has known false positives.

The matcher now supports the existing comparative-adjective pattern and a constrained `more/less common that <token containing a digit>` pattern. I also updated `match_to_lint` to locate the matched `that` token dynamically, then added true-positive tests for the reported MP3 comparison and false-positive tests for valid `less/more common that ...` clauses.

Verification:
- `cargo test -p harper-core that_than -- --nocapture`
- `cargo run -p harper-cli -- lint "This format is way less common that mp3."`
- `cargo run -p harper-cli -- lint "It is less common that people configure this manually."`
- `cargo fmt -- harper-core\src\linting\that_than.rs`
- `git diff --check`
