### PR TITLE
fix(web): use correct font

### DIFF
--- a/packages/components/src/lib/styles.css
+++ b/packages/components/src/lib/styles.css
@@ -8,6 +8,8 @@
 @source "./node_modules/flowbite-svelte/**/*.{svelte,ts,js}";
 
 @theme {
+	--font-serif: Domine, serif;
+
 	--color-primary-50: #fef4e7; /* honey bronze */
 	--color-primary-100: #fce9cf;
 	--color-primary-200: #f9d49f;

--- a/packages/harper-editor/src/lib/styles.css
+++ b/packages/harper-editor/src/lib/styles.css
@@ -4,6 +4,10 @@
 
 @source "./**/*.{svelte,ts}";
 
+@theme {
+	--font-serif: Domine, serif;
+}
+
 .harper-editor {
 	--harper-editor-font-size: inherit;
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

In my recent PR to reorganize the components used by the `web` package, I inadvertantly broke the font setup.
This PR fixes the `harper-editor` and `components` packages to use the correct Domine font.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.


# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
