### PR TITLE
Fix false positive for modal 'may be'.

### DIFF
--- a/harper-core/src/expr/mergeable_words.rs
+++ b/harper-core/src/expr/mergeable_words.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use super::{Expr, SequenceExpr};
 use crate::spell::{Dictionary, FstDictionary};
-use crate::{CharString, DictWordMetadata, Span, Token};
+use crate::{CharString, CharStringExt, DictWordMetadata, Span, Token};
 
 type PredicateFn =
     dyn Fn(Option<&DictWordMetadata>, Option<&DictWordMetadata>) -> bool + Send + Sync;
@@ -41,6 +41,12 @@ impl MergeableWords {
     ) -> Option<CharString> {
         let a_chars: CharString = word_a.get_ch(source).into();
         let b_chars: CharString = word_b.get_ch(source).into();
+
+        // Don't treat "may be" as a split compound noun for "maybe" here.
+        // Deciding whether "may be" should be "maybe" depends on context and belongs in a dedicated linter.
+        if a_chars.eq_str("may") && b_chars.eq_str("be") {
+            return None;
+        }
 
         // First check if the open compound exists in the dictionary
         let mut compound = a_chars.clone();
@@ -149,5 +155,16 @@ mod tests {
         let merged = MergeableWords::new(predicate).get_merged_word(a, b, doc.get_source());
 
         assert_eq!(merged, Some("frontline".chars().collect()));
+    }
+
+    #[test]
+    fn does_not_merge_modal_may_be() {
+        let doc = Document::new_plain_english_curated("may be");
+        let a = doc.tokens().next().unwrap();
+        let b = doc.tokens().nth(2).unwrap();
+
+        let merged = MergeableWords::new(predicate).get_merged_word(a, b, doc.get_source());
+
+        assert_eq!(merged, None);
     }
 }

--- a/harper-core/src/linting/compound_nouns/mod.rs
+++ b/harper-core/src/linting/compound_nouns/mod.rs
@@ -374,6 +374,38 @@ mod tests {
     }
 
     #[test]
+    fn allow_issue_1553_short() {
+        assert_no_lints(
+            "Other people that may be interested should be able to opt in.",
+            CompoundNouns::default(),
+        );
+    }
+
+    #[test]
+    fn allow_issue_1923_key_may_be_missing() {
+        assert_no_lints(
+            "This key may be missing from the configuration.",
+            CompoundNouns::default(),
+        );
+    }
+
+    #[test]
+    fn allow_issue_1923_this_may_be_useful() {
+        assert_no_lints(
+            "This may be useful to see what a given website looks like.",
+            CompoundNouns::default(),
+        );
+    }
+
+    #[test]
+    fn allow_issue_1923_command_prompt_may_be_located() {
+        assert_no_lints(
+            "Once you've installed the build tools, this command prompt may be easily located by searching the start menu.",
+            CompoundNouns::default(),
+        );
+    }
+
+    #[test]
     fn allow_issue_1496() {
         assert_no_lints(
             "I am not able to respond to messages.",


### PR DESCRIPTION
## Summary
- Prevent `may be` from being treated as a split compound noun for `maybe`
- Add regression coverage for reported `may be` false positives

## Testing
- `cargo test -p harper-core`
- `cargo fmt --check`
