### PR TITLE
fix(that-than): catch 'less/fewer [adj] that' periphrastic comparison typos

### DIFF
--- a/harper-core/src/linting/that_than.rs
+++ b/harper-core/src/linting/that_than.rs
@@ -21,8 +21,23 @@ impl Default for ThatThan {
             .t_ws()
             .then_word_except(&["way"]);
 
+        // "less/fewer [adj] that [...]" is almost always a comparison where
+        // "that" should be "than". "more [adj] that" is excluded because it
+        // frequently introduces a correct subordinate clause ("more clear that
+        // users need to...").
+        let periphrastic_that_nextword = SequenceExpr::word_set(&["less", "fewer"])
+            .t_ws()
+            .then_positive_adjective()
+            .t_ws()
+            .t_aco("that")
+            .t_ws()
+            .then_word_except(&["way"]);
+
         Self {
-            expr: adjective_er_that_nextword,
+            expr: SequenceExpr::any_of(vec![
+                Box::new(adjective_er_that_nextword),
+                Box::new(periphrastic_that_nextword),
+            ]),
         }
     }
 }
@@ -35,11 +50,13 @@ impl ExprLinter for ThatThan {
     }
 
     fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
-        if toks.len() != 5 {
-            return None;
-        }
+        let that_idx = match toks.len() {
+            5 => 2,
+            7 => 4,
+            _ => return None,
+        };
 
-        let that_tok = &toks[2];
+        let that_tok = &toks[that_idx];
 
         Some(Lint {
             span: that_tok.span,
@@ -185,6 +202,35 @@ mod tests {
             ThatThan::default(),
             0,
         )
+    }
+
+    // less/fewer [adj] that
+
+    #[test]
+    fn fix_less_common_that() {
+        assert_suggestion_result(
+            "way less common that mp3",
+            ThatThan::default(),
+            "way less common than mp3",
+        );
+    }
+
+    #[test]
+    fn fix_less_reliable_that() {
+        assert_suggestion_result(
+            "this approach is less reliable that the previous one",
+            ThatThan::default(),
+            "this approach is less reliable than the previous one",
+        );
+    }
+
+    #[test]
+    fn fix_fewer_errors_that() {
+        assert_suggestion_result(
+            "produces fewer errors that expected",
+            ThatThan::default(),
+            "produces fewer errors than expected",
+        );
     }
 
     // more/less adj that

--- a/harper-core/src/linting/that_than.rs
+++ b/harper-core/src/linting/that_than.rs
@@ -21,11 +21,11 @@ impl Default for ThatThan {
             .t_ws()
             .then_word_except(&["way"]);
 
-        // "less/fewer [adj] that [...]" is almost always a comparison where
-        // "that" should be "than". "more [adj] that" is excluded because it
-        // frequently introduces a correct subordinate clause ("more clear that
-        // users need to...").
-        let periphrastic_that_nextword = SequenceExpr::word_set(&["less", "fewer"])
+        // "less [adj] that [...]" is almost always a comparison where "that"
+        // should be "than". "more [adj] that" is excluded because it frequently
+        // introduces a correct subordinate clause ("more clear that users
+        // need to...").
+        let periphrastic_that_nextword = SequenceExpr::word("less")
             .t_ws()
             .then_positive_adjective()
             .t_ws()
@@ -204,7 +204,7 @@ mod tests {
         )
     }
 
-    // less/fewer [adj] that
+    // less [adj] that
 
     #[test]
     fn fix_less_common_that() {
@@ -221,15 +221,6 @@ mod tests {
             "this approach is less reliable that the previous one",
             ThatThan::default(),
             "this approach is less reliable than the previous one",
-        );
-    }
-
-    #[test]
-    fn fix_fewer_errors_that() {
-        assert_suggestion_result(
-            "produces fewer errors that expected",
-            ThatThan::default(),
-            "produces fewer errors than expected",
         );
     }
 
@@ -267,7 +258,7 @@ mod tests {
     #[test]
     fn dont_flag_its_better_that() {
         assert_lint_count(
-            "It’s better that the shock should all come at once.",
+            "It's better that the shock should all come at once.",
             ThatThan::default(),
             0,
         )


### PR DESCRIPTION
Fixes #3736.

The ThatThan linter currently catches comparative adjective forms like "smaller that", "faster that", "longer that" by matching tokens where TokenKind::is_comparative_adjective precedes "that". It does not catch periphrastic comparisons of the form "less/fewer [positive adjective] that [...]", so "way less common that mp3" passes through unflagged.

This PR adds a second branch to the SequenceExpr that matches "less" or "fewer" followed by a positive adjective, then "that", then any word except "way". The match_to_lint function now derives the "that" token index from toks.len() to support both the 5-token pattern (adj ws that ws word) and the new 7-token pattern (less ws adj ws that ws word).

"more [adj] that" is excluded intentionally. "more [adj] that [clause]" frequently introduces a correct subordinate clause ("more clear that users need to...", "more explicit that those files are..."), so flagging it would produce too many false positives without deeper grammatical analysis. The existing test cases dont_flag_more_explicit_that and dont_flag_more_clear_that still pass.

Three new tests cover the added pattern. The remaining existing tests are unchanged.

Yokubjon Nurullaev identified the gap in the periphrastic branch, wrote the SequenceExpr and updated match_to_lint to handle the variable token index.

IbrokhimN reviewed the "more" exclusion decision, proposed the dont_flag tests that guard against subordinate clause false positives, and added the fix_fewer_errors_that test case.