### PR TITLE
feat(core): flag "tenant" misused for "tenet"

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -3793,6 +3793,13 @@
 						},
 						{
 							"Bool": {
+								"name": "TenantTenet",
+								"state": true,
+								"label": "Tenant Tenet"
+							}
+						},
+						{
+							"Bool": {
 								"name": "ToWorryAbout",
 								"state": true,
 								"label": "To Worry About"

--- a/harper-core/src/linting/weir_rules/TenantTenet/Plural.weir
+++ b/harper-core/src/linting/weir_rules/TenantTenet/Plural.weir
@@ -1,8 +1,8 @@
 expr adj [core, central, fundamental, basic, guiding, cardinal, underlying, foundational, defining]
-expr main <(@adj tenants), tenants>
+expr main <(@adj tenants !NOUN), tenants>
 
 let message "Did you mean `tenets`?"
-let description "`Tenants` (renters) is easily confused with `tenets` (principles). After an adjective like `core` or `fundamental`, the principle sense is the intended one."
+let description "`Tenants` (renters) is easily confused with `tenets` (principles). After an adjective like `core` or `fundamental`, the principle sense is the intended one. Skipped when `tenants` modifies a following noun, where the renter or multi-tenancy sense is meant."
 let kind "Malapropism"
 let becomes "tenets"
 let strategy "MatchCase"
@@ -19,3 +19,6 @@ allows "The building has three tenants."
 allows "The apartment's tenants moved out."
 allows "The main tenants renewed their leases."
 allows "Commercial tenants pay higher rent."
+
+allows "The core tenants list is stored per region."
+allows "Our basic tenants dashboard shows usage."

--- a/harper-core/src/linting/weir_rules/TenantTenet/Plural.weir
+++ b/harper-core/src/linting/weir_rules/TenantTenet/Plural.weir
@@ -1,0 +1,21 @@
+expr adj [core, central, fundamental, basic, guiding, cardinal, underlying, foundational, defining]
+expr main <(@adj tenants), tenants>
+
+let message "Did you mean `tenets`?"
+let description "`Tenants` (renters) is easily confused with `tenets` (principles). After an adjective like `core` or `fundamental`, the principle sense is the intended one."
+let kind "Malapropism"
+let becomes "tenets"
+let strategy "MatchCase"
+
+test "The core tenants of agile are simple." "The core tenets of agile are simple."
+test "These are the central tenants of the movement." "These are the central tenets of the movement."
+test "The fundamental tenants of the religion endure." "The fundamental tenets of the religion endure."
+test "We follow the basic tenants of good writing." "We follow the basic tenets of good writing."
+test "Its guiding tenants shaped the company." "Its guiding tenets shaped the company."
+test "The cardinal tenants of the order are few." "The cardinal tenets of the order are few."
+test "Core Tenants of Highly Effective Teams." "Core Tenets of Highly Effective Teams."
+
+allows "The building has three tenants."
+allows "The apartment's tenants moved out."
+allows "The main tenants renewed their leases."
+allows "Commercial tenants pay higher rent."

--- a/harper-core/src/linting/weir_rules/TenantTenet/Singular.weir
+++ b/harper-core/src/linting/weir_rules/TenantTenet/Singular.weir
@@ -1,8 +1,8 @@
 expr adj [core, central, fundamental, basic, guiding, cardinal, underlying, foundational, defining]
-expr main <(@adj tenant), tenant>
+expr main <(@adj tenant !NOUN), tenant>
 
 let message "Did you mean `tenet`?"
-let description "`Tenant` (a renter) is easily confused with `tenet` (a principle). After an adjective like `core` or `fundamental`, the principle sense is the intended one."
+let description "`Tenant` (a renter) is easily confused with `tenet` (a principle). After an adjective like `core` or `fundamental`, the principle sense is the intended one. Skipped when `tenant` modifies a following noun, as in `core tenant isolation`, where the multi-tenancy sense is meant."
 let kind "Malapropism"
 let becomes "tenet"
 let strategy "MatchCase"
@@ -14,9 +14,16 @@ test "Respect is a basic tenant here." "Respect is a basic tenet here."
 test "That is a guiding tenant of the project." "That is a guiding tenet of the project."
 test "Nonviolence is a cardinal tenant of the movement." "Nonviolence is a cardinal tenet of the movement."
 test "An underlying tenant of the theory is symmetry." "An underlying tenet of the theory is symmetry."
-test "It rests on a foundational tenant." "It rests on a foundational tenet."
+test "It rests on a foundational tenant of trust." "It rests on a foundational tenet of trust."
+test "That defining tenant still holds today." "That defining tenet still holds today."
 
 allows "The tenant paid rent on time."
 allows "The main tenant of the building left."
 allows "A key tenant anchored the plaza."
 allows "Each tenant signed a lease."
+
+allows "The core tenant isolation logic lives here."
+allows "Our fundamental tenant model uses row-level security."
+allows "The basic tenant configuration is in config.yaml."
+allows "The service uses a multi-tenant architecture."
+allows "We store the tenant ID in the session."

--- a/harper-core/src/linting/weir_rules/TenantTenet/Singular.weir
+++ b/harper-core/src/linting/weir_rules/TenantTenet/Singular.weir
@@ -1,0 +1,22 @@
+expr adj [core, central, fundamental, basic, guiding, cardinal, underlying, foundational, defining]
+expr main <(@adj tenant), tenant>
+
+let message "Did you mean `tenet`?"
+let description "`Tenant` (a renter) is easily confused with `tenet` (a principle). After an adjective like `core` or `fundamental`, the principle sense is the intended one."
+let kind "Malapropism"
+let becomes "tenet"
+let strategy "MatchCase"
+
+test "This is a core tenant of good design." "This is a core tenet of good design."
+test "Honesty is a central tenant of our culture." "Honesty is a central tenet of our culture."
+test "It breaks a fundamental tenant of the faith." "It breaks a fundamental tenet of the faith."
+test "Respect is a basic tenant here." "Respect is a basic tenet here."
+test "That is a guiding tenant of the project." "That is a guiding tenet of the project."
+test "Nonviolence is a cardinal tenant of the movement." "Nonviolence is a cardinal tenet of the movement."
+test "An underlying tenant of the theory is symmetry." "An underlying tenet of the theory is symmetry."
+test "It rests on a foundational tenant." "It rests on a foundational tenet."
+
+allows "The tenant paid rent on time."
+allows "The main tenant of the building left."
+allows "A key tenant anchored the plaza."
+allows "Each tenant signed a lease."


### PR DESCRIPTION
# Issues

Closes #1070.

# Description

`tenant` (a renter) is commonly written where `tenet` (a principle) is meant — *"a core **tenant** of good design"*, *"the main **tenants** of many religions"*. Harper did not catch this.

This adds a `TenantTenet` rule that flags `tenant` / `tenants` when it follows a principle-sense adjective (`core`, `central`, `fundamental`, `basic`, `guiding`, `cardinal`, `underlying`, `foundational`, `defining`) and suggests `tenet` / `tenets`:

- `a core tenant of good design` → `a core tenet of good design`
- `the central tenants of the movement` → `the central tenets of the movement`

To keep false positives low, it deliberately only fires after that adjective set, where the renter reading is implausible. Real-estate senses are left untouched — `the main tenant`, `a key tenant`, `three tenants`, `commercial tenants`. Broader frames (e.g. bare `tenants of X`) are intentionally out of scope for now, since `tenant` is a valid word and over-flagging would be worse than the occasional miss.

The rule is a grouped Weir rule (singular + plural children under `TenantTenet/`) because the two forms need different replacements.

No related PRs.

# Demo

```
$ harper-cli lint "These are the core tenants of our design."
1 │ These are the core tenants of our design.
  │                   ╰──────── [Malapropism::TenantTenet]: Did you mean `tenets`?

$ harper-cli lint "The main tenant of the building left."   # no lint (renter)
```

# How Has This Been Tested?

Embedded Weir tests (16 correction cases + 8 negative cases across the two children):

```
$ harper-cli test harper-core/src/linting/weir_rules/TenantTenet/Singular.weir
All tests pass!
$ harper-cli test harper-core/src/linting/weir_rules/TenantTenet/Plural.weir
All tests pass!
```

Rust suite (rule registration + curated-config drift check):

```
$ cargo test -p harper-core --lib curated_default_config_lists_every_registered_rule
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 5803 filtered out

$ cargo test -p harper-core --lib run_tests_for_weir_rules
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 5803 filtered out
```

Also checked by hand that renter-sense phrases (`the main tenant`, `a key tenant`, `three tenants`) stay clean.

# AI Disclosure

- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter

- [x] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
