### PR TITLE
fix(core): avoid overall quantifier false positives

### DIFF
--- a/harper-core/src/linting/closed_compounds.rs
+++ b/harper-core/src/linting/closed_compounds.rs
@@ -1,6 +1,52 @@
-use crate::linting::LintGroup;
+use crate::{
+    Token,
+    expr::Expr,
+    linting::{
+        ExprLinter, Lint, LintGroup,
+        expr_linter::{Chunk, preceded_by_word},
+    },
+};
 
 use super::MapPhraseLinter;
+
+struct Overall {
+    inner: MapPhraseLinter,
+}
+
+impl Default for Overall {
+    fn default() -> Self {
+        Self {
+            inner: MapPhraseLinter::new_closed_compound(["over all"], "overall"),
+        }
+    }
+}
+
+impl ExprLinter for Overall {
+    type Unit = Chunk;
+
+    fn expr(&self) -> &dyn Expr {
+        self.inner.expr()
+    }
+
+    fn match_to_lint_with_context(
+        &self,
+        matched_tokens: &[Token],
+        source: &[char],
+        context: Option<(&[Token], &[Token])>,
+    ) -> Option<Lint> {
+        // "Over all" is normally a preposition followed by a quantifier. Only treat it as the
+        // adjective "overall" when a preceding determiner establishes that grammatical role.
+        if !preceded_by_word(context, |word| word.kind.is_determiner()) {
+            return None;
+        }
+
+        self.inner.match_to_lint(matched_tokens, source)
+    }
+
+    fn description(&self) -> &str {
+        self.inner.description()
+    }
+}
 
 pub fn lint_group() -> LintGroup {
     let mut group = LintGroup::empty();
@@ -57,7 +103,6 @@ pub fn lint_group() -> LintGroup {
         "Nothing"         => (&["no thing"][..], "nothing"),
         "Notwithstanding" => (&["not with standing"][..], "notwithstanding"),
         "Nowhere"         => (&["no where"][..], "nowhere"),
-        "Overall"         => (&["over all"][..], "overall"),
         "Overclocking"    => (&["over clocking"][..], "overclocking"),
         "Overload"        => (&["over load"][..], "overload"),
         "Overnight"       => (&["over night"][..], "overnight"),
@@ -82,6 +127,8 @@ pub fn lint_group() -> LintGroup {
         "Worldwide"       => (&["world wide"][..], "worldwide"),
         "Worthwhile"      => (&["worth while", "worth-while"][..], "worthwhile"),
     });
+
+    group.add("Overall", Box::new(Overall::default()));
 
     group.set_all_rules_to(Some(true));
 
@@ -155,6 +202,40 @@ mod tests {
         let test_sentence = "The over all performance was good.";
         let expected = "The overall performance was good.";
         assert_suggestion_result(test_sentence, lint_group(), expected);
+    }
+
+    #[test]
+    fn allow_over_all_the() {
+        assert_no_lints("Iterate over all the save data in the slot.", lint_group());
+    }
+
+    #[test]
+    fn allow_over_all_of_the() {
+        assert_no_lints(
+            "Iterate over all of the save data in the slot.",
+            lint_group(),
+        );
+    }
+
+    #[test]
+    fn allow_over_all_plural_noun() {
+        assert_no_lints(
+            "Congress may exercise authority over all places purchased by consent.",
+            lint_group(),
+        );
+    }
+
+    #[test]
+    fn allow_over_all_pronoun() {
+        assert_no_lints("A thrill passed over all of us.", lint_group());
+    }
+
+    #[test]
+    fn allow_over_all_at_sentence_start() {
+        assert_no_lints(
+            "Over all these years, the rule stayed the same.",
+            lint_group(),
+        );
     }
 
     #[test]

--- a/harper-core/src/linting/closed_compounds.rs
+++ b/harper-core/src/linting/closed_compounds.rs
@@ -226,7 +226,7 @@ mod tests {
     }
 
     #[test]
-    fn allow_over_all_pronoun() {
+    fn allow_over_all_of_pronoun() {
         assert_no_lints("A thrill passed over all of us.", lint_group());
     }
 

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -472,15 +472,6 @@ Suggest:
 
 
 
-Lint:    Miscellaneous (31 priority)
-Message: |
-     238 | puzzle!” And she began thinking over all the children she knew that were of the
-         |                                 ^~~~~~~~ Did you mean the closed compound `overall`?
-Suggest:
-  - Replace with: “overall”
-
-
-
 Lint:    Capitalization (31 priority)
 Message: |
      243 | all sorts of things, and she, oh! she knows such a very little! Besides, she’s
@@ -1700,16 +1691,6 @@ Message: |
          |                                     ^~~~~~~~ Use `find` instead of `find out` when you mean to discover something directly.
 Suggest:
   - Replace with: “find”
-
-
-
-Lint:    Miscellaneous (31 priority)
-Message: |
-    1415 | dropped, and the party sat silent for a minute, while Alice thought over all she
-         |                                                                     ^~~~~~~~ Did you mean the closed compound `overall`?
-    1416 | could remember about ravens and writing-desks, which wasn’t much.
-Suggest:
-  - Replace with: “overall”
 
 
 

--- a/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
+++ b/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
@@ -685,17 +685,6 @@ Suggest:
 
 
 
-Lint:    Miscellaneous (31 priority)
-Message: |
-     253 | the Acceptance of Congress, become the Seat of the Government of the United
-     254 | States, and to exercise like Authority over all Places purchased by the Consent
-         |                                        ^~~~~~~~ Did you mean the closed compound `overall`?
-     255 | of the Legislature of the State in which the Same shall be, for the Erection of
-Suggest:
-  - Replace with: “overall”
-
-
-
 Lint:    Readability (127 priority)
 Message: |
      265 | The Migration or Importation of such Persons as any of the

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -1549,15 +1549,6 @@ Suggest:
 
 
 
-Lint:    Miscellaneous (31 priority)
-Message: |
-    1307 | A thrill passed over all of us. The three Mr. Mumbles bent forward and listened
-         |                 ^~~~~~~~ Did you mean the closed compound `overall`?
-Suggest:
-  - Replace with: “overall”
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
     1310 | “I don’t think it’s so much that,” argued Lucille sceptically; “it’s more that


### PR DESCRIPTION
> AI disclosure: This pull request was authored autonomously by OpenAI Codex. I reviewed Harper's contributing and agent policies, issue #1249, the related closed PR, the implementation diff, and the validation output before submission.

# Issues

Fixes #1249

# Description

The `Overall` closed-compound rule previously suggested `overall` for every occurrence of `over all`. In normal phrases such as “iterate over all the save data,” however, `over` is a preposition and `all` is a quantifier.

This change gives `Overall` a small context-aware wrapper and emits the existing `MapPhraseLinter` correction only when a preceding determiner establishes the adjectival use, as in the existing “The over all performance...” positive test. It adds the two issue examples plus quantifier cases covering a plural noun, a pronoun, and sentence-initial usage. Regenerated corpus snapshots remove four existing false positives from the U.S. Constitution, *Alice's Adventures in Wonderland*, and *The Great Gatsby*.

Related: #3455 was an earlier attempt that special-cased words following `over all`; its author closed it. This patch uses grammatical context and covers the additional false positives already present in Harper's corpus snapshots.

# Demo

Not visual.

# How Has This Been Tested?

- `just format`
- `cargo test -p harper-core -- closed_compounds::tests` (40 passed)
- `cargo test -p harper-core --test linters -- test_most_lints` (snapshot regeneration followed by a clean pass)
- `cargo test -p harper-core --lib` (5,526 passed, 284 existing ignored, 0 failed)
- `cargo clippy -p harper-core --lib -- -D warnings -D clippy::dbg_macro -D clippy::needless_raw_string_hashes`
- `cargo check -p harper-core`
- `just test-rust` (full Rust workspace, 0 failed)
- `git diff --check`

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [x] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter

- [ ] I made up the sentences in the unit tests.
- [x] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
