### PR TITLE
fix(cli): report the real Harper version from `--version`

### DIFF
--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -42,7 +42,7 @@ use lint::LintOptions;
 
 /// A debugging tool for the Harper grammar checker.
 #[derive(Parser)]
-#[command(version, about)]
+#[command(version = harper_core::core_version(), about)]
 struct Cli {
     /// Disable colored output.
     #[arg(long, global = true)]

--- a/harper-cli/tests/version.rs
+++ b/harper-cli/tests/version.rs
@@ -1,0 +1,37 @@
+use std::process::Command;
+
+fn harper_cli() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_harper-cli"))
+}
+
+/// Regression test for the prebuilt executable always reporting `0.1.0`.
+///
+/// `harper-cli` is `publish = false`, so its own crate version was never bumped
+/// and stayed at `0.1.0`. `--version` must report the real Harper version, which
+/// is tracked by `harper-core`.
+#[test]
+fn version_reports_harper_core_version() {
+    let output = harper_cli().arg("--version").output().unwrap();
+
+    assert!(
+        output.status.success(),
+        "--version should exit successfully"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let reported = stdout
+        .trim()
+        .rsplit(' ')
+        .next()
+        .expect("--version output should contain a version");
+
+    assert_eq!(
+        reported,
+        harper_core::core_version(),
+        "--version must report the harper-core version, got {stdout:?}"
+    );
+    assert_ne!(
+        reported, "0.1.0",
+        "--version must not report the stale harper-cli crate version"
+    );
+}


### PR DESCRIPTION
> Disclaimer: this PR was prepared with the assistance of an LLM-based agent, per Harper's agent policy.

## What

`harper-cli --version` always reports `0.1.0`, regardless of the release the binary was built from. This changes the derived version so it reflects the actual Harper version.

## Why

`harper-cli` is declared `publish = false`, so its crate version was never bumped and has stayed at `0.1.0`. `clap`'s `#[command(version)]` derives the version from `CARGO_PKG_VERSION`, i.e. the `harper-cli` crate version, so every prebuilt executable prints `0.1.0`.

```
$ harper-cli --version
harper-cli 0.1.0   # before
harper-cli 2.6.0   # after
```

The real Harper version is tracked by `harper-core` (already exposed through the existing `core-version` subcommand: `println!("harper-core v{}", harper_core::core_version())`). This wires `--version` to the same source:

```rust
#[command(version = harper_core::core_version(), about)]
```

Fixes #3829

## Test evidence

Added `harper-cli/tests/version.rs`, which runs the built binary and asserts `--version` reports the `harper-core` version and not the stale `0.1.0`.

- Before the change the test fails: `--version must report the harper-core version, got "harper-cli 0.1.0\n" (left: "0.1.0", right: "2.6.0")`.
- After the change it passes.

```
$ cargo test -p harper-cli
   Running tests/no_color.rs        ... 3 passed
   Running tests/output_format.rs   ... 6 passed
   Running tests/version.rs         ... 1 passed
```

`cargo fmt -- --check` and `cargo clippy -p harper-cli --tests -- -Dwarnings` are clean on the touched files.