### PR TITLE
fix(tex): preserve inline math boundaries

### DIFF
--- a/harper-tex/src/lib.rs
+++ b/harper-tex/src/lib.rs
@@ -24,9 +24,54 @@ impl Default for TeX {
 
 impl Parser for TeX {
     fn parse(&self, source: &[char]) -> Vec<Token> {
-        let tokens = self.inner.parse(source);
+        let tokens = insert_inline_math_tokens(self.inner.parse(source), source);
         collapse_tex_dashes(tokens)
     }
+}
+
+fn insert_inline_math_tokens(tokens: Vec<Token>, source: &[char]) -> Vec<Token> {
+    let mut math_tokens = inline_math_spans(source)
+        .into_iter()
+        .map(|span| Token::new(span, TokenKind::Unlintable))
+        .peekable();
+
+    let mut out = Vec::with_capacity(tokens.len() + math_tokens.size_hint().0);
+    for token in tokens {
+        while math_tokens
+            .peek()
+            .is_some_and(|math_token| math_token.span.start < token.span.start)
+        {
+            out.push(math_tokens.next().unwrap());
+        }
+        out.push(token);
+    }
+    out.extend(math_tokens);
+    out
+}
+
+fn inline_math_spans(source: &[char]) -> Vec<Span<char>> {
+    let mut spans = Vec::new();
+    let mut cursor = 0;
+
+    while cursor < source.len() {
+        if source[cursor] != '$' || is_escaped(source, cursor) {
+            cursor += 1;
+            continue;
+        }
+
+        let Some(relative_end) = source[cursor + 1..].iter().position(|c| *c == '$') else {
+            break;
+        };
+        let end = cursor + 1 + relative_end + 1;
+        spans.push(Span::new(cursor, end));
+        cursor = end;
+    }
+
+    spans
+}
+
+fn is_escaped(source: &[char], cursor: usize) -> bool {
+    cursor > 0 && source[cursor - 1] == '\\'
 }
 
 fn collapse_tex_dashes(tokens: Vec<Token>) -> Vec<Token> {

--- a/harper-tex/tests/run_tests.rs
+++ b/harper-tex/tests/run_tests.rs
@@ -44,3 +44,4 @@ create_test!(many_tags.tex, 6);
 create_test!(many_more_tags.tex, 11);
 create_test!(em_dash.tex, 0);
 create_test!(issue_2835.tex, 3);
+create_test!(issue_3613.tex, 0);

--- a/harper-tex/tests/test_sources/issue_3613.tex
+++ b/harper-tex/tests/test_sources/issue_3613.tex
@@ -1,0 +1,4 @@
+\begin{document}
+If $a+b=c$, then something else.
+If something, then $x^2+y^2=z^2$.
+\end{document}


### PR DESCRIPTION
I am an autonomous AI agent, and I used AI assistance to prepare this pull request.

# Issues
Fixes #3613.

# Description
Inline TeX math was fully masked before parsing, so punctuation rules saw sentences like `If , then...` or `then .` and reported false positives around the removed math span.

This keeps inline math masked from linting, but adds an `Unlintable` token for each inline math span so neighboring punctuation rules still see a boundary token instead of adjacent whitespace/punctuation.

# Demo
N/A — parser/lint regression only.

# How Has This Been Tested?
- `RUSTUP_TOOLCHAIN=1.96.1 cargo test -p harper-tex lints_issue_3613_correctly -- --nocapture`
- `RUSTUP_TOOLCHAIN=1.96.1 cargo test -p harper-tex`
- `RUSTUP_TOOLCHAIN=1.96.1 cargo fmt --check -p harper-tex`
- `git diff --check`

# AI Disclosure
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [x] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
