### PR TITLE
fix: LaTeX diagnostics halt after unmatched inline math ($) inside a macro

### DIFF
--- a/harper-tex/src/masker.rs
+++ b/harper-tex/src/masker.rs
@@ -61,14 +61,12 @@ fn math_mode_at_cursor(cursor: usize, source: &[char]) -> Option<usize> {
         return None;
     }
 
-    Some(
-        source
-            .iter()
-            .skip(cursor + 1)
-            .take_while(|t| **t != '$')
-            .count()
-            + 2,
-    )
+    let closing_delimiter = source
+        .iter()
+        .skip(cursor + 1)
+        .position(|character| *character == '$')?;
+
+    Some(closing_delimiter + 2)
 }
 
 /// Check whether there is a command at the current cursor. If so, this function will update the action queue to mask out the hidden elements.
@@ -242,6 +240,16 @@ mod tests {
 
     use super::{Masker, deconstruct_command};
 
+    fn allowed_text(source: &str) -> Vec<String> {
+        let source: Vec<_> = source.chars().collect();
+
+        Masker::default()
+            .create_mask(&source)
+            .iter_allowed(&source)
+            .map(|(_, chars)| chars.iter().collect())
+            .collect()
+    }
+
     #[test]
     fn ignores_many_comment_signs() {
         let source: Vec<_> = "%%%".chars().collect();
@@ -272,6 +280,36 @@ mod tests {
         let mask = Masker::default().create_mask(&source);
 
         assert_eq!(mask.iter_allowed(&source).count(), 2)
+    }
+
+    #[test]
+    fn leaves_text_after_unmatched_inline_math_allowed() {
+        assert_eq!(allowed_text("before $after"), ["before $after"]);
+    }
+
+    #[test]
+    fn masks_paired_inline_math() {
+        assert_eq!(allowed_text("before $x$ after"), ["before ", " after"]);
+    }
+
+    #[test]
+    fn masks_text_between_escaped_dollars() {
+        assert_eq!(allowed_text(r"before \$x\$ after"), ["before ", " after"]);
+    }
+
+    #[test]
+    fn masks_text_between_parenthesized_math_delimiters() {
+        assert_eq!(allowed_text(r"before \(x\) after"), ["before ", " after"]);
+    }
+
+    #[test]
+    fn masks_empty_inline_math() {
+        assert_eq!(allowed_text("before $$ after"), ["before ", " after"]);
+    }
+
+    #[test]
+    fn leaves_trailing_dollar_allowed() {
+        assert_eq!(allowed_text("before $"), ["before $"]);
     }
 
     #[test]

--- a/harper-tex/tests/run_tests.rs
+++ b/harper-tex/tests/run_tests.rs
@@ -44,3 +44,4 @@ create_test!(many_tags.tex, 6);
 create_test!(many_more_tags.tex, 11);
 create_test!(em_dash.tex, 0);
 create_test!(issue_2835.tex, 3);
+create_test!(issue_3791.tex, 2);

--- a/harper-tex/tests/test_sources/issue_3791.tex
+++ b/harper-tex/tests/test_sources/issue_3791.tex
@@ -1,0 +1,9 @@
+\documentclass[11pt]{article}
+
+\begin{document}
+errawr
+\begin{figure}
+\caption{A sample ($N_{THC}$).}
+\end{figure}
+errawr
+\end{document}


### PR DESCRIPTION
# Issues
Fixes #3791

# Description
The tex masker lives in `harper-tex/src/masker.rs`. Its top-level `create_mask` loop reaches `\caption{...}` and calls `deconstruct_command`, whose curly-content scan stops at the FIRST `}` (the inner `}` of `N_{THC}`), truncating the caption argument so the cursor lands on the second, now-unpaired `$`. The loop then calls `math_mode_at_cursor` on that lone `$`; because there is no closing `$` left in the document it counts every remaining character and returns `remaining + 2`, so the following `PushMaskAndIncBy` masks the entire rest of the file - dropping all later tokens and hence all diagnostics. Primary fix: make `math_mode_at_cursor` require a matching closing `$` - when no closing `$` follows the opener, return `None` (or mask only the single `$`) instead of consuming to end-of-file, mirroring the running-off-the-end guard already present in `equation_at_cursor`. This restores diagnostics for the remainder of the document exactly as the reporter expects, and is a minimal, convergent change. The deeper root cause (naive first-`}` curly-argument parsing in `deconstruct_command` not balancing nested braces) may optionally be hardened in the same function, but the reported halt is fully resolved by the `math_mode_at_cursor` guard, so scope stays tight to avoid regressing existing tex snapshots.

# Demo
N/A - behavioral fix; validated by the tests below.

# How Has This Been Tested?
- Happy path: add `harper-tex/tests/test_sources/issue_3791.tex` reproducing the issue snippet (two `errawr` typos around a `\caption{ ... ($N_{THC}$` block) and a `create_test!(issue_3791.tex, N)` entry in `run_tests.rs` asserting both typos are still linted (rest-of-file diagnostics no longer suppressed), following the existing `issue_2835.tex` precedent.
- Unit test in the `#[cfg(test)] mod tests` block of `masker.rs`: a lone/unmatched `$` does not mask the remainder - text after the stray `$` remains in the allowed spans of the mask.
- Edge cases: a correctly paired top-level `$...$` is still fully masked; `\$ ... \$` and `\( ... \)` continue to work; empty `$$` and a trailing `$` at end-of-file neither panic nor over-consume.
- Error path: `create_mask` does not panic on a document that ends with an unclosed `$` (extends the existing trailing-backslash non-panic guarantees).

# AI Disclosure
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [x] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
