### PR TITLE
feat: a little of practice → a little / a bit of

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5375,6 +5375,13 @@
 								"state": true,
 								"label": "For The Nth Time"
 							}
+						},
+						{
+							"Bool": {
+								"name": "ALittleOfPractice",
+								"state": true,
+								"label": "A Little of Practice"
+							}
 						}
 					]
 				}

--- a/harper-core/src/linting/weir_rules/ALittleOfPractice.weir
+++ b/harper-core/src/linting/weir_rules/ALittleOfPractice.weir
@@ -1,0 +1,11 @@
+expr main (a little of practice)
+
+let message "Have you perhaps confused `a little practice` or `a bit of practice`?"
+let description "Corrects `a little of practice` to `a little practice` or `a bit of practice`."
+let kind "Usage"
+let becomes ["a little practice", "a bit of practice"]
+
+test "Developing a theme takes a little of practice. There are multiple templates for each module." "Developing a theme takes a little practice. There are multiple templates for each module."
+test "I think with a little of practice I'll get better at making these." "I think with a bit of practice I'll get better at making these."
+test "But first you need a little of practice, and here we are:" "But first you need a little practice, and here we are:"
+test "Although it requires a little of practice and a learning curve, it totally worthy." "Although it requires a bit of practice and a learning curve, it totally worthy."


### PR DESCRIPTION
# Issues 
N/A

# Description

I ran across the phrase "a little of practice" in a comment thread. It seems more like nonnative English than like a typo. It seems common enough to find examples for tests and I also found no false positives.

So I made a Weird rule.

This might be part of a wider usage mistake as I found an example of "a little of advice" while looking for real-world examples.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
