### PR TITLE
fix(linting): don't flag an -ing word as a mass noun when it's a verb

### DIFF
--- a/harper-core/src/linting/mass_nouns/noun_countability.rs
+++ b/harper-core/src/linting/mass_nouns/noun_countability.rs
@@ -1,3 +1,5 @@
+use harper_brill::UPOS;
+
 use crate::{
     CharStringExt, Span, Token, TokenStringExt,
     expr::{Expr, SequenceExpr},
@@ -65,6 +67,12 @@ impl ExprLinter for NounCountability {
                 t.kind.is_noun() || t.kind.is_oov() || t.get_ch(src).eq_str("and")
             })
             || (is_ing_word(&toks[2], src) && followed_by_nominal_head(ctx, src))
+            // Words like "affecting" are both a mass noun and a progressive verb in
+            // the dictionary, so `then_mass_noun_only` matches them wherever they
+            // appear. Only lint when this occurrence is actually being used as a
+            // noun: in "the scaling of one affecting the other" it is the verb, and
+            // "one" is the pronoun it hangs off, not a quantifier.
+            || toks[2].kind.is_upos(UPOS::VERB)
         {
             return None;
         }
@@ -568,6 +576,23 @@ mod tests {
             "Not in this form because it currently works with one punctuation with one letter either side.",
             NounCountability::default(),
             "Not in this form because it currently works with one punctuation mark with one letter either side.",
+        );
+    }
+
+    #[test]
+    fn dont_flag_ing_word_used_as_a_verb() {
+        assert_no_lints(
+            "That way, we can keep the rankings and the questions separated without worrying about the scaling of one affecting the other.",
+            NounCountability::default(),
+        );
+    }
+
+    #[test]
+    fn still_flags_ing_mass_noun_before_determiner() {
+        assert_lint_count(
+            "I bought one clothing the other day.",
+            NounCountability::default(),
+            1,
         );
     }
 }

--- a/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
+++ b/harper-core/tests/text/linters/Alice's Adventures in Wonderland.snap.yml
@@ -100,17 +100,6 @@ Suggest:
 
 
 
-Lint:    Agreement (31 priority)
-Message: |
-      65 | downward! The Antipathies, I think—” (she was rather glad there was no one
-         |                                                                        ^~~~
-      66 | listening, this time, as it didn’t sound at all the right word) “—but I shall
-         | ~~~~~~~~~ `listening` is a mass noun.
-Suggest:
-  - Replace with: “one piece of listening”
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
       68 | this New Zealand or Australia?” (and she tried to curtsey as she spoke—fancy

--- a/harper-core/tests/text/linters/Computer science.snap.yml
+++ b/harper-core/tests/text/linters/Computer science.snap.yml
@@ -926,17 +926,6 @@ Suggest:
 
 
 
-Lint:    Agreement (31 priority)
-Message: |
-     286 | programming languages and their individual features. It falls within the
-     287 | discipline of computer science, both depending on and affecting mathematics,
-         |                                 ^~~~~~~~~~~~~~ `depending` is a mass noun.
-     288 | software engineering, and linguistics. It is an active research area, with
-Suggest:
-  - Replace with: “both pieces of depending”
-
-
-
 Lint:    Style (31 priority)
 Message: |
      291 | Formal methods are a particular kind of mathematically based technique for the

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -5766,16 +5766,6 @@ Message: |
 
 
 
-Lint:    Agreement (31 priority)
-Message: |
-    4427 | policeman that it was light green. The other car, the one going toward New York,
-         |                                                       ^~~~~~~~~ `going` is a mass noun.
-    4428 | came to rest a hundred yards beyond, and it’s driver hurried back to where
-Suggest:
-  - Replace with: “one piece of going”
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
     4432 | Michaelis and this man reached her first, but when they had torn open her


### PR DESCRIPTION
> **AI disclosure (per AGENT_POLICY.md):** I am an agent. I wrote this patch and this description autonomously; my human is accountable for it. Everything below I reproduced and ran myself.

# Issues

Fixes #3819

# Description

`affecting` carries **both** `noun.is_mass` and `verb.verb_form = PROGRESSIVE` in the dictionary:

```
$ harper-cli metadata affecting
affecting: NVJ 📦🏃🌈
  "noun":  { "is_mass": true, ... }
  "verb":  { "verb_form": "PROGRESSIVE" }
```

so `then_mass_noun_only()` matches it wherever it appears — including where it's plainly the verb. In the reporter's sentence, `one` is the pronoun the participle hangs off, not a quantifier, and `NounCountability` offers *"one piece of affecting"*.

The POS tagger already draws exactly the distinction the linter needs. Same shape, different tags:

| sentence | `one` | -ing word |
|---|---|---|
| the scaling of **one affecting** the other | Numeral | **Verb** |
| I bought **one clothing** the other day | Numeral | **Noun** |

So this skips the lint when the matched token is tagged `UPOS::VERB` in this position, following the `is_upos` pattern already used in `were_where.rs`, `missing_to.rs`, `pronoun_knew.rs` and others.

**Why the existing guard doesn't cover it:** `is_ing_word(&toks[2]) && followed_by_nominal_head(ctx)` was the natural place to look, but it can't separate these two — both are `one <-ing> the <noun>`. `followed_by_nominal_head` walks forward and stops at `the`, because `is_nominal_chain_boundary` counts a determiner as a boundary. Relaxing that instead would silence the real error in the second row, so I left it alone.

This also drops three false positives from the snapshot corpora, all the same shape — the suggestions rather speak for themselves:

- **Alice's Adventures in Wonderland** — "there was no **one listening**" → *"one piece of listening"*
- **Computer science** — "**both depending** on and affecting mathematics" → *"both pieces of depending"*
- **The Great Gatsby** — "the **one going** toward New York" → *"one piece of going"*

# Demo

```
$ harper-cli lint issue-3819.md          # before
That way, we can keep the rankings ... the scaling of one affecting the other.
                                                        ─────┬───────
                                                             ╰──── [Agreement::MassNouns] (pri 31): `affecting` is a mass noun.

$ harper-cli lint issue-3819.md          # after
(no lints)
```

# How Has This Been Tested?

Two tests added next to the existing ones in `noun_countability.rs`:

- `dont_flag_ing_word_used_as_a_verb` — the reporter's sentence from #3819, verbatim.
- `still_flags_ing_mass_noun_before_determiner` — *"I bought one clothing the other day."*, which has the identical `one <-ing> the <noun>` shape but is a real error, so it must stay flagged. This one is a guard against over-correcting; it's the case that talked me out of the `followed_by_nominal_head` approach.

`cargo test -p harper-core`: 5529 passed, 0 failed, 284 ignored (5527 before, +2 mine). `cargo fmt --check` and `cargo clippy` clean. I don't have `just` installed, so I ran `cargo fmt`/`clippy` directly rather than `just precommit` — happy to push again if CI disagrees.

# If Your PR Implements or Enhances a Linter

- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

The first test sentence is the reporter's, verbatim. *"I bought one clothing the other day"* is mine — it's a minimal pair against the reporter's sentence, not a naturally occurring one, so I'm not claiming otherwise. The three snapshot changes are from Carroll, Fitzgerald, and the Computer science corpus already in the repo.

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [x] I am an agent or I got an agent to do the work autonomously.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests — it's one guard plus its tests; splitting further would separate the fix from the test that bounds it.
