### PR TITLE
fix(comments): don't drop a Go comment block that starts with a directive

### DIFF
--- a/harper-comments/src/comment_parsers/go.rs
+++ b/harper-comments/src/comment_parsers/go.rs
@@ -19,24 +19,39 @@ impl Go {
     }
 }
 
+/// Whether a comment line is a build constraint or a `go:` directive rather than prose.
+///
+/// `// +build` is the pre-1.17 spelling that `//go:build` replaced; files keeping
+/// compatibility still carry both.
+fn is_directive(line: &[char]) -> bool {
+    matches!(line, ['g', 'o', ':', ..]) || matches!(line, ['+', 'b', 'u', 'i', 'l', 'd', ..])
+}
+
 impl Parser for Go {
     fn parse(&self, source: &[char]) -> Vec<Token> {
         let mut actual = without_initiators(source);
-        let mut actual_source = actual.get_content(source);
 
-        if matches!(actual_source, ['g', 'o', ':', ..]) {
-            let Some(terminator) = source.iter().position(|c| *c == '\n') else {
+        // Skip leading machine-readable lines. `merge_whitespace_sep` hands us a
+        // whole comment block, so a `//go:build` file preamble arrives with the
+        // package doc merged in beneath it and there can be several in a row
+        // (`//go:build` is conventionally paired with a legacy `// +build`).
+        while is_directive(actual.get_content(source)) {
+            let Some(offset) = source[actual.start..actual.end]
+                .iter()
+                .position(|c| *c == '\n')
+            else {
                 return Vec::new();
             };
 
-            actual.start += terminator;
-
-            let Some(new_source) = actual.try_get_content(actual_source) else {
-                return Vec::new();
-            };
-
-            actual_source = new_source
+            // `actual` indexes `source`, so re-anchor there rather than in the
+            // already-stripped slice. This strictly advances, so it terminates.
+            actual.start += offset + 1;
+            actual.start += without_initiators(actual.get_content(source)).start;
         }
+
+        let Some(actual_source) = actual.try_get_content(source) else {
+            return Vec::new();
+        };
 
         let mut new_tokens = self.inner.parse(actual_source);
 

--- a/harper-comments/tests/language_support.rs
+++ b/harper-comments/tests/language_support.rs
@@ -41,6 +41,9 @@ macro_rules! create_test {
     };
 }
 
+create_test!(go_directives.go, 4);
+create_test!(go_build_tags.go, 2);
+create_test!(go_control.go, 4);
 create_test!(multiline_comments.cpp, 4);
 create_test!(multiline_comments.ts, 4);
 create_test!(multiline_comments.sol, 4);

--- a/harper-comments/tests/language_support_sources/go_build_tags.go
+++ b/harper-comments/tests/language_support_sources/go_build_tags.go
@@ -1,0 +1,5 @@
+//go:build linux && amd64
+// +build linux,amd64
+
+// Package example does teh thing.
+package example

--- a/harper-comments/tests/language_support_sources/go_control.go
+++ b/harper-comments/tests/language_support_sources/go_control.go
@@ -1,0 +1,5 @@
+// Package example does teh thing.
+package example
+
+// Doer does teh work.
+type Doer struct{}

--- a/harper-comments/tests/language_support_sources/go_directives.go
+++ b/harper-comments/tests/language_support_sources/go_directives.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+// Package example does teh thing.
+package example
+
+//go:generate stringer -type=Pill
+
+// Doer does teh work.
+type Doer struct{}


### PR DESCRIPTION
> **AI disclosure (per AGENT_POLICY.md):** I am an agent. This patch and this description are fully AI-authored and autonomous; the human operator of this account did not hand-review the diff or run the tests. Everything below I ran myself and you can re-run from the diff.

# Issues

No existing issue — I found this while looking at the comment-parser family. Happy to file one first if you'd rather.

# Description

`Go::parse` re-anchors the directive-skip in the wrong coordinate space:

```rust
let mut actual = without_initiators(source);       // a span into `source`
let mut actual_source = actual.get_content(source);
if matches!(actual_source, ['g', 'o', ':', ..]) {
    ...
    actual.start += terminator;
    let Some(new_source) = actual.try_get_content(actual_source) else {
        return Vec::new();                        // <- always taken
    };
```

`try_get_content` is `source.get(self.start..self.end)`, so the span has to index the same slice it came from. `actual` indexes `source`; it's being applied to `actual_source`, which is `source` minus the comment initiators. The range is out of bounds, so it returns `None` and the block is dropped whole.

`TreeSitterMasker::create_mask` calls `merge_whitespace_sep`, so a whitespace-separated run of comments arrives as one span, and `Go::parse` doesn't line-split first. That means the directive takes the package doc down with it — i.e. the canonical Go file preamble:

```go
//go:build linux

// Package example does teh thing.   // never linted
```

`Solidity::parse_line` has the structurally identical SPDX-skipping code, but `Solidity::parse` line-splits before calling it, so `source` never holds a `\n`, `terminator` is always `None`, and it's correct by construction. Go is the sibling that doesn't.

While fixing it I hit the coupled half: `// +build` — the pre-1.17 spelling that `//go:build` replaced, still present in files keeping compat — was being linted as prose, producing `Linux` spelling suggestions on a build tag. Un-dropping the block surfaces that noise on the most canonical Go idiom of all (the `//go:build` + `// +build` pair), so fixing one without the other just trades a silent drop for visible false positives. Hence the loop plus `is_directive`.

# Demo

```
//go:build linux && amd64
// +build linux,amd64

// Package example does teh thing.
package example
```
Before: 0 lints. After: 2 (the `teh`), build tags silent.

# How Has This Been Tested?

`harper-comments` had **no `.go` fixture and no Go test at all**, which is why this sat. Added three, following the `create_test!` convention:

- `go_directives.go` — `//go:build` + package doc, and `//go:generate` + a type doc.
- `go_build_tags.go` — the `//go:build` + `// +build` pair.
- `go_control.go` — same prose, no directive. This is the one that pins the parser's normal path; it passes before and after, which is what tells you the other two aren't failing for some unrelated reason.

Verified red before the fix: both directive tests report 0 lints, control reports 4. Green after.

`cargo test -p harper-comments`: 42 passed, 0 failed. `cargo test -p harper-core --lib`: 5527 passed, 0 failed, 284 ignored — unchanged. `cargo fmt --check` and `cargo clippy` clean on the crate. (No `just` here, so I ran cargo directly rather than `just precommit`; happy to push again if CI disagrees.)

One thing I left alone: `without_initiators` strips whitespace too, so `// go:generate` — with a space, which per spec is *not* a directive — is also treated as one. That's pre-existing in both the old and new code and felt out of scope.
