### PR TITLE
fix(core): major issues with `SplitWords`

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -21216,6 +21216,7 @@ desert/~NwSgJ>VdGZ
 deserter/NgS
 desertification/Nmg
 desertion/~NwSg
+deserve/~V>SZ
 deserved/~JYVU
 deserving/~JNVU
 desi/NgS₹

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -13788,7 +13788,7 @@ azalea/NSg
 azimuth/~N0g
 azimuths/N9
 azure/~NSgJV
-b/~J^VdK
+b/J^VdK
 baa/~NSgVdG
 babble/VGd>SNmgZ
 babbler/~Ng
@@ -16267,7 +16267,7 @@ bytecode/NwgS
 byway/~NSg
 byword/NSg
 byzantine/~JN
-c/~NSViE
+c/NSViE
 ca/P
 cab/~NSgV>Z
 cab sav/Nmg†_       # Australia slang = Cabernet Sauvignon
@@ -22711,7 +22711,7 @@ dystopi
 dystopia/NwgS
 dystopian/~J
 dz/NV
-e/~NSId^W
+e/NSId^W
 e-book/NgS
 e-commerce/Nmg
 e'en/
@@ -24916,7 +24916,6 @@ fewness/Ng
 fey/~JN
 fez/~Ng
 fezzes/N
-ff/~V
 fiance/NgVe
 fiancee/NgS
 fiances/N
@@ -26346,7 +26345,7 @@ fuzziness/Ng
 fuzzy/~J^>pNS
 fwd/~JNV
 fwy/N
-g/~NSnXvB
+g/NSnXvB
 gab/~NSgV
 gabardine/NSg
 gabbed/VtT
@@ -27764,7 +27763,7 @@ gyrofrequency/NgS
 gyroscope/NgS
 gyroscopic/J
 gyve/NgSVGd
-h/~NJGnXZvz         # removed `>` 'her' is not comparative of 'h'
+h/NJGnXZvz         # removed `>` 'her' is not comparative of 'h'
 h'm/
 ha/~
 hah/~
@@ -31076,7 +31075,7 @@ iv/~U
 ivory/~NwSgJ
 ivy/~NSgd
 ix/~
-j/~NW
+j/NW
 jab/NSgV
 jabbed/VtTJ
 jabber/Vd>GSNgZ
@@ -37947,7 +37946,7 @@ oxymoronic/J
 oyster/~NSgJV
 oz/~N
 ozone/~NgV
-p/~PNV>G^nXz
+p/PNV>G^nXz
 p.m./
 pH/
 pa/~NSgH
@@ -41443,7 +41442,7 @@ pyruvate/~N
 python/~NSg
 pyx/NgSV
 pzazz/N
-q/~N
+q/N
 qr/~N
 qt/~NS
 qty/N
@@ -53566,7 +53565,7 @@ wurst/NSg
 wuss/NgSV
 wussy/J>^NSg
 wyvern/NSg
-x/~                 # removed `5` and `7` adjective and `conjunction`
+x/                 # removed `5` and `7` adjective and `conjunction`
 x-axis/Ng
 x64/Ng
 x86/~Ng

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -24223,7 +24223,7 @@ expenditure/~NwSg
 expense/~NwgSV
 expensive/~JYpi
 expensiveness/Nmgi
-experience/~Nw0gVd
+experience/~Nw0gVdi
 experiences/~N9Vh
 experiencing/~V6N
 experiential/~J

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -15950,7 +15950,7 @@ brute force/NwgSVdG
 brutish/JYp
 brutishness/Nmg
 brutus/
-bu/~N
+bu/N
 bub/NSgV
 bubble/~NSgVdG>
 bubble tea/NwgS
@@ -21680,7 +21680,7 @@ dirtball/NS
 dirtily/Ry
 dirtiness/Nmg
 dirty/~J^>pVdSG
-dis/~VNgI(
+dis/VNgI(
 disable/~VdSGJL
 disablement/Ng
 disambiguate/~VSdGn
@@ -22720,7 +22720,6 @@ e.g./~N
 eBay/OgV
 eMusic/g
 eSIM/NgS
-ea/~N
 each/~Dq
 each other/I
 eager/~J^Y>pVN
@@ -22853,7 +22852,7 @@ ecumenical/~JY
 ecumenicism/Ng
 ecumenism/Nmg
 eczema/Nwg
-ed/~NSgre
+ed/NSgre
 edamame/N
 eddy/~NSgVdG
 edelweiss/Ng
@@ -46929,7 +46928,7 @@ squish/NgSVGd
 squishy/J>^N
 sriracha/N
 ssh/~VO
-st/~N
+st/N
 stab/~NgSVJY
 stabbed/~VtT
 stabber/NgS
@@ -49610,7 +49609,7 @@ tinder/NgV
 tinderbox/NgS
 tine/NgSJV
 tinfoil/NmgV
-ting/~NgVdGY
+ting/NgVdGY
 tinge/NSgV
 tingeing/V
 tingle/VdGSNgz
@@ -54714,3 +54713,4 @@ vicontiel/J         # As above, alternative version
 viscomital/J        # As above, alternative version
 WordCamp/Og
 worldbuild/V>G
+playthrough/gNS

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -24223,7 +24223,7 @@ expenditure/~NwSg
 expense/~NwgSV
 expensive/~JYpi
 expensiveness/Nmgi
-experience/~Nw0gVdi
+experience/~Nw0gVd
 experiences/~N9Vh
 experiencing/~V6N
 experiential/~J
@@ -30205,7 +30205,7 @@ inexorability/N
 inexorable/J
 inexorably/Ry
 inexpedient/J
-inexperience/Nmg
+inexperience/~Nmgd
 inexpert/JYN
 inexpiable/J
 inexplicably/~Ry

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -1165,6 +1165,43 @@ mod tests {
         );
     }
 
+    #[test]
+    fn fix_stoped() {
+        assert_suggestion_result("He stoped to think.", test_group(), "He stopped to think.");
+    }
+
+    #[test]
+    fn allow_playthrough() {
+        assert_no_lints("I recently did a playthrough.", test_group());
+    }
+
+    #[test]
+    fn fixes_politicans() {
+        assert_suggestion_result(
+            "I guess politicans like to complain.",
+            test_group(),
+            "I guess politicans like to complain.",
+        );
+    }
+
+    #[test]
+    fn fixes_benefitting() {
+        assert_suggestion_result(
+            "Who is really benefitting from it?",
+            test_group(),
+            "Who is really benefiting from it?",
+        );
+    }
+
+    #[test]
+    fn fixes_easir() {
+        assert_suggestion_result(
+            "It makes it easir to select it.",
+            test_group(),
+            "It makes it easier to select it.",
+        );
+    }
+
     /// Tests that no linters' descriptions contain errors handled by other linters.
     ///
     /// This test verifies that the description of each linter (which is written in natural language)

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -1202,6 +1202,24 @@ mod tests {
         );
     }
 
+    #[test]
+    fn fixes_disserve() {
+        assert_suggestion_result(
+            "I think you disserve a reward.",
+            test_group(),
+            "I think you deserve a reward.",
+        );
+    }
+
+    #[test]
+    fn fixes_buget() {
+        assert_suggestion_result(
+            "It was in their buget range.",
+            test_group(),
+            "It was in their budget range.",
+        );
+    }
+
     /// Tests that no linters' descriptions contain errors handled by other linters.
     ///
     /// This test verifies that the description of each linter (which is written in natural language)

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -1203,15 +1203,6 @@ mod tests {
     }
 
     #[test]
-    fn fixes_disserve() {
-        assert_suggestion_result(
-            "I think you disserve a reward.",
-            test_group(),
-            "I think you deserve a reward.",
-        );
-    }
-
-    #[test]
     fn fixes_buget() {
         assert_suggestion_result(
             "It was in their buget range.",

--- a/harper-core/src/linting/split_words.rs
+++ b/harper-core/src/linting/split_words.rs
@@ -208,10 +208,14 @@ fn should_defer_to_spellcheck(
 
 #[cfg(test)]
 mod tests {
+    use itertools::Itertools;
+
+    use crate::Document;
     use crate::linting::tests::{
         assert_good_and_bad_suggestions, assert_lint_message, assert_no_lints,
         assert_suggestion_result,
     };
+    use crate::linting::{Linter, Suggestion};
 
     use super::SplitWords;
 
@@ -363,6 +367,53 @@ mod tests {
     fn allows_informal_laughter() {
         for source in ["hah", "haha", "hahah", "hahaha", "Hahahah"] {
             assert_no_lints(source, SplitWords::default());
+        }
+    }
+
+    #[test]
+    fn does_not_split_iff() {
+        assert_no_lints("iff", SplitWords::default());
+    }
+
+    /// Checks for a condition where the SplitWords rule would correct a word to be composed of a
+    /// single letter (which is not a word), followed by a valid word.
+    ///
+    /// For example, `comitted` -> `c omitted`.
+    #[test]
+    fn never_corrects_to_invalid_single_letter_words() {
+        let triggers = [
+            "comitted", "testc", "testh", "testb", "testq", "testx", "testg", "teste", "testi",
+            "testj",
+        ];
+        let relevant_letters = ['c', 'd', 't', 'h', 'b', 'x', 'e', 'i', 'j'];
+
+        for trigger in triggers {
+            let mut rule = SplitWords::default();
+
+            let doc = Document::new_plain_english_curated(trigger);
+            let lints = rule.lint(&doc);
+
+            for lint in lints {
+                dbg!(&lint);
+
+                for sug in lint.suggestions {
+                    match sug {
+                        Suggestion::ReplaceWith(items) => {
+                            // Words created by the rule.
+                            let created_words = items.split(|c| c == &' ');
+
+                            for word in created_words {
+                                if word.len() == 1
+                                    && relevant_letters.iter().contains(&word.first().unwrap())
+                                {
+                                    panic!("Encountered bad output {word:?}")
+                                }
+                            }
+                        }
+                        _ => (),
+                    }
+                }
+            }
         }
     }
 }

--- a/harper-core/src/linting/split_words.rs
+++ b/harper-core/src/linting/split_words.rs
@@ -383,8 +383,9 @@ mod tests {
     fn never_corrects_to_invalid_single_letter_words() {
         let triggers = [
             "comitted", "testc", "testh", "testb", "testq", "testx", "testg", "teste", "testj",
+            "shes",
         ];
-        let relevant_letters = ['c', 'd', 't', 'h', 'b', 'x', 'e', 'j'];
+        let relevant_letters = ['c', 'd', 't', 'h', 'b', 'x', 'e', 'j', 's'];
 
         for trigger in triggers {
             let mut rule = SplitWords::default();

--- a/harper-core/src/linting/split_words.rs
+++ b/harper-core/src/linting/split_words.rs
@@ -382,10 +382,9 @@ mod tests {
     #[test]
     fn never_corrects_to_invalid_single_letter_words() {
         let triggers = [
-            "comitted", "testc", "testh", "testb", "testq", "testx", "testg", "teste", "testi",
-            "testj",
+            "comitted", "testc", "testh", "testb", "testq", "testx", "testg", "teste", "testj",
         ];
-        let relevant_letters = ['c', 'd', 't', 'h', 'b', 'x', 'e', 'i', 'j'];
+        let relevant_letters = ['c', 'd', 't', 'h', 'b', 'x', 'e', 'j'];
 
         for trigger in triggers {
             let mut rule = SplitWords::default();

--- a/harper-core/src/spell/mutable_dictionary.rs
+++ b/harper-core/src/spell/mutable_dictionary.rs
@@ -407,6 +407,11 @@ mod tests {
     }
 
     #[test]
+    fn contains_inexperienced() {
+        assert!(MutableDictionary::curated().contains_word_str("inexperienced"))
+    }
+
+    #[test]
     fn has_is_not_a_nominal() {
         let dict = MutableDictionary::curated();
 

--- a/harper-core/tests/text/linters/Part-of-speech tagging.snap.yml
+++ b/harper-core/tests/text/linters/Part-of-speech tagging.snap.yml
@@ -47,9 +47,9 @@ Message: |
       18 | two distinctive groups: rule-based and stochastic. E. Brill's tagger, one of the
          |                                                    ^~ Did you mean to spell `E.` this way?
 Suggest:
-  - Replace with: “E”
-  - Replace with: “Ea”
   - Replace with: “Eh”
+  - Replace with: “Em”
+  - Replace with: “Ex”
 
 
 

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -5,7 +5,7 @@ Message: |
 Suggest:
   - Replace with: “Fa”
   - Replace with: “Fe”
-  - Replace with: “Ff”
+  - Replace with: “Ft”
 
 
 
@@ -782,8 +782,8 @@ Message: |
          |                                                         ^~ Did you mean to spell `J.` this way?
 Suggest:
   - Replace with: “Jo”
-  - Replace with: “J”
   - Replace with: “Jg”
+  - Replace with: “Jr”
 
 
 
@@ -816,8 +816,8 @@ Message: |
          |              ^~ Did you mean to spell `J.` this way?
 Suggest:
   - Replace with: “Jo”
-  - Replace with: “J”
   - Replace with: “Jg”
+  - Replace with: “Jr”
 
 
 
@@ -893,7 +893,7 @@ Message: |
 Suggest:
   - Replace with: “Be”
   - Replace with: “Bi”
-  - Replace with: “Bu”
+  - Replace with: “BO”
 
 
 
@@ -1144,7 +1144,7 @@ Message: |
 Suggest:
   - Replace with: “Be”
   - Replace with: “Bi”
-  - Replace with: “Bu”
+  - Replace with: “BO”
 
 
 
@@ -1700,15 +1700,6 @@ Suggest:
   - Replace with: “banjo's”
   - Replace with: “banjos”
   - Replace with: “bandies”
-
-
-
-Lint:    Typo (31 priority)
-Message: |
-    1413 | trembling a little to the stiff, tinny drip of the banjoes on the lawn.
-         |                                                    ^~~~~~~ `banjoes` should probably be written as `banjo es`.
-Suggest:
-  - Replace with: “banjo es”
 
 
 
@@ -2379,7 +2370,7 @@ Message: |
 Suggest:
   - Replace with: “Be”
   - Replace with: “Bi”
-  - Replace with: “Bu”
+  - Replace with: “BO”
 
 
 
@@ -2607,7 +2598,7 @@ Message: |
 Suggest:
   - Replace with: “Be”
   - Replace with: “Bi”
-  - Replace with: “Bu”
+  - Replace with: “BO”
 
 
 
@@ -3566,11 +3557,10 @@ Suggest:
 Lint:    Typo (31 priority)
 Message: |
     2319 | That was nineteen-seventeen. By the next year I had a few beaux myself, and I
-         |                                                           ^~~~~ `beaux` has a missing space between words.
+         |                                                           ^~~~~ `beaux` should probably be written as `be aux`.
     2320 | began to play in tournaments, so I didn’t see Daisy very often. She went with a
 Suggest:
   - Replace with: “be aux”
-  - Replace with: “beau x”
 
 
 
@@ -3642,15 +3632,6 @@ Suggest:
   - Replace with: “dear's”
   - Replace with: “dares”
   - Replace with: “dearies”
-
-
-
-Lint:    Typo (31 priority)
-Message: |
-    2349 | “Here, deares’.” She groped around in a wastebasket she had with her on the bed
-         |        ^~~~~~ `deares` should probably be written as `dear es`.
-Suggest:
-  - Replace with: “dear es”
 
 
 
@@ -4997,15 +4978,6 @@ Suggest:
 
 
 
-Lint:    Typo (31 priority)
-Message: |
-    3646 | “The bles-sed pre-cious! Did mother get powder on your old yellowy hair? Stand
-         |      ^~~~ `bles` should probably be written as `bl es`.
-Suggest:
-  - Replace with: “bl es”
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
     3646 | “The bles-sed pre-cious! Did mother get powder on your old yellowy hair? Stand
@@ -5154,8 +5126,8 @@ Message: |
          |                                     ^~ Did you mean to spell `J.` this way?
 Suggest:
   - Replace with: “Jo”
-  - Replace with: “J”
   - Replace with: “Jg”
+  - Replace with: “Jr”
 
 
 
@@ -5232,8 +5204,8 @@ Message: |
          |                                                       ^~ Did you mean to spell `J.` this way?
 Suggest:
   - Replace with: “Jo”
-  - Replace with: “J”
   - Replace with: “Jg”
+  - Replace with: “Jr”
 
 
 
@@ -5426,6 +5398,28 @@ Message: |
          |                                                ^~~ If you mean the informal word for `yes` and not the biblical or legalistic `yea`, the standard spelling is `yeah`.
 Suggest:
   - Replace with: “Yeah”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4070 | the window, followed by intermittent cries of “Yea—ea—ea!” and finally by a
+         |                                                    ^~ Did you mean to spell `ea` this way?
+Suggest:
+  - Replace with: “ear”
+  - Replace with: “eat”
+  - Replace with: “eh”
+
+
+
+Lint:    Spelling (63 priority)
+Message: |
+    4070 | the window, followed by intermittent cries of “Yea—ea—ea!” and finally by a
+         |                                                       ^~ Did you mean to spell `ea` this way?
+Suggest:
+  - Replace with: “ear”
+  - Replace with: “eat”
+  - Replace with: “eh”
 
 
 
@@ -5947,7 +5941,7 @@ Message: |
 Suggest:
   - Replace with: “re”
   - Replace with: “a”
-  - Replace with: “e”
+  - Replace with: “i”
 
 
 
@@ -5958,7 +5952,7 @@ Message: |
 Suggest:
   - Replace with: “re”
   - Replace with: “a”
-  - Replace with: “e”
+  - Replace with: “i”
 
 
 
@@ -5989,7 +5983,7 @@ Message: |
 Suggest:
   - Replace with: “re”
   - Replace with: “a”
-  - Replace with: “e”
+  - Replace with: “i”
 
 
 
@@ -6057,9 +6051,8 @@ Suggest:
 Lint:    Typo (31 priority)
 Message: |
     4503 | “She ran out ina road. Son-of-a-bitch didn’t even stopus car.”
-         |                                                   ^~~~~~ `stopus` has a missing space between words.
+         |                                                   ^~~~~~ `stopus` should probably be written as `stop us`.
 Suggest:
-  - Replace with: “st opus”
   - Replace with: “stop us”
 
 
@@ -6783,8 +6776,8 @@ Message: |
          |              ^~ Did you mean to spell `J.` this way?
 Suggest:
   - Replace with: “Jo”
-  - Replace with: “J”
   - Replace with: “Jg”
+  - Replace with: “Jr”
 
 
 
@@ -7285,8 +7278,8 @@ Message: |
          |                                                               ^~ Did you mean to spell `J.` this way?
 Suggest:
   - Replace with: “Jo”
-  - Replace with: “J”
   - Replace with: “Jg”
+  - Replace with: “Jr”
 
 
 
@@ -7317,7 +7310,7 @@ Message: |
 Suggest:
   - Replace with: “Be”
   - Replace with: “Bi”
-  - Replace with: “Bu”
+  - Replace with: “BO”
 
 
 
@@ -7328,7 +7321,7 @@ Message: |
 Suggest:
   - Replace with: “Fa”
   - Replace with: “Fe”
-  - Replace with: “Ff”
+  - Replace with: “Ft”
 
 
 
@@ -7574,9 +7567,9 @@ Message: |
     5613 | great for that. He told me I et like a hog once, and I beat him for it.”
          |                              ^~ Did you mean to spell `et` this way?
 Suggest:
-  - Replace with: “e”
-  - Replace with: “ea”
   - Replace with: “eat”
+  - Replace with: “eh”
+  - Replace with: “em”
 
 
 
@@ -7842,8 +7835,8 @@ Message: |
          |                                                                   ^~ Did you mean to spell `El` this way?
 Suggest:
   - Replace with: “Ell”
-  - Replace with: “E”
-  - Replace with: “Ea”
+  - Replace with: “Eel”
+  - Replace with: “Eh”
 
 
 

--- a/harper-core/tests/text/tagged/The Great Gatsby.md
+++ b/harper-core/tests/text/tagged/The Great Gatsby.md
@@ -3005,7 +3005,7 @@
 > the lower     East   Side     of New   York . That      was  comprehensible . But     young     men
 # D   NSg/VB/JC NPr/J+ NSg/VB/J P  NSg/J NPr+ . I/C/Ddem+ VLPt J              . NSg/C/P NPr/VB/J+ NPl+
 > didn’t — at    least    in        my  provincial inexperience I       believed they didn’t — drift
-# VXPt   . NSg/P NSg/J/Dq NPr/J/R/P D$+ NSg/J      Nᴹ           ISg/#r+ VP/J     IPl+ VXPt   . NSg/VB
+# VXPt   . NSg/P NSg/J/Dq NPr/J/R/P D$+ NSg/J      N🅪Sg/VB      ISg/#r+ VP/J     IPl+ VXPt   . NSg/VB
 > coolly out          of nowhere and  buy    a   palace  on  Long     Island  Sound      .
 # R      NSg/VB/J/R/P P  NSg/J   VB/C NSg/VB D/P NSg/VB+ J/P NPr/VB/J NSg/VB+ N🅪Sg/VB/J+ .
 >
@@ -8136,8 +8136,8 @@
 #
 > The music      had died down        as    the ceremony began and  now       a    long      cheer   floated in        at
 # D+  N🅪Sg/VB/J+ VP  VP/J N🅪Sg/VB/J/P R/C/P D+  N🅪Sg+    VPt   VB/C NSg/J/R/C D/P+ NPr/VB/J+ NSg/VB+ VP/J    NPr/J/R/P NSg/P
-> the window  , followed by    intermittent cries  of “ Yea   — ea  — ea  ! ” and  finally by    a
-# D+  NSg/VB+ . VP/J     NSg/P NSg/J        NPl/V3 P  . NSg/C . NSg . NSg . . VB/C R       NSg/P D/P
+> the window  , followed by    intermittent cries  of “ Yea   — ea — ea ! ” and  finally by    a
+# D+  NSg/VB+ . VP/J     NSg/P NSg/J        NPl/V3 P  . NSg/C . ?  . ?  . . VB/C R       NSg/P D/P
 > burst  of jazz    as    the dancing began .
 # NSg/VB P  NSg/VB+ R/C/P D   Nᴹ/Vg/J VPt   .
 >

--- a/harper-core/tests/text/tagged/The Great Gatsby.md
+++ b/harper-core/tests/text/tagged/The Great Gatsby.md
@@ -3005,7 +3005,7 @@
 > the lower     East   Side     of New   York . That      was  comprehensible . But     young     men
 # D   NSg/VB/JC NPr/J+ NSg/VB/J P  NSg/J NPr+ . I/C/Ddem+ VLPt J              . NSg/C/P NPr/VB/J+ NPl+
 > didn’t — at    least    in        my  provincial inexperience I       believed they didn’t — drift
-# VXPt   . NSg/P NSg/J/Dq NPr/J/R/P D$+ NSg/J      N🅪Sg/VB      ISg/#r+ VP/J     IPl+ VXPt   . NSg/VB
+# VXPt   . NSg/P NSg/J/Dq NPr/J/R/P D$+ NSg/J      Nᴹ           ISg/#r+ VP/J     IPl+ VXPt   . NSg/VB
 > coolly out          of nowhere and  buy    a   palace  on  Long     Island  Sound      .
 # R      NSg/VB/J/R/P P  NSg/J   VB/C NSg/VB D/P NSg/VB+ J/P NPr/VB/J NSg/VB+ N🅪Sg/VB/J+ .
 >


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

N/A

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

`SplitWords` is the single most commonly reported rule, besides `SpellCheck`. I've gone through the reports and addressed several of the most common issues. 

Those include:

1. Single letters are sometimes emitted as a whole word (i.e. `c ommitted`).
2. Cases that _should_ be handled by `SpellCheck` are overridden by `SplitWords`.
3. Missing or improperly tagged words in the dictionary.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Additional unit tests.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [x] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
