### PR TITLE
docs(web): add JetBrains IDE integration guide (LSP4IJ)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ Agents should remind humans of this when possible.
 - `packages/web/src/routes/docs/integrations/emacs/+page.md`: Emacs setup using `harper-ls`, plus optional and common config tweaks.
 - `packages/web/src/routes/docs/integrations/zed/+page.md`: Zed extension entry point and link to canonical extension README.
 - `packages/web/src/routes/docs/integrations/sublime-text/+page.md`: Sublime Text setup with `harper-ls` and LSP package configuration.
+- `packages/web/src/routes/docs/integrations/jetbrains/+page.md`: JetBrains IDE setup via the LSP4IJ plugin's built-in `harper-ls` support.
 - `packages/web/src/routes/docs/harperjs/introduction/+page.md`: `harper.js` mission, package overview, and installation starting point.
 - `packages/web/src/routes/docs/harperjs/linting/+page.md`: Core `harper.js` lint workflow and linter usage patterns.
 - `packages/web/src/routes/docs/harperjs/spans/+page.md`: Explains span objects and how to use them to locate/handle lint ranges.

--- a/packages/web/src/routes/docs/integrations/jetbrains/+page.md
+++ b/packages/web/src/routes/docs/integrations/jetbrains/+page.md
@@ -1,0 +1,21 @@
+---
+title: JetBrains IDEs
+---
+
+You can use [`harper-ls`](./language-server) in any IDE built on the IntelliJ Platform — IntelliJ IDEA, WebStorm, PyCharm, Rider, GoLand, RustRover, CLion, PhpStorm, RubyMine, and more — through the community [LSP4IJ](https://plugins.jetbrains.com/plugin/23257-lsp4ij) plugin, which ships with `harper-ls` support built in. No Harper-specific plugin is required.
+
+## Required Setup
+
+Make sure you have `harper-ls` installed and available on your `PATH`. You can do this using the [supported installation methods](./language-server#Installation).
+
+Install [LSP4IJ](https://plugins.jetbrains.com/plugin/23257-lsp4ij) from `Settings/Preferences > Plugins > Marketplace`, then search for "LSP4IJ" and click "Install".
+
+## Enabling `harper-ls`
+
+LSP4IJ includes a predefined entry for `harper-ls` under `Settings/Preferences > Languages & Frameworks > Language Servers`. Enable it there, or add `harper-ls` as a user-defined language server pointing at your installed binary if your version of LSP4IJ doesn't list it yet.
+
+For the exact, up-to-date steps and screenshots, see [LSP4IJ's `harper-ls` documentation](https://github.com/redhat-developer/lsp4ij/blob/main/docs/user-defined-ls/harper-ls.md), since that page is maintained by the LSP4IJ project and may change independently of Harper.
+
+## Configuration
+
+`harper-ls` is configured the same way regardless of editor. See the [configuration section](./language-server#Configuration) of our `harper-ls` documentation for the full list of options, including dialect, dictionaries, and which linters to enable.

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -121,6 +121,10 @@ export default defineConfig(async () => {
 											title: 'Sublime Text',
 											to: '/docs/integrations/sublime-text',
 										},
+										{
+											title: 'JetBrains IDEs',
+											to: '/docs/integrations/jetbrains',
+										},
 									],
 								},
 								{


### PR DESCRIPTION
## Disclosure

Parts of this PR (research and the doc page draft) were produced with AI assistance (Claude Code), per Harper's [agent PR policy](https://github.com/automattic/harper/blob/master/AGENT_POLICY.md).

## Summary

Closes #362.

That issue asked for JetBrains IDE support. The thread already converged on the right answer: [LSP4IJ](https://plugins.jetbrains.com/plugin/23257-lsp4ij) (a community LSP client plugin for the IntelliJ Platform) ships with built-in support for `harper-ls` as a predefined language server — see [LSP4IJ's harper-ls docs](https://github.com/redhat-developer/lsp4ij/blob/main/docs/user-defined-ls/harper-ls.md). A separate custom Harper plugin isn't needed, and another contributor who tried building one directly against `harper-core`/`harper-ls` ran into "typical Gradle horrors and version incompatibilities" in the issue thread.

@elijah-potter had explicitly asked for exactly this doc page in the issue thread:

> If you'd put something in `packages/web/src/routes/docs/integrations/intellij/+page.md`, I can take care of the rest.

This PR adds that page (at `.../integrations/jetbrains/+page.md` to match the "JetBrains IDEs" framing used for the sidebar entry, since the plugin/IDE family covers more than just IntelliJ IDEA), covering:
- Required setup (`harper-ls` + the LSP4IJ plugin)
- Enabling `harper-ls` in LSP4IJ
- A pointer to the shared `harper-ls` configuration reference

## Changes

- `packages/web/src/routes/docs/integrations/jetbrains/+page.md` (new): the integration guide, modeled on the existing `visual-studio-code` and `sublime-text` pages.
- `packages/web/vite.config.ts`: registers the new page in the docs sidebar under "Integrations".
- `AGENTS.md`: adds the new page to the sidebar file inventory, per the existing convention.

## Test plan

- [x] `pnpm dev` in `packages/web`, confirmed `/docs/integrations/jetbrains` renders (200) with the new sidebar entry linking correctly.
- [x] `npx @biomejs/biome check` on the changed files (no issues).
- [ ] Maintainer review of tone/content, since I'm not a JetBrains/LSP4IJ user myself — happy to adjust wording.