### PR TITLE
feat(dictionary): add entries for 'precess' and derivatives

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -40355,6 +40355,8 @@ precedence/~Ng
 precedent/~NSgJVdG
 precept/NSgV
 preceptor/NSg
+precess/vVG
+precession/N
 precinct/~NgS
 preciosity/Ng
 precious/~JYpN


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->
Add 'precess' verb and derivatives (mainly 'precession' noun and 'precessive' adjective) to the dictionary. These are often used in classical and quantum mechanics literature, it designates a rotation movement where the rotation axis itself rotates around another axis ([wikipedia](https://en.wikipedia.org/wiki/Precession)).

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
Laziness disclosure, I did not. I am not sure how to go about it efficiently for dictionary changes.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [N/A] I have added tests to cover my changes
- [N/A] I have considered splitting this into smaller pull requests.
