### PR TITLE
fix: coerce fn items to fn pointers in then_kind_any arrays (fixes build on rustc 1.93)

### DIFF
--- a/harper-core/src/linting/for_free_of_charge.rs
+++ b/harper-core/src/linting/for_free_of_charge.rs
@@ -13,13 +13,13 @@ impl Default for ForFreeOfCharge {
         Self {
             expr: SequenceExpr::word_seq(&["for", "free", "of", "charge"]).then_any_of(vec![
                 Box::new(SequenceExpr::default().then_kind_any(&[
-                    TokenKind::is_sentence_terminator,
+                    TokenKind::is_sentence_terminator as fn(&TokenKind) -> bool,
                     TokenKind::is_comma,
                     TokenKind::is_quote,
                 ])),
                 Box::new(SequenceExpr::whitespace().then_kind_any_but_not(
                     &[
-                        TokenKind::is_conjunction,
+                        TokenKind::is_conjunction as fn(&TokenKind) -> bool,
                         TokenKind::is_preposition,
                         TokenKind::is_verb,
                     ],

--- a/harper-core/src/linting/in_demand_in_depth.rs
+++ b/harper-core/src/linting/in_demand_in_depth.rs
@@ -22,7 +22,7 @@ impl Default for InDemandInDepth {
                     // ✘ [Defense] in Depth                                - abstract/mass noun
                     // ✘ and [MCP] in depth                                - mass noun
                     &[
-                        TokenKind::is_verb_lemma,
+                        TokenKind::is_verb_lemma as fn(&TokenKind) -> bool,
                         TokenKind::is_preposition,
                         TokenKind::is_quantifier,
                         TokenKind::is_degree_adverb,

--- a/harper-core/src/linting/naked_eye.rs
+++ b/harper-core/src/linting/naked_eye.rs
@@ -20,7 +20,7 @@ impl Default for NakedEye {
                     SequenceExpr::optional(
                         SequenceExpr::default()
                             .then_kind_any(&[
-                                TokenKind::is_determiner,
+                                TokenKind::is_determiner as fn(&TokenKind) -> bool,
                                 TokenKind::is_adjective,
                                 TokenKind::is_oov,
                             ])


### PR DESCRIPTION
harper-core fails to build on rustc 1.93 (stable, 2026-02-11) with three `E0308` errors:

```
error[E0308]: mismatched types
  --> harper-core/src/linting/for_free_of_charge.rs:15:64
   = note: expected reference `&'static [for<'a> fn(&'a TokenKind) -> bool {TokenKind::is_sentence_terminator}]`
              found reference `&[for<'a> fn(&'a TokenKind) -> bool; 3]`
```

## Cause

`then_kind_any<F>(self, preds_is: &'static [F])` infers `F` from the first array element, which is that function's unique *fn-item* type. The array literal, meanwhile, LUB-coerces all of its elements to the *fn-pointer* type `fn(&TokenKind) -> bool`. On recent rustc those two no longer unify, so the call fails to typecheck.

## Fix

Annotate the first element of each affected array, which pins `F` to the fn-pointer type before coercion happens. No behavioural change, three call sites:

- `linting/for_free_of_charge.rs` (2)
- `linting/in_demand_in_depth.rs` (1)
- `linting/naked_eye.rs` (1)

## Verification

`cargo build` succeeds on rustc 1.93.1 with the patch applied; it fails without it on `master` (efa59c3), and on published 2.3.0/2.4.0/2.5.0 as well.