### PR TITLE
fix(core): flag 'get access at' and suggest 'get access to' (#3309)

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5734,6 +5734,13 @@
 						},
 						{
 							"Bool": {
+								"name": "GetAccessAt",
+								"state": true,
+								"label": "Get Access At"
+							}
+						},
+						{
+							"Bool": {
 								"name": "GoSoFarAsTo",
 								"state": true,
 								"label": "Go So Far As To"

--- a/harper-core/src/linting/get_access_at.rs
+++ b/harper-core/src/linting/get_access_at.rs
@@ -30,11 +30,7 @@ impl Default for GetAccessAt {
             .t_ws()
             .t_aco("access")
             .t_ws()
-            .t_aco("at")
-            .t_ws()
-            .then_word_except(&["all", "least"])
-            .t_ws()
-            .then_any_word();
+            .t_aco("at");
 
         Self { expr: pattern }
     }
@@ -48,29 +44,37 @@ impl ExprLinter for GetAccessAt {
     }
 
     fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
-        let at_tok = toks.get(4)?;
+        let at_tok = toks.last()?;
+        let rest: String = src.get(at_tok.span.end..)?.iter().collect();
+        let rest_lower = rest.to_lowercase();
 
-        if let Some(next) = toks.get(6) {
-            let next_str = next.get_str(src).to_lowercase();
+        // False positive checks: "at all", "at least"
+        if rest_lower.starts_with(" all") || rest_lower.starts_with(" least") {
+            return None;
+        }
 
-            // False positive check: URLs / Web addresses
-            if next_str.starts_with("http://")
-                || next_str.starts_with("https://")
-                || next_str.contains("www.")
-            {
-                return None;
-            }
+        // False positive check: URLs / Web addresses
+        if rest_lower.starts_with(" http://")
+            || rest_lower.starts_with(" https://")
+            || rest_lower.starts_with(" www.")
+        {
+            return None;
+        }
 
-            // False positive check: "at this time", "at the moment", "at the level", "at the stage"
-            let is_time_or_level = matches!(next_str.as_str(), "this" | "that" | "the")
-                && toks.get(8).is_some_and(|following| {
-                    let fol_str = following.get_str(src).to_lowercase();
-                    matches!(fol_str.as_str(), "time" | "moment" | "stage" | "level")
-                });
-
-            if is_time_or_level {
-                return None;
-            }
+        // False positive check: "at this time", "at the moment", "at the level", "at the stage", etc.
+        if rest_lower.starts_with(" this time")
+            || rest_lower.starts_with(" this moment")
+            || rest_lower.starts_with(" this stage")
+            || rest_lower.starts_with(" this level")
+            || rest_lower.starts_with(" that time")
+            || rest_lower.starts_with(" that moment")
+            || rest_lower.starts_with(" that stage")
+            || rest_lower.starts_with(" that level")
+            || rest_lower.starts_with(" the moment")
+            || rest_lower.starts_with(" the stage")
+            || rest_lower.starts_with(" the level")
+        {
+            return None;
         }
 
         Some(Lint {

--- a/harper-core/src/linting/get_access_at.rs
+++ b/harper-core/src/linting/get_access_at.rs
@@ -58,22 +58,21 @@ impl ExprLinter for GetAccessAt {
             let next_word = next.get_str(src).to_lowercase();
 
             // False positive checks: "at all", "at least"
-            if next_word == "all" || next_word == "least" {
+            if matches!(next_word.as_str(), "all" | "least") {
                 return None;
             }
 
             // False positive check: "at this time", "at the moment", "at the level", etc.
-            if next_word == "this" || next_word == "that" || next_word == "the" {
-                if let Some(following) = following_tok {
+            let is_time_or_level = match (next_word.as_str(), following_tok) {
+                ("this" | "that" | "the", Some(following)) => {
                     let fol_word = following.get_str(src).to_lowercase();
-                    if fol_word == "time"
-                        || fol_word == "moment"
-                        || fol_word == "stage"
-                        || fol_word == "level"
-                    {
-                        return None;
-                    }
+                    matches!(fol_word.as_str(), "time" | "moment" | "stage" | "level")
                 }
+                _ => false,
+            };
+
+            if is_time_or_level {
+                return None;
             }
 
             // False positive check: URLs / Web addresses

--- a/harper-core/src/linting/get_access_at.rs
+++ b/harper-core/src/linting/get_access_at.rs
@@ -62,13 +62,14 @@ impl ExprLinter for GetAccessAt {
             }
 
             // False positive check: "at this time", "at the moment", "at the level", "at the stage"
-            if matches!(next_str.as_str(), "this" | "that" | "the") {
-                if let Some(following) = toks.get(8) {
+            let is_time_or_level = matches!(next_str.as_str(), "this" | "that" | "the")
+                && toks.get(8).is_some_and(|following| {
                     let fol_str = following.get_str(src).to_lowercase();
-                    if matches!(fol_str.as_str(), "time" | "moment" | "stage" | "level") {
-                        return None;
-                    }
-                }
+                    matches!(fol_str.as_str(), "time" | "moment" | "stage" | "level")
+                });
+
+            if is_time_or_level {
+                return None;
             }
         }
 

--- a/harper-core/src/linting/get_access_at.rs
+++ b/harper-core/src/linting/get_access_at.rs
@@ -1,9 +1,8 @@
 use crate::expr::{Expr, SequenceExpr};
 use crate::linting::expr_linter::Chunk;
 use crate::{
-    Lrc, Token,
-    linting::{ExprLinter, Lint, LintKind, Suggestion},
-    patterns::WordSet,
+    Lint, Token,
+    linting::{ExprLinter, LintKind, Suggestion},
 };
 
 /// Corrects "get access at <resource>" to "get access to <resource>", while avoiding
@@ -14,7 +13,7 @@ pub struct GetAccessAt {
 
 impl Default for GetAccessAt {
     fn default() -> Self {
-        let verbs = Lrc::new(WordSet::new(&[
+        let verbs = &[
             "get",
             "gets",
             "got",
@@ -25,15 +24,15 @@ impl Default for GetAccessAt {
             "obtains",
             "obtained",
             "obtaining",
-        ]));
-        let access = Lrc::new(WordSet::new(&["access"]));
-        let at = Lrc::new(WordSet::new(&["at"]));
+        ];
 
-        let pattern = SequenceExpr::with(verbs)
-            .then_whitespace()
-            .then(access)
-            .then_whitespace()
-            .then(at);
+        let pattern = SequenceExpr::word_set(verbs)
+            .t_ws()
+            .t_aco("access")
+            .t_ws()
+            .t_aco("at")
+            .t_ws()
+            .then_word_except(&["all", "least", "this", "that", "the"]);
 
         Self { expr: pattern }
     }
@@ -47,38 +46,13 @@ impl ExprLinter for GetAccessAt {
     }
 
     fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
-        let at_tok = toks.last()?;
-        let at_idx = toks.len() - 1;
+        let at_tok = toks.get(4)?;
 
-        // Look at the tokens following "at" to prevent false positives
-        let next_tok = toks.get(at_idx + 1);
-        let following_tok = toks.get(at_idx + 2);
-
-        if let Some(next) = next_tok {
-            let next_word = next.get_str(src).to_lowercase();
-
-            // False positive checks: "at all", "at least"
-            if matches!(next_word.as_str(), "all" | "least") {
-                return None;
-            }
-
-            // False positive check: "at this time", "at the moment", "at the level", etc.
-            let is_time_or_level = match (next_word.as_str(), following_tok) {
-                ("this" | "that" | "the", Some(following)) => {
-                    let fol_word = following.get_str(src).to_lowercase();
-                    matches!(fol_word.as_str(), "time" | "moment" | "stage" | "level")
-                }
-                _ => false,
-            };
-
-            if is_time_or_level {
-                return None;
-            }
-
-            // False positive check: URLs / Web addresses
-            if next_word.starts_with("http://")
-                || next_word.starts_with("https://")
-                || next_word.contains("www.")
+        if let Some(next) = toks.get(6) {
+            let next_str = next.get_str(src).to_lowercase();
+            if next_str.starts_with("http://")
+                || next_str.starts_with("https://")
+                || next_str.contains("www.")
             {
                 return None;
             }

--- a/harper-core/src/linting/get_access_at.rs
+++ b/harper-core/src/linting/get_access_at.rs
@@ -1,0 +1,164 @@
+use crate::expr::{Expr, OwnedExprExt, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
+use crate::{
+    Lrc, Token,
+    linting::{ExprLinter, Lint, LintKind, Suggestion},
+    patterns::WordSet,
+};
+
+/// Corrects "get access at <resource>" to "get access to <resource>", while avoiding
+/// false positives like "get access at all", "get access at least", URLs, or time expressions.
+pub struct GetAccessAt {
+    expr: SequenceExpr,
+}
+
+impl Default for GetAccessAt {
+    fn default() -> Self {
+        let verbs = Lrc::new(WordSet::new(&[
+            "get", "gets", "got", "getting", "gained", "gaining", "obtain", "obtains", "obtained",
+            "obtaining",
+        ]));
+        let access = Lrc::new(WordSet::new(&["access"]));
+        let at = Lrc::new(WordSet::new(&["at"]));
+
+        let pattern = SequenceExpr::with(verbs)
+            .then_whitespace()
+            .then(access)
+            .then_whitespace()
+            .then(at);
+
+        Self { expr: pattern }
+    }
+}
+
+impl ExprLinter for GetAccessAt {
+    type Unit = Chunk;
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        let at_tok = toks.last()?;
+        let at_idx = toks.len() - 1;
+
+        // Look at the tokens following "at" to prevent false positives
+        let next_tok = toks.get(at_idx + 1);
+        let following_tok = toks.get(at_idx + 2);
+
+        if let Some(next) = next_tok {
+            let next_word = next.get_str(src).to_lowercase();
+
+            // False positive checks: "at all", "at least"
+            if next_word == "all" || next_word == "least" {
+                return None;
+            }
+
+            // False positive check: "at this time", "at the moment", "at the level", etc.
+            if next_word == "this" || next_word == "that" || next_word == "the" {
+                if let Some(following) = following_tok {
+                    let fol_word = following.get_str(src).to_lowercase();
+                    if fol_word == "time"
+                        || fol_word == "moment"
+                        || fol_word == "stage"
+                        || fol_word == "level"
+                    {
+                        return None;
+                    }
+                }
+            }
+
+            // False positive check: URLs / Web addresses
+            if next_word.starts_with("http://")
+                || next_word.starts_with("https://")
+                || next_word.contains("www.")
+            {
+                return None;
+            }
+        }
+
+        Some(Lint {
+            span: at_tok.span,
+            lint_kind: LintKind::Grammar,
+            suggestions: vec![Suggestion::ReplaceWith("to".chars().collect())],
+            message: "Did you mean `to` instead of `at` when specifying what is being accessed?"
+                .to_owned(),
+            priority: 45,
+        })
+    }
+
+    fn description(&self) -> &str {
+        "Flags 'get access at' and suggests replacing 'at' with 'to'."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GetAccessAt;
+    use crate::linting::tests::{assert_lint_count, assert_suggestion_result};
+
+    #[test]
+    fn test_get_access_at_cpu() {
+        assert_suggestion_result(
+            "They really need to get access at some CPU time.",
+            GetAccessAt::default(),
+            "They really need to get access to some CPU time.",
+        );
+    }
+
+    #[test]
+    fn test_get_access_at_models() {
+        assert_suggestion_result(
+            "In order to get access at models, send a request.",
+            GetAccessAt::default(),
+            "In order to get access to models, send a request.",
+        );
+    }
+
+    #[test]
+    fn test_got_access_at_database() {
+        assert_suggestion_result(
+            "I got access at the server database.",
+            GetAccessAt::default(),
+            "I got access to the server database.",
+        );
+    }
+
+    // --- False Positive Tests ---
+
+    #[test]
+    fn ignore_access_at_all() {
+        assert_lint_count(
+            "I didn't manage to get access at all.",
+            GetAccessAt::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn ignore_access_at_least() {
+        assert_lint_count(
+            "Is it possible to get access at least to the file content?",
+            GetAccessAt::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn ignore_access_at_this_time() {
+        assert_lint_count(
+            "The quickest method to get access at this time is to submit a form.",
+            GetAccessAt::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn ignore_access_at_url() {
+        assert_lint_count(
+            "Get access at https://example.com/login",
+            GetAccessAt::default(),
+            0,
+        );
+    }
+}

--- a/harper-core/src/linting/get_access_at.rs
+++ b/harper-core/src/linting/get_access_at.rs
@@ -32,7 +32,9 @@ impl Default for GetAccessAt {
             .t_ws()
             .t_aco("at")
             .t_ws()
-            .then_word_except(&["all", "least", "this", "that", "the"]);
+            .then_word_except(&["all", "least"])
+            .t_ws()
+            .then_any_word();
 
         Self { expr: pattern }
     }
@@ -50,11 +52,23 @@ impl ExprLinter for GetAccessAt {
 
         if let Some(next) = toks.get(6) {
             let next_str = next.get_str(src).to_lowercase();
+
+            // False positive check: URLs / Web addresses
             if next_str.starts_with("http://")
                 || next_str.starts_with("https://")
                 || next_str.contains("www.")
             {
                 return None;
+            }
+
+            // False positive check: "at this time", "at the moment", "at the level", "at the stage"
+            if matches!(next_str.as_str(), "this" | "that" | "the") {
+                if let Some(following) = toks.get(8) {
+                    let fol_str = following.get_str(src).to_lowercase();
+                    if matches!(fol_str.as_str(), "time" | "moment" | "stage" | "level") {
+                        return None;
+                    }
+                }
             }
         }
 

--- a/harper-core/src/linting/get_access_at.rs
+++ b/harper-core/src/linting/get_access_at.rs
@@ -1,4 +1,4 @@
-use crate::expr::{Expr, OwnedExprExt, SequenceExpr};
+use crate::expr::{Expr, SequenceExpr};
 use crate::linting::expr_linter::Chunk;
 use crate::{
     Lrc, Token,

--- a/harper-core/src/linting/get_access_at.rs
+++ b/harper-core/src/linting/get_access_at.rs
@@ -15,7 +15,15 @@ pub struct GetAccessAt {
 impl Default for GetAccessAt {
     fn default() -> Self {
         let verbs = Lrc::new(WordSet::new(&[
-            "get", "gets", "got", "getting", "gained", "gaining", "obtain", "obtains", "obtained",
+            "get",
+            "gets",
+            "got",
+            "getting",
+            "gained",
+            "gaining",
+            "obtain",
+            "obtains",
+            "obtained",
             "obtaining",
         ]));
         let access = Lrc::new(WordSet::new(&["access"]));

--- a/harper-core/src/linting/get_access_at.rs
+++ b/harper-core/src/linting/get_access_at.rs
@@ -88,7 +88,7 @@ impl ExprLinter for GetAccessAt {
     }
 
     fn description(&self) -> &str {
-        "Flags 'get access at' and suggests replacing 'at' with 'to'."
+        "Flags `get access at` and suggests replacing `at` with `to`."
     }
 }
 

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -102,6 +102,7 @@ use super::for_noun::ForNoun;
 use super::for_the_nth_time::ForTheNthTime;
 use super::free_predicate::FreePredicate;
 use super::friend_of_me::FriendOfMe;
+use super::get_access_at::GetAccessAt;
 use super::go_so_far_as_to::GoSoFarAsTo;
 use super::go_to_war::GoToWar;
 use super::good_at::GoodAt;
@@ -689,6 +690,7 @@ impl LintGroup {
         insert_expr_rule!(ForTheNthTime);
         insert_expr_rule!(FreePredicate);
         insert_expr_rule!(FriendOfMe);
+        insert_expr_rule!(GetAccessAt);
         insert_expr_rule!(GoSoFarAsTo);
         insert_expr_rule!(GoToWar);
         insert_expr_rule!(GoodAt);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -103,6 +103,7 @@ mod for_noun;
 mod for_the_nth_time;
 mod free_predicate;
 mod friend_of_me;
+mod get_access_at;
 mod go_so_far_as_to;
 mod go_to_war;
 mod good_at;


### PR DESCRIPTION
# Issues 
Fixes #3309

# Description
Adds a new `ExprLinter` rule (`GetAccessAt`) in `harper-core` that catches wrong preposition usage like `get access at` and suggests `get access to`.
Includes false-positive filtering for phrases like `at all`, `at least`, time expressions (`at this time`, `at the moment`), and URLs.

# Demo
N/A (Core linting rule covered by unit tests).

# How Has This Been Tested?
Implemented unit tests in `harper-core/src/linting/get_access_at.rs` covering both valid corrections and false-positive exclusions. Verified clean execution across the entire `harper-core` test suite and CI checks.

# AI Disclosure
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
