### PR TITLE
fix(core): avoid to-too false positives outside adjective contexts

### DIFF
--- a/harper-core/src/linting/to_two_too/mod.rs
+++ b/harper-core/src/linting/to_two_too/mod.rs
@@ -101,6 +101,11 @@ mod tests {
     }
 
     #[test]
+    fn no_lint_to_audio() {
+        assert_no_lints("Convert a book to audio.", ToTwoToo::default());
+    }
+
+    #[test]
     fn fixes_too_go() {
         assert_suggestion_result(
             "I want too go abroad.",

--- a/harper-core/src/linting/to_two_too/to_too_adjective_end.rs
+++ b/harper-core/src/linting/to_two_too/to_too_adjective_end.rs
@@ -1,3 +1,5 @@
+use harper_brill::UPOS;
+
 use crate::{
     Token, TokenKind,
     char_string::CharStringExt,
@@ -54,6 +56,7 @@ impl ExprLinter for ToTooAdjectiveEnd {
         if idx >= tokens.len()
             || !tokens[idx].kind.is_adjective()
             || !tokens[idx].kind.is_positive_adjective()
+            || !tokens[idx].kind.is_upos(UPOS::ADJ)
         {
             return None;
         }

--- a/harper-core/src/linting/to_two_too/to_too_adjective_punct.rs
+++ b/harper-core/src/linting/to_two_too/to_too_adjective_punct.rs
@@ -1,3 +1,5 @@
+use harper_brill::UPOS;
+
 use crate::{
     Token, TokenKind,
     char_string::CharStringExt,
@@ -51,7 +53,10 @@ impl ExprLinter for ToTooAdjectivePunct {
             return None;
         }
         let adjective = &tokens[idx];
-        if !adjective.kind.is_adjective() || !adjective.kind.is_positive_adjective() {
+        if !adjective.kind.is_adjective()
+            || !adjective.kind.is_positive_adjective()
+            || !adjective.kind.is_upos(UPOS::ADJ)
+        {
             return None;
         }
         if adjective.kind.is_preposition() {

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -1920,16 +1920,6 @@ Suggest:
 
 
 
-Lint:    WordChoice (127 priority)
-Message: |
-    1667 | “Don’t ask me,” said Owl Eyes, washing his hands of the whole matter. “I know
-    1668 | very little about driving—next to nothing. It happened, and that’s all I know.”
-         |                                ^~ Use `too` here to mean ‘also’ or an excessive degree.
-Suggest:
-  - Replace with: “too”
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
     1683 | The shock that followed this declaration found voice in a sustained “Ah-h-h!” as
@@ -4665,15 +4655,6 @@ Message: |
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     3353 | inhabitants along a short-cut from nothing to nothing. She saw something awful
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 48 words long.
-
-
-
-Lint:    WordChoice (127 priority)
-Message: |
-    3353 | inhabitants along a short-cut from nothing to nothing. She saw something awful
-         |                                            ^~ Use `too` here to mean ‘also’ or an excessive degree.
-Suggest:
-  - Replace with: “too”
 
 
 


### PR DESCRIPTION
**AI disclosure:** This pull request was prepared by an AI agent and reviewed against the repository policy, focused tests, the full `harper-core` suite, and the complete diff.

# Issues

Fixes #3856

# Description

The `ToTwoToo` adjective-terminal paths treated every dictionary word with adjective metadata as an adjective in context. That made correct prepositional phrases such as “to audio” look like misspellings of “too audio.”

Require the contextual part-of-speech tag to be `ADJ` before either adjective-terminal path emits a suggestion. This keeps existing true positives such as “to cold” while removing the reported false positive and two matching real-text false positives in the Great Gatsby corpus: “next to nothing” and “from nothing to nothing.”

# Demo

Not applicable; this changes grammar-engine output and is covered by the issue sentence plus corpus snapshots.

# How Has This Been Tested?

- Added the issue sentence as a regression and observed it fail on current `master` before the production change.
- `cargo test linting::to_two_too::tests` — 61 passed.
- `cargo test -p harper-core` — 5,675 passed, 289 ignored; integration, snapshot, POS-tag, run-tests, and 6 doc tests also passed.
- `just format` — passed.
- `git diff --check` — passed.

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [x] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter

- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
