### PR TITLE
test: pin phrasal-verb handling of "rollback" and "comeback" (#3239)

### DIFF
--- a/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
+++ b/harper-core/src/linting/phrasal_verb_as_compound_noun.rs
@@ -353,6 +353,37 @@ mod tests {
         );
     }
 
+    // Issue #3239. Both of these are compound nouns whose dictionary entries once
+    // carried a stray verb flag, so the linter skipped them as legitimate verbs.
+    // The entries are correct now and the linter handles them, but nothing pinned
+    // that, and the shape of the bug (a data flag silently disabling a rule) is
+    // easy to reintroduce.
+    #[test]
+    fn flag_rollback_used_as_a_verb_issue_3239() {
+        assert_suggestion_result(
+            "I already did a rollback. I'm not going to rollback again.",
+            PhrasalVerbAsCompoundNoun::default(),
+            "I already did a rollback. I'm not going to roll back again.",
+        );
+    }
+
+    #[test]
+    fn flag_comeback_used_as_a_verb_issue_3239() {
+        assert_suggestion_result(
+            "I already did a comeback. I'm not going to comeback again.",
+            PhrasalVerbAsCompoundNoun::default(),
+            "I already did a comeback. I'm not going to come back again.",
+        );
+    }
+
+    #[test]
+    fn dont_flag_rollback_or_comeback_as_nouns_issue_3239() {
+        assert_no_lints(
+            "I already did a rollback. It was quite a comeback.",
+            PhrasalVerbAsCompoundNoun::default(),
+        );
+    }
+
     #[test]
     fn dont_flag_random_words_that_happen_to_end_like_a_particle() {
         assert_no_lints("I like bacon.", PhrasalVerbAsCompoundNoun::default());


### PR DESCRIPTION
Re: #3239

## What I found

I went to fix this and found it already works on `master`. Both sentences from the issue behave correctly now:

```
"I already did a rollback. I'm not going to rollback again."
  -> "I already did a rollback. I'm not going to roll back again."

"I already did a comeback. I'm not going to comeback again."
  -> "I already did a comeback. I'm not going to come back again."
```

The dictionary entries are clean `rollback/~NSg` and `comeback/~NgS`, no `V` flag so `PhrasalVerbAsCompoundNoun` reaches them and the generic particle logic does the rest (`back` is in `particle_endings`, and `roll`/`come` both carry `V`).

So **this issue looks resolvable as fixed**, and I didn't want to open a PR pretending otherwise.

## What this PR adds instead

Regression tests, because nothing currently pins it. I grepped  there is no test mentioning `rollback` or `comeback` anywhere in the suite.

That gap seemed worth closing specifically because of *how* this bug worked: a stray verb flag in the dictionary silently disables the rule for that word. It throws no error, and the linter keeps passing all its other tests, so the regression would be invisible until someone reported it again.

Three tests using the issue's own sentences:

- `flag_rollback_used_as_a_verb_issue_3239`
- `flag_comeback_used_as_a_verb_issue_3239`
- `dont_flag_rollback_or_comeback_as_nouns_issue_3239` negative case, so the nouns themselves stay unflagged

`cargo test -p harper-core --lib`: **5677 passed, 0 failed.**

Happy to close this if you'd rather just close the issue without the tests, or to fold them into an existing test if you prefer them grouped differently.