### PR TITLE
feat: support "over 1000+" in addition to "over 1000 plus"

### DIFF
--- a/harper-core/src/expr/sequence_expr.rs
+++ b/harper-core/src/expr/sequence_expr.rs
@@ -673,6 +673,7 @@ impl SequenceExpr {
     gen_then_from_is!(single_prime);
     gen_then_from_is!(double_prime);
     gen_then_from_is!(backtick);
+    gen_then_from_is!(plus);
 
     // Other
 

--- a/harper-core/src/linting/over_plus.rs
+++ b/harper-core/src/linting/over_plus.rs
@@ -24,8 +24,14 @@ impl Default for OverPlus {
                 .then_optional(
                     SequenceExpr::whitespace().t_set(&["thousand", "million", "billion"]),
                 )
-                .t_ws()
-                .then(SequenceExpr::aco("plus").but_not(Word::new_exact("PLUS")))
+                .then_any_of([
+                    Box::new(
+                        SequenceExpr::whitespace()
+                            .t_aco("plus")
+                            .but_not(Word::new_exact("PLUS")),
+                    ) as Box<dyn Expr>,
+                    Box::new(SequenceExpr::default().then_plus()),
+                ])
                 .but_not(SequenceExpr::anything().t_any().t_aco("one")),
         }
     }
@@ -49,11 +55,14 @@ impl ExprLinter for OverPlus {
             return None;
         }
 
-        let slices = [toks.get_rel_slice(0, -3)?, &toks[2..]];
+        let token_slices = [
+            toks.get_rel_slice(0, -2 - (toks.last()?.kind.is_word() as isize))?,
+            &toks[2..],
+        ];
 
         let span = toks.span()?;
 
-        let suggestions = slices
+        let suggestions = token_slices
             .iter()
             .map(|t| {
                 Suggestion::replace_with_match_case(
@@ -219,6 +228,19 @@ mod tests {
         assert_no_lints(
             "over 5,000 PLUS personnel will be on duty to assist highway users",
             OverPlus::default(),
+        );
+    }
+
+    #[test]
+    fn fix_plus_sign() {
+        assert_good_and_bad_suggestions(
+            "It took me over 1000+ blocks to make \"Livin' on a Prayer\" in Stardew Valley",
+            OverPlus::default(),
+            &[
+                "It took me over 1000 blocks to make \"Livin' on a Prayer\" in Stardew Valley",
+                "It took me 1000+ blocks to make \"Livin' on a Prayer\" in Stardew Valley",
+            ],
+            &[],
         );
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

I stumbled across a YouTube video with "over 1000+" in its title and I had a hunch the linter I made recently only worked with the word "plus".
This PR extends the linter to also work with the `+` symbol.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

I used AIs for some intermediate iterations but the initial one and the final one were handwritten by me.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
