### PR TITLE
fix(core): flag 'less <adjective> that' as a typo for 'than' (#3736)

### DIFF
--- a/harper-core/src/linting/that_than.rs
+++ b/harper-core/src/linting/that_than.rs
@@ -21,8 +21,20 @@ impl Default for ThatThan {
             .t_ws()
             .then_word_except(&["way"]);
 
+        let less_adjective_that_noun = SequenceExpr::word_set(&["less"])
+            .t_ws()
+            .then_kind_where(|kind| kind.is_adjective())
+            .t_ws()
+            .t_aco("that")
+            .t_ws()
+            .then_word_except(&[
+                "way", "is", "was", "were", "would", "had", "has", "can", "could", "did", "does",
+                "do", "should", "it", "they", "he", "she", "we", "you", "i", "those", "these",
+                "users", "the", "a", "an",
+            ]);
+
         Self {
-            expr: adjective_er_that_nextword,
+            expr: adjective_er_that_nextword.or_longest(less_adjective_that_noun),
         }
     }
 }
@@ -35,11 +47,11 @@ impl ExprLinter for ThatThan {
     }
 
     fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
-        if toks.len() != 5 {
-            return None;
-        }
-
-        let that_tok = &toks[2];
+        let that_tok = match toks.len() {
+            5 => &toks[2],
+            7 => &toks[4],
+            _ => return None,
+        };
 
         Some(Lint {
             span: that_tok.span,
@@ -204,6 +216,24 @@ mod tests {
             "Make it more clear that users need to download the VS tooling installer for .NET Core in VS.",
             ThatThan::default(),
             0,
+        );
+    }
+
+    #[test]
+    fn fix_way_less_common_that() {
+        assert_suggestion_result(
+            "Format is way less common that mp3 format.",
+            ThatThan::default(),
+            "Format is way less common than mp3 format.",
+        );
+    }
+
+    #[test]
+    fn fix_less_frequent_that() {
+        assert_suggestion_result(
+            "Errors are less frequent that expected.",
+            ThatThan::default(),
+            "Errors are less frequent than expected.",
         );
     }
 


### PR DESCRIPTION
# Issues 
Fixes #3736

# Description
Enhances the `ThatThan` linter in `harper-core` to catch false negatives when `that` is used as a typo for `than` in multi-word comparative phrases formed as `less <adjective> that` (e.g. *"way less common that mp3"* -> *"way less common than mp3"*).
Guards against false positives by excluding clause-starting words (`is`, `was`, `would`, `had`, `it`, `they`, `those`, `users`, etc.) following `that`.

# Demo
N/A (Core linting rule covered by unit tests).

# How Has This Been Tested?
Added unit tests in `harper-core/src/linting/that_than.rs` (`fix_way_less_common_that`, `fix_less_frequent_that`). Verified zero regression against existing `ThatThan` tests and full test suite.

# AI Disclosure
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
