### PR TITLE
fix(desktop): only repaint the highlighter overlay when something changes

### DIFF
--- a/harper-desktop/src-tauri/src/highlighter/render_state.rs
+++ b/harper-desktop/src-tauri/src/highlighter/render_state.rs
@@ -91,13 +91,24 @@ impl RenderState {
             add_to_dictionary,
             disable_rule,
         };
-        state.set_rects(rects);
+        let _ = state.set_rects(rects);
         state
     }
 
     /// Replaces the accessibility-derived lint geometry while preventing a popup from pointing at a
     /// lint index that no longer exists after the latest read.
-    pub fn set_rects(&mut self, rects: Vec<ActionableLint>) {
+    ///
+    /// Returns whether the next frame would differ from the last one. The overlay reads
+    /// accessibility state dozens of times per second, and the vast majority of those reads produce
+    /// exactly the same rectangles; repainting anyway means the process submits a GPU frame forever,
+    /// even while the machine sits idle overnight.
+    pub fn set_rects(&mut self, rects: Vec<ActionableLint>) -> bool {
+        let changed = rects.len() != self.rects.len()
+            || rects
+                .iter()
+                .zip(&self.rects)
+                .any(|(new, old)| !new.renders_same_as(old));
+
         self.rects = rects;
 
         if self
@@ -105,7 +116,10 @@ impl RenderState {
             .is_some_and(|index| index >= self.rects.len())
         {
             self.highlighted_lint = None;
+            return true;
         }
+
+        changed
     }
 
     /// Updates which lint owns the suggestion popup without exposing render-state internals.
@@ -763,4 +777,109 @@ fn blend(from: egui::Color32, to: egui::Color32, to_weight: f32) -> egui::Color3
         ((f32::from(fg) * from_weight) + (f32::from(tg) * to_weight)) as u8,
         ((f32::from(fb) * from_weight) + (f32::from(tb) * to_weight)) as u8,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use harper_core::Span;
+    use harper_core::linting::LintKind;
+
+    use super::*;
+    use crate::rect::Rect;
+
+    fn lint(message: &str) -> Lint {
+        Lint {
+            span: Span::new(0, 4),
+            lint_kind: LintKind::Spelling,
+            suggestions: Vec::new(),
+            message: message.to_string(),
+            priority: 31,
+        }
+    }
+
+    fn actionable_lint(rect: Rect, message: &str, source_text: &str) -> ActionableLint {
+        ActionableLint::new(
+            rect,
+            "TestRule".to_string(),
+            lint(message),
+            source_text.to_string(),
+            |_| {},
+        )
+    }
+
+    fn render_state(rects: Vec<ActionableLint>) -> RenderState {
+        RenderState::new(
+            rects,
+            Box::new(|_, _| {}),
+            Box::new(|_| {}),
+            Box::new(|_| {}),
+        )
+    }
+
+    fn rect() -> Rect {
+        Rect::new(10.0, 20.0, 30.0, 40.0)
+    }
+
+    #[test]
+    fn identical_reads_do_not_request_a_repaint() {
+        let mut state = render_state(vec![actionable_lint(rect(), "Typo", "teh cat")]);
+
+        assert!(!state.set_rects(vec![actionable_lint(rect(), "Typo", "teh cat")]));
+    }
+
+    #[test]
+    fn empty_reads_do_not_request_a_repaint() {
+        let mut state = render_state(Vec::new());
+
+        assert!(!state.set_rects(Vec::new()));
+    }
+
+    #[test]
+    fn moved_highlights_request_a_repaint() {
+        let mut state = render_state(vec![actionable_lint(rect(), "Typo", "teh cat")]);
+
+        assert!(state.set_rects(vec![actionable_lint(
+            Rect::new(11.0, 20.0, 30.0, 40.0),
+            "Typo",
+            "teh cat",
+        )]));
+    }
+
+    #[test]
+    fn changed_lints_request_a_repaint() {
+        let mut state = render_state(vec![actionable_lint(rect(), "Typo", "teh cat")]);
+
+        assert!(state.set_rects(vec![actionable_lint(rect(), "Spelling", "teh cat")]));
+    }
+
+    #[test]
+    fn edited_source_text_requests_a_repaint() {
+        let mut state = render_state(vec![actionable_lint(rect(), "Typo", "teh cat")]);
+
+        assert!(state.set_rects(vec![actionable_lint(rect(), "Typo", "teh cats")]));
+    }
+
+    #[test]
+    fn added_and_removed_highlights_request_a_repaint() {
+        let mut state = render_state(vec![actionable_lint(rect(), "Typo", "teh cat")]);
+
+        assert!(state.set_rects(vec![
+            actionable_lint(rect(), "Typo", "teh cat"),
+            actionable_lint(rect(), "Typo", "teh cat"),
+        ]));
+        assert!(state.set_rects(Vec::new()));
+    }
+
+    #[test]
+    fn dropping_a_stale_popup_requests_a_repaint() {
+        let mut state = render_state(vec![
+            actionable_lint(rect(), "Typo", "teh cat"),
+            actionable_lint(rect(), "Typo", "teh cat"),
+        ]);
+        state.set_highlighted_lint(Some(1));
+
+        // The same highlights are still on screen, but the popup they anchored is not.
+        assert!(state.set_rects(vec![actionable_lint(rect(), "Typo", "teh cat")]));
+        assert_eq!(state.popup_rect(), None);
+    }
 }

--- a/harper-desktop/src-tauri/src/highlighter/window.rs
+++ b/harper-desktop/src-tauri/src/highlighter/window.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroU32;
 use std::sync::Arc;
+use std::time::Duration;
 
 use egui_wgpu::winit::Painter;
 use egui_wgpu::{RendererOptions, WgpuConfiguration, WgpuSetup};
@@ -120,7 +121,12 @@ impl Window {
         }
     }
 
-    pub fn render(&mut self, render_state: &mut RenderState) {
+    /// Draws one frame and reports how long egui wants to wait before the next one.
+    ///
+    /// A `Duration::MAX` delay means egui is idle and the overlay can stop painting until something
+    /// actually changes. Honoring that is what keeps a transparent, permanently open overlay from
+    /// submitting GPU work every frame for as long as the app is running.
+    pub fn render(&mut self, render_state: &mut RenderState) -> Duration {
         let context = self.egui_state.egui_ctx().clone();
         let input = self.egui_state.take_egui_input(&self.inner);
         let output = context.run_ui(input, |ui| {
@@ -139,5 +145,10 @@ impl Window {
             &output.textures_delta,
             Vec::new(),
         );
+
+        output
+            .viewport_output
+            .get(&self.viewport_id)
+            .map_or(Duration::MAX, |viewport| viewport.repaint_delay)
     }
 }

--- a/harper-desktop/src-tauri/src/highlighter/window_manager.rs
+++ b/harper-desktop/src-tauri/src/highlighter/window_manager.rs
@@ -120,7 +120,56 @@ struct WindowManagerApp {
     refresh_config: RefreshConfig,
     hovered_lint: Option<usize>,
     cursor_hittest_enabled: bool,
+    repaint_schedule: RepaintSchedule,
     error: Option<Error>,
+}
+
+/// Remembers the earliest moment egui asked to be repainted.
+///
+/// The overlay only paints when something changed, so egui's own repaint requests — tooltip fade
+/// ins, hover feedback, popups closing themselves — are the one thing that still has to wake the
+/// windows up on a timer. Keeping that deadline here means an idle overlay schedules no frames at
+/// all instead of submitting one every refresh interval for the lifetime of the process.
+#[derive(Default)]
+struct RepaintSchedule {
+    next_repaint: Option<Instant>,
+}
+
+impl RepaintSchedule {
+    /// Records a repaint egui asked for, keeping the soonest of any competing requests.
+    ///
+    /// A `Duration::MAX` delay is egui's way of saying "nothing is animating", so it schedules
+    /// nothing at all.
+    fn schedule(&mut self, delay: Duration, now: Instant) {
+        if delay == Duration::MAX {
+            return;
+        }
+
+        let repaint_at = now.checked_add(delay).unwrap_or(now);
+
+        self.next_repaint = Some(match self.next_repaint {
+            Some(existing) => existing.min(repaint_at),
+            None => repaint_at,
+        });
+    }
+
+    /// Consumes the pending repaint when it comes due.
+    fn take_due(&mut self, now: Instant) -> bool {
+        if self
+            .next_repaint
+            .is_some_and(|repaint_at| repaint_at <= now)
+        {
+            self.next_repaint = None;
+            return true;
+        }
+
+        false
+    }
+
+    /// The moment the event loop has to wake up for the pending repaint, if there is one.
+    fn deadline(&self) -> Option<Instant> {
+        self.next_repaint
+    }
 }
 
 impl WindowManagerApp {
@@ -150,15 +199,23 @@ impl WindowManagerApp {
             refresh_config: callbacks.refresh_config,
             hovered_lint: None,
             cursor_hittest_enabled: false,
+            repaint_schedule: RepaintSchedule::default(),
             error: None,
         }
     }
 
     /// Refreshes lint geometry from the OS broker inside the event loop so repaint requests happen on
     /// the same thread that owns the overlay windows.
+    ///
+    /// Reads happen at the monitor's refresh rate, but almost none of them change what is on screen.
+    /// Only redrawing when the geometry actually moved keeps an overlay that is left open for days
+    /// from rendering, tessellating and submitting a GPU frame millions of times over.
     fn read_rect_updates(&mut self) {
         let rects = self.os_broker.get_boxes(self.lint_text.as_mut());
-        self.render_state.set_rects(rects);
+
+        if !self.render_state.set_rects(rects) {
+            return;
+        }
 
         for window in &self.windows {
             window.request_redraw();
@@ -241,9 +298,18 @@ impl ApplicationHandler for WindowManagerApp {
 
         self.update_cursor_hittest(event_loop);
 
+        if self.repaint_schedule.take_due(now) {
+            for window in &self.windows {
+                window.request_redraw();
+            }
+        }
+
         let next_read = self.last_read + self.read_interval;
         let next_config_poll = self.last_config_poll + CONFIG_POLL_INTERVAL;
-        event_loop.set_control_flow(ControlFlow::WaitUntil(next_read.min(next_config_poll)));
+        let next_wake = next_read
+            .min(next_config_poll)
+            .min(self.repaint_schedule.deadline().unwrap_or(next_read));
+        event_loop.set_control_flow(ControlFlow::WaitUntil(next_wake));
     }
 
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
@@ -285,6 +351,8 @@ impl ApplicationHandler for WindowManagerApp {
         );
         let should_render = matches!(&event, WindowEvent::RedrawRequested);
 
+        let mut repaint_delay = None;
+
         if let Some(window) = self
             .windows
             .iter_mut()
@@ -293,8 +361,13 @@ impl ApplicationHandler for WindowManagerApp {
             window.handle_event(&event);
 
             if should_render {
-                window.render(&mut self.render_state);
+                repaint_delay = Some(window.render(&mut self.render_state));
             }
+        }
+
+        if let Some(repaint_delay) = repaint_delay {
+            self.repaint_schedule
+                .schedule(repaint_delay, Instant::now());
         }
 
         if should_select_hit_lint {
@@ -304,5 +377,57 @@ impl ApplicationHandler for WindowManagerApp {
         if matches!(&event, WindowEvent::CloseRequested) {
             event_loop.exit();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn idle_egui_schedules_no_repaint() {
+        let mut schedule = RepaintSchedule::default();
+        let now = Instant::now();
+
+        schedule.schedule(Duration::MAX, now);
+
+        assert_eq!(schedule.deadline(), None);
+        assert!(!schedule.take_due(now + Duration::from_secs(60 * 60)));
+    }
+
+    #[test]
+    fn pending_repaint_comes_due_once() {
+        let mut schedule = RepaintSchedule::default();
+        let now = Instant::now();
+
+        schedule.schedule(Duration::from_millis(100), now);
+
+        assert_eq!(schedule.deadline(), Some(now + Duration::from_millis(100)));
+        assert!(!schedule.take_due(now + Duration::from_millis(99)));
+        assert!(schedule.take_due(now + Duration::from_millis(100)));
+        assert!(!schedule.take_due(now + Duration::from_millis(101)));
+        assert_eq!(schedule.deadline(), None);
+    }
+
+    #[test]
+    fn soonest_requested_repaint_wins() {
+        let mut schedule = RepaintSchedule::default();
+        let now = Instant::now();
+
+        schedule.schedule(Duration::from_millis(200), now);
+        schedule.schedule(Duration::from_millis(50), now);
+        schedule.schedule(Duration::from_millis(500), now);
+
+        assert_eq!(schedule.deadline(), Some(now + Duration::from_millis(50)));
+    }
+
+    #[test]
+    fn immediate_repaint_is_due_right_away() {
+        let mut schedule = RepaintSchedule::default();
+        let now = Instant::now();
+
+        schedule.schedule(Duration::ZERO, now);
+
+        assert!(schedule.take_due(now));
     }
 }

--- a/harper-desktop/src-tauri/src/rect.rs
+++ b/harper-desktop/src-tauri/src/rect.rs
@@ -80,6 +80,19 @@ impl ActionableLint {
             apply_suggestion(suggestion);
         }
     }
+
+    /// Reports whether two lints would produce the same highlight and popup.
+    ///
+    /// `ActionableLint` cannot implement `PartialEq` because it owns a suggestion callback, but the
+    /// highlighter still needs to know whether a fresh accessibility read actually changed anything
+    /// on screen. Comparing only the rendered fields lets the overlay skip redraws when it would
+    /// paint the exact same frame again.
+    pub fn renders_same_as(&self, other: &Self) -> bool {
+        self.rect == other.rect
+            && self.rule_name == other.rule_name
+            && self.lint == other.lint
+            && self.source_text == other.source_text
+    }
 }
 
 impl ColoredRect {


### PR DESCRIPTION
> **Disclaimer:** this patch was written by an LLM agent (Claude Opus 5), driven and reviewed by me. Per [Harper's policy on agent PRs](https://writewithharper.com/docs/contributors/introduction), I'm saying so up front.

Addresses #3874 (I'm one of the reporters there).

## The problem

The highlighter overlay never stops painting. `WindowManagerApp::about_to_wait` reads accessibility state every `read_interval` — the fastest monitor's refresh interval, so ~16 ms — and `read_rect_updates` then calls `request_redraw()` on every overlay window unconditionally, whether or not the read produced different rectangles.

So for as long as Harper is running — including all night on a machine nobody is touching — the process runs a full egui pass, tessellates, uploads buffers and submits a wgpu queue every 16 ms per monitor. That is the loop the diagnostics on #3874 sampled:

```
harper_desktop_lib::highlighter::window::Window::render
  -> egui::context::Context::begin_pass -> hashbrown::set::HashSet::extend
  -> egui_wgpu::winit::Painter::paint_and_update_textures
     -> wgpu_core::device::queue::Queue::submit -> bit_vec::BitVec::grow
```

## The change

Redraws become demand-driven:

- `RenderState::set_rects` now reports whether the new accessibility read would actually paint a different frame (geometry, lint, rule name or source text changed, a highlight was added or removed, or a popup was invalidated). `read_rect_updates` only requests a redraw when it did.
- `Window::render` returns the repaint delay egui asked for (`FullOutput::viewport_output[…].repaint_delay`), and `WindowManagerApp` keeps the earliest pending deadline in a small `RepaintSchedule`. `Duration::MAX` — egui's "nothing is animating" — schedules nothing at all. Anything shorter wakes the windows up on time, so hover feedback, tooltips, popups closing themselves and any egui animation still get the frames they need.

Nothing changes about how often the accessibility tree is read or how quickly a moved highlight follows its text; only frames that would be pixel-identical to the previous one are skipped. An idle overlay now submits zero GPU frames instead of ~60 per second per monitor.

## Honesty about scope

I want to be clear about what this does and does not prove. I did not bisect the allocation to a single leaking object — that needs a multi-hour soak on a real Metal surface. What I can say is that this removes the unbounded per-frame renderer work that the reported stacks point at and that runs even when the machine is completely idle, which is exactly the "leave it open overnight" scenario in the issue. If growth persists after this, the next thing to look at is the renderer setup itself.

Related and deliberately **not** in this PR, to keep it reviewable:

- `Window::new` builds one `egui_wgpu::winit::Painter` — and therefore one wgpu instance/device — *per monitor*, while egui-wgpu's contract is a single painter shared across viewports. Any per-submission resource cost is multiplied per display today.
- `Window::render` drops `FullOutput::viewport_output` on the floor apart from the repaint delay this PR reads. There are no child viewports in this UI, so nothing appears to accumulate, but it is not the documented backend contract.

Happy to follow up on either if you'd like them addressed.

## Tests

11 new unit tests, no GPU or window required (`cargo test -p harper-desktop --lib`, 63 passing):

- `render_state`: identical reads and empty reads request no repaint; moved rectangles, changed lints, edited source text, added/removed highlights, and a popup invalidated by a shrinking read all do.
- `window_manager`: `RepaintSchedule` ignores `Duration::MAX`, keeps the soonest of competing requests, fires a due repaint exactly once, and treats `Duration::ZERO` as immediately due.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
