### PR TITLE
fix(harper-ls): keep fileified paths relative on Windows

### DIFF
--- a/harper-ls/src/io_utils.rs
+++ b/harper-ls/src/io_utils.rs
@@ -1,24 +1,104 @@
 use anyhow::anyhow;
-use std::path::{Component, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use tower_lsp_server::{UriExt, lsp_types::Uri};
 
 /// Rewrites a path to a filename using the same conventions as
 /// [Neovim's undo-files](https://neovim.io/doc/user/options.html#'undodir').
+/// Windows path prefixes are sanitized into one segment, so the result is always
+/// relative and can be safely joined to the config directory.
 pub fn fileify_path(uri: &Uri) -> anyhow::Result<PathBuf> {
+    // We assume all URLs are local files and have a base.
+    let path = uri
+        .to_file_path()
+        .ok_or_else(|| anyhow!("Unable to convert URI to file path."))?;
+    Ok(fileify_file_path(&path).into())
+}
+
+fn fileify_file_path(path: &Path) -> String {
+    fileify_path_segments(path.components().filter_map(|seg| match seg {
+        Component::RootDir => None,
+        Component::Prefix(p) => Some(sanitize_windows_prefix(&p.as_os_str().to_string_lossy())),
+        other => Some(other.as_os_str().to_string_lossy().into_owned()),
+    }))
+}
+
+fn fileify_path_segments<I, S>(segments: I) -> String
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
     let mut rewritten = String::new();
 
-    // We assume all URLs are local files and have a base.
-    for seg in uri
-        .to_file_path()
-        .ok_or_else(|| anyhow!("Unable to convert URI to file path."))?
-        .components()
-    {
-        if !matches!(seg, Component::RootDir) {
-            rewritten.push_str(&seg.as_os_str().to_string_lossy());
-            rewritten.push('%');
-        }
+    for segment in segments {
+        let segment = segment.as_ref();
+
+        rewritten.push_str(segment);
+        rewritten.push('%');
     }
 
-    Ok(rewritten.into())
+    rewritten
+}
+
+/// Windows path prefixes (`C:`, `\\server\share`, `\\?\C:`) contain characters that are
+/// illegal in a filename, which made the joined config path escape its base (#3667).
+/// Strip them so the flattened name stays relative while drives/shares stay distinct.
+/// Unreachable on Unix, where `Component::Prefix` never occurs.
+fn sanitize_windows_prefix(prefix: &str) -> String {
+    prefix
+        .chars()
+        .filter(|c| !matches!(c, '\\' | '/' | ':' | '*' | '?' | '"' | '<' | '>' | '|'))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(windows)]
+    use super::fileify_file_path;
+    use super::{fileify_path_segments, sanitize_windows_prefix};
+    use std::path::Path;
+
+    #[test]
+    fn preserves_unix_path_format() {
+        let rewritten = fileify_path_segments(["home", "user", "proj", "README.md"]);
+
+        assert_eq!(rewritten, "home%user%proj%README.md%");
+    }
+
+    #[test]
+    fn fileified_path_stays_under_base_when_joined() {
+        let rewritten = fileify_path_segments([
+            sanitize_windows_prefix("C:"),
+            "Users".into(),
+            "proj".into(),
+            "README.md".into(),
+        ]);
+
+        assert_eq!(rewritten, "C%Users%proj%README.md%");
+        assert!(Path::new(&rewritten).is_relative());
+    }
+
+    #[test]
+    fn preserves_colons_and_backslashes_in_unix_segments() {
+        let rewritten = fileify_path_segments(["home", "user", "notes:draft.md", r"back\slash.md"]);
+
+        assert_eq!(rewritten, r"home%user%notes:draft.md%back\slash.md%");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn fileifies_windows_paths() {
+        assert_ne!(
+            fileify_file_path(Path::new(r"C:\proj\a.md")),
+            fileify_file_path(Path::new(r"D:\proj\a.md"))
+        );
+        assert_eq!(
+            fileify_file_path(Path::new(r"C:\Users\x\proj\README.md")),
+            "C%Users%x%proj%README.md%"
+        );
+        assert_eq!(
+            fileify_file_path(Path::new(r"\\server\share\proj\a.md")),
+            "servershare%proj%a.md%"
+        );
+    }
 }


### PR DESCRIPTION
> **Disclaimer per [`AGENT_POLICY.md`](https://github.com/Automattic/harper/blob/master/AGENT_POLICY.md):** this patch was produced with the help of an LLM (Claude). The diagnosis, the test cases and the mutation check described below were verified by running them locally; the reasoning about Unix behaviour is stated explicitly so it can be checked rather than taken on trust.

Fixes #3667.

## The bug

`fileify_path` skips `Component::RootDir` but not `Component::Prefix`, so on Windows a path flattens to `C:%Users%x%proj%README.md%` — a string that still carries a drive prefix.

That matters because `PathBuf::join` **discards the base entirely** when the joined path has a prefix:

```rust
Path::new(r"C:\config\harper-ls").join(r"C:%Users%x%a.md%")
// -> "C:%Users%x%a.md%"   (the base is gone)
```

So the file-local dictionary and ignored-lints files land in the current directory of the C: drive instead of under the configured directory, which is why `fileDictPath` / `ignoredLintsPath` look like they are being ignored. The language-server docs state these paths are "always resolved relative to the root of the workspace", so this is a contract violation rather than a preference.

## The fix

Prefixes are **sanitized into one leading segment** rather than dropped:

- the result is relative again, so `join` keeps the base;
- `C:\proj\a.md` and `D:\proj\a.md` still map to different names — dropping the prefix would have collided them onto one dictionary;
- `\\server\share\proj\a.md` becomes `servershare%proj%a.md%`.

The segment loop itself is unchanged, so **Unix output is byte-identical**. `:` and `\` are legal in Unix filenames (macOS Finder's `/` is `:` at the POSIX layer), so they are still preserved verbatim — `preserves_colons_and_backslashes_in_unix_segments` pins that.

An earlier draft of this patch sanitized *every* segment, not just the prefix. That was wrong twice over: it changed existing Unix output, and it was not injective — `a:b.md` and `ab.md` would have collapsed onto the same name and silently shared a dictionary. That approach was dropped.

`fileify_file_path(&Path)` is factored out of `fileify_path(&Uri)` so the Windows behaviour is reachable from tests without constructing a URI.

## Verification

- `cargo test -p harper-ls` — 15 passed.
- `cargo fmt --check` — clean.
- Mutation check: reverting the prefix handling to the old drop-it behaviour turns `fileifies_windows_paths` red; restoring it goes green again.

## Known limitation

`fileifies_windows_paths` is behind `#[cfg(windows)]`. `Component::Prefix` does not exist on Unix, so the cross-drive case cannot be exercised on the Linux CI runners — that test only runs for contributors on Windows. I could not find a way around this that did not amount to testing a mock instead of the real path logic.

## Out of scope

Issue #3667 also floats the idea of switching to workspace-relative naming for these files. That is a larger design change with migration implications for existing dictionaries, so this PR only fixes the escaping bug and leaves the naming scheme alone.
