### PR TITLE
fix(harper-ls): assign statsPath to stats_path, not file_dict_path

### DIFF
--- a/harper-ls/src/config.rs
+++ b/harper-ls/src/config.rs
@@ -147,9 +147,9 @@ impl Config {
 
         if let Some(v) = value.get("statsPath") {
             if let Value::String(path) = v {
-                base.file_dict_path = path.try_resolve_in(workspace_root)?.to_path_buf();
+                base.stats_path = path.try_resolve_in(workspace_root)?.to_path_buf();
             } else {
-                bail!("fileDict path must be a string.");
+                bail!("statsPath must be a string.");
             }
         }
 
@@ -227,5 +227,39 @@ impl Default for Config {
             max_file_length: 120_000,
             exclude_patterns: GlobSet::empty(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::Config;
+
+    /// `statsPath` used to assign to `file_dict_path`, so setting it silently
+    /// redirected the file-local dictionary as well.
+    #[test]
+    fn stats_path_does_not_overwrite_file_dict_path() {
+        let workspace_root = std::env::temp_dir();
+        let defaults = Config::default();
+
+        let config = Config::from_lsp_config(
+            &workspace_root,
+            json!({"harper-ls": {"statsPath": "s.txt"}}),
+        )
+        .unwrap();
+
+        assert!(config.stats_path.ends_with("s.txt"));
+        assert_eq!(config.file_dict_path, defaults.file_dict_path);
+    }
+
+    #[test]
+    fn non_string_stats_path_is_rejected() {
+        let workspace_root = std::env::temp_dir();
+
+        let result =
+            Config::from_lsp_config(&workspace_root, json!({"harper-ls": {"statsPath": 7}}));
+
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
> **Disclaimer per [`AGENT_POLICY.md`](https://github.com/Automattic/harper/blob/master/AGENT_POLICY.md):** this patch was produced with the help of an LLM (Claude). The bug and the test were verified locally.

## The bug

In `Config::from_lsp_config`, the `statsPath` branch assigns to the wrong field:

```rust
if let Some(v) = value.get("statsPath") {
    if let Value::String(path) = v {
        base.file_dict_path = path.try_resolve_in(workspace_root)?.to_path_buf();
        //   ^^^^^^^^^^^^^^ should be stats_path
    } else {
        bail!("fileDict path must be a string.");
        //     ^^^^^^^^ message names the wrong setting too
    }
}
```

Two consequences for anyone who sets `statsPath`:

- `stats_path` silently keeps its default, so the setting appears to do nothing;
- `file_dict_path` is redirected to the stats location, so file-local dictionaries are written somewhere the user never asked for — and a `fileDictPath` set earlier in the same config is overwritten, because this branch runs after it.

The error message for a non-string value also names `fileDict`, which sends anyone debugging it to the wrong setting.

## The fix

Assign to `stats_path` and correct the message. Two lines, plus a test covering both the field assignment and the rejection of a non-string value.

`cargo test -p harper-ls` — 13 passed. `cargo fmt --check` — clean. Mutation check: restoring the `file_dict_path` assignment turns `stats_path_does_not_overwrite_file_dict_path` red.

Kept separate from #3667 (the Windows path-prefix fix in `io_utils.rs`) as they are unrelated, per the guidance in `AGENT_POLICY.md` about small PRs.
