### PR TITLE
fix: "steamer that" no longer flagged as typo

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -47144,7 +47144,7 @@ stealth/~NgVJ
 stealthily/Ry
 stealthiness/Ng
 stealthy/J^>p
-steam/~NwSgVd>GJZ
+steam/~NwSgVdGJZ
 steamboat/~NgSV
 steamer/~NgV
 steamfitter/NSg

--- a/harper-core/src/linting/that_than.rs
+++ b/harper-core/src/linting/that_than.rs
@@ -62,7 +62,7 @@ impl ExprLinter for ThatThan {
 #[cfg(test)]
 mod tests {
     use super::ThatThan;
-    use crate::linting::tests::{assert_lint_count, assert_suggestion_result};
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
 
     // adj-er that
 
@@ -77,28 +77,25 @@ mod tests {
 
     #[test]
     fn dont_flag_more_that() {
-        assert_lint_count(
+        assert_no_lints(
             "so it's probably more that Croatian had an easier test",
             ThatThan::default(),
-            0,
         );
     }
 
     #[test]
     fn dont_flag_easier_that_way() {
-        assert_lint_count(
+        assert_no_lints(
             "Given svelte now has signals, it might actually be easier that way.",
             ThatThan::default(),
-            0,
         );
     }
 
     #[test]
     fn dont_flag_better_that() {
-        assert_lint_count(
+        assert_no_lints(
             "So I am wondering if its better that I run SCENIC+ once on the integrated dataset or 3 times on the individual datasets",
             ThatThan::default(),
-            0,
         );
     }
 
@@ -171,19 +168,17 @@ mod tests {
     #[test]
 
     fn dont_fix_faster_that_way() {
-        assert_lint_count(
+        assert_no_lints(
             "You will get an answer quicker that way!",
             ThatThan::default(),
-            0,
         )
     }
 
     #[test]
     fn dont_fix_lighter_that() {
-        assert_lint_count(
+        assert_no_lints(
             "This is the code for Seed-Studio-based timer and desk lighter that I built as a gift for a good friend.",
             ThatThan::default(),
-            0,
         )
     }
 
@@ -191,19 +186,17 @@ mod tests {
 
     #[test]
     fn dont_flag_more_explicit_that() {
-        assert_lint_count(
+        assert_no_lints(
             "make it more explicit that those files are auto ...",
             ThatThan::default(),
-            0,
         );
     }
 
     #[test]
     fn dont_flag_more_clear_that() {
-        assert_lint_count(
+        assert_no_lints(
             "Make it more clear that users need to download the VS tooling installer for .NET Core in VS.",
             ThatThan::default(),
-            0,
         );
     }
 
@@ -211,28 +204,35 @@ mod tests {
 
     #[test]
     fn dont_flag_i_gathered_later_that() {
-        assert_lint_count(
+        assert_no_lints(
             "and I gathered later that he was a photographer",
             ThatThan::default(),
-            0,
         );
     }
 
     #[test]
     fn dont_flag_its_better_that() {
-        assert_lint_count(
+        assert_no_lints(
             "It’s better that the shock should all come at once.",
             ThatThan::default(),
-            0,
+        )
+    }
+
+    // GitHub issues
+
+    #[test]
+    fn dont_flag_number_that_1663() {
+        assert_no_lints(
+            " 455 │ `MAJOR.MINOR.PATCH` version number that increments with:",
+            ThatThan::default(),
         )
     }
 
     #[test]
-    fn dont_flag_number_that_1663() {
-        assert_lint_count(
-            " 455 │ `MAJOR.MINOR.PATCH` version number that increments with:",
+    fn issue_3902() {
+        assert_no_lints(
+            "A fish steamer that spans two burners is essential.",
             ThatThan::default(),
-            0,
-        )
+        );
     }
 }


### PR DESCRIPTION
# Issues 
Fixes #3902

# Description

"that steamer" was flagged as a typo for "than steamer".
This was due to a leftover artefact of the Hunspell origin of Harper's dictionary.
In Hunspell a single annotation flag added "-er" to words.
In Harper, this annotation was extended to assign a "comparative" property to resulting words when the base word included an adjective annotation. Most dictionaries don't include an adjective sense for "steam" but Collins and Wiktionary do.
Efforts were made to remove any of those which were not on adjectives but it was difficult to automate so some words slipped through.

The annotation flag, now `>` was simply removed as we already had a separate entry for "steamer" that was correctly annotated.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Added the sentence from the bug report as a new test and verified that `just test` still passes.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
