### PR TITLE
fix: dictionary had `//` comments instead of `#`

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -20648,9 +20648,9 @@ deafen/VbGd
 deafening/JYV6N
 deafness/~Ng
 deal/~NSgVG>JzZ
-dealbreaker/NgS     // Cambridge, Collins, Longman (MW also)
-deal-breaker/NgS    // Merriam-Webster, Oxford Learners
-deal breaker/NgS    // OED (MW, Longman also)
+dealbreaker/NgS     # Cambridge, Collins, Longman (MW also)
+deal-breaker/NgS    # Merriam-Webster, Oxford Learners
+deal breaker/NgS    # OED (MW, Longman also)
 dealer/~Ng
 dealership/~NSg
 dealing/~NgV


### PR DESCRIPTION
# Issues 
N/A

# Description

While testing #3323 I discovered "deal-breaker" was generating several spurious derived forms such as "dedeal-breaker" - it turned out three lines had C++ style comments instead of the correct `#` comments and the `//` comments tricked the dictionary+annotation parsing logic to treat it like a separator between the base word and the annotation flags.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
