### PR TITLE
fix: run into further troubles→further trouble

### DIFF
--- a/harper-core/src/linting/run_into_problems_or_trouble.rs
+++ b/harper-core/src/linting/run_into_problems_or_trouble.rs
@@ -1,5 +1,6 @@
 use crate::{
     Lint, Token, TokenStringExt,
+    char_string::CharStringExt,
     expr::{Expr, SequenceExpr},
     linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
     patterns::WordSet,
@@ -19,6 +20,7 @@ impl Default for RunIntoProblemsOrTrouble {
                 .then_any_of([
                     Box::new(WordSet::new(&["problem", "troubles"])) as Box<dyn Expr>,
                     Box::new(SequenceExpr::word_seq(&["a", "trouble"])),
+                    Box::new(SequenceExpr::word_seq(&["further", "troubles"])),
                 ]),
         }
     }
@@ -28,13 +30,23 @@ impl ExprLinter for RunIntoProblemsOrTrouble {
     type Unit = Chunk;
 
     fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
-        let a = match toks.len() {
+        // 3 words = 5 tokens, 4 words = 7 tokens
+        let four_words = match toks.len() {
             5 => false,
             7 => true,
             _ => return None,
         };
 
-        let nptoks = &toks[4..];
+        // Are we replacing just the noun or also the 'a' before it?
+        let from = if four_words && !toks[4].get_ch(src).eq_ch(&['a']) {
+            6
+        } else {
+            4
+        };
+        // let from = toks.get_rel_slice(-1, 0)?.span()?;
+
+        let nptoks = &toks[from..];
+
         let npspan = nptoks.span()?;
         let noun = nptoks.last()?;
         let first = noun.get_ch(src).iter().next()?;
@@ -43,7 +55,7 @@ impl ExprLinter for RunIntoProblemsOrTrouble {
         // into   problem  -> problems / a problem
         // into a trouble  -> trouble
         // into   troubles -> trouble
-        let (replacements, msg): (&[&str], &str) = match (a, first, last) {
+        let (replacements, msg): (&[&str], &str) = match (four_words, first, last) {
             (false, &'p' | &'P', &'m' | &'M') => (
                 &["problems", "a problem"],
                 "The noun `problem` is countable. Use the plural `problems` or add the article `a`.",
@@ -52,7 +64,7 @@ impl ExprLinter for RunIntoProblemsOrTrouble {
                 &["trouble"],
                 "The noun `trouble` is uncountable. Drop the article `a`.",
             ),
-            (false, &'t' | &'T', &'s' | &'S') => (
+            (_, &'t' | &'T', &'s' | &'S') => (
                 &["trouble"],
                 "The idiom is `run into trouble`. Use the singular form.",
             ),
@@ -194,6 +206,15 @@ mod tests {
                 "Serving FaceNet with Tensorflow Serving runs into a problem with PyFunc",
             ],
             &[],
+        );
+    }
+
+    #[test]
+    fn run_into_further_troubles() {
+        assert_suggestion_result(
+            "Let me know if you run into further troubles!",
+            RunIntoProblemsOrTrouble::default(),
+            "Let me know if you run into further trouble!",
         );
     }
 }

--- a/harper-core/src/linting/run_into_problems_or_trouble.rs
+++ b/harper-core/src/linting/run_into_problems_or_trouble.rs
@@ -43,7 +43,6 @@ impl ExprLinter for RunIntoProblemsOrTrouble {
         } else {
             4
         };
-        // let from = toks.get_rel_slice(-1, 0)?.span()?;
 
         let nptoks = &toks[from..];
 


### PR DESCRIPTION
# Issues 
N/A

# Description

A comment on another GitHub repo used the wording "run into further troubles".
I knew we had a linter for flagging the plural "troubles" and correct it to "trouble" but upon testing I verified that it didn't work with the qualifier.

To be on the safe side of unforeseen false positives I modified it to only handled "further troubles". Other variants can be added when they are spotted in the wild.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
