### PR TITLE
feat: mixing up "little known" and "a little known"

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -4895,6 +4895,13 @@
 						},
 						{
 							"Bool": {
+								"name": "LittleKnown",
+								"state": true,
+								"label": "Little Known"
+							}
+						},
+						{
+							"Bool": {
 								"name": "LongTimeAgo",
 								"state": true,
 								"label": "Long Time Ago"

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -141,6 +141,7 @@ use super::less_worse::LessWorse;
 use super::let_to_do::LetToDo;
 use super::lets_confusion::LetsConfusion;
 use super::likewise::Likewise;
+use super::little_known::LittleKnown;
 use super::long_sentences::LongSentences;
 use super::long_time_ago::LongTimeAgo;
 use super::look_down_ones_nose::LookDownOnesNose;
@@ -729,6 +730,7 @@ impl LintGroup {
         insert_expr_rule!(LetToDo);
         insert_struct_rule!(LetsConfusion);
         insert_expr_rule!(Likewise);
+        insert_struct_rule!(LittleKnown);
         insert_struct_rule!(LongSentences);
         insert_expr_rule!(LongTimeAgo);
         insert_expr_rule!(LookDownOnesNose);

--- a/harper-core/src/linting/little_known.rs
+++ b/harper-core/src/linting/little_known.rs
@@ -61,7 +61,7 @@ impl ExprLinter for LittleKnown {
 
 #[cfg(test)]
 mod tests {
-    use crate::linting::tests::{assert_good_and_bad_suggestions, assert_suggestion_result};
+    use crate::linting::tests::assert_suggestion_result;
 
     use super::LittleKnown;
 

--- a/harper-core/src/linting/little_known.rs
+++ b/harper-core/src/linting/little_known.rs
@@ -1,0 +1,103 @@
+/// Linter for detecting and fixing mixing up "it's little known" and "it's a little known"
+use crate::{
+    Lint, Token, TokenStringExt,
+    expr::{Expr, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+};
+
+pub struct LittleKnown {
+    expr: SequenceExpr,
+}
+
+impl Default for LittleKnown {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::word_set(&["it's", "its"])
+                .t_ws()
+                .then_optional(SequenceExpr::aco("a").t_ws())
+                .t_aco("little")
+                .t_ws_h()
+                .t_aco("known")
+                .t_ws()
+                .t_set(&["fact", "that"]),
+        }
+    }
+}
+
+impl ExprLinter for LittleKnown {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        let (span, sugg, action) = match (
+            toks.len(),
+            toks.last()?.get_ch(src).first()?.to_ascii_lowercase(),
+        ) {
+            (7, 'f') => (
+                toks[0].span,
+                Suggestion::InsertAfter(vec![' ', 'a']),
+                "Insert",
+            ),
+            (9, 't') => (toks[1..=2].span()?, Suggestion::Remove, "Remove"),
+            _ => return None,
+        };
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::Usage,
+            suggestions: vec![sugg],
+            message: format!("{} the indefinnite article `a`.", action),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "A linter skeleton for contributors to copy into `harper_core/src/linting/` and rename."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_good_and_bad_suggestions, assert_suggestion_result};
+
+    use super::LittleKnown;
+
+    #[test]
+    fn fix_fact_needs_article_with_space() {
+        assert_suggestion_result(
+            "It's little known fact that Legolas did have a dialogue in the Frodo waking up scene",
+            LittleKnown::default(),
+            "It's a little known fact that Legolas did have a dialogue in the Frodo waking up scene",
+        );
+    }
+
+    #[test]
+    fn fix_fact_needs_article_with_hyphen() {
+        assert_suggestion_result(
+            "It's little-known fact among family and close friends, but it doesn't really come up.",
+            LittleKnown::default(),
+            "It's a little-known fact among family and close friends, but it doesn't really come up.",
+        );
+    }
+
+    #[test]
+    fn fix_that_shouldnt_have_article_hyphen() {
+        assert_suggestion_result(
+            "In the Macedonian and in the Turkish scientific public, it's a little-known that Mustafa Kemal visited Shtip in july 1909.",
+            LittleKnown::default(),
+            "In the Macedonian and in the Turkish scientific public, it's little-known that Mustafa Kemal visited Shtip in july 1909.",
+        );
+    }
+
+    #[test]
+    fn fix_that_shouldnt_have_article_space() {
+        assert_suggestion_result(
+            "And so it's a little known that the first post-war chancellor of Germany, Konrad Adenauer, who took charge of the democratic rebirth of Germany ...",
+            LittleKnown::default(),
+            "And so it's little known that the first post-war chancellor of Germany, Konrad Adenauer, who took charge of the democratic rebirth of Germany ...",
+        );
+    }
+}

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -151,6 +151,7 @@ mod likewise;
 mod lint;
 mod lint_group;
 mod lint_kind;
+mod little_known;
 mod long_sentences;
 mod long_time_ago;
 mod look_down_ones_nose;


### PR DESCRIPTION
# Issues 
N/A

# Description

In a YouTube video I was listening to one of the participants said "it's a little known that ..." where it should just be "it's little known that ...".

I used my Google Ngrams Viewer tool to compare contexts and found that the opposite happens mostly with "it's little known fact that ..."

This linter removes the extraneous "a" in the first case and adds the missing "a" in the second case.

# How Has This Been Tested?

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
