### PR TITLE
refactor(harper-comments): migrate Unit, Lua, and Solidity onto LineWise [WIP - Do Not Merge]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3451,6 +3451,7 @@ dependencies = [
  "harper-html",
  "harper-literate-haskell",
  "harper-typst",
+ "harper-yaml",
  "libfuzzer-sys",
 ]
 
@@ -4206,6 +4207,7 @@ dependencies = [
  "harper-stats",
  "harper-tex",
  "harper-typst",
+ "harper-yaml",
  "hashbrown 0.16.1",
  "rayon",
  "serde",
@@ -4416,6 +4418,7 @@ dependencies = [
  "harper-stats",
  "harper-tex",
  "harper-typst",
+ "harper-yaml",
  "open",
  "resolve-path",
  "serde",
@@ -4532,6 +4535,17 @@ dependencies = [
  "tracing",
  "tracing-wasm",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "harper-yaml"
+version = "2.6.0"
+dependencies = [
+ "harper-core",
+ "harper-tree-sitter",
+ "paste",
+ "tree-sitter",
+ "tree-sitter-yaml",
 ]
 
 [[package]]
@@ -9941,6 +9955,16 @@ name = "tree-sitter-typescript"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-yaml"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["harper-cli", "harper-core", "harper-ls", "harper-comments", "harper-wasm", "harper-tree-sitter", "harper-html", "harper-literate-haskell", "harper-typst", "harper-stats", "harper-pos-utils", "harper-brill", "harper-ink", "harper-python", "harper-jjdescription", "harper-thesaurus", "harper-asciidoc", "fuzz", "harper-tex", "harper-desktop/src-tauri", "harper-git-commit/"]
+members = ["harper-cli", "harper-core", "harper-ls", "harper-comments", "harper-wasm", "harper-tree-sitter", "harper-html", "harper-literate-haskell", "harper-typst", "harper-stats", "harper-pos-utils", "harper-brill", "harper-ink", "harper-python", "harper-yaml", "harper-jjdescription", "harper-thesaurus", "harper-asciidoc", "fuzz", "harper-tex", "harper-desktop/src-tauri", "harper-git-commit/"]
 resolver = "2"
 
 [profile.test]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,6 +15,7 @@ harper-typst = { path = "../harper-typst" }
 harper-literate-haskell = { path = "../harper-literate-haskell" }
 harper-html = { path = "../harper-html" }
 harper-comments = { path = "../harper-comments" }
+harper-yaml = { path = "../harper-yaml" }
 
 [[bin]]
 name = "fuzz_harper_typst"
@@ -47,6 +48,13 @@ bench = false
 [[bin]]
 name = "fuzz_harper_core_markdown"
 path = "fuzz_targets/fuzz_harper_core_markdown.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_harper_yaml"
+path = "fuzz_targets/fuzz_harper_yaml.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/fuzz_harper_yaml.rs
+++ b/fuzz/fuzz_targets/fuzz_harper_yaml.rs
@@ -1,0 +1,9 @@
+#![no_main]
+
+use harper_core::parsers::StrParser;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &str| {
+    let parser = harper_yaml::YamlParser::default();
+    let _res = parser.parse_str(data);
+});

--- a/harper-cli/Cargo.toml
+++ b/harper-cli/Cargo.toml
@@ -14,6 +14,7 @@ harper-stats = { path = "../harper-stats", version = "2.0.0" }
 dirs = "6.0.0"
 harper-literate-haskell = { path = "../harper-literate-haskell", version = "2.0.0" }
 harper-python = { path = "../harper-python", version = "2.0.0" }
+harper-yaml = { path = "../harper-yaml", version = "2.0.0" }
 harper-asciidoc = { path = "../harper-asciidoc", version = "2.0.0" }
 harper-core = { path = "../harper-core", version = "2.0.0" }
 harper-pos-utils = { path = "../harper-pos-utils", version = "2.0.0", features = [] }

--- a/harper-cli/src/input/single_input.rs
+++ b/harper-cli/src/input/single_input.rs
@@ -15,6 +15,7 @@ use harper_core::{
 use harper_ink::InkParser;
 use harper_literate_haskell::LiterateHaskellParser;
 use harper_python::PythonParser;
+use harper_yaml::YamlParser;
 
 use super::InputTrait;
 
@@ -146,6 +147,7 @@ impl SingleInputTrait for FileInput {
             Some("tex" | "latex" | "sty" | "cls" | "dtx") => Box::new(harper_tex::TeX::default()),
             Some("typ") => Box::new(harper_typst::Typst),
             Some("py") | Some("pyi") => Box::new(PythonParser::default()),
+            Some("yaml") | Some("yml") => Box::new(YamlParser::default()),
             Some("adoc") | Some("asciidoc") => Box::new(AsciidocParser::default()),
             Some("txt") => Box::new(PlainEnglish),
             _ => {

--- a/harper-cli/src/main.rs
+++ b/harper-cli/src/main.rs
@@ -709,7 +709,7 @@ fn main() -> anyhow::Result<()> {
 
             // Update affixes (text-based replacement with context awareness)
             let updated_affixes_string =
-                affixes_string.replace(&format!("\"{}\":", old), &format!("\"{}\":", new));
+                affixes_string.replace(&format!("\"{old}\":"), &format!("\"{new}\":"));
 
             // Verify that the updated affixes string is valid JSON
             serde_json::from_str::<Value>(&updated_affixes_string)

--- a/harper-comments/src/comment_parsers/lua.rs
+++ b/harper-comments/src/comment_parsers/lua.rs
@@ -1,7 +1,6 @@
 use harper_core::Lrc;
-use harper_core::Span;
 use harper_core::Token;
-use harper_core::parsers::{Markdown, MarkdownOptions, Parser};
+use harper_core::parsers::{LineClass, LineWise, Markdown, MarkdownOptions, Parser};
 
 use super::without_initiators;
 
@@ -22,62 +21,24 @@ impl Lua {
 
 impl Parser for Lua {
     fn parse(&self, source: &[char]) -> Vec<Token> {
-        let mut tokens = Vec::new();
-
-        let mut chars_traversed = 0;
-
-        for line in source.split(|c| *c == '\n') {
-            if starts_with_prefix(line) {
-                tokens.push(Token::new(
-                    Span::empty(chars_traversed),
-                    harper_core::TokenKind::Newline(2),
-                ));
-                chars_traversed += line.len() + 1;
-                continue;
-            }
-
-            let mut new_tokens = parse_line(line, self.inner.clone());
-
-            if chars_traversed + line.len() < source.len() {
-                new_tokens.push(Token::new(
-                    Span::new_with_len(line.len(), 1),
-                    harper_core::TokenKind::Newline(1),
-                ));
-            }
-
-            new_tokens
-                .iter_mut()
-                .for_each(|t| t.span.push_by(chars_traversed));
-
-            chars_traversed += line.len() + 1;
-            tokens.append(&mut new_tokens);
-        }
-
-        tokens
+        LineWise::new(self.inner.clone(), classify as fn(&[char]) -> LineClass).parse(source)
     }
 }
 
-fn starts_with_prefix(source: &[char]) -> bool {
-    let actual = without_initiators(source);
-    let actual_chars = actual.get_content(source);
+fn classify(line: &[char]) -> LineClass {
+    let actual = without_initiators(line);
+    let actual_chars = actual.get_content(line);
 
-    matches!(actual_chars, ['@', ..])
-}
-
-fn parse_line(source: &[char], parser: Lrc<dyn Parser>) -> Vec<Token> {
-    let actual = without_initiators(source);
+    // A `@tag` annotation line (e.g. LuaDoc's `---@param`) is never
+    // parsed as prose; it's treated as its own paragraph break so it
+    // doesn't get glued onto the surrounding sentence.
+    if matches!(actual_chars, ['@', ..]) {
+        return LineClass::skip_with_newline(2);
+    }
 
     if actual.is_empty() {
-        return Vec::new();
+        return LineClass::skip();
     }
 
-    let source = actual.get_content(source);
-
-    let mut new_tokens = parser.parse(source);
-
-    new_tokens
-        .iter_mut()
-        .for_each(|t| t.span.push_by(actual.start));
-
-    new_tokens
+    LineClass::parse(actual)
 }

--- a/harper-comments/src/comment_parsers/solidity.rs
+++ b/harper-comments/src/comment_parsers/solidity.rs
@@ -1,7 +1,6 @@
 use harper_core::Lrc;
-use harper_core::Span;
 use harper_core::Token;
-use harper_core::parsers::{MarkdownOptions, Parser};
+use harper_core::parsers::{LineClass, LineWise, MarkdownOptions, Parser};
 
 use super::jsdoc::JsDoc;
 use super::without_initiators;
@@ -23,59 +22,24 @@ impl Solidity {
 
 impl Parser for Solidity {
     fn parse(&self, source: &[char]) -> Vec<Token> {
-        let mut tokens = Vec::new();
-
-        let mut chars_traversed = 0;
-
-        for line in source.split(|c| *c == '\n') {
-            let mut new_tokens = parse_line(line, self.inner.clone());
-
-            if chars_traversed + line.len() < source.len() {
-                new_tokens.push(Token::new(
-                    Span::new_with_len(line.len(), 1),
-                    harper_core::TokenKind::Newline(1),
-                ));
-            }
-
-            new_tokens
-                .iter_mut()
-                .for_each(|t| t.span.push_by(chars_traversed));
-
-            chars_traversed += line.len() + 1;
-            tokens.append(&mut new_tokens);
-        }
-
-        tokens
+        LineWise::new(self.inner.clone(), classify as fn(&[char]) -> LineClass).parse(source)
     }
 }
 
-fn parse_line(source: &[char], parser: Lrc<dyn Parser>) -> Vec<Token> {
-    let mut actual = without_initiators(source);
+fn classify(line: &[char]) -> LineClass {
+    let actual = without_initiators(line);
     if actual.is_empty() {
-        return Vec::new();
+        return LineClass::skip();
     }
-    let mut actual_source = actual.get_content(source);
 
-    // ignore the special SPDX-License-Identifier comment
+    let actual_source = actual.get_content(line);
+
+    // Ignore the special SPDX-License-Identifier comment. `line` has
+    // already been split on '\n' by `LineWise`, so it never contains
+    // one - this always swallows the whole line.
     if actual_source.starts_with(&['S', 'P', 'D', 'X', '-']) {
-        let Some(terminator) = source.iter().position(|c| *c == '\n') else {
-            return Vec::new();
-        };
-
-        actual.start += terminator;
-
-        let Some(new_source) = actual.try_get_content(actual_source) else {
-            return Vec::new();
-        };
-
-        actual_source = new_source
+        return LineClass::skip();
     }
 
-    let mut new_tokens = parser.parse(actual_source);
-
-    new_tokens
-        .iter_mut()
-        .for_each(|t| t.span.push_by(actual.start));
-
-    new_tokens
+    LineClass::parse(actual)
 }

--- a/harper-comments/src/comment_parsers/unit.rs
+++ b/harper-comments/src/comment_parsers/unit.rs
@@ -1,6 +1,8 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use harper_core::Lrc;
-use harper_core::parsers::{Markdown, MarkdownOptions, Parser};
-use harper_core::{Span, Token};
+use harper_core::Token;
+use harper_core::parsers::{LineClass, LineWise, Markdown, MarkdownOptions, Parser};
 
 use super::without_initiators;
 
@@ -27,58 +29,35 @@ impl Unit {
 
 impl Parser for Unit {
     fn parse(&self, source: &[char]) -> Vec<Token> {
-        let mut tokens = Vec::new();
+        // Tracks whether we're currently inside a fenced code block,
+        // toggled by `classify` as it walks the lines in order. Reset
+        // fresh on every `parse` call, since `AtomicBool` (rather than
+        // `Cell`) is needed only to satisfy `LineWise`'s `Send + Sync`
+        // bound - there's no real concurrency here.
+        let in_code_fence = AtomicBool::new(false);
 
-        let mut chars_traversed = 0;
-        let mut in_code_fence = false;
-
-        for line in source.split(|c| *c == '\n') {
+        let classify = move |line: &[char]| -> LineClass {
             if line_is_code_fence(line) {
-                in_code_fence = !in_code_fence;
+                in_code_fence.fetch_xor(true, Ordering::Relaxed);
             }
 
-            if in_code_fence {
-                chars_traversed += line.len() + 1;
-                continue;
+            if in_code_fence.load(Ordering::Relaxed) {
+                // Fully swallow lines inside (and the opening marker of)
+                // a fenced code block: no content, no separator token.
+                return LineClass::skip_silently();
             }
 
-            let mut new_tokens = parse_line(line, self.inner.clone());
+            let actual = without_initiators(line);
 
-            if chars_traversed + line.len() < source.len() {
-                new_tokens.push(Token::new(
-                    Span::new_with_len(line.len(), 1),
-                    harper_core::TokenKind::Newline(1),
-                ));
+            if actual.is_empty() {
+                return LineClass::skip();
             }
 
-            new_tokens
-                .iter_mut()
-                .for_each(|t| t.span.push_by(chars_traversed));
+            LineClass::parse(actual)
+        };
 
-            chars_traversed += line.len() + 1;
-            tokens.append(&mut new_tokens);
-        }
-
-        tokens
+        LineWise::new(self.inner.clone(), classify).parse(source)
     }
-}
-
-fn parse_line(source: &[char], parser: Lrc<dyn Parser>) -> Vec<Token> {
-    let actual = without_initiators(source);
-
-    if actual.is_empty() {
-        return Vec::new();
-    }
-
-    let source = actual.get_content(source);
-
-    let mut new_tokens = parser.parse(source);
-
-    new_tokens
-        .iter_mut()
-        .for_each(|t| t.span.push_by(actual.start));
-
-    new_tokens
 }
 
 fn line_is_code_fence(source: &[char]) -> bool {

--- a/harper-core/src/linting/regionalisms.rs
+++ b/harper-core/src/linting/regionalisms.rs
@@ -710,6 +710,7 @@ impl ExprLinter for Regionalisms {
             return None;
         }
 
+        // No matching term found, so nothing to lint.
         let concept = REGIONAL_TERMS
             .iter()
             .find(|row| row.term == flagged_term_string)?

--- a/harper-core/src/parsers/line_wise.rs
+++ b/harper-core/src/parsers/line_wise.rs
@@ -1,0 +1,148 @@
+use super::Parser;
+use crate::{LSend, Span, Token, TokenKind};
+
+/// Wraps a `Parser`, parsing a (possibly multiline) span one line at a
+/// time. Each line is first reduced by `strip` to the sub-span that
+/// should actually be parsed (e.g. trimming whitespace or comment
+/// initiators) — an empty span means the line is skipped entirely.
+/// Per-line results are stitched back together with a single explicit
+/// [`TokenKind::Newline`] token between lines, with spans remapped
+/// back onto the original, untrimmed source.
+pub struct LineWise<P, S> {
+    inner: P,
+    strip: S,
+}
+
+impl<P, S> LineWise<P, S>
+where
+    P: Parser,
+    S: Fn(&[char]) -> Span<char> + LSend,
+{
+    pub fn new(inner: P, strip: S) -> Self {
+        Self { inner, strip }
+    }
+}
+
+impl<P, S> Parser for LineWise<P, S>
+where
+    P: Parser,
+    S: Fn(&[char]) -> Span<char> + LSend,
+{
+    fn parse(&self, source: &[char]) -> Vec<Token> {
+        let mut tokens = Vec::new();
+        let mut chars_traversed = 0;
+
+        for line in source.split(|c| *c == '\n') {
+            let stripped = (self.strip)(line);
+
+            if !stripped.is_empty() {
+                let mut new_tokens = self.inner.parse(stripped.get_content(line));
+
+                new_tokens
+                    .iter_mut()
+                    .for_each(|t| t.span.push_by(chars_traversed + stripped.start));
+
+                tokens.append(&mut new_tokens);
+            }
+
+            let line_end = chars_traversed + line.len();
+
+            if line_end < source.len() {
+                tokens.push(Token::new(
+                    Span::new_with_len(line_end, 1),
+                    TokenKind::Newline(1),
+                ));
+            }
+
+            chars_traversed += line.len() + 1;
+        }
+
+        tokens
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LineWise;
+    use crate::Span;
+    use crate::TokenKind;
+    use crate::parsers::{Parser, PlainEnglish};
+
+    fn trim_whitespace(line: &[char]) -> Span<char> {
+        let Some(start) = line.iter().position(|c| !c.is_whitespace()) else {
+            return Span::new(0, 0);
+        };
+        let end = line.len() - line.iter().rev().position(|c| !c.is_whitespace()).unwrap();
+
+        Span::new(start, end)
+    }
+
+    fn parse(source: &str) -> Vec<crate::Token> {
+        let chars: Vec<char> = source.chars().collect();
+        LineWise::new(PlainEnglish, trim_whitespace).parse(&chars)
+    }
+
+    #[test]
+    fn dedents_indented_continuation_line() {
+        let tokens = parse("hello\n  world");
+
+        for token in &tokens {
+            if let TokenKind::Space(count) = token.kind {
+                assert_eq!(count, 1, "found a multi-space token: {tokens:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn inserts_single_newline_between_lines() {
+        let tokens = parse("hello\nworld");
+        let newline_count = tokens
+            .iter()
+            .filter(|t| matches!(t.kind, TokenKind::Newline(_)))
+            .count();
+
+        assert_eq!(newline_count, 1);
+    }
+
+    #[test]
+    fn skips_blank_lines_without_panicking() {
+        let tokens = parse("hello\n\nworld");
+        assert!(!tokens.is_empty());
+    }
+
+    #[test]
+    fn spans_map_back_to_original_source() {
+        let source = "hello\n  world";
+        let chars: Vec<char> = source.chars().collect();
+        let tokens = parse(source);
+
+        for token in &tokens {
+            assert!(token.span.try_get_content(&chars).is_some());
+        }
+    }
+
+    #[test]
+    fn strip_function_is_not_limited_to_whitespace() {
+        // A strip function that chops a leading "> " blockquote marker,
+        // proving the combinator generalizes beyond whitespace-trimming.
+        fn strip_quote_marker(line: &[char]) -> Span<char> {
+            if line.starts_with(&['>', ' ']) {
+                Span::new(2, line.len())
+            } else {
+                Span::new(0, line.len())
+            }
+        }
+
+        let source = "> hello\n> world";
+        let chars: Vec<char> = source.chars().collect();
+        let tokens = LineWise::new(PlainEnglish, strip_quote_marker).parse(&chars);
+
+        for token in &tokens {
+            let content: String = token.span.get_content(&chars).iter().collect();
+            assert!(
+                !content.starts_with('>'),
+                "marker leaked into token: {content:?}"
+            );
+        }
+    }
+}

--- a/harper-core/src/parsers/line_wise.rs
+++ b/harper-core/src/parsers/line_wise.rs
@@ -1,56 +1,108 @@
 use super::Parser;
 use crate::{LSend, Span, Token, TokenKind};
 
+/// Describes how [`LineWise`] should handle a single line.
+pub struct LineClass {
+    /// The sub-span of the line to hand to the inner parser. An empty
+    /// span means nothing on this line gets parsed.
+    pub span: Span<char>,
+    /// The weight of the `Newline` token to insert after this line (if
+    /// there is a following line), or `None` to insert no separator
+    /// token at all — e.g. to fully swallow a line inside a fenced code
+    /// block.
+    pub newline: Option<usize>,
+}
+
+impl LineClass {
+    /// Parse `span`, followed by a normal single-weight newline separator.
+    pub fn parse(span: Span<char>) -> Self {
+        Self {
+            span,
+            newline: Some(1),
+        }
+    }
+
+    /// Skip the line's content, but still insert a normal newline
+    /// separator (e.g. a blank line).
+    pub fn skip() -> Self {
+        Self {
+            span: Span::new(0, 0),
+            newline: Some(1),
+        }
+    }
+
+    /// Skip the line's content and suppress the following separator
+    /// entirely.
+    pub fn skip_silently() -> Self {
+        Self {
+            span: Span::new(0, 0),
+            newline: None,
+        }
+    }
+
+    /// Skip the line's content, inserting a custom-weight newline
+    /// separator (e.g. a paragraph break).
+    pub fn skip_with_newline(weight: usize) -> Self {
+        Self {
+            span: Span::new(0, 0),
+            newline: Some(weight),
+        }
+    }
+}
+
 /// Wraps a `Parser`, parsing a (possibly multiline) span one line at a
-/// time. Each line is first reduced by `strip` to the sub-span that
-/// should actually be parsed (e.g. trimming whitespace or comment
-/// initiators) — an empty span means the line is skipped entirely.
-/// Per-line results are stitched back together with a single explicit
-/// [`TokenKind::Newline`] token between lines, with spans remapped
+/// time. Each line is first reduced by `classify` to a [`LineClass`]
+/// describing which sub-span (if any) should be parsed, and what
+/// [`TokenKind::Newline`] separator (if any) should follow it — e.g.
+/// trimming whitespace or comment initiators, or overriding the
+/// separator to mark a paragraph break or swallow a line entirely.
+/// Per-line results are stitched back together, with spans remapped
 /// back onto the original, untrimmed source.
 pub struct LineWise<P, S> {
     inner: P,
-    strip: S,
+    classify: S,
 }
 
 impl<P, S> LineWise<P, S>
 where
     P: Parser,
-    S: Fn(&[char]) -> Span<char> + LSend,
+    S: Fn(&[char]) -> LineClass + LSend,
 {
-    pub fn new(inner: P, strip: S) -> Self {
-        Self { inner, strip }
+    pub fn new(inner: P, classify: S) -> Self {
+        Self { inner, classify }
     }
 }
 
 impl<P, S> Parser for LineWise<P, S>
 where
     P: Parser,
-    S: Fn(&[char]) -> Span<char> + LSend,
+    S: Fn(&[char]) -> LineClass + LSend,
 {
     fn parse(&self, source: &[char]) -> Vec<Token> {
         let mut tokens = Vec::new();
         let mut chars_traversed = 0;
 
         for line in source.split(|c| *c == '\n') {
-            let stripped = (self.strip)(line);
+            let class = (self.classify)(line);
 
-            if !stripped.is_empty() {
-                let mut new_tokens = self.inner.parse(stripped.get_content(line));
+            if !class.span.is_empty() {
+                let mut new_tokens = self.inner.parse(class.span.get_content(line));
 
                 new_tokens
                     .iter_mut()
-                    .for_each(|t| t.span.push_by(chars_traversed + stripped.start));
+                    .for_each(|t| t.span.push_by(chars_traversed + class.span.start));
 
                 tokens.append(&mut new_tokens);
             }
 
             let line_end = chars_traversed + line.len();
 
-            if line_end < source.len() {
+            if line_end < source.len()
+                && let Some(weight) = class.newline
+            {
                 tokens.push(Token::new(
                     Span::new_with_len(line_end, 1),
-                    TokenKind::Newline(1),
+                    TokenKind::Newline(weight),
                 ));
             }
 
@@ -63,18 +115,18 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::LineWise;
+    use super::{LineClass, LineWise};
     use crate::Span;
     use crate::TokenKind;
     use crate::parsers::{Parser, PlainEnglish};
 
-    fn trim_whitespace(line: &[char]) -> Span<char> {
+    fn trim_whitespace(line: &[char]) -> LineClass {
         let Some(start) = line.iter().position(|c| !c.is_whitespace()) else {
-            return Span::new(0, 0);
+            return LineClass::skip();
         };
         let end = line.len() - line.iter().rev().position(|c| !c.is_whitespace()).unwrap();
 
-        Span::new(start, end)
+        LineClass::parse(Span::new(start, end))
     }
 
     fn parse(source: &str) -> Vec<crate::Token> {
@@ -122,14 +174,14 @@ mod tests {
     }
 
     #[test]
-    fn strip_function_is_not_limited_to_whitespace() {
-        // A strip function that chops a leading "> " blockquote marker,
+    fn classify_function_is_not_limited_to_whitespace() {
+        // A classify function that chops a leading "> " blockquote marker,
         // proving the combinator generalizes beyond whitespace-trimming.
-        fn strip_quote_marker(line: &[char]) -> Span<char> {
+        fn strip_quote_marker(line: &[char]) -> LineClass {
             if line.starts_with(&['>', ' ']) {
-                Span::new(2, line.len())
+                LineClass::parse(Span::new(2, line.len()))
             } else {
-                Span::new(0, line.len())
+                LineClass::parse(Span::new(0, line.len()))
             }
         }
 
@@ -144,5 +196,79 @@ mod tests {
                 "marker leaked into token: {content:?}"
             );
         }
+    }
+
+    #[test]
+    fn skip_silently_suppresses_the_separator_token() {
+        fn classify(line: &[char]) -> LineClass {
+            if line == ['-', '-', '-'] {
+                LineClass::skip_silently()
+            } else {
+                LineClass::parse(Span::new(0, line.len()))
+            }
+        }
+
+        let source = "hello\n---\nworld";
+        let chars: Vec<char> = source.chars().collect();
+        let tokens = LineWise::new(PlainEnglish, classify).parse(&chars);
+
+        let newline_count = tokens
+            .iter()
+            .filter(|t| matches!(t.kind, TokenKind::Newline(_)))
+            .count();
+
+        // Only the separator after "hello" should survive - the "---"
+        // line's own trailing separator is suppressed by skip_silently,
+        // so a naive implementation (2 separators) would fail this.
+        assert_eq!(newline_count, 1, "unexpected separator count: {tokens:?}");
+    }
+
+    #[test]
+    fn skip_with_newline_overrides_the_separator_weight() {
+        fn classify(line: &[char]) -> LineClass {
+            if line.starts_with(&['@']) {
+                LineClass::skip_with_newline(2)
+            } else {
+                LineClass::parse(Span::new(0, line.len()))
+            }
+        }
+
+        let source = "hello\n@tag\nworld";
+        let chars: Vec<char> = source.chars().collect();
+        let tokens = LineWise::new(PlainEnglish, classify).parse(&chars);
+
+        let newline_weights: Vec<usize> = tokens
+            .iter()
+            .filter_map(|t| match t.kind {
+                TokenKind::Newline(n) => Some(n),
+                _ => None,
+            })
+            .collect();
+
+        // "hello"'s own (default-weight) separator comes first, followed
+        // by "@tag"'s overridden weight-2 separator.
+        assert_eq!(newline_weights, vec![1, 2]);
+    }
+
+    #[test]
+    fn skip_with_newline_on_the_final_line_emits_no_trailing_separator() {
+        fn classify(line: &[char]) -> LineClass {
+            if line.starts_with(&['@']) {
+                LineClass::skip_with_newline(2)
+            } else {
+                LineClass::parse(Span::new(0, line.len()))
+            }
+        }
+
+        // "@tag" is the only, and therefore final, line - its requested
+        // separator weight must not produce a dangling trailing token.
+        let source = "@tag";
+        let chars: Vec<char> = source.chars().collect();
+        let tokens = LineWise::new(PlainEnglish, classify).parse(&chars);
+
+        assert!(
+            tokens.is_empty(),
+            "did not expect any tokens for a swallowed final line: {tokens:?}"
+        );
     }
 }

--- a/harper-core/src/parsers/mod.rs
+++ b/harper-core/src/parsers/mod.rs
@@ -2,6 +2,7 @@
 
 mod collapse_identifiers;
 mod isolate_english;
+mod line_wise;
 mod markdown;
 mod mask;
 mod oops_all_headings;
@@ -11,6 +12,7 @@ mod plain_english;
 use blanket::blanket;
 pub use collapse_identifiers::CollapseIdentifiers;
 pub use isolate_english::IsolateEnglish;
+pub use line_wise::LineWise;
 pub use markdown::{Markdown, MarkdownOptions};
 pub use mask::Mask;
 pub use oops_all_headings::OopsAllHeadings;

--- a/harper-core/src/parsers/mod.rs
+++ b/harper-core/src/parsers/mod.rs
@@ -12,7 +12,7 @@ mod plain_english;
 use blanket::blanket;
 pub use collapse_identifiers::CollapseIdentifiers;
 pub use isolate_english::IsolateEnglish;
-pub use line_wise::LineWise;
+pub use line_wise::{LineClass, LineWise};
 pub use markdown::{Markdown, MarkdownOptions};
 pub use mask::Mask;
 pub use oops_all_headings::OopsAllHeadings;

--- a/harper-desktop/src-tauri/src/mac_broker/mod.rs
+++ b/harper-desktop/src-tauri/src/mac_broker/mod.rs
@@ -31,7 +31,7 @@ use std::{
     time::Instant,
 };
 
-use crate::config::{Config, Integration};
+use crate::config::Integration;
 use crate::os_broker::{AccessibilityPermissionStatus, AppSearchResult, OsBroker};
 use crate::rect::ActionableLint;
 

--- a/harper-ls/Cargo.toml
+++ b/harper-ls/Cargo.toml
@@ -19,6 +19,7 @@ harper-typst = { path = "../harper-typst", version = "2.0.0" }
 harper-tex = { path = "../harper-tex", version = "2.0.0" }
 harper-html = { path = "../harper-html", version = "2.0.0" }
 harper-python = { path = "../harper-python", version = "2.0.0" }
+harper-yaml = { path = "../harper-yaml", version = "2.0.0" }
 harper-asciidoc = { path = "../harper-asciidoc", version = "2.0.0" }
 tower-lsp-server = "0.22.1"
 tokio = { version = "1.52.1", default-features = false, features = ["fs", "io-std", "io-util", "macros", "net", "rt-multi-thread", "sync"] }

--- a/harper-ls/src/backend.rs
+++ b/harper-ls/src/backend.rs
@@ -28,6 +28,7 @@ use harper_python::PythonParser;
 use harper_stats::{Record, Stats};
 use harper_tex::TeX;
 use harper_typst::Typst;
+use harper_yaml::YamlParser;
 use serde_json::{Value, json};
 use tokio::sync::{Mutex, RwLock};
 use tower_lsp_server::jsonrpc::Result as JsonResult;
@@ -399,6 +400,7 @@ impl Backend {
             "python" => Some(Box::new(PythonParser::default())),
             "typst" => Some(Box::new(Typst)),
             "tex" | "plaintex" | "latex" => Some(Box::new(TeX::default())),
+            "yaml" => Some(Box::new(YamlParser::default())),
             _ => None,
         };
 

--- a/harper-yaml/Cargo.toml
+++ b/harper-yaml/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "harper-yaml"
+version = "2.6.0"
+edition = "2024"
+description = "The language checker for developers."
+license = "Apache-2.0"
+repository = "https://github.com/automattic/harper"
+
+[dependencies]
+harper-core = { path = "../harper-core", version = "2.0.0" }
+harper-tree-sitter = { path = "../harper-tree-sitter", version = "2.0.0" }
+tree-sitter-yaml = "0.7.2"
+tree-sitter = "0.25.10"
+
+[dev-dependencies]
+paste = "1.0.15"

--- a/harper-yaml/src/dedent.rs
+++ b/harper-yaml/src/dedent.rs
@@ -1,10 +1,9 @@
-use harper_core::parsers::Parser;
-use harper_core::{Span, Token, TokenKind};
+use harper_core::parsers::{LineWise, Parser};
+use harper_core::{Span, Token};
 
-/// Wraps a `Parser`, parsing each line of a (possibly multiline) span
-/// independently after trimming its leading/trailing whitespace, then
-/// stitching the results back together with a single explicit
-/// [`TokenKind::Newline`] token between lines.
+/// Parses each line of a (possibly multiline) span independently after
+/// trimming its leading/trailing whitespace, then stitches the results
+/// back together with a single explicit `Newline` token between lines.
 ///
 /// This exists for YAML block/folded scalars: their continuation lines
 /// carry literal indentation (e.g. two leading spaces). Feeding
@@ -13,55 +12,36 @@ use harper_core::{Span, Token, TokenKind};
 /// incorrectly triggers Harper's "double space" formatting rule.
 /// De-denting each line before parsing avoids that, without needing to
 /// understand YAML's specific indentation rules.
-pub(crate) struct DedentLines<P> {
-    inner: P,
-}
+///
+/// The actual line-splitting/stitching mechanism is shared with other
+/// per-line parsers (see `harper_core::parsers::LineWise`); this type
+/// only supplies the YAML-specific "strip" policy (trim whitespace).
+pub(crate) struct DedentLines<P>(Inner<P>);
+
+type StripFn = fn(&[char]) -> Span<char>;
+type Inner<P> = LineWise<P, StripFn>;
 
 impl<P: Parser> DedentLines<P> {
     pub(crate) fn new(inner: P) -> Self {
-        Self { inner }
+        Self(LineWise::new(inner, trim as StripFn))
     }
 }
 
 impl<P: Parser> Parser for DedentLines<P> {
     fn parse(&self, source: &[char]) -> Vec<Token> {
-        let mut tokens = Vec::new();
-        let mut chars_traversed = 0;
-
-        for line in source.split(|c| *c == '\n') {
-            if let Some(trimmed) = trim(line) {
-                let mut new_tokens = self.inner.parse(trimmed.get_content(line));
-
-                new_tokens
-                    .iter_mut()
-                    .for_each(|t| t.span.push_by(chars_traversed + trimmed.start));
-
-                tokens.append(&mut new_tokens);
-            }
-
-            let line_end = chars_traversed + line.len();
-
-            if line_end < source.len() {
-                tokens.push(Token::new(
-                    Span::new_with_len(line_end, 1),
-                    TokenKind::Newline(1),
-                ));
-            }
-
-            chars_traversed += line.len() + 1;
-        }
-
-        tokens
+        self.0.parse(source)
     }
 }
 
-/// The span of `line` with leading/trailing whitespace trimmed, or
-/// `None` if the line is entirely whitespace.
-fn trim(line: &[char]) -> Option<Span<char>> {
-    let start = line.iter().position(|c| !c.is_whitespace())?;
-    let end = line.len() - line.iter().rev().position(|c| !c.is_whitespace())?;
+/// The span of `line` with leading/trailing whitespace trimmed, or an
+/// empty span if the line is entirely whitespace.
+fn trim(line: &[char]) -> Span<char> {
+    let Some(start) = line.iter().position(|c| !c.is_whitespace()) else {
+        return Span::new(0, 0);
+    };
+    let end = line.len() - line.iter().rev().position(|c| !c.is_whitespace()).unwrap();
 
-    Some(Span::new(start, end))
+    Span::new(start, end)
 }
 
 #[cfg(test)]

--- a/harper-yaml/src/dedent.rs
+++ b/harper-yaml/src/dedent.rs
@@ -1,0 +1,120 @@
+use harper_core::parsers::Parser;
+use harper_core::{Span, Token, TokenKind};
+
+/// Wraps a `Parser`, parsing each line of a (possibly multiline) span
+/// independently after trimming its leading/trailing whitespace, then
+/// stitching the results back together with a single explicit
+/// [`TokenKind::Newline`] token between lines.
+///
+/// This exists for YAML block/folded scalars: their continuation lines
+/// carry literal indentation (e.g. two leading spaces). Feeding
+/// that raw text straight to a prose parser makes the newline-plus-
+/// indentation read as a run of several space characters, which
+/// incorrectly triggers Harper's "double space" formatting rule.
+/// De-denting each line before parsing avoids that, without needing to
+/// understand YAML's specific indentation rules.
+pub(crate) struct DedentLines<P> {
+    inner: P,
+}
+
+impl<P: Parser> DedentLines<P> {
+    pub(crate) fn new(inner: P) -> Self {
+        Self { inner }
+    }
+}
+
+impl<P: Parser> Parser for DedentLines<P> {
+    fn parse(&self, source: &[char]) -> Vec<Token> {
+        let mut tokens = Vec::new();
+        let mut chars_traversed = 0;
+
+        for line in source.split(|c| *c == '\n') {
+            if let Some(trimmed) = trim(line) {
+                let mut new_tokens = self.inner.parse(trimmed.get_content(line));
+
+                new_tokens
+                    .iter_mut()
+                    .for_each(|t| t.span.push_by(chars_traversed + trimmed.start));
+
+                tokens.append(&mut new_tokens);
+            }
+
+            let line_end = chars_traversed + line.len();
+
+            if line_end < source.len() {
+                tokens.push(Token::new(
+                    Span::new_with_len(line_end, 1),
+                    TokenKind::Newline(1),
+                ));
+            }
+
+            chars_traversed += line.len() + 1;
+        }
+
+        tokens
+    }
+}
+
+/// The span of `line` with leading/trailing whitespace trimmed, or
+/// `None` if the line is entirely whitespace.
+fn trim(line: &[char]) -> Option<Span<char>> {
+    let start = line.iter().position(|c| !c.is_whitespace())?;
+    let end = line.len() - line.iter().rev().position(|c| !c.is_whitespace())?;
+
+    Some(Span::new(start, end))
+}
+
+#[cfg(test)]
+mod tests {
+    use harper_core::TokenKind;
+    use harper_core::parsers::{Parser, PlainEnglish};
+
+    use super::DedentLines;
+
+    fn parse(source: &str) -> Vec<harper_core::Token> {
+        let chars: Vec<char> = source.chars().collect();
+        DedentLines::new(PlainEnglish).parse(&chars)
+    }
+
+    #[test]
+    fn dedents_indented_continuation_line() {
+        let source = "hello\n  world";
+        let tokens = parse(source);
+
+        // No token should be a run of more than one space - the two
+        // leading spaces before "world" must have been trimmed away.
+        for token in &tokens {
+            if let TokenKind::Space(count) = token.kind {
+                assert_eq!(count, 1, "found a multi-space token: {tokens:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn inserts_single_newline_between_lines() {
+        let tokens = parse("hello\nworld");
+        let newline_count = tokens
+            .iter()
+            .filter(|t| matches!(t.kind, TokenKind::Newline(_)))
+            .count();
+
+        assert_eq!(newline_count, 1);
+    }
+
+    #[test]
+    fn skips_blank_lines_without_panicking() {
+        let tokens = parse("hello\n\nworld");
+        assert!(!tokens.is_empty());
+    }
+
+    #[test]
+    fn spans_map_back_to_original_source() {
+        let source = "hello\n  world";
+        let chars: Vec<char> = source.chars().collect();
+        let tokens = parse(source);
+
+        for token in &tokens {
+            assert!(token.span.try_get_content(&chars).is_some());
+        }
+    }
+}

--- a/harper-yaml/src/dedent.rs
+++ b/harper-yaml/src/dedent.rs
@@ -1,4 +1,4 @@
-use harper_core::parsers::{LineWise, Parser};
+use harper_core::parsers::{LineClass, LineWise, Parser};
 use harper_core::{Span, Token};
 
 /// Parses each line of a (possibly multiline) span independently after
@@ -18,7 +18,7 @@ use harper_core::{Span, Token};
 /// only supplies the YAML-specific "strip" policy (trim whitespace).
 pub(crate) struct DedentLines<P>(Inner<P>);
 
-type StripFn = fn(&[char]) -> Span<char>;
+type StripFn = fn(&[char]) -> LineClass;
 type Inner<P> = LineWise<P, StripFn>;
 
 impl<P: Parser> DedentLines<P> {
@@ -33,15 +33,15 @@ impl<P: Parser> Parser for DedentLines<P> {
     }
 }
 
-/// The span of `line` with leading/trailing whitespace trimmed, or an
-/// empty span if the line is entirely whitespace.
-fn trim(line: &[char]) -> Span<char> {
+/// Trims leading/trailing whitespace from `line`, or skips it entirely
+/// if it's whitespace-only.
+fn trim(line: &[char]) -> LineClass {
     let Some(start) = line.iter().position(|c| !c.is_whitespace()) else {
-        return Span::new(0, 0);
+        return LineClass::skip();
     };
     let end = line.len() - line.iter().rev().position(|c| !c.is_whitespace()).unwrap();
 
-    Span::new(start, end)
+    LineClass::parse(Span::new(start, end))
 }
 
 #[cfg(test)]

--- a/harper-yaml/src/heuristics.rs
+++ b/harper-yaml/src/heuristics.rs
@@ -1,0 +1,211 @@
+/// Decides whether a YAML scalar value looks like prose worth
+/// grammar-checking, as opposed to structural config data
+/// (identifiers, enum values, URLs, paths, version strings).
+///
+/// Comments are never passed through this function — they're
+/// always linted, handled separately in `YamlMasker`.
+pub(crate) fn is_prose_scalar(text: &str) -> bool {
+    let word_count = text.split_whitespace().count();
+
+    word_count >= 3 && !looks_url_path_or_version(text) && !looks_like_identifier(text)
+}
+
+/// True only if `text` is, in its entirety, a single whitespace-separated
+/// token that is itself URL-, path-, or version-shaped (e.g. `v1.2.3`,
+/// `0.15.9`, `https://example.com`, `/usr/local/bin`) — not merely a
+/// sentence that happens to mention one (e.g. "Update the library to
+/// version 1.2.3" is prose worth checking, not a bare version string).
+///
+/// A value with 3+ words already fails `is_prose_scalar`'s word-count
+/// gate before this function's result can matter, so in practice this
+/// only ever returns `true` for single-token values. Kept explicit and
+/// correct on its own terms rather than relying on that gate implicitly.
+fn looks_url_path_or_version(text: &str) -> bool {
+    let mut words = text.split_whitespace();
+
+    let Some(only_word) = words.next() else {
+        return false;
+    };
+
+    if words.next().is_some() {
+        return false;
+    }
+
+    only_word.starts_with("http://")
+        || only_word.starts_with("https://")
+        || only_word.starts_with("ftp://")
+        || only_word.contains('/')
+        || only_word.contains('\\')
+        || is_semver_like(only_word)
+}
+
+/// Matches strings shaped like `1.2.3`, `v1.2.3`, or `12.34.56.7`
+/// (semver-ish): an optional leading `v`/`V`, then digit groups
+/// separated by dots, at least two dots, no other characters.
+fn is_semver_like(word: &str) -> bool {
+    let trimmed = word.trim_matches(|c: char| !c.is_ascii_alphanumeric());
+    let trimmed = trimmed.strip_prefix(['v', 'V']).unwrap_or(trimmed);
+    let parts: Vec<&str> = trimmed.split('.').collect();
+
+    parts.len() >= 3
+        && parts
+            .iter()
+            .all(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_digit()))
+}
+
+/// True if the whole value reads as an identifier/enum/constant
+/// rather than a sentence: entirely uppercase, or snake_case, or
+/// kebab-case.
+fn looks_like_identifier(text: &str) -> bool {
+    let has_letters = text.chars().any(|c| c.is_alphabetic());
+
+    if !has_letters {
+        return false;
+    }
+
+    let is_all_caps = text.chars().any(|c| c.is_alphabetic())
+        && text
+            .chars()
+            .filter(|c| c.is_alphabetic())
+            .all(|c| c.is_uppercase());
+
+    if is_all_caps {
+        return true;
+    }
+
+    is_snake_or_kebab_case(text)
+}
+
+/// True if the entire string is a single token of the shape
+/// `word(_word)*` or `word(-word)*` with no spaces — i.e. it reads
+/// as one identifier, not a sentence.
+fn is_snake_or_kebab_case(text: &str) -> bool {
+    if text.contains(char::is_whitespace) {
+        return false;
+    }
+
+    let is_snake = text.contains('_')
+        && text
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_');
+
+    let is_kebab = text.contains('-')
+        && text
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-');
+
+    is_snake || is_kebab
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_prose_scalar;
+
+    #[test]
+    fn accepts_plain_sentence() {
+        assert!(is_prose_scalar("The quick brown fox jumps"));
+    }
+
+    #[test]
+    fn accepts_multiline_description() {
+        assert!(is_prose_scalar(
+            "This service handles user authentication and session\nmanagement for the platform."
+        ));
+    }
+
+    #[test]
+    fn rejects_single_word() {
+        assert!(!is_prose_scalar("enabled"));
+    }
+
+    #[test]
+    fn rejects_two_words() {
+        assert!(!is_prose_scalar("not found"));
+    }
+
+    #[test]
+    fn rejects_url() {
+        assert!(!is_prose_scalar("https://example.com/some/long/path/here"));
+    }
+
+    #[test]
+    fn accepts_sentence_containing_embedded_url() {
+        // A URL mentioned inside a real sentence is prose worth
+        // checking, not a bare URL value.
+        assert!(is_prose_scalar("See http://example.com for more details"));
+    }
+
+    #[test]
+    fn rejects_filesystem_path() {
+        assert!(!is_prose_scalar("/usr/local/bin/some/long/tool/path"));
+    }
+
+    #[test]
+    fn rejects_windows_path() {
+        assert!(!is_prose_scalar(r"C:\Users\rod\some\long\windows\path"));
+    }
+
+    #[test]
+    fn accepts_sentence_containing_embedded_path() {
+        // A path mentioned inside a real sentence is prose worth
+        // checking, not a bare path value.
+        assert!(is_prose_scalar(
+            "Update the config at /etc/config.yaml please"
+        ));
+    }
+
+    #[test]
+    fn rejects_bare_semver_value() {
+        assert!(!is_prose_scalar("1.2.3"));
+    }
+
+    #[test]
+    fn rejects_bare_v_prefixed_semver_value() {
+        assert!(!is_prose_scalar("v1.2.3"));
+    }
+
+    #[test]
+    fn accepts_sentence_containing_embedded_semver() {
+        // A version number mentioned inside a real sentence is prose
+        // worth checking, not a bare version string - only a value
+        // that is *solely* a version string should be skipped.
+        assert!(is_prose_scalar("please upgrade to 1.2.3 today now"));
+    }
+
+    #[test]
+    fn rejects_all_caps() {
+        assert!(!is_prose_scalar("THIS IS A CONSTANT VALUE HERE"));
+    }
+
+    #[test]
+    fn rejects_snake_case() {
+        assert!(!is_prose_scalar("this_is_a_snake_case_identifier"));
+    }
+
+    #[test]
+    fn rejects_kebab_case() {
+        assert!(!is_prose_scalar("this-is-a-kebab-case-identifier"));
+    }
+
+    #[test]
+    fn accepts_sentence_with_hyphenated_word() {
+        assert!(is_prose_scalar(
+            "This is a well-known and widely-used approach"
+        ));
+    }
+
+    #[test]
+    fn accepts_sentence_containing_a_period() {
+        assert!(is_prose_scalar("Restart the service. It will recover."));
+    }
+
+    #[test]
+    fn rejects_empty_string() {
+        assert!(!is_prose_scalar(""));
+    }
+
+    #[test]
+    fn rejects_whitespace_only() {
+        assert!(!is_prose_scalar("   \n  "));
+    }
+}

--- a/harper-yaml/src/heuristics.rs
+++ b/harper-yaml/src/heuristics.rs
@@ -1,61 +1,53 @@
 /// Decides whether a YAML scalar value looks like prose worth
 /// grammar-checking, as opposed to structural config data
-/// (identifiers, enum values, URLs, paths, version strings).
+/// (identifiers, enum values, etc).
 ///
 /// Comments are never passed through this function — they're
 /// always linted, handled separately in `YamlMasker`.
 pub(crate) fn is_prose_scalar(text: &str) -> bool {
+    let text = strip_block_scalar_indicator(text);
     let word_count = text.split_whitespace().count();
 
-    word_count >= 3 && !looks_url_path_or_version(text) && !looks_like_identifier(text)
+    word_count >= 3 && !looks_like_identifier(text)
 }
 
-/// True only if `text` is, in its entirety, a single whitespace-separated
-/// token that is itself URL-, path-, or version-shaped (e.g. `v1.2.3`,
-/// `0.15.9`, `https://example.com`, `/usr/local/bin`) — not merely a
-/// sentence that happens to mention one (e.g. "Update the library to
-/// version 1.2.3" is prose worth checking, not a bare version string).
+/// YAML block scalars (`|`, `>`, and their chomping/indent variants
+/// like `|-`, `>+`, `|2`, `>-2`) are masked including their leading
+/// indicator line. That indicator line is not part of the prose body
+/// and shouldn't count toward the word-count gate, so strip it off
+/// before measuring.
 ///
-/// A value with 3+ words already fails `is_prose_scalar`'s word-count
-/// gate before this function's result can matter, so in practice this
-/// only ever returns `true` for single-token values. Kept explicit and
-/// correct on its own terms rather than relying on that gate implicitly.
-fn looks_url_path_or_version(text: &str) -> bool {
-    let mut words = text.split_whitespace();
-
-    let Some(only_word) = words.next() else {
-        return false;
+/// Only strips when the trimmed first line is *entirely* a block
+/// scalar header token — a plain scalar that merely contains a
+/// literal `|` or `>` mid-sentence is left untouched.
+fn strip_block_scalar_indicator(text: &str) -> &str {
+    let (first_line, rest) = match text.split_once('\n') {
+        Some((first, rest)) => (first, Some(rest)),
+        None => (text, None),
     };
 
-    if words.next().is_some() {
-        return false;
+    let trimmed = first_line.trim();
+
+    let Some(after_marker) = trimmed
+        .strip_prefix('|')
+        .or_else(|| trimmed.strip_prefix('>'))
+    else {
+        return text;
+    };
+
+    let is_header = after_marker
+        .chars()
+        .all(|c| c == '+' || c == '-' || c.is_ascii_digit());
+
+    if !is_header {
+        return text;
     }
 
-    only_word.starts_with("http://")
-        || only_word.starts_with("https://")
-        || only_word.starts_with("ftp://")
-        || only_word.contains('/')
-        || only_word.contains('\\')
-        || is_semver_like(only_word)
-}
-
-/// Matches strings shaped like `1.2.3`, `v1.2.3`, or `12.34.56.7`
-/// (semver-ish): an optional leading `v`/`V`, then digit groups
-/// separated by dots, at least two dots, no other characters.
-fn is_semver_like(word: &str) -> bool {
-    let trimmed = word.trim_matches(|c: char| !c.is_ascii_alphanumeric());
-    let trimmed = trimmed.strip_prefix(['v', 'V']).unwrap_or(trimmed);
-    let parts: Vec<&str> = trimmed.split('.').collect();
-
-    parts.len() >= 3
-        && parts
-            .iter()
-            .all(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_digit()))
+    rest.unwrap_or("")
 }
 
 /// True if the whole value reads as an identifier/enum/constant
-/// rather than a sentence: entirely uppercase, or snake_case, or
-/// kebab-case.
+/// rather than a sentence: entirely uppercase.
 fn looks_like_identifier(text: &str) -> bool {
     let has_letters = text.chars().any(|c| c.is_alphabetic());
 
@@ -63,38 +55,9 @@ fn looks_like_identifier(text: &str) -> bool {
         return false;
     }
 
-    let is_all_caps = text.chars().any(|c| c.is_alphabetic())
-        && text
-            .chars()
-            .filter(|c| c.is_alphabetic())
-            .all(|c| c.is_uppercase());
-
-    if is_all_caps {
-        return true;
-    }
-
-    is_snake_or_kebab_case(text)
-}
-
-/// True if the entire string is a single token of the shape
-/// `word(_word)*` or `word(-word)*` with no spaces — i.e. it reads
-/// as one identifier, not a sentence.
-fn is_snake_or_kebab_case(text: &str) -> bool {
-    if text.contains(char::is_whitespace) {
-        return false;
-    }
-
-    let is_snake = text.contains('_')
-        && text
-            .chars()
-            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_');
-
-    let is_kebab = text.contains('-')
-        && text
-            .chars()
-            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-');
-
-    is_snake || is_kebab
+    text.chars()
+        .filter(|c| c.is_alphabetic())
+        .all(|c| c.is_uppercase())
 }
 
 #[cfg(test)]
@@ -207,5 +170,27 @@ mod tests {
     #[test]
     fn rejects_whitespace_only() {
         assert!(!is_prose_scalar("   \n  "));
+    }
+
+    #[test]
+    fn rejects_block_scalar_with_short_body() {
+        assert!(!is_prose_scalar("|\n  hello world"));
+    }
+
+    #[test]
+    fn accepts_block_scalar_with_prose_body() {
+        assert!(is_prose_scalar("|\n  the quick brown fox"));
+    }
+
+    #[test]
+    fn rejects_folded_block_scalar_with_chomping_and_short_body() {
+        assert!(!is_prose_scalar(">-\n  hello world"));
+    }
+
+    #[test]
+    fn accepts_sentence_with_literal_pipe_not_a_block_header() {
+        // The `|` here is mid-sentence, not a block scalar header on
+        // its own line, so it must not be stripped.
+        assert!(is_prose_scalar("run foo | grep bar please"));
     }
 }

--- a/harper-yaml/src/lib.rs
+++ b/harper-yaml/src/lib.rs
@@ -43,18 +43,23 @@ impl YamlMasker {
         is_candidate_kind && !Self::is_mapping_key(n)
     }
 
-    /// True if `n` sits in the "key" slot of its nearest enclosing
-    /// `block_mapping_pair`/`flow_pair` ancestor - i.e. its start position
-    /// coincides with the pair's start position (the key is always the
-    /// first token in a mapping pair; the value always starts later, after
-    /// `key:`).
+    /// True if `n` lies within the "key" field of its nearest enclosing
+    /// `block_mapping_pair`/`flow_pair` ancestor. This uses tree-sitter's
+    /// named `key` field rather than a byte-position heuristic, so it
+    /// correctly handles explicit-key syntax (`? key` / `: value`), where
+    /// the key node does not start at the same byte offset as the pair
+    /// itself.
     fn is_mapping_key(n: &Node) -> bool {
         let n_start = n.start_byte();
+        let n_end = n.end_byte();
         let mut node = *n;
 
         while let Some(parent) = node.parent() {
             if matches!(parent.kind(), "block_mapping_pair" | "flow_pair") {
-                return parent.start_byte() == n_start;
+                return match parent.child_by_field_name("key") {
+                    Some(key) => key.start_byte() <= n_start && n_end <= key.end_byte(),
+                    None => false,
+                };
             }
             node = parent;
         }
@@ -89,7 +94,26 @@ impl Masker for YamlMasker {
         }
 
         spans.sort_by_key(|s| s.start);
-        spans.into_iter().collect()
+
+        // Defensive guard: `Mask`'s `FromIterator` panics on overlapping
+        // spans. The comment pass and the scalar pass are independent
+        // tree-sitter queries, and under adversarial input / parser error
+        // recovery they could theoretically produce overlapping spans. To
+        // avoid turning that into a panic (a DoS in harper-ls), coalesce any
+        // overlapping (or touching) spans by merging them, keeping all
+        // prose rather than silently dropping any of it.
+        let mut coalesced: Vec<Span<char>> = Vec::with_capacity(spans.len());
+        for span in spans {
+            if let Some(last) = coalesced.last_mut()
+                && span.start <= last.end
+            {
+                last.end = last.end.max(span.end);
+                continue;
+            }
+            coalesced.push(span);
+        }
+
+        coalesced.into_iter().collect()
     }
 }
 
@@ -295,6 +319,23 @@ mod yaml_masker_tests {
         // never be linted -- keys are not prose.
         let texts = allowed_text("\"a fairly long key name\": short value\n");
         assert!(texts.is_empty());
+    }
+
+    #[test]
+    fn excludes_explicit_key_from_lint_pass() {
+        // Explicit-key YAML syntax (`? key` / `: value`) puts the key node
+        // in a different byte position than the pair itself, which used to
+        // trip up the old byte-position heuristic and let the key bleed
+        // into the lint pass. It must still be excluded, just like an
+        // implicit key would be.
+        let texts = allowed_text("? a genuinely long explicit key here\n: short\n");
+
+        assert!(
+            !texts
+                .iter()
+                .any(|t| t.contains("a genuinely long explicit key here")),
+            "explicit key leaked into an allowed span: {texts:?}"
+        );
     }
 
     #[test]

--- a/harper-yaml/src/lib.rs
+++ b/harper-yaml/src/lib.rs
@@ -1,0 +1,312 @@
+mod dedent;
+mod heuristics;
+
+use dedent::DedentLines;
+use harper_core::parsers::{self, Parser, PlainEnglish};
+use harper_core::{Mask, Masker, Span, Token};
+use harper_tree_sitter::TreeSitterMasker;
+use tree_sitter::Node;
+
+fn is_ignored_comment(text: &str) -> bool {
+    text.contains("spellchecker:ignore")
+        || text.contains("spellchecker: ignore")
+        || text.contains("spell-checker:ignore")
+        || text.contains("spell-checker: ignore")
+        || text.contains("spellcheck:ignore")
+        || text.contains("spellcheck: ignore")
+        || text.contains("harper:ignore")
+        || text.contains("harper: ignore")
+}
+
+/// Isolates YAML `#` comments and prose-like scalar values (plain,
+/// quoted, or block scalars) from the rest of a YAML document's
+/// structure (keys, punctuation, enum-like values).
+struct YamlMasker {
+    language: tree_sitter::Language,
+}
+
+impl YamlMasker {
+    fn new(language: tree_sitter::Language) -> Self {
+        Self { language }
+    }
+
+    fn is_comment_node(n: &Node) -> bool {
+        n.kind() == "comment"
+    }
+
+    fn is_scalar_node(n: &Node) -> bool {
+        let is_candidate_kind = matches!(
+            n.kind(),
+            "plain_scalar" | "single_quote_scalar" | "double_quote_scalar" | "block_scalar"
+        );
+
+        is_candidate_kind && !Self::is_mapping_key(n)
+    }
+
+    /// True if `n` sits in the "key" slot of its nearest enclosing
+    /// `block_mapping_pair`/`flow_pair` ancestor - i.e. its start position
+    /// coincides with the pair's start position (the key is always the
+    /// first token in a mapping pair; the value always starts later, after
+    /// `key:`).
+    fn is_mapping_key(n: &Node) -> bool {
+        let n_start = n.start_byte();
+        let mut node = *n;
+
+        while let Some(parent) = node.parent() {
+            if matches!(parent.kind(), "block_mapping_pair" | "flow_pair") {
+                return parent.start_byte() == n_start;
+            }
+            node = parent;
+        }
+
+        false
+    }
+}
+
+impl Masker for YamlMasker {
+    fn create_mask(&self, source: &[char]) -> Mask {
+        let comment_mask =
+            TreeSitterMasker::new(self.language.clone(), Self::is_comment_node).create_mask(source);
+        let scalar_mask =
+            TreeSitterMasker::new(self.language.clone(), Self::is_scalar_node).create_mask(source);
+
+        let mut spans: Vec<Span<char>> = Vec::new();
+
+        for (span, chars) in comment_mask.iter_allowed(source) {
+            let text: String = chars.iter().collect();
+
+            if !is_ignored_comment(&text) {
+                spans.push(span);
+            }
+        }
+
+        for (span, chars) in scalar_mask.iter_allowed(source) {
+            let text: String = chars.iter().collect();
+
+            if heuristics::is_prose_scalar(&text) {
+                spans.push(span);
+            }
+        }
+
+        spans.sort_by_key(|s| s.start);
+        spans.into_iter().collect()
+    }
+}
+
+/// A standalone parser for YAML documents. Lints `#` comments and
+/// prose-like scalar values (plain, quoted, or block scalars), while
+/// leaving structural YAML (keys, identifiers, enum-like values) alone.
+pub struct YamlParser {
+    inner: parsers::Mask<YamlMasker, DedentLines<PlainEnglish>>,
+}
+
+impl Default for YamlParser {
+    fn default() -> Self {
+        Self {
+            inner: parsers::Mask::new(
+                YamlMasker::new(tree_sitter_yaml::LANGUAGE.into()),
+                DedentLines::new(PlainEnglish),
+            ),
+        }
+    }
+}
+
+impl Parser for YamlParser {
+    fn parse(&self, source: &[char]) -> Vec<Token> {
+        self.inner.parse(source)
+    }
+}
+
+#[cfg(test)]
+mod yaml_masker_tests {
+    use harper_core::Masker;
+
+    use super::YamlMasker;
+
+    fn allowed_text(source: &str) -> Vec<String> {
+        let chars: Vec<char> = source.chars().collect();
+        let masker = YamlMasker::new(tree_sitter_yaml::LANGUAGE.into());
+        let mask = masker.create_mask(&chars);
+
+        mask.iter_allowed(&chars)
+            .map(|(_, content)| content.iter().collect())
+            .collect()
+    }
+
+    #[test]
+    fn keeps_comment() {
+        let texts = allowed_text("# a short comment\nname: value\n");
+        assert_eq!(texts, vec!["# a short comment".to_string()]);
+    }
+
+    #[test]
+    fn drops_comment_tagged_spellchecker_ignore_no_space() {
+        let texts = allowed_text("# spellchecker:ignore an intentional splling error\n");
+        assert!(texts.is_empty());
+    }
+
+    #[test]
+    fn drops_comment_tagged_spellchecker_ignore_with_space() {
+        let texts = allowed_text("# spellchecker: ignore an intentional splling error\n");
+        assert!(texts.is_empty());
+    }
+
+    #[test]
+    fn drops_comment_tagged_spell_checker_ignore() {
+        let texts = allowed_text("# spell-checker:ignore an intentional splling error\n");
+        assert!(texts.is_empty());
+    }
+
+    #[test]
+    fn drops_comment_tagged_spellcheck_ignore() {
+        let texts = allowed_text("# spellcheck:ignore an intentional splling error\n");
+        assert!(texts.is_empty());
+    }
+
+    #[test]
+    fn drops_comment_tagged_harper_ignore() {
+        let texts = allowed_text("# harper:ignore an intentional splling error\n");
+        assert!(texts.is_empty());
+    }
+
+    #[test]
+    fn keeps_other_comments_on_the_same_document_as_an_ignored_one() {
+        // Only the tagged comment should be suppressed - an unrelated
+        // comment elsewhere in the same document must still be linted.
+        let texts = allowed_text(
+            "# spellchecker:ignore an intentional splling error\nname: value\n# a normal comment worth checking\n",
+        );
+
+        assert_eq!(texts, vec!["# a normal comment worth checking".to_string()]);
+    }
+
+    #[test]
+    fn keeps_prose_like_plain_scalar() {
+        let texts = allowed_text("description: This service handles user login and session\n");
+        assert!(
+            texts
+                .iter()
+                .any(|t| t.contains("This service handles user login"))
+        );
+    }
+
+    #[test]
+    fn drops_short_identifier_value() {
+        let texts = allowed_text("status: enabled\n");
+        assert!(texts.is_empty());
+    }
+
+    #[test]
+    fn keeps_prose_like_double_quoted_scalar() {
+        let texts = allowed_text("summary: \"This is a longer human readable description\"\n");
+        assert!(
+            texts
+                .iter()
+                .any(|t| t.contains("This is a longer human readable description"))
+        );
+    }
+
+    #[test]
+    fn keeps_block_scalar_prose() {
+        let texts =
+            allowed_text("notes: |\n  This is a long form block of\n  descriptive prose text.\n");
+        assert!(texts.iter().any(|t| t.contains("descriptive prose text")));
+    }
+
+    #[test]
+    fn drops_kebab_case_value() {
+        let texts = allowed_text("mode: production-ready-config\n");
+        assert!(texts.is_empty());
+    }
+
+    #[test]
+    fn keeps_scalar_and_trailing_comment_on_same_line() {
+        let texts = allowed_text("description: This is a fairly long value # a trailing note\n");
+
+        // The scalar prose and the trailing comment must come back as two
+        // distinct spans, not merged into a single whole-line passthrough.
+        assert_eq!(texts.len(), 2);
+
+        // The YAML key itself must never leak into either allowed span.
+        assert!(texts.iter().all(|t| !t.contains("description")));
+
+        let comment_spans: Vec<&String> = texts.iter().filter(|t| t.contains('#')).collect();
+        let scalar_spans: Vec<&String> = texts.iter().filter(|t| !t.contains('#')).collect();
+
+        assert_eq!(comment_spans.len(), 1);
+        assert_eq!(scalar_spans.len(), 1);
+
+        assert!(comment_spans[0].trim_start().starts_with('#'));
+        assert!(comment_spans[0].contains("a trailing note"));
+        assert!(!comment_spans[0].contains("This is a fairly long value"));
+
+        assert!(scalar_spans[0].contains("This is a fairly long value"));
+        assert!(!scalar_spans[0].contains("a trailing note"));
+
+        let joined = texts.join(" ");
+        assert!(joined.contains("This is a fairly long value"));
+        assert!(joined.contains("a trailing note"));
+    }
+
+    #[test]
+    fn does_not_bleed_prose_value_into_following_key() {
+        // Regression test: a prose value on one line and a plain-scalar key
+        // on the very next line are separated only by a newline. Before the
+        // fix, YamlMasker treated the following key as a scalar candidate
+        // too, so TreeSitterMasker::create_mask's whitespace-only-gap merge
+        // welded the two adjacent allowed spans into one, e.g.
+        // "...here\ntags". Excluding mapping keys from the scalar candidate
+        // set means the gap now contains "tags:" (non-whitespace), so no
+        // merge happens.
+        let texts = allowed_text(
+            "name: foo\nmode: bar\ndescription: This is a genuinely long prose sentence here\ntags: something\n",
+        );
+
+        // The prose value must survive as its own clean span, not welded to
+        // the following key.
+        assert!(
+            texts
+                .iter()
+                .any(|t| t.contains("This is a genuinely long prose sentence here"))
+        );
+
+        // No allowed span may contain both the tail of the prose value and
+        // the following key's name -- that's exactly what the bug produced.
+        assert!(
+            !texts
+                .iter()
+                .any(|t| t.contains("here") && t.contains("tags"))
+        );
+
+        // None of the short key names should ever appear bled into a kept
+        // span alongside other content.
+        for key in ["name", "mode", "description", "tags"] {
+            assert!(
+                !texts.iter().any(|t| t.contains(key)),
+                "key `{key}` leaked into an allowed span: {texts:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn keeps_multi_word_quoted_key_out_of_lint_pass() {
+        // Even a key that would otherwise pass the word-count prose
+        // heuristic (a multi-word quoted string used as a mapping key) must
+        // never be linted -- keys are not prose.
+        let texts = allowed_text("\"a fairly long key name\": short value\n");
+        assert!(texts.is_empty());
+    }
+
+    #[test]
+    fn block_scalar_hash_is_literal_content_not_a_comment() {
+        // A `#` inside a block scalar's indented content is literal text,
+        // not a real YAML comment -- the two TreeSitterMasker passes must
+        // never produce overlapping spans for this, since Mask::from_iter
+        // panics on overlap.
+        let texts =
+            allowed_text("notes: |\n  This is prose text with a # character in it for testing.\n");
+
+        assert_eq!(texts.len(), 1);
+        assert!(texts[0].contains("a # character in it for testing"));
+    }
+}

--- a/harper-yaml/tests/run_tests.rs
+++ b/harper-yaml/tests/run_tests.rs
@@ -1,0 +1,41 @@
+use harper_core::linting::{LintGroup, Linter};
+use harper_core::spell::FstDictionary;
+use harper_core::{Dialect, Document};
+use harper_yaml::YamlParser;
+
+/// Creates a unit test checking that the linting of a YAML source file (in
+/// `test_sources`) produces the expected number of lints.
+macro_rules! create_test {
+    ($filename:ident.yaml, $correct_expected:expr) => {
+        paste::paste! {
+            #[test]
+            fn [<lints_ $filename _correctly>](){
+                 let source = include_str!(
+                    concat!(
+                        "./test_sources/",
+                        concat!(stringify!($filename), ".yaml")
+                    )
+                 );
+
+                 let parser = YamlParser::default();
+                 let dict = FstDictionary::curated();
+                 let document = Document::new(&source, &parser, &dict);
+
+                 let mut linter = LintGroup::new_curated(dict, Dialect::American);
+                 let lints = linter.lint(&document);
+
+                 dbg!(&lints);
+                 assert_eq!(lints.len(), $correct_expected);
+
+                 // Make sure that all generated tokens span real characters
+                 for token in document.tokens(){
+                     assert!(token.span.try_get_content(document.get_source()).is_some());
+                 }
+            }
+        }
+    };
+}
+
+create_test!(clean.yaml, 0);
+create_test!(dirty.yaml, 1);
+create_test!(filtered_values.yaml, 0);

--- a/harper-yaml/tests/test_sources/clean.yaml
+++ b/harper-yaml/tests/test_sources/clean.yaml
@@ -1,0 +1,11 @@
+# This file configures the deployment for our staging environment.
+name: staging-deployment
+version: 1.4.2
+replicas: 3
+tags:
+  - production-ready
+  - internal-only
+homepage: https://example.com/docs/staging
+description: >
+  This service handles user authentication and session management
+  for the platform.

--- a/harper-yaml/tests/test_sources/dirty.yaml
+++ b/harper-yaml/tests/test_sources/dirty.yaml
@@ -1,0 +1,5 @@
+# A configuration file with a single deliberate grammar mistake.
+name: example-service
+description: >
+  This service handles user authentication and session management
+  for the platform. They handles requests concurrently.

--- a/harper-yaml/tests/test_sources/filtered_values.yaml
+++ b/harper-yaml/tests/test_sources/filtered_values.yaml
@@ -1,0 +1,6 @@
+status: enabled
+mode: production-ready-config
+level: HIGH_PRIORITY_ONLY
+version: 2.10.4
+homepage: https://example.com/some/long/path/here
+script_path: /usr/local/bin/some/tool

--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -73,6 +73,7 @@
 		"onLanguage:typescript",
 		"onLanguage:typescriptreact",
 		"onLanguage:typst",
+		"onLanguage:yaml",
 		"onLanguage:zig"
 	],
 	"main": "./build/extension.js",

--- a/packages/vscode-plugin/src/tests/fixtures/languages/yaml.yaml
+++ b/packages/vscode-plugin/src/tests/fixtures/languages/yaml.yaml
@@ -1,0 +1,3 @@
+name: hello-world
+# Errorz
+output: "Hello World!"

--- a/packages/vscode-plugin/src/tests/suite/languages.test.ts
+++ b/packages/vscode-plugin/src/tests/suite/languages.test.ts
@@ -53,6 +53,7 @@ describe('Languages >', () => {
 		{ type: 'TypeScript', file: 'typescript.ts', row: 0, column: 32 },
 		{ type: 'TypeScript JSX', file: 'typescriptreact.tsx', row: 3, column: 7 },
 		{ type: 'LaTeX', file: 'latex.tex', row: 4, column: 0 },
+		{ type: 'YAML', file: 'yaml.yaml', row: 1, column: 2 },
 	].forEach((testCase) => {
 		it(`gives correct diagnostics for ${testCase.type} files`, async () => {
 			const uri = getUri('languages', testCase.file);

--- a/packages/web/src/routes/docs/integrations/language-server/+page.md
+++ b/packages/web/src/routes/docs/integrations/language-server/+page.md
@@ -314,6 +314,7 @@ These configs are under the `markdown` key:
 | TypeScript          |         `typescript`          |            ✅ |
 | TypeScript React    |       `typescriptreact`       |            ✅ |
 | Typst               |            `typst`            |               |
+| YAML                |         `yaml`/`yml`          |               |
 | Zig                 |             `zig`             |            ✅ |
 | LaTeX/TeX           | `latex`/`tex`/`plaintex`      |               |
 


### PR DESCRIPTION
> **AI disclosure:** this PR was written by an AI coding agent (Claude), working with me interactively over the course of a session. I reviewed and directed the work throughout — see the "AI Disclosure" section below for specifics.

**Draft / work in progress — depends on #3757 landing first.**

# Issues
<!-- No tracked issue; follow-up work identified during review. -->

# Description

Follow-up to the `LineWise` combinator introduced in #3757 (see [this review discussion](https://github.com/Automattic/harper/pull/3757#discussion_r3565553587)), which deliberately scoped `LineWise` to `harper-yaml` only and left `Unit`, `Lua`, and `Solidity` in `harper-comments` as a follow-up, since they share the same split-by-line/strip/parse/stitch shape but each have quirks that don't fit the plain trim-a-span contract:

- **Unit** swallows lines inside fenced code blocks entirely (no tokens, no separator), tracked via a toggle that must persist across lines within one `parse()` call.
- **Lua** turns an `@tag` line into a paragraph break (`Newline(2)`) instead of parsing it.
- **Solidity**'s SPDX-License-Identifier special case turned out to be unreachable dead code: it searches for a `\n` terminator within a span that has already been split on `\n`, so it always falls through to swallowing the whole line. Preserved that observed behavior (line contributes no tokens) without carrying the dead branch forward.

To support these cases, `LineWise`'s strip contract is extended from a bare `Span<char>` to a small `LineClass { span, newline: Option<usize> }` struct, so the per-line classifier can also control the separator: suppress it (`skip_silently`, for Unit's fences), reweight it (`skip_with_newline`, for Lua's `@`-lines), or leave it as the default single `Newline` (matching `DedentLines`' existing behavior unchanged).

One intentional, test-uncovered normalization: Lua previously emitted a dangling `Newline(2)` after an `@`-line even when it was the last line in the source, with nothing following it. `LineWise` now gates all separators uniformly on "is there a next line", so that dangling token is no longer emitted. No fixture exercises this edge case either way.

This branch is currently rebased on top of #3757 and will need re-rebasing onto `master` once that PR lands (and shrink to just this one commit's diff at that point).

# Demo
N/A — internal parser refactor, no user-visible behavior change beyond the one noted normalization above.

# How Has This Been Tested?

- `cargo test --workspace` — full workspace suite passes; all 40 `harper-comments` `language_support` fixtures keep their exact lint counts.
- `cargo clippy -- -Dwarnings` passes clean on the touched files.

# AI Disclosure
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
