### PR TITLE
fix(core): flag misplaced period spacing

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -1619,6 +1619,13 @@
 						},
 						{
 							"Bool": {
+								"name": "MissingSpace",
+								"state": true,
+								"label": "Missing Space"
+							}
+						},
+						{
+							"Bool": {
 								"name": "NoFrenchSpaces",
 								"state": true,
 								"label": "No French Spaces"

--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -1654,6 +1654,13 @@
 						},
 						{
 							"Bool": {
+								"name": "MissingSpace",
+								"state": true,
+								"label": "Missing Space"
+							}
+						},
+						{
+							"Bool": {
 								"name": "NoFrenchSpaces",
 								"state": true,
 								"label": "No French Spaces"

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -162,6 +162,7 @@ use super::mass_nouns::MassNouns;
 use super::means_a_lot_to::MeansALotTo;
 use super::merge_words::MergeWords;
 use super::missing_preposition::MissingPreposition;
+use super::missing_space::MissingSpace;
 use super::missing_to::MissingTo;
 use super::misspell::Misspell;
 use super::mixed_bag::MixedBag;
@@ -769,6 +770,7 @@ impl LintGroup {
         insert_expr_rule!(MeansALotTo);
         insert_struct_rule!(MergeWords);
         insert_expr_rule!(MissingPreposition);
+        insert_struct_rule!(MissingSpace);
         insert_expr_rule!(MissingTo);
         insert_expr_rule!(Misspell);
         insert_expr_rule!(MixedBag);
@@ -1140,6 +1142,18 @@ mod tests {
     #[test]
     fn its_not_perfect_keeps_apostrophe() {
         assert_no_lints("It's not perfect", test_linter());
+    }
+
+    #[test]
+    fn issue_3800_reports_both_spacing_errors() {
+        let document = Document::new_plain_english_curated(
+            "The government .Once the policy changed, the program ended.",
+        );
+        let group = test_linter();
+        let organized = group.run_with_inner(|l| l.organized_lints(&document));
+
+        assert_eq!(organized.get("Spaces").map(Vec::len), Some(1));
+        assert_eq!(organized.get("MissingSpace").map(Vec::len), Some(1));
     }
 
     #[test]

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -150,6 +150,7 @@ use super::mass_nouns::MassNouns;
 use super::means_a_lot_to::MeansALotTo;
 use super::merge_words::MergeWords;
 use super::missing_preposition::MissingPreposition;
+use super::missing_space::MissingSpace;
 use super::missing_to::MissingTo;
 use super::misspell::Misspell;
 use super::mixed_bag::MixedBag;
@@ -738,6 +739,7 @@ impl LintGroup {
         insert_expr_rule!(MeansALotTo);
         insert_struct_rule!(MergeWords);
         insert_expr_rule!(MissingPreposition);
+        insert_struct_rule!(MissingSpace);
         insert_expr_rule!(MissingTo);
         insert_expr_rule!(Misspell);
         insert_expr_rule!(MixedBag);
@@ -1098,6 +1100,18 @@ mod tests {
     #[test]
     fn its_not_perfect_keeps_apostrophe() {
         assert_no_lints("It's not perfect", test_linter());
+    }
+
+    #[test]
+    fn issue_3800_reports_both_spacing_errors() {
+        let document = Document::new_plain_english_curated(
+            "The government .Once the policy changed, the program ended.",
+        );
+        let group = test_linter();
+        let organized = group.run_with_inner(|l| l.organized_lints(&document));
+
+        assert_eq!(organized.get("Spaces").map(Vec::len), Some(1));
+        assert_eq!(organized.get("MissingSpace").map(Vec::len), Some(1));
     }
 
     #[test]

--- a/harper-core/src/linting/missing_space.rs
+++ b/harper-core/src/linting/missing_space.rs
@@ -1,48 +1,71 @@
-use itertools::Itertools;
-
 use crate::{Document, Punctuation};
 
 use super::{Lint, LintKind, Linter, Suggestion};
 
+#[derive(Debug, Default)]
 pub struct MissingSpace;
 
 impl Linter for MissingSpace {
     fn lint(&mut self, document: &Document) -> Vec<Lint> {
         let mut lints = Vec::new();
 
-        for (a, b, c) in document.tokens().tuple_windows() {
-            if let Some(punct) = b.kind.as_punctuation()
-                && [
-                    Punctuation::Period,
-                    Punctuation::Bang,
-                    Punctuation::Question,
-                    Punctuation::Semicolon,
-                ]
-                .contains(punct)
-                && a.kind.is_word()
-                && c.kind.is_word()
+        for (index, token) in document.tokens().enumerate() {
+            let Some(punct) = token.kind.as_punctuation() else {
+                continue;
+            };
+
+            let Some(next) = document.get_token_offset(index, 1) else {
+                continue;
+            };
+
+            if ![
+                Punctuation::Period,
+                Punctuation::Bang,
+                Punctuation::Question,
+                Punctuation::Semicolon,
+            ]
+            .contains(punct)
+                || !next.kind.is_word()
+                || (punct == &Punctuation::Period
+                    && !document
+                        .get_span_content(&next.span)
+                        .first()
+                        .is_some_and(|character| character.is_uppercase()))
             {
-                lints.push(Lint {
-                    span: b.span,
-                    lint_kind: LintKind::Formatting,
-                    suggestions: vec![Suggestion::InsertAfter(vec![' '])],
-                    message: "It looks like you're missing a space here.".to_owned(),
-                    priority: 31,
-                });
+                continue;
             }
+
+            let previous = document.get_token_offset(index, -1);
+            let has_word_before = previous.is_some_and(|previous| previous.kind.is_word())
+                || (previous.is_some_and(|previous| previous.kind.is_space())
+                    && document
+                        .get_token_offset(index, -2)
+                        .is_some_and(|previous| previous.kind.is_word()));
+
+            if !has_word_before {
+                continue;
+            }
+
+            lints.push(Lint {
+                span: token.span,
+                lint_kind: LintKind::Formatting,
+                suggestions: vec![Suggestion::InsertAfter(vec![' '])],
+                message: "It looks like you're missing a space here.".to_owned(),
+                priority: 31,
+            });
         }
 
         lints
     }
 
     fn description(&self) -> &str {
-        "Looks for missing spaces after a comma or period."
+        "Looks for missing spaces after periods, exclamation points, question marks, and semicolons."
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::linting::tests::assert_suggestion_result;
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
 
     use super::MissingSpace;
 
@@ -53,6 +76,30 @@ mod tests {
             MissingSpace,
             "people that can help us. So I feel like there",
         );
+    }
+
+    #[test]
+    fn issue_3800() {
+        assert_suggestion_result(
+            "The government .Once the policy changed, the program ended.",
+            MissingSpace,
+            "The government . Once the policy changed, the program ended.",
+        );
+    }
+
+    #[test]
+    fn allows_domain_names() {
+        assert_no_lints("WordPress.com is a managed hosting provider.", MissingSpace);
+    }
+
+    #[test]
+    fn allows_file_names() {
+        assert_no_lints("Open composer.json to edit the dependencies.", MissingSpace);
+    }
+
+    #[test]
+    fn allows_dotfiles() {
+        assert_no_lints("Use the .harper file for configuration.", MissingSpace);
     }
 
     #[test]

--- a/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
+++ b/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
@@ -959,6 +959,16 @@ Message: |
 
 
 
+Lint:    Formatting (31 priority)
+Message: |
+     367 | and such person shall act accordingly until a President or Vice President shall
+     368 | have qualified.The Congress may by law provide for the case of the death of any
+         |               ^ It looks like you're missing a space here.
+Suggest:
+  - Insert “ ”
+
+
+
 Lint:    Readability (127 priority)
 Message: |
      368 | have qualified.The Congress may by law provide for the case of the death of any

--- a/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
+++ b/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
@@ -949,6 +949,16 @@ Message: |
 
 
 
+Lint:    Formatting (31 priority)
+Message: |
+     367 | and such person shall act accordingly until a President or Vice President shall
+     368 | have qualified.The Congress may by law provide for the case of the death of any
+         |               ^ It looks like you're missing a space here.
+Suggest:
+  - Insert “ ”
+
+
+
 Lint:    Readability (127 priority)
 Message: |
      368 | have qualified.The Congress may by law provide for the case of the death of any


### PR DESCRIPTION
Disclosure: This pull request was prepared with assistance from an LLM-based coding agent.

# Issues

Fixes #3800

# Description

Harper already flags the space before a misplaced period, but it did not report the missing space after the period.

- Register the existing `MissingSpace` linter in the curated lint group and default configuration.
- Recognize missing spaces after punctuation when a space was placed before the punctuation instead.
- Require sentence-like capitalization after periods to avoid false positives for domains, filenames, and dotfiles.
- Add regression, integration, negative-case, and corpus snapshot coverage.

# Demo

For input such as `The government .Once the policy changed`, Harper now reports both spacing errors so the text can be corrected to `The government. Once the policy changed`.

# How Has This Been Tested?

- `cargo test issue_3800 -- --nocapture`
- `cargo test missing_space -- --nocapture`
- `cargo test curated_default_config_lists_every_registered_rule -- --nocapture`
- `cargo test -q`
- `cargo fmt --all -- --check`
- `cargo clippy -p harper-core --lib --no-deps --message-format=short`
- `git diff --check`

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [x] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter

- [ ] I made up the sentences in the unit tests.
- [x] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
