### PR TITLE
Obsidian sidebar

### DIFF
--- a/packages/obsidian-plugin/src/SidebarView.ts
+++ b/packages/obsidian-plugin/src/SidebarView.ts
@@ -2,15 +2,13 @@ import { type IconName, ItemView, Menu, setIcon, type WorkspaceLeaf } from 'obsi
 import type HarperPlugin from './index';
 import { LINT_KIND_COLORS } from './lintKindColor';
 
-export const Harper_Sidebar_View = 'harper-sidebar-view';
-
 export class SidebarView extends ItemView {
 	constructor(leaf: WorkspaceLeaf, _plugin: HarperPlugin) {
 		super(leaf);
 	}
 
 	getViewType() {
-		return Harper_Sidebar_View;
+		return 'harper-sidebar-view';
 	}
 
 	getDisplayText() {
@@ -18,7 +16,7 @@ export class SidebarView extends ItemView {
 	}
 
 	getIcon(): IconName {
-		return 'book-open-check';
+		return 'harper-logo';
 	}
 
 	async onOpen() {
@@ -37,17 +35,8 @@ export class SidebarView extends ItemView {
 		const listContainer = document.createElement('div');
 
 		// initial card
-		const initialCard = document.createElement('div');
-		initialCard.style.display = 'flex';
-		initialCard.style.flexDirection = 'column';
-		initialCard.style.padding = '12px 16px';
-		initialCard.style.borderBottom = '1px solid var(--background-modifier-border)'; // add var
-		initialCard.style.gap = '8px';
-
-		const initialTitle = document.createElement('span');
-		initialTitle.style.fontWeight = 'bold';
-		initialTitle.textContent = 'Loading errors...';
-
+		const initialCard = createCard();
+		const initialTitle = createTitle('Loading errors...');
 		initialCard.appendChild(initialTitle);
 
 		listContainer.appendChild(initialCard);
@@ -63,180 +52,206 @@ export class SidebarView extends ItemView {
 				listContainer.innerHTML = '';
 
 				if (!errors || errors.length === 0) {
-					const card = document.createElement('div');
-					card.style.display = 'flex';
-					card.style.flexDirection = 'column';
-					card.style.padding = '12px 16px';
-					card.style.borderBottom = '1px solid var(--background-modifier-border)'; // add var
-					card.style.gap = '8px';
-
-					const title = document.createElement('span');
-					title.style.fontWeight = 'bold';
-					title.textContent = 'No grammar errors found!';
-
+					const card = createCard();
+					const title = createTitle('No grammar errors found!');
 					card.appendChild(title);
-
 					listContainer.appendChild(card);
 					return;
 				}
 
 				errors.forEach((error) => {
-					try {
-						// find card color
-						let severityColor = '';
-
-						if (error.markClass) {
-							const classes = error.markClass.split(' ');
-
-							const harperClass = classes.find((c: string) => c.startsWith('harper-lintRange-'));
-							if (harperClass) {
-								const lintKind = harperClass.replace('harper-lintRange-', '');
-								if (LINT_KIND_COLORS?.[lintKind]) {
-									severityColor = LINT_KIND_COLORS[lintKind];
-								}
-							}
-						}
-
-						const card = document.createElement('div');
-						card.style.display = 'flex';
-						card.style.flexDirection = 'column';
-						card.style.padding = '12px 16px';
-						card.style.borderBottom = '1px solid var(--background-modifier-border)'; // add var
-						card.style.gap = '8px';
-
-						const titleDiv = document.createElement('div');
-						titleDiv.style.display = 'flex';
-						titleDiv.style.flexWrap = 'wrap';
-						titleDiv.style.gap = '6px';
-						titleDiv.style.marginTop = '4px';
-
-						const title = document.createElement('span');
-						title.style.fontWeight = 'bold';
-						title.style.color = severityColor;
-						title.textContent = error.title || 'Harper Suggestion';
-
-						const doc = editorView.state.doc;
-						const problemText = doc.sliceString(error.from, error.to);
-
-						// get 18 char before and after the word
-						const rawPrefix = doc.sliceString(Math.max(0, error.from - 18), error.from);
-						const rawSuffix = doc.sliceString(error.to, Math.min(doc.length, error.to + 18));
-						// trim to be only 3 words before and after.
-						let prefix = rawPrefix.split(/[.!?\n]/).pop() || '';
-						const prefixWords = prefix
-							.trim()
-							.split(/\s+/)
-							.filter((w) => w.length > 0);
-						prefix = prefixWords.slice(-3).join(' ');
-						if (prefix.length > 0) prefix += ' ';
-
-						let suffix = rawSuffix.split(/[.!?\n]/)[0] || '';
-						const suffixWords = suffix
-							.trim()
-							.split(/\s+/)
-							.filter((w) => w.length > 0);
-						suffix = suffixWords.slice(0, 3).join(' ');
-						if (suffix.length > 0) suffix = ` ${suffix}`;
-
-						// text container
-						const textContainer = document.createElement('span');
-						textContainer.style.fontSize = 'var(--font-ui-small)';
-
-						if (prefix) {
-							textContainer.appendChild(document.createTextNode(prefix));
-						}
-
-						const boldWord = document.createElement('strong');
-						boldWord.textContent = problemText;
-						boldWord.style.color = severityColor;
-						textContainer.appendChild(boldWord);
-
-						if (suffix) {
-							textContainer.appendChild(document.createTextNode(suffix));
-						}
-
-						if (error.actions && error.actions.length > 0) {
-							const actionConst = document.createElement('div');
-							actionConst.style.display = 'flex';
-							actionConst.style.flexWrap = 'wrap';
-							actionConst.style.gap = '6px';
-							actionConst.style.marginTop = '4px';
-
-							error.actions.forEach((action: any) => {
-								const btn = document.createElement('button');
-								btn.textContent = action.name;
-								btn.title = action.title;
-
-								btn.style.fontSize = 'var(--font-ui-smaller)';
-								btn.style.cursor = 'var(--cursor)';
-
-								btn.onclick = () => {
-									action.apply(editorView, error.from, error.to);
-								};
-
-								actionConst.appendChild(btn);
-							});
-							// add the options ignore diagnostic and Disable Rule in a dropdown btn
-							if (error.ignore || error.disable) {
-								const btn = document.createElement('div');
-								setIcon(btn, 'more-vertical');
-								btn.style.cursor = 'var(--cursor)';
-								btn.style.color = 'var(--text-muted)';
-								btn.style.display = 'flex';
-								btn.style.alignItems = 'center';
-								btn.style.padding = '2px 4px';
-								btn.style.borderRadius = 'var(--radius-s)';
-								btn.style.marginLeft = 'auto';
-
-								btn.onmouseover = () => {
-									btn.style.backgroundColor = 'var(--background-modifier-hover)';
-								};
-								btn.onmouseout = () => {
-									btn.style.backgroundColor = 'transparent';
-								};
-
-								btn.onclick = (e) => {
-									const menu = new Menu();
-
-									if (error.ignore) {
-										menu.addItem((item) => {
-											item
-												.setTitle('Ignore Diagnostic')
-												.setIcon('eye-off')
-												.onClick(() => {
-													error.ignore();
-												});
-										});
-									}
-									if (error.disable) {
-										menu.addItem((item) => {
-											item
-												.setTitle('Disable Rule')
-												.setIcon('ban')
-												.onClick(() => {
-													error.disable();
-												});
-										});
-									}
-
-									menu.showAtMouseEvent(e);
-								};
-
-								titleDiv.appendChild(title);
-								titleDiv.appendChild(btn);
-								card.appendChild(titleDiv);
-								card.appendChild(textContainer);
-								card.appendChild(actionConst);
-							}
-						}
-						listContainer.appendChild(card);
-					} catch (err) {
-						console.error('Harper Sidebar failed to read: ', err, error);
-					}
+					createErrorCard(error, editorView, listContainer);
 				});
 			}),
 		);
 	}
 
 	async onClose() {}
+}
+
+function createCard(): HTMLDivElement {
+	const card = document.createElement('div');
+	card.style.display = 'flex';
+	card.style.flexDirection = 'column';
+	card.style.padding = '12px 16px';
+	card.style.borderBottom = '1px solid var(--background-modifier-border)';
+	card.style.gap = '8px';
+	return card;
+}
+
+function createTitle(text: string, color?: string): HTMLSpanElement {
+	const title = document.createElement('span');
+	title.style.fontWeight = 'bold';
+	if (color) {
+		title.style.color = color;
+	}
+	title.textContent = text;
+	return title;
+}
+
+function getSeverityColor(error: any) {
+	// find card color
+	let severityColor = '';
+
+	if (error.markClass) {
+		const classes = error.markClass.split(' ');
+
+		const harperClass = classes.find((c: string) => c.startsWith('harper-lintRange-'));
+		if (harperClass) {
+			const lintKind = harperClass.replace('harper-lintRange-', '');
+			if (LINT_KIND_COLORS?.[lintKind]) {
+				severityColor = LINT_KIND_COLORS[lintKind];
+			}
+		}
+	}
+	return severityColor;
+}
+
+function createTitleDiv(error: any): HTMLDivElement {
+	const titleDiv = document.createElement('div');
+	titleDiv.style.display = 'flex';
+	titleDiv.style.flexWrap = 'wrap';
+	titleDiv.style.gap = '6px';
+	titleDiv.style.marginTop = '4px';
+
+	const title = createTitle(error.title || 'Harper Suggestion', getSeverityColor(error));
+
+	// add the options ignore diagnostic and Disable Rule in a dropdown btn
+	if (error.ignore || error.disable) {
+		const btn = document.createElement('div');
+		setIcon(btn, 'more-vertical');
+		btn.style.cursor = 'var(--cursor)';
+		btn.style.color = 'var(--text-muted)';
+		btn.style.display = 'flex';
+		btn.style.alignItems = 'center';
+		btn.style.padding = '2px 4px';
+		btn.style.borderRadius = 'var(--radius-s)';
+		btn.style.marginLeft = 'auto';
+
+		btn.onmouseover = () => {
+			btn.style.backgroundColor = 'var(--background-modifier-hover)';
+		};
+		btn.onmouseout = () => {
+			btn.style.backgroundColor = 'transparent';
+		};
+
+		btn.onclick = (e) => {
+			const menu = new Menu();
+
+			if (error.ignore) {
+				menu.addItem((item) => {
+					item
+						.setTitle('Ignore Diagnostic')
+						.setIcon('eye-off')
+						.onClick(() => {
+							error.ignore();
+						});
+				});
+			}
+			if (error.disable) {
+				menu.addItem((item) => {
+					item
+						.setTitle('Disable Rule')
+						.setIcon('ban')
+						.onClick(() => {
+							error.disable();
+						});
+				});
+			}
+
+			menu.showAtMouseEvent(e);
+		};
+
+		titleDiv.appendChild(title);
+		titleDiv.appendChild(btn);
+	}
+	return titleDiv;
+}
+
+function getWordsArroundError(error: any, editorView: any) {
+	const doc = editorView.state.doc;
+	const problemText = doc.sliceString(error.from, error.to);
+
+	// get 18 char before and after the word
+	const rawPrefix = doc.sliceString(Math.max(0, error.from - 18), error.from);
+	const rawSuffix = doc.sliceString(error.to, Math.min(doc.length, error.to + 18));
+	// trim to be only 3 words before and after.
+	let prefix = rawPrefix.split(/[.!?\n]/).pop() || '';
+	const prefixWords = prefix
+		.trim()
+		.split(/\s+/)
+		.filter((w) => w.length > 0);
+	prefix = prefixWords.slice(-3).join(' ');
+	if (prefix.length > 0) prefix += ' ';
+
+	let suffix = rawSuffix.split(/[.!?\n]/)[0] || '';
+	const suffixWords = suffix
+		.trim()
+		.split(/\s+/)
+		.filter((w) => w.length > 0);
+	suffix = suffixWords.slice(0, 3).join(' ');
+	if (suffix.length > 0) suffix = ` ${suffix}`;
+
+	// text container
+	const textContainer = document.createElement('span');
+	textContainer.style.fontSize = 'var(--font-ui-small)';
+
+	if (prefix) {
+		textContainer.appendChild(document.createTextNode(prefix));
+	}
+
+	const boldWord = document.createElement('strong');
+	boldWord.textContent = problemText;
+	boldWord.style.color = getSeverityColor(error);
+	textContainer.appendChild(boldWord);
+
+	if (suffix) {
+		textContainer.appendChild(document.createTextNode(suffix));
+	}
+	return textContainer;
+}
+
+function getErrorActions(error: any, editorView: any): HTMLDivElement {
+	if (error.actions && error.actions.length > 0) {
+		const actionConst = document.createElement('div');
+		actionConst.style.display = 'flex';
+		actionConst.style.flexWrap = 'wrap';
+		actionConst.style.gap = '6px';
+		actionConst.style.marginTop = '4px';
+
+		error.actions.forEach((action: any) => {
+			const btn = document.createElement('button');
+			btn.textContent = action.name;
+			btn.title = action.title;
+
+			btn.style.fontSize = 'var(--font-ui-smaller)';
+			btn.style.cursor = 'var(--cursor)';
+
+			btn.onclick = () => {
+				action.apply(editorView, error.from, error.to);
+			};
+
+			actionConst.appendChild(btn);
+		});
+		return actionConst;
+	}
+	return document.createElement('div');
+}
+
+function createErrorCard(error: any, editorView: any, listContainer: HTMLDivElement) {
+	try {
+		const card = createCard();
+
+		const titleDiv = createTitleDiv(error);
+		const textContainer = getWordsArroundError(error, editorView);
+		const actionConst = getErrorActions(error, editorView);
+
+		card.appendChild(titleDiv);
+		card.appendChild(textContainer);
+		card.appendChild(actionConst);
+
+		listContainer.appendChild(card);
+	} catch (err) {
+		console.error('Harper Sidebar failed to read: ', err, error);
+	}
 }

--- a/packages/obsidian-plugin/src/SidebarView.ts
+++ b/packages/obsidian-plugin/src/SidebarView.ts
@@ -1,228 +1,242 @@
-import { IconName, ItemView, WorkspaceLeaf, Menu, setIcon } from 'obsidian';
-import HarperPlugin from './index';
+import { type IconName, ItemView, Menu, setIcon, type WorkspaceLeaf } from 'obsidian';
+import type HarperPlugin from './index';
 import { LINT_KIND_COLORS } from './lintKindColor';
 
-export const Harper_Sidebar_View = "harper-sidebar-view";
+export const Harper_Sidebar_View = 'harper-sidebar-view';
 
 export class SidebarView extends ItemView {
-    constructor(leaf : WorkspaceLeaf, private plugin: HarperPlugin){
-        super(leaf);
-    }
+	constructor(leaf: WorkspaceLeaf, _plugin: HarperPlugin) {
+		super(leaf);
+	}
 
-    getViewType(){
-        return Harper_Sidebar_View;
-    }
+	getViewType() {
+		return Harper_Sidebar_View;
+	}
 
-    getDisplayText(){
-        return "Harper Grammar";
-    }
+	getDisplayText() {
+		return 'Harper Grammar';
+	}
 
-    getIcon(): IconName {
-        return "book-open-check";
-    }
+	getIcon(): IconName {
+		return 'book-open-check';
+	}
 
-    async onOpen(){
-        this.update();
-    }
+	async onOpen() {
+		this.update();
+	}
 
-    update(){
-        const container = this.containerEl;
-        container.empty();
+	update() {
+		const container = this.containerEl;
+		container.empty();
 
-        container.style.padding = "0";
-        container.style.display= "flex";
-        container.style.flexDirection = "column";
-        container.style.justifyContent= "flex-start";
+		container.style.padding = '0';
+		container.style.display = 'flex';
+		container.style.flexDirection = 'column';
+		container.style.justifyContent = 'flex-start';
 
-        const listContainer = document.createElement("div");
+		const listContainer = document.createElement('div');
 
-        // initial card
-        const initialCard = document.createElement("div");
-        initialCard.style.display= "flex";
-        initialCard.style.flexDirection = "column";
-        initialCard.style.padding = "12px 16px";
-        initialCard.style.borderBottom = "1px solid var(--background-modifier-border)"; // add var
-        initialCard.style.gap = "8px";
-        
-        const initialTitle = document.createElement("span");
-        initialTitle.style.fontWeight = "bold";
-        initialTitle.textContent =  "Loading errors...";
+		// initial card
+		const initialCard = document.createElement('div');
+		initialCard.style.display = 'flex';
+		initialCard.style.flexDirection = 'column';
+		initialCard.style.padding = '12px 16px';
+		initialCard.style.borderBottom = '1px solid var(--background-modifier-border)'; // add var
+		initialCard.style.gap = '8px';
 
-        initialCard.appendChild(initialTitle);
-                    
-        listContainer.appendChild(initialCard);
+		const initialTitle = document.createElement('span');
+		initialTitle.style.fontWeight = 'bold';
+		initialTitle.textContent = 'Loading errors...';
 
-        listContainer.id = "harper-error-list";
-        listContainer.style.height = "100%";
-        listContainer.style.overflowY = "auto";
+		initialCard.appendChild(initialTitle);
 
-        container.appendChild(listContainer);
+		listContainer.appendChild(initialCard);
 
-        this.registerEvent(
-            this.app.workspace.on('harper:lint-updated', (errors: any[], editorView: any)=>{
+		listContainer.id = 'harper-error-list';
+		listContainer.style.height = '100%';
+		listContainer.style.overflowY = 'auto';
 
-                listContainer.innerHTML = "";
+		container.appendChild(listContainer);
 
-                if (!errors || errors.length === 0){
-                    const card = document.createElement("div");
-                    card.style.display= "flex";
-                    card.style.flexDirection = "column";
-                    card.style.padding = "12px 16px";
-                    card.style.borderBottom = "1px solid var(--background-modifier-border)"; // add var
-                    card.style.gap = "8px";
+		this.registerEvent(
+			this.app.workspace.on('harper:lint-updated', (errors: any[], editorView: any) => {
+				listContainer.innerHTML = '';
 
-                    const title = document.createElement("span");
-                    title.style.fontWeight = "bold";
-                    title.textContent =  "No grammer errors found!";
+				if (!errors || errors.length === 0) {
+					const card = document.createElement('div');
+					card.style.display = 'flex';
+					card.style.flexDirection = 'column';
+					card.style.padding = '12px 16px';
+					card.style.borderBottom = '1px solid var(--background-modifier-border)'; // add var
+					card.style.gap = '8px';
 
-                    card.appendChild(title);
-                    
-                    listContainer.appendChild(card);
-                    return;
-                }
+					const title = document.createElement('span');
+					title.style.fontWeight = 'bold';
+					title.textContent = 'No grammar errors found!';
 
-                errors.forEach(error => {
-                    try {
-                    // find card color
-                    let severityColor = "";
-                    
-                    if (error.markClass ){
-                        const classes = error.markClass.split(' ');
+					card.appendChild(title);
 
-                        const harperClass = classes.find((c: string) => c.startsWith('harper-lintRange-'));
-                        if (harperClass){
-                            const lintKind = harperClass.replace('harper-lintRange-', '');
-                            if(LINT_KIND_COLORS && LINT_KIND_COLORS[lintKind]){
-                                severityColor = LINT_KIND_COLORS[lintKind];
-                            }
-                        }
-                    }
+					listContainer.appendChild(card);
+					return;
+				}
 
-                    const card = document.createElement("div");
-                    card.style.display= "flex";
-                    card.style.flexDirection = "column";
-                    card.style.padding = "12px 16px";
-                    card.style.borderBottom = "1px solid var(--background-modifier-border)"; // add var
-                    card.style.gap = "8px";
-                    
-                    const titleDiv = document.createElement("div");
-                    titleDiv.style.display = "flex";
-                    titleDiv.style.flexWrap = "wrap";
-                    titleDiv.style.gap = "6px";
-                    titleDiv.style.marginTop = "4px";
+				errors.forEach((error) => {
+					try {
+						// find card color
+						let severityColor = '';
 
-                    const title = document.createElement("span");
-                    title.style.fontWeight = "bold";
-                    title.style.color = severityColor;
-                    title.textContent = error.title || "Harper Sugestion";
-                    
-                    const doc = editorView.state.doc;
-                    const problemText = doc.sliceString(error.from, error.to);
+						if (error.markClass) {
+							const classes = error.markClass.split(' ');
 
-                    // get 18 char before and after the word
-                    const rawPrefix = doc.sliceString(Math.max(0, error.from-18), error.from);
-                    const rawSuffix = doc.sliceString(error.to, Math.min(doc.length, error.to+18));
-                    // trim to be only 3 words before and after. 
-                    let prefix = rawPrefix.split(/[.!?\n]/).pop() || "";
-                    let prefixWords = prefix.trim().split(/\s+/).filter(w => w.length>0);
-                    prefix = prefixWords.slice(-3).join(" ");
-                    if (prefix.length > 0) prefix += " ";
+							const harperClass = classes.find((c: string) => c.startsWith('harper-lintRange-'));
+							if (harperClass) {
+								const lintKind = harperClass.replace('harper-lintRange-', '');
+								if (LINT_KIND_COLORS?.[lintKind]) {
+									severityColor = LINT_KIND_COLORS[lintKind];
+								}
+							}
+						}
 
-                    let suffix = rawSuffix.split(/[.!?\n]/)[0] || "";
-                    let suffixWords = suffix.trim().split(/\s+/).filter(w => w.length>0);
-                    suffix = suffixWords.slice(0,3).join(" ");
-                    if (suffix.length > 0) suffix = " " + suffix;
-                    
-                    // text container
-                    const textContainer = document.createElement("span");
-                    textContainer.style.fontSize = "var(--font-ui-small)";
+						const card = document.createElement('div');
+						card.style.display = 'flex';
+						card.style.flexDirection = 'column';
+						card.style.padding = '12px 16px';
+						card.style.borderBottom = '1px solid var(--background-modifier-border)'; // add var
+						card.style.gap = '8px';
 
-                    if (prefix) {
-                        textContainer.appendChild(document.createTextNode(prefix));
-                    }
-                    
-                    const boldWord = document.createElement("strong");
-                    boldWord.textContent = problemText;
-                    boldWord.style.color = severityColor;
-                    textContainer.appendChild(boldWord);
+						const titleDiv = document.createElement('div');
+						titleDiv.style.display = 'flex';
+						titleDiv.style.flexWrap = 'wrap';
+						titleDiv.style.gap = '6px';
+						titleDiv.style.marginTop = '4px';
 
-                    if (suffix) {
-                        textContainer.appendChild(document.createTextNode(suffix));
-                    }
+						const title = document.createElement('span');
+						title.style.fontWeight = 'bold';
+						title.style.color = severityColor;
+						title.textContent = error.title || 'Harper Suggestion';
 
-                    if (error.actions && error.actions.length > 0){
-                        const actionConst = document.createElement("div");
-                        actionConst.style.display = "flex";
-                        actionConst.style.flexWrap = "wrap";
-                        actionConst.style.gap = "6px";
-                        actionConst.style.marginTop = "4px";
+						const doc = editorView.state.doc;
+						const problemText = doc.sliceString(error.from, error.to);
 
-                        error.actions.forEach((action: any) => {
-                            const btn = document.createElement("button");
-                            btn.textContent = action.name;
-                            btn.title = action.title;
+						// get 18 char before and after the word
+						const rawPrefix = doc.sliceString(Math.max(0, error.from - 18), error.from);
+						const rawSuffix = doc.sliceString(error.to, Math.min(doc.length, error.to + 18));
+						// trim to be only 3 words before and after.
+						let prefix = rawPrefix.split(/[.!?\n]/).pop() || '';
+						const prefixWords = prefix
+							.trim()
+							.split(/\s+/)
+							.filter((w) => w.length > 0);
+						prefix = prefixWords.slice(-3).join(' ');
+						if (prefix.length > 0) prefix += ' ';
 
-                            btn.style.fontSize = "var(--font-ui-smaller)";
-                            btn.style.cursor = "var(--cursor)";
+						let suffix = rawSuffix.split(/[.!?\n]/)[0] || '';
+						const suffixWords = suffix
+							.trim()
+							.split(/\s+/)
+							.filter((w) => w.length > 0);
+						suffix = suffixWords.slice(0, 3).join(' ');
+						if (suffix.length > 0) suffix = ` ${suffix}`;
 
-                            btn.onclick = () => {
-                                action.apply(editorView, error.from, error.to);
-                            };
+						// text container
+						const textContainer = document.createElement('span');
+						textContainer.style.fontSize = 'var(--font-ui-small)';
 
-                            actionConst.appendChild(btn);
-                        });
-                        // add the options ignore diagnostic and Disable Rule in a dropdown btn
-                        if (error.ignore || error.disable) {
-                            const btn = document.createElement("div");
-                            setIcon(btn, "more-vertical");
-                            btn.style.cursor = "var(--cursor)";
-                            btn.style.color = "var(--text-muted)";
-                            btn.style.display = "flex";
-                            btn.style.alignItems = "center";
-                            btn.style.padding = "2px 4px";
-                            btn.style.borderRadius = "var(--radius-s)";
-                            btn.style.marginLeft = "auto";
-                        
-                            btn.onmouseover = () => btn.style.backgroundColor = "var(--background-modifier-hover)";
-                            btn.onmouseout = () => btn.style.backgroundColor = "transparent";
-                        
-                            btn.onclick = (e) => {
-                                const menu = new Menu();
-                            
-                                if (error.ignore){
-                                    menu.addItem((item) => {
-                                        item.setTitle("Ignore Diagnostic").setIcon("eye-off").onClick(() => {error.ignore();});
-                                    });
-                                }
-                                if (error.disable){
-                                    menu.addItem((item) => {
-                                        item.setTitle("Disable Rule").setIcon("ban").onClick(() => {error.disable();});
-                                    });
-                                }
-                            
-                                menu.showAtMouseEvent(e);
-                            }
+						if (prefix) {
+							textContainer.appendChild(document.createTextNode(prefix));
+						}
 
-                            titleDiv.appendChild(title);
-                            titleDiv.appendChild(btn);
-                            card.appendChild(titleDiv);
-                            card.appendChild(textContainer);
-                            card.appendChild(actionConst);
-                        }
-                        
-                    }
-                    listContainer.appendChild(card);
-                    
-                }
-                catch (err){
-                    console.error("Harper Sidebar failed to read: ", err, error);
-                }
-                });
-            })
-        )
-    }
+						const boldWord = document.createElement('strong');
+						boldWord.textContent = problemText;
+						boldWord.style.color = severityColor;
+						textContainer.appendChild(boldWord);
 
-    async onClose(){
+						if (suffix) {
+							textContainer.appendChild(document.createTextNode(suffix));
+						}
 
-    }
+						if (error.actions && error.actions.length > 0) {
+							const actionConst = document.createElement('div');
+							actionConst.style.display = 'flex';
+							actionConst.style.flexWrap = 'wrap';
+							actionConst.style.gap = '6px';
+							actionConst.style.marginTop = '4px';
+
+							error.actions.forEach((action: any) => {
+								const btn = document.createElement('button');
+								btn.textContent = action.name;
+								btn.title = action.title;
+
+								btn.style.fontSize = 'var(--font-ui-smaller)';
+								btn.style.cursor = 'var(--cursor)';
+
+								btn.onclick = () => {
+									action.apply(editorView, error.from, error.to);
+								};
+
+								actionConst.appendChild(btn);
+							});
+							// add the options ignore diagnostic and Disable Rule in a dropdown btn
+							if (error.ignore || error.disable) {
+								const btn = document.createElement('div');
+								setIcon(btn, 'more-vertical');
+								btn.style.cursor = 'var(--cursor)';
+								btn.style.color = 'var(--text-muted)';
+								btn.style.display = 'flex';
+								btn.style.alignItems = 'center';
+								btn.style.padding = '2px 4px';
+								btn.style.borderRadius = 'var(--radius-s)';
+								btn.style.marginLeft = 'auto';
+
+								btn.onmouseover = () => {
+									btn.style.backgroundColor = 'var(--background-modifier-hover)';
+								};
+								btn.onmouseout = () => {
+									btn.style.backgroundColor = 'transparent';
+								};
+
+								btn.onclick = (e) => {
+									const menu = new Menu();
+
+									if (error.ignore) {
+										menu.addItem((item) => {
+											item
+												.setTitle('Ignore Diagnostic')
+												.setIcon('eye-off')
+												.onClick(() => {
+													error.ignore();
+												});
+										});
+									}
+									if (error.disable) {
+										menu.addItem((item) => {
+											item
+												.setTitle('Disable Rule')
+												.setIcon('ban')
+												.onClick(() => {
+													error.disable();
+												});
+										});
+									}
+
+									menu.showAtMouseEvent(e);
+								};
+
+								titleDiv.appendChild(title);
+								titleDiv.appendChild(btn);
+								card.appendChild(titleDiv);
+								card.appendChild(textContainer);
+								card.appendChild(actionConst);
+							}
+						}
+						listContainer.appendChild(card);
+					} catch (err) {
+						console.error('Harper Sidebar failed to read: ', err, error);
+					}
+				});
+			}),
+		);
+	}
+
+	async onClose() {}
 }

--- a/packages/obsidian-plugin/src/SidebarView.ts
+++ b/packages/obsidian-plugin/src/SidebarView.ts
@@ -1,0 +1,228 @@
+import { IconName, ItemView, WorkspaceLeaf, Menu, setIcon } from 'obsidian';
+import HarperPlugin from './index';
+import { LINT_KIND_COLORS } from './lintKindColor';
+
+export const Harper_Sidebar_View = "harper-sidebar-view";
+
+export class SidebarView extends ItemView {
+    constructor(leaf : WorkspaceLeaf, private plugin: HarperPlugin){
+        super(leaf);
+    }
+
+    getViewType(){
+        return Harper_Sidebar_View;
+    }
+
+    getDisplayText(){
+        return "Harper Grammar";
+    }
+
+    getIcon(): IconName {
+        return "book-open-check";
+    }
+
+    async onOpen(){
+        this.update();
+    }
+
+    update(){
+        const container = this.containerEl;
+        container.empty();
+
+        container.style.padding = "0";
+        container.style.display= "flex";
+        container.style.flexDirection = "column";
+        container.style.justifyContent= "flex-start";
+
+        const listContainer = document.createElement("div");
+
+        // initial card
+        const initialCard = document.createElement("div");
+        initialCard.style.display= "flex";
+        initialCard.style.flexDirection = "column";
+        initialCard.style.padding = "12px 16px";
+        initialCard.style.borderBottom = "1px solid var(--background-modifier-border)"; // add var
+        initialCard.style.gap = "8px";
+        
+        const initialTitle = document.createElement("span");
+        initialTitle.style.fontWeight = "bold";
+        initialTitle.textContent =  "Loading errors...";
+
+        initialCard.appendChild(initialTitle);
+                    
+        listContainer.appendChild(initialCard);
+
+        listContainer.id = "harper-error-list";
+        listContainer.style.height = "100%";
+        listContainer.style.overflowY = "auto";
+
+        container.appendChild(listContainer);
+
+        this.registerEvent(
+            this.app.workspace.on('harper:lint-updated', (errors: any[], editorView: any)=>{
+
+                listContainer.innerHTML = "";
+
+                if (!errors || errors.length === 0){
+                    const card = document.createElement("div");
+                    card.style.display= "flex";
+                    card.style.flexDirection = "column";
+                    card.style.padding = "12px 16px";
+                    card.style.borderBottom = "1px solid var(--background-modifier-border)"; // add var
+                    card.style.gap = "8px";
+
+                    const title = document.createElement("span");
+                    title.style.fontWeight = "bold";
+                    title.textContent =  "No grammer errors found!";
+
+                    card.appendChild(title);
+                    
+                    listContainer.appendChild(card);
+                    return;
+                }
+
+                errors.forEach(error => {
+                    try {
+                    // find card color
+                    let severityColor = "";
+                    
+                    if (error.markClass ){
+                        const classes = error.markClass.split(' ');
+
+                        const harperClass = classes.find((c: string) => c.startsWith('harper-lintRange-'));
+                        if (harperClass){
+                            const lintKind = harperClass.replace('harper-lintRange-', '');
+                            if(LINT_KIND_COLORS && LINT_KIND_COLORS[lintKind]){
+                                severityColor = LINT_KIND_COLORS[lintKind];
+                            }
+                        }
+                    }
+
+                    const card = document.createElement("div");
+                    card.style.display= "flex";
+                    card.style.flexDirection = "column";
+                    card.style.padding = "12px 16px";
+                    card.style.borderBottom = "1px solid var(--background-modifier-border)"; // add var
+                    card.style.gap = "8px";
+                    
+                    const titleDiv = document.createElement("div");
+                    titleDiv.style.display = "flex";
+                    titleDiv.style.flexWrap = "wrap";
+                    titleDiv.style.gap = "6px";
+                    titleDiv.style.marginTop = "4px";
+
+                    const title = document.createElement("span");
+                    title.style.fontWeight = "bold";
+                    title.style.color = severityColor;
+                    title.textContent = error.title || "Harper Sugestion";
+                    
+                    const doc = editorView.state.doc;
+                    const problemText = doc.sliceString(error.from, error.to);
+
+                    // get 18 char before and after the word
+                    const rawPrefix = doc.sliceString(Math.max(0, error.from-18), error.from);
+                    const rawSuffix = doc.sliceString(error.to, Math.min(doc.length, error.to+18));
+                    // trim to be only 3 words before and after. 
+                    let prefix = rawPrefix.split(/[.!?\n]/).pop() || "";
+                    let prefixWords = prefix.trim().split(/\s+/).filter(w => w.length>0);
+                    prefix = prefixWords.slice(-3).join(" ");
+                    if (prefix.length > 0) prefix += " ";
+
+                    let suffix = rawSuffix.split(/[.!?\n]/)[0] || "";
+                    let suffixWords = suffix.trim().split(/\s+/).filter(w => w.length>0);
+                    suffix = suffixWords.slice(0,3).join(" ");
+                    if (suffix.length > 0) suffix = " " + suffix;
+                    
+                    // text container
+                    const textContainer = document.createElement("span");
+                    textContainer.style.fontSize = "var(--font-ui-small)";
+
+                    if (prefix) {
+                        textContainer.appendChild(document.createTextNode(prefix));
+                    }
+                    
+                    const boldWord = document.createElement("strong");
+                    boldWord.textContent = problemText;
+                    boldWord.style.color = severityColor;
+                    textContainer.appendChild(boldWord);
+
+                    if (suffix) {
+                        textContainer.appendChild(document.createTextNode(suffix));
+                    }
+
+                    if (error.actions && error.actions.length > 0){
+                        const actionConst = document.createElement("div");
+                        actionConst.style.display = "flex";
+                        actionConst.style.flexWrap = "wrap";
+                        actionConst.style.gap = "6px";
+                        actionConst.style.marginTop = "4px";
+
+                        error.actions.forEach((action: any) => {
+                            const btn = document.createElement("button");
+                            btn.textContent = action.name;
+                            btn.title = action.title;
+
+                            btn.style.fontSize = "var(--font-ui-smaller)";
+                            btn.style.cursor = "var(--cursor)";
+
+                            btn.onclick = () => {
+                                action.apply(editorView, error.from, error.to);
+                            };
+
+                            actionConst.appendChild(btn);
+                        });
+                        // add the options ignore diagnostic and Disable Rule in a dropdown btn
+                        if (error.ignore || error.disable) {
+                            const btn = document.createElement("div");
+                            setIcon(btn, "more-vertical");
+                            btn.style.cursor = "var(--cursor)";
+                            btn.style.color = "var(--text-muted)";
+                            btn.style.display = "flex";
+                            btn.style.alignItems = "center";
+                            btn.style.padding = "2px 4px";
+                            btn.style.borderRadius = "var(--radius-s)";
+                            btn.style.marginLeft = "auto";
+                        
+                            btn.onmouseover = () => btn.style.backgroundColor = "var(--background-modifier-hover)";
+                            btn.onmouseout = () => btn.style.backgroundColor = "transparent";
+                        
+                            btn.onclick = (e) => {
+                                const menu = new Menu();
+                            
+                                if (error.ignore){
+                                    menu.addItem((item) => {
+                                        item.setTitle("Ignore Diagnostic").setIcon("eye-off").onClick(() => {error.ignore();});
+                                    });
+                                }
+                                if (error.disable){
+                                    menu.addItem((item) => {
+                                        item.setTitle("Disable Rule").setIcon("ban").onClick(() => {error.disable();});
+                                    });
+                                }
+                            
+                                menu.showAtMouseEvent(e);
+                            }
+
+                            titleDiv.appendChild(title);
+                            titleDiv.appendChild(btn);
+                            card.appendChild(titleDiv);
+                            card.appendChild(textContainer);
+                            card.appendChild(actionConst);
+                        }
+                        
+                    }
+                    listContainer.appendChild(card);
+                    
+                }
+                catch (err){
+                    console.error("Harper Sidebar failed to read: ", err, error);
+                }
+                });
+            })
+        )
+    }
+
+    async onClose(){
+
+    }
+}

--- a/packages/obsidian-plugin/src/index.ts
+++ b/packages/obsidian-plugin/src/index.ts
@@ -1,6 +1,6 @@
 import type { EditorView } from '@codemirror/view';
 import { Dialect } from 'harper.js';
-import { editorInfoField, MarkdownView, Menu, Notice, Plugin } from 'obsidian';
+import { addIcon, editorInfoField, MarkdownView, Menu, Notice, Plugin } from 'obsidian';
 import logoSvg from '../logo.svg?raw';
 import logoSvgDisabled from '../logo-disabled.svg?raw';
 import { HarperSettingTab } from './HarperSettingTab';
@@ -16,7 +16,7 @@ import {
 	ignoreVisibleTooltipDiagnostic,
 	navigateDiagnostic,
 } from './lint';
-import { Harper_Sidebar_View, SidebarView } from './SidebarView';
+import { SidebarView } from './SidebarView';
 import State from './State';
 
 export default class HarperPlugin extends Plugin {
@@ -30,6 +30,8 @@ export default class HarperPlugin extends Plugin {
 			new Notice('Please update your Electron version before running Harper.', 0);
 			return;
 		}
+
+		addIcon('harper-logo', logoSvg);
 
 		this.app.workspace.onLayoutReady(async () => {
 			this.state = new State(
@@ -46,18 +48,18 @@ export default class HarperPlugin extends Plugin {
 		this.settings = new HarperSettingTab(this.app, this);
 		this.addSettingTab(this.settings);
 
-		this.registerView(Harper_Sidebar_View, (leaf) => new SidebarView(leaf, this));
+		this.registerView('harper-sidebar-view', (leaf) => new SidebarView(leaf, this));
 
 		this.setupCommands();
 	}
 
 	async activateSidebarView() {
-		if (this.app.workspace.getLeavesOfType(Harper_Sidebar_View).length > 0) {
+		if (this.app.workspace.getLeavesOfType('harper-sidebar-view').length > 0) {
 			return;
 		}
 		const leaf = this.app.workspace.getRightLeaf(false);
 		await leaf.setViewState({
-			type: Harper_Sidebar_View,
+			type: 'harper-sidebar-view',
 			active: true,
 		});
 		this.app.workspace.revealLeaf(leaf);
@@ -68,7 +70,7 @@ export default class HarperPlugin extends Plugin {
 		const editorView = this.getActiveEditorView();
 		if (!editorView) return;
 
-		const leaves = this.app.workspace.getLeavesOfType(Harper_Sidebar_View);
+		const leaves = this.app.workspace.getLeavesOfType('harper-sidebar-view');
 		if (leaves.length > 0) {
 			const sidebar = leaves[0].view as SidebarView;
 			if (sidebar) {
@@ -172,13 +174,14 @@ export default class HarperPlugin extends Plugin {
 	}
 
 	private async toggleSidebar() {
-		const existingLeaves = this.app.workspace.getLeavesOfType(Harper_Sidebar_View);
+		const existingLeaves = this.app.workspace.getLeavesOfType('harper-sidebar-view');
 		if (existingLeaves.length > 0) {
 			existingLeaves.forEach((leaf) => {
 				leaf.detach();
 			});
 		} else {
 			await this.activateSidebarView();
+			await this.state.reinitialize();
 		}
 	}
 
@@ -193,7 +196,7 @@ export default class HarperPlugin extends Plugin {
 
 		this.addCommand({
 			id: 'harper-toggle-sidebar',
-			name: 'Toggle harper spellcheck sidebar',
+			name: 'Toggle spellcheck sidebar',
 			callback: () => {
 				this.toggleSidebar();
 			},

--- a/packages/obsidian-plugin/src/index.ts
+++ b/packages/obsidian-plugin/src/index.ts
@@ -17,6 +17,7 @@ import {
 	navigateDiagnostic,
 } from './lint';
 import State from './State';
+import {Harper_Sidebar_View, SidebarView} from "./SidebarView";
 
 export default class HarperPlugin extends Plugin {
 	state: State;
@@ -45,7 +46,35 @@ export default class HarperPlugin extends Plugin {
 		this.settings = new HarperSettingTab(this.app, this);
 		this.addSettingTab(this.settings);
 
+		this.registerView(Harper_Sidebar_View, (leaf) => new SidebarView(leaf, this));
+
 		this.setupCommands();
+	}
+
+	async activateSidebarView() {
+		if (this.app.workspace.getLeavesOfType(Harper_Sidebar_View).length > 0){
+			return;
+		}
+		const leaf = this.app.workspace.getRightLeaf(false);
+		await leaf.setViewState({
+			type: Harper_Sidebar_View,
+			active: true,
+		});
+		this.app.workspace.revealLeaf(leaf);
+		this.updateSidebar();
+	}
+
+	private updateSidebar(){
+		const editorView = this.getActiveEditorView();
+		if (!editorView) return;
+
+		const leaves = this.app.workspace.getLeavesOfType(Harper_Sidebar_View);
+		if (leaves.length>0){
+			const sidebar = leaves[0].view as SidebarView;
+			if (sidebar){
+				sidebar.update();
+			}
+		}
 	}
 
 	async onExternalSettingsChange() {
@@ -142,12 +171,29 @@ export default class HarperPlugin extends Plugin {
 		this.updateStatusBar();
 	}
 
+	private async toggleSidebar() {
+		const existingLeaves = this.app.workspace.getLeavesOfType(Harper_Sidebar_View);
+		if ( existingLeaves.length > 0 ){
+			existingLeaves.forEach(leaf => leaf.detach());
+		} else {
+			await this.activateSidebarView();
+		}
+	}
+
 	private setupCommands() {
 		this.addCommand({
 			id: 'harper-toggle-auto-lint',
 			name: 'Toggle automatic grammar checking',
 			callback: () => {
 				this.toggleAutoLint();
+			},
+		});
+
+		this.addCommand({
+			id: 'harper-toggle-sidebar',
+			name: 'Open harper spellcheck sidebar',
+			callback: () => {
+				this.toggleSidebar();
 			},
 		});
 

--- a/packages/obsidian-plugin/src/index.ts
+++ b/packages/obsidian-plugin/src/index.ts
@@ -16,8 +16,8 @@ import {
 	ignoreVisibleTooltipDiagnostic,
 	navigateDiagnostic,
 } from './lint';
+import { Harper_Sidebar_View, SidebarView } from './SidebarView';
 import State from './State';
-import {Harper_Sidebar_View, SidebarView} from "./SidebarView";
 
 export default class HarperPlugin extends Plugin {
 	state: State;
@@ -52,7 +52,7 @@ export default class HarperPlugin extends Plugin {
 	}
 
 	async activateSidebarView() {
-		if (this.app.workspace.getLeavesOfType(Harper_Sidebar_View).length > 0){
+		if (this.app.workspace.getLeavesOfType(Harper_Sidebar_View).length > 0) {
 			return;
 		}
 		const leaf = this.app.workspace.getRightLeaf(false);
@@ -64,14 +64,14 @@ export default class HarperPlugin extends Plugin {
 		this.updateSidebar();
 	}
 
-	private updateSidebar(){
+	private updateSidebar() {
 		const editorView = this.getActiveEditorView();
 		if (!editorView) return;
 
 		const leaves = this.app.workspace.getLeavesOfType(Harper_Sidebar_View);
-		if (leaves.length>0){
+		if (leaves.length > 0) {
 			const sidebar = leaves[0].view as SidebarView;
-			if (sidebar){
+			if (sidebar) {
 				sidebar.update();
 			}
 		}
@@ -173,8 +173,10 @@ export default class HarperPlugin extends Plugin {
 
 	private async toggleSidebar() {
 		const existingLeaves = this.app.workspace.getLeavesOfType(Harper_Sidebar_View);
-		if ( existingLeaves.length > 0 ){
-			existingLeaves.forEach(leaf => leaf.detach());
+		if (existingLeaves.length > 0) {
+			existingLeaves.forEach((leaf) => {
+				leaf.detach();
+			});
 		} else {
 			await this.activateSidebarView();
 		}
@@ -191,7 +193,7 @@ export default class HarperPlugin extends Plugin {
 
 		this.addCommand({
 			id: 'harper-toggle-sidebar',
-			name: 'Open harper spellcheck sidebar',
+			name: 'Toggle harper spellcheck sidebar',
 			callback: () => {
 				this.toggleSidebar();
 			},

--- a/packages/obsidian-plugin/src/lint.ts
+++ b/packages/obsidian-plugin/src/lint.ts
@@ -323,6 +323,9 @@ const lintPlugin = ViewPlugin.fromClass(
 					Promise.all(sources.map((source) => Promise.resolve(source(this.view)))).then(
 						(annotations) => {
 							const all = annotations.reduce((a, b) => a.concat(b));
+							if ((window as any).app) {
+								(window as any).app.workspace.trigger('harper:lint-updated', all, this.view);
+							}
 							if (this.view.state.doc == state.doc)
 								this.view.dispatch(setDiagnostics(this.view.state, all));
 						},


### PR DESCRIPTION
# Issues 
none

# Description
I added a sidebar for Obsidian. The sidebar will show all of the improvements that Harper finds in the active page. You can open this sidebar with the command line in Obsidian under "Harper: Open Harper spellcheck sidebar". This will open the sidebar showing all of the errors. This sidebar was inspired by how Grammarly will allow the user to see all of their errors in a list, and it makes correcting errors much faster. The sidebar also brings in the 3 words before and after the mistake so that it is easier to see the correct word from the sidebar. A picture is below. 

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->
<img width="1920" height="1080" alt="sidebar" src="https://github.com/user-attachments/assets/be5d12f9-1a5f-4aaa-a972-1725ba32aa9d" />

# How Has This Been Tested?
I tested my changes on my Linux computer by compiling them into main.js and running it in Obsidian. It runs good and I have a screenshot above. 

# AI Disclosure
I am human and used AI outside of my editor and did not use any agents. I used Google Gemini to understand some parts of Obsidian. 

# If Your PR Implements or Enhances a Linter
I did not change the linter. 

# Checklist

- [X] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [X] I have considered splitting this into smaller pull requests.
