### PR TITLE
fix: avoid memory leak in JS products

### DIFF
--- a/packages/chrome-plugin/src/ProtocolClient.ts
+++ b/packages/chrome-plugin/src/ProtocolClient.ts
@@ -6,7 +6,8 @@ import type { ActivationKey, Hotkey, WeirpackMeta } from './protocol';
 export default class ProtocolClient {
 	private static readonly lintCache = new LRUCache<string, Promise<UnpackedLintGroups>>({
 		max: 5000,
-		ttl: 5_000,
+		ttl: 60_000,
+		ttlAutopurge: true,
 	});
 
 	private static cacheKey(text: string, domain: string, options?: LintOptions): string {

--- a/packages/chrome-plugin/src/background/index.ts
+++ b/packages/chrome-plugin/src/background/index.ts
@@ -308,6 +308,12 @@ async function handleLint(
 	const unpackedEntries = await Promise.all(
 		Object.entries(grouped).map(async ([source, lints]) => {
 			const unpacked = await Promise.all(lints.map((lint) => unpackLint(req.text, lint, linter)));
+
+			// Free the lints
+			lints.forEach((l) => {
+				l.free();
+			});
+
 			return [source, unpacked] as const;
 		}),
 	);

--- a/packages/harper-editor/src/lib/Editor.svelte
+++ b/packages/harper-editor/src/lib/Editor.svelte
@@ -65,6 +65,10 @@ let lfw = new LintFramework(
 		const entries = await Promise.all(
 			Object.entries(raw).map(async ([source, lintGroup]: [string, Lint[]]) => {
 				const unpacked = await Promise.all(lintGroup.map((lint) => unpackLint(text, lint, linter)));
+				lintGroup.forEach((l) => {
+					l.free();
+				});
+
 				return [source, unpacked] as const;
 			}),
 		);

--- a/packages/lint-framework/src/lint/unpackLint.ts
+++ b/packages/lint-framework/src/lint/unpackLint.ts
@@ -31,8 +31,8 @@ export default async function unpackLint(
 	linter: Linter,
 ): Promise<UnpackedLint> {
 	const span = lint.span();
-  let unpackedSpan = { start: span.start, end: span.end };
-  span.free();
+	const unpackedSpan = { start: span.start, end: span.end };
+	span.free();
 
 	return {
 		span: unpackedSpan,
@@ -41,8 +41,8 @@ export default async function unpackLint(
 		lint_kind: lint.lint_kind() as LintKind,
 		lint_kind_pretty: lint.lint_kind_pretty(),
 		suggestions: lint.suggestions().map((sug) => {
-      const unpacked = { kind: sug.kind(), replacement_text: sug.get_replacement_text() };
-      sug.free();
+			const unpacked = { kind: sug.kind(), replacement_text: sug.get_replacement_text() };
+			sug.free();
 			return unpacked;
 		}),
 		context_hash: (await linter.contextHash(text, lint)).toString(),

--- a/packages/lint-framework/src/lint/unpackLint.ts
+++ b/packages/lint-framework/src/lint/unpackLint.ts
@@ -31,15 +31,19 @@ export default async function unpackLint(
 	linter: Linter,
 ): Promise<UnpackedLint> {
 	const span = lint.span();
+  let unpackedSpan = { start: span.start, end: span.end };
+  span.free();
 
 	return {
-		span: { start: span.start, end: span.end },
+		span: unpackedSpan,
 		message_html: lint.message_html(),
 		problem_text: lint.get_problem_text(),
 		lint_kind: lint.lint_kind() as LintKind,
 		lint_kind_pretty: lint.lint_kind_pretty(),
 		suggestions: lint.suggestions().map((sug) => {
-			return { kind: sug.kind(), replacement_text: sug.get_replacement_text() };
+      const unpacked = { kind: sug.kind(), replacement_text: sug.get_replacement_text() };
+      sug.free();
+			return unpacked;
 		}),
 		context_hash: (await linter.contextHash(text, lint)).toString(),
 		source: text,


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

Related to #3874

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

In Harper editor and the Harper Chrome Extension, we were failing to properly free generated lints in a hot path. Over time, this created unrecoverable memory consuming all available. 

I have fixed the issue by simply freeing the memory correctly.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
