### PR TITLE
feat: PCB board redundancy

### DIFF
--- a/harper-core/src/linting/redundant_acronyms.rs
+++ b/harper-core/src/linting/redundant_acronyms.rs
@@ -28,6 +28,7 @@ const ACRONYMS: &[(&str, &[&str], &str, Flag)] = &[
     ("GUI", &["graphical user"], "interface", None),
     ("LCD", &["liquid crystal"], "display", None),
     ("LLM", &["large language"], "model", None),
+    ("PCB", &["printed circuit"], "board", None),
     // Note: "pin number" (not capitalized) is used to refer to GPIO pins etc.
     ("PIN", &["personal identification"], "number", AllCapsOnly),
     (
@@ -424,6 +425,32 @@ mod tests {
             &[
                 "And because I didn't have US dollars, I used zip ties [music] instead of a proper microonal bass.",
                 "And because I didn't have USD, I used zip ties [music] instead of a proper microonal bass.",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn correct_pcb_board() {
+        assert_good_and_bad_suggestions(
+            "The PCB board is based on an STM32F microcontroller.",
+            RedundantAcronyms::default(),
+            &[
+                "The PCB is based on an STM32F microcontroller.",
+                "The printed circuit board is based on an STM32F microcontroller.",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn correct_pcb_boards() {
+        assert_good_and_bad_suggestions(
+            "course project aimed to classify PCB boards as defect or non-defect - ChethanaVaisali/PCB_Classification.",
+            RedundantAcronyms::default(),
+            &[
+                "course project aimed to classify PCBs as defect or non-defect - ChethanaVaisali/PCB_Classification.",
+                "course project aimed to classify printed circuit boards as defect or non-defect - ChethanaVaisali/PCB_Classification.",
             ],
             &[],
         );


### PR DESCRIPTION
# Issues 
N/A

# Description

Adds support for "PCB board(s)" to the redundant acronym module after I heard somebody use it the other day and found plenty of examples in the wild.

# How Has This Been Tested?

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
