### PR TITLE
feat: take care about→take care of

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -3767,7 +3767,14 @@
 							"Bool": {
 								"name": "TakeALookTo",
 								"state": true,
-								"label": "Take A Look To"
+								"label": "Take a Look to"
+							}
+						},
+						{
+							"Bool": {
+								"name": "TakeCareOf",
+								"state": true,
+								"label": "Take Care of"
 							}
 						},
 						{

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -249,6 +249,7 @@ use super::spelled_numbers::SpelledNumbers;
 use super::split_words::SplitWords;
 use super::subject_pronoun::SubjectPronoun;
 use super::take_a_look_to::TakeALookTo;
+use super::take_care_of::TakeCareOf;
 use super::take_medicine::TakeMedicine;
 use super::that_than::ThatThan;
 use super::that_which::ThatWhich;
@@ -833,6 +834,7 @@ impl LintGroup {
         insert_expr_rule!(SplitWords);
         insert_struct_rule!(SubjectPronoun);
         insert_expr_rule!(TakeALookTo);
+        insert_expr_rule!(TakeCareOf);
         insert_expr_rule!(TakeMedicine);
         insert_expr_rule!(ThatThan);
         insert_expr_rule!(ThatWhich);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -267,6 +267,7 @@ mod split_words;
 mod subject_pronoun;
 mod suggestion;
 mod take_a_look_to;
+mod take_care_of;
 mod take_medicine;
 mod take_serious;
 mod that_than;

--- a/harper-core/src/linting/take_care_of.rs
+++ b/harper-core/src/linting/take_care_of.rs
@@ -1,0 +1,98 @@
+use crate::{
+    Lint, Token, TokenStringExt,
+    expr::{Expr, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+};
+
+pub struct TakeCareOf {
+    expr: SequenceExpr,
+}
+
+impl Default for TakeCareOf {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::word_set(&["take", "taken", "takes", "taking", "took"])
+                .t_ws()
+                .then_word_seq(&["care", "about"]),
+        }
+    }
+}
+
+impl ExprLinter for TakeCareOf {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        let span = toks.last()?.span;
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::Usage,
+            suggestions: vec![Suggestion::replace_with_match_case_str(
+                "of",
+                span.get_content(src),
+            )],
+            message: "Are you confusing `care about` with `take care of`?".to_owned(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects `take care about` to `take care of`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::assert_suggestion_result;
+
+    use super::TakeCareOf;
+
+    #[test]
+    fn fix_take() {
+        assert_suggestion_result(
+            "OSGi: Take care about dynamically changed routes (and other initial data)",
+            TakeCareOf::default(),
+            "OSGi: Take care of dynamically changed routes (and other initial data)",
+        );
+    }
+
+    #[test]
+    fn fix_taken() {
+        assert_suggestion_result(
+            "But this would mean that the creator of the logfile has taken care about making the fraction 6 characters long",
+            TakeCareOf::default(),
+            "But this would mean that the creator of the logfile has taken care of making the fraction 6 characters long",
+        );
+    }
+
+    #[test]
+    fn fix_takes() {
+        assert_suggestion_result(
+            "I like that Dart actively takes care about this and provides this consistent package",
+            TakeCareOf::default(),
+            "I like that Dart actively takes care of this and provides this consistent package",
+        );
+    }
+
+    #[test]
+    fn fix_taking() {
+        assert_suggestion_result(
+            "second one is taking care about analysis of output",
+            TakeCareOf::default(),
+            "second one is taking care of analysis of output",
+        );
+    }
+
+    #[test]
+    fn fix_took() {
+        assert_suggestion_result(
+            "then this * function took care about the ndisc option",
+            TakeCareOf::default(),
+            "then this * function took care of the ndisc option",
+        );
+    }
+}

--- a/harper-core/src/linting/take_care_of.rs
+++ b/harper-core/src/linting/take_care_of.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Lint, Token, TokenStringExt,
+    Lint, Token,
     expr::{Expr, SequenceExpr},
     linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
 };

--- a/harper-core/tests/text/linters/Part-of-speech tagging.snap.yml
+++ b/harper-core/tests/text/linters/Part-of-speech tagging.snap.yml
@@ -65,16 +65,6 @@ Suggest:
 
 
 
-Lint:    Style (127 priority)
-Message: |
-      32 | Correct grammatical tagging will reflect that "dogs" is here used as a verb, not
-      33 | as the more common plural noun. Grammatical context is one way to determine
-         |        ^~~~~~~~~~~ This is not an error, but an inflected form of this adjective also exists
-Suggest:
-  - Replace with: “commoner”
-
-
-
 Lint:    Readability (127 priority)
 Message: |
       33 | as the more common plural noun. Grammatical context is one way to determine
@@ -346,16 +336,6 @@ Suggest:
 
 
 
-Lint:    Style (127 priority)
-Message: |
-     125 | program can decide that "can" in "the can" is far more likely to be a noun than
-         |                                                   ^~~~~~~~~~~ This is not an error, but an inflected form of this adjective also exists
-     126 | a verb or a modal. The same method can, of course, be used to benefit from
-Suggest:
-  - Replace with: “likelier”
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
      129 | More advanced ("higher-order") HMMs learn the probabilities not only of pairs
@@ -390,16 +370,6 @@ Suggest:
   - Replace with: “Cardiac”
   - Replace with: “Carnal”
   - Replace with: “Carnival”
-
-
-
-Lint:    Style (127 priority)
-Message: |
-     142 | parsing (1997) that merely assigning the most common tag to each known word and
-         |                                          ^~~~~~~~~~~ This is not an error, but an inflected form of this adjective also exists
-     143 | the tag "proper noun" to all unknowns will approach 90% accuracy because many
-Suggest:
-  - Replace with: “commonest”
 
 
 

--- a/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
+++ b/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
@@ -22,16 +22,6 @@ Message: |
 
 
 
-Lint:    Style (127 priority)
-Message: |
-       5 | **We the People** of the United States, in Order to form a more perfect Union,
-         |                                                            ^~~~~~~~~~~~ This is not an error, but an inflected form of this adjective also exists
-       6 | establish Justice, insure domestic Tranquility, provide for the common defence,
-Suggest:
-  - Replace with: “perfecter”
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
        6 | establish Justice, insure domestic Tranquility, provide for the common defence,

--- a/harper-core/tests/text/linters/The Great Gatsby.snap.yml
+++ b/harper-core/tests/text/linters/The Great Gatsby.snap.yml
@@ -521,17 +521,6 @@ Suggest:
 
 
 
-Lint:    Style (127 priority)
-Message: |
-     397 | There was something pathetic in his concentration, as if his complacency, more
-         |                                                                           ^~~~~
-     398 | acute than of old, was not enough to him any more. When, almost immediately, the
-         | ~~~~~ This is not an error, but an inflected form of this adjective also exists
-Suggest:
-  - Replace with: “acuter”
-
-
-
 Lint:    Readability (127 priority)
 Message: |
      416 | For a moment the last sunshine fell with romantic affection upon her glowing
@@ -1148,15 +1137,6 @@ Suggest:
 
 
 
-Lint:    Style (127 priority)
-Message: |
-    1017 | “It’d be more discreet to go to Europe.”
-         |          ^~~~~~~~~~~~~ This is not an error, but an inflected form of this adjective also exists
-Suggest:
-  - Replace with: “discreeter”
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
     1029 | over twelve hundred dollars when we started, but we got gyped out of it all in
@@ -1178,15 +1158,6 @@ Suggest:
   - Replace with: “kike”
   - Replace with: “dyke”
   - Replace with: “tyke”
-
-
-
-Lint:    Style (127 priority)
-Message: |
-    1060 | I never was any more crazy about him than I was about that man there.”
-         |                 ^~~~~~~~~~ This is not an error, but an inflected form of this adjective also exists
-Suggest:
-  - Replace with: “crazier”
 
 
 
@@ -1451,16 +1422,6 @@ Message: |
          |           ^~~~~~~~ An Oxford comma is necessary here.
 Suggest:
   - Insert “,”
-
-
-
-Lint:    Style (127 priority)
-Message: |
-    1202 | confident girls who weave here and there among the stouter and more stable,
-         |                                                                ^~~~~~~~~~~ This is not an error, but an inflected form of this adjective also exists
-    1203 | become for a sharp, joyous moment the centre of a group, and then, excited with
-Suggest:
-  - Replace with: “stabler”
 
 
 
@@ -1794,16 +1755,6 @@ Suggest:
 
 
 
-Lint:    Style (127 priority)
-Message: |
-    1528 | drinking helped to set him off from his guests, for it seemed to me that he grew
-    1529 | more correct as the fraternal hilarity increased. When the “Jazz History of the
-         | ^~~~~~~~~~~~ This is not an error, but an inflected form of this adjective also exists
-Suggest:
-  - Replace with: “correcter”
-
-
-
 Lint:    Readability (127 priority)
 Message: |
     1529 | more correct as the fraternal hilarity increased. When the “Jazz History of the
@@ -2098,16 +2049,6 @@ Message: |
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1792 | smile turned to the world and yet satisfy the demands of her hard, jaunty body.
          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ This sentence is 48 words long.
-
-
-
-Lint:    Style (127 priority)
-Message: |
-    1800 | “You’re a rotten driver,” I protested. “Either you ought to be more careful, or
-         |                                                                ^~~~~~~~~~~~ This is not an error, but an inflected form of this adjective also exists
-    1801 | you oughtn’t to drive at all.”
-Suggest:
-  - Replace with: “carefuller”
 
 
 
@@ -3128,16 +3069,6 @@ Message: |
          |               ^~~~~~~~~~ Did you mean `Greensboro`?
 Suggest:
   - Replace with: “Greensboro”
-
-
-
-Lint:    Style (127 priority)
-Message: |
-    2073 | A dead man passed us in a hearse heaped with blooms, followed by two carriages
-    2074 | with drawn blinds, and by more cheerful carriages for friends. The friends
-         |                           ^~~~~~~~~~~~~ This is not an error, but an inflected form of this adjective also exists
-Suggest:
-  - Replace with: “cheerfuller”
 
 
 
@@ -6430,16 +6361,6 @@ Suggest:
 
 
 
-Lint:    Style (127 priority)
-Message: |
-    4883 | “Of course she might have loved him just for a minute, when they were first
-    4884 | married—and loved me more even then, do you see?”
-         |                      ^~~~~~~~~ This is not an error, but an inflected form of this adjective also exists
-Suggest:
-  - Replace with: “evener”
-
-
-
 Lint:    Spelling (63 priority)
 Message: |
     4921 | “I’m going to drain the pool to-day, Mr. Gatsby. Leaves’ll start falling pretty
@@ -6636,17 +6557,6 @@ Message: |
          |                     ^~~~~~~~~~ Did you mean the closed compound noun “workbench”?
 Suggest:
   - Replace with: “workbench”
-
-
-
-Lint:    Style (127 priority)
-Message: |
-    5062 | morning—and from time to time sat down beside Wilson trying to keep him more
-         |                                                                         ^~~~~
-    5063 | quiet.
-         | ~~~~~ This is not an error, but an inflected form of this adjective also exists
-Suggest:
-  - Replace with: “quieter”
 
 
 
@@ -7469,16 +7379,6 @@ Suggest:
 
 
 
-Lint:    Style (127 priority)
-Message: |
-    5568 | admiration from my eyes. He had shown it so often that I think it was more real
-         |                                                                       ^~~~~~~~~ This is not an error, but an inflected form of this adjective also exists
-    5569 | to him now than the house itself.
-Suggest:
-  - Replace with: “realer”
-
-
-
 Lint:    Agreement (127 priority)
 Message: |
     5575 | “He come out to see me two years ago and bought me the house I live in now. Of
@@ -7640,15 +7540,6 @@ Message: |
          |                                    ^~~~ This sentence does not start with a capital letter
 Suggest:
   - Replace with: “They”
-
-
-
-Lint:    Style (127 priority)
-Message: |
-    5659 | One of my most vivid memories is of coming back West from prep school and later
-         |           ^~~~~~~~~~ This is not an error, but an inflected form of this adjective also exists
-Suggest:
-  - Replace with: “vividest”
 
 
 


### PR DESCRIPTION
# Issues 
N/A

# Description

This is a common mistake that's been in my inbox for a while. I think almost always nonnative speakers mixing up "care about" and "take care of".

All inflections of "take care about" are changed to us "of". There seem to be no legit false positives.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
