### PR TITLE
chore: "YAMLs" was incorrectly generated

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -54468,7 +54468,7 @@ XeTeX/Og            # TeX typesetting engine
 Xilinx/Og           # FPGA company
 Xorg/ONSg
 Y2K/g               # year 2000
-YAML/OgS            # markup language
+YAML/Omg            # markup language
 Yazi/ONSg
 Yoast/Og            # seo
 YubiKey/Sg


### PR DESCRIPTION
# Issues 
N/A

# Description

While working on something unrelated a few days ago I noticed a side-effect of Harper including a plural, "YAMLs" of the word "YAML". I think it was when I had a script running on the word-provenance tool from #3323

This PR just marks it as a mass noun and removes the `/S` plural-generating flag. (I don't have other stuff to make a normal "dictionary curation" PR at the moment.)

# How Has This Been Tested?

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
