### PR TITLE
docs(harper.js): add Chrome extension example and docs page

### DIFF
--- a/packages/harper.js/examples/chrome-extension/README.md
+++ b/packages/harper.js/examples/chrome-extension/README.md
@@ -1,0 +1,14 @@
+# Chrome Extension Example
+
+A minimal [Manifest V3](https://developer.chrome.com/docs/extensions/develop/migrate/what-is-mv3) Chrome extension whose popup lints text with `harper.js` and shows the bundled Harper version.
+
+Extensions cannot load remote code, so `build.js` copies the `harper.js` distribution into the extension directory next to the popup's own files. See [the accompanying documentation](https://writewithharper.com/docs/harperjs/chrome-extension) for a walkthrough of the extension-specific pitfalls.
+
+To try it out:
+
+```bash
+pnpm install
+pnpm build
+```
+
+Then open `chrome://extensions`, enable "Developer mode", click "Load unpacked" and select this example's `dist/` directory.

--- a/packages/harper.js/examples/chrome-extension/build.js
+++ b/packages/harper.js/examples/chrome-extension/build.js
@@ -1,0 +1,30 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Chrome extensions cannot load remote code, so we assemble a self-contained
+// `dist/` directory: the extension's own files plus a local copy of the
+// `harper.js` distribution.
+const root = path.dirname(fileURLToPath(import.meta.url));
+const outDir = path.join(root, 'dist');
+
+const harperDist = path.dirname(fileURLToPath(import.meta.resolve('harper.js')));
+
+fs.rmSync(outDir, { recursive: true, force: true });
+fs.mkdirSync(outDir, { recursive: true });
+
+fs.cpSync(path.join(root, 'src'), outDir, { recursive: true });
+fs.cpSync(harperDist, path.join(outDir, 'vendor', 'harper.js'), {
+	recursive: true,
+});
+
+// Expose the bundled `harper.js` version to the popup. The `harper.js` package
+// is versioned in lockstep with `harper-core`, so this is also the version of
+// the underlying grammar engine.
+const { version } = JSON.parse(
+	fs.readFileSync(path.join(harperDist, '..', 'package.json'), 'utf8'),
+);
+fs.writeFileSync(path.join(outDir, 'version.js'), `export const harperVersion = '${version}';\n`);
+
+console.log(`Built extension into ${outDir}`);
+console.log('Load it via chrome://extensions → "Load unpacked" → select dist/');

--- a/packages/harper.js/examples/chrome-extension/package.json
+++ b/packages/harper.js/examples/chrome-extension/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "chrome-extension-example",
+	"version": "0.0.1",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"build": "node build.js"
+	},
+	"dependencies": {
+		"harper.js": "workspace:*"
+	}
+}

--- a/packages/harper.js/examples/chrome-extension/src/manifest.json
+++ b/packages/harper.js/examples/chrome-extension/src/manifest.json
@@ -1,0 +1,12 @@
+{
+	"manifest_version": 3,
+	"name": "Harper Example",
+	"version": "1.0.0",
+	"description": "A minimal example that runs harper.js inside a Chrome extension popup.",
+	"action": {
+		"default_popup": "popup.html"
+	},
+	"content_security_policy": {
+		"extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
+	}
+}

--- a/packages/harper.js/examples/chrome-extension/src/popup.html
+++ b/packages/harper.js/examples/chrome-extension/src/popup.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<!-- Remote stylesheets are not allowed in extensions, so keep styling inline. -->
+		<style>
+			body {
+				width: 360px;
+				font-family: sans-serif;
+				padding: 8px;
+			}
+
+			textarea {
+				width: 100%;
+				box-sizing: border-box;
+			}
+
+			footer {
+				color: gray;
+				font-size: 0.8em;
+			}
+		</style>
+		<script type="module" src="popup.js"></script>
+	</head>
+
+	<body>
+		<h1>Harper</h1>
+		<textarea id="maininput" rows="4">This is a example of how to use `harper.js` in an Chrome extension.</textarea>
+		<ul id="errorlist"></ul>
+		<footer id="version"></footer>
+	</body>
+</html>

--- a/packages/harper.js/examples/chrome-extension/src/popup.js
+++ b/packages/harper.js/examples/chrome-extension/src/popup.js
@@ -1,0 +1,31 @@
+// These files are copied out of the `harper.js` package by `build.js`, since
+// extensions must ship all of their code locally.
+import { binaryInlined } from './vendor/harper.js/binaryInlined.js';
+import { Dialect, LocalLinter } from './vendor/harper.js/index.js';
+import { harperVersion } from './version.js';
+
+// Use `LocalLinter` here: `WorkerLinter` spawns its Web Worker from a blob URL,
+// which the extension content security policy does not permit.
+const linter = new LocalLinter({
+	binary: binaryInlined,
+	dialect: Dialect.American,
+});
+
+async function onInput(e) {
+	const lints = await linter.lint(e.target.value);
+
+	const list = document.getElementById('errorlist');
+	list.innerHTML = '';
+
+	for (const lint of lints) {
+		const item = document.createElement('LI');
+		item.appendChild(document.createTextNode(lint.message()));
+		list.appendChild(item);
+	}
+}
+
+const inputField = document.getElementById('maininput');
+inputField.addEventListener('input', onInput);
+onInput({ target: inputField });
+
+document.getElementById('version').innerText = `harper.js ${harperVersion}`;

--- a/packages/web/src/routes/docs/harperjs/chrome-extension/+page.md
+++ b/packages/web/src/routes/docs/harperjs/chrome-extension/+page.md
@@ -1,0 +1,28 @@
+---
+title: Chrome Extensions
+---
+
+`harper.js` works inside Chrome extensions, but [Manifest V3](https://developer.chrome.com/docs/extensions/develop/migrate/what-is-mv3) imposes three constraints that trip people up.
+This page walks through them, and [a complete working example is available in the repository](https://github.com/Automattic/harper/tree/master/packages/harper.js/examples/chrome-extension).
+
+## Ship `harper.js` inside the extension
+
+Extensions [may not load remotely hosted code](https://developer.chrome.com/docs/extensions/develop/migrate/improve-security#remove-remote-code), so you cannot import `harper.js` from a CDN [like a normal web page can](./CDN).
+Instead, copy the package's `dist/` directory into your extension (or use a bundler) and import it with a relative path.
+Importing `binaryInlined` avoids a separate fetch for the WebAssembly binary, since it ships the binary inside the JavaScript module.
+
+## Allow WebAssembly in the content security policy
+
+Compiling WebAssembly is blocked by the default extension content security policy.
+Your `manifest.json` must opt in with [`wasm-unsafe-eval`](https://developer.chrome.com/docs/extensions/reference/manifest/content-security-policy):
+
+@code(../../../../../../harper.js/examples/chrome-extension/src/manifest.json)
+
+## Use `LocalLinter`
+
+On ordinary web pages we recommend `WorkerLinter`, but it spawns its Web Worker from a blob URL, which the extension content security policy does not permit.
+Inside an extension, use `LocalLinter` instead:
+
+@code(../../../../../../harper.js/examples/chrome-extension/src/popup.js)
+
+Note that `harper.js` does not expose a function that reports the version of the underlying engine: the `harper.js` package version shown above is released in lockstep with `harper-core`, so it identifies the engine version as well.

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -151,6 +151,10 @@ export default defineConfig(async () => {
 											to: '/docs/harperjs/CDN',
 										},
 										{
+											title: 'Chrome Extensions',
+											to: '/docs/harperjs/chrome-extension',
+										},
+										{
 											title: 'API Reference',
 											to: '/docs/harperjs/ref/index.html',
 										},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,6 +345,12 @@ importers:
         specifier: ^4.0.16
         version: 4.0.16(@types/node@22.13.10)(@vitest/browser-playwright@4.0.16)(@vitest/ui@4.0.16)(jiti@2.6.1)(jsdom@20.0.3)(lightningcss@1.32.0)(msw@2.7.3(@types/node@22.13.10)(typescript@5.9.3))(sass@1.85.1)(terser@5.39.0)(tsx@4.20.6)(yaml@2.7.0)
 
+  packages/harper.js/examples/chrome-extension:
+    dependencies:
+      harper.js:
+        specifier: workspace:*
+        version: link:../..
+
   packages/harper.js/examples/commonjs-simple:
     dependencies:
       harper.js:


### PR DESCRIPTION
> [!NOTE]
> Per [Harper's policy on agent PRs](https://github.com/Automattic/harper/blob/master/AGENT_POLICY.md): this PR was authored with an LLM-based agent (Claude Code), human-directed and reviewed. End-to-end verification is described below.

Closes #3628

## What

- New example `packages/harper.js/examples/chrome-extension/`: a minimal Manifest V3 extension whose popup lints a textarea with `harper.js` and shows the bundled version — the "tiny example… opens a popup… and displays the harper-core version" asked for in #3628.
- New docs page `/docs/harperjs/chrome-extension` covering the three MV3 pitfalls that make this "next level complicated":
  1. Extensions may not load remote code, so the CDN approach doesn't apply — `build.js` copies the `harper.js` dist into the extension, and `binaryInlined` avoids a separate fetch for the wasm binary.
  2. The default extension CSP blocks WebAssembly compilation — the manifest opts in with `wasm-unsafe-eval`.
  3. `WorkerLinter` spawns its Web Worker from a blob URL, which the extension CSP blocks — so the example uses `LocalLinter`.
- Sidebar entry under *harper.js* after "CDN" in `packages/web/vite.config.ts`.

## Verification

- Built the example against published `harper.js@2.7.0` and loaded the resulting `dist/` as a real unpacked extension in Chromium (Playwright, `--load-extension`):
  - popup loads with zero page/console errors, i.e. the wasm engine compiles under the manifest CSP
  - the intentionally flawed sample text yields 3 lints (two "Incorrect indefinite article", one proper-noun hint)
  - the footer renders `harper.js 2.7.0`
- `biome check` clean on the new files.

The version question raised in the issue is addressed at the bottom of the docs page: there is no runtime API exposing the engine version, but `harper.js` and `harper-core` are versioned together (both currently 2.7.0), so the package version identifies the engine.
