### PR TITLE
fix(core): tag fought and wrought as past forms

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -25868,7 +25868,7 @@ fossilise/VGdS!_₹
 fossilization/Ng
 fossilize/VGdS
 foster/~JNSVGd
-fought/~V
+fought/~VtT
 foul/~JY^>pVdGSNg
 foulard/Ng
 foulmouthed/J
@@ -53555,7 +53555,7 @@ wrongheadedness/Ng
 wrongness/Ng
 wrote/~Vtr
 wroth/J
-wrought/~JV
+wrought/~JVtT
 wrung/V
 wry/~JYVN
 wryer/Jc

--- a/harper-core/src/linting/pronoun_verb_agreement.rs
+++ b/harper-core/src/linting/pronoun_verb_agreement.rs
@@ -290,6 +290,14 @@ mod lints {
         assert_no_lints("He likes this place. I sit under the AC.", test_linter());
     }
 
+    #[test]
+    fn issue_3925_dont_flag_simple_past_forms() {
+        assert_no_lints(
+            "He fought tenaciously. He wrought tenaciously.",
+            test_linter(),
+        );
+    }
+
     // Every pronoun systematically
 
     // Expected to get corrected

--- a/harper-core/tests/text/tagged/Difficult sentences.md
+++ b/harper-core/tests/text/tagged/Difficult sentences.md
@@ -269,7 +269,7 @@
 > I've lived here for   three years .
 # K    VP/J  J/R  R/C/P NSg   NPl+  .
 > They fought for   days over    a    silly  pencil  .
-# IPl+ VB     R/C/P NPl+ NSg/J/P D/P+ NSg/J+ NSg/VB+ .
+# IPl+ VP     R/C/P NPl+ NSg/J/P D/P+ NSg/J+ NSg/VB+ .
 > The store   is  closed for   the day     .
 # D+  NSg/VB+ VL3 VP/J   R/C/P D+  NPr🅪Sg+ .
 > I       can     see    for   miles  .

--- a/harper-core/tests/text/tagged/The Great Gatsby.md
+++ b/harper-core/tests/text/tagged/The Great Gatsby.md
@@ -8675,7 +8675,7 @@
 > word    she  was  drawing   further and  further into herself , so          he       gave that      up         , and
 # NSg/VB+ ISg+ VLPt N🅪Sg/Vg/J VB/JC   VB/C VB/JC   P    ISg+    . NSg/I/J/R/C NPr/ISg+ VPt  I/C/Ddem+ NSg/VB/J/P . VB/C
 > only  the dead      dream     fought on  as    the afternoon slipped away , trying  to touch
-# J/R/C D+  NSg/VB/J+ NSg/VB/J+ VB     J/P R/C/P D+  N🅪Sg+     VP/J    VB/J . Nᴹ/Vg/J P  N🅪Sg/VB
+# J/R/C D+  NSg/VB/J+ NSg/VB/J+ VP     J/P R/C/P D+  N🅪Sg+     VP/J    VB/J . Nᴹ/Vg/J P  N🅪Sg/VB
 > what   was  no       longer tangible , struggling unhappily , undespairingly , toward that
 # NSg/I+ VLPt NSg/Dq/P NSg/JC NSg/J    . Nᴹ/Vg/J    R         . ?              . J/P    I/C/Ddem+
 > lost voice   across the room       .


### PR DESCRIPTION
> **AI disclosure:** This contribution was produced with autonomous AI-agent assistance.

# Issues

Fixes #3925

# Description

`fought` and `wrought` were tagged as generic verb lemmas, so `PronounVerbAgreement` treated correct simple-past sentences such as “He fought tenaciously” as present-tense agreement errors.

This marks both words as preterite and past-participle forms in the curated dictionary. The existing real-text POS snapshots now classify `fought` as past tense, and the focused regression covers both examples from the issue.

# How Has This Been Tested?

- `cargo test -p harper-core linting::pronoun_verb_agreement::lints::issue_3925_dont_flag_simple_past_forms -- --exact` — passed
- `cargo test -p harper-core` — 6,076 unit tests passed (290 ignored), plus integration, POS snapshot, text-corpus, and doc tests
- `just format` — passed
- `git diff --check` — passed

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [x] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter

- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
