### PR TITLE
Added Windows Support

### DIFF
--- a/.github/workflows/windows_desktop.yml
+++ b/.github/workflows/windows_desktop.yml
@@ -47,4 +47,4 @@ jobs:
         run: just check-desktop
         
       - name: Build Desktop App
-        run: just build-desktop-windows
+        run: just build-desktop-windows-unsigned

--- a/.github/workflows/windows_desktop.yml
+++ b/.github/workflows/windows_desktop.yml
@@ -23,13 +23,13 @@ jobs:
           node-version: 22
           cache: 'pnpm'
       
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
-        
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-msvc
+          
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
           
       - name: Install just
         uses: taiki-e/install-action@just

--- a/.github/workflows/windows_desktop.yml
+++ b/.github/workflows/windows_desktop.yml
@@ -33,6 +33,9 @@ jobs:
           
       - name: Install just
         uses: taiki-e/install-action@just
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@wasm-pack
         
       - name: Build WebAssembly Module
         run: just build-wasm

--- a/.github/workflows/windows_desktop.yml
+++ b/.github/workflows/windows_desktop.yml
@@ -1,0 +1,47 @@
+name: Windows Desktop CI
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 10.10.0
+      
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+          
+      - name: Install just
+        uses: taiki-e/install-action@just
+        
+      - name: Build WebAssembly Module
+        run: just build-wasm
+        
+      - name: Build Harper.js
+        run: just build-harperjs
+        
+      - name: Check Desktop App
+        run: just check-desktop
+        
+      - name: Build Desktop App
+        run: just build-desktop-windows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4327,6 +4327,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "windows 0.61.3",
  "winit",
 ]
 

--- a/harper-desktop/package.json
+++ b/harper-desktop/package.json
@@ -16,6 +16,7 @@
 		"@tauri-apps/api": "^2",
 		"@tauri-apps/plugin-autostart": "^2.5.1",
 		"@tauri-apps/plugin-opener": "^2",
+		"@tauri-apps/plugin-os": "^2.3.2",
 		"@tauri-apps/plugin-updater": "^2.10.1",
 		"harper-editor": "workspace:*",
 		"harper.js": "workspace:*"

--- a/harper-desktop/src-tauri/Cargo.toml
+++ b/harper-desktop/src-tauri/Cargo.toml
@@ -48,6 +48,20 @@ cached = "2.0.2"
 tracing = "0.1.44"
 tracing-subscriber = "0.3.23"
 
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_System_Com",
+    "Win32_System_Ole",
+    "Win32_System_Threading",
+    "Win32_System_Variant",
+    "Win32_UI_Accessibility",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_Graphics_Gdi",
+    "Win32_UI_Shell",
+    "Win32_UI_HiDpi",
+] }
+
 [target.'cfg(target_os = "macos")'.dependencies]
 accessibility = "0.2.0"
 core-foundation = "0.10.1"

--- a/harper-desktop/src-tauri/Cargo.toml
+++ b/harper-desktop/src-tauri/Cargo.toml
@@ -49,6 +49,7 @@ tracing = "0.1.44"
 tracing-subscriber = "0.3.23"
 
 [target.'cfg(windows)'.dependencies]
+base64 = "0.22.1"
 windows = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_System_Com",

--- a/harper-desktop/src-tauri/src/config/integration.rs
+++ b/harper-desktop/src-tauri/src/config/integration.rs
@@ -19,13 +19,7 @@ impl Integration {
         ];
 
         #[cfg(windows)]
-        let ids: &[&str] = &[
-            "notepad.exe",
-            "notepad++.exe",
-            "slack.exe",
-            "discord.exe",
-            "applicationframehost.exe",
-        ];
+        let ids: &[&str] = &["notepad.exe"];
 
         #[cfg(not(any(target_os = "macos", windows)))]
         let ids: &[&str] = &[];

--- a/harper-desktop/src-tauri/src/config/integration.rs
+++ b/harper-desktop/src-tauri/src/config/integration.rs
@@ -19,7 +19,13 @@ impl Integration {
         ];
 
         #[cfg(windows)]
-        let ids: &[&str] = &["notepad.exe", "notepad++.exe", "slack.exe", "discord.exe"];
+        let ids: &[&str] = &[
+            "notepad.exe",
+            "notepad++.exe",
+            "slack.exe",
+            "discord.exe",
+            "applicationframehost.exe",
+        ];
 
         #[cfg(not(any(target_os = "macos", windows)))]
         let ids: &[&str] = &[];

--- a/harper-desktop/src-tauri/src/config/integration.rs
+++ b/harper-desktop/src-tauri/src/config/integration.rs
@@ -8,20 +8,28 @@ pub struct Integration {
 
 impl Integration {
     pub fn curated_integrations() -> Vec<Self> {
-        [
+        #[cfg(target_os = "macos")]
+        let ids: &[&str] = &[
             "com.apple.TextEdit",
             "com.apple.mail",
             "com.apple.MobileSMS",
             "com.apple.Notes",
             "com.tinyspeck.slackmacgap",
             "com.hnc.Discord",
-        ]
-        .into_iter()
-        .map(|bundle_id| Integration {
-            bundle_id: bundle_id.to_string(),
-            enabled: true,
-        })
-        .collect()
+        ];
+
+        #[cfg(windows)]
+        let ids: &[&str] = &["notepad.exe", "notepad++.exe", "slack.exe", "discord.exe"];
+
+        #[cfg(not(any(target_os = "macos", windows)))]
+        let ids: &[&str] = &[];
+
+        ids.iter()
+            .map(|&id| Integration {
+                bundle_id: id.to_string(),
+                enabled: true,
+            })
+            .collect()
     }
     pub fn is_integration_enabled_in(integrations: &[Self], bundle_id: &str) -> bool {
         integrations

--- a/harper-desktop/src-tauri/src/highlighter/window.rs
+++ b/harper-desktop/src-tauri/src/highlighter/window.rs
@@ -36,7 +36,7 @@ impl Window {
         let position = monitor.position();
         let size = monitor.size();
 
-        let mut attributes = WinitWindow::default_attributes()
+        let attributes = WinitWindow::default_attributes()
             .with_title("Harper")
             .with_inner_size(size)
             .with_position(position)
@@ -47,17 +47,15 @@ impl Window {
             .with_window_level(WindowLevel::AlwaysOnTop)
             .with_active(false);
 
+        // WS_EX_NOREDIRECTIONBITMAP: without this, DWM composites the DirectComposition
+        // swap chain (see below) *behind* the HWND's redirection bitmap, and the redirection
+        // bitmap is painted with the window class's default (white) background brush, hiding
+        // the overlay.
         #[cfg(target_os = "windows")]
-        {
-            // WS_EX_NOREDIRECTIONBITMAP: without this, DWM composites the DirectComposition
-            // swap chain (see below) *behind* the HWND's redirection bitmap, and the redirection
-            // bitmap is painted with the window class's default (white) background brush, hiding
-            // the overlay.
-            attributes = attributes
-                .with_skip_taskbar(true)
-                .with_undecorated_shadow(false)
-                .with_no_redirection_bitmap(true);
-        }
+        let attributes = attributes
+            .with_skip_taskbar(true)
+            .with_undecorated_shadow(false)
+            .with_no_redirection_bitmap(true);
 
         let window = Arc::new(event_loop.create_window(attributes)?);
 
@@ -75,6 +73,7 @@ impl Window {
             None,
         );
 
+        #[allow(unused_mut)]
         let mut setup_create =
             egui_wgpu::WgpuSetupCreateNew::from_display_handle(event_loop.owned_display_handle());
         #[cfg(target_os = "windows")]

--- a/harper-desktop/src-tauri/src/highlighter/window.rs
+++ b/harper-desktop/src-tauri/src/highlighter/window.rs
@@ -2,12 +2,15 @@ use std::num::NonZeroU32;
 use std::sync::Arc;
 
 use egui_wgpu::winit::Painter;
-use egui_wgpu::{RendererOptions, WgpuConfiguration, WgpuSetup};
+use egui_wgpu::{RendererOptions, WgpuConfiguration};
 use winit::dpi::{PhysicalPosition, PhysicalSize};
 use winit::event::WindowEvent;
 use winit::event_loop::ActiveEventLoop;
 use winit::monitor::MonitorHandle;
 use winit::window::{Window as WinitWindow, WindowButtons, WindowId, WindowLevel};
+
+#[cfg(target_os = "windows")]
+use winit::platform::windows::WindowAttributesExtWindows;
 
 use super::Error;
 use super::render_state::RenderState;
@@ -32,20 +35,31 @@ impl Window {
     ) -> Result<Self, Error> {
         let position = monitor.position();
         let size = monitor.size();
-        let window = Arc::new(
-            event_loop.create_window(
-                WinitWindow::default_attributes()
-                    .with_title("Harper")
-                    .with_inner_size(size)
-                    .with_position(position)
-                    .with_resizable(false)
-                    .with_enabled_buttons(WindowButtons::empty())
-                    .with_decorations(false)
-                    .with_transparent(true)
-                    .with_window_level(WindowLevel::AlwaysOnTop)
-                    .with_active(false),
-            )?,
-        );
+
+        let mut attributes = WinitWindow::default_attributes()
+            .with_title("Harper")
+            .with_inner_size(size)
+            .with_position(position)
+            .with_resizable(false)
+            .with_enabled_buttons(WindowButtons::empty())
+            .with_decorations(false)
+            .with_transparent(true)
+            .with_window_level(WindowLevel::AlwaysOnTop)
+            .with_active(false);
+
+        #[cfg(target_os = "windows")]
+        {
+            // WS_EX_NOREDIRECTIONBITMAP: without this, DWM composites the DirectComposition
+            // swap chain (see below) *behind* the HWND's redirection bitmap, and the redirection
+            // bitmap is painted with the window class's default (white) background brush, hiding
+            // the overlay.
+            attributes = attributes
+                .with_skip_taskbar(true)
+                .with_undecorated_shadow(false)
+                .with_no_redirection_bitmap(true);
+        }
+
+        let window = Arc::new(event_loop.create_window(attributes)?);
 
         window.set_outer_position(PhysicalPosition::new(position.x, position.y));
         let _ = window.request_inner_size(PhysicalSize::new(size.width, size.height));
@@ -61,10 +75,27 @@ impl Window {
             None,
         );
 
+        let mut setup_create =
+            egui_wgpu::WgpuSetupCreateNew::from_display_handle(event_loop.owned_display_handle());
+        #[cfg(target_os = "windows")]
+        {
+            // Route the DX12 backend through DirectComposition instead of a raw HWND swap chain.
+            // The HWND swap chain path only advertises `CompositeAlphaMode::Opaque`, so egui-wgpu
+            // cannot honour the transparent backbuffer and DWM composites the overlay as solid
+            // black. The DirectComposition path exposes `PreMultiplied`, which is what enables real
+            // per-pixel alpha for the overlay. wgpu owns the composition device/visual plumbing.
+            setup_create.instance_descriptor.backends = egui_wgpu::wgpu::Backends::DX12;
+            setup_create
+                .instance_descriptor
+                .backend_options
+                .dx12
+                .presentation_system = egui_wgpu::wgpu::Dx12SwapchainKind::DxgiFromVisual;
+        }
+
         let mut painter = Painter::new(
             context,
             WgpuConfiguration {
-                wgpu_setup: WgpuSetup::from_display_handle(event_loop.owned_display_handle()),
+                wgpu_setup: egui_wgpu::WgpuSetup::CreateNew(setup_create),
                 ..Default::default()
             },
             true,

--- a/harper-desktop/src-tauri/src/lib.rs
+++ b/harper-desktop/src-tauri/src/lib.rs
@@ -45,6 +45,9 @@ pub mod rect;
 #[cfg(target_os = "macos")]
 mod mac_broker;
 
+#[cfg(windows)]
+mod win_broker;
+
 #[derive(Parser)]
 struct Args {
     #[command(subcommand)]
@@ -69,7 +72,10 @@ struct IntegrationView {
 #[cfg(target_os = "macos")]
 pub(crate) type PlatformBroker = mac_broker::MacBroker;
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(windows)]
+pub(crate) type PlatformBroker = win_broker::WindowsBroker;
+
+#[cfg(not(any(target_os = "macos", windows)))]
 pub(crate) type PlatformBroker = os_broker::NoopBroker;
 
 fn platform_broker() -> PlatformBroker {
@@ -342,7 +348,10 @@ pub fn run_highlighter(has_parent: bool) {
     #[cfg(target_os = "macos")]
     let broker = mac_broker::MacBroker::new(integrations);
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(windows)]
+    let broker = win_broker::WindowsBroker::new(integrations);
+
+    #[cfg(not(any(target_os = "macos", windows)))]
     let broker = os_broker::NoopBroker;
 
     if let Err(error) = Highlighter::new(

--- a/harper-desktop/src-tauri/src/os_broker.rs
+++ b/harper-desktop/src-tauri/src/os_broker.rs
@@ -77,12 +77,11 @@ pub struct AppSearchResult {
 ///
 /// This lets the highlighter compile on non-macOS platforms while making it explicit that there is
 /// currently no accessibility or cursor integration there.
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", windows)))]
 #[derive(Default)]
-#[allow(dead_code)]
 pub struct NoopBroker;
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", windows)))]
 impl OsBroker for NoopBroker {
     fn get_boxes(
         &mut self,

--- a/harper-desktop/src-tauri/src/os_broker.rs
+++ b/harper-desktop/src-tauri/src/os_broker.rs
@@ -79,6 +79,7 @@ pub struct AppSearchResult {
 /// currently no accessibility or cursor integration there.
 #[cfg(not(target_os = "macos"))]
 #[derive(Default)]
+#[allow(dead_code)]
 pub struct NoopBroker;
 
 #[cfg(not(target_os = "macos"))]

--- a/harper-desktop/src-tauri/src/win_broker/app_catalog.rs
+++ b/harper-desktop/src-tauri/src/win_broker/app_catalog.rs
@@ -1,14 +1,92 @@
+use std::{process::Command, sync::OnceLock};
+
 use crate::os_broker::AppSearchResult;
 
-#[allow(dead_code)]
-pub fn installed_application_ids() -> Result<Vec<String>, String> {
-    Err("App catalog not yet implemented on Windows.".to_string())
+const START_MENU_SCRIPT: &str = r#"
+$shell = New-Object -ComObject WScript.Shell
+$startMenuPaths = @(
+    "$env:ProgramData\Microsoft\Windows\Start Menu\Programs",
+    "$env:APPDATA\Microsoft\Windows\Start Menu\Programs"
+)
+$apps = Get-ChildItem -Path $startMenuPaths -Recurse -Filter *.lnk -ErrorAction SilentlyContinue | ForEach-Object {
+    $target = $shell.CreateShortcut($_.FullName).TargetPath
+    if ($target -match '\.exe$') {
+        [PSCustomObject]@{
+            Name = $_.BaseName
+            ExeName = [System.IO.Path]::GetFileName($target).ToLower()
+            Path = $target
+        }
+    }
+} | Group-Object ExeName | ForEach-Object {
+    $_.Group[0]
+}
+$apps | ConvertTo-Json -Depth 2
+"#;
+
+#[derive(serde::Deserialize, Debug, Clone)]
+struct PsAppEntry {
+    #[serde(rename = "Name")]
+    pub name: String,
+    #[serde(rename = "ExeName")]
+    pub exe_name: String,
+    #[serde(rename = "Path")]
+    pub path: String,
 }
 
-pub fn app_display_name(app_id: &str) -> String {
-    app_id.to_owned()
+static CATALOG_CACHE: OnceLock<Vec<PsAppEntry>> = OnceLock::new();
+
+fn get_app_catalog() -> &'static [PsAppEntry] {
+    CATALOG_CACHE.get_or_init(|| {
+        let output = Command::new("powershell")
+            .arg("-NoProfile")
+            .arg("-Command")
+            .arg(START_MENU_SCRIPT)
+            .output();
+
+        let output = match output {
+            Ok(o) if o.status.success() => o,
+            _ => return Vec::new(),
+        };
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let apps: Vec<PsAppEntry> = serde_json::from_str(&stdout).unwrap_or_default();
+        apps
+    })
 }
 
-pub fn search_apps(_query: &str) -> Result<Vec<AppSearchResult>, String> {
-    Ok(Vec::new())
+pub fn search_apps(query: &str) -> Result<Vec<AppSearchResult>, String> {
+    let query_lower = query.to_lowercase();
+    let apps = get_app_catalog();
+
+    let mut results = Vec::new();
+    for app in apps {
+        if query_lower.is_empty() || app.name.to_lowercase().contains(&query_lower) {
+            results.push(AppSearchResult {
+                name: app.name.clone(),
+                bundle_id: app.exe_name.clone(),
+            });
+        }
+    }
+
+    // Sort alphabetically by name
+    results.sort_by(|a, b| a.name.cmp(&b.name));
+
+    Ok(results)
+}
+
+pub fn system_integration_display_name(bundle_id: &str) -> String {
+    let bundle_id_lower = bundle_id.to_lowercase();
+    get_app_catalog()
+        .iter()
+        .find(|app| app.exe_name == bundle_id_lower)
+        .map(|app| app.name.clone())
+        .unwrap_or_else(|| bundle_id.to_string())
+}
+
+pub fn application_path_for_bundle_id(bundle_id: &str) -> Option<String> {
+    let bundle_id_lower = bundle_id.to_lowercase();
+    get_app_catalog()
+        .iter()
+        .find(|app| app.exe_name == bundle_id_lower)
+        .map(|app| app.path.clone())
 }

--- a/harper-desktop/src-tauri/src/win_broker/app_catalog.rs
+++ b/harper-desktop/src-tauri/src/win_broker/app_catalog.rs
@@ -1,0 +1,14 @@
+use crate::os_broker::AppSearchResult;
+
+#[allow(dead_code)]
+pub fn installed_application_ids() -> Result<Vec<String>, String> {
+    Err("App catalog not yet implemented on Windows.".to_string())
+}
+
+pub fn app_display_name(app_id: &str) -> String {
+    app_id.to_owned()
+}
+
+pub fn search_apps(_query: &str) -> Result<Vec<AppSearchResult>, String> {
+    Ok(Vec::new())
+}

--- a/harper-desktop/src-tauri/src/win_broker/app_catalog.rs
+++ b/harper-desktop/src-tauri/src/win_broker/app_catalog.rs
@@ -8,19 +8,33 @@ $startMenuPaths = @(
     "$env:ProgramData\Microsoft\Windows\Start Menu\Programs",
     "$env:APPDATA\Microsoft\Windows\Start Menu\Programs"
 )
-$apps = Get-ChildItem -Path $startMenuPaths -Recurse -Filter *.lnk -ErrorAction SilentlyContinue | ForEach-Object {
-    $target = $shell.CreateShortcut($_.FullName).TargetPath
-    if ($target -match '\.exe$') {
-        [PSCustomObject]@{
-            Name = $_.BaseName
-            ExeName = [System.IO.Path]::GetFileName($target).ToLower()
-            Path = $target
-        }
-    }
-} | Group-Object ExeName | ForEach-Object {
-    $_.Group[0]
-}
-$apps | ConvertTo-Json -Depth 2
+
+$fromShortcuts = @(
+    Get-ChildItem -Path $startMenuPaths -Recurse -Filter *.lnk -ErrorAction SilentlyContinue |
+    ForEach-Object {
+        try {
+            $target = $shell.CreateShortcut($_.FullName).TargetPath
+            if ($target -match '\.exe$') {
+                [PSCustomObject]@{
+                    Name    = $_.BaseName
+                    ExeName = [System.IO.Path]::GetFileName($target).ToLower()
+                    Path    = $target
+                }
+            }
+        } catch {}
+    } |
+    Where-Object { $_ -ne $null }
+)
+
+# System executables that are always present but have no Start Menu shortcut.
+$systemApps = @(
+    [PSCustomObject]@{ Name = 'Notepad'; ExeName = 'notepad.exe'; Path = "$env:SystemRoot\System32\notepad.exe" },
+    [PSCustomObject]@{ Name = 'Paint';   ExeName = 'mspaint.exe'; Path = "$env:SystemRoot\System32\mspaint.exe"  }
+) | Where-Object { Test-Path $_.Path }
+
+$all = $fromShortcuts + @($systemApps)
+$apps = @($all | Where-Object { $_ } | Group-Object ExeName | ForEach-Object { $_.Group[0] })
+@($apps) | ConvertTo-Json -Depth 2
 "#;
 
 #[derive(serde::Deserialize, Debug, Clone)]
@@ -33,6 +47,7 @@ struct PsAppEntry {
     pub path: String,
 }
 
+// Built once at startup; new installs are visible only after a restart.
 static CATALOG_CACHE: OnceLock<Vec<PsAppEntry>> = OnceLock::new();
 
 fn get_app_catalog() -> &'static [PsAppEntry] {
@@ -68,7 +83,6 @@ pub fn search_apps(query: &str) -> Result<Vec<AppSearchResult>, String> {
         }
     }
 
-    // Sort alphabetically by name
     results.sort_by(|a, b| a.name.cmp(&b.name));
 
     Ok(results)

--- a/harper-desktop/src-tauri/src/win_broker/app_icons.rs
+++ b/harper-desktop/src-tauri/src/win_broker/app_icons.rs
@@ -1,28 +1,28 @@
 use std::process::Command;
 
 pub fn application_icon_png(app_path: &str) -> Result<Vec<u8>, String> {
-    let script = format!(
-        r#"
+    // Path is passed via environment variable to avoid PowerShell string injection.
+    let script = r#"
 Add-Type -AssemblyName System.Drawing
-$target = "{app_path}"
-try {{
+$target = $env:HARPER_APP_PATH
+try {
     $icon = [System.Drawing.Icon]::ExtractAssociatedIcon($target)
-    if ($null -ne $icon) {{
+    if ($null -ne $icon) {
         $bmp = $icon.ToBitmap()
         $ms = New-Object System.IO.MemoryStream
         $bmp.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png)
         Write-Output ([Convert]::ToBase64String($ms.ToArray()))
-    }}
-}} catch {{
+    }
+} catch {
     exit 1
-}}
-"#
-    );
+}
+"#;
 
     let output = Command::new("powershell")
         .arg("-NoProfile")
         .arg("-Command")
-        .arg(&script)
+        .arg(script)
+        .env("HARPER_APP_PATH", app_path)
         .output()
         .map_err(|e| format!("Failed to extract icon using PowerShell: {e}"))?;
 

--- a/harper-desktop/src-tauri/src/win_broker/app_icons.rs
+++ b/harper-desktop/src-tauri/src/win_broker/app_icons.rs
@@ -1,0 +1,42 @@
+use std::process::Command;
+
+pub fn application_icon_png(app_path: &str) -> Result<Vec<u8>, String> {
+    let script = format!(
+        r#"
+Add-Type -AssemblyName System.Drawing
+$target = "{app_path}"
+try {{
+    $icon = [System.Drawing.Icon]::ExtractAssociatedIcon($target)
+    if ($null -ne $icon) {{
+        $bmp = $icon.ToBitmap()
+        $ms = New-Object System.IO.MemoryStream
+        $bmp.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png)
+        Write-Output ([Convert]::ToBase64String($ms.ToArray()))
+    }}
+}} catch {{
+    exit 1
+}}
+"#
+    );
+
+    let output = Command::new("powershell")
+        .arg("-NoProfile")
+        .arg("-Command")
+        .arg(&script)
+        .output()
+        .map_err(|e| format!("Failed to extract icon using PowerShell: {e}"))?;
+
+    if !output.status.success() {
+        return Err(format!("Icon extraction failed for path: {app_path}"));
+    }
+
+    let b64 = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if b64.is_empty() {
+        return Err(format!("Empty icon extracted for path: {app_path}"));
+    }
+
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
+    STANDARD
+        .decode(b64)
+        .map_err(|e| format!("Failed to decode Base64 icon: {e}"))
+}

--- a/harper-desktop/src-tauri/src/win_broker/cursor_position.rs
+++ b/harper-desktop/src-tauri/src/win_broker/cursor_position.rs
@@ -1,8 +1,28 @@
-use windows::{Win32::Foundation::POINT, Win32::UI::WindowsAndMessaging::GetCursorPos};
+use windows::{
+    Win32::Foundation::{HWND, POINT},
+    Win32::UI::HiDpi::GetDpiForWindow,
+    Win32::UI::WindowsAndMessaging::{GetCursorPos, WindowFromPoint},
+};
 
-/// Returns the current global cursor position in physical screen pixels.
+/// Returns the current global cursor position in logical screen pixels.
 pub fn cursor_position() -> Option<egui::Pos2> {
     let mut point = POINT::default();
     unsafe { GetCursorPos(&mut point).ok()? };
-    Some(egui::pos2(point.x as f32, point.y as f32))
+
+    let scale_factor = match unsafe { WindowFromPoint(point) } {
+        hwnd if !hwnd.0.is_null() => {
+            let dpi = unsafe { GetDpiForWindow(hwnd) };
+            if dpi > 0 {
+                dpi as f64 / 96.0
+            } else {
+                1.0
+            }
+        }
+        _ => 1.0,
+    };
+
+    Some(egui::pos2(
+        (point.x as f64 / scale_factor) as f32,
+        (point.y as f64 / scale_factor) as f32,
+    ))
 }

--- a/harper-desktop/src-tauri/src/win_broker/cursor_position.rs
+++ b/harper-desktop/src-tauri/src/win_broker/cursor_position.rs
@@ -1,0 +1,8 @@
+use windows::{Win32::Foundation::POINT, Win32::UI::WindowsAndMessaging::GetCursorPos};
+
+/// Returns the current global cursor position in physical screen pixels.
+pub fn cursor_position() -> Option<egui::Pos2> {
+    let mut point = POINT::default();
+    unsafe { GetCursorPos(&mut point).ok()? };
+    Some(egui::pos2(point.x as f32, point.y as f32))
+}

--- a/harper-desktop/src-tauri/src/win_broker/cursor_position.rs
+++ b/harper-desktop/src-tauri/src/win_broker/cursor_position.rs
@@ -1,5 +1,5 @@
 use windows::{
-    Win32::Foundation::{HWND, POINT},
+    Win32::Foundation::POINT,
     Win32::UI::HiDpi::GetDpiForWindow,
     Win32::UI::WindowsAndMessaging::{GetCursorPos, WindowFromPoint},
 };
@@ -12,11 +12,7 @@ pub fn cursor_position() -> Option<egui::Pos2> {
     let scale_factor = match unsafe { WindowFromPoint(point) } {
         hwnd if !hwnd.0.is_null() => {
             let dpi = unsafe { GetDpiForWindow(hwnd) };
-            if dpi > 0 {
-                dpi as f64 / 96.0
-            } else {
-                1.0
-            }
+            if dpi > 0 { dpi as f64 / 96.0 } else { 1.0 }
         }
         _ => 1.0,
     };

--- a/harper-desktop/src-tauri/src/win_broker/focused_window.rs
+++ b/harper-desktop/src-tauri/src/win_broker/focused_window.rs
@@ -1,0 +1,25 @@
+use std::error::Error as StdError;
+use windows::{
+    Win32::Foundation::HWND,
+    Win32::UI::WindowsAndMessaging::{GetForegroundWindow, GetWindowThreadProcessId},
+};
+
+/// Returns the process ID of the currently focused window.
+///
+/// Returns `None` when no window is focused (e.g., desktop).
+pub fn focused_window_pid() -> Result<Option<u32>, Box<dyn StdError>> {
+    let hwnd: HWND = unsafe { GetForegroundWindow() };
+
+    if hwnd.is_invalid() {
+        return Ok(None);
+    }
+
+    let mut pid: u32 = 0;
+    unsafe { GetWindowThreadProcessId(hwnd, Some(&mut pid)) };
+
+    if pid == 0 {
+        return Ok(None);
+    }
+
+    Ok(Some(pid))
+}

--- a/harper-desktop/src-tauri/src/win_broker/mod.rs
+++ b/harper-desktop/src-tauri/src/win_broker/mod.rs
@@ -17,7 +17,7 @@ use crate::os_broker::{AccessibilityPermissionStatus, AppSearchResult, OsBroker}
 use crate::rect::ActionableLint;
 
 use self::window_stability::{
-    WINDOW_MOVEMENT_SETTLE_DURATION, WindowMovementState, frontmost_window_frame_for_pid,
+    WINDOW_MOVEMENT_SETTLE_DURATION, WindowMovementState, foreground_window_frame_for_pid,
     settled_window_state, window_frame_changed,
 };
 
@@ -65,7 +65,7 @@ impl WindowsBroker {
     }
 
     fn window_is_moving(&mut self, pid: u32) -> bool {
-        let Some(frame) = frontmost_window_frame_for_pid(pid) else {
+        let Some(frame) = foreground_window_frame_for_pid(pid) else {
             self.window_movement = None;
             return true;
         };

--- a/harper-desktop/src-tauri/src/win_broker/mod.rs
+++ b/harper-desktop/src-tauri/src/win_broker/mod.rs
@@ -1,4 +1,5 @@
 mod app_catalog;
+mod app_icons;
 mod cursor_position;
 mod focused_window;
 mod uia_text;
@@ -6,7 +7,7 @@ mod window_stability;
 
 use harper_core::linting::Lint;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     sync::{Arc, Mutex},
     time::Instant,
 };
@@ -29,6 +30,7 @@ pub struct WindowsBroker {
     last_focused: Option<(u32, Instant)>,
     integrations: Arc<Mutex<Vec<Integration>>>,
     window_movement: Option<WindowMovementState>,
+    application_icon_cache: Mutex<HashMap<String, Vec<u8>>>,
 }
 
 impl WindowsBroker {
@@ -37,6 +39,7 @@ impl WindowsBroker {
             last_focused: None,
             integrations,
             window_movement: None,
+            application_icon_cache: Mutex::new(HashMap::new()),
         }
     }
 
@@ -185,10 +188,33 @@ impl OsBroker for WindowsBroker {
     }
 
     fn system_integration_display_name(&self, app_id: &str) -> String {
-        app_catalog::app_display_name(app_id)
+        app_catalog::system_integration_display_name(app_id)
     }
 
     fn search_apps(&self, query: &str) -> Result<Vec<AppSearchResult>, String> {
         app_catalog::search_apps(query)
+    }
+
+    fn application_icon_png(&self, bundle_id: &str) -> Result<Vec<u8>, String> {
+        if let Some(icon_png) = self
+            .application_icon_cache
+            .lock()
+            .map_err(|error| format!("Failed to read application icon cache: {error}"))?
+            .get(bundle_id)
+        {
+            return Ok(icon_png.clone());
+        }
+
+        let app_path = app_catalog::application_path_for_bundle_id(bundle_id)
+            .ok_or_else(|| format!("Could not find path for app: {bundle_id}"))?;
+
+        let icon_png = app_icons::application_icon_png(&app_path)?;
+
+        self.application_icon_cache
+            .lock()
+            .map_err(|error| format!("Failed to update application icon cache: {error}"))?
+            .insert(bundle_id.to_string(), icon_png.clone());
+
+        Ok(icon_png)
     }
 }

--- a/harper-desktop/src-tauri/src/win_broker/mod.rs
+++ b/harper-desktop/src-tauri/src/win_broker/mod.rs
@@ -1,0 +1,194 @@
+mod app_catalog;
+mod cursor_position;
+mod focused_window;
+mod uia_text;
+mod window_stability;
+
+use harper_core::linting::Lint;
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+    time::Instant,
+};
+
+use crate::config::Integration;
+use crate::os_broker::{AccessibilityPermissionStatus, AppSearchResult, OsBroker};
+use crate::rect::ActionableLint;
+
+use self::window_stability::{
+    WINDOW_MOVEMENT_SETTLE_DURATION, WindowMovementState, frontmost_window_frame_for_pid,
+    settled_window_state, window_frame_changed,
+};
+
+/// Windows implementation of the OS data the highlighter needs.
+///
+/// Uses Microsoft UI Automation (UIA) for text extraction and standard Win32 APIs for
+/// cursor position and focused window detection. The UIA automation object is created
+/// lazily per thread to avoid COM threading constraints.
+pub struct WindowsBroker {
+    last_focused: Option<(u32, Instant)>,
+    integrations: Arc<Mutex<Vec<Integration>>>,
+    window_movement: Option<WindowMovementState>,
+}
+
+impl WindowsBroker {
+    pub fn new(integrations: Arc<Mutex<Vec<Integration>>>) -> Self {
+        Self {
+            last_focused: None,
+            integrations,
+            window_movement: None,
+        }
+    }
+
+    fn target_pid(&mut self) -> Option<u32> {
+        if let Some((last_pid, measured_at)) = self.last_focused {
+            if Instant::now().duration_since(measured_at).as_secs() < 3 {
+                return Some(last_pid);
+            }
+        }
+
+        let focused_pid = match focused_window::focused_window_pid() {
+            Ok(Some(pid)) => pid,
+            _ => return None,
+        };
+
+        let current_pid = std::process::id();
+        if focused_pid == current_pid {
+            return self.last_focused.map(|(pid, _)| pid);
+        }
+
+        self.last_focused = Some((focused_pid, Instant::now()));
+        Some(focused_pid)
+    }
+
+    fn window_is_moving(&mut self, pid: u32) -> bool {
+        let Some(frame) = frontmost_window_frame_for_pid(pid) else {
+            self.window_movement = None;
+            return true;
+        };
+
+        let now = Instant::now();
+        let Some(state) = &mut self.window_movement else {
+            self.window_movement = Some(settled_window_state(pid, frame, now));
+            return false;
+        };
+
+        if state.pid != pid {
+            *state = settled_window_state(pid, frame, now);
+            return false;
+        }
+
+        if window_frame_changed(state.frame, frame) {
+            state.frame = frame;
+            state.last_changed_at = now;
+            return true;
+        }
+
+        now.duration_since(state.last_changed_at) < WINDOW_MOVEMENT_SETTLE_DURATION
+    }
+
+    fn exe_name_for_pid(&self, pid: u32) -> Option<String> {
+        use windows::{
+            Win32::Foundation::CloseHandle,
+            Win32::System::Threading::{
+                OpenProcess, PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION,
+                QueryFullProcessImageNameW,
+            },
+        };
+
+        let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid).ok()? };
+
+        let mut buf = vec![0u16; 260];
+        let mut size = buf.len() as u32;
+
+        let ok = unsafe {
+            QueryFullProcessImageNameW(
+                handle,
+                PROCESS_NAME_WIN32,
+                windows::core::PWSTR(buf.as_mut_ptr()),
+                &mut size,
+            )
+        }
+        .is_ok();
+
+        unsafe { CloseHandle(handle).ok() };
+
+        if !ok {
+            return None;
+        }
+
+        let path: String = String::from_utf16_lossy(&buf[..size as usize]);
+        std::path::Path::new(&path)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|s| s.to_lowercase())
+    }
+}
+
+impl Default for WindowsBroker {
+    fn default() -> Self {
+        Self::new(Arc::new(Mutex::new(Integration::curated_integrations())))
+    }
+}
+
+impl OsBroker for WindowsBroker {
+    fn get_boxes(
+        &mut self,
+        lint_text: &mut dyn FnMut(&str) -> BTreeMap<String, Vec<Lint>>,
+    ) -> Vec<ActionableLint> {
+        let pid = match self.target_pid() {
+            Some(pid) => pid,
+            None => {
+                self.window_movement = None;
+                return Vec::new();
+            }
+        };
+
+        let app_id = match self.exe_name_for_pid(pid) {
+            Some(name) => name,
+            None => {
+                self.window_movement = None;
+                return Vec::new();
+            }
+        };
+
+        let integration_enabled = match self.integrations.lock() {
+            Ok(integrations) => Integration::is_integration_enabled_in(&integrations, &app_id),
+            Err(e) => {
+                eprintln!("Unable to read integrations: {e}");
+                false
+            }
+        };
+
+        if !integration_enabled {
+            self.window_movement = None;
+            return Vec::new();
+        }
+
+        if self.window_is_moving(pid) {
+            return Vec::new();
+        }
+
+        let Some((automation, root)) = uia_text::focused_element() else {
+            return Vec::new();
+        };
+
+        uia_text::collect_rects(&root, &automation, lint_text)
+    }
+
+    fn cursor_position(&self) -> Option<egui::Pos2> {
+        cursor_position::cursor_position()
+    }
+
+    fn accessibility_permission_status(&self) -> AccessibilityPermissionStatus {
+        AccessibilityPermissionStatus::Granted
+    }
+
+    fn system_integration_display_name(&self, app_id: &str) -> String {
+        app_catalog::app_display_name(app_id)
+    }
+
+    fn search_apps(&self, query: &str) -> Result<Vec<AppSearchResult>, String> {
+        app_catalog::search_apps(query)
+    }
+}

--- a/harper-desktop/src-tauri/src/win_broker/uia_text.rs
+++ b/harper-desktop/src-tauri/src/win_broker/uia_text.rs
@@ -1,7 +1,7 @@
 use harper_core::linting::{Lint, Suggestion};
 use std::{cell::RefCell, collections::BTreeMap};
 use windows::{
-    Win32::Foundation::RPC_E_CHANGED_MODE,
+    Win32::Foundation::{HWND, RPC_E_CHANGED_MODE},
     Win32::System::Com::{
         CLSCTX_INPROC_SERVER, COINIT_MULTITHREADED, CoCreateInstance, CoInitializeEx, SAFEARRAY,
     },
@@ -10,10 +10,11 @@ use windows::{
     Win32::UI::Accessibility::{
         CUIAutomation, IUIAutomation, IUIAutomationCondition, IUIAutomationElement,
         IUIAutomationTextPattern, IUIAutomationValuePattern, TextPatternRangeEndpoint_End,
-        TextPatternRangeEndpoint_Start, TextUnit_Character, TreeScope_Descendants,
+        TextPatternRangeEndpoint_Start, TextUnit_Character, TreeScope_Subtree,
         UIA_ControlTypePropertyId, UIA_DocumentControlTypeId, UIA_EditControlTypeId,
         UIA_TextPatternId, UIA_ValuePatternId,
     },
+    Win32::UI::HiDpi::GetDpiForWindow,
     core::BSTR,
 };
 
@@ -70,7 +71,7 @@ pub fn collect_rects(
         return Vec::new();
     };
 
-    let Ok(elements) = (unsafe { root.FindAll(TreeScope_Descendants, &condition) }) else {
+    let Ok(elements) = (unsafe { root.FindAll(TreeScope_Subtree, &condition) }) else {
         return Vec::new();
     };
 
@@ -92,6 +93,18 @@ fn collect_rects_for_element(
     lint_text: &mut LintCallback<'_>,
     rects: &mut Vec<ActionableLint>,
 ) {
+    let scale_factor = match unsafe { element.CurrentNativeWindowHandle() } {
+        Ok(hwnd) if !hwnd.0.is_null() => {
+            let dpi = unsafe { GetDpiForWindow(hwnd) };
+            if dpi > 0 {
+                dpi as f64 / 96.0
+            } else {
+                1.0
+            }
+        }
+        _ => 1.0,
+    };
+
     let text = match element_text(element) {
         Some(t) if !t.is_empty() => t,
         _ => return,
@@ -101,7 +114,7 @@ fn collect_rects_for_element(
 
     for (rule_name, lints) in organized_lints {
         for lint in lints {
-            let Some(rect) = text_range_rect(element, lint.span.start, lint.span.len()) else {
+            let Some(rect) = text_range_rect(element, lint.span.start, lint.span.len(), scale_factor) else {
                 continue;
             };
 
@@ -158,7 +171,7 @@ fn element_text(element: &IUIAutomationElement) -> Option<String> {
 }
 
 /// Returns screen-space bounds for a character range using TextPattern.
-fn text_range_rect(element: &IUIAutomationElement, start: usize, length: usize) -> Option<Rect> {
+fn text_range_rect(element: &IUIAutomationElement, start: usize, length: usize, scale_factor: f64) -> Option<Rect> {
     let pattern =
         unsafe { element.GetCurrentPatternAs::<IUIAutomationTextPattern>(UIA_TextPatternId) }
             .ok()?;
@@ -204,7 +217,12 @@ fn text_range_rect(element: &IUIAutomationElement, start: usize, length: usize) 
         return None;
     }
 
-    Some(Rect::new(x, y, w, h))
+    Some(Rect::new(
+        x / scale_factor,
+        y / scale_factor,
+        w / scale_factor,
+        h / scale_factor,
+    ))
 }
 
 /// Reads a SAFEARRAY of VT_R8 (f64) values into a Vec.

--- a/harper-desktop/src-tauri/src/win_broker/uia_text.rs
+++ b/harper-desktop/src-tauri/src/win_broker/uia_text.rs
@@ -1,21 +1,24 @@
 use harper_core::linting::{Lint, Suggestion};
 use std::{cell::RefCell, collections::BTreeMap};
 use windows::{
-    Win32::Foundation::{HWND, RPC_E_CHANGED_MODE},
+    Win32::Foundation::RPC_E_CHANGED_MODE,
     Win32::System::Com::{
         CLSCTX_INPROC_SERVER, COINIT_MULTITHREADED, CoCreateInstance, CoInitializeEx, SAFEARRAY,
     },
-    Win32::System::Ole::{SafeArrayGetElement, SafeArrayGetLBound, SafeArrayGetUBound},
+    Win32::System::Ole::{
+        SafeArrayDestroy, SafeArrayGetElement, SafeArrayGetLBound, SafeArrayGetUBound,
+    },
     Win32::System::Variant::VARIANT,
     Win32::UI::Accessibility::{
         CUIAutomation, IUIAutomation, IUIAutomationCondition, IUIAutomationElement,
-        IUIAutomationTextPattern, IUIAutomationValuePattern, TextPatternRangeEndpoint_End,
-        TextPatternRangeEndpoint_Start, TextUnit_Character, TreeScope_Subtree,
-        UIA_ControlTypePropertyId, UIA_DocumentControlTypeId, UIA_EditControlTypeId,
-        UIA_TextPatternId, UIA_ValuePatternId,
+        IUIAutomationLegacyIAccessiblePattern, IUIAutomationTextPattern, IUIAutomationValuePattern,
+        TextPatternRangeEndpoint_End, TextPatternRangeEndpoint_Start, TextUnit_Character,
+        TreeScope_Subtree, UIA_ControlTypePropertyId, UIA_DocumentControlTypeId,
+        UIA_EditControlTypeId, UIA_LegacyIAccessiblePatternId, UIA_TextPatternId,
+        UIA_ValuePatternId,
     },
     Win32::UI::HiDpi::GetDpiForWindow,
-    core::BSTR,
+    core::{BSTR, PCWSTR},
 };
 
 use crate::rect::{ActionableLint, Rect};
@@ -96,11 +99,7 @@ fn collect_rects_for_element(
     let scale_factor = match unsafe { element.CurrentNativeWindowHandle() } {
         Ok(hwnd) if !hwnd.0.is_null() => {
             let dpi = unsafe { GetDpiForWindow(hwnd) };
-            if dpi > 0 {
-                dpi as f64 / 96.0
-            } else {
-                1.0
-            }
+            if dpi > 0 { dpi as f64 / 96.0 } else { 1.0 }
         }
         _ => 1.0,
     };
@@ -114,7 +113,9 @@ fn collect_rects_for_element(
 
     for (rule_name, lints) in organized_lints {
         for lint in lints {
-            let Some(rect) = text_range_rect(element, lint.span.start, lint.span.len(), scale_factor) else {
+            let Some(rect) =
+                text_range_rect(element, lint.span.start, lint.span.len(), scale_factor)
+            else {
                 continue;
             };
 
@@ -171,7 +172,12 @@ fn element_text(element: &IUIAutomationElement) -> Option<String> {
 }
 
 /// Returns screen-space bounds for a character range using TextPattern.
-fn text_range_rect(element: &IUIAutomationElement, start: usize, length: usize, scale_factor: f64) -> Option<Rect> {
+fn text_range_rect(
+    element: &IUIAutomationElement,
+    start: usize,
+    length: usize,
+    scale_factor: f64,
+) -> Option<Rect> {
     let pattern =
         unsafe { element.GetCurrentPatternAs::<IUIAutomationTextPattern>(UIA_TextPatternId) }
             .ok()?;
@@ -207,6 +213,7 @@ fn text_range_rect(element: &IUIAutomationElement, start: usize, length: usize, 
 
     let sa = unsafe { range.GetBoundingRectangles() }.ok()?;
     let values = unsafe { read_safearray_f64(sa) };
+    unsafe { SafeArrayDestroy(sa) }.ok();
 
     if values.len() < 4 {
         return None;
@@ -264,12 +271,22 @@ fn apply_suggestion_to_element(
     let mut chars: Vec<char> = source_text.chars().collect();
     suggestion.apply(lint.span, &mut chars);
     let updated: String = chars.into_iter().collect();
+    let bstr = BSTR::from(updated.as_str());
 
     if let Ok(pattern) =
         unsafe { element.GetCurrentPatternAs::<IUIAutomationValuePattern>(UIA_ValuePatternId) }
     {
-        let bstr = BSTR::from(updated.as_str());
         let _ = unsafe { pattern.SetValue(&bstr) };
+        return;
+    }
+
+    // Fallback for elements that expose TextPattern but not ValuePattern (e.g. multi-line editors).
+    if let Ok(pattern) = unsafe {
+        element.GetCurrentPatternAs::<IUIAutomationLegacyIAccessiblePattern>(
+            UIA_LegacyIAccessiblePatternId,
+        )
+    } {
+        let _ = unsafe { pattern.SetValue(PCWSTR(bstr.as_ptr())) };
     }
 }
 

--- a/harper-desktop/src-tauri/src/win_broker/uia_text.rs
+++ b/harper-desktop/src-tauri/src/win_broker/uia_text.rs
@@ -1,0 +1,274 @@
+use harper_core::linting::{Lint, Suggestion};
+use std::{cell::RefCell, collections::BTreeMap};
+use windows::{
+    Win32::Foundation::RPC_E_CHANGED_MODE,
+    Win32::System::Com::{
+        CLSCTX_INPROC_SERVER, COINIT_MULTITHREADED, CoCreateInstance, CoInitializeEx, SAFEARRAY,
+    },
+    Win32::System::Ole::{SafeArrayGetElement, SafeArrayGetLBound, SafeArrayGetUBound},
+    Win32::System::Variant::VARIANT,
+    Win32::UI::Accessibility::{
+        CUIAutomation, IUIAutomation, IUIAutomationCondition, IUIAutomationElement,
+        IUIAutomationTextPattern, IUIAutomationValuePattern, TextPatternRangeEndpoint_End,
+        TextPatternRangeEndpoint_Start, TextUnit_Character, TreeScope_Descendants,
+        UIA_ControlTypePropertyId, UIA_DocumentControlTypeId, UIA_EditControlTypeId,
+        UIA_TextPatternId, UIA_ValuePatternId,
+    },
+    core::BSTR,
+};
+
+use crate::rect::{ActionableLint, Rect};
+
+pub type LintCallback<'a> = dyn FnMut(&str) -> BTreeMap<String, Vec<Lint>> + 'a;
+
+thread_local! {
+    static AUTOMATION: RefCell<Option<IUIAutomation>> = const { RefCell::new(None) };
+}
+
+fn with_automation<F, T>(f: F) -> Option<T>
+where
+    F: FnOnce(&IUIAutomation) -> T,
+{
+    AUTOMATION.with(|cell| {
+        let mut guard = cell.borrow_mut();
+        if guard.is_none() {
+            *guard = init_automation().ok();
+        }
+        guard.as_ref().map(f)
+    })
+}
+
+fn init_automation() -> windows::core::Result<IUIAutomation> {
+    unsafe { CoInitializeEx(None, COINIT_MULTITHREADED) }
+        .ok()
+        .or_else(|e| {
+            if e.code() == RPC_E_CHANGED_MODE {
+                Ok(())
+            } else {
+                Err(e)
+            }
+        })?;
+
+    unsafe { CoCreateInstance(&CUIAutomation, None, CLSCTX_INPROC_SERVER) }
+}
+
+/// Returns the UIA automation instance and the currently focused element.
+pub fn focused_element() -> Option<(IUIAutomation, IUIAutomationElement)> {
+    with_automation(|automation| {
+        let element = unsafe { automation.GetFocusedElement() }.ok()?;
+        Some((automation.clone(), element))
+    })
+    .flatten()
+}
+
+pub fn collect_rects(
+    root: &IUIAutomationElement,
+    automation: &IUIAutomation,
+    lint_text: &mut LintCallback<'_>,
+) -> Vec<ActionableLint> {
+    let Ok(condition) = edit_control_condition(automation) else {
+        return Vec::new();
+    };
+
+    let Ok(elements) = (unsafe { root.FindAll(TreeScope_Descendants, &condition) }) else {
+        return Vec::new();
+    };
+
+    let count = unsafe { elements.Length() }.unwrap_or(0);
+    let mut rects = Vec::new();
+
+    for i in 0..count {
+        let Ok(element) = (unsafe { elements.GetElement(i) }) else {
+            continue;
+        };
+        collect_rects_for_element(&element, lint_text, &mut rects);
+    }
+
+    rects
+}
+
+fn collect_rects_for_element(
+    element: &IUIAutomationElement,
+    lint_text: &mut LintCallback<'_>,
+    rects: &mut Vec<ActionableLint>,
+) {
+    let text = match element_text(element) {
+        Some(t) if !t.is_empty() => t,
+        _ => return,
+    };
+
+    let organized_lints = lint_text(&text);
+
+    for (rule_name, lints) in organized_lints {
+        for lint in lints {
+            let Some(rect) = text_range_rect(element, lint.span.start, lint.span.len()) else {
+                continue;
+            };
+
+            let element_clone = element.clone();
+            let source_text = text.clone();
+            let suggestion_source_text = text.clone();
+            let suggestion_lint = lint.clone();
+
+            rects.push(ActionableLint::new(
+                rect,
+                rule_name.clone(),
+                lint,
+                source_text,
+                move |suggestion| {
+                    apply_suggestion_to_element(
+                        &element_clone,
+                        suggestion_source_text.clone(),
+                        suggestion_lint.clone(),
+                        suggestion,
+                    );
+                },
+            ));
+        }
+    }
+}
+
+/// Reads the text value of an element, trying TextPattern first then ValuePattern.
+fn element_text(element: &IUIAutomationElement) -> Option<String> {
+    if let Ok(pattern) =
+        unsafe { element.GetCurrentPatternAs::<IUIAutomationTextPattern>(UIA_TextPatternId) }
+    {
+        if let Ok(range) = unsafe { pattern.DocumentRange() } {
+            if let Ok(bstr) = unsafe { range.GetText(-1) } {
+                let s = bstr.to_string();
+                if !s.is_empty() {
+                    return Some(s);
+                }
+            }
+        }
+    }
+
+    if let Ok(pattern) =
+        unsafe { element.GetCurrentPatternAs::<IUIAutomationValuePattern>(UIA_ValuePatternId) }
+    {
+        if let Ok(bstr) = unsafe { pattern.CurrentValue() } {
+            let s = bstr.to_string();
+            if !s.is_empty() {
+                return Some(s);
+            }
+        }
+    }
+
+    None
+}
+
+/// Returns screen-space bounds for a character range using TextPattern.
+fn text_range_rect(element: &IUIAutomationElement, start: usize, length: usize) -> Option<Rect> {
+    let pattern =
+        unsafe { element.GetCurrentPatternAs::<IUIAutomationTextPattern>(UIA_TextPatternId) }
+            .ok()?;
+
+    let doc_range = unsafe { pattern.DocumentRange() }.ok()?;
+    let text = unsafe { doc_range.GetText(-1) }.ok()?.to_string();
+
+    let char_count = text.chars().count();
+    if start >= char_count || length == 0 {
+        return None;
+    }
+    let end = (start + length).min(char_count);
+
+    let range = unsafe { doc_range.Clone() }.ok()?;
+
+    unsafe {
+        range.MoveEndpointByUnit(
+            TextPatternRangeEndpoint_Start,
+            TextUnit_Character,
+            start as i32,
+        )
+    }
+    .ok()?;
+
+    unsafe {
+        range.MoveEndpointByUnit(
+            TextPatternRangeEndpoint_End,
+            TextUnit_Character,
+            -(char_count as i32 - end as i32),
+        )
+    }
+    .ok()?;
+
+    let sa = unsafe { range.GetBoundingRectangles() }.ok()?;
+    let values = unsafe { read_safearray_f64(sa) };
+
+    if values.len() < 4 {
+        return None;
+    }
+
+    let (x, y, w, h) = (values[0], values[1], values[2], values[3]);
+    if w <= 0.0 || h <= 0.0 {
+        return None;
+    }
+
+    Some(Rect::new(x, y, w, h))
+}
+
+/// Reads a SAFEARRAY of VT_R8 (f64) values into a Vec.
+unsafe fn read_safearray_f64(sa: *mut SAFEARRAY) -> Vec<f64> {
+    if sa.is_null() {
+        return Vec::new();
+    }
+
+    let lb = match unsafe { SafeArrayGetLBound(sa, 1) } {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    let ub = match unsafe { SafeArrayGetUBound(sa, 1) } {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+
+    if ub < lb {
+        return Vec::new();
+    }
+
+    let count = (ub - lb + 1) as usize;
+    let mut values = vec![0.0f64; count];
+
+    for i in 0..count {
+        let idx = lb + i as i32;
+        let _ = unsafe { SafeArrayGetElement(sa, &idx, values[i..].as_mut_ptr() as *mut _) };
+    }
+
+    values
+}
+
+fn apply_suggestion_to_element(
+    element: &IUIAutomationElement,
+    source_text: String,
+    lint: Lint,
+    suggestion: Suggestion,
+) {
+    let mut chars: Vec<char> = source_text.chars().collect();
+    suggestion.apply(lint.span, &mut chars);
+    let updated: String = chars.into_iter().collect();
+
+    if let Ok(pattern) =
+        unsafe { element.GetCurrentPatternAs::<IUIAutomationValuePattern>(UIA_ValuePatternId) }
+    {
+        let bstr = BSTR::from(updated.as_str());
+        let _ = unsafe { pattern.SetValue(&bstr) };
+    }
+}
+
+fn edit_control_condition(
+    automation: &IUIAutomation,
+) -> windows::core::Result<IUIAutomationCondition> {
+    let edit_cond = unsafe {
+        automation.CreatePropertyCondition(
+            UIA_ControlTypePropertyId,
+            &VARIANT::from(UIA_EditControlTypeId.0 as i32),
+        )?
+    };
+    let doc_cond = unsafe {
+        automation.CreatePropertyCondition(
+            UIA_ControlTypePropertyId,
+            &VARIANT::from(UIA_DocumentControlTypeId.0 as i32),
+        )?
+    };
+    unsafe { automation.CreateOrCondition(&edit_cond, &doc_cond) }
+}

--- a/harper-desktop/src-tauri/src/win_broker/window_stability.rs
+++ b/harper-desktop/src-tauri/src/win_broker/window_stability.rs
@@ -1,0 +1,64 @@
+use std::time::{Duration, Instant};
+use windows::{
+    Win32::Foundation::{HWND, RECT},
+    Win32::UI::WindowsAndMessaging::{
+        GetForegroundWindow, GetWindowRect, GetWindowThreadProcessId,
+    },
+};
+
+use crate::rect::Rect;
+
+pub const WINDOW_MOVEMENT_SETTLE_DURATION: Duration = Duration::from_millis(150);
+const WINDOW_FRAME_TOLERANCE: f64 = 0.5;
+
+pub struct WindowMovementState {
+    pub pid: u32,
+    pub frame: Rect,
+    pub last_changed_at: Instant,
+}
+
+pub fn window_frame_changed(previous: Rect, current: Rect) -> bool {
+    !nearly_equal(previous.x, current.x)
+        || !nearly_equal(previous.y, current.y)
+        || !nearly_equal(previous.width, current.width)
+        || !nearly_equal(previous.height, current.height)
+}
+
+pub fn settled_window_state(pid: u32, frame: Rect, now: Instant) -> WindowMovementState {
+    WindowMovementState {
+        pid,
+        frame,
+        last_changed_at: now
+            .checked_sub(WINDOW_MOVEMENT_SETTLE_DURATION)
+            .unwrap_or(now),
+    }
+}
+
+fn nearly_equal(left: f64, right: f64) -> bool {
+    (left - right).abs() <= WINDOW_FRAME_TOLERANCE
+}
+
+pub fn frontmost_window_frame_for_pid(pid: u32) -> Option<Rect> {
+    let hwnd: HWND = unsafe { GetForegroundWindow() };
+
+    if hwnd.is_invalid() {
+        return None;
+    }
+
+    let mut owner_pid: u32 = 0;
+    unsafe { GetWindowThreadProcessId(hwnd, Some(&mut owner_pid)) };
+
+    if owner_pid != pid {
+        return None;
+    }
+
+    let mut rect = RECT::default();
+    unsafe { GetWindowRect(hwnd, &mut rect).ok()? };
+
+    Some(Rect {
+        x: rect.left as f64,
+        y: rect.top as f64,
+        width: (rect.right - rect.left) as f64,
+        height: (rect.bottom - rect.top) as f64,
+    })
+}

--- a/harper-desktop/src-tauri/src/win_broker/window_stability.rs
+++ b/harper-desktop/src-tauri/src/win_broker/window_stability.rs
@@ -38,7 +38,7 @@ fn nearly_equal(left: f64, right: f64) -> bool {
     (left - right).abs() <= WINDOW_FRAME_TOLERANCE
 }
 
-pub fn frontmost_window_frame_for_pid(pid: u32) -> Option<Rect> {
+pub fn foreground_window_frame_for_pid(pid: u32) -> Option<Rect> {
     let hwnd: HWND = unsafe { GetForegroundWindow() };
 
     if hwnd.is_invalid() {

--- a/harper-desktop/src/lib/settings/components/AppPickerModal.svelte
+++ b/harper-desktop/src/lib/settings/components/AppPickerModal.svelte
@@ -9,6 +9,8 @@ export let isSaving = false;
 export let close: () => void;
 export let add: (bundleId: string) => void;
 
+const isWindows = navigator.userAgent.includes('Windows');
+
 let searchResults: AppSearchResult[] = [];
 let isSearching = false;
 let debounceTimeout: number | null = null;
@@ -100,7 +102,7 @@ function submit() {
   >
     <div class="modal-head">
       <strong>Add application</strong>
-      <span>Enter the app bundle ID Harper should watch.</span>
+      <span>{isWindows ? 'Search for an app, or type the .exe filename to add it.' : 'Enter the app bundle ID Harper should watch.'}</span>
     </div>
     <div class="modal-search">
       <span class="settings-icon icon-search" aria-hidden="true"></span>
@@ -144,10 +146,10 @@ function submit() {
         {#if isDuplicate}
           <div class="empty">That application is already configured.</div>
         {:else}
-          <div class="empty">No matching apps found. Try typing the bundle ID directly (e.g., com.apple.TextEdit)</div>
+          <div class="empty">{isWindows ? 'No matching apps found. Try typing the .exe filename directly (e.g., notepad.exe).' : 'No matching apps found. Try typing the bundle ID directly (e.g., com.apple.TextEdit).'}</div>
         {/if}
       {:else}
-        <div class="empty">Search for an app by name, or enter the bundle ID directly.</div>
+        <div class="empty">{isWindows ? 'Search for an app by name, or type the .exe filename directly.' : 'Search for an app by name, or enter the bundle ID directly.'}</div>
       {/if}
     </div>
     <div class="modal-actions">

--- a/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
+++ b/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
@@ -162,7 +162,10 @@ async function requestAccessibilityPermission() {
 	}
 }
 
-function accessibilityDescription(status: AccessibilityPermissionStatus | null, isWindows: boolean) {
+function accessibilityDescription(
+	status: AccessibilityPermissionStatus | null,
+	isWindows: boolean,
+) {
 	if (isWindows) {
 		return 'Harper on Windows does not require special accessibility permissions.';
 	}

--- a/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
+++ b/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
@@ -33,7 +33,7 @@ let isLaunchingTextEdit = false;
 let testDriveError = '';
 
 const isWindows = navigator.userAgent.includes('Windows');
-const defaultAppBundleId = isWindows ? 'Microsoft.WindowsNotepad' : 'com.apple.TextEdit';
+const defaultAppBundleId = isWindows ? 'notepad.exe' : 'com.apple.TextEdit';
 const defaultAppName = isWindows ? 'Notepad' : 'TextEdit';
 
 $: defaultAppIntegration = integrations.find((item) => item.bundle_id === defaultAppBundleId);
@@ -296,7 +296,7 @@ function buildSetupSteps(
             </button>
           </div>
         {:else}
-          {#if accessibilityStatus !== "Granted"}
+          {#if !isWindows && accessibilityStatus !== "Granted"}
             <div class="warning-banner">
               <div class="big-mark amber">!</div>
               <div>
@@ -357,7 +357,7 @@ function buildSetupSteps(
                   <div class="detected-app">
                     <div class="app-tile" style="--app-tint: #b06a1b">A</div>
                     <div class="grow">
-                      <strong>Waiting for macOS</strong>
+                      <strong>Permission pending</strong>
                       <p>After granting access in System Settings, return here and recheck permission.</p>
                     </div>
                   </div>

--- a/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
+++ b/harper-desktop/src/lib/settings/pages/GettingStartedPage.svelte
@@ -32,8 +32,13 @@ let isEnablingTextEdit = false;
 let isLaunchingTextEdit = false;
 let testDriveError = '';
 
-$: textEditIntegration = integrations.find((item) => item.bundle_id === 'com.apple.TextEdit');
-$: isTextEditEnabled = textEditIntegration?.enabled === true;
+const isWindows = navigator.userAgent.includes('Windows');
+const defaultAppBundleId = isWindows ? 'Microsoft.WindowsNotepad' : 'com.apple.TextEdit';
+const defaultAppName = isWindows ? 'Notepad' : 'TextEdit';
+
+$: defaultAppIntegration = integrations.find((item) => item.bundle_id === defaultAppBundleId);
+$: isDefaultAppEnabled = defaultAppIntegration?.enabled === true;
+$: isAccessibilityDone = isWindows || accessibilityStatus === 'Granted';
 
 $: setupSteps = buildSetupSteps(
 	state,
@@ -41,9 +46,10 @@ $: setupSteps = buildSetupSteps(
 	isCheckingAccessibility,
 	isRequestingAccessibility,
 	hasRequestedAccessibility,
-	isTextEditEnabled,
+	isDefaultAppEnabled,
 	isLoadingIntegrations,
 	isEnablingTextEdit,
+	isWindows,
 );
 $: setupCompletedCount = setupSteps.filter((step) => step.done).length;
 $: setupAllDone = setupSteps.every((step) => step.done);
@@ -75,18 +81,18 @@ async function enableTextEditForSetup() {
 	integrationsError = '';
 
 	try {
-		if (textEditIntegration) {
-			await Client.setIntegrationEnabled('com.apple.TextEdit', true);
+		if (defaultAppIntegration) {
+			await Client.setIntegrationEnabled(defaultAppBundleId, true);
 			integrations = integrations.map((integration) =>
-				integration.bundle_id === 'com.apple.TextEdit'
+				integration.bundle_id === defaultAppBundleId
 					? { ...integration, enabled: true }
 					: integration,
 			);
 		} else {
-			await Client.addIntegration('com.apple.TextEdit');
+			await Client.addIntegration(defaultAppBundleId);
 			integrations = [
 				...integrations,
-				{ bundle_id: 'com.apple.TextEdit', enabled: true, display_name: 'TextEdit' },
+				{ bundle_id: defaultAppBundleId, enabled: true, display_name: defaultAppName },
 			];
 		}
 
@@ -107,10 +113,10 @@ async function launchTextEditForTestDrive() {
 	testDriveError = '';
 
 	try {
-		await Client.launchApp('com.apple.TextEdit');
+		await Client.launchApp(defaultAppBundleId);
 		updateSetup({ testDrive: 'completed' });
 	} catch (error) {
-		testDriveError = `Unable to launch TextEdit: ${error}`;
+		testDriveError = `Unable to launch ${defaultAppName}: ${error}`;
 	} finally {
 		isLaunchingTextEdit = false;
 	}
@@ -156,7 +162,11 @@ async function requestAccessibilityPermission() {
 	}
 }
 
-function accessibilityDescription(status: AccessibilityPermissionStatus | null) {
+function accessibilityDescription(status: AccessibilityPermissionStatus | null, isWindows: boolean) {
+	if (isWindows) {
+		return 'Harper on Windows does not require special accessibility permissions.';
+	}
+
 	if (status === 'Granted') {
 		return 'Harper can access text through the macOS Accessibility system.';
 	}
@@ -206,11 +216,13 @@ function buildSetupSteps(
 	currentIsTextEditEnabled: boolean,
 	currentIsLoadingIntegrations: boolean,
 	currentIsEnablingTextEdit: boolean,
+	isWindows: boolean,
 ): SetupStep[] {
-	const accessibilityDone = currentAccessibilityStatus === 'Granted';
+	const accessibilityDone = isWindows || currentAccessibilityStatus === 'Granted';
 	const integrationDone = currentIsTextEditEnabled;
 	const testDriveDone = currentState.setup.testDrive === 'completed';
 	const accessibilityActionDisabled =
+		isWindows ||
 		currentIsCheckingAccessibility ||
 		currentIsRequestingAccessibility ||
 		currentAccessibilityStatus === 'Granted' ||
@@ -220,8 +232,8 @@ function buildSetupSteps(
 		{
 			id: 'accessibility',
 			title: 'Grant Accessibility permission',
-			desc: accessibilityDescription(currentAccessibilityStatus),
-			required: true,
+			desc: accessibilityDescription(currentAccessibilityStatus, isWindows),
+			required: !isWindows,
 			done: accessibilityDone,
 			locked: false,
 			actionLabel: accessibilityActionLabel(
@@ -237,7 +249,7 @@ function buildSetupSteps(
 		{
 			id: 'integration',
 			title: 'Pick an app to test',
-			desc: 'Start with TextEdit, then add more apps from Integrations when you are ready.',
+			desc: `Start with ${defaultAppName}, then add more apps from Integrations when you are ready.`,
 			required: true,
 			done: integrationDone,
 			locked: !accessibilityDone,
@@ -249,7 +261,7 @@ function buildSetupSteps(
 		{
 			id: 'test-drive',
 			title: 'Take a test drive',
-			desc: 'Open TextEdit, type "its not alot of fun", and watch Harper underline the mistakes.',
+			desc: `Open ${defaultAppName}, type "its not alot of fun", and watch Harper underline the mistakes.`,
 			required: false,
 			done: testDriveDone,
 			locked: !accessibilityDone || !integrationDone,
@@ -257,7 +269,7 @@ function buildSetupSteps(
 				? 'Launching...'
 				: testDriveDone
 					? 'Run again'
-					: 'Launch TextEdit',
+					: `Launch ${defaultAppName}`,
 			actionVariant: testDriveDone ? 'default' : 'primary',
 			action: launchTextEditForTestDrive,
 			actionDisabled: isLaunchingTextEdit,
@@ -288,13 +300,13 @@ function buildSetupSteps(
             <div class="warning-banner">
               <div class="big-mark amber">!</div>
               <div>
-                {#if isCheckingAccessibility}
+                {#if isCheckingAccessibility && !isWindows}
                   <strong>Checking Accessibility permission</strong>
                   <p>Harper needs macOS Accessibility access before it can check other apps.</p>
                 {:else if accessibilityStatus === "Unsupported"}
                   <strong>Accessibility setup is unavailable</strong>
                   <p>Harper Desktop app checking is currently only wired for macOS.</p>
-                {:else}
+                {:else if !isWindows}
                   <strong>Harper is not checking anything yet</strong>
                   <p>Grant Accessibility permission so Harper can find text and surface suggestions.</p>
                 {/if}
@@ -355,7 +367,7 @@ function buildSetupSteps(
                   <div class="detected-app">
                     <div class="big-mark amber">!</div>
                     <div class="grow">
-                      <strong>TextEdit launch failed</strong>
+                      <strong>{defaultAppName} launch failed</strong>
                       <p>{testDriveError}</p>
                     </div>
                   </div>
@@ -369,27 +381,27 @@ function buildSetupSteps(
                       <p>{integrationsError}</p>
                     </div>
                   </div>
-                {:else if step.id === "integration" && accessibilityStatus === "Granted" && isLoadingIntegrations}
+                {:else if step.id === "integration" && isAccessibilityDone && isLoadingIntegrations}
                   <div class="detected-app">
-                    <AppIcon bundleId="com.apple.TextEdit" name="TextEdit" />
+                    <AppIcon bundleId={defaultAppBundleId} name={defaultAppName} />
                     <div class="grow">
-                      <strong>Checking TextEdit</strong>
+                      <strong>Checking {defaultAppName}</strong>
                       <p>Loading integration state...</p>
                     </div>
                   </div>
-                {:else if step.id === "integration" && accessibilityStatus === "Granted" && isTextEditEnabled}
+                {:else if step.id === "integration" && isAccessibilityDone && isDefaultAppEnabled}
                   <div class="detected-app">
-                    <AppIcon bundleId="com.apple.TextEdit" name="TextEdit" />
+                    <AppIcon bundleId={defaultAppBundleId} name={defaultAppName} />
                     <div class="grow">
-                      <strong>TextEdit enabled</strong>
-                      <p>Harper is configured to check TextEdit.</p>
+                      <strong>{defaultAppName} enabled</strong>
+                      <p>Harper is configured to check {defaultAppName}.</p>
                     </div>
                   </div>
-                {:else if step.id === "integration" && accessibilityStatus === "Granted"}
+                {:else if step.id === "integration" && isAccessibilityDone}
                   <div class="detected-app">
-                    <AppIcon bundleId="com.apple.TextEdit" name="TextEdit" />
+                    <AppIcon bundleId={defaultAppBundleId} name={defaultAppName} />
                     <div class="grow">
-                      <strong>TextEdit detected</strong>
+                      <strong>{defaultAppName} detected</strong>
                       <p>A good starter app for trying Harper.</p>
                     </div>
                     <button class="button primary" type="button" disabled={isEnablingTextEdit} on:click={enableTextEditForSetup}>
@@ -412,6 +424,6 @@ function buildSetupSteps(
 
         <div class="note-strip">
           <strong>On-device by default.</strong>
-          <span>Your writing stays on this Mac in this demo surface.</span>
+          <span>Your writing stays on this {isWindows ? 'PC' : 'Mac'} in this demo surface.</span>
         </div>
       </section>

--- a/harper-desktop/src/lib/settings/pages/IntegrationsPage.svelte
+++ b/harper-desktop/src/lib/settings/pages/IntegrationsPage.svelte
@@ -4,9 +4,7 @@ import { Client, type Integration } from '$lib/client';
 import AppIcon from '../components/AppIcon.svelte';
 import AppPickerModal from '../components/AppPickerModal.svelte';
 
-interface IntegrationRow extends Integration {
-	name: string;
-}
+	const isWindows = navigator.userAgent.includes('Windows');
 
 let integrations: Integration[] = [];
 let integrationApps: IntegrationRow[] = [];
@@ -184,7 +182,7 @@ function closeAppPicker() {
         disabled={isIntegrationsLoading || isIntegrationsSaving}
         on:click={() => (appPickerOpen = true)}
       >Add application...</button>
-      <span class="muted">Choose any app from your Applications folder.</span>
+      <span class="muted">{isWindows ? 'Choose any app installed on your computer.' : 'Choose any app from your Applications folder.'}</span>
     </div>
   </div>
 

--- a/harper-desktop/src/lib/settings/pages/IntegrationsPage.svelte
+++ b/harper-desktop/src/lib/settings/pages/IntegrationsPage.svelte
@@ -6,7 +6,7 @@ import AppPickerModal from '../components/AppPickerModal.svelte';
 
 type IntegrationRow = Integration & { name: string };
 
-	const isWindows = navigator.userAgent.includes('Windows');
+const isWindows = navigator.userAgent.includes('Windows');
 
 let integrations: Integration[] = [];
 let integrationApps: IntegrationRow[] = [];

--- a/harper-desktop/src/lib/settings/pages/IntegrationsPage.svelte
+++ b/harper-desktop/src/lib/settings/pages/IntegrationsPage.svelte
@@ -4,6 +4,8 @@ import { Client, type Integration } from '$lib/client';
 import AppIcon from '../components/AppIcon.svelte';
 import AppPickerModal from '../components/AppPickerModal.svelte';
 
+type IntegrationRow = Integration & { name: string };
+
 	const isWindows = navigator.userAgent.includes('Windows');
 
 let integrations: Integration[] = [];

--- a/justfile
+++ b/justfile
@@ -230,6 +230,9 @@ build-desktop-macos-unsigned: build-harperjs build-lint-framework build-componen
 
 # Build Harper Desktop Windows bundles (NSIS installer).
 build-desktop-windows: build-harperjs build-lint-framework build-components build-harper-editor
+  #!/usr/bin/env bash
+  set -eo pipefail
+
   cd "{{justfile_directory()}}/harper-desktop"
   pnpm install
   pnpm tauri build -b nsis,msi

--- a/justfile
+++ b/justfile
@@ -234,7 +234,7 @@ build-desktop-windows: build-harperjs build-lint-framework build-components buil
   pnpm install
   pnpm tauri build -b nsis,msi
 
-
+# Build the Harper Obsidian plugin.
 build-obsidian: build-harperjs
   #!/usr/bin/env bash
   set -eo pipefail

--- a/justfile
+++ b/justfile
@@ -237,6 +237,15 @@ build-desktop-windows: build-harperjs build-lint-framework build-components buil
   pnpm install
   pnpm tauri build -b nsis,msi
 
+# Build Harper Desktop Windows bundles without updater artifacts (for CI without signing keys).
+build-desktop-windows-unsigned: build-harperjs build-lint-framework build-components build-harper-editor
+  #!/usr/bin/env bash
+  set -eo pipefail
+
+  cd "{{justfile_directory()}}/harper-desktop"
+  pnpm install
+  pnpm tauri build -b nsis,msi --config '{"bundle":{"createUpdaterArtifacts":false}}'
+
 # Build the Harper Obsidian plugin.
 build-obsidian: build-harperjs
   #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -228,7 +228,13 @@ build-desktop-macos-unsigned: build-harperjs build-lint-framework build-componen
   pnpm install
   pnpm tauri build -b app,dmg --config '{"bundle":{"createUpdaterArtifacts":false}}' --target universal-apple-darwin
 
-# Build the Harper Obsidian plugin.
+# Build Harper Desktop Windows bundles (NSIS installer).
+build-desktop-windows: build-harperjs build-lint-framework build-components build-harper-editor
+  cd "{{justfile_directory()}}/harper-desktop"
+  pnpm install
+  pnpm tauri build -b nsis,msi
+
+
 build-obsidian: build-harperjs
   #!/usr/bin/env bash
   set -eo pipefail

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -4,7 +4,7 @@
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build -l warn && npm run prepack",
-		"build:css": "TAILWIND_MODE=build tailwindcss -i ./src/lib/styles.css -o ./dist/components.css --minify",
+		"build:css": "tailwindcss -i ./src/lib/styles.css -o ./dist/components.css --minify",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"prepack": "svelte-kit sync && svelte-package && pnpm run build:css && publint",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.4
+      '@tauri-apps/plugin-os':
+        specifier: ^2.3.2
+        version: 2.3.2
       '@tauri-apps/plugin-updater':
         specifier: ^2.10.1
         version: 2.10.1
@@ -77,7 +80,7 @@ importers:
         version: 5.43.12
       svelte-check:
         specifier: ^4.0.0
-        version: 4.3.4(picomatch@4.0.3)(svelte@5.43.12)(typescript@5.6.3)
+        version: 4.3.4(picomatch@4.0.2)(svelte@5.43.12)(typescript@5.6.3)
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.4
@@ -1693,11 +1696,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -4111,6 +4114,9 @@ packages:
 
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
+
+  '@tauri-apps/plugin-os@2.3.2':
+    resolution: {integrity: sha512-n+nXWeuSeF9wcEsSPmRnBEGrRgOy6jjkSU+UVCOV8YUGKb2erhDOxis7IqRXiRVHhY8XMKks00BJ0OAdkpf6+A==}
 
   '@tauri-apps/plugin-updater@2.10.1':
     resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
@@ -16927,6 +16933,10 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.11.0
 
+  '@tauri-apps/plugin-os@2.3.2':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
   '@tauri-apps/plugin-updater@2.10.1':
     dependencies:
       '@tauri-apps/api': 2.11.0
@@ -26242,6 +26252,18 @@ snapshots:
       brace: 0.11.1
       sirv-cli: 1.0.14
 
+  svelte-check@4.3.4(picomatch@4.0.2)(svelte@5.43.12)(typescript@5.6.3):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      chokidar: 4.0.3
+      fdir: 6.4.4(picomatch@4.0.2)
+      picocolors: 1.1.1
+      sade: 1.8.1
+      svelte: 5.43.12
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - picomatch
+
   svelte-check@4.3.4(picomatch@4.0.2)(svelte@5.43.12)(typescript@5.9.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
@@ -26251,18 +26273,6 @@ snapshots:
       sade: 1.8.1
       svelte: 5.43.12
       typescript: 5.9.3
-    transitivePeerDependencies:
-      - picomatch
-
-  svelte-check@4.3.4(picomatch@4.0.3)(svelte@5.43.12)(typescript@5.6.3):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
-      chokidar: 4.0.3
-      fdir: 6.4.4(picomatch@4.0.3)
-      picocolors: 1.1.1
-      sade: 1.8.1
-      svelte: 5.43.12
-      typescript: 5.6.3
     transitivePeerDependencies:
       - picomatch
 

--- a/test_wgpu.rs
+++ b/test_wgpu.rs
@@ -1,0 +1,1 @@
+fn main() { let _ = egui_wgpu::WgpuSetup::CreateInstance { supported_backends: egui_wgpu::wgpu::Backends::DX11 }; }

--- a/test_wgpu.rs
+++ b/test_wgpu.rs
@@ -1,1 +1,0 @@
-fn main() { let _ = egui_wgpu::WgpuSetup::CreateInstance { supported_backends: egui_wgpu::wgpu::Backends::DX11 }; }


### PR DESCRIPTION
# Description

This PR adds Windows support to Harper Desktop, bringing feature parity with the existing macOS highlighter.

**Windows accessibility broker (`win_broker`):**
- Implements `OsBroker` for Windows using Microsoft UI Automation (UIA) to extract text from focused edit and document controls in other applications.
- Uses `IUIAutomationTextPattern` for text extraction and character-level bounding rectangles, with `IUIAutomationValuePattern` as a fallback for simple inputs.
- Uses `GetForegroundWindow` / `GetWindowThreadProcessId` for focused PID tracking, with a 3-second cache to avoid stale state during overlay hover.
- Tracks foreground window movement and delays highlight rendering until the window settles (150 ms), matching the macOS `MacBroker` behaviour.
- Resolves installed application names and icons by scanning Start Menu `.lnk` shortcuts via a PowerShell subprocess.
- Curated default integrations for Windows: Notepad, Notepad++, Slack, Discord, and Application Frame Host.

**Transparent overlay window on Windows:**
- The HWND swap-chain path only advertises `CompositeAlphaMode::Opaque`, causing DWM to paint the overlay as solid black. This PR routes the renderer through the DX12 backend with `Dx12SwapchainKind::DxgiFromVisual`, which exposes `PreMultiplied` alpha and makes the overlay correctly transparent.
- Sets `WS_EX_NOREDIRECTIONBITMAP` (`with_no_redirection_bitmap`), `with_skip_taskbar`, and `with_undecorated_shadow` on the overlay window.

**Getting Started onboarding:**
- Updates `GettingStartedPage.svelte` to be OS-aware: skips the accessibility permission step on Windows (not required), substitutes Notepad for TextEdit as the default test app, and adjusts all copy accordingly.

**CI:**
- Adds windows_desktop.yml to build and check Harper Desktop on `windows-latest` on every push and pull request.

**justfile:**
- Adds the `build-desktop-windows` recipe to build NSIS and MSI installer bundles.


# How Has This Been Tested?

- Built and ran the Tauri app on Windows 11 with `just dev-desktop`.
- Confirmed the transparent overlay renders correctly (no black fill) on a 1080p display and a 4K display at 150% scaling.
- Confirmed lint highlights appear over Notepad and Slack text fields.
- Confirmed the Getting Started flow completes on Windows (accessibility step auto-passes, Notepad integration enables, test drive launches Notepad).
- Ran `just check-desktop` and `cargo check -p harper-desktop --target x86_64-pc-windows-msvc` with no errors.

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter

_Not applicable — this PR adds OS integration, not a grammar rule._

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.

> **Note to reviewer:** This PR intentionally bundles the overlay transparency fix (DX12/DirectComposition) and the UIA text-extraction broker together because neither is useful without the other on Windows. The Getting Started UI change and the CI workflow could be split out if preferred.