### PR TITLE
fix: "a software renderer" no longer flagged

### DIFF
--- a/harper-core/src/linting/mass_nouns/noun_countability.rs
+++ b/harper-core/src/linting/mass_nouns/noun_countability.rs
@@ -75,6 +75,11 @@ impl ExprLinter for NounCountability {
         // the mass noun
         let noun = toks[2].get_str(src).to_lowercase();
 
+        // specific exceptions
+        if noun == "software" && followed_by_word(ctx, |t| t.get_ch(src).eq_str("rendered")) {
+            return None;
+        }
+
         let synonym_corrections: &'static [Correction] = match (noun.as_str(), dq.as_str()) {
             ("advice", "a" | "an" | "another" | "each" | "every" | "one") => &[
                 ReplaceNounWith("tip"),
@@ -568,6 +573,14 @@ mod tests {
             "Not in this form because it currently works with one punctuation with one letter either side.",
             NounCountability::default(),
             "Not in this form because it currently works with one punctuation mark with one letter either side.",
+        );
+    }
+
+    #[test]
+    fn dont_flag_a_software_rendered_game() {
+        assert_no_lints(
+            "There was a software rendered game in vein of Tomb Raider",
+            NounCountability::default(),
         );
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

I noticed that "a software renderer" was falsely flagged due to "a software" being a mistake.

I added a new section for specific exceptions, with this being the first one.

# How Has This Been Tested?

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
