### PR TITLE
docs(github): add a new option to the "AI Disclosure section"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,7 @@
 <!-- It helps us review PRs when we know about AI assistance. -->
 - [ ] I am a human and didn't use any AI.
 - [ ] I used LLM features of my editor, but not an agent.
+- [ ] I consulted one or more coding AIs, but didn't use an agent.
 - [ ] I used an AI agent interactively.
 - [ ] I am an agent or I got an agent to do the work autonomously.
 
@@ -29,7 +30,6 @@
 
 # Checklist
 <!-- Go over all the following points, and put an `x` in all the boxes that apply -->
-
 - [ ] I have performed a self-review of my own code
 - [ ] I have added tests to cover my changes
 - [ ] I have considered splitting this into smaller pull requests.


### PR DESCRIPTION
# Issues 

N/A

# Description

For weeks or more I've been adding notes on how I use AI in some PRs when I'm not using an agent but I'm using more than just the editor's built-in AI stuff.

This PR adds a new item to the AI section of the PR template:
> I consulted one or more coding AIs, but didn't use an agent.

I often get good analysis, tips, refactoring, or ideas from asking the AI in Google Search. But other people may do something similarish in their contributions.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->
<img width="589" height="243" alt="image" src="https://github.com/user-attachments/assets/d5628961-21fc-44a7-8766-b5ff88824763" />

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
