### PR TITLE
chore: dictionary curation

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -18206,6 +18206,7 @@ coco/~NgS
 cocoa/~NwSgJ
 coconut/~NwSg
 cocoon/~NSgVdG
+cocreate/VdSG
 cod/~NSg09JV        # singular and plural, also has a plural in -s
 coda/~NgS
 codded/VtT
@@ -19111,7 +19112,7 @@ constituent/~JNSg
 constitute/~VdGSNrnv
 constitution/~Ngr
 constitutional/~JYNgS
-constitutionalism/N
+constitutionalism/Ng
 constitutionality/~NgU
 constitutions/~N
 constrained/~VJU
@@ -27266,6 +27267,7 @@ gram/~NOSgVK
 grammar/~NwgSV
 grammarian/~NSg
 grammatical/~JYU
+grammaticality/Nmg
 gramophone/~NgS
 grampus/~NgS
 gran/~NS
@@ -40485,6 +40487,7 @@ prelate/~NSgV
 prelim/JNSg
 preliminarily
 preliminary/~JNSg
+prelinguistic/J
 preliterate/JN
 preload/VdSG
 prelude/~NgSV
@@ -51367,6 +51370,8 @@ unpowered/J
 unpractical/J
 unprecedented/~JY
 unpredicted/J
+unproblematic/J
+unproblematically/R
 unprofessional/JYN
 unpromising/JV
 unpropitious/J


### PR DESCRIPTION
# Issues 
Addresses #3952

# Description
+cocreate
-constitutionalism - generate possessive
+grammaticality
+prelinguistic
+unproblematic
+unproblematically

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`just lint` with the example from the issue:
```
% just lint
cargo run --bin harper-cli -- lint
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 17.84s
     Running `target/debug/harper-cli lint`
Note: Using user dictionary at /Users/hippietrail/Library/Application Support/harper-ls/dictionary.txt
> "It happens unproblematically." "…constitutionalism’s origins…" "prelinguistic infants" "The document was cocreated by both teams."
<stdin>: No lints found
```

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
