### PR TITLE
fix: remove dead TAILWIND_MODE env var that breaks Windows builds

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -4,7 +4,7 @@
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build -l warn && npm run prepack",
-		"build:css": "TAILWIND_MODE=build tailwindcss -i ./src/lib/styles.css -o ./dist/components.css --minify",
+		"build:css": "tailwindcss -i ./src/lib/styles.css -o ./dist/components.css --minify",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"prepack": "svelte-kit sync && svelte-package && pnpm run build:css && publint",


### PR DESCRIPTION
TAILWIND_MODE was a Tailwind v2 JIT-era flag. This repo is on Tailwind v4.1.x, where the variable has no meaning, and it appears nowhere else in the tree.

Because npm scripts run through cmd.exe on Windows, the POSIX inline assignment `TAILWIND_MODE=build tailwindcss ...` is parsed as an attempt to execute a program named TAILWIND_MODE:

    'TAILWIND_MODE' is not recognized as an internal or external command

so `just check-desktop` fails in build-components on any native Windows checkout. CI cannot catch this: every task in just_checks.yml runs on ubuntu-latest, and the only Windows job (binaries.yml) builds harper-ls and harper-cli with plain cargo, executing no npm scripts.

# Issues
Relates to #3554 (Windows desktop support).

# Description
`just check-desktop` fails on Windows before it reaches any Rust. The recipe sets `TAILWIND_MODE=build` using POSIX inline-environment syntax, which `cmd.exe` executes as a command rather than treating as an assignment.

The variable is dead configuration. `TAILWIND_MODE` was a Tailwind v2 mechanism; this repo is on v4.1.x, where it does nothing. Deleting it fixes Windows and changes nothing anywhere else.

This is the first of a ten-part stack implementing Windows support for Harper Desktop, sent one piece at a time so each is small enough to review on its own. The remaining branches are public and CI-green if you want to see where this is
going: https://github.com/willherr72/harper/branches/all?query=will%2Fwin-

I should also flag that #3936 independently implements Windows support by a different route. I would rather that be visible up front than discovered in review — happy to consolidate if that is more useful to you than two parallel attempts.

# How Has This Been Tested?
- CSS output is byte-identical with and without the variable (diffed the built output).
- On Windows, `just check-desktop` goes from failing to passing.
- Full CI green on a fork run of this exact commit, including Linux and macOS.

# AI Disclosure
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes — this deletes dead configuration; the evidence is the byte-identical CSS output.
- [x] I have considered splitting this into smaller pull requests.
