### PR TITLE
feat: implement into→implement in

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -4678,6 +4678,13 @@
 						},
 						{
 							"Bool": {
+								"name": "ImplementIn",
+								"state": true,
+								"label": "Implement In"
+							}
+						},
+						{
+							"Bool": {
 								"name": "Impressed",
 								"state": true,
 								"label": "Impressed"

--- a/harper-core/src/linting/implement_in.rs
+++ b/harper-core/src/linting/implement_in.rs
@@ -1,0 +1,188 @@
+use crate::{
+    CharStringExt, Lint, Token,
+    expr::{Expr, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+};
+
+pub struct ImplementIn {
+    expr: SequenceExpr,
+}
+
+impl Default for ImplementIn {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::word_set(&[
+                "implement",
+                "implemented",
+                "implementing",
+                "implements",
+            ])
+            .t_ws()
+            // Note: I would use .then_optional() here but see #3958
+            .then_any_of([
+                Box::new(SequenceExpr::aco("into")),
+                Box::new(SequenceExpr::any_word().t_ws().t_aco("into")),
+            ]),
+        }
+    }
+}
+
+impl ExprLinter for ImplementIn {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        let (vtok, midtok, itok) = match toks.len() {
+            3 => (&toks[0], None, &toks[2]),
+            5 => (&toks[0], Some(&toks[2]), &toks[4]),
+            _ => return None,
+        };
+
+        // "Implement" and "implements" are nouns as well as verbs.
+        // Check for either followed by a verb.
+        // brought/came/come/coming/fall/fell/imported/introduced/going/put into are common.
+        if vtok.kind.is_noun() && midtok.is_some_and(|t| t.kind.is_verb() && !t.kind.is_noun()) {
+            return None;
+        }
+
+        // If "Into" is in title case and the middle word isn't there or is "the"
+        //   it's probably the rust trait.
+        if (midtok.is_none() || midtok.is_some_and(|t| t.get_ch(src).eq_ch(&['t', 'h', 'e'])))
+            && itok.get_ch(src) == &['I', 'n', 't', 'o']
+        {
+            return None;
+        }
+
+        let span = toks.last()?.span;
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::Usage,
+            suggestions: vec![Suggestion::replace_with_match_case_str(
+                "in",
+                span.get_content(src),
+            )],
+            message: "Prefer `in` over `into` in this usage.".to_owned(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects nonstandard `implement into` to `implement in`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    use super::ImplementIn;
+
+    #[test]
+    fn fix_implement_something_lowercase() {
+        assert_suggestion_result(
+            "How to implement overlay into your code?",
+            ImplementIn::default(),
+            "How to implement overlay in your code?",
+        );
+    }
+
+    #[test]
+    fn fix_implement_something_titlecase() {
+        assert_suggestion_result(
+            "Implement Connectors into the Testbed",
+            ImplementIn::default(),
+            "Implement Connectors in the Testbed",
+        );
+    }
+
+    #[test]
+    fn fix_implement_something() {
+        assert_suggestion_result(
+            "So why not implement it into links or w3m?",
+            ImplementIn::default(),
+            "So why not implement it in links or w3m?",
+        );
+    }
+
+    #[test]
+    fn fix_implement_into() {
+        assert_suggestion_result(
+            "Use ngx-daterangepicker-material as Storybook Angular (Issue about Ranges Clicked and Dates Updated) when implement into other project",
+            ImplementIn::default(),
+            "Use ngx-daterangepicker-material as Storybook Angular (Issue about Ranges Clicked and Dates Updated) when implement in other project",
+        );
+    }
+
+    #[test]
+    fn fix_implemented_into() {
+        assert_suggestion_result(
+            "Demo of MCTS AI implemented into a platformer with a level editor.",
+            ImplementIn::default(),
+            "Demo of MCTS AI implemented in a platformer with a level editor.",
+        );
+    }
+
+    #[test]
+    fn fix_implemented_something() {
+        assert_suggestion_result(
+            "Trained and implemented autoencoder into a pipeline with Google Cloud transcription API",
+            ImplementIn::default(),
+            "Trained and implemented autoencoder in a pipeline with Google Cloud transcription API",
+        );
+    }
+
+    #[test]
+    fn fix_implementing_something() {
+        assert_suggestion_result(
+            "Problem with implementing library into the Vue.js webpack-based project",
+            ImplementIn::default(),
+            "Problem with implementing library in the Vue.js webpack-based project",
+        );
+    }
+
+    #[test]
+    fn fix_implementing_something_title_case() {
+        assert_suggestion_result(
+            "Implementing breadcrumbs into site with AngularJS v1.2.16.",
+            ImplementIn::default(),
+            "Implementing breadcrumbs in site with AngularJS v1.2.16.",
+        );
+    }
+
+    #[test]
+    fn fix_implements_something() {
+        assert_suggestion_result(
+            "A plugin that implements latex into discord.",
+            ImplementIn::default(),
+            "A plugin that implements latex in discord.",
+        );
+    }
+
+    #[test]
+    fn dont_flag_implements_into_trait() {
+        assert_no_lints(
+            "I suppose there is a concern that somebody may define a struct which implements Into",
+            ImplementIn::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_implementing_into_trait() {
+        assert_no_lints(
+            "There might still be cases where one cannot implement From but implementing Into is possible.",
+            ImplementIn::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_implementing_the_into_trait() {
+        assert_no_lints(
+            "I'm having trouble implementing the Into trait for a generic struct in Rust.",
+            ImplementIn::default(),
+        );
+    }
+}

--- a/harper-core/src/linting/implement_in.rs
+++ b/harper-core/src/linting/implement_in.rs
@@ -47,7 +47,7 @@ impl ExprLinter for ImplementIn {
         // If "Into" is in title case and the middle word isn't there or is "the"
         //   it's probably the rust trait.
         if (midtok.is_none() || midtok.is_some_and(|t| t.get_ch(src).eq_ch(&['t', 'h', 'e'])))
-            && itok.get_ch(src) == &['I', 'n', 't', 'o']
+            && itok.get_ch(src) == ['I', 'n', 't', 'o']
         {
             return None;
         }

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -121,6 +121,7 @@ use super::how_to::HowTo;
 use super::hyphenate_number_day::HyphenateNumberDay;
 use super::i_am_agreement::IAmAgreement;
 use super::if_wouldve::IfWouldve;
+use super::implement_in::ImplementIn;
 use super::in_demand_in_depth::InDemandInDepth;
 use super::in_favour_of_doing::InFavourOfDoing;
 use super::in_on_the_cards::InOnTheCards;
@@ -710,6 +711,7 @@ impl LintGroup {
         insert_expr_rule!(HyphenateNumberDay);
         insert_expr_rule!(IAmAgreement);
         insert_expr_rule!(IfWouldve);
+        insert_expr_rule!(ImplementIn);
         insert_expr_rule!(InDemandInDepth);
         insert_expr_rule!(InFavourOfDoing);
         insert_struct_rule_with_dialect!(InOnTheCards);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -123,6 +123,7 @@ mod how_to;
 mod hyphenate_number_day;
 mod i_am_agreement;
 mod if_wouldve;
+mod implement_in;
 mod in_demand_in_depth;
 mod in_favour_of_doing;
 mod in_on_the_cards;


### PR DESCRIPTION
# Issues 

N/A

# Description

This has been in my inbox for a while. I've been noticing quite frequently recently people using the wording "implement into".
This linter suggests the correction "implement in". I'm not sure but there might be other/better fixes in some contexts?

The linter handles all inflections and handles a single word between "implement" and "into", so it will miss cases with noun phrases.

One very common pattern it avoids is in the context of Rust talking about implementing the `Into` trait.

# How Has This Been Tested?

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

I did struggle with an AI to try to get the `Expr` to work with `Optional`, but neither of us could get it to work and I filed a bug report.
Instead, I implemented it by hand using `FirstMatchOf`/`.then_any_of()` instead.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
