### PR TITLE
Dictionary curation 2026 08 04 b

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -11938,7 +11938,7 @@ afternoon/~NwgS
 aftershave/NwSg
 aftershock/NSg
 aftertaste/NwSg
-afterthought/NSgV
+afterthought/NSg
 afterward/~R<
 afterwards/R!@_₹
 afterword/NgS
@@ -14637,7 +14637,7 @@ besom/NgSV
 besot/VS
 besotted/VtTJ
 besotting/V6
-besought/V
+besought/VtT
 bespangle/VdSG
 bespatter/VGSd
 bespeak/VGSN
@@ -14672,7 +14672,7 @@ betaken/V
 betcha/
 betel/Ng
 bethink/VSG
-bethought/JV
+bethought/JVtT
 betide/VGdS
 betimes/
 betoken/VGdS
@@ -25746,7 +25746,7 @@ forestland/Ng
 forestry/~Nmg
 foretaste/NSgVdG
 foretell/VGS
-forethought/NgJV
+forethought/NgJ
 foretold/VtT
 forever/~NgJ
 forevermore/
@@ -34249,7 +34249,7 @@ methodicalness/Ng
 methodological/~JY
 methodology/~NSg
 methotrexate/N
-methought/V
+methought/Vt
 methyl/~Ng
 meticulous/~JYp
 meticulousness/Ng
@@ -36621,7 +36621,7 @@ notoriety/~Nmg
 notorious/~JY
 notwithstanding/~CP
 nougat/NwgS
-nought/NgSJVRI!@_₹
+nought/NgSJRI!@_₹
 noughties/9!_₹
 noun/~NgSVK
 nourish/NSVdGL
@@ -37492,7 +37492,7 @@ outfitter/NgS
 outfitting/V6N
 outflank/VGSd
 outflow/~NgSV
-outfought/V
+outfought/VtT
 outfox/VGdS
 outgo/Ngz
 outgoing/J
@@ -37900,7 +37900,7 @@ overwound/VtT/J
 overwrite/VGSN
 overwritten/VT
 overwrote/Vt
-overwrought/VJ
+overwrought/J
 overzealous/JY
 oviduct/NSg
 oviparous/J
@@ -42884,7 +42884,7 @@ retention/~Ng
 retentive/JYpN
 retentiveness/Ng
 rethink/VGSNg
-rethought/V
+rethought/VtT
 reticence/NgV
 reticent/JY
 reticulated/J

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -51470,6 +51470,7 @@ untidy/J^>pV
 until/~PC
 untimely/~J^
 untiring/JY
+untaoasted/J
 untouchable/JNgS
 untoward/J
 untracked/J

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -16249,7 +16249,7 @@ buzzword/NSg
 buzzy/H
 bx/~N
 bxs/N
-by/~PNg             # removed adjective sense
+by/~P               # removed adjective & noun sense
 bye/~NSgJP
 bygone/JNSg
 bylaw/NSg
@@ -18974,7 +18974,7 @@ congregation/~Ng
 congregational/~J
 congregationalism/Ng
 congregationalist/~JNgS
-congress/~NgSV
+congress/~NgS
 congressional/~JY
 congressman/~N0g
 congressmen/~N9
@@ -40592,7 +40592,7 @@ preshrink/VbGS
 preshrunk/VT
 preside/~VGdS
 presidency/~NSg
-president/~NgSV     # removed `5` adj. sense archaic, interferes with heuristics
+president/~NgS      # removed `5` adj. sense archaic, `V` v. sense marginal
 presidential/~J
 presidium/~Ng
 presort/VdGS
@@ -52044,7 +52044,7 @@ vicar/~NSg
 vicarage/~NSg
 vicarious/JYp
 vicariousness/Ng
-vice/~NgSVJP(e
+vice/~NgSJP(e
 viced/JVtT
 vicegerent/NSgJ
 vicennial/JN

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -23292,7 +23292,7 @@ emulsification/Nmg
 emulsifier/~NgS
 emulsify/Vd>SGnZ
 emulsion/~NwgSV
-en/NSgPI(
+en/NSgP(
 en masse
 enable/~Vd>SGZ
 enabler/NgS

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -14432,7 +14432,7 @@ beehive/~NgSV
 beekeeper/NgS
 beekeeping/Nmg
 beeline/NgSV
-been/~VlTN
+been/~VlTxr
 beep/NSgVGd>Z
 beeper/Ng
 beer/~NwgV
@@ -28075,7 +28075,7 @@ hardwired/JV
 hardwood/~NSgJ
 hardworking/~J
 hardy/~J^>pN
-hare/~NgSVGdJ
+hare/~NgS
 harebell/NgS
 harebrained/J
 harelip/NSgV
@@ -43314,7 +43314,7 @@ rooftop/~NSg
 rook/~NgSVdG
 rookery/NSg
 rookie/~NSgJV
-room/~NwgSVd>GJZ
+room/~NwgSVd>GZ
 roomer/Ng
 roomette/NSg
 roomful/NSgJ
@@ -43836,7 +43836,7 @@ sashay/NSgVGd
 sass/NgSVGd
 sassafras/NgS
 sassy/~J>^
-sat/~JVtTN
+sat/~VtTN
 satanic/~J
 satanical/JY
 satanism/~Nmg

--- a/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
+++ b/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
@@ -190,8 +190,8 @@
 #
 > There were doors   all          round      the hall , but     they were all          locked ; and  when    Alice
 # R+    VLPt NPl/V3+ NSg/I/J/C/Dq NSg/VB/J/P D+  NPr+ . NSg/C/P IPl+ VLPt NSg/I/J/C/Dq VP/J   . VB/C NSg/I/C NPr+
-> had been     all          the way   down        one      side      and  up         the other    , trying  every door    , she
-# VP  NSg/VLPp NSg/I/J/C/Dq D   NSg/J N🅪Sg/VB/J/P NSg/I/J+ NSg/VB/J+ VB/C NSg/VB/J/P D   NSg/VB/J . Nᴹ/Vg/J Dq+   NSg/VB+ . ISg+
+> had been   all          the way   down        one      side      and  up         the other    , trying  every door    , she
+# VP  VLPp/B NSg/I/J/C/Dq D   NSg/J N🅪Sg/VB/J/P NSg/I/J+ NSg/VB/J+ VB/C NSg/VB/J/P D   NSg/VB/J . Nᴹ/Vg/J Dq+   NSg/VB+ . ISg+
 > walked sadly down        the middle   , wondering how   she  was  ever to get    out          again .
 # VP/J   R     N🅪Sg/VB/J/P D   NSg/VB/J . Nᴹ/Vg/J   NSg/C ISg+ VLPt J/R  P  NSg/VB NSg/VB/J/R/P P     .
 >
@@ -314,8 +314,8 @@
 # J/P     D   NPr🅪Sg/VB+ . VB/C ISg+ VP/J  ISg/D$+ NPr/VXB/JS P  NSg/VB NSg/VB/J/P NSg/I/J P  D   NPl/V3 P  D
 > table   , but     it       was  too slippery ; and  when    she  had tired herself out          with trying  ,
 # NSg/VB+ . NSg/C/P NPr/ISg+ VLPt R   J        . VB/C NSg/I/C ISg+ VP  VP/J  ISg+    NSg/VB/J/R/P P    Nᴹ/Vg/J .
-> the poor     little     thing sat      down        and  cried .
-# D   NSg/VB/J NPr/I/J/Dq NSg+  NSg/VP/J N🅪Sg/VB/J/P VB/C VP/J  .
+> the poor     little     thing sat    down        and  cried .
+# D   NSg/VB/J NPr/I/J/Dq NSg+  NSg/VP N🅪Sg/VB/J/P VB/C VP/J  .
 >
 #
 > “ Come       , there’s no       use     in        crying  like         that      ! ” said Alice to herself , rather
@@ -424,8 +424,8 @@
 # NSg/VB/J+ NPr+  . NPr/ISg+ VLPt R/C/P NSg/I/J/R/Dq R/C/P ISg+ NSg/VXB VXB . Nᴹ/Vg/J N🅪Sg/VB/J/P J/P NSg/I/J+ NSg/VB/J+ . P  NSg/VB
 > through into the garden    with one      eye     ; but     to get    through was  more         hopeless than
 # J/P     P    D   NSg/VB/J+ P    NSg/I/J+ NSg/VB+ . NSg/C/P P  NSg/VB J/P     VLPt NPr/I/J/R/Dq J        C/P
-> ever : she  sat      down        and  began to cry    again .
-# J/R  . ISg+ NSg/VP/J N🅪Sg/VB/J/P VB/C VPt   P  NSg/VB P     .
+> ever : she  sat    down        and  began to cry    again .
+# J/R  . ISg+ NSg/VP N🅪Sg/VB/J/P VB/C VPt   P  NSg/VB P     .
 >
 #
 > “ You    ought     to be       ashamed of yourself , ” said Alice , “ a   great girl    like         you    , ” ( she
@@ -466,16 +466,16 @@
 # NSg/Vg  ISg+    NSg/I/J/C/Dq D   N🅪Sg/VB/J+ ISg+ NSg/VPt J/P Nᴹ/Vg/J . . NSg/VB/J . NSg/VB/J . NSg/C NSg/VB/J
 > everything is  to - day     ! And  yesterday things went    on  just as    usual . I       wonder  if
 # NSg/I/VB+  VL3 P  . NPr🅪Sg+ . VB/C NSg+      NPl+   NSg/VPt J/P J/R  R/C/P NSg/J . ISg/#r+ N🅪Sg/VB NSg/C
-> I’ve been     changed in        the night    ? Let     me       think  : was  I       the same when    I       got up         this
-# K    NSg/VLPp VP/J    NPr/J/R/P D   N🅪Sg/VB+ . NSg/VBP NPr/ISg+ NSg/VB . VLPt ISg/#r+ D   I/J  NSg/I/C ISg/#r+ VP  NSg/VB/J/P I/Ddem+
+> I’ve been   changed in        the night    ? Let     me       think  : was  I       the same when    I       got up         this
+# K    VLPp/B VP/J    NPr/J/R/P D   N🅪Sg/VB+ . NSg/VBP NPr/ISg+ NSg/VB . VLPt ISg/#r+ D   I/J  NSg/I/C ISg/#r+ VP  NSg/VB/J/P I/Ddem+
 > morning    ? I       almost think  I       can     remember feeling   a   little     different . But     if    I’m
 # N🅪Sg/Vg/J+ . ISg/#r+ R      NSg/VB ISg/#r+ NPr/VXB NSg/VB   N🅪Sg/Vg/J D/P NPr/I/J/Dq NSg/J     . NSg/C/P NSg/C K
 > not     the same , the next    question is  , Who    in        the world   am        I       ? Ah       , that’s the great
 # NSg/R/C D   I/J  . D   NSg/J/P NSg/VB+  VL3 . NPr/I+ NPr/J/R/P D   NSg/VB+ NPr/VLB/J ISg/#r+ . NSg/I/VB . K      D   NSg/J
 > puzzle ! ” And  she  began thinking over    all           the children she  knew that      were of the
 # NSg/VB . . VB/C ISg+ VPt   Nᴹ/Vg/J  NSg/J/P NSg/I/J/C/Dq+ D+  NPl+     ISg+ VPt  I/C/Ddem+ VLPt P  D+
-> same age      as    herself , to see    if    she  could   have    been     changed for   any    of them     .
-# I/J+ N🅪Sg/VB+ R/C/P ISg+    . P  NSg/VB NSg/C ISg+ NSg/VXB NSg/VXB NSg/VLPp VP/J    R/C/P I/R/Dq P  NSg/IPl+ .
+> same age      as    herself , to see    if    she  could   have    been   changed for   any    of them     .
+# I/J+ N🅪Sg/VB+ R/C/P ISg+    . P  NSg/VB NSg/C ISg+ NSg/VXB NSg/VXB VLPp/B VP/J    R/C/P I/R/Dq P  NSg/IPl+ .
 >
 #
 > “ I’m sure I’m not     Ada  , ” she  said , “ for   her     hair     goes   in        such  long     ringlets , and
@@ -494,8 +494,8 @@
 # I/C/Ddem+ NSg/VB+ . C       . D   Nᴹ             NSg/VB+ VX3     VB      . NSg$  NSg/VB/J
 > Geography . London is  the capital of Paris , and  Paris is  the capital of Rome , and
 # N🅪Sg+     . NPr+   VL3 D   N🅪Sg/J  P  NPr+  . VB/C NPr+  VL3 D   N🅪Sg/J  P  NPr+ . VB/C
-> Rome — no       , that’s all          wrong      , I’m certain ! I       must    have    been     changed for   Mabel ! I’ll
-# NPr+ . NSg/Dq/P . K      NSg/I/J/C/Dq NSg/VB/J/R . K   I/J     . ISg/#r+ NSg/VXB NSg/VXB NSg/VLPp VP/J    R/C/P NPr   . K
+> Rome — no       , that’s all          wrong      , I’m certain ! I       must    have    been   changed for   Mabel ! I’ll
+# NPr+ . NSg/Dq/P . K      NSg/I/J/C/Dq NSg/VB/J/R . K   I/J     . ISg/#r+ NSg/VXB NSg/VXB VLPp/B VP/J    R/C/P NPr   . K
 > try      and  say    ‘ How   doth the little     — ’ ” and  she  crossed her     hands   on  her     lap       as    if
 # NSg/VB/J VB/C NSg/VB . NSg/C V3   D   NPr/I/J/Dq . . . VB/C ISg+ VP/J    ISg/D$+ NPl/V3+ J/P ISg/D$+ NSg/VB/J+ R/C/P NSg/C
 > she  were saying    lessons , and  began to repeat it       , but     her     voice   sounded hoarse
@@ -576,8 +576,8 @@
 # NSg/VB/J/P P  ISg/D$+ NPr/VB+ NPr/J/R/P NPr🅪Sg/VB/J+ N🅪Sg/VB+ . ISg/D$+ NSg/J+ NSg+ VLPt I/C/Ddem ISg+ VP  R       VPp/J
 > into the sea  , “ and  in        that     case       I       can     go       back     by    railway , ” she  said to herself .
 # P    D+  NSg+ . . VB/C NPr/J/R/P I/C/Ddem NPr🅪Sg/VB+ ISg/#r+ NPr/VXB NSg/VB/J NSg/VB/J NSg/P NSg+    . . ISg+ VP/J P  ISg+    .
-> ( Alice had been     to the seaside once  in        her     life     , and  had come       to the general
-# . NPr+  VP  NSg/VLPp P  D   NPr/J   NSg/C NPr/J/R/P ISg/D$+ N🅪Sg/VB+ . VB/C VP  NSg/VBPp/P P  D   NSg/VB/J
+> ( Alice had been   to the seaside once  in        her     life     , and  had come       to the general
+# . NPr+  VP  VLPp/B P  D   NPr/J   NSg/C NPr/J/R/P ISg/D$+ N🅪Sg/VB+ . VB/C VP  NSg/VBPp/P P  D   NSg/VB/J
 > conclusion , that      wherever you    go       to on  the English      coast   you    find   a   number     of
 # NSg+       . I/C/Ddem+ C        ISgPl+ NSg/VB/J P  J/P D   NPr🅪Sg/VB/J+ NSg/VB+ ISgPl+ NSg/VB D/P N🅪Sg/VB/JC P
 > bathing machines in        the sea  , some     children digging in        the sand      with wooden
@@ -760,8 +760,8 @@
 # NSg/P NSg/VB/J D+  NSg/VB+ . NPr/I+ VP/J   P  NSg/VLXB D/P NSg/VB P  N🅪Sg+     P     NSg/IPl+ . VP/J
 > out          , “ Sit    down        , all          of you    , and  listen to me       ! I’ll soon make   you    dry      enough ! ”
 # NSg/VB/J/R/P . . NSg/VB N🅪Sg/VB/J/P . NSg/I/J/C/Dq P  ISgPl+ . VB/C NSg/VB P  NPr/ISg+ . K    J/R  NSg/VB ISgPl+ NSg/VB/J NSg/I  . .
-> They all          sat      down        at    once  , in        a    large  ring    , with the Mouse   in        the middle   . Alice
-# IPl+ NSg/I/J/C/Dq NSg/VP/J N🅪Sg/VB/J/P NSg/P NSg/C . NPr/J/R/P D/P+ NSg/J+ NSg/VB+ . P    D+  NSg/VB+ NPr/J/R/P D   NSg/VB/J . NPr+
+> They all          sat    down        at    once  , in        a    large  ring    , with the Mouse   in        the middle   . Alice
+# IPl+ NSg/I/J/C/Dq NSg/VP N🅪Sg/VB/J/P NSg/P NSg/C . NPr/J/R/P D/P+ NSg/J+ NSg/VB+ . P    D+  NSg/VB+ NPr/J/R/P D   NSg/VB/J . NPr+
 > kept her     eyes    anxiously fixed on  it       , for   she  felt      sure she  would catch  a   bad
 # VP   ISg/D$+ NPl/V3+ R         VP/J  J/P NPr/ISg+ . R/C/P ISg+ N🅪Sg/VP/J J    ISg+ VXB   NSg/VB D/P NSg/VB/J
 > cold  if    she  did  not     get    dry      very soon .
@@ -774,8 +774,8 @@
 # JS     NSg   ISg/#r+ VB   . NSg/VB+ NSg/I/J/C/Dq NSg/VB/J/P . NSg/C ISgPl+ VB     . . NPr+    D   NSg       .
 > whose cause      was  favoured  by    the pope    , was  soon submitted to by    the English      , who
 # I+    N🅪Sg/VB/C+ VLPt VP/J/Comm NSg/P D   NPr/VB+ . VLPt J/R  VP        P  NSg/P D   NPr🅪Sg/VB/J+ . NPr/I+
-> wanted leaders , and  had been     of late  much         accustomed to usurpation and  conquest .
-# VP/J   NPl+    . VB/C VP  NSg/VLPp P  NSg/J NSg/I/J/R/Dq VP/J       P  NSg        VB/C NSg/VB+  .
+> wanted leaders , and  had been   of late  much         accustomed to usurpation and  conquest .
+# VP/J   NPl+    . VB/C VP  VLPp/B P  NSg/J NSg/I/J/R/Dq VP/J       P  NSg        VB/C NSg/VB+  .
 > Edwin and  Morcar , the earls of Mercia and  Northumbria — ’ ”
 # NPr+  VB/C ?      . D   NPl+  P  NPr    VB/C ?           . . .
 >
@@ -878,8 +878,8 @@
 # J/R  VB/C R     . R+    VLPt NSg/Dq/P . NSg/I/J+ . NSg . NSg   . VB/C VB/J . . NSg/C/P IPl+ VPt   Nᴹ/Vg/J/P
 > when    they liked , and  left     off        when    they liked , so          that     it       was  not     easy     to know
 # NSg/I/C IPl+ VP/J  . VB/C NPr/VP/J NSg/VB/J/P NSg/I/C IPl+ VP/J  . NSg/I/J/R/C I/C/Ddem NPr/ISg+ VLPt NSg/R/C NSg/VB/J P  VB
-> when    the race     was  over    . However , when    they had been     running   half      an   hour or    so          ,
-# NSg/I/C D+  N🅪Sg/VB+ VLPt NSg/J/P . C       . NSg/I/C IPl+ VP  NSg/VLPp Nᴹ/Vg/J/P N🅪Sg/J/P+ D/P+ NSg+ NPr/C NSg/I/J/R/C .
+> when    the race     was  over    . However , when    they had been   running   half      an   hour or    so          ,
+# NSg/I/C D+  N🅪Sg/VB+ VLPt NSg/J/P . C       . NSg/I/C IPl+ VP  VLPp/B Nᴹ/Vg/J/P N🅪Sg/J/P+ D/P+ NSg+ NPr/C NSg/I/J/R/C .
 > and  were quite dry      again , the Dodo suddenly called out          “ The race     is  over    ! ” and
 # VB/C VLPt R     NSg/VB/J P     . D   NSg  R        VP/J   NSg/VB/J/R/P . D   N🅪Sg/VB+ VL3 NSg/J/P . . VB/C
 > they all          crowded round      it       , panting , and  asking  , “ But     who    has won      ? ”
@@ -888,8 +888,8 @@
 #
 > This    question the Dodo could   not     answer  without a   great deal     of thought  , and  it
 # I/Ddem+ NSg/VB+  D   NSg  NSg/VXB NSg/R/C NSg/VB+ C/P     D/P NSg/J NSg/VB/J P  N🅪Sg/VP+ . VB/C NPr/ISg+
-> sat      for   a   long     time       with one     finger  pressed upon its     forehead ( the position in
-# NSg/VP/J R/C/P D/P NPr/VB/J N🅪Sg/VB/J+ P    NSg/I/J NSg/VB+ VP/J    P    ISg/D$+ NSg      . D   NSg/VB+  NPr/J/R/P
+> sat    for   a   long     time       with one     finger  pressed upon its     forehead ( the position in
+# NSg/VP R/C/P D/P NPr/VB/J N🅪Sg/VB/J+ P    NSg/I/J NSg/VB+ VP/J    P    ISg/D$+ NSg      . D   NSg/VB+  NPr/J/R/P
 > which you    usually see    Shakespeare , in        the pictures of him  ) , while      the rest
 # I/C+  ISgPl+ R       NSg/VB NPr/VB+     . NPr/J/R/P D   NPl/V3   P  ISg+ . . NSg/VB/C/P D   NSg/VB+
 > waited in        silence . At    last     the Dodo said , “ Everybody has won      , and  all          must    have
@@ -958,8 +958,8 @@
 # D   NSg/J NPl/V3+ VP/J       I/C/Ddem IPl+ NSg/VXB NSg/R/C NSg/VB/J I+     . VB/C D   NPr/VB/J NPl+
 > choked and  had to be       patted on  the back     . However , it       was  over    at    last     , and  they
 # VP/J   VB/C VP  P  NSg/VLXB VP     J/P D   NSg/VB/J . C       . NPr/ISg+ VLPt NSg/J/P NSg/P NSg/VB/J . VB/C IPl+
-> sat      down        again in        a    ring    , and  begged the Mouse   to tell   them     something more         .
-# NSg/VP/J N🅪Sg/VB/J/P P     NPr/J/R/P D/P+ NSg/VB+ . VB/C VP     D+  NSg/VB+ P  NPr/VB NSg/IPl+ NSg/I/J+  NPr/I/J/R/Dq .
+> sat    down        again in        a    ring    , and  begged the Mouse   to tell   them     something more         .
+# NSg/VP N🅪Sg/VB/J/P P     NPr/J/R/P D/P+ NSg/VB+ . VB/C VP     D+  NSg/VB+ P  NPr/VB NSg/IPl+ NSg/I/J+  NPr/I/J/R/Dq .
 >
 #
 > “ You    promised to tell   me       your history , you    know , ” said Alice , “ and  why    it       is  you
@@ -1180,14 +1180,14 @@
 # NSg/VB NPr/J/R/P D   NPr/VB+ NSg/C NPr/ISg+ VPt   Nᴹ/Vg/J  NPl/VB+ J/P   NSg/VB/J/C/P I/C/Ddem+ . .
 >
 #
-> By    this    time       she  had found  her     way    into a   tidy     little     room      with a   table   in        the
-# NSg/P I/Ddem+ N🅪Sg/VB/J+ ISg+ VP  NSg/VP ISg/D$+ NSg/J+ P    D/P NSg/VB/J NPr/I/J/Dq N🅪Sg/VB/J P    D/P NSg/VB+ NPr/J/R/P D
+> By    this    time       she  had found  her     way    into a   tidy     little     room    with a   table   in        the
+# NSg/P I/Ddem+ N🅪Sg/VB/J+ ISg+ VP  NSg/VP ISg/D$+ NSg/J+ P    D/P NSg/VB/J NPr/I/J/Dq N🅪Sg/VB P    D/P NSg/VB+ NPr/J/R/P D
 > window  , and  on  it       ( as    she  had hoped ) a   fan     and  two or    three pairs  of tiny  white
 # NSg/VB+ . VB/C J/P NPr/ISg+ . R/C/P ISg+ VP  VP/J  . D/P NSg/VB+ VB/C NSg NPr/C NSg   NPl/V3 P  NSg/J NPr🅪Sg/VB/J
 > kid     gloves  : she  took up         the fan     and  a   pair   of the gloves  , and  was  just going   to
 # NSg/VB+ NPl/V3+ . ISg+ VPt  NSg/VB/J/P D   NSg/VB+ VB/C D/P NSg/VB P  D   NPl/V3+ . VB/C VLPt J/R  Nᴹ/Vg/J P
-> leave  the room       , when    her     eye     fell      upon a   little     bottle  that      stood near       the
-# NSg/VB D   N🅪Sg/VB/J+ . NSg/I/C ISg/D$+ NSg/VB+ NSg/VPt/J P    D/P NPr/I/J/Dq NSg/VB+ I/C/Ddem+ VP    NSg/VB/J/P D
+> leave  the room     , when    her     eye     fell      upon a   little     bottle  that      stood near       the
+# NSg/VB D   N🅪Sg/VB+ . NSg/I/C ISg/D$+ NSg/VB+ NSg/VPt/J P    D/P NPr/I/J/Dq NSg/VB+ I/C/Ddem+ VP    NSg/VB/J/P D
 > looking  - glass      . There was  no        label   this   time       with the words   “ DRINK   ME       , ” but
 # Nᴹ/Vg/J+ . NPr🅪Sg/VB+ . R+    VLPt NSg/Dq/P+ NSg/VB+ I/Ddem N🅪Sg/VB/J+ P    D+  NPl/V3+ . NSg/VB+ NPr/ISg+ . . NSg/C/P
 > nevertheless she  uncorked it       and  put     it       to her     lips    . “ I       know something
@@ -1215,7 +1215,7 @@
 > Alas  ! it       was  too late  to wish   that      ! She  went    on  growing , and  growing , and  very
 # NPrPl . NPr/ISg+ VLPt R   NSg/J P  NSg/VB I/C/Ddem+ . ISg+ NSg/VPt J/P Nᴹ/Vg/J . VB/C Nᴹ/Vg/J . VB/C J/R
 > soon had to kneel down        on  the floor   : in        another minute    there was  not     even       room
-# J/R  VP  P  VB    N🅪Sg/VB/J/P J/P D   NSg/VB+ . NPr/J/R/P I/D     NSg/VB/J+ R+    VLPt NSg/R/C NSg/VB/J/R N🅪Sg/VB/J+
+# J/R  VP  P  VB    N🅪Sg/VB/J/P J/P D   NSg/VB+ . NPr/J/R/P I/D     NSg/VB/J+ R+    VLPt NSg/R/C NSg/VB/J/R N🅪Sg/VB+
 > for   this    , and  she  tried the effect  of lying   down        with one     elbow   against the
 # R/C/P I/Ddem+ . VB/C ISg+ VP/J  D   NSg/VB+ P  Nᴹ/Vg/J N🅪Sg/VB/J/P P    NSg/I/J NSg/VB+ C/P     D
 > door    , and  the other    arm       curled round      her     head      . Still      she  went    on  growing , and  ,
@@ -1232,8 +1232,8 @@
 # R       R/C/P NPr+  . D+  NPr/I/J/Dq+ N🅪Sg/VB/J+ NSg/VB+ VP  NSg/J/R/C VP  ISg/D$+ NSg/VB/J+ NSg/VB+ . VB/C ISg+
 > grew no       larger : still      it       was  very uncomfortable , and  , as    there seemed to be       no
 # VPt  NSg/Dq/P JC     . NSg/VB/J/R NPr/ISg+ VLPt J/R  J             . VB/C . R/C/P R+    VP/J   P  NSg/VLXB NSg/Dq/P
-> sort   of chance   of her     ever getting out          of the room       again , no       wonder  she  felt
-# NSg/VB P  NPr/VB/J P  ISg/D$+ J/R  NSg/Vg  NSg/VB/J/R/P P  D+  N🅪Sg/VB/J+ P     . NSg/Dq/P N🅪Sg/VB ISg+ N🅪Sg/VP/J
+> sort   of chance   of her     ever getting out          of the room     again , no       wonder  she  felt
+# NSg/VB P  NPr/VB/J P  ISg/D$+ J/R  NSg/Vg  NSg/VB/J/R/P P  D+  N🅪Sg/VB+ P     . NSg/Dq/P N🅪Sg/VB ISg+ N🅪Sg/VP/J
 > unhappy  .
 # NSg/VB/J .
 >
@@ -1252,8 +1252,8 @@
 # VB/C NSg/J/R/C J/R  ISg/#r+ NPr/VLB/J NPr/J/R/P D   NSg/VB/J P  NSg/I/J . R+    NSg/I/VXB P  NSg/VLXB D/P NSg/VB+ VPp/J   J/P
 > me       , that     there ought     ! And  when    I       grow up         , I’ll write  one     — but     I’m grown up         now       , ”
 # NPr/ISg+ . I/C/Ddem R+    NSg/I/VXB . VB/C NSg/I/C ISg/#r+ VB   NSg/VB/J/P . K    NSg/VB NSg/I/J . NSg/C/P K   VB/J  NSg/VB/J/P NSg/J/R/C . .
-> she  added in        a   sorrowful tone       ; “ at    least    there’s no       room       to grow up         any    more
-# ISg+ VP/J  NPr/J/R/P D/P J         N🅪Sg/I/VB+ . . NSg/P NSg/J/Dq K       NSg/Dq/P N🅪Sg/VB/J+ P  VB   NSg/VB/J/P I/R/Dq NPr/I/J/R/Dq
+> she  added in        a   sorrowful tone       ; “ at    least    there’s no       room     to grow up         any    more
+# ISg+ VP/J  NPr/J/R/P D/P J         N🅪Sg/I/VB+ . . NSg/P NSg/J/Dq K       NSg/Dq/P N🅪Sg/VB+ P  VB   NSg/VB/J/P I/R/Dq NPr/I/J/R/Dq
 > here . ”
 # J/R  . .
 >
@@ -1268,8 +1268,8 @@
 #
 > “ Oh     , you    foolish Alice ! ” she  answered herself . “ How   can     you    learn  lessons in
 # . NPr/VB . ISgPl+ J+      NPr+  . . ISg+ VP/J     ISg+    . . NSg/C NPr/VXB ISgPl+ NSg/VB NPl/V3+ NPr/J/R/P
-> here ? Why    , there’s hardly room       for   you    , and  no       room       at    all          for   any
-# J/R  . NSg/VB . K       R      N🅪Sg/VB/J+ R/C/P ISgPl+ . VB/C NSg/Dq/P N🅪Sg/VB/J+ NSg/P NSg/I/J/C/Dq R/C/P I/R/Dq
+> here ? Why    , there’s hardly room     for   you    , and  no       room     at    all          for   any
+# J/R  . NSg/VB . K       R      N🅪Sg/VB+ R/C/P ISgPl+ . VB/C NSg/Dq/P N🅪Sg/VB+ NSg/P NSg/I/J/C/Dq R/C/P I/R/Dq
 > lesson  - books   ! ”
 # NSg/VB+ . NPl/V3+ . .
 >
@@ -1538,8 +1538,8 @@
 # P     . NSg/J/R/C D   NSg/VB+ VPt   D/P NSgPl  P  NPr/VB/J/P NPl/V3+ NSg/P D   NSg/VB/J+ . Nᴹ/Vg/J/P D/P
 > very little     way    forwards each time       and  a   long     way    back     , and  barking  hoarsely all
 # J/R  NPr/I/J/Dq NSg/J+ NPl/V3   Dq   N🅪Sg/VB/J+ VB/C D/P NPr/VB/J NSg/J+ NSg/VB/J . VB/C Nᴹ/Vg/J+ R        NSg/I/J/C/Dq
-> the while      , till       at    last     it       sat      down        a   good     way    off        , panting , with its     tongue
-# D   NSg/VB/C/P . NSg/VB/C/P NSg/P NSg/VB/J NPr/ISg+ NSg/VP/J N🅪Sg/VB/J/P D/P NPr/VB/J NSg/J+ NSg/VB/J/P . Nᴹ/Vg/J . P    ISg/D$+ N🅪Sg/VB+
+> the while      , till       at    last     it       sat    down        a   good     way    off        , panting , with its     tongue
+# D   NSg/VB/C/P . NSg/VB/C/P NSg/P NSg/VB/J NPr/ISg+ NSg/VP N🅪Sg/VB/J/P D/P NPr/VB/J NSg/J+ NSg/VB/J/P . Nᴹ/Vg/J . P    ISg/D$+ N🅪Sg/VB+
 > hanging out          of its     mouth   , and  its     great  eyes    half      shut      .
 # Nᴹ/Vg/J NSg/VB/J/R/P P  ISg/D$+ NSg/VB+ . VB/C ISg/D$+ NSg/J+ NPl/V3+ N🅪Sg/J/P+ NSg/VBP/J .
 >
@@ -1556,8 +1556,8 @@
 # . VB/C NSg/VB/C NSg/I+ D/P+ NSg/VB/J+ NPr/I/J/Dq+ NSg/VB+ NPr/ISg+ VLPt . . VP/J NPr+  . R/C/P ISg+ ?     C/P     D/P
 > buttercup to rest   herself , and  fanned herself with one     of the leaves  : “ I       should
 # NSg       P  NSg/VB ISg+    . VB/C VP     ISg+    P    NSg/I/J P  D   NPl/V3+ . . ISg/#r+ VXB
-> have    liked teaching   it       tricks  very much         , if    — if    I’d only  been     the right    size     to
-# NSg/VXB VP/J  N🅪Sg/Vg/J+ NPr/ISg+ NPl/V3+ J/R  NSg/I/J/R/Dq . NSg/C . NSg/C K   J/R/C NSg/VLPp D   NPr/VB/J N🅪Sg/VB+ P
+> have    liked teaching   it       tricks  very much         , if    — if    I’d only  been   the right    size     to
+# NSg/VXB VP/J  N🅪Sg/Vg/J+ NPr/ISg+ NPl/V3+ J/R  NSg/I/J/R/Dq . NSg/C . NSg/C K   J/R/C VLPp/B D   NPr/VB/J N🅪Sg/VB+ P
 > do  it       ! Oh     dear     ! I’d nearly forgotten that     I’ve got to grow up         again ! Let     me
 # VXB NPr/ISg+ . NPr/VB NSg/VB/J . K   R      NSg/VPp/J I/C/Ddem K    VP  P  VB   NSg/VB/J/P P     . NSg/VBP NPr/ISg+
 > see    — how   is  it       to be       managed ? I       suppose I       ought     to eat or    drink   something or
@@ -1610,8 +1610,8 @@
 # I/Ddem+ VLPt NSg/R/C D/P Nᴹ/Vg/J     Nᴹ/Vg/J R/C/P D/P+ N🅪Sg/VB+     . NPr+  VP/J    . NPr/VB/J/R
 > shyly , “ I       — I       hardly know , sir     , just at    present  — at    least    I       know who    I       was  when    I
 # R     . . ISg/#r+ . ISg/#r+ R      VB   . NPr/VB+ . J/R  NSg/P NSg/VB/J . NSg/P NSg/J/Dq ISg/#r+ VB   NPr/I+ ISg/#r+ VLPt NSg/I/C ISg/#r+
-> got up         this   morning    , but     I       think  I       must    have    been     changed several times   since
-# VP  NSg/VB/J/P I/Ddem N🅪Sg/Vg/J+ . NSg/C/P ISg/#r+ NSg/VB ISg/#r+ NSg/VXB NSg/VXB NSg/VLPp VP/J    J/Dq    NPl/V3+ C/P
+> got up         this   morning    , but     I       think  I       must    have    been   changed several times   since
+# VP  NSg/VB/J/P I/Ddem N🅪Sg/Vg/J+ . NSg/C/P ISg/#r+ NSg/VB ISg/#r+ NSg/VXB NSg/VXB VLPp/B VP/J    J/Dq    NPl/V3+ C/P
 > then      . ”
 # NSg/J/R/C . .
 >
@@ -1840,8 +1840,8 @@
 # . ISg/#r+ VXB   VB   . . VP/J D   NSg/VB      .
 >
 #
-> Alice said nothing  : she  had never been     so          much         contradicted in        her     life     before ,
-# NPr+  VP/J NSg/I/J+ . ISg+ VP  R     NSg/VLPp NSg/I/J/R/C NSg/I/J/R/Dq VP/J         NPr/J/R/P ISg/D$+ N🅪Sg/VB+ C/P    .
+> Alice said nothing  : she  had never been   so          much         contradicted in        her     life     before ,
+# NPr+  VP/J NSg/I/J+ . ISg+ VP  R     VLPp/B NSg/I/J/R/C NSg/I/J/R/Dq VP/J         NPr/J/R/P ISg/D$+ N🅪Sg/VB+ C/P    .
 > and  she  felt      that     she  was  losing  her     temper     .
 # VB/C ISg+ N🅪Sg/VP/J I/C/Ddem ISg+ VLPt Nᴹ/Vg/J ISg/D$+ NSg/VB/JC+ .
 >
@@ -1920,8 +1920,8 @@
 # R+    VLPt NSg/Dq/P N🅪Sg/VB/J+ P  NSg/VLXB VP/J . R/C/P ISg+ VLPt Nᴹ/Vg/J   R       . NSg/I/J/R/C ISg+ NPr/VBP/J P  N🅪Sg/VB
 > at    once  to eat some     of the other     bit      . Her     chin    was  pressed so          closely against
 # NSg/P NSg/C P  VB  I/J/R/Dq P  D+  NSg/VB/J+ NSg/VPt+ . ISg/D$+ NPr/VB+ VLPt VP/J    NSg/I/J/R/C R       C/P
-> her     foot    , that     there was  hardly room       to open     her     mouth   ; but     she  did  it       at    last     ,
-# ISg/D$+ NSg/VB+ . I/C/Ddem R+    VLPt R      N🅪Sg/VB/J+ P  NSg/VB/J ISg/D$+ NSg/VB+ . NSg/C/P ISg+ VXPt NPr/ISg+ NSg/P NSg/VB/J .
+> her     foot    , that     there was  hardly room     to open     her     mouth   ; but     she  did  it       at    last     ,
+# ISg/D$+ NSg/VB+ . I/C/Ddem R+    VLPt R      N🅪Sg/VB+ P  NSg/VB/J ISg/D$+ NSg/VB+ . NSg/C/P ISg+ VXPt NPr/ISg+ NSg/P NSg/VB/J .
 > and  managed to swallow a   morsel of the lefthand bit      .
 # VB/C VP/J    P  NSg/VB  D/P NSg/VB P  D   ?        NSg/VPt+ .
 >
@@ -1957,7 +1957,7 @@
 > it       down        into a   graceful zigzag   , and  was  going   to dive   in        among the leaves  , which
 # NPr/ISg+ N🅪Sg/VB/J/P P    D/P J        NSg/VB/J . VB/C VLPt Nᴹ/Vg/J P  NSg/VB NPr/J/R/P P     D   NPl/V3+ . I/C+
 > she  found  to be       nothing  but     the tops   of the trees   under   which she  had been
-# ISg+ NSg/VP P  NSg/VLXB NSg/I/J+ NSg/C/P D   NPl/V3 P  D   NPl/V3+ NSg/J/P I/C+  ISg+ VP  NSg/VLPp
+# ISg+ NSg/VP P  NSg/VLXB NSg/I/J+ NSg/C/P D   NPl/V3 P  D   NPl/V3+ NSg/J/P I/C+  ISg+ VP  VLPp/B
 > wandering , when    a   sharp    hiss    made her     draw   back     in        a   hurry   : a   large pigeon  had
 # Nᴹ/Vg/J   . NSg/I/C D/P NPr/VB/J NSg/VB+ VP   ISg/D$+ NSg/VB NSg/VB/J NPr/J/R/P D/P NSg/VB+ . D/P NSg/J NSg/VB+ VP
 > flown into her     face    , and  was  beating her     violently with its     wings   .
@@ -2006,8 +2006,8 @@
 # N🅪Sg/VB+ I/Ddem NSg   NPrPl+ . .
 >
 #
-> “ I’m very sorry    you’ve been     annoyed , ” said Alice , who    was  beginning to see    its
-# . K   J/R  NSg/VB/J K      NSg/VLPp VP/J    . . VP/J NPr+  . NPr/I+ VLPt NSg/Vg/J+ P  NSg/VB ISg/D$+
+> “ I’m very sorry    you’ve been   annoyed , ” said Alice , who    was  beginning to see    its
+# . K   J/R  NSg/VB/J K      VLPp/B VP/J    . . VP/J NPr+  . NPr/I+ VLPt NSg/Vg/J+ P  NSg/VB ISg/D$+
 > meaning    .
 # N🅪Sg/Vg/J+ .
 >
@@ -2092,8 +2092,8 @@
 # NSg/JC  . C/P   ISg+ VP  VP/J      NPr/J/R/P Nᴹ/Vg/J  ISg+    N🅪Sg/VB/J/P P  ISg/D$+ NSg/J N🅪Sg+  .
 >
 #
-> It       was  so          long     since she  had been     anything  near       the right     size     , that     it       felt
-# NPr/ISg+ VLPt NSg/I/J/R/C NPr/VB/J C/P   ISg+ VP  NSg/VLPp NSg/I/VB+ NSg/VB/J/P D+  NPr/VB/J+ N🅪Sg/VB+ . I/C/Ddem NPr/ISg+ N🅪Sg/VP/J
+> It       was  so          long     since she  had been   anything  near       the right     size     , that     it       felt
+# NPr/ISg+ VLPt NSg/I/J/R/C NPr/VB/J C/P   ISg+ VP  VLPp/B NSg/I/VB+ NSg/VB/J/P D+  NPr/VB/J+ N🅪Sg/VB+ . I/C/Ddem NPr/ISg+ N🅪Sg/VP/J
 > quite strange  at    first ; but     she  got used to it       in        a    few       minutes , and  began
 # R     NSg/VB/J NSg/P NSg/J . NSg/C/P ISg+ VP  VP/J P  NPr/ISg+ NPr/J/R/P D/P+ NSg/I/Dq+ NPl/V3+ . VB/C VPt
 > talking to herself , as    usual . “ Come       , there’s half      my  plan    done      now       ! How   puzzling
@@ -2178,8 +2178,8 @@
 # R         R+    VLPt D/P NSg/I/J/R/Dq NSg/J         N🅪Sg/VB Nᴹ/Vg/J J/P NSg/J/P . D/P NSg/J
 > howling and  sneezing , and  every now       and  then      a   great crash     , as    if    a   dish    or
 # Nᴹ/Vg/J VB/C Nᴹ/Vg/J  . VB/C Dq    NSg/J/R/C VB/C NSg/J/R/C D/P NSg/J NSg/VB/J+ . R/C/P NSg/C D/P NSg/VB+ NPr/C
-> kettle had been     broken to pieces .
-# NSg/VB VP  NSg/VLPp VPp/J  P  NPl/V3 .
+> kettle had been   broken to pieces .
+# NSg/VB VP  VLPp/B VPp/J  P  NPl/V3 .
 >
 #
 > “ Please , then      , ” said Alice , “ how   am        I       to get    in        ? ”
@@ -2428,8 +2428,8 @@
 # . J/R  . ISgPl+ NPr/VXB NSg/VB NPr/ISg+ D/P+ NSg/VPt+ . NSg/C ISgPl+ NSg/VB/J/C/P . . D   NSg/VB  VP/J P  NPr+  . Nᴹ/Vg/J
 > the baby      at    her     as    she  spoke   . “ I       must    go       and  get    ready    to play    croquet with the
 # D   NSg/VB/J+ NSg/P ISg/D$+ R/C/P ISg+ NSg/VPt . . ISg/#r+ NSg/VXB NSg/VB/J VB/C NSg/VB NSg/VB/J P  N🅪Sg/VB NSg/VB  P    D+
-> Queen     , ” and  she  hurried out          of the room       . The cook   threw a   frying  - pan      after her
-# NPr/VB/J+ . . VB/C ISg+ VP/J    NSg/VB/J/R/P P  D   N🅪Sg/VB/J+ . D   NPr/VB VPt   D/P Nᴹ/Vg/J . NPr/VB/J P     ISg/D$+
+> Queen     , ” and  she  hurried out          of the room     . The cook   threw a   frying  - pan      after her
+# NPr/VB/J+ . . VB/C ISg+ VP/J    NSg/VB/J/R/P P  D   N🅪Sg/VB+ . D   NPr/VB VPt   D/P Nᴹ/Vg/J . NPr/VB/J P     ISg/D$+
 > as    she  went    out          , but     it       just missed her     .
 # R/C/P ISg+ NSg/VPt NSg/VB/J/R/P . NSg/C/P NPr/ISg+ J/R  VP/J   ISg/D$+ .
 >
@@ -2564,8 +2564,8 @@
 #
 > “ In        that      direction , ” the Cat       said , waving  its     right     paw     round      , “ lives a   Hatter :
 # . NPr/J/R/P I/C/Ddem+ N🅪Sg+     . . D+  NSg/VB/J+ VP/J . Nᴹ/Vg/J ISg/D$+ NPr/VB/J+ NSg/VB+ NSg/VB/J/P . . V3+   D/P NSg/VB .
-> and  in        that     direction , ” waving  the other    paw     , “ lives a   March   Hare      . Visit  either
-# VB/C NPr/J/R/P I/C/Ddem N🅪Sg+     . . Nᴹ/Vg/J D   NSg/VB/J NSg/VB+ . . V3+   D/P NPr/VB+ NSg/VB/J+ . NSg/VB I/C
+> and  in        that     direction , ” waving  the other    paw     , “ lives a   March   Hare . Visit  either
+# VB/C NPr/J/R/P I/C/Ddem N🅪Sg+     . . Nᴹ/Vg/J D   NSg/VB/J NSg/VB+ . . V3+   D/P NPr/VB+ NSg+ . NSg/VB I/C
 > you    like         : they’re both   mad      . ”
 # ISgPl+ NSg/VB/J/C/P . K       I/C/Dq NSg/VB/J . .
 >
@@ -2620,8 +2620,8 @@
 # P  . NPr🅪Sg+ . .
 >
 #
-> “ I       should like         it       very much         , ” said Alice , “ but     I       haven’t been     invited  yet      . ”
-# . ISg/#r+ VXB    NSg/VB/J/C/P NPr/ISg+ J/R  NSg/I/J/R/Dq . . VP/J NPr+  . . NSg/C/P ISg/#r+ VXB     NSg/VLPp NSg/VP/J NSg/VB/C . .
+> “ I       should like         it       very much         , ” said Alice , “ but     I       haven’t been   invited  yet      . ”
+# . ISg/#r+ VXB    NSg/VB/J/C/P NPr/ISg+ J/R  NSg/I/J/R/Dq . . VP/J NPr+  . . NSg/C/P ISg/#r+ VXB     VLPp/B NSg/VP/J NSg/VB/C . .
 >
 #
 > “ You’ll see    me       there , ” said the Cat       , and  vanished .
@@ -2630,8 +2630,8 @@
 #
 > Alice was  not     much         surprised at    this    , she  was  getting so          used to queer     things
 # NPr+  VLPt NSg/R/C NSg/I/J/R/Dq VP/J      NSg/P I/Ddem+ . ISg+ VLPt NSg/Vg  NSg/I/J/R/C VP/J P  NSg/VB/J+ NPl+
-> happening . While      she  was  looking at    the place    where   it       had been     , it       suddenly
-# N🅪Sg/Vg/J . NSg/VB/C/P ISg+ VLPt Nᴹ/Vg/J NSg/P D+  N🅪Sg/VB+ NSg/R/C NPr/ISg+ VP  NSg/VLPp . NPr/ISg+ R
+> happening . While      she  was  looking at    the place    where   it       had been   , it       suddenly
+# N🅪Sg/Vg/J . NSg/VB/C/P ISg+ VLPt Nᴹ/Vg/J NSg/P D+  N🅪Sg/VB+ NSg/R/C NPr/ISg+ VP  VLPp/B . NPr/ISg+ R
 > appeared again .
 # VP/J     P     .
 >
@@ -2655,11 +2655,11 @@
 > Alice waited a   little     , half      expecting to see    it       again , but     it       did  not     appear ,
 # NPr+  VP/J   D/P NPr/I/J/Dq . N🅪Sg/J/P+ Nᴹ/Vg/J   P  NSg/VB NPr/ISg+ P     . NSg/C/P NPr/ISg+ VXPt NSg/R/C VB     .
 > and  after a    minute    or    two she  walked on  in        the direction in        which the March   Hare
-# VB/C P     D/P+ NSg/VB/J+ NPr/C NSg ISg+ VP/J   J/P NPr/J/R/P D+  N🅪Sg+     NPr/J/R/P I/C+  D+  NPr/VB+ NSg/VB/J+
+# VB/C P     D/P+ NSg/VB/J+ NPr/C NSg ISg+ VP/J   J/P NPr/J/R/P D+  N🅪Sg+     NPr/J/R/P I/C+  D+  NPr/VB+ NSg+
 > was  said to live . “ I’ve seen    hatters before , ” she  said to herself ; “ the March
 # VLPt VP/J P  VB/J . . K    NSg/VPp NPl/V3  C/P    . . ISg+ VP/J P  ISg+    . . D   NPr/VB+
-> Hare      will    be       much         the most         interesting , and  perhaps as    this    is  May     it       won’t be
-# NSg/VB/J+ NPr/VXB NSg/VLXB NSg/I/J/R/Dq D   NSg/I/J/R/Dq Vg/J        . VB/C NSg/R   R/C/P I/Ddem+ VL3 NPr/VXB NPr/ISg+ VXB   NSg/VLXB
+> Hare will    be       much         the most         interesting , and  perhaps as    this    is  May     it       won’t be
+# NSg+ NPr/VXB NSg/VLXB NSg/I/J/R/Dq D   NSg/I/J/R/Dq Vg/J        . VB/C NSg/R   R/C/P I/Ddem+ VL3 NPr/VXB NPr/ISg+ VXB   NSg/VLXB
 > raving  mad      — at    least    not     so          mad      as    it       was  in        March   . ” As    she  said this    , she  looked
 # Nᴹ/Vg/J NSg/VB/J . NSg/P NSg/J/Dq NSg/R/C NSg/I/J/R/C NSg/VB/J R/C/P NPr/ISg+ VLPt NPr/J/R/P NPr/VB+ . . R/C/P ISg+ VP/J I/Ddem+ . ISg+ VP/J
 > up         , and  there was  the Cat       again , sitting  on  a   branch of a    tree    .
@@ -2692,8 +2692,8 @@
 #
 > She  had not     gone    much         farther before she  came      in        sight   of the house  of the March
 # ISg+ VP  NSg/R/C VPp/J/P NSg/I/J/R/Dq VB/JC   C/P    ISg+ NSg/VPt/P NPr/J/R/P N🅪Sg/VB P  D   NPr/VB P  D+  NPr/VB+
-> Hare      : she  thought it       must    be       the right     house   , because the chimneys were shaped
-# NSg/VB/J+ . ISg+ N🅪Sg/VP NPr/ISg+ NSg/VXB NSg/VLXB D+  NPr/VB/J+ NPr/VB+ . C/P     D+  NPl/V3+  VLPt VP/J
+> Hare : she  thought it       must    be       the right     house   , because the chimneys were shaped
+# NSg+ . ISg+ N🅪Sg/VP NPr/ISg+ NSg/VXB NSg/VLXB D+  NPr/VB/J+ NPr/VB+ . C/P     D+  NPl/V3+  VLPt VP/J
 > like         ears   and  the roof    was  thatched with fur          . It       was  so          large a   house   , that     she
 # NSg/VB/J/C/P NPl/V3 VB/C D+  NSg/VB+ VLPt VP/J     P    N🅪Sg/VB/C/P+ . NPr/ISg+ VLPt NSg/I/J/R/C NSg/J D/P NPr/VB+ . I/C/Ddem ISg+
 > did  not     like         to go       nearer till       she  had nibbled some     more         of the lefthand bit      of
@@ -2711,7 +2711,7 @@
 >
 #
 > There was  a    table   set       out          under   a   tree    in        front    of the house   , and  the March   Hare
-# R+    VLPt D/P+ NSg/VB+ NPr/VBP/J NSg/VB/J/R/P NSg/J/P D/P NSg/VB+ NPr/J/R/P NSg/VB/J P  D+  NPr/VB+ . VB/C D+  NPr/VB+ NSg/VB/J+
+# R+    VLPt D/P+ NSg/VB+ NPr/VBP/J NSg/VB/J/R/P NSg/J/P D/P NSg/VB+ NPr/J/R/P NSg/VB/J P  D+  NPr/VB+ . VB/C D+  NPr/VB+ NSg+
 > and  the Hatter were having  tea      at    it       : a   Dormouse was  sitting  between them     , fast
 # VB/C D   NSg/VB VLPt Nᴹ/Vg/J N🅪Sg/VB+ NSg/P NPr/ISg+ . D/P NSg      VLPt NSg/Vg/J NSg/P   NSg/IPl+ . NSg/VB/J/R
 > asleep , and  the other    two were  using   it       as    a   cushion , resting  their elbows  on
@@ -2724,16 +2724,16 @@
 #
 > The table   was  a   large one     , but     the three were  all          crowded together at    one     corner
 # D+  NSg/VB+ VLPt D/P NSg/J NSg/I/J . NSg/C/P D+  NSg+  VLPt+ NSg/I/J/C/Dq VP/J    J        NSg/P NSg/I/J NSg/VB
-> of it       : “ No        room       ! No        room       ! ” they cried out          when    they saw     Alice coming  . “ There’s
-# P  NPr/ISg+ . . NSg/Dq/P+ N🅪Sg/VB/J+ . NSg/Dq/P+ N🅪Sg/VB/J+ . . IPl+ VP/J  NSg/VB/J/R/P NSg/I/C IPl+ NSg/VPt NPr+  Nᴹ/Vg/J . . K
-> plenty  of room       ! ” said Alice indignantly , and  she  sat      down        in        a   large arm       - chair
-# NSg/I/J P  N🅪Sg/VB/J+ . . VP/J NPr+  R           . VB/C ISg+ NSg/VP/J N🅪Sg/VB/J/P NPr/J/R/P D/P NSg/J NSg/VB/J+ . NSg/VB+
+> of it       : “ No        room     ! No        room     ! ” they cried out          when    they saw     Alice coming  . “ There’s
+# P  NPr/ISg+ . . NSg/Dq/P+ N🅪Sg/VB+ . NSg/Dq/P+ N🅪Sg/VB+ . . IPl+ VP/J  NSg/VB/J/R/P NSg/I/C IPl+ NSg/VPt NPr+  Nᴹ/Vg/J . . K
+> plenty  of room     ! ” said Alice indignantly , and  she  sat    down        in        a   large arm       - chair
+# NSg/I/J P  N🅪Sg/VB+ . . VP/J NPr+  R           . VB/C ISg+ NSg/VP N🅪Sg/VB/J/P NPr/J/R/P D/P NSg/J NSg/VB/J+ . NSg/VB+
 > at    one     end    of the table   .
 # NSg/P NSg/I/J NSg/VB P  D   NSg/VB+ .
 >
 #
-> “ Have    some      wine     , ” the March   Hare      said in        an   encouraging tone       .
-# . NSg/VXB I/J/R/Dq+ N🅪Sg/VB+ . . D+  NPr/VB+ NSg/VB/J+ VP/J NPr/J/R/P D/P+ Nᴹ/Vg/J     N🅪Sg/I/VB+ .
+> “ Have    some      wine     , ” the March   Hare said in        an   encouraging tone       .
+# . NSg/VXB I/J/R/Dq+ N🅪Sg/VB+ . . D+  NPr/VB+ NSg+ VP/J NPr/J/R/P D/P+ Nᴹ/Vg/J     N🅪Sg/I/VB+ .
 >
 #
 > Alice looked all          round      the table   , but     there was  nothing  on  it       but     tea      . “ I       don’t
@@ -2742,8 +2742,8 @@
 # NSg/VB I/R/Dq N🅪Sg/VB+ . . ISg+ VP/J     .
 >
 #
-> “ There isn’t   any    , ” said the March   Hare      .
-# . R+    NSg/VX3 I/R/Dq . . VP/J D   NPr/VB+ NSg/VB/J+ .
+> “ There isn’t   any    , ” said the March   Hare .
+# . R+    NSg/VX3 I/R/Dq . . VP/J D   NPr/VB+ NSg+ .
 >
 #
 > “ Then      it       wasn’t very civil of you    to offer  it       , ” said Alice angrily .
@@ -2752,8 +2752,8 @@
 #
 > “ It       wasn’t very civil of you    to sit    down        without being        invited  , ” said the March
 # . NPr/ISg+ VPt    J/R  J     P  ISgPl+ P  NSg/VB N🅪Sg/VB/J/P C/P     N🅪Sg/VLg/J/C NSg/VP/J . . VP/J D   NPr/VB+
-> Hare      .
-# NSg/VB/J+ .
+> Hare .
+# NSg+ .
 >
 #
 > “ I       didn’t know it       was  your table   , ” said Alice ; “ it’s laid for   a   great many       more
@@ -2762,8 +2762,8 @@
 # C/P  NSg   . .
 >
 #
-> “ Your hair     wants  cutting  , ” said the Hatter . He       had been     looking at    Alice for
-# . D$+  N🅪Sg/VB+ NPl/V3 NSg/Vg/J . . VP/J D   NSg/VB . NPr/ISg+ VP  NSg/VLPp Nᴹ/Vg/J NSg/P NPr+  R/C/P
+> “ Your hair     wants  cutting  , ” said the Hatter . He       had been   looking at    Alice for
+# . D$+  N🅪Sg/VB+ NPl/V3 NSg/Vg/J . . VP/J D   NSg/VB . NPr/ISg+ VP  VLPp/B Nᴹ/Vg/J NSg/P NPr+  R/C/P
 > some     time      with great  curiosity , and  this    was  his     first  speech   .
 # I/J/R/Dq N🅪Sg/VB/J P    NSg/J+ NSg+      . VB/C I/Ddem+ VLPt ISg/D$+ NSg/J+ N🅪Sg/VB+ .
 >
@@ -2788,16 +2788,16 @@
 #
 > “ Do  you    mean     that     you    think  you    can     find   out          the answer  to it       ? ” said the March
 # . VXB ISgPl+ NSg/VB/J I/C/Ddem ISgPl+ NSg/VB ISgPl+ NPr/VXB NSg/VB NSg/VB/J/R/P D+  NSg/VB+ P  NPr/ISg+ . . VP/J D+  NPr/VB+
-> Hare      .
-# NSg/VB/J+ .
+> Hare .
+# NSg+ .
 >
 #
 > “ Exactly so          , ” said Alice .
 # . R       NSg/I/J/R/C . . VP/J NPr+  .
 >
 #
-> “ Then      you    should say    what   you    mean     , ” the March   Hare      went    on  .
-# . NSg/J/R/C ISgPl+ VXB    NSg/VB NSg/I+ ISgPl+ NSg/VB/J . . D+  NPr/VB+ NSg/VB/J+ NSg/VPt J/P .
+> “ Then      you    should say    what   you    mean     , ” the March   Hare went    on  .
+# . NSg/J/R/C ISgPl+ VXB    NSg/VB NSg/I+ ISgPl+ NSg/VB/J . . D+  NPr/VB+ NSg+ NSg/VPt J/P .
 >
 #
 > “ I       do  , ” Alice hastily replied ; “ at    least    — at    least    I       mean     what   I       say    — that’s the
@@ -2812,8 +2812,8 @@
 # NSg/VB NSg/I+ ISg/#r+ VB  . VL3 D+  I/J+ NSg+  R/C/P . ISg/#r+ VB  NSg/I+ ISg/#r+ NSg/VB . . .
 >
 #
-> “ You    might    just as    well       say    , ” added the March   Hare      , “ that      ‘ I       like         what   I       get    ’ is
-# . ISgPl+ Nᴹ/VXB/J J/R  R/C/P NSg/VB/J/R NSg/VB . . VP/J  D+  NPr/VB+ NSg/VB/J+ . . I/C/Ddem+ . ISg/#r+ NSg/VB/J/C/P NSg/I+ ISg/#r+ NSg/VB . VL3
+> “ You    might    just as    well       say    , ” added the March   Hare , “ that      ‘ I       like         what   I       get    ’ is
+# . ISgPl+ Nᴹ/VXB/J J/R  R/C/P NSg/VB/J/R NSg/VB . . VP/J  D+  NPr/VB+ NSg+ . . I/C/Ddem+ . ISg/#r+ NSg/VB/J/C/P NSg/I+ ISg/#r+ NSg/VB . VL3
 > the same thing as    ‘ I       get    what   I       like         ’ ! ”
 # D+  I/J+ NSg+  R/C/P . ISg/#r+ NSg/VB NSg/I+ ISg/#r+ NSg/VB/J/C/P . . .
 >
@@ -2828,8 +2828,8 @@
 #
 > “ It       is  the same thing with you    , ” said the Hatter , and  here the conversation
 # . NPr/ISg+ VL3 D   I/J  NSg   P    ISgPl+ . . VP/J D   NSg/VB . VB/C J/R  D   N🅪Sg/VB+
-> dropped , and  the party     sat      silent for   a   minute    , while      Alice thought over    all          she
-# VP/J    . VB/C D   NSg/VB/J+ NSg/VP/J NSg/J  R/C/P D/P NSg/VB/J+ . NSg/VB/C/P NPr+  N🅪Sg/VP NSg/J/P NSg/I/J/C/Dq ISg+
+> dropped , and  the party     sat    silent for   a   minute    , while      Alice thought over    all          she
+# VP/J    . VB/C D   NSg/VB/J+ NSg/VP NSg/J  R/C/P D/P NSg/VB/J+ . NSg/VB/C/P NPr+  N🅪Sg/VP NSg/J/P NSg/I/J/C/Dq ISg+
 > could   remember about ravens and  writing - desks   , which wasn’t much         .
 # NSg/VXB NSg/VB   J/P   NPl/V3 VB/C Nᴹ/Vg/J . NPl/V3+ . I/C+  VPt    NSg/I/J/R/Dq .
 >
@@ -2850,12 +2850,12 @@
 #
 > “ Two  days wrong      ! ” sighed the Hatter . “ I       told you    butter  wouldn’t suit    the
 # . NSg+ NPl+ NSg/VB/J/R . . VP/J   D   NSg/VB . . ISg/#r+ VP   ISgPl+ NSg/VB+ VXB      NSg/VB+ D
-> works   ! ” he       added looking angrily at    the March   Hare      .
-# NPl/V3+ . . NPr/ISg+ VP/J  Nᴹ/Vg/J R       NSg/P D+  NPr/VB+ NSg/VB/J+ .
+> works   ! ” he       added looking angrily at    the March   Hare .
+# NPl/V3+ . . NPr/ISg+ VP/J  Nᴹ/Vg/J R       NSg/P D+  NPr/VB+ NSg+ .
 >
 #
-> “ It       was  the best       butter , ” the March   Hare      meekly replied .
-# . NPr/ISg+ VLPt D   NPr/VXB/JS NSg/VB . . D+  NPr/VB+ NSg/VB/J+ R      VP/J    .
+> “ It       was  the best       butter , ” the March   Hare meekly replied .
+# . NPr/ISg+ VLPt D   NPr/VXB/JS NSg/VB . . D+  NPr/VB+ NSg+ R      VP/J    .
 >
 #
 > “ Yes    , but     some      crumbs  must    have    got in        as    well       , ” the Hatter grumbled : “ you
@@ -2864,16 +2864,16 @@
 # VXB       NSg/VXB NSg/VBP NPr/ISg+ NPr/J/R/P P    D   N🅪Sg/VB+ . NSg/VB+ . .
 >
 #
-> The March   Hare      took the watch  and  looked at    it       gloomily : then      he       dipped it       into
-# D+  NPr/VB+ NSg/VB/J+ VPt  D   NSg/VB VB/C VP/J   NSg/P NPr/ISg+ R        . NSg/J/R/C NPr/ISg+ VP/J   NPr/ISg+ P
+> The March   Hare took the watch  and  looked at    it       gloomily : then      he       dipped it       into
+# D+  NPr/VB+ NSg+ VPt  D   NSg/VB VB/C VP/J   NSg/P NPr/ISg+ R        . NSg/J/R/C NPr/ISg+ VP/J   NPr/ISg+ P
 > his     cup    of tea      , and  looked at    it       again : but     he       could   think  of nothing  better     to
 # ISg/D$+ NSg/VB P  N🅪Sg/VB+ . VB/C VP/J   NSg/P NPr/ISg+ P     . NSg/C/P NPr/ISg+ NSg/VXB NSg/VB P  NSg/I/J+ NSg/VXB/JC P
 > say    than his     first remark  , “ It       was  the best       butter  , you    know . ”
 # NSg/VB C/P  ISg/D$+ NSg/J NSg/VB+ . . NPr/ISg+ VLPt D   NPr/VXB/JS NSg/VB+ . ISgPl+ VB   . .
 >
 #
-> Alice had been     looking over    his     shoulder with some      curiosity . “ What   a    funny
-# NPr+  VP  NSg/VLPp Nᴹ/Vg/J NSg/J/P ISg/D$+ NSg/VB+  P    I/J/R/Dq+ NSg+      . . NSg/I+ D/P+ NSg/J+
+> Alice had been   looking over    his     shoulder with some      curiosity . “ What   a    funny
+# NPr+  VP  VLPp/B Nᴹ/Vg/J NSg/J/P ISg/D$+ NSg/VB+  P    I/J/R/Dq+ NSg+      . . NSg/I+ D/P+ NSg/J+
 > watch   ! ” she  remarked . “ It       tells  the day    of the month  , and  doesn’t tell   what
 # NSg/VB+ . . ISg+ VP/J     . . NPr/ISg+ NPl/V3 D   NPr🅪Sg P  D+  NSg/J+ . VB/C VX3     NPr/VB NSg/I+
 > o’clock it       is  ! ”
@@ -2928,8 +2928,8 @@
 # . ISg/#r+ VXB     D+  JS        NSg+ . . VP/J D   NSg/VB .
 >
 #
-> “ Nor   I       , ” said the March   Hare      .
-# . NSg/C ISg/#r+ . . VP/J D+  NPr/VB+ NSg/VB/J+ .
+> “ Nor   I       , ” said the March   Hare .
+# . NSg/C ISg/#r+ . . VP/J D+  NPr/VB+ NSg+ .
 >
 #
 > Alice sighed wearily . “ I       think  you    might    do  something better     with the time       , ” she
@@ -2972,8 +2972,8 @@
 # NSg/VB+ NPr/J/R/P D/P N🅪Sg/Vg/J . N🅪Sg/J/P+ . NSg/VB/J/P NSg/I/J . N🅪Sg/VB/J R/C/P N🅪Sg/VB+ . .
 >
 #
-> ( “ I       only  wish   it       was  , ” the March   Hare      said to itself in        a    whisper . )
-# . . ISg/#r+ J/R/C NSg/VB NPr/ISg+ VLPt . . D+  NPr/VB+ NSg/VB/J+ VP/J P  ISg+   NPr/J/R/P D/P+ NSg/VB+ . .
+> ( “ I       only  wish   it       was  , ” the March   Hare said to itself in        a    whisper . )
+# . . ISg/#r+ J/R/C NSg/VB NPr/ISg+ VLPt . . D+  NPr/VB+ NSg+ VP/J P  ISg+   NPr/J/R/P D/P+ NSg/VB+ . .
 >
 #
 > “ That      would be       grand , certainly , ” said Alice thoughtfully : “ but     then      — I       shouldn’t
@@ -2996,8 +2996,8 @@
 # D   NSg/VB NSg/VPt/J ISg/D$+ NPr/VB/J+ R          . . NSg/R/C ISg/#r+ . . NPr/ISg+ VP/J    . . IPl+ VP/Comm    NSg/VB/J
 > March   — just before he       went    mad      , you    know — ” ( pointing with his     tea      spoon   at    the
 # NPr/VB+ . J/R  C/P    NPr/ISg+ NSg/VPt NSg/VB/J . ISgPl+ VB   . . . Nᴹ/Vg/J  P    ISg/D$+ N🅪Sg/VB+ NSg/VB+ NSg/P D
-> March   Hare      , ) “ — it       was  at    the great concert given       by    the Queen    of Hearts  , and  I
-# NPr/VB+ NSg/VB/J+ . . . . NPr/ISg+ VLPt NSg/P D   NSg/J NSg/VB+ NSg/VPp/J/P NSg/P D   NPr/VB/J P  NPl/V3+ . VB/C ISg/#r+
+> March   Hare , ) “ — it       was  at    the great concert given       by    the Queen    of Hearts  , and  I
+# NPr/VB+ NSg+ . . . . NPr/ISg+ VLPt NSg/P D   NSg/J NSg/VB+ NSg/VPp/J/P NSg/P D   NPr/VB/J P  NPl/V3+ . VB/C ISg/#r+
 > had to sing
 # VP  P  NSg/VB/J
 >
@@ -3070,8 +3070,8 @@
 # . NSg/C/P NSg/I+ V3      NSg/I/C ISgPl+ NSg/VBPp/P P  D+  NSg/Vg/J+ P     . . NPr+  VP/J     P  NSg/VB .
 >
 #
-> “ Suppose we   change  the subject   , ” the March   Hare      interrupted , yawning . “ I’m
-# . VB      IPl+ N🅪Sg/VB D+  NSg/VB/J+ . . D+  NPr/VB+ NSg/VB/J+ VP/J        . Nᴹ/Vg/J . . K
+> “ Suppose we   change  the subject   , ” the March   Hare interrupted , yawning . “ I’m
+# . VB      IPl+ N🅪Sg/VB D+  NSg/VB/J+ . . D+  NPr/VB+ NSg+ VP/J        . Nᴹ/Vg/J . . K
 > getting tired of this    . I       vote   the young     lady    tells  us       a    story   . ”
 # NSg/Vg  VP/J  P  I/Ddem+ . ISg/#r+ NSg/VB D+  NPr/VB/J+ NPr/VB+ NPl/V3 NPr/IPl+ D/P+ NSg/VB+ . .
 >
@@ -3092,8 +3092,8 @@
 # VB/J   NSg/VB+ . . ISg/#r+ VP/J  Dq    NSg/VB+ ISgPl+ NPl+    VLPt N🅪Sg/Vg/J . .
 >
 #
-> “ Tell   us       a    story   ! ” said the March   Hare      .
-# . NPr/VB NPr/IPl+ D/P+ NSg/VB+ . . VP/J D+  NPr/VB+ NSg/VB/J+ .
+> “ Tell   us       a    story   ! ” said the March   Hare .
+# . NPr/VB NPr/IPl+ D/P+ NSg/VB+ . . VP/J D+  NPr/VB+ NSg+ .
 >
 #
 > “ Yes    , please do  ! ” pleaded Alice .
@@ -3126,8 +3126,8 @@
 #
 > “ They couldn’t have    done      that      , you    know , ” Alice gently remarked ; “ they’d have
 # . IPl+ VXB      NSg/VXB NSg/VPp/J I/C/Ddem+ . ISgPl+ VB   . . NPr+  R      VP/J     . . K      NSg/VXB
-> been     ill      . ”
-# NSg/VLPp NSg/VB/J . .
+> been   ill      . ”
+# VLPp/B NSg/VB/J . .
 >
 #
 > “ So          they were , ” said the Dormouse ; “ very ill      . ”
@@ -3142,8 +3142,8 @@
 # D   NSg/VB/J P  D/P+ NSg/VB/J/R+ . .
 >
 #
-> “ Take   some      more          tea      , ” the March   Hare      said to Alice , very earnestly .
-# . NSg/VB I/J/R/Dq+ NPr/I/J/R/Dq+ N🅪Sg/VB+ . . D+  NPr/VB+ NSg/VB/J+ VP/J P  NPr+  . J/R  R         .
+> “ Take   some      more          tea      , ” the March   Hare said to Alice , very earnestly .
+# . NSg/VB I/J/R/Dq+ NPr/I/J/R/Dq+ N🅪Sg/VB+ . . D+  NPr/VB+ NSg+ VP/J P  NPr+  . J/R  R         .
 >
 #
 > “ I’ve had nothing  yet      , ” Alice replied in        an  offended tone       , “ so          I       can’t take
@@ -3182,8 +3182,8 @@
 #
 > “ There’s no        such  thing ! ” Alice was  beginning very angrily , but     the Hatter and
 # . K       NSg/Dq/P+ NSg/I NSg+  . . NPr+  VLPt NSg/Vg/J+ J/R  R       . NSg/C/P D   NSg/VB VB/C
-> the March   Hare      went    “ Sh ! sh ! ” and  the Dormouse sulkily remarked , “ If    you    can’t
-# D   NPr/VB+ NSg/VB/J+ NSg/VPt . W? . W? . . VB/C D   NSg      R       VP/J     . . NSg/C ISgPl+ VXB
+> the March   Hare went    “ Sh ! sh ! ” and  the Dormouse sulkily remarked , “ If    you    can’t
+# D   NPr/VB+ NSg+ NSg/VPt . W? . W? . . VB/C D   NSg      R       VP/J     . . NSg/C ISgPl+ VXB
 > be       civil , you’d better     finish the story   for   yourself . ”
 # NSg/VLXB J     . K     NSg/VXB/JC NSg/VB D   NSg/VB+ R/C/P ISg+     . .
 >
@@ -3212,14 +3212,14 @@
 # . ISg/#r+ NSg/VB D/P+ NSg/VB/J+ NSg/VB+ . . VP/J        D   NSg/VB . . NSg$  NSg/I/J/C/Dq NSg/VB NSg/I/J N🅪Sg/VB+ J/P . .
 >
 #
-> He       moved on  as    he       spoke   , and  the Dormouse followed him  : the March   Hare      moved
-# NPr/ISg+ VP/J  J/P R/C/P NPr/ISg+ NSg/VPt . VB/C D   NSg      VP/J     ISg+ . D   NPr/VB+ NSg/VB/J+ VP/J
+> He       moved on  as    he       spoke   , and  the Dormouse followed him  : the March   Hare moved
+# NPr/ISg+ VP/J  J/P R/C/P NPr/ISg+ NSg/VPt . VB/C D   NSg      VP/J     ISg+ . D   NPr/VB+ NSg+ VP/J
 > into the Dormouse’s place    , and  Alice rather     unwillingly took the place   of the
 # P    D   NSg$       N🅪Sg/VB+ . VB/C NPr+  NPr/VB/J/R R           VPt  D   N🅪Sg/VB P  D
-> March   Hare      . The Hatter was  the only  one      who    got any    advantage from the change   :
-# NPr/VB+ NSg/VB/J+ . D   NSg/VB VLPt D   J/R/C NSg/I/J+ NPr/I+ VP  I/R/Dq N🅪Sg/VB+  P    D   N🅪Sg/VB+ .
-> and  Alice was  a   good     deal      worse     off        than before , as    the March   Hare      had just
-# VB/C NPr+  VLPt D/P NPr/VB/J NSg/VB/J+ NSg/VB/JC NSg/VB/J/P C/P  C/P    . R/C/P D   NPr/VB+ NSg/VB/J+ VP  J/R
+> March   Hare . The Hatter was  the only  one      who    got any    advantage from the change   :
+# NPr/VB+ NSg+ . D   NSg/VB VLPt D   J/R/C NSg/I/J+ NPr/I+ VP  I/R/Dq N🅪Sg/VB+  P    D   N🅪Sg/VB+ .
+> and  Alice was  a   good     deal      worse     off        than before , as    the March   Hare had just
+# VB/C NPr+  VLPt D/P NPr/VB/J NSg/VB/J+ NSg/VB/JC NSg/VB/J/P C/P  C/P    . R/C/P D   NPr/VB+ NSg+ VP  J/R
 > upset    the milk     - jug     into his     plate   .
 # NSg/VB/J D   N🅪Sg/VB+ . NSg/VB+ P    ISg/D$+ NSg/VB+ .
 >
@@ -3264,8 +3264,8 @@
 # . NSg/VB P    D/P NPr/VB/J/#r . . VP/J NPr+  .
 >
 #
-> “ Why    not     ? ” said the March   Hare      .
-# . NSg/VB NSg/R/C . . VP/J D+  NPr/VB+ NSg/VB/J+ .
+> “ Why    not     ? ” said the March   Hare .
+# . NSg/VB NSg/R/C . . VP/J D+  NPr/VB+ NSg+ .
 >
 #
 > Alice was  silent .
@@ -3398,14 +3398,14 @@
 #
 > Five and  Seven said nothing  , but     looked at    Two . Two began in        a    low         voice   , “ Why
 # NSg  VB/C NSg   VP/J NSg/I/J+ . NSg/C/P VP/J   NSg/P NSg . NSg VPt   NPr/J/R/P D/P+ NSg/VB/J/R+ NSg/VB+ . . NSg/VB
-> the fact is  , you    see    , Miss   , this   here ought     to have    been     a   red    rose      - tree    , and  we
-# D+  NSg+ VL3 . ISgPl+ NSg/VB . NSg/VB . I/Ddem J/R  NSg/I/VXB P  NSg/VXB NSg/VLPp D/P N🅪Sg/J NPr/VPt/J . NSg/VB+ . VB/C IPl+
+> the fact is  , you    see    , Miss   , this   here ought     to have    been   a   red    rose      - tree    , and  we
+# D+  NSg+ VL3 . ISgPl+ NSg/VB . NSg/VB . I/Ddem J/R  NSg/I/VXB P  NSg/VXB VLPp/B D/P N🅪Sg/J NPr/VPt/J . NSg/VB+ . VB/C IPl+
 > put     a   white       one      in        by    mistake ; and  if    the Queen     was  to find   it       out          , we   should
 # NSg/VBP D/P NPr🅪Sg/VB/J NSg/I/J+ NPr/J/R/P NSg/P NSg/VB+ . VB/C NSg/C D+  NPr/VB/J+ VLPt P  NSg/VB NPr/ISg+ NSg/VB/J/R/P . IPl+ VXB
 > all          have    our heads   cut       off        , you    know . So          you    see    , Miss   , we’re doing   our best       ,
 # NSg/I/J/C/Dq NSg/VXB D$+ NPl/V3+ NSg/VBP/J NSg/VB/J/P . ISgPl+ VB   . NSg/I/J/R/C ISgPl+ NSg/VB . NSg/VB . K     Nᴹ/Vg/J D$+ NPr/VXB/JS .
-> afore she  comes  , to — ” At    this   moment Five , who    had been     anxiously looking across
-# R/C/P ISg+ NPl/V3 . P  . . NSg/P I/Ddem NSg+   NSg  . NPr/I+ VP  NSg/VLPp R         Nᴹ/Vg/J NSg/P
+> afore she  comes  , to — ” At    this   moment Five , who    had been   anxiously looking across
+# R/C/P ISg+ NPl/V3 . P  . . NSg/P I/Ddem NSg+   NSg  . NPr/I+ VP  VLPp/B R         Nᴹ/Vg/J NSg/P
 > the garden    , called out          “ The Queen     ! The Queen     ! ” and  the three gardeners instantly
 # D   NSg/VB/J+ . VP/J   NSg/VB/J/R/P . D   NPr/VB/J+ . D+  NPr/VB/J+ . . VB/C D+  NSg+  NPl+      R
 > threw themselves flat     upon their faces   . There was  a   sound     of many        footsteps , and
@@ -3524,8 +3524,8 @@
 #
 > “ Leave  off        that      ! ” screamed the Queen     . “ You    make   me       giddy    . ” And  then      , turning to
 # . NSg/VB NSg/VB/J/P I/C/Ddem+ . . VP/J     D+  NPr/VB/J+ . . ISgPl+ NSg/VB NPr/ISg+ NSg/VB/J . . VB/C NSg/J/R/C . Nᴹ/Vg/J P
-> the rose       - tree    , she  went    on  , “ What   have    you    been     doing   here ? ”
-# D+  NPr/VPt/J+ . NSg/VB+ . ISg+ NSg/VPt J/P . . NSg/I+ NSg/VXB ISgPl+ NSg/VLPp Nᴹ/Vg/J J/R  . .
+> the rose       - tree    , she  went    on  , “ What   have    you    been   doing   here ? ”
+# D+  NPr/VPt/J+ . NSg/VB+ . ISg+ NSg/VPt J/P . . NSg/I+ NSg/VXB ISgPl+ VLPp/B Nᴹ/Vg/J J/R  . .
 >
 #
 > “ May     it       please your Majesty , ” said Two , in        a   very humble   tone       , going   down        on  one
@@ -3534,8 +3534,8 @@
 # NSg/VB+ R/C/P NPr/ISg+ NSg/VPt . . IPl+ VLPt Nᴹ/Vg/J . .
 >
 #
-> “ I       see    ! ” said the Queen     , who    had meanwhile been     examining the roses   . “ Off        with
-# . ISg/#r+ NSg/VB . . VP/J D+  NPr/VB/J+ . NPr/I+ VP  NSg       NSg/VLPp Nᴹ/Vg/J   D+  NPl/V3+ . . NSg/VB/J/P P
+> “ I       see    ! ” said the Queen     , who    had meanwhile been   examining the roses   . “ Off        with
+# . ISg/#r+ NSg/VB . . VP/J D+  NPr/VB/J+ . NPr/I+ VP  NSg       VLPp/B Nᴹ/Vg/J   D+  NPl/V3+ . . NSg/VB/J/P P
 > their heads   ! ” and  the procession moved on  , three of the soldiers remaining
 # D$+   NPl/V3+ . . VB/C D+  NSg/VB+    VP/J  J/P . NSg   P  D+  NPl/V3+  Nᴹ/Vg/J
 > behind  to execute the unfortunate gardeners , who    ran to Alice for   protection .
@@ -4046,8 +4046,8 @@
 # ISgPl+ VXB   VB   P  NSg/VLXB . . NPr/C NSg/C K     NSg/VB/J/C/P NPr/ISg+ NSg/VBP NPr/I/J/R/Dq R      . . R     NSg/VB
 > yourself not     to be       otherwise than what   it       might    appear to others that     what   you
 # ISg+     NSg/R/C P  NSg/VLXB J/R/C     C/P  NSg/I+ NPr/ISg+ Nᴹ/VXB/J VB     P  NPl/V3 I/C/Ddem NSg/I+ ISgPl+
-> were or    might    have    been     was  not     otherwise than what   you    had been     would have
-# VLPt NPr/C Nᴹ/VXB/J NSg/VXB NSg/VLPp VLPt NSg/R/C J/R/C     C/P  NSg/I+ ISgPl+ VP  NSg/VLPp VXB   NSg/VXB
+> were or    might    have    been   was  not     otherwise than what   you    had been   would have
+# VLPt NPr/C Nᴹ/VXB/J NSg/VXB VLPp/B VLPt NSg/R/C J/R/C     C/P  NSg/I+ ISgPl+ VP  VLPp/B VXB   NSg/VXB
 > appeared to them     to be       otherwise . ’ ”
 # VP/J     P  NSg/IPl+ P  NSg/VLXB J/R/C     . . .
 >
@@ -4196,8 +4196,8 @@
 # R/C/P P  NSg/VB/J P     I/C/Ddem NPr/VB/J+ NPr/VB/J+ . NSg/I/J/R/C ISg+ VP/J   .
 >
 #
-> The Gryphon sat      up         and  rubbed its     eyes    : then      it       watched the Queen     till       she  was
-# D   ?       NSg/VP/J NSg/VB/J/P VB/C VP/J   ISg/D$+ NPl/V3+ . NSg/J/R/C NPr/ISg+ VP/J    D   NPr/VB/J+ NSg/VB/C/P ISg+ VLPt
+> The Gryphon sat    up         and  rubbed its     eyes    : then      it       watched the Queen     till       she  was
+# D   ?       NSg/VP NSg/VB/J/P VB/C VP/J   ISg/D$+ NPl/V3+ . NSg/J/R/C NPr/ISg+ VP/J    D   NPr/VB/J+ NSg/VB/C/P ISg+ VLPt
 > out          of sight    : then      it       chuckled . “ What   fun     ! ” said the Gryphon , half      to itself ,
 # NSg/VB/J/R/P P  N🅪Sg/VB+ . NSg/J/R/C NPr/ISg+ VP/J     . . NSg/I+ Nᴹ/VB/J . . VP/J D   ?       . N🅪Sg/J/P+ P  ISg+   .
 > half      to Alice .
@@ -4252,8 +4252,8 @@
 # P  ISgPl+ . VB/C VXB   NSg/VB D/P NSg/VB+ NSg/VB/C/P K    VP/J     . .
 >
 #
-> So          they sat      down        , and  nobody spoke   for   some      minutes . Alice thought to herself ,
-# NSg/I/J/R/C IPl+ NSg/VP/J N🅪Sg/VB/J/P . VB/C NSg/I+ NSg/VPt R/C/P I/J/R/Dq+ NPl/V3+ . NPr+  N🅪Sg/VP P  ISg+    .
+> So          they sat    down        , and  nobody spoke   for   some      minutes . Alice thought to herself ,
+# NSg/I/J/R/C IPl+ NSg/VP N🅪Sg/VB/J/P . VB/C NSg/I+ NSg/VPt R/C/P I/J/R/Dq+ NPl/V3+ . NPr+  N🅪Sg/VP P  ISg+    .
 > “ I       don’t see    how   he       can     ever finish , if    he       doesn’t begin  . ” But     she  waited
 # . ISg/#r+ VXB   NSg/VB NSg/C NPr/ISg+ NPr/VXB J/R  NSg/VB . NSg/C NPr/ISg+ VX3     NSg/VB . . NSg/C/P ISg+ VP/J
 > patiently .
@@ -4272,8 +4272,8 @@
 # D   NSg/VB/J NSg/VB+ . NPr+  VLPt J/R  R      NSg/Vg  NSg/VB/J/P VB/C N🅪Sg/Vg/J . . NSg/VB ISgPl+ . NPr/VB+ .
 > for   your interesting story   , ” but     she  could   not     help   thinking there must    be       more
 # R/C/P D$+  Vg/J+       NSg/VB+ . . NSg/C/P ISg+ NSg/VXB NSg/R/C NSg/VB Nᴹ/Vg/J  R+    NSg/VXB NSg/VLXB NPr/I/J/R/Dq
-> to come       , so          she  sat      still      and  said nothing  .
-# P  NSg/VBPp/P . NSg/I/J/R/C ISg+ NSg/VP/J NSg/VB/J/R VB/C VP/J NSg/I/J+ .
+> to come       , so          she  sat    still      and  said nothing  .
+# P  NSg/VBPp/P . NSg/I/J/R/C ISg+ NSg/VP NSg/VB/J/R VB/C VP/J NSg/I/J+ .
 >
 #
 > “ When    we   were little     , ” the Mock      Turtle  went    on  at    last     , more         calmly , though
@@ -4296,8 +4296,8 @@
 #
 > “ You    ought     to be       ashamed of yourself for   asking  such   a    simple    question , ” added
 # . ISgPl+ NSg/I/VXB P  NSg/VLXB J       P  ISg+     R/C/P Nᴹ/Vg/J NSg/I+ D/P+ NSg/VB/J+ NSg/VB+  . . VP/J
-> the Gryphon ; and  then      they both   sat      silent and  looked at    poor     Alice , who    felt
-# D   ?       . VB/C NSg/J/R/C IPl+ I/C/Dq NSg/VP/J NSg/J  VB/C VP/J   NSg/P NSg/VB/J NPr+  . NPr/I+ N🅪Sg/VP/J
+> the Gryphon ; and  then      they both   sat    silent and  looked at    poor     Alice , who    felt
+# D   ?       . VB/C NSg/J/R/C IPl+ I/C/Dq NSg/VP NSg/J  VB/C VP/J   NSg/P NSg/VB/J NPr+  . NPr/I+ N🅪Sg/VP/J
 > ready    to sink   into the earth    . At    last     the Gryphon said to the Mock     Turtle  ,
 # NSg/VB/J P  NSg/VB P    D   NPrᴹ/VB+ . NSg/P NSg/VB/J D   ?       VP/J P  D   NSg/VB/J NSg/VB+ .
 > “ Drive   on  , old   fellow ! Don’t be       all          day     about it       ! ” and  he       went    on  in        these
@@ -4328,8 +4328,8 @@
 # . IPl+ VP  D   NPr/VXB/JS P  NPl        . NPr/J/R/P NSg+ . IPl+ NSg/VPt P  N🅪Sg/VB Dq    NPr🅪Sg+ . .
 >
 #
-> “ I’ve been     to a   day     - school   , too , ” said Alice ; “ you    needn’t be       so          proud as    all
-# . K    NSg/VLPp P  D/P NPr🅪Sg+ . N🅪Sg/VB+ . R   . . VP/J NPr+  . . ISgPl+ VXB     NSg/VLXB NSg/I/J/R/C J     R/C/P NSg/I/J/C/Dq
+> “ I’ve been   to a   day     - school   , too , ” said Alice ; “ you    needn’t be       so          proud as    all
+# . K    VLPp/B P  D/P NPr🅪Sg+ . N🅪Sg/VB+ . R   . . VP/J NPr+  . . ISgPl+ VXB     NSg/VLXB NSg/I/J/R/C J     R/C/P NSg/I/J/C/Dq
 > that      . ”
 # I/C/Ddem+ . .
 >
@@ -4468,8 +4468,8 @@
 #
 > This    was  quite a   new   idea to Alice , and  she  thought it       over    a   little     before she
 # I/Ddem+ VLPt R     D/P NSg/J NSg  P  NPr+  . VB/C ISg+ N🅪Sg/VP NPr/ISg+ NSg/J/P D/P NPr/I/J/Dq C/P    ISg+
-> made her     next     remark  . “ Then      the eleventh day     must    have    been     a    holiday ? ”
-# VP   ISg/D$+ NSg/J/P+ NSg/VB+ . . NSg/J/R/C D+  NSg/J+   NPr🅪Sg+ NSg/VXB NSg/VXB NSg/VLPp D/P+ NPr/VB+ . .
+> made her     next     remark  . “ Then      the eleventh day     must    have    been   a    holiday ? ”
+# VP   ISg/D$+ NSg/J/P+ NSg/VB+ . . NSg/J/R/C D+  NSg/J+   NPr🅪Sg+ NSg/VXB NSg/VXB VLPp/B D/P+ NPr/VB+ . .
 >
 #
 > “ Of course  it       was  , ” said the Mock      Turtle  .
@@ -4572,10 +4572,10 @@
 #
 > “ Back     to land      again , and  that’s all          the first figure  , ” said the Mock     Turtle  ,
 # . NSg/VB/J P  NPr🅪Sg/VB P     . VB/C K      NSg/I/J/C/Dq D   NSg/J NSg/VB+ . . VP/J D   NSg/VB/J NSg/VB+ .
-> suddenly dropping his     voice   ; and  the two creatures , who    had been     jumping about
-# R        NSg/Vg   ISg/D$+ NSg/VB+ . VB/C D   NSg NPl+      . NPr/I+ VP  NSg/VLPp Nᴹ/Vg/J J/P
-> like         mad      things all          this   time       , sat      down        again very sadly and  quietly , and  looked
-# NSg/VB/J/C/P NSg/VB/J NPl+   NSg/I/J/C/Dq I/Ddem N🅪Sg/VB/J+ . NSg/VP/J N🅪Sg/VB/J/P P     J/R  R     VB/C R       . VB/C VP/J
+> suddenly dropping his     voice   ; and  the two creatures , who    had been   jumping about
+# R        NSg/Vg   ISg/D$+ NSg/VB+ . VB/C D   NSg NPl+      . NPr/I+ VP  VLPp/B Nᴹ/Vg/J J/P
+> like         mad      things all          this   time       , sat    down        again very sadly and  quietly , and  looked
+# NSg/VB/J/C/P NSg/VB/J NPl+   NSg/I/J/C/Dq I/Ddem N🅪Sg/VB/J+ . NSg/VP N🅪Sg/VB/J/P P     J/R  R     VB/C R       . VB/C VP/J
 > at    Alice .
 # NSg/P NPr+  .
 >
@@ -4754,8 +4754,8 @@
 # NSg/VXB NSg/VXB VP   ISgPl+ I/C/Ddem+ . .
 >
 #
-> “ If    I’d been     the whiting      , ” said Alice , whose thoughts were still      running   on  the
-# . NSg/C K   NSg/VLPp D   N🅪SgPl/Vg/J+ . . VP/J NPr+  . I+    NPl/V3+  VLPt NSg/VB/J/R Nᴹ/Vg/J/P J/P D
+> “ If    I’d been   the whiting      , ” said Alice , whose thoughts were still      running   on  the
+# . NSg/C K   VLPp/B D   N🅪SgPl/Vg/J+ . . VP/J NPr+  . I+    NPl/V3+  VLPt NSg/VB/J/R Nᴹ/Vg/J/P J/P D
 > song  , “ I’d have    said to the porpoise , ‘ Keep   back     , please : we   don’t want   you    with
 # N🅪Sg+ . . K   NSg/VXB VP/J P  D   NSg/VB+  . . NSg/VB NSg/VB/J . VB     . IPl+ VXB   NSg/VB ISgPl+ P
 > us       ! ’ ”
@@ -4874,8 +4874,8 @@
 # Nᴹ/VB/J+ . .
 >
 #
-> Alice said nothing  ; she  had sat      down        with her     face    in        her     hands   , wondering if
-# NPr+  VP/J NSg/I/J+ . ISg+ VP  NSg/VP/J N🅪Sg/VB/J/P P    ISg/D$+ NSg/VB+ NPr/J/R/P ISg/D$+ NPl/V3+ . Nᴹ/Vg/J   NSg/C
+> Alice said nothing  ; she  had sat    down        with her     face    in        her     hands   , wondering if
+# NPr+  VP/J NSg/I/J+ . ISg+ VP  NSg/VP N🅪Sg/VB/J/P P    ISg/D$+ NSg/VB+ NPr/J/R/P ISg/D$+ NPl/V3+ . Nᴹ/Vg/J   NSg/C
 > anything  would ever happen in        a    natural way    again .
 # NSg/I/VB+ VXB   J/R  VB     NPr/J/R/P D/P+ NSg/J+  NSg/J+ P     .
 >
@@ -5034,8 +5034,8 @@
 # D+  N🅪Sg/VB/J+ .
 >
 #
-> Alice had never been     in        a   court     of justice before , but     she  had read    about them
-# NPr+  VP  R     NSg/VLPp NPr/J/R/P D/P N🅪Sg/VB/J P  NPr🅪Sg+ C/P    . NSg/C/P ISg+ VP  NSg/VBP J/P   NSg/IPl+
+> Alice had never been   in        a   court     of justice before , but     she  had read    about them
+# NPr+  VP  R     VLPp/B NPr/J/R/P D/P N🅪Sg/VB/J P  NPr🅪Sg+ C/P    . NSg/C/P ISg+ VP  NSg/VBP J/P   NSg/IPl+
 > in        books   , and  she  was  quite pleased to find   that     she  knew the name   of nearly
 # NPr/J/R/P NPl/V3+ . VB/C ISg+ VLPt R     VP/J    P  NSg/VB I/C/Ddem ISg+ VPt  D   NSg/VB P  R
 > everything there . “ That’s the judge   , ” she  said to herself , “ because of his     great
@@ -5160,14 +5160,14 @@
 # . ISgPl+ NSg/I/VXB P  NSg/VXB VP/J     . . VP/J D+  NPr/VB/J+ . . NSg/I/C VXPt ISgPl+ NSg/VB . .
 >
 #
-> The Hatter looked at    the March   Hare      , who    had followed him  into the court      ,
-# D   NSg/VB VP/J   NSg/P D   NPr/VB+ NSg/VB/J+ . NPr/I+ VP  VP/J     ISg+ P    D   N🅪Sg/VB/J+ .
+> The Hatter looked at    the March   Hare , who    had followed him  into the court      ,
+# D   NSg/VB VP/J   NSg/P D   NPr/VB+ NSg+ . NPr/I+ VP  VP/J     ISg+ P    D   N🅪Sg/VB/J+ .
 > arm       - in        - arm       with the Dormouse . “ Fourteenth of March   , I       think  it       was  , ” he       said .
 # NSg/VB/J+ . NPr/J/R/P . NSg/VB/J+ P    D   NSg      . . NSg/J      P  NPr/VB+ . ISg/#r+ NSg/VB NPr/ISg+ VLPt . . NPr/ISg+ VP/J .
 >
 #
-> “ Fifteenth , ” said the March   Hare      .
-# . NSg/J+    . . VP/J D+  NPr/VB+ NSg/VB/J+ .
+> “ Fifteenth , ” said the March   Hare .
+# . NSg/J+    . . VP/J D+  NPr/VB+ NSg+ .
 >
 #
 > “ Sixteenth , ” added the Dormouse .
@@ -5229,7 +5229,7 @@
 > again , and  she  thought at    first she  would get    up         and  leave  the court      ; but     on
 # P     . VB/C ISg+ N🅪Sg/VP NSg/P NSg/J ISg+ VXB   NSg/VB NSg/VB/J/P VB/C NSg/VB D+  N🅪Sg/VB/J+ . NSg/C/P J/P
 > second    thoughts she  decided  to remain where   she  was  as    long     as    there was  room
-# NSg/VB/J+ NPl/V3+  ISg+ NSg/VP/J P  NSg/VB NSg/R/C ISg+ VLPt R/C/P NPr/VB/J R/C/P R+    VLPt N🅪Sg/VB/J+
+# NSg/VB/J+ NPl/V3+  ISg+ NSg/VP/J P  NSg/VB NSg/R/C ISg+ VLPt R/C/P NPr/VB/J R/C/P R+    VLPt N🅪Sg/VB+
 > for   her     .
 # R/C/P ISg/D$+ .
 >
@@ -5300,20 +5300,20 @@
 #
 > “ I’m a    poor     man     , ” the Hatter went    on  , “ and  most         things twinkled after that      — only
 # . K   D/P+ NSg/VB/J NPr/VB+ . . D   NSg/VB NSg/VPt J/P . . VB/C NSg/I/J/R/Dq NPl+   VP/J     P     I/C/Ddem+ . J/R/C
-> the March   Hare      said — ”
-# D   NPr/VB+ NSg/VB/J+ VP/J . .
+> the March   Hare said — ”
+# D   NPr/VB+ NSg+ VP/J . .
 >
 #
-> “ I       didn’t ! ” the March   Hare      interrupted in        a    great  hurry   .
-# . ISg/#r+ VXPt   . . D+  NPr/VB+ NSg/VB/J+ VP/J        NPr/J/R/P D/P+ NSg/J+ NSg/VB+ .
+> “ I       didn’t ! ” the March   Hare interrupted in        a    great  hurry   .
+# . ISg/#r+ VXPt   . . D+  NPr/VB+ NSg+ VP/J        NPr/J/R/P D/P+ NSg/J+ NSg/VB+ .
 >
 #
 > “ You    did  ! ” said the Hatter .
 # . ISgPl+ VXPt . . VP/J D   NSg/VB .
 >
 #
-> “ I       deny it       ! ” said the March   Hare      .
-# . ISg/#r+ VB   NPr/ISg+ . . VP/J D+  NPr/VB+ NSg/VB/J+ .
+> “ I       deny it       ! ” said the March   Hare .
+# . ISg/#r+ VB   NPr/ISg+ . . VP/J D+  NPr/VB+ NSg+ .
 >
 #
 > “ He       denies it       , ” said the King      : “ leave  out          that     part      . ”
@@ -5361,7 +5361,7 @@
 > you    how   it       was  done      . They had a    large  canvas  bag     , which tied up         at    the mouth
 # ISgPl+ NSg/C NPr/ISg+ VLPt NSg/VPp/J . IPl+ VP  D/P+ NSg/J+ NSg/VB+ NSg/VB+ . I/C+  VP/J NSg/VB/J/P NSg/P D   NSg/VB+
 > with strings : into this    they slipped the guinea - pig    , head      first , and  then      sat
-# P    NPl/V3+ . P    I/Ddem+ IPl+ VP/J    D   NPr+   . NSg/VB . NPr/VB/J+ NSg/J . VB/C NSg/J/R/C NSg/VP/J
+# P    NPl/V3+ . P    I/Ddem+ IPl+ VP/J    D   NPr+   . NSg/VB . NPr/VB/J+ NSg/J . VB/C NSg/J/R/C NSg/VP
 > upon it       . )
 # P    NPr/ISg+ . .
 >
@@ -5538,8 +5538,8 @@
 #
 > As    soon as    the jury      had a   little     recovered from the shock  of being        upset    , and
 # R/C/P J/R  R/C/P D+  NSg/VB/J+ VP  D/P NPr/I/J/Dq VP/J+     P    D   N🅪Sg/J P  N🅪Sg/VLg/J/C NSg/VB/J . VB/C
-> their slates and  pencils had been     found  and  handed back     to them     , they set       to
-# D$+   NPl/V3 VB/C NPl/V3+ VP  NSg/VLPp NSg/VP VB/C VP/J   NSg/VB/J P  NSg/IPl+ . IPl+ NPr/VBP/J P
+> their slates and  pencils had been   found  and  handed back     to them     , they set       to
+# D$+   NPl/V3 VB/C NPl/V3+ VP  VLPp/B NSg/VP VB/C VP/J   NSg/VB/J P  NSg/IPl+ . IPl+ NPr/VBP/J P
 > work    very diligently to write  out          a   history of the accident , all          except the
 # N🅪Sg/VB J/R  R          P  NSg/VB NSg/VB/J/R/P D/P N🅪Sg    P  D   NSg/J+   . NSg/I/J/C/Dq VB/C/P D
 > Lizard , who    seemed too much         overcome to do  anything  but     sit    with its     mouth   open     ,
@@ -5594,8 +5594,8 @@
 # N🅪Sg/VB+ D/P NSg/VPt+ . . ISg+ N🅪Sg/VP P  ISg+    .
 >
 #
-> At    this    moment the King      , who    had been     for   some      time       busily writing in        his
-# NSg/P I/Ddem+ NSg+   D+  NPr/VB/J+ . NPr/I+ VP  NSg/VLPp R/C/P I/J/R/Dq+ N🅪Sg/VB/J+ R      Nᴹ/Vg/J NPr/J/R/P ISg/D$+
+> At    this    moment the King      , who    had been   for   some      time       busily writing in        his
+# NSg/P I/Ddem+ NSg+   D+  NPr/VB/J+ . NPr/I+ VP  VLPp/B R/C/P I/J/R/Dq+ N🅪Sg/VB/J+ R      Nᴹ/Vg/J NPr/J/R/P ISg/D$+
 > note    - book    , cackled out          “ Silence ! ” and  read    out          from his     book    , “ Rule    Forty - two .
 # NSg/VB+ . NSg/VB+ . VP/J    NSg/VB/J/R/P . NSg/VB+ . . VB/C NSg/VBP NSg/VB/J/R/P P    ISg/D$+ NSg/VB+ . . NSg/VB+ NSg/J . NSg .
 > All           persons more         than a    mile high       to leave  the court      . ”
@@ -5640,8 +5640,8 @@
 #
 > “ There’s more         evidence to come       yet      , please your Majesty , ” said the White       Rabbit  ,
 # . K       NPr/I/J/R/Dq Nᴹ/VB+   P  NSg/VBPp/P NSg/VB/C . VB     D$+  N🅪Sg/I+ . . VP/J D   NPr🅪Sg/VB/J NSg/VB+ .
-> jumping up         in        a   great hurry   ; “ this   paper      has just been     picked up         . ”
-# Nᴹ/Vg/J NSg/VB/J/P NPr/J/R/P D/P NSg/J NSg/VB+ . . I/Ddem N🅪Sg/VB/J+ V3  J/R  NSg/VLPp VP/J   NSg/VB/J/P . .
+> jumping up         in        a   great hurry   ; “ this   paper      has just been   picked up         . ”
+# Nᴹ/Vg/J NSg/VB/J/P NPr/J/R/P D/P NSg/J NSg/VB+ . . I/Ddem N🅪Sg/VB/J+ V3  J/R  VLPp/B VP/J   NSg/VB/J/P . .
 >
 #
 > “ What’s in        it       ? ” said the Queen     .
@@ -5654,8 +5654,8 @@
 # VPp/J   NSg/P D   NSg+     P  . P  NSg/I+   . .
 >
 #
-> “ It       must    have    been     that      , ” said the King      , “ unless it       was  written to nobody , which
-# . NPr/ISg+ NSg/VXB NSg/VXB NSg/VLPp I/C/Ddem+ . . VP/J D+  NPr/VB/J+ . . C      NPr/ISg+ VLPt VPp/J   P  NSg/I+ . I/C+
+> “ It       must    have    been   that      , ” said the King      , “ unless it       was  written to nobody , which
+# . NPr/ISg+ NSg/VXB NSg/VXB VLPp/B I/C/Ddem+ . . VP/J D+  NPr/VB/J+ . . C      NPr/ISg+ VLPt VPp/J   P  NSg/I+ . I/C+
 > isn’t   usual , you    know . ”
 # NSg/VX3 NSg/J . ISgPl+ VB   . .
 >
@@ -5738,8 +5738,8 @@
 # I/Ddem+ VLPt D   NPl/V3 D   NPr🅪Sg/VB/J NSg/VB+ NSg/VBP . .
 >
 #
-> “ They told me       you    had been     to her     , And  mentioned me       to him  : She  gave me       a    good
-# . IPl+ VP   NPr/ISg+ ISgPl+ VP  NSg/VLPp P  ISg/D$+ . VB/C VP/J      NPr/ISg+ P  ISg+ . ISg+ VPt  NPr/ISg+ D/P+ NPr/VB/J+
+> “ They told me       you    had been   to her     , And  mentioned me       to him  : She  gave me       a    good
+# . IPl+ VP   NPr/ISg+ ISgPl+ VP  VLPp/B P  ISg/D$+ . VB/C VP/J      NPr/ISg+ P  ISg+ . ISg+ VPt  NPr/ISg+ D/P+ NPr/VB/J+
 > character , But     said I       could   not     swim   .
 # N🅪Sg/VB+  . NSg/C/P VP/J ISg/#r+ NSg/VXB NSg/R/C NSg/VB .
 >
@@ -5762,8 +5762,8 @@
 # NPr/VBP/J NSg/IPl+ NSg/VB/J . R       R/C/P IPl+ VLPt .
 >
 #
-> My  notion was  that     you    had been     ( Before she  had this    fit        ) An   obstacle that
-# D$+ NSg+   VLPt I/C/Ddem ISgPl+ VP  NSg/VLPp . C/P    ISg+ VP  I/Ddem+ NSg/VBP/J+ . D/P+ NSg+     I/C/Ddem+
+> My  notion was  that     you    had been   ( Before she  had this    fit        ) An   obstacle that
+# D$+ NSg+   VLPt I/C/Ddem ISgPl+ VP  VLPp/B . C/P    ISg+ VP  I/Ddem+ NSg/VBP/J+ . D/P+ NSg+     I/C/Ddem+
 > came      between Him  , and  ourselves , and  it       .
 # NSg/VPt/P NSg/P   ISg+ . VB/C IPl+      . VB/C NPr/ISg+ .
 >
@@ -5904,18 +5904,18 @@
 # . NPr/VB . K    VP  NSg/I D/P J       NSg/VB/J+ . . VP/J NPr+  . VB/C ISg+ VP   ISg/D$+ NSg/VB+ . R/C/P
 > well       as    she  could   remember them     , all          these  strange  Adventures of hers that     you
 # NSg/VB/J/R R/C/P ISg+ NSg/VXB NSg/VB   NSg/IPl+ . NSg/I/J/C/Dq I/Ddem NSg/VB/J NPl/V3     P  ISg+ I/C/Ddem ISgPl+
-> have    just been     reading     about ; and  when    she  had finished , her     sister  kissed her     ,
-# NSg/VXB J/R  NSg/VLPp NPr🅪Sg/Vg/J J/P   . VB/C NSg/I/C ISg+ VP  VP/J     . ISg/D$+ NSg/VB+ VP/J   ISg/D$+ .
+> have    just been   reading     about ; and  when    she  had finished , her     sister  kissed her     ,
+# NSg/VXB J/R  VLPp/B NPr🅪Sg/Vg/J J/P   . VB/C NSg/I/C ISg+ VP  VP/J     . ISg/D$+ NSg/VB+ VP/J   ISg/D$+ .
 > and  said , “ It       was  a   curious dream    , dear     , certainly : but     now       run      in        to your tea      ;
 # VB/C VP/J . . NPr/ISg+ VLPt D/P J       NSg/VB/J . NSg/VB/J . R         . NSg/C/P NSg/J/R/C NSg/VBPp NPr/J/R/P P  D$+  N🅪Sg/VB+ .
 > it’s getting late  . ” So          Alice got up         and  ran off        , thinking while      she  ran , as    well
 # K    NSg/Vg  NSg/J . . NSg/I/J/R/C NPr+  VP  NSg/VB/J/P VB/C VPt NSg/VB/J/P . Nᴹ/Vg/J  NSg/VB/C/P ISg+ VPt . R/C/P NSg/VB/J/R
-> she  might    , what   a    wonderful dream     it       had been     .
-# ISg+ Nᴹ/VXB/J . NSg/I+ D/P+ J+        NSg/VB/J+ NPr/ISg+ VP  NSg/VLPp .
+> she  might    , what   a    wonderful dream     it       had been   .
+# ISg+ Nᴹ/VXB/J . NSg/I+ D/P+ J+        NSg/VB/J+ NPr/ISg+ VP  VLPp/B .
 >
 #
-> But     her     sister  sat      still      just as    she  left     her     , leaning her     head      on  her     hand    ,
-# NSg/C/P ISg/D$+ NSg/VB+ NSg/VP/J NSg/VB/J/R J/R  R/C/P ISg+ NPr/VP/J ISg/D$+ . Nᴹ/Vg/J ISg/D$+ NPr/VB/J+ J/P ISg/D$+ NSg/VB+ .
+> But     her     sister  sat    still      just as    she  left     her     , leaning her     head      on  her     hand    ,
+# NSg/C/P ISg/D$+ NSg/VB+ NSg/VP NSg/VB/J/R J/R  R/C/P ISg+ NPr/VP/J ISg/D$+ . Nᴹ/Vg/J ISg/D$+ NPr/VB/J+ J/P ISg/D$+ NSg/VB+ .
 > watching the setting    sun     , and  thinking of little      Alice and  all           her     wonderful
 # Nᴹ/Vg/J  D+  N🅪Sg/Vg/J+ NPr/VB+ . VB/C Nᴹ/Vg/J  P  NPr/I/J/Dq+ NPr+  VB/C NSg/I/J/C/Dq+ ISg/D$+ J+
 > Adventures , till       she  too began dreaming after a    fashion  , and  this    was  her
@@ -5942,8 +5942,8 @@
 # D+  NPr/VB/J+ NPr🅪Sg/VB+ VP/J    NSg/P ISg/D$+ NPl+ R/C/P D   NPr🅪Sg/VB/J NSg/VB+ VP/J    NSg/P . D   VP/J
 > Mouse   splashed his     way    through the neighbouring pool    — she  could   hear the rattle
 # NSg/VB+ VP/J     ISg/D$+ NSg/J+ J/P     D   Nᴹ/Vg/J/Comm NSg/VB+ . ISg+ NSg/VXB VB   D   NSg/VB
-> of the teacups as    the March   Hare      and  his     friends   shared their never - ending  meal    ,
-# P  D   NPl     R/C/P D   NPr/VB+ NSg/VB/J+ VB/C ISg/D$+ NPrPl/V3+ VP/J   D$+   R     . Nᴹ/Vg/J NSg/VB+ .
+> of the teacups as    the March   Hare and  his     friends   shared their never - ending  meal    ,
+# P  D   NPl     R/C/P D   NPr/VB+ NSg+ VB/C ISg/D$+ NPrPl/V3+ VP/J   D$+   R     . Nᴹ/Vg/J NSg/VB+ .
 > and  the shrill   voice  of the Queen     ordering off        her     unfortunate guests  to
 # VB/C D   NSg/VB/J NSg/VB P  D   NPr/VB/J+ Nᴹ/Vg/J+ NSg/VB/J/P ISg/D$+ NSg/J       NPl/V3+ P
 > execution — once  more         the pig     - baby      was  sneezing on  the Duchess’s knee    , while
@@ -5958,8 +5958,8 @@
 # NSg/VB/J NSg/VB+ .
 >
 #
-> So          she  sat      on  , with closed eyes    , and  half      believed herself in        Wonderland , though
-# NSg/I/J/R/C ISg+ NSg/VP/J J/P . P    VP/J   NPl/V3+ . VB/C N🅪Sg/J/P+ VP/J     ISg+    NPr/J/R/P NSg+       . C
+> So          she  sat    on  , with closed eyes    , and  half      believed herself in        Wonderland , though
+# NSg/I/J/R/C ISg+ NSg/VP J/P . P    VP/J   NPl/V3+ . VB/C N🅪Sg/J/P+ VP/J     ISg+    NPr/J/R/P NSg+       . C
 > she  knew she  had but     to open     them     again , and  all          would change  to dull
 # ISg+ VPt  ISg+ VP  NSg/C/P P  NSg/VB/J NSg/IPl+ P     . VB/C NSg/I/J/C/Dq VXB   N🅪Sg/VB P  VB/J+
 > reality — the grass      would be       only  rustling in        the wind     , and  the pool    rippling to

--- a/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
+++ b/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
@@ -2,8 +2,8 @@
 # HeadingStart NPr$    NPl/V3     NPr/J/R/P NSg+
 >
 #
-> by    Lewis Carroll
-# NSg/P NPr+  NPr+
+> by Lewis Carroll
+# P  NPr+  NPr+
 >
 #
 > THE MILLENNIUM FULCRUM EDITION 3.0
@@ -14,8 +14,8 @@
 # HeadingStart NSg/VB+ ISg/#r+ . N🅪Sg/VB/J/P D   NSg/VB+ . NSg/VB+
 >
 #
-> Alice was  beginning to get    very tired of sitting  by    her     sister  on  the bank    , and
-# NPr+  VLPt NSg/Vg/J  P  NSg/VB J/R  VP/J  P  NSg/Vg/J NSg/P ISg/D$+ NSg/VB+ J/P D+  NSg/VB+ . VB/C
+> Alice was  beginning to get    very tired of sitting  by her     sister  on  the bank    , and
+# NPr+  VLPt NSg/Vg/J  P  NSg/VB J/R  VP/J  P  NSg/Vg/J P  ISg/D$+ NSg/VB+ J/P D+  NSg/VB+ . VB/C
 > of having  nothing  to do  : once  or    twice she  had peeped into the book    her     sister
 # P  Nᴹ/Vg/J NSg/I/J+ P  VXB . NSg/C NPr/C R     ISg+ VP  VP/J   P    D+  NSg/VB+ ISg/D$+ NSg/VB+
 > was  reading     , but     it       had no       pictures or    conversations in        it       , “ and  what   is  the use
@@ -30,8 +30,8 @@
 # VP   ISg/D$+ NSg/I/VB J/R  NSg/J  VB/C NSg/J  . . I/C     D   NSg/VB   P  Nᴹ/Vg/J D/P+
 > daisy - chain    would be       worth    the trouble of getting up         and  picking the daisies ,
 # NPr+  . N🅪Sg/VB+ VXB   NSg/VLXB NSg/VB/J D   N🅪Sg/VB P  NSg/Vg  NSg/VB/J/P VB/C Nᴹ/Vg/J D   NPl     .
-> when    suddenly a   White       Rabbit  with pink      eyes    ran close    by    her     .
-# NSg/I/C R        D/P NPr🅪Sg/VB/J NSg/VB+ P    N🅪Sg/VB/J NPl/V3+ VPt NSg/VB/J NSg/P ISg/D$+ .
+> when    suddenly a   White       Rabbit  with pink      eyes    ran close    by her     .
+# NSg/I/C R        D/P NPr🅪Sg/VB/J NSg/VB+ P    N🅪Sg/VB/J NPl/V3+ VPt NSg/VB/J P  ISg/D$+ .
 >
 #
 > There was  nothing  so          very remarkable in        that      ; nor   did  Alice think  it       so          very
@@ -104,8 +104,8 @@
 #
 > Down        , down        , down        . Would the fall     never come       to an   end     ? “ I       wonder  how   many        miles
 # N🅪Sg/VB/J/P . N🅪Sg/VB/J/P . N🅪Sg/VB/J/P . VXB   D+  N🅪Sg/VB+ R     NSg/VBPp/P P  D/P+ NSg/VB+ . . ISg/#r+ N🅪Sg/VB NSg/C NSg/I/J/Dq+ NPrPl+
-> I’ve fallen by    this   time       ? ” she  said aloud . “ I       must    be       getting somewhere near       the
-# K    VPp/J  NSg/P I/Ddem N🅪Sg/VB/J+ . . ISg+ VP/J J     . . ISg/#r+ NSg/VXB NSg/VLXB NSg/Vg  R         NSg/VB/J/P D
+> I’ve fallen by this   time       ? ” she  said aloud . “ I       must    be       getting somewhere near       the
+# K    VPp/J  P  I/Ddem N🅪Sg/VB/J+ . . ISg+ VP/J J     . . ISg/#r+ NSg/VXB NSg/VLXB NSg/Vg  R         NSg/VB/J/P D
 > centre      of the earth    . Let     me       see    : that      would be       four thousand miles  down        , I
 # NSg/VB/Comm P  D+  NPrᴹ/VB+ . NSg/VBP NPr/ISg+ NSg/VB . I/C/Ddem+ VXB   NSg/VLXB NSg+ NSg+     NPrPl+ N🅪Sg/VB/J/P . ISg/#r+
 > think  — ” ( for   , you    see    , Alice had learnt several things of this    sort    in        her
@@ -182,8 +182,8 @@
 # NPr/ISg+ NSg/VB . R/C/P NPr/ISg+ VP/J   D/P+ NSg/VB+ . . NPr/VB D$+ NPl/V3+ VB/C NPl      . NSg/C NSg/J K    NSg/Vg  . .
 > She  was  close    behind  it       when    she  turned the corner  , but     the Rabbit  was  no       longer
 # ISg+ VLPt NSg/VB/J NSg/J/P NPr/ISg+ NSg/I/C ISg+ VP/J   D+  NSg/VB+ . NSg/C/P D+  NSg/VB+ VLPt NSg/Dq/P NSg/JC
-> to be       seen    : she  found  herself in        a   long     , low         hall , which was  lit      up         by    a   row    of
-# P  NSg/VLXB NSg/VPp . ISg+ NSg/VP ISg+    NPr/J/R/P D/P NPr/VB/J . NSg/VB/J/R+ NPr+ . I/C+  VLPt NSg/VP/J NSg/VB/J/P NSg/P D/P NSg/VB P
+> to be       seen    : she  found  herself in        a   long     , low         hall , which was  lit      up         by a   row    of
+# P  NSg/VLXB NSg/VPp . ISg+ NSg/VP ISg+    NPr/J/R/P D/P NPr/VB/J . NSg/VB/J/R+ NPr+ . I/C+  VLPt NSg/VP/J NSg/VB/J/P P  D/P NSg/VB P
 > lamps   hanging from the roof    .
 # NPl/V3+ Nᴹ/Vg/J P    D+  NSg/VB+ .
 >
@@ -236,8 +236,8 @@
 # R      NSg/J      .
 >
 #
-> There seemed to be       no       use     in        waiting  by    the little      door    , so          she  went    back     to the
-# R+    VP/J   P  NSg/VLXB NSg/Dq/P N🅪Sg/VB NPr/J/R/P Nᴹ/Vg/J+ NSg/P D+  NPr/I/J/Dq+ NSg/VB+ . NSg/I/J/R/C ISg+ NSg/VPt NSg/VB/J P  D+
+> There seemed to be       no       use     in        waiting  by the little      door    , so          she  went    back     to the
+# R+    VP/J   P  NSg/VLXB NSg/Dq/P N🅪Sg/VB NPr/J/R/P Nᴹ/Vg/J+ P  D+  NPr/I/J/Dq+ NSg/VB+ . NSg/I/J/R/C ISg+ NSg/VPt NSg/VB/J P  D+
 > table   , half      hoping  she  might    find   another key      on  it       , or    at    any    rate    a   book   of
 # NSg/VB+ . N🅪Sg/J/P+ Nᴹ/Vg/J ISg+ Nᴹ/VXB/J NSg/VB I/D     NPr/VB/J J/P NPr/ISg+ . NPr/C NSg/P I/R/Dq NSg/VB+ D/P NSg/VB P
 > rules   for   shutting people  up         like         telescopes : this   time       she  found  a   little
@@ -256,8 +256,8 @@
 # P  VXB I/C/Ddem+ NPr/J/R/P D/P+ NSg/VB+ . . NSg/Dq/P . K    NSg/VB NSg/J . . ISg+ VP/J . . VB/C NSg/VB I/C     K
 > marked ‘ poison   ’ or    not     ” ; for   she  had read    several nice  little     histories about
 # VP/J   . N🅪Sg/VB+ . NPr/C NSg/R/C . . R/C/P ISg+ VP  NSg/VBP J/Dq    NPr/J NPr/I/J/Dq NPl       J/P
-> children who    had got burnt , and  eaten up         by    wild     beasts and  other    unpleasant
-# NPl+     NPr/I+ VP  VP  VB/J  . VB/C VPp/J NSg/VB/J/P NSg/P NSg/VB/J NPl/V3 VB/C NSg/VB/J NSg/J
+> children who    had got burnt , and  eaten up         by wild     beasts and  other    unpleasant
+# NPl+     NPr/I+ VP  VP  VB/J  . VB/C VPp/J NSg/VB/J/P P  NSg/VB/J NPl/V3 VB/C NSg/VB/J NSg/J
 > things , all          because they would not     remember the simple   rules   their friends   had
 # NPl+   . NSg/I/J/C/Dq C/P     IPl+ VXB   NSg/R/C NSg/VB   D   NSg/VB/J NPl/V3+ D$+   NPrPl/V3+ VP
 > taught them     : such  as    , that     a   red    - hot      poker   will    burn   you    if    you    hold     it       too
@@ -397,7 +397,7 @@
 >
 #
 > And  she  went    on  planning to herself how   she  would manage it       . “ They must    go       by
-# VB/C ISg+ NSg/VPt J/P NSg/Vg   P  ISg+    NSg/C ISg+ VXB   NSg/VB NPr/ISg+ . . IPl+ NSg/VXB NSg/VB/J NSg/P
+# VB/C ISg+ NSg/VPt J/P NSg/Vg   P  ISg+    NSg/C ISg+ VXB   NSg/VB NPr/ISg+ . . IPl+ NSg/VXB NSg/VB/J P
 > the carrier , ” she  thought ; “ and  how   funny it’ll seem , sending presents to one’s
 # D+  NPr+    . . ISg+ N🅪Sg/VP . . VB/C NSg/C NSg/J K     VB   . Nᴹ/Vg/J NPl/V3+  P  NSg$
 > own      feet ! And  how   odd    the directions will    look   !
@@ -544,8 +544,8 @@
 # VP  NSg/VBP J/P NSg/I/J P  D   NSg$     NPr/I/J/Dq NPr🅪Sg/VB/J NSg/VB+ NPl/V3+ NSg/VB/C/P ISg+ VLPt Nᴹ/Vg/J .
 > “ How   can     I       have    done      that      ? ” she  thought . “ I       must    be       growing small    again . ” She
 # . NSg/C NPr/VXB ISg/#r+ NSg/VXB NSg/VPp/J I/C/Ddem+ . . ISg+ N🅪Sg/VP . . ISg/#r+ NSg/VXB NSg/VLXB Nᴹ/Vg/J NPr/VB/J P     . . ISg+
-> got up         and  went    to the table   to measure herself by    it       , and  found  that      , as    nearly
-# VP  NSg/VB/J/P VB/C NSg/VPt P  D+  NSg/VB+ P  NSg/VB  ISg+    NSg/P NPr/ISg+ . VB/C NSg/VP I/C/Ddem+ . R/C/P R
+> got up         and  went    to the table   to measure herself by it       , and  found  that      , as    nearly
+# VP  NSg/VB/J/P VB/C NSg/VPt P  D+  NSg/VB+ P  NSg/VB  ISg+    P  NPr/ISg+ . VB/C NSg/VP I/C/Ddem+ . R/C/P R
 > as    she  could   guess  , she  was  now       about two  feet high       , and  was  going   on  shrinking
 # R/C/P ISg+ NSg/VXB NSg/VB . ISg+ VLPt NSg/J/R/C J/P   NSg+ NPl+ NSg/VB/J/R . VB/C VLPt Nᴹ/Vg/J J/P Nᴹ/Vg/J
 > rapidly : she  soon found  out          that     the cause     of this    was  the fan    she  was  holding ,
@@ -574,8 +574,8 @@
 # R/C/P ISg+ VP/J I/Ddem+ NPl/V3+ ISg/D$+ NSg/VB+ VP/J    . VB/C NPr/J/R/P I/D+    NSg+   . NSg/VB+ . ISg+ VLPt
 > up         to her     chin    in        salt         water    . Her     first  idea was  that     she  had somehow fallen
 # NSg/VB/J/P P  ISg/D$+ NPr/VB+ NPr/J/R/P NPr🅪Sg/VB/J+ N🅪Sg/VB+ . ISg/D$+ NSg/J+ NSg+ VLPt I/C/Ddem ISg+ VP  R       VPp/J
-> into the sea  , “ and  in        that     case       I       can     go       back     by    railway , ” she  said to herself .
-# P    D+  NSg+ . . VB/C NPr/J/R/P I/C/Ddem NPr🅪Sg/VB+ ISg/#r+ NPr/VXB NSg/VB/J NSg/VB/J NSg/P NSg+    . . ISg+ VP/J P  ISg+    .
+> into the sea  , “ and  in        that     case       I       can     go       back     by railway , ” she  said to herself .
+# P    D+  NSg+ . . VB/C NPr/J/R/P I/C/Ddem NPr🅪Sg/VB+ ISg/#r+ NPr/VXB NSg/VB/J NSg/VB/J P  NSg+    . . ISg+ VP/J P  ISg+    .
 > ( Alice had been   to the seaside once  in        her     life     , and  had come       to the general
 # . NPr+  VP  VLPp/B P  D   NPr/J   NSg/C NPr/J/R/P ISg/D$+ N🅪Sg/VB+ . VB/C VP  NSg/VBPp/P P  D   NSg/VB/J
 > conclusion , that      wherever you    go       to on  the English      coast   you    find   a   number     of
@@ -592,8 +592,8 @@
 #
 > “ I       wish   I       hadn’t cried so          much         ! ” said Alice , as    she  swam about , trying  to find
 # . ISg/#r+ NSg/VB ISg/#r+ VPt    VP/J  NSg/I/J/R/C NSg/I/J/R/Dq . . VP/J NPr+  . R/C/P ISg+ VPt  J/P   . Nᴹ/Vg/J P  NSg/VB
-> her     way    out          . “ I       shall be       punished for   it       now       , I       suppose , by    being        drowned in        my
-# ISg/D$+ NSg/J+ NSg/VB/J/R/P . . ISg/#r+ VXB   NSg/VLXB VP/J     R/C/P NPr/ISg+ NSg/J/R/C . ISg/#r+ VB      . NSg/P N🅪Sg/VLg/J/C VP/J    NPr/J/R/P D$+
+> her     way    out          . “ I       shall be       punished for   it       now       , I       suppose , by being        drowned in        my
+# ISg/D$+ NSg/J+ NSg/VB/J/R/P . . ISg/#r+ VXB   NSg/VLXB VP/J     R/C/P NPr/ISg+ NSg/J/R/C . ISg/#r+ VB      . P  N🅪Sg/VLg/J/C VP/J    NPr/J/R/P D$+
 > own       tears   ! That      will    be       a   queer     thing , to be       sure ! However , everything is  queer
 # NSg/VB/J+ NPl/V3+ . I/C/Ddem+ NPr/VXB NSg/VLXB D/P NSg/VB/J+ NSg+  . P  NSg/VLXB J    . C       . NSg/I/VB+  VL3 NSg/VB/J
 > to - day     . ”
@@ -660,8 +660,8 @@
 # NPl/V3 NSg/C ISgPl+ NSg/VXB J/R/C NSg/VB ISg/D$+ . ISg+ VL3 NSg/I D/P NSg/VB/J N🅪Sg/VB/J NSg   . . NPr+  NSg/VPt J/P .
 > half      to herself , as    she  swam lazily about in        the pool    , “ and  she  sits   purring so
 # N🅪Sg/J/P+ P  ISg+    . R/C/P ISg+ VPt  R      J/P   NPr/J/R/P D+  NSg/VB+ . . VB/C ISg+ NPl/V3 Nᴹ/Vg/J NSg/I/J/R/C
-> nicely by    the fire       , licking her     paws    and  washing her     face    — and  she  is  such  a   nice
-# R      NSg/P D   N🅪Sg/VB/J+ . Nᴹ/Vg/J ISg/D$+ NPl/V3+ VB/C Nᴹ/Vg/J ISg/D$+ NSg/VB+ . VB/C ISg+ VL3 NSg/I D/P NPr/J
+> nicely by the fire       , licking her     paws    and  washing her     face    — and  she  is  such  a   nice
+# R      P  D   N🅪Sg/VB/J+ . Nᴹ/Vg/J ISg/D$+ NPl/V3+ VB/C Nᴹ/Vg/J ISg/D$+ NSg/VB+ . VB/C ISg+ VL3 NSg/I D/P NPr/J
 > soft  thing to nurse  — and  she’s such  a   capital one      for   catching mice    — oh     , I       beg
 # NSg/J NSg+  P  NSg/VB . VB/C K     NSg/I D/P N🅪Sg/J+ NSg/I/J+ R/C/P Nᴹ/Vg/J  NPl/VB+ . NPr/VB . ISg/#r+ NSg/VB
 > your pardon ! ” cried Alice again , for   this    time       the Mouse   was  bristling all          over    ,
@@ -772,8 +772,8 @@
 # . VB   . . VP/J D   NSg/VB+ P    D/P+ J+        N🅪Sg/VB+ . . VLB ISgPl+ NSg/I/J/C/Dq NSg/VB/J . I/Ddem+ VL3 D
 > driest thing I       know . Silence all          round      , if    you    please ! ‘ William the Conqueror ,
 # JS     NSg   ISg/#r+ VB   . NSg/VB+ NSg/I/J/C/Dq NSg/VB/J/P . NSg/C ISgPl+ VB     . . NPr+    D   NSg       .
-> whose cause      was  favoured  by    the pope    , was  soon submitted to by    the English      , who
-# I+    N🅪Sg/VB/C+ VLPt VP/J/Comm NSg/P D   NPr/VB+ . VLPt J/R  VP        P  NSg/P D   NPr🅪Sg/VB/J+ . NPr/I+
+> whose cause      was  favoured  by the pope    , was  soon submitted to by the English      , who
+# I+    N🅪Sg/VB/C+ VLPt VP/J/Comm P  D   NPr/VB+ . VLPt J/R  VP        P  P  D   NPr🅪Sg/VB/J+ . NPr/I+
 > wanted leaders , and  had been   of late  much         accustomed to usurpation and  conquest .
 # VP/J   NPl+    . VB/C VP  VLPp/B P  NSg/J NSg/I/J/R/Dq VP/J       P  NSg        VB/C NSg/VB+  .
 > Edwin and  Morcar , the earls of Mercia and  Northumbria — ’ ”
@@ -1030,8 +1030,8 @@
 #
 > “ I       shall do  nothing of the sort    , ” said the Mouse   , getting up         and  walking away .
 # . ISg/#r+ VXB   VXB NSg/I/J P  D+  NSg/VB+ . . VP/J D+  NSg/VB+ . NSg/Vg  NSg/VB/J/P VB/C Nᴹ/Vg/J VB/J .
-> “ You    insult  me       by    talking such   nonsense ! ”
-# . ISgPl+ NSg/VB+ NPr/ISg+ NSg/P Nᴹ/Vg/J NSg/I+ Nᴹ/VB/J+ . .
+> “ You    insult  me       by talking such   nonsense ! ”
+# . ISgPl+ NSg/VB+ NPr/ISg+ P  Nᴹ/Vg/J NSg/I+ Nᴹ/VB/J+ . .
 >
 #
 > “ I       didn’t mean     it       ! ” pleaded poor      Alice . “ But     you’re so          easily offended , you
@@ -1180,8 +1180,8 @@
 # NSg/VB NPr/J/R/P D   NPr/VB+ NSg/C NPr/ISg+ VPt   Nᴹ/Vg/J  NPl/VB+ J/P   NSg/VB/J/C/P I/C/Ddem+ . .
 >
 #
-> By    this    time       she  had found  her     way    into a   tidy     little     room    with a   table   in        the
-# NSg/P I/Ddem+ N🅪Sg/VB/J+ ISg+ VP  NSg/VP ISg/D$+ NSg/J+ P    D/P NSg/VB/J NPr/I/J/Dq N🅪Sg/VB P    D/P NSg/VB+ NPr/J/R/P D
+> By this    time       she  had found  her     way    into a   tidy     little     room    with a   table   in        the
+# P  I/Ddem+ N🅪Sg/VB/J+ ISg+ VP  NSg/VP ISg/D$+ NSg/J+ P    D/P NSg/VB/J NPr/I/J/Dq N🅪Sg/VB P    D/P NSg/VB+ NPr/J/R/P D
 > window  , and  on  it       ( as    she  had hoped ) a   fan     and  two or    three pairs  of tiny  white
 # NSg/VB+ . VB/C J/P NPr/ISg+ . R/C/P ISg+ VP  VP/J  . D/P NSg/VB+ VB/C NSg NPr/C NSg   NPl/V3 P  NSg/J NPr🅪Sg/VB/J
 > kid     gloves  : she  took up         the fan     and  a   pair   of the gloves  , and  was  just going   to
@@ -1240,8 +1240,8 @@
 #
 > “ It       was  much         pleasanter at    home      , ” thought poor     Alice , “ when    one     wasn’t always
 # . NPr/ISg+ VLPt NSg/I/J/R/Dq JC         NSg/P NSg/VB/J+ . . N🅪Sg/VP NSg/VB/J NPr+  . . NSg/I/C NSg/I/J VPt    R
-> growing larger and  smaller , and  being        ordered about by    mice   and  rabbits . I
-# Nᴹ/Vg/J JC     VB/C NSg/JC  . VB/C N🅪Sg/VLg/J/C VP/J    J/P   NSg/P NPl/VB VB/C NPl/V3+ . ISg/#r+
+> growing larger and  smaller , and  being        ordered about by mice   and  rabbits . I
+# Nᴹ/Vg/J JC     VB/C NSg/JC  . VB/C N🅪Sg/VLg/J/C VP/J    J/P   P  NPl/VB VB/C NPl/V3+ . ISg/#r+
 > almost wish   I       hadn’t gone    down        that     rabbit  - hole    — and  yet      — and  yet      — it’s rather
 # R      NSg/VB ISg/#r+ VPt    VPp/J/P N🅪Sg/VB/J/P I/C/Ddem NSg/VB+ . NSg/VB+ . VB/C NSg/VB/C . VB/C NSg/VB/C . K    NPr/VB/J/R
 > curious , you    know , this   sort   of life     ! I       do  wonder  what   can     have    happened to me       !
@@ -1412,8 +1412,8 @@
 #
 > The first  thing she  heard was  a   general  chorus of “ There goes   Bill    ! ” then      the
 # D+  NSg/J+ NSg+  ISg+ VP/J  VLPt D/P NSg/VB/J NSg/VB P  . R+    NPl/V3 NPr/VB+ . . NSg/J/R/C D
-> Rabbit’s voice   along — “ Catch  him  , you    by    the hedge   ! ” then      silence , and  then
-# NSg$     NSg/VB+ P     . . NSg/VB ISg+ . ISgPl+ NSg/P D   NSg/VB+ . . NSg/J/R/C NSg/VB+ . VB/C NSg/J/R/C
+> Rabbit’s voice   along — “ Catch  him  , you    by the hedge   ! ” then      silence , and  then
+# NSg$     NSg/VB+ P     . . NSg/VB ISg+ . ISgPl+ P  D   NSg/VB+ . . NSg/J/R/C NSg/VB+ . VB/C NSg/J/R/C
 > another confusion of voices  — “ Hold     up         his     head      — Brandy  now       — Don’t choke  him  — How   was
 # I/D     N🅪Sg/VB   P  NPl/V3+ . . NSg/VB/J NSg/VB/J/P ISg/D$+ NPr/VB/J+ . NPr/VB+ NSg/J/R/C . VXB   NSg/VB ISg+ . NSg/C VLPt
 > it       , old   fellow ? What   happened to you    ? Tell   us       all          about it       ! ”
@@ -1480,8 +1480,8 @@
 # VPt NSg/VB/J/R/P P  D+  NPr/VB+ . VB/C NSg/VP R     D/P NSg/VB P  NPr/I/J/Dq NPl     VB/C NPl/V3+
 > waiting outside   . The poor     little     Lizard , Bill    , was  in        the middle   , being        held up
 # Nᴹ/Vg/J Nᴹ/VB/J/P . D   NSg/VB/J NPr/I/J/Dq NSg    . NPr/VB+ . VLPt NPr/J/R/P D   NSg/VB/J . N🅪Sg/VLg/J/C VP   NSg/VB/J/P
-> by    two guinea - pigs    , who    were giving  it       something out          of a   bottle  . They all          made
-# NSg/P NSg NPr+   . NPl/V3+ . NPr/I+ VLPt Nᴹ/Vg/J NPr/ISg+ NSg/I/J+  NSg/VB/J/R/P P  D/P NSg/VB+ . IPl+ NSg/I/J/C/Dq VP
+> by two guinea - pigs    , who    were giving  it       something out          of a   bottle  . They all          made
+# P  NSg NPr+   . NPl/V3+ . NPr/I+ VLPt Nᴹ/Vg/J NPr/ISg+ NSg/I/J+  NSg/VB/J/R/P P  D/P NSg/VB+ . IPl+ NSg/I/J/C/Dq VP
 > a   rush      at    Alice the moment she  appeared ; but     she  ran off        as    hard     as    she  could   ,
 # D/P NPr/VB/J+ NSg/P NPr+  D+  NSg+   ISg+ VP/J     . NSg/C/P ISg+ VPt NSg/VB/J/P R/C/P N🅪Sg/J/R R/C/P ISg+ NSg/VXB .
 > and  soon found  herself safe     in        a    thick     wood         .
@@ -1616,8 +1616,8 @@
 # NSg/J/R/C . .
 >
 #
-> “ What   do  you    mean     by    that      ? ” said the Caterpillar sternly . “ Explain yourself ! ”
-# . NSg/I+ VXB ISgPl+ NSg/VB/J NSg/P I/C/Ddem+ . . VP/J D   NSg/VB      R       . . VB      ISg+     . .
+> “ What   do  you    mean     by that      ? ” said the Caterpillar sternly . “ Explain yourself ! ”
+# . NSg/I+ VXB ISgPl+ NSg/VB/J P  I/C/Ddem+ . . VP/J D   NSg/VB      R       . . VB      ISg+     . .
 >
 #
 > “ I       can’t explain myself , I’m afraid , sir     , ” said Alice , “ because I’m not     myself ,
@@ -1768,8 +1768,8 @@
 #
 > “ In        my  youth , ” said the sage     , as    he       shook     his     grey              locks   , “ I       kept all           my  limbs
 # . NPr/J/R/P D$+ NSg+  . . VP/J D   NSg/VB/J . R/C/P NPr/ISg+ NSg/VPt/J ISg/D$+ NPr🅪Sg/VB/J/Comm+ NPl/V3+ . . ISg/#r+ VP   NSg/I/J/C/Dq+ D$+ NPl/V3+
-> very supple By    the use     of this   ointment — one     shilling  the box     — Allow me       to sell
-# J/R  VB/J   NSg/P D   N🅪Sg/VB P  I/Ddem N🅪Sg     . NSg/I/J N🅪Sg/Vg/J D   NSg/VB+ . VB    NPr/ISg+ P  NSg/VB
+> very supple By the use     of this   ointment — one     shilling  the box     — Allow me       to sell
+# J/R  VB/J   P  D   N🅪Sg/VB P  I/Ddem N🅪Sg     . NSg/I/J N🅪Sg/Vg/J D   NSg/VB+ . VB    NPr/ISg+ P  NSg/VB
 > you    a   couple    ? ”
 # ISgPl+ D/P NSg/VB/J+ . .
 >
@@ -1914,8 +1914,8 @@
 # NSg/J/P    ISg/D$+ NPr/VB+ . NPr/ISg+ VP  VB     ISg/D$+ NSg/VB+ .
 >
 #
-> She  was  a   good     deal     frightened by    this   very sudden change  , but     she  felt      that
-# ISg+ VLPt D/P NPr/VB/J NSg/VB/J VP/J       NSg/P I/Ddem J/R  NSg/J  N🅪Sg/VB . NSg/C/P ISg+ N🅪Sg/VP/J I/C/Ddem
+> She  was  a   good     deal     frightened by this   very sudden change  , but     she  felt      that
+# ISg+ VLPt D/P NPr/VB/J NSg/VB/J VP/J       P  I/Ddem J/R  NSg/J  N🅪Sg/VB . NSg/C/P ISg+ N🅪Sg/VP/J I/C/Ddem
 > there was  no       time       to be       lost , as    she  was  shrinking rapidly ; so          she  set       to work
 # R+    VLPt NSg/Dq/P N🅪Sg/VB/J+ P  NSg/VLXB VP/J . R/C/P ISg+ VLPt Nᴹ/Vg/J   R       . NSg/I/J/R/C ISg+ NPr/VBP/J P  N🅪Sg/VB
 > at    once  to eat some     of the other     bit      . Her     chin    was  pressed so          closely against
@@ -2125,11 +2125,11 @@
 > next    , when    suddenly a   footman in        livery   came      running   out          of the wood         — ( she
 # NSg/J/P . NSg/I/C R        D/P NSg     NPr/J/R/P NSg/VB/J NSg/VPt/P Nᴹ/Vg/J/P NSg/VB/J/R/P P  D   NPr🅪Sg/VB/J+ . . ISg+
 > considered him  to be       a   footman because he       was  in        livery   : otherwise , judging by
-# VP/J       ISg+ P  NSg/VLXB D/P NSg     C/P     NPr/ISg+ VLPt NPr/J/R/P NSg/VB/J . J/R/C     . Nᴹ/Vg/J NSg/P
+# VP/J       ISg+ P  NSg/VLXB D/P NSg     C/P     NPr/ISg+ VLPt NPr/J/R/P NSg/VB/J . J/R/C     . Nᴹ/Vg/J P
 > his     face    only  , she  would have    called him  a   fish       ) — and  rapped loudly at    the door
 # ISg/D$+ NSg/VB+ J/R/C . ISg+ VXB   NSg/VXB VP/J   ISg+ D/P N🅪SgPl/VB+ . . VB/C VP     R      NSg/P D   NSg/VB+
-> with his     knuckles . It       was  opened by    another footman in        livery   , with a   round
-# P    ISg/D$+ NPl/V3   . NPr/ISg+ VLPt VP/J   NSg/P I/D     NSg     NPr/J/R/P NSg/VB/J . P    D/P NSg/VB/J/P
+> with his     knuckles . It       was  opened by another footman in        livery   , with a   round
+# P    ISg/D$+ NPl/V3   . NPr/ISg+ VLPt VP/J   P  I/D     NSg     NPr/J/R/P NSg/VB/J . P    D/P NSg/VB/J/P
 > face    , and  large eyes    like         a   frog   ; and  both   footmen , Alice noticed , had powdered
 # NSg/VB+ . VB/C NSg/J NPl/V3+ NSg/VB/J/C/P D/P NSg/VB . VB/C I/C/Dq NPl     . NPr+  VP/J    . VP  VP/J
 > hair     that      curled all          over    their heads   . She  felt      very curious to know what   it       was
@@ -2138,8 +2138,8 @@
 # NSg/I/J/C/Dq J/P   . VB/C VP    D/P NPr/I/J/Dq+ NSg/J+ NSg/VB/J/R/P P  D+  NPr🅪Sg/VB/J+ P  NSg/VB .
 >
 #
-> The Fish       - Footman began by    producing from under   his     arm      a   great letter  , nearly as
-# D+  N🅪SgPl/VB+ . NSg     VPt   NSg/P Nᴹ/Vg/J   P    NSg/J/P ISg/D$+ NSg/VB/J D/P NSg/J NSg/VB+ . R      R/C/P
+> The Fish       - Footman began by producing from under   his     arm      a   great letter  , nearly as
+# D+  N🅪SgPl/VB+ . NSg     VPt   P  Nᴹ/Vg/J   P    NSg/J/P ISg/D$+ NSg/VB/J D/P NSg/J NSg/VB+ . R      R/C/P
 > large as    himself , and  this   he       handed over    to the other    , saying    , in        a   solemn
 # NSg/J R/C/P ISg+    . VB/C I/Ddem NPr/ISg+ VP/J   NSg/J/P P  D   NSg/VB/J . N🅪Sg/Vg/J . NPr/J/R/P D/P J
 > tone       , “ For   the Duchess . An  invitation from the Queen     to play    croquet . ” The
@@ -2348,8 +2348,8 @@
 # . NPr/VB . VB     NSg/VB+ NSg/I+ K      Nᴹ/Vg/J . . VP/J  NPr+  . Nᴹ/Vg/J NSg/VB/J/P VB/C N🅪Sg/VB/J/P NPr/J/R/P D/P
 > agony of terror . “ Oh     , there goes   his     precious nose    ! ” as    an  unusually large
 # N🅪Sg  P  N🅪Sg+  . . NPr/VB . R+    NPl/V3 ISg/D$+ NSg/J+   NSg/VB+ . . R/C/P D/P R         NSg/J+
-> saucepan flew      close    by    it       , and  very nearly carried it       off        .
-# NSg/VB+  NSg/VPt/J NSg/VB/J NSg/P NPr/ISg+ . VB/C J/R  R      VP/J    NPr/ISg+ NSg/VB/J/P .
+> saucepan flew      close    by it       , and  very nearly carried it       off        .
+# NSg/VB+  NSg/VPt/J NSg/VB/J P  NPr/ISg+ . VB/C J/R  R      VP/J    NPr/ISg+ NSg/VB/J/P .
 >
 #
 > “ If    everybody minded their own       business , ” the Duchess said in        a   hoarse   growl  ,
@@ -2460,8 +2460,8 @@
 # NPr/J/R/P D/P NPr🅪Sg+ NPr/C NSg . VXB      NPr/ISg+ NSg/VLXB N🅪Sg/VB+ P  NSg/VB NPr/ISg+ NSg/J/P . . ISg+ VP/J D+  NSg/VB/J+
 > words   out          loud  , and  the little      thing grunted in        reply   ( it       had left     off        sneezing
 # NPl/V3+ NSg/VB/J/R/P NSg/J . VB/C D+  NPr/I/J/Dq+ NSg+  VP/J    NPr/J/R/P NSg/VB+ . NPr/ISg+ VP  NPr/VP/J NSg/VB/J/P Nᴹ/Vg/J
-> by    this   time       ) . “ Don’t grunt   , ” said Alice ; “ that’s not     at    all          a   proper way   of
-# NSg/P I/Ddem N🅪Sg/VB/J+ . . . VXB   NSg/VB+ . . VP/J NPr+  . . K      NSg/R/C NSg/P NSg/I/J/C/Dq D/P NSg/J  NSg/J P
+> by this   time       ) . “ Don’t grunt   , ” said Alice ; “ that’s not     at    all          a   proper way   of
+# P  I/Ddem N🅪Sg/VB/J+ . . . VXB   NSg/VB+ . . VP/J NPr+  . . K      NSg/R/C NSg/P NSg/I/J/C/Dq D/P NSg/J  NSg/J P
 > expressing yourself . ”
 # Nᴹ/Vg/J    ISg+     . .
 >
@@ -2512,8 +2512,8 @@
 # ISg+ VPt   Nᴹ/Vg/J  NSg/J/P NSg/VB/J+ NPl+     ISg+ VPt  . NPr/I+ Nᴹ/VXB/J VXB J/R  NSg/VB/J/R R/C/P NPl/V3+ .
 > and  was  just saying    to herself , “ if    one     only  knew the right    way    to change  them     — ”
 # VB/C VLPt J/R  N🅪Sg/Vg/J P  ISg+    . . NSg/C NSg/I/J J/R/C VPt  D   NPr/VB/J NSg/J+ P  N🅪Sg/VB NSg/IPl+ . .
-> when    she  was  a   little     startled by    seeing     the Cheshire Cat       sitting  on  a   bough of
-# NSg/I/C ISg+ VLPt D/P NPr/I/J/Dq VP/J     NSg/P NSg/Vg/J/C D   NPr      NSg/VB/J+ NSg/Vg/J J/P D/P NSg   P
+> when    she  was  a   little     startled by seeing     the Cheshire Cat       sitting  on  a   bough of
+# NSg/I/C ISg+ VLPt D/P NPr/I/J/Dq VP/J     P  NSg/Vg/J/C D   NPr      NSg/VB/J+ NSg/Vg/J J/P D/P NSg   P
 > a   tree    a   few      yards   off        .
 # D/P NSg/VB+ D/P NSg/I/Dq NPl/V3+ NSg/VB/J/P .
 >
@@ -2636,8 +2636,8 @@
 # VP/J     P     .
 >
 #
-> “ By    - the - bye     , what   became of the baby      ? ” said the Cat       . “ I’d nearly forgotten to
-# . NSg/P . D   . NSg/J/P . NSg/I+ VPt    P  D+  NSg/VB/J+ . . VP/J D+  NSg/VB/J+ . . K   R      NSg/VPp/J P
+> “ By - the - bye     , what   became of the baby      ? ” said the Cat       . “ I’d nearly forgotten to
+# . P  . D   . NSg/J/P . NSg/I+ VPt    P  D+  NSg/VB/J+ . . VP/J D+  NSg/VB/J+ . . K   R      NSg/VPp/J P
 > ask    . ”
 # NSg/VB . .
 >
@@ -2996,8 +2996,8 @@
 # D   NSg/VB NSg/VPt/J ISg/D$+ NPr/VB/J+ R          . . NSg/R/C ISg/#r+ . . NPr/ISg+ VP/J    . . IPl+ VP/Comm    NSg/VB/J
 > March   — just before he       went    mad      , you    know — ” ( pointing with his     tea      spoon   at    the
 # NPr/VB+ . J/R  C/P    NPr/ISg+ NSg/VPt NSg/VB/J . ISgPl+ VB   . . . Nᴹ/Vg/J  P    ISg/D$+ N🅪Sg/VB+ NSg/VB+ NSg/P D
-> March   Hare , ) “ — it       was  at    the great concert given       by    the Queen    of Hearts  , and  I
-# NPr/VB+ NSg+ . . . . NPr/ISg+ VLPt NSg/P D   NSg/J NSg/VB+ NSg/VPp/J/P NSg/P D   NPr/VB/J P  NPl/V3+ . VB/C ISg/#r+
+> March   Hare , ) “ — it       was  at    the great concert given       by the Queen    of Hearts  , and  I
+# NPr/VB+ NSg+ . . . . NPr/ISg+ VLPt NSg/P D   NSg/J NSg/VB+ NSg/VPp/J/P P  D   NPr/VB/J P  NPl/V3+ . VB/C ISg/#r+
 > had to sing
 # VP  P  NSg/VB/J
 >
@@ -3272,10 +3272,10 @@
 # NPr+  VLPt NSg/J  .
 >
 #
-> The Dormouse had closed its     eyes    by    this   time       , and  was  going   off        into a   doze   ;
-# D   NSg      VP  VP/J   ISg/D$+ NPl/V3+ NSg/P I/Ddem N🅪Sg/VB/J+ . VB/C VLPt Nᴹ/Vg/J NSg/VB/J/P P    D/P NSg/VB .
-> but     , on  being        pinched by    the Hatter , it       woke     up         again with a   little     shriek , and
-# NSg/C/P . J/P N🅪Sg/VLg/J/C VP/J    NSg/P D   NSg/VB . NPr/ISg+ NSg/VB/J NSg/VB/J/P P     P    D/P NPr/I/J/Dq NSg/VB . VB/C
+> The Dormouse had closed its     eyes    by this   time       , and  was  going   off        into a   doze   ;
+# D   NSg      VP  VP/J   ISg/D$+ NPl/V3+ P  I/Ddem N🅪Sg/VB/J+ . VB/C VLPt Nᴹ/Vg/J NSg/VB/J/P P    D/P NSg/VB .
+> but     , on  being        pinched by the Hatter , it       woke     up         again with a   little     shriek , and
+# NSg/C/P . J/P N🅪Sg/VLg/J/C VP/J    P  D   NSg/VB . NPr/ISg+ NSg/VB/J NSg/VB/J/P P     P    D/P NPr/I/J/Dq NSg/VB . VB/C
 > went    on  : “ — that      begins with an  M           , such  as    mouse   - traps  , and  the moon    , and  memory ,
 # NSg/VPt J/P . . . I/C/Ddem+ NPl/V3 P    D/P NPr/VB/J/#r . NSg/I R/C/P NSg/VB+ . NPl/V3 . VB/C D   NPr/VB+ . VB/C N🅪Sg+  .
 > and  muchness — you    know you    say    things are “ much         of a   muchness ” — did  you    ever see
@@ -3321,7 +3321,7 @@
 > Once  more         she  found  herself in        the long      hall , and  close    to the little      glass
 # NSg/C NPr/I/J/R/Dq ISg+ NSg/VP ISg+    NPr/J/R/P D+  NPr/VB/J+ NPr+ . VB/C NSg/VB/J P  D+  NPr/I/J/Dq+ NPr🅪Sg/VB+
 > table   . “ Now       , I’ll manage better     this   time       , ” she  said to herself , and  began by
-# NSg/VB+ . . NSg/J/R/C . K    NSg/VB NSg/VXB/JC I/Ddem N🅪Sg/VB/J+ . . ISg+ VP/J P  ISg+    . VB/C VPt   NSg/P
+# NSg/VB+ . . NSg/J/R/C . K    NSg/VB NSg/VXB/JC I/Ddem N🅪Sg/VB/J+ . . ISg+ VP/J P  ISg+    . VB/C VPt   P
 > taking   the little     golden   key      , and  unlocking the door    that      led      into the garden    .
 # NSg/Vg/J D   NPr/I/J/Dq NPr/VB/J NPr/VB/J . VB/C Nᴹ/Vg/J   D   NSg/VB+ I/C/Ddem+ NSg/VP/J P    D   NSg/VB/J+ .
 > Then      she  went    to work    nibbling at    the mushroom  ( she  had kept a   piece  of it       in
@@ -3400,8 +3400,8 @@
 # NSg  VB/C NSg   VP/J NSg/I/J+ . NSg/C/P VP/J   NSg/P NSg . NSg VPt   NPr/J/R/P D/P+ NSg/VB/J/R+ NSg/VB+ . . NSg/VB
 > the fact is  , you    see    , Miss   , this   here ought     to have    been   a   red    rose      - tree    , and  we
 # D+  NSg+ VL3 . ISgPl+ NSg/VB . NSg/VB . I/Ddem J/R  NSg/I/VXB P  NSg/VXB VLPp/B D/P N🅪Sg/J NPr/VPt/J . NSg/VB+ . VB/C IPl+
-> put     a   white       one      in        by    mistake ; and  if    the Queen     was  to find   it       out          , we   should
-# NSg/VBP D/P NPr🅪Sg/VB/J NSg/I/J+ NPr/J/R/P NSg/P NSg/VB+ . VB/C NSg/C D+  NPr/VB/J+ VLPt P  NSg/VB NPr/ISg+ NSg/VB/J/R/P . IPl+ VXB
+> put     a   white       one      in        by mistake ; and  if    the Queen     was  to find   it       out          , we   should
+# NSg/VBP D/P NPr🅪Sg/VB/J NSg/I/J+ NPr/J/R/P P  NSg/VB+ . VB/C NSg/C D+  NPr/VB/J+ VLPt P  NSg/VB NPr/ISg+ NSg/VB/J/R/P . IPl+ VXB
 > all          have    our heads   cut       off        , you    know . So          you    see    , Miss   , we’re doing   our best       ,
 # NSg/I/J/C/Dq NSg/VXB D$+ NPl/V3+ NSg/VBP/J NSg/VB/J/P . ISgPl+ VB   . NSg/I/J/R/C ISgPl+ NSg/VB . NSg/VB . K     Nᴹ/Vg/J D$+ NPr/VXB/JS .
 > afore she  comes  , to — ” At    this   moment Five , who    had been   anxiously looking across
@@ -3428,8 +3428,8 @@
 # IPl+ VLPt NSg/I/J/C/Dq VP/J       P    NPl/V3+ . NSg/J/P NSg/VPt/P D+  NPl/V3+ . R      NPl/V3+ VB/C
 > Queens   , and  among them     Alice recognised the White       Rabbit  : it       was  talking in        a
 # NPrPl/V3 . VB/C P     NSg/IPl+ NPr+  VP/J/Au/Br D   NPr🅪Sg/VB/J NSg/VB+ . NPr/ISg+ VLPt Nᴹ/Vg/J NPr/J/R/P D/P
-> hurried nervous manner , smiling at    everything that      was  said , and  went    by    without
-# VP/J+   J+      NSg+   . Nᴹ/Vg/J NSg/P NSg/I/VB+  I/C/Ddem+ VLPt VP/J . VB/C NSg/VPt NSg/P C/P
+> hurried nervous manner , smiling at    everything that      was  said , and  went    by without
+# VP/J+   J+      NSg+   . Nᴹ/Vg/J NSg/P NSg/I/VB+  I/C/Ddem+ VLPt VP/J . VB/C NSg/VPt P  C/P
 > noticing her     . Then      followed the Knave of Hearts  , carrying the King’s crown     on  a
 # Nᴹ/Vg/J  ISg/D$+ . NSg/J/R/C VP/J     D   NSg   P  NPl/V3+ . Nᴹ/Vg/J  D   NPr$   NSg/VB/J+ J/P D/P
 > crimson  velvet   cushion ; and  , last     of all          this   grand procession , came      THE KING
@@ -3581,7 +3581,7 @@
 >
 #
 > “ It’s — it’s a   very fine     day     ! ” said a    timid voice   at    her     side      . She  was  walking by
-# . K    . K    D/P J/R  NSg/VB/J NPr🅪Sg+ . . VP/J D/P+ J+    NSg/VB+ NSg/P ISg/D$+ NSg/VB/J+ . ISg+ VLPt Nᴹ/Vg/J NSg/P
+# . K    . K    D/P J/R  NSg/VB/J NPr🅪Sg+ . . VP/J D/P+ J+    NSg/VB+ NSg/P ISg/D$+ NSg/VB/J+ . ISg+ VLPt Nᴹ/Vg/J P
 > the White        Rabbit  , who    was  peeping anxiously into her     face    .
 # D+  NPr🅪Sg/VB/J+ NSg/VB+ . NPr/I+ VLPt Nᴹ/Vg/J R         P    ISg/D$+ NSg/VB+ .
 >
@@ -3822,8 +3822,8 @@
 # D/P NSg/VB+ .
 >
 #
-> By    the time       she  had caught the flamingo and  brought it       back     , the fight   was  over    ,
-# NSg/P D+  N🅪Sg/VB/J+ ISg+ VP  VP/J   D   NSg/J    VB/C VP      NPr/ISg+ NSg/VB/J . D   NSg/VB+ VLPt NSg/J/P .
+> By the time       she  had caught the flamingo and  brought it       back     , the fight   was  over    ,
+# P  D+  N🅪Sg/VB/J+ ISg+ VP  VP/J   D   NSg/J    VB/C VP      NPr/ISg+ NSg/VB/J . D   NSg/VB+ VLPt NSg/J/P .
 > and  both   the hedgehogs were out          of sight    : “ but     it       doesn’t matter   much         , ” thought
 # VB/C I/C/Dq D   NPl/V3    VLPt NSg/VB/J/R/P P  N🅪Sg/VB+ . . NSg/C/P NPr/ISg+ VX3     N🅪Sg/VB+ NSg/I/J/R/Dq . . N🅪Sg/VP
 > Alice , “ as    all          the arches are gone    from this   side     of the ground     . ” So          she  tucked
@@ -3844,8 +3844,8 @@
 # R     NSg/J  . VB/C VP/J   J/R  J             .
 >
 #
-> The moment Alice appeared , she  was  appealed to by    all          three to settle the
-# D+  NSg+   NPr+  VP/J     . ISg+ VLPt VP/J     P  NSg/P NSg/I/J/C/Dq NSg   P  NSg/VB D+
+> The moment Alice appeared , she  was  appealed to by all          three to settle the
+# D+  NSg+   NPr+  VP/J     . ISg+ VLPt VP/J     P  P  NSg/I/J/C/Dq NSg   P  NSg/VB D+
 > question , and  they repeated their arguments to her     , though , as    they all           spoke    at
 # NSg/VB+  . VB/C IPl+ VP/J     D$+   NPl/V3+   P  ISg/D$+ . C      . R/C/P IPl+ NSg/I/J/C/Dq+ NSg/VPt+ NSg/P
 > once  , she  found  it       very hard     indeed to make   out          exactly what   they said .
@@ -3886,8 +3886,8 @@
 # NSg         NSg/VPt+ NSg/VB/J/P NSg/VB/J/C/P D/P NSg/VB+ .
 >
 #
-> The Cat’s head      began fading  away the moment he       was  gone    , and  , by    the time       he       had
-# D   NSg$  NPr/VB/J+ VPt   Nᴹ/Vg/J VB/J D   NSg+   NPr/ISg+ VLPt VPp/J/P . VB/C . NSg/P D   N🅪Sg/VB/J+ NPr/ISg+ VP
+> The Cat’s head      began fading  away the moment he       was  gone    , and  , by the time       he       had
+# D   NSg$  NPr/VB/J+ VPt   Nᴹ/Vg/J VB/J D   NSg+   NPr/ISg+ VLPt VPp/J/P . VB/C . P  D   N🅪Sg/VB/J+ NPr/ISg+ VP
 > come       back     with the Duchess , it       had entirely disappeared ; so          the King      and  the
 # NSg/VBPp/P NSg/VB/J P    D   NSg/VB  . NPr/ISg+ VP  R        VP/J        . NSg/I/J/R/C D   NPr/VB/J+ VB/C D
 > executioner ran wildly up         and  down        looking for   it       , while      the rest   of the party
@@ -3932,8 +3932,8 @@
 # VXB      NSg/VLXB NSg/I/J/R/C J      J/P   NPr/ISg+ . ISgPl+ VB   . .
 >
 #
-> She  had quite forgotten the Duchess by    this   time       , and  was  a   little     startled when
-# ISg+ VP  R     NSg/VPp/J D   NSg/VB  NSg/P I/Ddem N🅪Sg/VB/J+ . VB/C VLPt D/P NPr/I/J/Dq VP/J     NSg/I/C
+> She  had quite forgotten the Duchess by this   time       , and  was  a   little     startled when
+# ISg+ VP  R     NSg/VPp/J D   NSg/VB  P  I/Ddem N🅪Sg/VB/J+ . VB/C VLPt D/P NPr/I/J/Dq VP/J     NSg/I/C
 > she  heard her     voice   close    to her     ear       . “ You’re thinking about something , my  dear     ,
 # ISg+ VP/J  ISg/D$+ NSg/VB+ NSg/VB/J P  ISg/D$+ NSg/VB/J+ . . K      Nᴹ/Vg/J  J/P   NSg/I/J+  . D$+ NSg/VB/J .
 > and  that      makes  you    forget to talk    . I       can’t tell   you    just now       what   the moral    of
@@ -3962,8 +3962,8 @@
 # VXPt NSg/R/C NSg/VB/J/C/P P  NSg/VLXB J    . NSg/I/J/R/C ISg+ NSg/VBPt NPr/ISg+ R/C/P NSg/VB/J/R R/C/P ISg+ NSg/VXB .
 >
 #
-> “ The game’s going   on  rather     better     now       , ” she  said , by    way   of keeping up         the
-# . D   NSg$   Nᴹ/Vg/J J/P NPr/VB/J/R NSg/VXB/JC NSg/J/R/C . . ISg+ VP/J . NSg/P NSg/J P  Nᴹ/Vg/J NSg/VB/J/P D
+> “ The game’s going   on  rather     better     now       , ” she  said , by way   of keeping up         the
+# . D   NSg$   Nᴹ/Vg/J J/P NPr/VB/J/R NSg/VXB/JC NSg/J/R/C . . ISg+ VP/J . P  NSg/J P  Nᴹ/Vg/J NSg/VB/J/P D
 > conversation a   little     .
 # N🅪Sg/VB+     D/P NPr/I/J/Dq .
 >
@@ -3974,8 +3974,8 @@
 # NPr🅪Sg/VB . I/C/Ddem+ NPl/V3 D   NSg/VB+ NSg/VB/J NSg/VB/J/P . . .
 >
 #
-> “ Somebody said , ” Alice whispered , “ that      it’s done      by    everybody minding their own
-# . NSg/I+   VP/J . . NPr+  VP/J      . . I/C/Ddem+ K    NSg/VPp/J NSg/P NSg/I+    Nᴹ/Vg/J D$+   NSg/VB/J
+> “ Somebody said , ” Alice whispered , “ that      it’s done      by everybody minding their own
+# . NSg/I+   VP/J . . NPr+  VP/J      . . I/C/Ddem+ K    NSg/VPp/J P  NSg/I+    Nᴹ/Vg/J D$+   NSg/VB/J
 > business ! ”
 # N🅪Sg/J+  . .
 >
@@ -4138,10 +4138,10 @@
 # NSg/I/J/C/Dq+ D+  N🅪Sg/VB/J+ IPl+ VLPt Nᴹ/Vg/J D+  NPr/VB/J+ R     NPr/VP/J NSg/VB/J/P Nᴹ/Vg/Comm  P    D
 > other    players , and  shouting “ Off        with his     head      ! ” or    “ Off        with her     head      ! ” Those
 # NSg/VB/J NPl+    . VB/C Nᴹ/Vg/J+ . NSg/VB/J/P P    ISg/D$+ NPr/VB/J+ . . NPr/C . NSg/VB/J/P P    ISg/D$+ NPr/VB/J+ . . I/Ddem+
-> whom she  sentenced were taken into custody by    the soldiers , who   of course  had to
-# I+   ISg+ VP/J      VLPt VPp/J P    Nᴹ+     NSg/P D   NPl/V3+  . NPr/I P  NSg/VB+ VP  P
-> leave  off        being        arches to do  this    , so          that      by    the end    of half      an  hour or    so
-# NSg/VB NSg/VB/J/P N🅪Sg/VLg/J/C NPl/V3 P  VXB I/Ddem+ . NSg/I/J/R/C I/C/Ddem+ NSg/P D   NSg/VB P  N🅪Sg/J/P+ D/P NSg+ NPr/C NSg/I/J/R/C
+> whom she  sentenced were taken into custody by the soldiers , who   of course  had to
+# I+   ISg+ VP/J      VLPt VPp/J P    Nᴹ+     P  D   NPl/V3+  . NPr/I P  NSg/VB+ VP  P
+> leave  off        being        arches to do  this    , so          that      by the end    of half      an  hour or    so
+# NSg/VB NSg/VB/J/P N🅪Sg/VLg/J/C NPl/V3 P  VXB I/Ddem+ . NSg/I/J/R/C I/C/Ddem+ P  D   NSg/VB P  N🅪Sg/J/P+ D/P NSg+ NPr/C NSg/I/J/R/C
 > there were no       arches left     , and  all          the players , except the King      , the Queen     , and
 # R+    VLPt NSg/Dq/P NPl/V3 NPr/VP/J . VB/C NSg/I/J/C/Dq D   NPl+    . VB/C/P D   NPr/VB/J+ . D   NPr/VB/J+ . VB/C
 > Alice , were in        custody and  under   sentence of execution .
@@ -4264,8 +4264,8 @@
 # . NSg/C . . VP/J D+  NSg/VB/J+ NSg/VB+ NSg/P NSg/VB/J . P    D/P NSg/J NSg/VB . . ISg/#r+ VLPt D/P NSg/J NSg/VB . .
 >
 #
-> These   words   were followed by    a   very long      silence , broken only  by    an  occasional
-# I/Ddem+ NPl/V3+ VLPt VP/J     NSg/P D/P J/R  NPr/VB/J+ NSg/VB+ . VPp/J  J/R/C NSg/P D/P NSg/J
+> These   words   were followed by a   very long      silence , broken only  by an  occasional
+# I/Ddem+ NPl/V3+ VLPt VP/J     P  D/P J/R  NPr/VB/J+ NSg/VB+ . VPp/J  J/R/C P  D/P NSg/J
 > exclamation of “ Hjckrrh ! ” from the Gryphon , and  the constant heavy    sobbing  of
 # NSg         P  . ?       . . P    D   ?       . VB/C D   NSg/J    NSg/VB/J NSg/Vg/J P
 > the Mock     Turtle  . Alice was  very nearly getting up         and  saying    , “ Thank  you    , sir     ,
@@ -4895,15 +4895,15 @@
 >
 #
 > “ It’s the first position in        dancing . ” Alice said ; but     was  dreadfully puzzled by
-# . K    D+  NSg/J NSg/VB+  NPr/J/R/P Nᴹ/Vg/J . . NPr+  VP/J . NSg/C/P VLPt R          VP/J    NSg/P
+# . K    D+  NSg/J NSg/VB+  NPr/J/R/P Nᴹ/Vg/J . . NPr+  VP/J . NSg/C/P VLPt R          VP/J    P
 > the whole thing , and  longed to change  the subject   .
 # D   NSg/J NSg+  . VB/C VP/J   P  N🅪Sg/VB D   NSg/VB/J+ .
 >
 #
 > “ Go       on  with the next    verse  , ” the Gryphon repeated impatiently : “ it       begins ‘ I
 # . NSg/VB/J J/P P    D   NSg/J/P NSg/VB . . D   ?       VP/J     R           . . NPr/ISg+ NPl/V3 . ISg/#r+
-> passed by    his     garden    . ’ ”
-# VP/J   NSg/P ISg/D$+ NSg/VB/J+ . . .
+> passed by his     garden    . ’ ”
+# VP/J   P  ISg/D$+ NSg/VB/J+ . . .
 >
 #
 > Alice did  not     dare    to disobey , though she  felt      sure it       would all          come       wrong      , and
@@ -4912,8 +4912,8 @@
 # ISg+ NSg/VPt J/P NPr/J/R/P D/P Nᴹ/Vg/J   NSg/VB+ . .
 >
 #
-> “ I       passed by    his     garden    , and  marked , with one      eye     , How   the Owl     and  the Panther
-# . ISg/#r+ VP/J   NSg/P ISg/D$+ NSg/VB/J+ . VB/C VP/J   . P    NSg/I/J+ NSg/VB+ . NSg/C D+  NSg/VB+ VB/C D   NSg
+> “ I       passed by his     garden    , and  marked , with one      eye     , How   the Owl     and  the Panther
+# . ISg/#r+ VP/J   P  ISg/D$+ NSg/VB/J+ . VB/C VP/J   . P    NSg/I/J+ NSg/VB+ . NSg/C D+  NSg/VB+ VB/C D   NSg
 > were sharing a   pie      — ”
 # VLPt Nᴹ/Vg/J D/P N🅪Sg/VB+ . .
 >
@@ -4932,8 +4932,8 @@
 #
 > “ What   is  the use     of repeating all           that      stuff  , ” the Mock      Turtle  interrupted , “ if
 # . NSg/I+ VL3 D   N🅪Sg/VB P  Nᴹ/Vg/J   NSg/I/J/C/Dq+ I/C/Ddem+ Nᴹ/VB+ . . D+  NSg/VB/J+ NSg/VB+ VP/J        . . NSg/C
-> you    don’t explain it       as    you    go       on  ? It’s by    far      the most         confusing thing I       ever
-# ISgPl+ VXB   VB      NPr/ISg+ R/C/P ISgPl+ NSg/VB/J J/P . K    NSg/P NSg/VB/J D   NSg/I/J/R/Dq Nᴹ/Vg/J   NSg+  ISg/#r+ J/R
+> you    don’t explain it       as    you    go       on  ? It’s by far      the most         confusing thing I       ever
+# ISgPl+ VXB   VB      NPr/ISg+ R/C/P ISgPl+ NSg/VB/J J/P . K    P  NSg/VB/J D   NSg/I/J/R/Dq Nᴹ/Vg/J   NSg+  ISg/#r+ J/R
 > heard ! ”
 # VP/J  . .
 >
@@ -4990,8 +4990,8 @@
 # NPr/ISg+ . NSg/I/C D/P NSg/VB P  . D   NSg$    NSg/Vg/J+ . . VLPt VP/J  NPr/J/R/P D+  N🅪Sg/VB+ .
 >
 #
-> “ Come       on  ! ” cried the Gryphon , and  , taking   Alice by    the hand    , it       hurried off        ,
-# . NSg/VBPp/P J/P . . VP/J  D   ?       . VB/C . NSg/Vg/J NPr+  NSg/P D   NSg/VB+ . NPr/ISg+ VP/J    NSg/VB/J/P .
+> “ Come       on  ! ” cried the Gryphon , and  , taking   Alice by the hand    , it       hurried off        ,
+# . NSg/VBPp/P J/P . . VP/J  D   ?       . VB/C . NSg/Vg/J NPr+  P  D   NSg/VB+ . NPr/ISg+ VP/J    NSg/VB/J/P .
 > without waiting for   the end    of the song  .
 # C/P     Nᴹ/Vg/J R/C/P D   NSg/VB P  D   N🅪Sg+ .
 >
@@ -5044,8 +5044,8 @@
 # NSg/VB+ . .
 >
 #
-> The judge   , by    the way    , was  the King      ; and  as    he       wore his     crown     over    the wig     ,
-# D+  NSg/VB+ . NSg/P D+  NSg/J+ . VLPt D+  NPr/VB/J+ . VB/C R/C/P NPr/ISg+ VPt  ISg/D$+ NSg/VB/J+ NSg/J/P D+  NSg/VB+ .
+> The judge   , by the way    , was  the King      ; and  as    he       wore his     crown     over    the wig     ,
+# D+  NSg/VB+ . P  D+  NSg/J+ . VLPt D+  NPr/VB/J+ . VB/C R/C/P NPr/ISg+ VPt  ISg/D$+ NSg/VB/J+ NSg/J/P D+  NSg/VB+ .
 > ( look   at    the frontispiece if    you    want   to see    how   he       did  it       , ) he       did  not     look   at
 # . NSg/VB NSg/P D   NSg/VB       NSg/C ISgPl+ NSg/VB P  NSg/VB NSg/C NPr/ISg+ VXPt NPr/ISg+ . . NPr/ISg+ VXPt NSg/R/C NSg/VB NSg/P
 > all          comfortable , and  it       was  certainly not     becoming .
@@ -5354,8 +5354,8 @@
 # . K      D/P J/R  NSg/VB/J NSg+    . . VP/J D   NPr/VB/J+ .
 >
 #
-> Here one     of the guinea - pigs    cheered , and  was  immediately suppressed by    the
-# J/R  NSg/I/J P  D+  NPr+   . NPl/V3+ VP/J    . VB/C VLPt R           VP/J       NSg/P D
+> Here one     of the guinea - pigs    cheered , and  was  immediately suppressed by the
+# J/R  NSg/I/J P  D+  NPr+   . NPl/V3+ VP/J    . VB/C VLPt R           VP/J       P  D
 > officers of the court      . ( As    that      is  rather     a   hard     word   , I       will    just explain to
 # NPl/V3   P  D+  N🅪Sg/VB/J+ . . R/C/P I/C/Ddem+ VL3 NPr/VB/J/R D/P N🅪Sg/J/R NSg/VB . ISg/#r+ NPr/VXB J/R  VB      P
 > you    how   it       was  done      . They had a    large  canvas  bag     , which tied up         at    the mouth
@@ -5370,8 +5370,8 @@
 # . K   NSg/VB/J K    NSg/VPp I/C/Ddem+ NSg/VPp/J . . N🅪Sg/VP NPr+  . . K    NSg/I/J/R/C R     NSg/VBP NPr/J/R/P D
 > newspapers , at    the end    of trials  , “ There was  some     attempts at    applause , which
 # NPl/V3+    . NSg/P D   NSg/VB P  NPl/V3+ . . R+    VLPt I/J/R/Dq NPl/V3+  NSg/P Nᴹ+      . I/C+
-> was  immediately suppressed by    the officers of the court      , ” and  I       never understood
-# VLPt R           VP/J       NSg/P D   NPl/V3   P  D   N🅪Sg/VB/J+ . . VB/C ISg/#r+ R     VP/J
+> was  immediately suppressed by the officers of the court      , ” and  I       never understood
+# VLPt R           VP/J       P  D   NPl/V3   P  D   N🅪Sg/VB/J+ . . VB/C ISg/#r+ R     VP/J
 > what   it       meant till       now       . ”
 # NSg/I+ NPr/ISg+ VP    NSg/VB/C/P NSg/J/R/C . .
 >
@@ -5422,8 +5422,8 @@
 #
 > The next     witness was  the Duchess’s cook   . She  carried the pepper   - box    in        her     hand    ,
 # D+  NSg/J/P+ NSg/VB+ VLPt D   NSg$      NPr/VB . ISg+ VP/J    D   N🅪Sg/VB+ . NSg/VB NPr/J/R/P ISg/D$+ NSg/VB+ .
-> and  Alice guessed who    it       was  , even       before she  got into the court      , by    the way    the
-# VB/C NPr+  VP/J    NPr/I+ NPr/ISg+ VLPt . NSg/VB/J/R C/P    ISg+ VP  P    D+  N🅪Sg/VB/J+ . NSg/P D+  NSg/J+ D
+> and  Alice guessed who    it       was  , even       before she  got into the court      , by the way    the
+# VB/C NPr+  VP/J    NPr/I+ NPr/ISg+ VLPt . NSg/VB/J/R C/P    ISg+ VP  P    D+  N🅪Sg/VB/J+ . P  D+  NSg/J+ D
 > people  near       the door    began sneezing all          at    once  .
 # NPl/VB+ NSg/VB/J/P D+  NSg/VB+ VPt   Nᴹ/Vg/J  NSg/I/J/C/Dq NSg/P NSg/C .
 >
@@ -5466,8 +5466,8 @@
 #
 > For   some      minutes the whole  court      was  in        confusion , getting the Dormouse turned
 # R/C/P I/J/R/Dq+ NPl/V3+ D+  NSg/J+ N🅪Sg/VB/J+ VLPt NPr/J/R/P N🅪Sg/VB+  . NSg/Vg  D   NSg      VP/J
-> out          , and  , by    the time       they had settled down        again , the cook    had disappeared .
-# NSg/VB/J/R/P . VB/C . NSg/P D   N🅪Sg/VB/J+ IPl+ VP  VP/J    N🅪Sg/VB/J/P P     . D   NPr/VB+ VP  VP/J        .
+> out          , and  , by the time       they had settled down        again , the cook    had disappeared .
+# NSg/VB/J/R/P . VB/C . P  D   N🅪Sg/VB/J+ IPl+ VP  VP/J    N🅪Sg/VB/J/P P     . D   NPr/VB+ VP  VP/J        .
 >
 #
 > “ Never mind    ! ” said the King      , with an  air     of great  relief . “ Call   the next
@@ -5650,8 +5650,8 @@
 #
 > “ I       haven’t opened it       yet      , ” said the White       Rabbit  , “ but     it       seems to be       a   letter  ,
 # . ISg/#r+ VXB     VP/J   NPr/ISg+ NSg/VB/C . . VP/J D   NPr🅪Sg/VB/J NSg/VB+ . . NSg/C/P NPr/ISg+ V3    P  NSg/VLXB D/P NSg/VB+ .
-> written by    the prisoner to — to somebody . ”
-# VPp/J   NSg/P D   NSg+     P  . P  NSg/I+   . .
+> written by the prisoner to — to somebody . ”
+# VPp/J   P  D   NSg+     P  . P  NSg/I+   . .
 >
 #
 > “ It       must    have    been   that      , ” said the King      , “ unless it       was  written to nobody , which
@@ -5878,8 +5878,8 @@
 # . NSg/VB/J/P P    ISg/D$+ NPr/VB/J+ . . D+  NPr/VB/J+ VP/J    NSg/P D   NSg/VB/J P  ISg/D$+ NSg/VB+ . NSg/I+ VP/J  .
 >
 #
-> “ Who    cares  for   you    ? ” said Alice , ( she  had grown to her     full      size     by    this    time       . )
-# . NPr/I+ NPl/V3 R/C/P ISgPl+ . . VP/J NPr+  . . ISg+ VP  VB/J  P  ISg/D$+ NSg/VB/J+ N🅪Sg/VB+ NSg/P I/Ddem+ N🅪Sg/VB/J+ . .
+> “ Who    cares  for   you    ? ” said Alice , ( she  had grown to her     full      size     by this    time       . )
+# . NPr/I+ NPl/V3 R/C/P ISgPl+ . . VP/J NPr+  . . ISg+ VP  VB/J  P  ISg/D$+ NSg/VB/J+ N🅪Sg/VB+ P  I/Ddem+ N🅪Sg/VB/J+ . .
 > “ You’re nothing  but     a   pack   of cards   ! ”
 # . K      NSg/I/J+ NSg/C/P D/P NSg/VB P  NPl/V3+ . .
 >
@@ -5938,8 +5938,8 @@
 # J     P    D   NSg/VB/J NPl       P  ISg/D$+ NPr/I/J/Dq NSg$     NSg/VB/J+ .
 >
 #
-> The long      grass      rustled at    her     feet as    the White       Rabbit  hurried by    — the frightened
-# D+  NPr/VB/J+ NPr🅪Sg/VB+ VP/J    NSg/P ISg/D$+ NPl+ R/C/P D   NPr🅪Sg/VB/J NSg/VB+ VP/J    NSg/P . D   VP/J
+> The long      grass      rustled at    her     feet as    the White       Rabbit  hurried by — the frightened
+# D+  NPr/VB/J+ NPr🅪Sg/VB+ VP/J    NSg/P ISg/D$+ NPl+ R/C/P D   NPr🅪Sg/VB/J NSg/VB+ VP/J    P  . D   VP/J
 > Mouse   splashed his     way    through the neighbouring pool    — she  could   hear the rattle
 # NSg/VB+ VP/J     ISg/D$+ NSg/J+ J/P     D   Nᴹ/Vg/J/Comm NSg/VB+ . ISg+ NSg/VXB VB   D   NSg/VB
 > of the teacups as    the March   Hare and  his     friends   shared their never - ending  meal    ,

--- a/harper-core/tests/text/tagged/Computer science.md
+++ b/harper-core/tests/text/tagged/Computer science.md
@@ -130,10 +130,10 @@
 # VP/J      D   #   P  D   J/R/C NSg NPl/V3+ R/C/P NSg/J      J          NPl/V3  NPr/J/R/P
 > history . In        1914 , the Spanish engineer Leonardo Torres Quevedo published his
 # N🅪Sg+   . NPr/J/R/P #    . D+  NPrᴹ/J+ NSg/VB+  NPr+     NPr    ?       VP/J      ISg/D$+
-> Essays  on  Automatics , and  designed , inspired by    Babbage , a   theoretical
-# NPl/V3+ J/P NPl        . VB/C VP/J     . VP/J     NSg/P NPr     . D/P J
-> electromechanical calculating machine which was  to be       controlled by    a   read     - only
-# J                 Nᴹ/Vg/J     NSg/VB+ I/C+  VLPt P  NSg/VLXB VP/J       NSg/P D/P NSg/VBP+ . J/R/C
+> Essays  on  Automatics , and  designed , inspired by Babbage , a   theoretical
+# NPl/V3+ J/P NPl        . VB/C VP/J     . VP/J     P  NPr     . D/P J
+> electromechanical calculating machine which was  to be       controlled by a   read     - only
+# J                 Nᴹ/Vg/J     NSg/VB+ I/C+  VLPt P  NSg/VLXB VP/J       P  D/P NSg/VBP+ . J/R/C
 > program . The paper      also introduced the idea of floating - point   arithmetic . In
 # NPr/VB+ . D+  N🅪Sg/VB/J+ R/C  VP/J       D   NSg  P  Nᴹ/Vg/J+ . NSg/VB+ Nᴹ/J       . NPr/J/R/P
 > 1920 , to celebrate the 100th anniversary of the invention of the arithmometer ,
@@ -208,8 +208,8 @@
 # NSg/VB  NPr/J/R/P NPl            P  D   NSg . NPr/J/R/P I/C+  NPr+  ?    V3     R/C/P D
 > creation of a   Graduate  School   in        Computer Sciences analogous to the creation of
 # NSg      P  D/P NSg/VB/J+ N🅪Sg/VB+ NPr/J/R/P NSg+     NPl/V3+  J         P  D   NSg      P
-> Harvard Business School   in        1921 . Louis justifies the name    by    arguing that      , like
-# NPr+    N🅪Sg/J+  N🅪Sg/VB+ NPr/J/R/P #    . NPr+  V3        D+  NSg/VB+ NSg/P Nᴹ/Vg/J I/C/Ddem+ . NSg/VB/J/C/P
+> Harvard Business School   in        1921 . Louis justifies the name    by arguing that      , like
+# NPr+    N🅪Sg/J+  N🅪Sg/VB+ NPr/J/R/P #    . NPr+  V3        D+  NSg/VB+ P  Nᴹ/Vg/J I/C/Ddem+ . NSg/VB/J/C/P
 > management science  , the subject   is  applied and  interdisciplinary in        nature   ,
 # N🅪Sg+      N🅪Sg/VB+ . D+  NSg/VB/J+ VL3 VP/J    VB/C J                 NPr/J/R/P N🅪Sg/VB+ .
 > while      having  the characteristics typical of an  academic discipline . His     efforts ,
@@ -236,8 +236,8 @@
 # NSg        P  ?        NSg/P D   NSg        P  NPr+       . VP/J    NPr/J/R/P #    . P
 > Peter      Naur being        the first professor in        datalogy . The term      is  used mainly in        the
 # NPr/VB/JC+ ?    N🅪Sg/VLg/J/C D   NSg/J NSg+      NPr/J/R/P ?        . D+  NSg/VB/J+ VL3 VP/J R      NPr/J/R/P D
-> Scandinavian countries . An   alternative term      , also proposed by    Naur , is  data
-# NSg/J        NPl+      . D/P+ NSg/J+      NSg/VB/J+ . R/C  VP/J     NSg/P ?    . VL3 N🅪Pl+
+> Scandinavian countries . An   alternative term      , also proposed by Naur , is  data
+# NSg/J        NPl+      . D/P+ NSg/J+      NSg/VB/J+ . R/C  VP/J     P  ?    . VL3 N🅪Pl+
 > science  ; this    is  now       used for   a   multi - disciplinary field  of data  analysis ,
 # N🅪Sg/VB+ . I/Ddem+ VL3 NSg/J/R/C VP/J R/C/P D/P NSg   . NSg/J        NSg/VB P  N🅪Pl+ N🅪Sg+    .
 > including statistics and  databases .
@@ -252,8 +252,8 @@
 # D   NSg . ?           . ?          . NSg/VB+ . NPl/V3+ . NPr/VB+ . VP/J    NSg/J . NSg+          .
 > and  applied epistemologist . Three months later in        the same journal   , comptologist
 # VB/C VP/J    NSg            . NSg+  NPl+   JC    NPr/J/R/P D+  I/J+ NSg/VB/J+ . ?
-> was  suggested , followed next    year by    hypologist . The term      computics has also
-# VLPt VP/J      . VP/J     NSg/J/P NSg+ NSg/P ?          . D+  NSg/VB/J+ ?         V3  R/C
+> was  suggested , followed next    year by hypologist . The term      computics has also
+# VLPt VP/J      . VP/J     NSg/J/P NSg+ P  ?          . D+  NSg/VB/J+ ?         V3  R/C
 > been   suggested . In        Europe , terms   derived from contracted translations of the
 # VLPp/B VP/J      . NPr/J/R/P NPr+   . NPl/V3+ VP/J    P    VP/J       NPl          P  D+
 > expression " automatic information " ( e.g. " informazione automatica " in        Italian )
@@ -276,8 +276,8 @@
 #
 > A   folkloric quotation , often attributed to — but     almost certainly not     first
 # D/P J         NSg       . R     VP/J       P  . NSg/C/P R      R         NSg/R/C NSg/J
-> formulated by    — Edsger Dijkstra , states    that      " computer science  is  no       more         about
-# VP/J       NSg/P . ?      NSg      . NPrPl/V3+ I/C/Ddem+ . NSg+     N🅪Sg/VB+ VL3 NSg/Dq/P NPr/I/J/R/Dq J/P
+> formulated by — Edsger Dijkstra , states    that      " computer science  is  no       more         about
+# VP/J       P  . ?      NSg      . NPrPl/V3+ I/C/Ddem+ . NSg+     N🅪Sg/VB+ VL3 NSg/Dq/P NPr/I/J/R/Dq J/P
 > computers than astronomy is  about telescopes . " [ note    3 ] The design  and  deployment
 # NPl+      C/P  Nᴹ+       VL3 J/P   NPl/V3     . . . NSg/VB+ # . D   N🅪Sg/VB VB/C NSg
 > of computers and  computer systems is  generally considered the province of
@@ -298,14 +298,14 @@
 # Nᴹ+         . NPl/V3+ . N🅪Sg+   . NPrᴹ/VB+ N🅪Sg/VB+ . NPl/V3+    . N🅪Sg/VB+   . VB/C Nᴹ/VB/J+ .
 >
 #
-> Computer science  is  considered by    some     to have    a   much         closer relationship with
-# NSg+     N🅪Sg/VB+ VL3 VP/J       NSg/P I/J/R/Dq P  NSg/VXB D/P NSg/I/J/R/Dq NSg/JC NSg          P
+> Computer science  is  considered by some     to have    a   much         closer relationship with
+# NSg+     N🅪Sg/VB+ VL3 VP/J       P  I/J/R/Dq P  NSg/VXB D/P NSg/I/J/R/Dq NSg/JC NSg          P
 > mathematics than many        scientific disciplines , with some      observers saying    that
 # Nᴹ+         C/P  NSg/I/J/Dq+ J+         NPl/V3+     . P    I/J/R/Dq+ NPl+      N🅪Sg/Vg/J I/C/Ddem
 > computing is  a   mathematical science . Early    computer science  was  strongly
 # Nᴹ/Vg/J+  VL3 D/P J            N🅪Sg/VB . NSg/J/R+ NSg+     N🅪Sg/VB+ VLPt R
-> influenced by    the work    of mathematicians such  as    Kurt Gödel , Alan Turing , John
-# VP/J       NSg/P D   N🅪Sg/VB P  NPl+           NSg/I R/C/P NPr  NPr   . NPr+ NPr    . NPr+
+> influenced by the work    of mathematicians such  as    Kurt Gödel , Alan Turing , John
+# VP/J       P  D   N🅪Sg/VB P  NPl+           NSg/I R/C/P NPr  NPr   . NPr+ NPr    . NPr+
 > von Neumann , Rózsa Péter and  Alonzo Church     and  there continues to be       a   useful
 # ?   ?       . ?     ?     VB/C NPr    NPr🅪Sg/VB+ VB/C R+    NPl/V3    P  NSg/VLXB D/P J
 > interchange of ideas between the two fields    in        areas such  as    mathematical logic    ,
@@ -316,8 +316,8 @@
 #
 > The relationship between computer science and  software engineering is  a
 # D   NSg          NSg/P   NSg+     N🅪Sg/VB VB/C Nᴹ+      Nᴹ/Vg/J+    VL3 D/P
-> contentious issue  , which is  further muddied by    disputes over    what   the term
-# J           NSg/VB . I/C+  VL3 VB/JC   VP/J    NSg/P NPl/V3+  NSg/J/P NSg/I+ D   NSg/VB/J+
+> contentious issue  , which is  further muddied by disputes over    what   the term
+# J           NSg/VB . I/C+  VL3 VB/JC   VP/J    P  NPl/V3+  NSg/J/P NSg/I+ D   NSg/VB/J+
 > " software engineering " means  , and  how   computer science  is  defined . David Parnas ,
 # . Nᴹ+      Nᴹ/Vg/J+    . NPl/V3 . VB/C NSg/C NSg+     N🅪Sg/VB+ VL3 VP/J    . NPr+  ?      .
 > taking   a   cue     from the relationship between other    engineering and  science
@@ -372,10 +372,10 @@
 # D   NSg/J        NSg+   . R           . IPl+ VLB NPl/V3+     . Dq+  NSg/J+ NSg/VB+
 > that      is  built is  an   experiment . Actually constructing the machine poses   a
 # I/C/Ddem+ VL3 VP/J  VL3 D/P+ NSg/VB+    . R        Nᴹ/Vg/J      D+  NSg/VB+ NPl/V3+ D/P+
-> question to nature  ; and  we   listen for   the answer  by    observing the machine in
-# NSg/VB+  P  N🅪Sg/VB . VB/C IPl+ NSg/VB R/C/P D+  NSg/VB+ NSg/P Nᴹ/Vg/J   D   NSg/VB+ NPr/J/R/P
-> operation and  analyzing it       by    all          analytical and  measurement means  available .
-# N🅪Sg+     VB/C Nᴹ/Vg/J   NPr/ISg+ NSg/P NSg/I/J/C/Dq J          VB/C N🅪Sg+       NPl/V3 J         .
+> question to nature  ; and  we   listen for   the answer  by observing the machine in
+# NSg/VB+  P  N🅪Sg/VB . VB/C IPl+ NSg/VB R/C/P D+  NSg/VB+ P  Nᴹ/Vg/J   D   NSg/VB+ NPr/J/R/P
+> operation and  analyzing it       by all          analytical and  measurement means  available .
+# N🅪Sg+     VB/C Nᴹ/Vg/J   NPr/ISg+ P  NSg/I/J/C/Dq J          VB/C N🅪Sg+       NPl/V3 J         .
 >
 #
 > It       has since been   argued that     computer science  can     be       classified as    an   empirical
@@ -510,8 +510,8 @@
 # NSg/VB+  . Nᴹ            N🅪Sg+  NPl/V3   I/C+  J+            NPl+     VLB
 > solvable on  various theoretical models of computation . The second    question is
 # J        J/P J       J           NPl/V3 P  NSg         . D+  NSg/VB/J+ NSg/VB+  VL3
-> addressed by    computational complexity theory , which studies the time      and  space
-# VP/J      NSg/P J             NSg        N🅪Sg+  . I/C+  NPl/V3  D   N🅪Sg/VB/J VB/C N🅪Sg/VB+
+> addressed by computational complexity theory , which studies the time      and  space
+# VP/J      P  J             NSg        N🅪Sg+  . I/C+  NPl/V3  D   N🅪Sg/VB/J VB/C N🅪Sg/VB+
 > costs   associated with different approaches to solving a   multitude of
 # NPl/V3+ VP/J       P    NSg/J     NPl/V3+    P  Nᴹ/Vg/J D/P NSg       P
 > computational problems .
@@ -530,8 +530,8 @@
 #
 > Information theory , closely related to probability and  statistics , is  related to
 # Nᴹ+         N🅪Sg+  . R       J       P  NSg         VB/C NPl/V3+    . VL3 J       P
-> the quantification of information . This    was  developed by    Claude Shannon to find
-# D   NSg            P  Nᴹ+         . I/Ddem+ VLPt VP/J      NSg/P NPr+   NPr+    P  NSg/VB
+> the quantification of information . This    was  developed by Claude Shannon to find
+# D   NSg            P  Nᴹ+         . I/Ddem+ VLPt VP/J      P  NPr+   NPr+    P  NSg/VB
 > fundamental limits on  signal    processing operations such  as    compressing data  and
 # NSg/J       NPl/V3 J/P NSg/VB/J+ Nᴹ/Vg/J+   NPl+       NSg/I R/C/P Nᴹ/Vg/J     N🅪Pl+ VB/C
 > on  reliably storing and  communicating data  . Coding   theory is  the study  of the
@@ -580,8 +580,8 @@
 # NSg/J+ NPl+    VLB D/P NSg/J      NSg/J P  R              VP/J  N🅪Sg+     R/C/P D+
 > specification , development and  verification of software and  hardware systems .
 # NSg+          . N🅪Sg        VB/C N🅪Sg         P  Nᴹ       VB/C Nᴹ+      NPl+    .
-> The use     of formal methods for   software and  hardware design   is  motivated by    the
-# D   N🅪Sg/VB P  NSg/J  NPl     R/C/P Nᴹ       VB/C Nᴹ+      N🅪Sg/VB+ VL3 VP/J      NSg/P D+
+> The use     of formal methods for   software and  hardware design   is  motivated by the
+# D   N🅪Sg/VB P  NSg/J  NPl     R/C/P Nᴹ       VB/C Nᴹ+      N🅪Sg/VB+ VL3 VP/J      P  D+
 > expectation that      , as    in        other     engineering disciplines , performing appropriate
 # N🅪Sg+       I/C/Ddem+ . R/C/P NPr/J/R/P NSg/VB/J+ Nᴹ/Vg/J+    NPl/V3+     . Nᴹ/Vg/J    VB/J+
 > mathematical analysis can     contribute to the reliability and  robustness of a
@@ -772,8 +772,8 @@
 # NSg+     N🅪Sg+        . NPr/C NSg/J+  NSg+     N🅪Sg+        . VL3 D   J
 > design   and  fundamental operational structure of a    computer system . It       focuses
 # N🅪Sg/VB+ VB/C NSg/J       J           N🅪Sg/VB   P  D/P+ NSg+     NSg+   . NPr/ISg+ NPl/V3
-> largely on  the way    by    which the central processing unit performs internally and
-# R       J/P D+  NSg/J+ NSg/P I/C+  D+  NPr/J+  Nᴹ/Vg/J+   NSg+ V3       R          VB/C
+> largely on  the way    by which the central processing unit performs internally and
+# R       J/P D+  NSg/J+ P  I/C+  D+  NPr/J+  Nᴹ/Vg/J+   NSg+ V3       R          VB/C
 > accesses addresses in        memory . Computer engineers study   computational logic   and
 # NPl/V3   NPl/V3    NPr/J/R/P N🅪Sg+  . NSg+     NPl/V3+   NSg/VB+ J             Nᴹ/VB/J VB/C
 > design  of computer hardware , from individual processor components ,
@@ -1060,5 +1060,5 @@
 # NSg/I/J VP/J     N🅪Sg+       R/C/P I/Ddem+ VL3 D   NSg/VB/J N🅪Sg        P  I/Ddem R
 > new   field   requires rapid review and  distribution of results , a    task    better
 # NSg/J NSg/VB+ NPl/V3   NSg/J NSg/VB VB/C NSg          P  NPl/V3+ . D/P+ NSg/VB+ NSg/VXB/JC
-> handled by    conferences than by    journals .
-# VP/J    NSg/P NPl/V3+     C/P  NSg/P NPl/V3+  .
+> handled by conferences than by journals .
+# VP/J    P  NPl/V3+     C/P  P  NPl/V3+  .

--- a/harper-core/tests/text/tagged/Computer science.md
+++ b/harper-core/tests/text/tagged/Computer science.md
@@ -222,8 +222,8 @@
 # NSg/VB/P ISg/D$+ NSg/VB+ . D/P NSg/J       NSg/VB P  NSg+     N🅪Sg/VB+ NPl/VX3 NSg/R/C VB      D
 > study  of computers themselves . Because of this    , several alternative names   have
 # NSg/VB P  NPl+      IPl+       . C/P     P  I/Ddem+ . J/Dq+   NSg/J+      NPl/V3+ NSg/VXB
-> been     proposed . Certain departments of major     universities prefer the term
-# NSg/VLPp VP/J     . I/J     NPl         P  NPr/VB/J+ NPl+         VB     D+  NSg/VB/J+
+> been   proposed . Certain departments of major     universities prefer the term
+# VLPp/B VP/J     . I/J     NPl         P  NPr/VB/J+ NPl+         VB     D+  NSg/VB/J+
 > computing science  , to emphasize precisely that      difference . Danish  scientist
 # Nᴹ/Vg/J+  N🅪Sg/VB+ . P  VB        R         I/C/Ddem+ N🅪Sg/VB+   . NPrᴹ/J+ NSg+
 > Peter      Naur suggested the term      datalogy , to reflect the fact that     the scientific
@@ -254,8 +254,8 @@
 # VB/C VP/J    NSg            . NSg+  NPl+   JC    NPr/J/R/P D+  I/J+ NSg/VB/J+ . ?
 > was  suggested , followed next    year by    hypologist . The term      computics has also
 # VLPt VP/J      . VP/J     NSg/J/P NSg+ NSg/P ?          . D+  NSg/VB/J+ ?         V3  R/C
-> been     suggested . In        Europe , terms   derived from contracted translations of the
-# NSg/VLPp VP/J      . NPr/J/R/P NPr+   . NPl/V3+ VP/J    P    VP/J       NPl          P  D+
+> been   suggested . In        Europe , terms   derived from contracted translations of the
+# VLPp/B VP/J      . NPr/J/R/P NPr+   . NPl/V3+ VP/J    P    VP/J       NPl          P  D+
 > expression " automatic information " ( e.g. " informazione automatica " in        Italian )
 # N🅪Sg+      . NSg/J+    Nᴹ+         . . NSg  . ?            ?          . NPr/J/R/P N🅪Sg/J  .
 > or    " information and  mathematics " are often used , e.g. informatique ( French      ) ,
@@ -265,7 +265,7 @@
 > Portuguese ) , informatika ( Slavic languages and  Hungarian ) or    pliroforiki
 # NPr/J      . . ?           . NSg/J  NPl+      VB/C NSg/J     . NPr/C ?
 > ( π          λ          η          ρ          ο          φ          ο          ρ          ι          κ          ή          , which means  informatics ) in        Greek    . Similar words   have    also been
-# . Unlintable Unlintable Unlintable Unlintable Unlintable Unlintable Unlintable Unlintable Unlintable Unlintable Unlintable . I/C+  NPl/V3 Nᴹ          . NPr/J/R/P NPr/VB/J . NSg/J+  NPl/V3+ NSg/VXB R/C  NSg/VLPp
+# . Unlintable Unlintable Unlintable Unlintable Unlintable Unlintable Unlintable Unlintable Unlintable Unlintable Unlintable . I/C+  NPl/V3 Nᴹ          . NPr/J/R/P NPr/VB/J . NSg/J+  NPl/V3+ NSg/VXB R/C  VLPp/B
 > adopted in        the UK   ( as    in        the School  of Informatics , University of Edinburgh ) .
 # VP/J    NPr/J/R/P D+  NPr+ . R/C/P NPr/J/R/P D   N🅪Sg/VB P  Nᴹ          . NSg        P  NPr+      . .
 > " In        the U.S. , however , informatics is  linked with applied computing , or
@@ -288,8 +288,8 @@
 # Nᴹ+      VL3 R       VP/J       NSg/VB/J P  NSg+     Nᴹ/Vg/J+    . NSg/VB/C/P D   NSg/VB P
 > commercial computer systems and  their deployment is  often called information
 # NSg/J+     NSg+     NPl+    VB/C D$+   NSg+       VL3 R     VP/J   Nᴹ+
-> technology or    information systems . However , there has been     exchange of ideas
-# N🅪Sg       NPr/C Nᴹ+         NPl+    . C       . R+    V3  NSg/VLPp NSg/VB   P  NPl+
+> technology or    information systems . However , there has been   exchange of ideas
+# N🅪Sg       NPr/C Nᴹ+         NPl+    . C       . R+    V3  VLPp/B NSg/VB   P  NPl+
 > between the various computer - related disciplines . Computer science  research also
 # NSg/P   D   J       NSg+     . J+      NPl/V3+     . NSg+     N🅪Sg/VB+ Nᴹ/VB+   R/C
 > often intersects other    disciplines , such  as    cognitive science , linguistics ,
@@ -378,8 +378,8 @@
 # N🅪Sg+     VB/C Nᴹ/Vg/J   NPr/ISg+ NSg/P NSg/I/J/C/Dq J          VB/C N🅪Sg+       NPl/V3 J         .
 >
 #
-> It       has since been     argued that     computer science  can     be       classified as    an   empirical
-# NPr/ISg+ V3  C/P+  NSg/VLPp VP/J   I/C/Ddem NSg+     N🅪Sg/VB+ NPr/VXB NSg/VLXB NSg/VP/J   R/C/P D/P+ NSg/J+
+> It       has since been   argued that     computer science  can     be       classified as    an   empirical
+# NPr/ISg+ V3  C/P+  VLPp/B VP/J   I/C/Ddem NSg+     N🅪Sg/VB+ NPr/VXB NSg/VLXB NSg/VP/J   R/C/P D/P+ NSg/J+
 > science  since it       makes  use     of empirical testing  to evaluate the correctness of
 # N🅪Sg/VB+ C/P   NPr/ISg+ NPl/V3 N🅪Sg/VB P  NSg/J     Nᴹ/Vg/J+ P  VB       D   NSg         P
 > programs  , but     a    problem remains in        defining the laws    and  theorems of computer
@@ -396,8 +396,8 @@
 # R/C  VB    I/C/Ddem NSg/VB/C/P NSg/J+    NPl/V3+  NSg/VB  NSg/I+ R         V3     . NSg+
 > science  observes what   is  possible to exist and  while      scientists discover  laws
 # N🅪Sg/VB+ NPl/V3   NSg/I+ VL3 NSg/J    P  VB    VB/C NSg/VB/C/P NPl+       N🅪Sg/VB/J NPl/V3
-> from observation , no        proper laws    have    been     found  in        computer science  and  it       is
-# P    N🅪Sg+       . NSg/Dq/P+ NSg/J+ NPl/V3+ NSg/VXB NSg/VLPp NSg/VP NPr/J/R/P NSg+     N🅪Sg/VB+ VB/C NPr/ISg+ VL3
+> from observation , no        proper laws    have    been   found  in        computer science  and  it       is
+# P    N🅪Sg+       . NSg/Dq/P+ NSg/J+ NPl/V3+ NSg/VXB VLPp/B NSg/VP NPr/J/R/P NSg+     N🅪Sg/VB+ VB/C NPr/ISg+ VL3
 > instead concerned with creating phenomena .
 # R       VP/J      P    Nᴹ/Vg/J  NSg+      .
 >
@@ -732,16 +732,16 @@
 # NSg/J         NSg+       . Nᴹ/Vg/J+ . VB/C N🅪Sg+         NSg/VP NPr/J/R/P NPl/V3 VB/C
 > animals . From its     origins in        cybernetics and  in        the Dartmouth Conference ( 1956 ) ,
 # NPl+    . P    ISg/D$+ NPl+    NPr/J/R/P Nᴹ          VB/C NPr/J/R/P D   NPr+      NSg/VB+    . #    . .
-> artificial intelligence research has been     necessarily cross       - disciplinary ,
-# J          N🅪Sg+        Nᴹ/VB+   V3  NSg/VLPp R           NPr/VB/J/P+ . NSg/J        .
+> artificial intelligence research has been   necessarily cross       - disciplinary ,
+# J          N🅪Sg+        Nᴹ/VB+   V3  VLPp/B R           NPr/VB/J/P+ . NSg/J        .
 > drawing   on  areas of expertise such  as    applied mathematics , symbolic logic    ,
 # N🅪Sg/Vg/J J/P NPl   P  Nᴹ/VB+    NSg/I R/C/P VP/J    Nᴹ+         . J        Nᴹ/VB/J+ .
 > semiotics , electrical engineering , philosophy of mind    , neurophysiology , and
 # Nᴹ        . NSg/J      Nᴹ/Vg/J+    . N🅪Sg/VB    P  NSg/VB+ . Nᴹ              . VB/C
 > social intelligence . AI    is  associated in        the popular mind    with robotic
 # NSg/J  N🅪Sg+        . N🅪Sg+ VL3 VP/J       NPr/J/R/P D   NSg/J   NSg/VB+ P    J+
-> development , but     the main     field  of practical application has been     as    an  embedded
-# N🅪Sg+       . NSg/C/P D   NSg/VB/J NSg/VB P  NSg/J+    NSg+        V3  NSg/VLPp R/C/P D/P VP/J
+> development , but     the main     field  of practical application has been   as    an  embedded
+# N🅪Sg+       . NSg/C/P D   NSg/VB/J NSg/VB P  NSg/J+    NSg+        V3  VLPp/B R/C/P D/P VP/J
 > component in        areas of software development , which require computational
 # NSg/J     NPr/J/R/P NPl   P  Nᴹ+      N🅪Sg+       . I/C+  NSg/VB  J+
 > understanding . The starting point   in        the late   1940s was  Alan Turing's question
@@ -752,8 +752,8 @@
 # C        D   NPr    NSg/VB+ VL3 NSg/VB/J/R VP/J P  VB     NSg+     N🅪Sg/VBP+ J/P D   N🅪Sg/VB P
 > human    intelligence . But     the automation of evaluative and  predictive tasks   has
 # NSg/VB/J N🅪Sg+        . NSg/C/P D   N🅪Sg       P  J          VB/C J          NPl/V3+ V3
-> been     increasingly successful as    a   substitute for   human    monitoring and
-# NSg/VLPp R            J          R/C/P D/P NSg/VB+    R/C/P NSg/VB/J Nᴹ/Vg/J    VB/C
+> been   increasingly successful as    a   substitute for   human    monitoring and
+# VLPp/B R            J          R/C/P D/P NSg/VB+    R/C/P NSg/VB/J Nᴹ/Vg/J    VB/C
 > intervention in        domains of computer application involving complex  real  - world
 # NSg+         NPr/J/R/P NPl     P  NSg+     NSg+        Nᴹ/Vg/J   NSg/VB/J NSg/J . NSg/VB+
 > data  .
@@ -796,8 +796,8 @@
 # N🅪Sg        VL3 D/P NSg/VB   P  NPl+    NPr/J/R/P I/C+  J/Dq    NPl          VLB Nᴹ/Vg/J
 > simultaneously , and  potentially interacting with each other    . A   number     of
 # R              . VB/C R           Nᴹ/Vg/J     P    Dq   NSg/VB/J . D/P N🅪Sg/VB/JC P
-> mathematical models  have    been     developed for   general  concurrent computation
-# J+           NPl/V3+ NSg/VXB NSg/VLPp VP/J      R/C/P NSg/VB/J NSg/J      NSg
+> mathematical models  have    been   developed for   general  concurrent computation
+# J+           NPl/V3+ NSg/VXB VLPp/B VP/J      R/C/P NSg/VB/J NSg/J      NSg
 > including Petri nets   , process calculi and  the parallel random   access   machine
 # Nᴹ/Vg/J   ?     NPl/V3 . NSg/VB+ NSg     VB/C D   NSg/VB/J NSg/VB/J N🅪Sg/VB+ NSg/VB+
 > model     . When    multiple  computers are connected in        a    network while      using

--- a/harper-core/tests/text/tagged/Difficult sentences.md
+++ b/harper-core/tests/text/tagged/Difficult sentences.md
@@ -10,8 +10,8 @@
 # NSg/VB+ I/C/Ddem I/J/R/Dq+ NSg/VB+ NPr/VXB NSg/R/C NSg/VLXB VP/J   R         NPr/VB/J NSg/J/R/C .
 >
 #
-> Most         example sentences are taken from https://en.wiktionary.org/. License : CC         BY    - SA        4.0 .
-# NSg/I/J/R/Dq NSg/VB+ NPl/V3+   VLB VPp/J P    Url                         NSg/VB+ . NSg/VB/#r+ NSg/P . NPr/VB/J+ #   .
+> Most         example sentences are taken from https://en.wiktionary.org/. License : CC         BY - SA        4.0 .
+# NSg/I/J/R/Dq NSg/VB+ NPl/V3+   VLB VPp/J P    Url                         NSg/VB+ . NSg/VB/#r+ P  . NPr/VB/J+ #   .
 >
 #
 >              A
@@ -85,121 +85,121 @@
 >
 #
 >              By
-# HeadingStart NSg/P
+# HeadingStart P
 >
 #
 >              Preposition
 # HeadingStart NSg/VB
 >
 #
-> The mailbox is  by    the bus     stop   .
-# D   NSg     VL3 NSg/P D   NSg/VB+ NSg/VB .
-> The stream  runs   by    our back     door    .
-# D+  NSg/VB+ NPl/V3 NSg/P D$+ NSg/VB/J NSg/VB+ .
-> He       ran straight   by    me       .
-# NPr/ISg+ VPt NSg/VB/J/R NSg/P NPr/ISg+ .
-> Be       back     by    ten o'clock ! .
-# NSg/VLXB NSg/VB/J NSg/P NSg R       . .
-> We'll find   someone by    the end    of March   .
-# K     NSg/VB NSg/I+  NSg/P D   NSg/VB P  NPr/VB+ .
-> We   will    send   it       by    the first week  of July .
-# IPl+ NPr/VXB NSg/VB NPr/ISg+ NSg/P D   NSg/J NSg/J P  NPr+ .
-> The matter   was  decided  by    the chairman .
-# D+  N🅪Sg/VB+ VLPt NSg/VP/J NSg/P D+  NSg/VB+  .
-> The boat    was  swamped by    the water    .
-# D+  NSg/VB+ VLPt VP/J    NSg/P D+  N🅪Sg/VB+ .
-> He       was  protected by    his     body    armour       .
-# NPr/ISg+ VLPt VP/J      NSg/P ISg/D$+ NSg/VB+ NPr/VB/Comm+ .
-> There was  a    call    by    the unions   for   a   30 % pay      rise    .
-# R+    VLPt D/P+ NSg/VB+ NSg/P D   NPrPl/V3 R/C/P D/P #  . NSg/VB/J NSg/VB+ .
-> I       was  aghast by    what   I       saw     .
-# ISg/#r+ VLPt J      NSg/P NSg/I+ ISg/#r+ NSg/VPt .
-> There are many       well       - known plays  by    William Shakespeare .
-# R+    VLB NSg/I/J/Dq NSg/VB/J/R . VPp/J NPl/V3 NSg/P NPr+    NPr/VB+     .
-> I       avoided the guards  by    moving  only  when    they weren't looking .
-# ISg/#r+ VP/J    D+  NPl/V3+ NSg/P Nᴹ/Vg/J J/R/C NSg/I/C IPl+ VPt     Nᴹ/Vg/J .
-> By    Pythagoras ' theorem , we   can     calculate the length  of the hypotenuse .
-# NSg/P NPr        . NSg/VB  . IPl+ NPr/VXB VB        D   N🅪Sg/VB P  D   NSg        .
-> We   went    by    bus     .
-# IPl+ NSg/VPt NSg/P NSg/VB+ .
-> I       discovered it       by    chance    .
-# ISg/#r+ VP/J       NPr/ISg+ NSg/P NPr/VB/J+ .
-> By    ' maybe   ' she  means  ' no       ' .
-# NSg/P . NSg/J/R . ISg+ NPl/V3 . NSg/Dq/P . .
-> The electricity was  cut       off        , so          we   had to read    by    candlelight .
-# D+  Nᴹ+         VLPt NSg/VBP/J NSg/VB/J/P . NSg/I/J/R/C IPl+ VP  P  NSg/VBP NSg/P Nᴹ          .
-> By    the power      vested in        me       , I       now       pronounce you    man    and  wife      .
-# NSg/P D+  N🅪Sg/VB/J+ VP/J   NPr/J/R/P NPr/ISg+ . ISg/#r+ NSg/J/R/C NSg/VB    ISgPl+ NPr/VB VB/C NSg/VB/J+ .
-> By    Jove ! I       think  she's got it       !
-# NSg/P NPr+ . ISg/#r+ NSg/VB K     VP  NPr/ISg+ .
-> By    all           that      is  holy    , I'll put     an  end     to this    .
-# NSg/P NSg/I/J/C/Dq+ I/C/Ddem+ VL3 NSg/J/R . K    NSg/VBP D/P NSg/VB+ P  I/Ddem+ .
-> I       sorted the items   by    category .
-# ISg/#r+ VP/J   D   NPl/V3+ NSg/P NSg+     .
-> Table   1 shows  details of our employees broken down        by    sex    and  age      .
-# NSg/VB+ # NPl/V3 NPl/V3  P  D$+ NPl+      VPp/J  N🅪Sg/VB/J/P NSg/P NSg/VB VB/C N🅪Sg/VB+ .
-> Our stock      is  up         by    ten  percent .
-# D$+ N🅪Sg/VB/J+ VL3 NSg/VB/J/P NSg/P NSg+ NSg+    .
-> We   won      by    six  goals   to three .
-# IPl+ NSgPl/VP NSg/P NSg+ NPl/V3+ P  NSg   .
-> His     date    of birth     was  wrong      by    ten  years .
-# ISg/D$+ N🅪Sg/VB P  NSg/VB/J+ VLPt NSg/VB/J/R NSg/P NSg+ NPl+  .
-> We   went    through the book    page    by    page    .
-# IPl+ NSg/VPt J/P     D+  NSg/VB+ NPr/VB+ NSg/P NPr/VB+ .
-> We   crawled forward  by    inches  .
-# IPl+ VP/J    NSg/VB/J NSg/P NPl/V3+ .
-> sold   by    the yard    ; cheaper if    bought by    the gross
-# NSg/VP NSg/P D+  NSg/VB+ . NSg/JC  NSg/C NSg/VP NSg/P D   NPr/VB/J
-> While      sitting  listening to the radio    by    the hour , she  can     drink   brandy  by    the bucketful !
-# NSg/VB/C/P NSg/Vg/J Nᴹ/Vg/J   P  D+  N🅪Sg/VB+ NSg/P D+  NSg+ . ISg+ NPr/VXB NSg/VB+ NPr/VB+ NSg/P D   NSg       .
-> He       sits   listening to the radio    by    the hour .
-# NPr/ISg+ NPl/V3 Nᴹ/Vg/J   P  D+  N🅪Sg/VB+ NSg/P D+  NSg+ .
-> His     health was  deteriorating by    the day     .
-# ISg/D$+ Nᴹ+    VLPt Nᴹ/Vg/J       NSg/P D+  NPr🅪Sg+ .
-> The pickers are paid by    the bushel .
-# D   W?      VLB VP/J NSg/P D   NSg/VB .
-> He       cheated by    his     own       admission .
-# NPr/ISg+ VP/J    NSg/P ISg/D$+ NSg/VB/J+ NSg+      .
-> By    my  reckoning , we   should be       nearly there .
-# NSg/P D$+ Nᴹ/Vg/J+  . IPl+ VXB    NSg/VLXB R      R     .
-> It       is  easy     to invert   a   2 - by    - 2 matrix .
-# NPr/ISg+ VL3 NSg/VB/J P  NSg/VB/J D/P # . NSg/P . # NSg+   .
-> The room     was  about 4 foot   by    6 foot    .
-# D+  N🅪Sg/VB+ VLPt J/P   # NSg/VB NSg/P # NSg/VB+ .
-> The bricks  used to build  the wall    measured 10 by    20 by    30 cm  .
-# D+  NPl/V3+ VP/J P  NSg/VB D+  NPr/VB+ VP/J     #  NSg/P #  NSg/P #  #r+ .
-> She's a   lovely little     filly , by    Big   Lad , out          of Damsel in        Distress .
-# K     D/P NSg/J  NPr/I/J/Dq NSg   . NSg/P NSg/J NSg . NSg/VB/J/R/P P  NSg    NPr/J/R/P Nᴹ/VB+   .
-> Are you    eating  by    Rabbi Fischer ? ( at    the house  of )
-# VLB ISgPl+ Nᴹ/Vg/J NSg/P NSg+  NPr+    . . NSg/P D   NPr/VB P  .
-> By    Chabad , it's different . ( with , among )
-# NSg/P ?      . +    NSg/J     . . P    . P     .
+> The mailbox is  by the bus     stop   .
+# D   NSg     VL3 P  D   NSg/VB+ NSg/VB .
+> The stream  runs   by our back     door    .
+# D+  NSg/VB+ NPl/V3 P  D$+ NSg/VB/J NSg/VB+ .
+> He       ran straight   by me       .
+# NPr/ISg+ VPt NSg/VB/J/R P  NPr/ISg+ .
+> Be       back     by ten o'clock ! .
+# NSg/VLXB NSg/VB/J P  NSg R       . .
+> We'll find   someone by the end    of March   .
+# K     NSg/VB NSg/I+  P  D   NSg/VB P  NPr/VB+ .
+> We   will    send   it       by the first week  of July .
+# IPl+ NPr/VXB NSg/VB NPr/ISg+ P  D   NSg/J NSg/J P  NPr+ .
+> The matter   was  decided  by the chairman .
+# D+  N🅪Sg/VB+ VLPt NSg/VP/J P  D+  NSg/VB+  .
+> The boat    was  swamped by the water    .
+# D+  NSg/VB+ VLPt VP/J    P  D+  N🅪Sg/VB+ .
+> He       was  protected by his     body    armour       .
+# NPr/ISg+ VLPt VP/J      P  ISg/D$+ NSg/VB+ NPr/VB/Comm+ .
+> There was  a    call    by the unions   for   a   30 % pay      rise    .
+# R+    VLPt D/P+ NSg/VB+ P  D   NPrPl/V3 R/C/P D/P #  . NSg/VB/J NSg/VB+ .
+> I       was  aghast by what   I       saw     .
+# ISg/#r+ VLPt J      P  NSg/I+ ISg/#r+ NSg/VPt .
+> There are many       well       - known plays  by William Shakespeare .
+# R+    VLB NSg/I/J/Dq NSg/VB/J/R . VPp/J NPl/V3 P  NPr+    NPr/VB+     .
+> I       avoided the guards  by moving  only  when    they weren't looking .
+# ISg/#r+ VP/J    D+  NPl/V3+ P  Nᴹ/Vg/J J/R/C NSg/I/C IPl+ VPt     Nᴹ/Vg/J .
+> By Pythagoras ' theorem , we   can     calculate the length  of the hypotenuse .
+# P  NPr        . NSg/VB  . IPl+ NPr/VXB VB        D   N🅪Sg/VB P  D   NSg        .
+> We   went    by bus     .
+# IPl+ NSg/VPt P  NSg/VB+ .
+> I       discovered it       by chance    .
+# ISg/#r+ VP/J       NPr/ISg+ P  NPr/VB/J+ .
+> By ' maybe   ' she  means  ' no       ' .
+# P  . NSg/J/R . ISg+ NPl/V3 . NSg/Dq/P . .
+> The electricity was  cut       off        , so          we   had to read    by candlelight .
+# D+  Nᴹ+         VLPt NSg/VBP/J NSg/VB/J/P . NSg/I/J/R/C IPl+ VP  P  NSg/VBP P  Nᴹ          .
+> By the power      vested in        me       , I       now       pronounce you    man    and  wife      .
+# P  D+  N🅪Sg/VB/J+ VP/J   NPr/J/R/P NPr/ISg+ . ISg/#r+ NSg/J/R/C NSg/VB    ISgPl+ NPr/VB VB/C NSg/VB/J+ .
+> By Jove ! I       think  she's got it       !
+# P  NPr+ . ISg/#r+ NSg/VB K     VP  NPr/ISg+ .
+> By all           that      is  holy    , I'll put     an  end     to this    .
+# P  NSg/I/J/C/Dq+ I/C/Ddem+ VL3 NSg/J/R . K    NSg/VBP D/P NSg/VB+ P  I/Ddem+ .
+> I       sorted the items   by category .
+# ISg/#r+ VP/J   D   NPl/V3+ P  NSg+     .
+> Table   1 shows  details of our employees broken down        by sex    and  age      .
+# NSg/VB+ # NPl/V3 NPl/V3  P  D$+ NPl+      VPp/J  N🅪Sg/VB/J/P P  NSg/VB VB/C N🅪Sg/VB+ .
+> Our stock      is  up         by ten  percent .
+# D$+ N🅪Sg/VB/J+ VL3 NSg/VB/J/P P  NSg+ NSg+    .
+> We   won      by six  goals   to three .
+# IPl+ NSgPl/VP P  NSg+ NPl/V3+ P  NSg   .
+> His     date    of birth     was  wrong      by ten  years .
+# ISg/D$+ N🅪Sg/VB P  NSg/VB/J+ VLPt NSg/VB/J/R P  NSg+ NPl+  .
+> We   went    through the book    page    by page    .
+# IPl+ NSg/VPt J/P     D+  NSg/VB+ NPr/VB+ P  NPr/VB+ .
+> We   crawled forward  by inches  .
+# IPl+ VP/J    NSg/VB/J P  NPl/V3+ .
+> sold   by the yard    ; cheaper if    bought by the gross
+# NSg/VP P  D+  NSg/VB+ . NSg/JC  NSg/C NSg/VP P  D   NPr/VB/J
+> While      sitting  listening to the radio    by the hour , she  can     drink   brandy  by the bucketful !
+# NSg/VB/C/P NSg/Vg/J Nᴹ/Vg/J   P  D+  N🅪Sg/VB+ P  D+  NSg+ . ISg+ NPr/VXB NSg/VB+ NPr/VB+ P  D   NSg       .
+> He       sits   listening to the radio    by the hour .
+# NPr/ISg+ NPl/V3 Nᴹ/Vg/J   P  D+  N🅪Sg/VB+ P  D+  NSg+ .
+> His     health was  deteriorating by the day     .
+# ISg/D$+ Nᴹ+    VLPt Nᴹ/Vg/J       P  D+  NPr🅪Sg+ .
+> The pickers are paid by the bushel .
+# D   W?      VLB VP/J P  D   NSg/VB .
+> He       cheated by his     own       admission .
+# NPr/ISg+ VP/J    P  ISg/D$+ NSg/VB/J+ NSg+      .
+> By my  reckoning , we   should be       nearly there .
+# P  D$+ Nᴹ/Vg/J+  . IPl+ VXB    NSg/VLXB R      R     .
+> It       is  easy     to invert   a   2 - by - 2 matrix .
+# NPr/ISg+ VL3 NSg/VB/J P  NSg/VB/J D/P # . P  . # NSg+   .
+> The room     was  about 4 foot   by 6 foot    .
+# D+  N🅪Sg/VB+ VLPt J/P   # NSg/VB P  # NSg/VB+ .
+> The bricks  used to build  the wall    measured 10 by 20 by 30 cm  .
+# D+  NPl/V3+ VP/J P  NSg/VB D+  NPr/VB+ VP/J     #  P  #  P  #  #r+ .
+> She's a   lovely little     filly , by Big   Lad , out          of Damsel in        Distress .
+# K     D/P NSg/J  NPr/I/J/Dq NSg   . P  NSg/J NSg . NSg/VB/J/R/P P  NSg    NPr/J/R/P Nᴹ/VB+   .
+> Are you    eating  by Rabbi Fischer ? ( at    the house  of )
+# VLB ISgPl+ Nᴹ/Vg/J P  NSg+  NPr+    . . NSg/P D   NPr/VB P  .
+> By Chabad , it's different . ( with , among )
+# P  ?      . +    NSg/J     . . P    . P     .
 >
 #
 >              Adverb
 # HeadingStart NSg/VB+
 >
 #
-> I       watched the parade  as    it       passed by    .
-# ISg/#r+ VP/J    D+  NSg/VB+ R/C/P NPr/ISg+ VP/J   NSg/P .
-> There was  a    shepherd close    by    .
-# R+    VLPt D/P+ NPr/VB+  NSg/VB/J NSg/P .
-> I'll stop   by    on  my  way    home     from work     .
-# K    NSg/VB NSg/P J/P D$+ NSg/J+ NSg/VB/J P    N🅪Sg/VB+ .
-> We're right    near       the lifeguard station . Come       by    before you    leave  .
-# K     NPr/VB/J NSg/VB/J/P D   NSg+      NSg/VB+ . NSg/VBPp/P NSg/P C/P    ISgPl+ NSg/VB .
-> The women spent much         time       after harvest putting jams    by    for   winter  and  spring   .
-# D+  NPl+  VP/J  NSg/I/J/R/Dq N🅪Sg/VB/J+ P     NSg/VB+ Nᴹ/Vg/J NPl/V3+ NSg/P R/C/P N🅪Sg/VB VB/C N🅪Sg/VB+ .
+> I       watched the parade  as    it       passed by .
+# ISg/#r+ VP/J    D+  NSg/VB+ R/C/P NPr/ISg+ VP/J   P  .
+> There was  a    shepherd close    by .
+# R+    VLPt D/P+ NPr/VB+  NSg/VB/J P  .
+> I'll stop   by on  my  way    home     from work     .
+# K    NSg/VB P  J/P D$+ NSg/J+ NSg/VB/J P    N🅪Sg/VB+ .
+> We're right    near       the lifeguard station . Come       by before you    leave  .
+# K     NPr/VB/J NSg/VB/J/P D   NSg+      NSg/VB+ . NSg/VBPp/P P  C/P    ISgPl+ NSg/VB .
+> The women spent much         time       after harvest putting jams    by for   winter  and  spring   .
+# D+  NPl+  VP/J  NSg/I/J/R/Dq N🅪Sg/VB/J+ P     NSg/VB+ Nᴹ/Vg/J NPl/V3+ P  R/C/P N🅪Sg/VB VB/C N🅪Sg/VB+ .
 >
 #
 >              Adjective
 # HeadingStart NSg/VB/J+
 >
 #
-> a   by    path    ; a   by    room     ( Out          of the way    , off        to one      side      . )
-# D/P NSg/P NSg/VB+ . D/P NSg/P N🅪Sg/VB+ . NSg/VB/J/R/P P  D+  NSg/J+ . NSg/VB/J/P P  NSg/I/J+ NSg/VB/J+ . .
-> by    catch  ; a   by    issue  ( Subsidiary , incidental . )
-# NSg/P NSg/VB . D/P NSg/P NSg/VB . NSg/J+     . NSg/J      . .
+> a   by path    ; a   by room     ( Out          of the way    , off        to one      side      . )
+# D/P P  NSg/VB+ . D/P P  N🅪Sg/VB+ . NSg/VB/J/R/P P  D+  NSg/J+ . NSg/VB/J/P P  NSg/I/J+ NSg/VB/J+ . .
+> by catch  ; a   by issue  ( Subsidiary , incidental . )
+# P  NSg/VB . D/P P  NSg/VB . NSg/J+     . NSg/J      . .
 >
 #
 >              For
@@ -250,16 +250,16 @@
 # NSg/I/J/C/Dq I/Ddem R/C/P D+  N🅪Sg/VB+ . NSg/VB D$+  NPl/V3+ .
 > Who's for   ice        - cream      ?
 # NPr$+ R/C/P NPr🅪Sg/VB+ . N🅪Sg/VB/J+ .
-> I'm for   going   by    train
-# K   R/C/P Nᴹ/Vg/J NSg/P NSg/VB+
+> I'm for   going   by train
+# K   R/C/P Nᴹ/Vg/J P  NSg/VB+
 > Ten voted for   , and  three against . ( with implied object  )
 # NSg VP/J  R/C/P . VB/C NSg   C/P     . . P    VP/J    NSg/VB+ .
 > Make   way   for   the president !
-# NSg/VB NSg/J R/C/P D+  NSg/VB+   .
+# NSg/VB NSg/J R/C/P D+  NSg+      .
 > Clear    the shelves for   our new    Christmas stock      !
 # NSg/VB/J D   NPl/V3  R/C/P D$+ NSg/J+ NPr/VB/J+ N🅪Sg/VB/J+ .
-> Stand  by    for   your cue     .
-# NSg/VB NSg/P R/C/P D$+  NSg/VB+ .
+> Stand  by for   your cue     .
+# NSg/VB P  R/C/P D$+  NSg/VB+ .
 > Prepare for   battle    .
 # VB      R/C/P NPr/VB/J+ .
 > They swept the area for   enemy   operatives .
@@ -282,8 +282,8 @@
 # NPr/ISg+ VL3 J            R/C/P D$+ NSg/VB/J+ P  NSg/VB   D$+ NPl/V3+ .
 > I       don't think  it's a   good     idea for   you    and  me       to meet     ever again .
 # ISg/#r+ VXB   NSg/VB +    D/P NPr/VB/J NSg+ R/C/P ISgPl+ VB/C NPr/ISg+ P  NSg/VB/J J/R  P     .
-> I       am        aiming  for   completion by    the end    of business Thursday .
-# ISg/#r+ NPr/VLB/J Nᴹ/Vg/J R/C/P NSg+       NSg/P D   NSg/VB P  N🅪Sg/J+  NSg+     .
+> I       am        aiming  for   completion by the end    of business Thursday .
+# ISg/#r+ NPr/VLB/J Nᴹ/Vg/J R/C/P NSg+       P  D   NSg/VB P  N🅪Sg/J+  NSg+     .
 > He's going   for   his     doctorate .
 # NPr$ Nᴹ/Vg/J R/C/P ISg/D$+ NSg/VB+   .
 > Do  you    want   to go       for   coffee     ?
@@ -492,8 +492,8 @@
 #
 > Is  Mr   . Smith   in        ?
 # VL3 NSg+ . NPr/VB+ NPr/J/R/P .
-> Little     by    little     I       pushed the snake   into the basket  , until finally all          of it       was  in        .
-# NPr/I/J/Dq NSg/P NPr/I/J/Dq ISg/#r+ VP/J   D+  NPr/VB+ P    D+  NSg/VB+ . C/P   R       NSg/I/J/C/Dq P  NPr/ISg+ VLPt NPr/J/R/P .
+> Little     by little     I       pushed the snake   into the basket  , until finally all          of it       was  in        .
+# NPr/I/J/Dq P  NPr/I/J/Dq ISg/#r+ VP/J   D+  NPr/VB+ P    D+  NSg/VB+ . C/P   R       NSg/I/J/C/Dq P  NPr/ISg+ VLPt NPr/J/R/P .
 > The bullet  is  about five centimetres in        .
 # D+  NSg/VB+ VL3 J/P   NSg  NPl/Comm    NPr/J/R/P .
 > If    the tennis  ball    bounces on  the line    then      it's in        .
@@ -508,8 +508,8 @@
 # D   NPr/J/R/P NSg/VB+ . Nᴹ/Vg/J  NSg/VB+ .
 > You    can't get    round      the headland when    the tide's in        .
 # ISgPl+ VXB   NSg/VB NSg/VB/J/P D   NSg      NSg/I/C D   NSg$   NPr/J/R/P .
-> in        by    descent  ;            in        by    purchase ;            in        of the seisin of her     husband
-# NPr/J/R/P NSg/P N🅪Sg/VB+ . Unlintable NPr/J/R/P NSg/P NSg/VB+  . Unlintable NPr/J/R/P P  D   ?      P  ISg/D$+ NSg/VB+
+> in        by descent  ;            in        by purchase ;            in        of the seisin of her     husband
+# NPr/J/R/P P  N🅪Sg/VB+ . Unlintable NPr/J/R/P P  NSg/VB+  . Unlintable NPr/J/R/P P  D   ?      P  ISg/D$+ NSg/VB+
 > He       is  very in        with the Joneses .
 # NPr/ISg+ VL3 J/R  NPr/J/R/P P    D   NPl/V3  .
 > I       need     to keep   in        with the neighbours   in        case       I       ever need     a    favour        from them     .

--- a/harper-core/tests/text/tagged/Difficult sentences.md
+++ b/harper-core/tests/text/tagged/Difficult sentences.md
@@ -164,8 +164,8 @@
 # NSg/P D$+ Nᴹ/Vg/J+  . IPl+ VXB    NSg/VLXB R      R     .
 > It       is  easy     to invert   a   2 - by    - 2 matrix .
 # NPr/ISg+ VL3 NSg/VB/J P  NSg/VB/J D/P # . NSg/P . # NSg+   .
-> The room       was  about 4 foot   by    6 foot    .
-# D+  N🅪Sg/VB/J+ VLPt J/P   # NSg/VB NSg/P # NSg/VB+ .
+> The room     was  about 4 foot   by    6 foot    .
+# D+  N🅪Sg/VB+ VLPt J/P   # NSg/VB NSg/P # NSg/VB+ .
 > The bricks  used to build  the wall    measured 10 by    20 by    30 cm  .
 # D+  NPl/V3+ VP/J P  NSg/VB D+  NPr/VB+ VP/J     #  NSg/P #  NSg/P #  #r+ .
 > She's a   lovely little     filly , by    Big   Lad , out          of Damsel in        Distress .
@@ -196,8 +196,8 @@
 # HeadingStart NSg/VB/J+
 >
 #
-> a   by    path    ; a   by    room       ( Out          of the way    , off        to one      side      . )
-# D/P NSg/P NSg/VB+ . D/P NSg/P N🅪Sg/VB/J+ . NSg/VB/J/R/P P  D+  NSg/J+ . NSg/VB/J/P P  NSg/I/J+ NSg/VB/J+ . .
+> a   by    path    ; a   by    room     ( Out          of the way    , off        to one      side      . )
+# D/P NSg/P NSg/VB+ . D/P NSg/P N🅪Sg/VB+ . NSg/VB/J/R/P P  D+  NSg/J+ . NSg/VB/J/P P  NSg/I/J+ NSg/VB/J+ . .
 > by    catch  ; a   by    issue  ( Subsidiary , incidental . )
 # NSg/P NSg/VB . D/P NSg/P NSg/VB . NSg/J+     . NSg/J      . .
 >
@@ -334,8 +334,8 @@
 # NPr/ISg+ VP  NPl/V3+ VP/J  P    NSg/VB+ P  NSg/VB  .
 > He       departed yesterday from Chicago .
 # NPr/ISg+ NSg/VP/J NSg       P    NPr+    .
-> This    figure  has been     changed from a    one      to a   seven .
-# I/Ddem+ NSg/VB+ V3  NSg/VLPp VP/J    P    D/P+ NSg/I/J+ P  D/P NSg   .
+> This    figure  has been   changed from a    one      to a   seven .
+# I/Ddem+ NSg/VB+ V3  VLPp/B VP/J    P    D/P+ NSg/I/J+ P  D/P NSg   .
 > Face    away from the wall    !
 # NSg/VB+ VB/J P    D+  NPr/VB+ .
 > The working day     runs   from 9 am         to 5 pm      .
@@ -356,8 +356,8 @@
 # D+  NSg/VB/J+ NSg/VPt+ NSg/VB/J/P J/R  #   NPl/V3+ P    NSg/R/C IPl+ VLPt Nᴹ/Vg/J  .
 > From the top      of the lighthouse you    can     just see    the mainland .
 # P    D   NSg/VB/J P  D+  NSg+       ISgPl+ NPr/VXB J/R  NSg/VB D+  NSg+     .
-> I’ve been     doing   this    from pickney .
-# K    NSg/VLPp Nᴹ/Vg/J I/Ddem+ P    ?       .
+> I’ve been   doing   this    from pickney .
+# K    VLPp/B Nᴹ/Vg/J I/Ddem+ P    ?       .
 > Your opinions differ    from mine      .
 # D$+  NPl+     NPr/VB/JC P    NSg/I/VB+ .
 > He       knows right    from wrong      .
@@ -432,8 +432,8 @@
 # K      VP  D/P NPr/VB/J+ NPr/J/R/P NPr/ISg+ .
 > He's met his     match   in        her     .
 # NPr$ VP  ISg/D$+ NSg/VB+ NPr/J/R/P ISg/D$+ .
-> There has been     no       change  in        his     condition .
-# R+    V3  NSg/VLPp NSg/Dq/P N🅪Sg/VB NPr/J/R/P ISg/D$+ N🅪Sg/VB+  .
+> There has been   no       change  in        his     condition .
+# R+    V3  VLPp/B NSg/Dq/P N🅪Sg/VB NPr/J/R/P ISg/D$+ N🅪Sg/VB+  .
 > What   grade   did  he       get    in        English      ?
 # NSg/I+ NSg/VB+ VXPt NPr/ISg+ NSg/VB NPr/J/R/P NPr🅪Sg/VB/J+ .
 > Please pay      me       in        cash       — preferably in        tens and  twenties .
@@ -538,8 +538,8 @@
 #
 > Take   the chicken    out          of the freezer .
 # NSg/VB D+  N🅪Sg/VB/J+ NSg/VB/J/R/P P  D+  NSg+    .
-> He       hasn't been     well       of late  .
-# NPr/ISg+ V3     NSg/VLPp NSg/VB/J/R P  NSg/J .
+> He       hasn't been   well       of late  .
+# NPr/ISg+ V3     VLPp/B NSg/VB/J/R P  NSg/J .
 > Finally she  was  relieved of the burden of caring  for   her     sick      husband .
 # R       ISg+ VLPt VP/J     P  D   NSg/VB P  Nᴹ/Vg/J R/C/P ISg/D$+ NSg/VB/J+ NSg/VB+ .
 > He       seemed devoid of human     feelings .
@@ -756,8 +756,8 @@
 # NPr$ J/P ISg/D$+ N🅪Sg/VB+ NSg/VB+ .
 > I'm on  nights  all          this   week   .
 # K   J/P NPl/V3+ NSg/I/J/C/Dq I/Ddem NSg/J+ .
-> You've been     on  these  antidepressants far      too long     .
-# K      NSg/VLPp J/P I/Ddem NPl             NSg/VB/J R   NPr/VB/J .
+> You've been   on  these  antidepressants far      too long     .
+# K      VLPp/B J/P I/Ddem NPl             NSg/VB/J R   NPr/VB/J .
 > I       depended on  them     for   assistance .
 # ISg/#r+ VP/J     J/P NSg/IPl+ R/C/P Nᴹ+        .
 > He       will    promise on  certain conditions .
@@ -878,8 +878,8 @@
 # NPr+ VLPt Nᴹ/Vg/J   P  NPr  P    ISg/D$+ NPl/V3+ VP/J   .
 > The match   result  was  10 - 5 , with John scoring  three goals   .
 # D+  NSg/VB+ NSg/VB+ VLPt #  . # . P    NPr+ Nᴹ/Vg/J+ NSg+  NPl/V3+ .
-> With a   heavy    sigh   , she  looked around the empty     room       .
-# P    D/P NSg/VB/J NSg/VB . ISg+ VP/J   J/P    D+  NSg/VB/J+ N🅪Sg/VB/J+ .
+> With a   heavy    sigh   , she  looked around the empty     room     .
+# P    D/P NSg/VB/J NSg/VB . ISg+ VP/J   J/P    D+  NSg/VB/J+ N🅪Sg/VB+ .
 > Four people  were injured , with one     of them     in        critical condition .
 # NSg+ NPl/VB+ VLPt VP/J    . P    NSg/I/J P  NSg/IPl+ NPr/J/R/P NSg/J+   N🅪Sg/VB+  .
 > With their reputation on  the line    , they decided  to fire      their PR   team    .

--- a/harper-core/tests/text/tagged/Part-of-speech tagging.md
+++ b/harper-core/tests/text/tagged/Part-of-speech tagging.md
@@ -132,8 +132,8 @@
 # R/C/P NSg/J/Dq NPl+      .
 >
 #
-> POS  tagging work     has been     done      in        a   variety of languages , and  the set       of POS
-# NSg+ NSg/Vg  N🅪Sg/VB+ V3  NSg/VLPp NSg/VPp/J NPr/J/R/P D/P N🅪Sg    P  NPl+      . VB/C D   NPr/VBP/J P  NSg+
+> POS  tagging work     has been   done      in        a   variety of languages , and  the set       of POS
+# NSg+ NSg/Vg  N🅪Sg/VB+ V3  VLPp/B NSg/VPp/J NPr/J/R/P D/P N🅪Sg    P  NPl+      . VB/C D   NPr/VBP/J P  NSg+
 > tags    used varies greatly with language . Tags    usually are designed to include
 # NPl/V3+ VP/J NPl/V3 R       P    N🅪Sg+    . NPl/V3+ R       VLB VP/J     P  NSg/VB
 > overt  morphological distinctions , although this   leads  to inconsistencies such  as
@@ -164,8 +164,8 @@
 # HeadingStart D+  NPr🅪Sg/VB/J NSg+
 >
 #
-> Research on  part      - of - speech   tagging has been     closely tied to corpus linguistics .
-# Nᴹ/VB    J/P NSg/VB/J+ . P  . N🅪Sg/VB+ NSg/Vg  V3  NSg/VLPp R       VP/J P  NSg    Nᴹ+         .
+> Research on  part      - of - speech   tagging has been   closely tied to corpus linguistics .
+# Nᴹ/VB    J/P NSg/VB/J+ . P  . N🅪Sg/VB+ NSg/Vg  V3  VLPp/B R       VP/J P  NSg    Nᴹ+         .
 > The first major    corpus of English     for   computer analysis was  the Brown       Corpus
 # D   NSg/J NPr/VB/J NSg    P  NPr🅪Sg/VB/J R/C/P NSg+     N🅪Sg+    VLPt D   NPr🅪Sg/VB/J NSg
 > developed at    Brown       University by    Henry Kučera and  W. Nelson Francis , in        the
@@ -198,16 +198,16 @@
 # +        Nᴹ/VXB/J NSg/R/C VB    . .
 >
 #
-> This    corpus has been     used for   innumerable studies of word    - frequency and  of
-# I/Ddem+ NSg+   V3  NSg/VLPp VP/J R/C/P J           NPl/V3  P  NSg/VB+ . NSg       VB/C P
+> This    corpus has been   used for   innumerable studies of word    - frequency and  of
+# I/Ddem+ NSg+   V3  VLPp/B VP/J R/C/P J           NPl/V3  P  NSg/VB+ . NSg       VB/C P
 > part      - of - speech   and  inspired the development of similar " tagged " corpora in        many
 # NSg/VB/J+ . P  . N🅪Sg/VB+ VB/C VP/J     D   N🅪Sg        P  NSg/J   . VP/J   . NPl+    NPr/J/R/P NSg/I/J/Dq
 > other    languages . Statistics derived by    analyzing it       formed the basis for   most
 # NSg/VB/J NPl+      . NPl/V3+    VP/J    NSg/P Nᴹ/Vg/J   NPr/ISg+ VP/J   D+  NSg+  R/C/P NSg/I/J/R/Dq
 > later part      - of - speech   tagging systems , such  as    CLAWS   and  VOLSUNGA . However , by
 # JC    NSg/VB/J+ . P  . N🅪Sg/VB+ NSg/Vg  NPl+    . NSg/I R/C/P NPl/V3+ VB/C ?        . C       . NSg/P
-> this    time       ( 2005 ) it       has been     superseded by    larger corpora such  as    the 100
-# I/Ddem+ N🅪Sg/VB/J+ . #    . NPr/ISg+ V3  NSg/VLPp VP/J       NSg/P JC     NPl+    NSg/I R/C/P D   #
+> this    time       ( 2005 ) it       has been   superseded by    larger corpora such  as    the 100
+# I/Ddem+ N🅪Sg/VB/J+ . #    . NPr/ISg+ V3  VLPp/B VP/J       NSg/P JC     NPl+    NSg/I R/C/P D   #
 > million word    British National Corpus , even       though larger corpora are rarely so
 # NSg     NSg/VB+ NPr/J   NSg/J    NSg+   . NSg/VB/J/R C      JC     NPl+    VLB R      NSg/I/J/R/C
 > thoroughly curated .
@@ -408,12 +408,12 @@
 # NSg/J/R/C V3      I/Ddem NPl/V3+  NPr/VB/J/R C/P  Nᴹ/Vg/J    D/P J           N🅪Sg+    .
 >
 #
-> Many        machine learning methods have    also been     applied to the problem of POS
-# NSg/I/J/Dq+ NSg/VB+ Nᴹ/Vg/J+ NPl+    NSg/VXB R/C  NSg/VLPp VP/J    P  D   NSg/J   P  NSg+
+> Many        machine learning methods have    also been   applied to the problem of POS
+# NSg/I/J/Dq+ NSg/VB+ Nᴹ/Vg/J+ NPl+    NSg/VXB R/C  VLPp/B VP/J    P  D   NSg/J   P  NSg+
 > tagging . Methods such  as    SVM , maximum entropy classifier , perceptron , and
 # NSg/Vg  . NPl+    NSg/I R/C/P ?   . NSg/J   NSg     NSg        . NSg        . VB/C
-> nearest - neighbor     have    all          been     tried , and  most         can     achieve accuracy above
-# JS      . NSg/VB/J/Am+ NSg/VXB NSg/I/J/C/Dq NSg/VLPp VP/J  . VB/C NSg/I/J/R/Dq NPr/VXB VB      N🅪Sg+    NSg/J/P
+> nearest - neighbor     have    all          been   tried , and  most         can     achieve accuracy above
+# JS      . NSg/VB/J/Am+ NSg/VXB NSg/I/J/C/Dq VLPp/B VP/J  . VB/C NSg/I/J/R/Dq NPr/VXB VB      N🅪Sg+    NSg/J/P
 > 95 % . [ citation needed ]
 # #  . . . NSg+     VP/J   .
 >
@@ -430,8 +430,8 @@
 # I/Ddem NSg/J      NSg     . . NSg  . NPr/ISg+ VXB    NSg/R/C NSg/VLXB VP/J    I/C/Ddem D+  NPl/V3+
 > reported here are the best       that      can     be       achieved with a    given        approach ; nor   even
 # VP/J     J/R  VLB D   NPr/VXB/JS I/C/Ddem+ NPr/VXB NSg/VLXB VP/J     P    D/P+ NSg/VPp/J/P+ N🅪Sg/VB+ . NSg/C NSg/VB/J/R
-> the best        that      have    been     achieved with a    given        approach .
-# D+  NPr/VXB/JS+ I/C/Ddem+ NSg/VXB NSg/VLPp VP/J     P    D/P+ NSg/VPp/J/P+ N🅪Sg/VB+ .
+> the best        that      have    been   achieved with a    given        approach .
+# D+  NPr/VXB/JS+ I/C/Ddem+ NSg/VXB VLPp/B VP/J     P    D/P+ NSg/VPp/J/P+ N🅪Sg/VB+ .
 >
 #
 > In        2014 , a    paper      reporting using   the structure regularization method for

--- a/harper-core/tests/text/tagged/Part-of-speech tagging.md
+++ b/harper-core/tests/text/tagged/Part-of-speech tagging.md
@@ -24,12 +24,12 @@
 # NPl/V3  . +
 >
 #
-> Once  performed by    hand    , POS  tagging is  now       done      in        the context of computational
-# NSg/C VP/J      NSg/P NSg/VB+ . NSg+ NSg/Vg  VL3 NSg/J/R/C NSg/VPp/J NPr/J/R/P D   N🅪Sg/VB P  J
+> Once  performed by hand    , POS  tagging is  now       done      in        the context of computational
+# NSg/C VP/J      P  NSg/VB+ . NSg+ NSg/Vg  VL3 NSg/J/R/C NSg/VPp/J NPr/J/R/P D   N🅪Sg/VB P  J
 > linguistics , using   algorithms which associate discrete terms   , as    well       as    hidden
 # Nᴹ+         . Nᴹ/Vg/J NPl+       I/C+  NSg/VB/J+ J        NPl/V3+ . R/C/P NSg/VB/J/R R/C/P VB/J
-> parts  of speech   , by    a   set       of descriptive tags    . POS  - tagging algorithms fall     into
-# NPl/V3 P  N🅪Sg/VB+ . NSg/P D/P NPr/VBP/J P  NSg/J       NPl/V3+ . NSg+ . NSg/Vg  NPl+       N🅪Sg/VB+ P
+> parts  of speech   , by a   set       of descriptive tags    . POS  - tagging algorithms fall     into
+# NPl/V3 P  N🅪Sg/VB+ . P  D/P NPr/VBP/J P  NSg/J       NPl/V3+ . NSg+ . NSg/Vg  NPl+       N🅪Sg/VB+ P
 > two distinctive groups  : rule    - based and  stochastic . E. Brill's tagger , one     of the
 # NSg NSg/J       NPl/V3+ . NSg/VB+ . VP/J  VB/C J          . ?  ?       NSg    . NSg/I/J P  D
 > first and  most         widely used English      POS  - taggers , employs rule    - based algorithms .
@@ -102,8 +102,8 @@
 # NSg/VB/J+ NSg/IPl+ R/C/P NPl/V3+  NSg/I/R  NSg/J       P    NSg/VB/J+ . P  . N🅪Sg/VB+ .
 >
 #
-> In        part      - of - speech   tagging by    computer , it       is  typical to distinguish from 50 to
-# NPr/J/R/P NSg/VB/J+ . P  . N🅪Sg/VB+ NSg/Vg  NSg/P NSg+     . NPr/ISg+ VL3 NSg/J   P  VB          P    #  P
+> In        part      - of - speech   tagging by computer , it       is  typical to distinguish from 50 to
+# NPr/J/R/P NSg/VB/J+ . P  . N🅪Sg/VB+ NSg/Vg  P  NSg+     . NPr/ISg+ VL3 NSg/J   P  VB          P    #  P
 > 150 separate parts  of speech  for   English      . Work    on  stochastic methods for   tagging
 # #   NSg/VB/J NPl/V3 P  N🅪Sg/VB R/C/P NPr🅪Sg/VB/J+ . N🅪Sg/VB J/P J          NPl+    R/C/P NSg/Vg
 > Koine Greek    ( DeRose 1990 ) has used over    1 , 000 parts  of speech   and  found  that
@@ -168,8 +168,8 @@
 # Nᴹ/VB    J/P NSg/VB/J+ . P  . N🅪Sg/VB+ NSg/Vg  V3  VLPp/B R       VP/J P  NSg    Nᴹ+         .
 > The first major    corpus of English     for   computer analysis was  the Brown       Corpus
 # D   NSg/J NPr/VB/J NSg    P  NPr🅪Sg/VB/J R/C/P NSg+     N🅪Sg+    VLPt D   NPr🅪Sg/VB/J NSg
-> developed at    Brown       University by    Henry Kučera and  W. Nelson Francis , in        the
-# VP/J      NSg/P NPr🅪Sg/VB/J NSg+       NSg/P NPr+  ?      VB/C ?  NPr+   NPr+    . NPr/J/R/P D
+> developed at    Brown       University by Henry Kučera and  W. Nelson Francis , in        the
+# VP/J      NSg/P NPr🅪Sg/VB/J NSg+       P  NPr+  ?      VB/C ?  NPr+   NPr+    . NPr/J/R/P D
 > mid      - 1960s . It       consists of about 1 , 000 , 000 words  of running   English      prose text     ,
 # NSg/J/P+ . #d    . NPr/ISg+ NPl/V3   P  J/P   # . #   . #   NPl/V3 P  Nᴹ/Vg/J/P NPr🅪Sg/VB/J+ Nᴹ/VB N🅪Sg/VB+ .
 > made up         of 500 samples from randomly chosen   publications . Each sample  is  2 , 000
@@ -182,16 +182,16 @@
 #
 > The Brown        Corpus was  painstakingly " tagged " with part      - of - speech   markers over
 # D+  NPr🅪Sg/VB/J+ NSg+   VLPt R             . VP/J   . P    NSg/VB/J+ . P  . N🅪Sg/VB+ NPl/V3  NSg/J/P
-> many        years . A    first  approximation was  done      with a    program by    Greene and  Rubin ,
-# NSg/I/J/Dq+ NPl+  . D/P+ NSg/J+ N🅪Sg+         VLPt NSg/VPp/J P    D/P+ NPr/VB+ NSg/P NPr    VB/C NPr   .
+> many        years . A    first  approximation was  done      with a    program by Greene and  Rubin ,
+# NSg/I/J/Dq+ NPl+  . D/P+ NSg/J+ N🅪Sg+         VLPt NSg/VPp/J P    D/P+ NPr/VB+ P  NPr    VB/C NPr   .
 > which consisted of a   huge handmade list   of what   categories could   co     - occur at
 # I/C+  VP/J      P  D/P J    NSg/J    NSg/VB P  NSg/I+ NPl+       NSg/VXB NPr/I+ . VB    NSg/P
 > all          . For   example , article then      noun    can     occur , but     article then      verb    ( arguably )
 # NSg/I/J/C/Dq . R/C/P NSg/VB+ . NSg/VB+ NSg/J/R/C NSg/VB+ NPr/VXB VB    . NSg/C/P NSg/VB+ NSg/J/R/C NSg/VB+ . R        .
 > cannot  . The program got about 70 % correct  . Its     results were repeatedly reviewed
 # NSg/VXB . D+  NPr/VB+ VP  J/P   #  . NSg/VB/J . ISg/D$+ NPl/V3+ VLPt R          VP/J
-> and  corrected by    hand    , and  later users sent   in        errata so          that      by    the late  70 s
-# VB/C VP/J      NSg/P NSg/VB+ . VB/C JC    NPl+  NSg/VP NPr/J/R/P NSg    NSg/I/J/R/C I/C/Ddem+ NSg/P D   NSg/J #  ?
+> and  corrected by hand    , and  later users sent   in        errata so          that      by the late  70 s
+# VB/C VP/J      P  NSg/VB+ . VB/C JC    NPl+  NSg/VP NPr/J/R/P NSg    NSg/I/J/R/C I/C/Ddem+ P  D   NSg/J #  ?
 > the tagging was  nearly perfect  ( allowing for   some     cases   on  which even       human
 # D   NSg/Vg  VLPt R      NSg/VB/J . Nᴹ/Vg/J  R/C/P I/J/R/Dq NPl/V3+ J/P I/C+  NSg/VB/J/R NSg/VB/J+
 > speakers might    not     agree ) .
@@ -202,12 +202,12 @@
 # I/Ddem+ NSg+   V3  VLPp/B VP/J R/C/P J           NPl/V3  P  NSg/VB+ . NSg       VB/C P
 > part      - of - speech   and  inspired the development of similar " tagged " corpora in        many
 # NSg/VB/J+ . P  . N🅪Sg/VB+ VB/C VP/J     D   N🅪Sg        P  NSg/J   . VP/J   . NPl+    NPr/J/R/P NSg/I/J/Dq
-> other    languages . Statistics derived by    analyzing it       formed the basis for   most
-# NSg/VB/J NPl+      . NPl/V3+    VP/J    NSg/P Nᴹ/Vg/J   NPr/ISg+ VP/J   D+  NSg+  R/C/P NSg/I/J/R/Dq
+> other    languages . Statistics derived by analyzing it       formed the basis for   most
+# NSg/VB/J NPl+      . NPl/V3+    VP/J    P  Nᴹ/Vg/J   NPr/ISg+ VP/J   D+  NSg+  R/C/P NSg/I/J/R/Dq
 > later part      - of - speech   tagging systems , such  as    CLAWS   and  VOLSUNGA . However , by
-# JC    NSg/VB/J+ . P  . N🅪Sg/VB+ NSg/Vg  NPl+    . NSg/I R/C/P NPl/V3+ VB/C ?        . C       . NSg/P
-> this    time       ( 2005 ) it       has been   superseded by    larger corpora such  as    the 100
-# I/Ddem+ N🅪Sg/VB/J+ . #    . NPr/ISg+ V3  VLPp/B VP/J       NSg/P JC     NPl+    NSg/I R/C/P D   #
+# JC    NSg/VB/J+ . P  . N🅪Sg/VB+ NSg/Vg  NPl+    . NSg/I R/C/P NPl/V3+ VB/C ?        . C       . P
+> this    time       ( 2005 ) it       has been   superseded by larger corpora such  as    the 100
+# I/Ddem+ N🅪Sg/VB/J+ . #    . NPr/ISg+ V3  VLPp/B VP/J       P  JC     NPl+    NSg/I R/C/P D   #
 > million word    British National Corpus , even       though larger corpora are rarely so
 # NSg     NSg/VB+ NPr/J   NSg/J    NSg+   . NSg/VB/J/R C      JC     NPl+    VLB R      NSg/I/J/R/C
 > thoroughly curated .
@@ -256,8 +256,8 @@
 # NPr/I/J/R/Dq VP/J     . . NSg/JC . N🅪Sg/VB . . ?    NSg/VB D   NPl+          NSg/R/C J/R/C P  NPl/V3+
 > but     triples or    even       larger sequences . So          , for   example , if    you've just seen    a
 # NSg/C/P NPl/V3  NPr/C NSg/VB/J/R JC     NPl/V3+   . NSg/I/J/R/C . R/C/P NSg/VB+ . NSg/C K      J/R  NSg/VPp D/P
-> noun    followed by    a   verb    , the next    item    may     be       very likely a   preposition ,
-# NSg/VB+ VP/J     NSg/P D/P NSg/VB+ . D   NSg/J/P NSg/VB+ NPr/VXB NSg/VLXB J/R  NSg/J  D/P NSg/VB      .
+> noun    followed by a   verb    , the next    item    may     be       very likely a   preposition ,
+# NSg/VB+ VP/J     P  D/P NSg/VB+ . D   NSg/J/P NSg/VB+ NPr/VXB NSg/VLXB J/R  NSg/J  D/P NSg/VB      .
 > article , or    noun    , but     much         less    likely another verb    .
 # NSg/VB+ . NPr/C NSg/VB+ . NSg/C/P NSg/I/J/R/Dq J/R/C/P NSg/J  I/D     NSg/VB+ .
 >
@@ -266,8 +266,8 @@
 # NSg/I/C J/Dq+   J+        NPl/V3+ VB    J        . D+  NPl+          NSg/VB   .
 > However , it       is  easy     to enumerate every combination and  to assign a   relative
 # C       . NPr/ISg+ VL3 NSg/VB/J P  VB        Dq+   N🅪Sg+       VB/C P  NSg/VB D/P NSg/J
-> probability to each one      , by    multiplying together the probabilities of each
-# NSg+        P  Dq   NSg/I/J+ . NSg/P Nᴹ/Vg/J     J        D   NPl           P  Dq
+> probability to each one      , by multiplying together the probabilities of each
+# NSg+        P  Dq   NSg/I/J+ . P  Nᴹ/Vg/J     J        D   NPl           P  Dq
 > choice  in        turn   . The combination with the highest probability is  then      chosen   . The
 # N🅪Sg/J+ NPr/J/R/P NSg/VB . D   N🅪Sg        P    D+  JS+     NSg+        VL3 NSg/J/R/C Nᴹ/VPp/J . D+
 > European group   developed CLAWS   , a   tagging program that      did  exactly this   and
@@ -368,8 +368,8 @@
 # NSg/VB NSg/VB+ NPl+          . NPr/ISg+ VL3 . C       . R/C  NSg/J    P  NSg/VB    Nᴹ/Vg/J
 > " unsupervised " tagging . Unsupervised tagging techniques use     an  untagged corpus
 # . VB/J         . NSg/Vg  . VB/J         NSg/Vg  NPl+       N🅪Sg/VB D/P VP/J     NSg+
-> for   their training data  and  produce the tagset by    induction . That      is  , they
-# R/C/P D$+   Nᴹ/Vg/J+ N🅪Pl+ VB/C Nᴹ/VB   D   NSg    NSg/P N🅪Sg      . I/C/Ddem+ VL3 . IPl+
+> for   their training data  and  produce the tagset by induction . That      is  , they
+# R/C/P D$+   Nᴹ/Vg/J+ N🅪Pl+ VB/C Nᴹ/VB   D   NSg    P  N🅪Sg      . I/C/Ddem+ VL3 . IPl+
 > observe patterns in        word    use     , and  derive part      - of - speech   categories themselves .
 # NSg/VB  NPl/V3+  NPr/J/R/P NSg/VB+ N🅪Sg/VB . VB/C NSg/VB NSg/VB/J+ . P  . N🅪Sg/VB+ NPl+       IPl+       .
 > For   example , statistics readily reveal that      " the " , " a   " , and  " an  " occur in

--- a/harper-core/tests/text/tagged/The Constitution of the United States.md
+++ b/harper-core/tests/text/tagged/The Constitution of the United States.md
@@ -27,9 +27,9 @@
 > All           legislative Powers    herein granted shall be       vested in        a
 # NSg/I/J/C/Dq+ NSg/J+      NPrPl/V3+ R      VP/J    VXB   NSg/VLXB VP/J   NPr/J/R/P D/P
 > Congress of the United States    , which shall consist of a   Senate and  House  of
-# NPr/VB   P  D+  VP/J   NPrPl/V3+ . I/C+  VXB   NSg/VB  P  D/P NPr+   VB/C NPr/VB P
+# NPr      P  D+  VP/J   NPrPl/V3+ . I/C+  VXB   NSg/VB  P  D/P NPr+   VB/C NPr/VB P
 > Representatives . Congress shall make   no        law      respecting an  establishment of
-# NPl+            . NPr/VB+  VXB   NSg/VB NSg/Dq/P+ N🅪Sg/VB+ Nᴹ/Vg/J    D/P NSg           P
+# NPl+            . NPr+     VXB   NSg/VB NSg/Dq/P+ N🅪Sg/VB+ Nᴹ/Vg/J    D/P NSg           P
 > religion , or    prohibiting the free     exercise thereof ; or    abridging the freedom of
 # NSg/VB+  . NPr/C Nᴹ/Vg/J     D+  NSg/VB/J N🅪Sg/VB+ R       . NPr/C Nᴹ/Vg/J   D   N🅪Sg    P
 > speech   , or    of the press   ; or    the right    of the people  peaceably to assemble , and
@@ -39,21 +39,21 @@
 >
 #
 > No        person  shall be       a   Senator or    Representative in        Congress , or    elector of
-# NSg/Dq/P+ NSg/VB+ VXB   NSg/VLXB D/P NSg     NPr/C NSg/J          NPr/J/R/P NPr/VB+  . NPr/C NSg     P
-> President and  Vice        President , or    hold     any    office  , civil or    military , under   the
-# NSg/VB    VB/C NSg/VB/J/P+ NSg/VB+   . NPr/C NSg/VB/J I/R/Dq NSg/VB+ . J     NPr/C NSg/J    . NSg/J/P D
+# NSg/Dq/P+ NSg/VB+ VXB   NSg/VLXB D/P NSg     NPr/C NSg/J          NPr/J/R/P NPr+     . NPr/C NSg     P
+> President and  Vice     President , or    hold     any    office  , civil or    military , under   the
+# NSg       VB/C NSg/J/P+ NSg+      . NPr/C NSg/VB/J I/R/Dq NSg/VB+ . J     NPr/C NSg/J    . NSg/J/P D
 > United States    , or    under   any    State    , who    , having  previously taken an  oath    , as    a
 # VP/J   NPrPl/V3+ . NPr/C NSg/J/P I/R/Dq N🅪Sg/VB+ . NPr/I+ . Nᴹ/Vg/J R          VPp/J D/P NSg/VB+ . R/C/P D/P
 > member of Congress , or    as    an  officer of the United States    , or    as    a   member of
-# NSg/VB P  NPr/VB+  . NPr/C R/C/P D/P NSg/VB  P  D   VP/J   NPrPl/V3+ . NPr/C R/C/P D/P NSg/VB P
+# NSg/VB P  NPr+     . NPr/C R/C/P D/P NSg/VB  P  D   VP/J   NPrPl/V3+ . NPr/C R/C/P D/P NSg/VB P
 > any    State    legislature , or    as    an  executive or    judicial officer of any    State    , to
 # I/R/Dq N🅪Sg/VB+ NSg+        . NPr/C R/C/P D/P NSg/J     NPr/C NSg/J    NSg/VB  P  I/R/Dq N🅪Sg/VB+ . P
 > support the Constitution of the United States    , shall have    engaged in
 # N🅪Sg/VB D   NPr          P  D   VP/J   NPrPl/V3+ . VXB   NSg/VXB VP/J    NPr/J/R/P
 > insurrection or    rebellion against the same , or    given       aid     or    comfort  to the
 # N🅪Sg         NPr/C N🅪Sg+     C/P     D   I/J  . NPr/C NSg/VPp/J/P N🅪Sg/VB NPr/C N🅪Sg/VB+ P  D
-> enemies thereof . But     Congress may     , by    a   vote   of two - thirds of each House   ,
-# NPl/V3+ R       . NSg/C/P NPr/VB+  NPr/VXB . NSg/P D/P NSg/VB P  NSg . NPl/V3 P  Dq+  NPr/VB+ .
+> enemies thereof . But     Congress may     , by a   vote   of two - thirds of each House   ,
+# NPl/V3+ R       . NSg/C/P NPr+     NPr/VXB . P  D/P NSg/VB P  NSg . NPl/V3 P  Dq+  NPr/VB+ .
 > remove such   disability .
 # NSg/VB NSg/I+ N🅪Sg+      .
 >
@@ -72,8 +72,8 @@
 #
 > The House  of Representatives shall be       composed of Members
 # D   NPr/VB P  NPl+            VXB   NSg/VLXB VP/J     P  NPl/V3+
-> chosen   every second    Year by    the People of the several States    , and  the Electors
-# Nᴹ/VPp/J Dq+   NSg/VB/J+ NSg+ NSg/P D   NPl/VB P  D+  J/Dq+   NPrPl/V3+ . VB/C D   NPl
+> chosen   every second    Year by the People of the several States    , and  the Electors
+# Nᴹ/VPp/J Dq+   NSg/VB/J+ NSg+ P  D   NPl/VB P  D+  J/Dq+   NPrPl/V3+ . VB/C D   NPl
 > in        each State    shall have    the Qualifications requisite for   Electors of the most
 # NPr/J/R/P Dq   N🅪Sg/VB+ VXB   NSg/VXB D   NPl+           NSg/J+    R/C/P NPl      P  D   NSg/I/J/R/Dq
 > numerous Branch of the State    Legislature .
@@ -96,10 +96,10 @@
 # D$+   J          NPrPl/V3+ . Nᴹ/Vg/J  D   NSg/J N🅪Sg/VB/JC P  NPl/V3+ NPr/J/R/P Dq   N🅪Sg/VB+ .
 > excluding Indians not     taxed . But     when    the right     to vote   at    any    election for   the
 # Nᴹ/Vg/J   NPrPl+  NSg/R/C VP/J  . NSg/C/P NSg/I/C D+  NPr/VB/J+ P  NSg/VB NSg/P I/R/Dq NSg+     R/C/P D
-> choice of electors for   President and  Vice        President of the United States    ,
-# N🅪Sg/J P  NPl      R/C/P NSg/VB    VB/C NSg/VB/J/P+ NSg/VB    P  D   VP/J   NPrPl/V3+ .
+> choice of electors for   President and  Vice     President of the United States    ,
+# N🅪Sg/J P  NPl      R/C/P NSg       VB/C NSg/J/P+ NSg       P  D   VP/J   NPrPl/V3+ .
 > Representatives in        Congress , the Executive and  Judicial officers of a   State    , or
-# NPl+            NPr/J/R/P NPr/VB+  . D   NSg/J     VB/C NSg/J    NPl/V3   P  D/P N🅪Sg/VB+ . NPr/C
+# NPl+            NPr/J/R/P NPr+     . D   NSg/J     VB/C NSg/J    NPl/V3   P  D/P N🅪Sg/VB+ . NPr/C
 > the members of the Legislature thereof , is  denied to any    of the male
 # D   NPl/V3  P  D   NSg+        R       . VL3 VP/J   P  I/R/Dq P  D   NPr/J+
 > inhabitants of such  State    , being         twenty - one     years of age      , and  citizens of the
@@ -115,9 +115,9 @@
 > Enumeration shall be       made within  three Years after the first Meeting   of the
 # N🅪Sg        VXB   NSg/VLXB VP   NSg/J/P NSg   NPl+  P     D   NSg/J N🅪Sg/Vg/J P  D
 > Congress of the United States    , and  within  every subsequent Term     of ten Years ,
-# NPr/VB   P  D   VP/J   NPrPl/V3+ . VB/C NSg/J/P Dq    NSg/J      NSg/VB/J P  NSg NPl+  .
-> in        such  Manner as    they shall by    Law      direct . The Number     of Representatives shall
-# NPr/J/R/P NSg/I NSg+   R/C/P IPl+ VXB   NSg/P N🅪Sg/VB+ VB/J   . D   N🅪Sg/VB/JC P  NPl+            VXB
+# NPr      P  D   VP/J   NPrPl/V3+ . VB/C NSg/J/P Dq    NSg/J      NSg/VB/J P  NSg NPl+  .
+> in        such  Manner as    they shall by Law      direct . The Number     of Representatives shall
+# NPr/J/R/P NSg/I NSg+   R/C/P IPl+ VXB   P  N🅪Sg/VB+ VB/J   . D   N🅪Sg/VB/JC P  NPl+            VXB
 > not     exceed one     for   every thirty Thousand , but     each State    shall have    at    Least
 # NSg/R/C VB     NSg/I/J R/C/P Dq    NSg    NSg      . NSg/C/P Dq+  N🅪Sg/VB+ VXB   NSg/VXB NSg/P NSg/J/Dq+
 > one      Representative ; and  until such  enumeration shall be       made , the State   of New
@@ -150,8 +150,8 @@
 #
 > The Senate of the United States    shall be       composed of two
 # D   NPr    P  D+  VP/J   NPrPl/V3+ VXB   NSg/VLXB VP/J     P  NSg
-> Senators from each State    , elected  by    the people  thereof , for   six years ; and
-# NPl+     P    Dq+  N🅪Sg/VB+ . NSg/VP/J NSg/P D+  NPl/VB+ R       . R/C/P NSg NPl+  . VB/C
+> Senators from each State    , elected  by the people  thereof , for   six years ; and
+# NPl+     P    Dq+  N🅪Sg/VB+ . NSg/VP/J P  D+  NPl/VB+ R       . R/C/P NSg NPl+  . VB/C
 > each Senator shall have    one     vote    . The electors in        each State    shall have    the
 # Dq   NSg+    VXB   NSg/VXB NSg/I/J NSg/VB+ . D   NPl      NPr/J/R/P Dq   N🅪Sg/VB+ VXB   NSg/VXB D
 > qualifications requisite for   electors of the most         numerous branch of the State
@@ -178,8 +178,8 @@
 # NPl/V3 P  NSg+     P  NSg/VB NSg/I NPl       . VP/J/C   . I/C/Ddem D   NSg         P  I/R/Dq
 > State    may     empower the executive thereof to make   temporary appointments until
 # N🅪Sg/VB+ NPr/VXB VB      D   NSg/J     R       P  NSg/VB NSg/J     NPl+         C/P
-> the people  fill   the vacancies by    election as    the legislature may     direct .
-# D   NPl/VB+ NSg/VB D   NPl       NSg/P NSg+     R/C/P D   NSg+        NPr/VXB VB/J   .
+> the people  fill   the vacancies by election as    the legislature may     direct .
+# D   NPl/VB+ NSg/VB D   NPl       P  NSg+     R/C/P D   NSg+        NPr/VXB VB/J   .
 >
 #
 > No        Person  shall be       a    Senator who    shall not     have    attained to the Age     of thirty
@@ -190,24 +190,24 @@
 # NSg/I/C NSg/VP/J . NSg/VLXB D/P NSg/J      P  I/C/Ddem N🅪Sg/VB+ R/C/P I/C+  NPr/ISg+ VXB   NSg/VLXB Nᴹ/VPp/J .
 >
 #
-> The Vice        President of the United States    shall be       President of the Senate , but
-# D   NSg/VB/J/P+ NSg/VB    P  D+  VP/J   NPrPl/V3+ VXB   NSg/VLXB NSg/VB    P  D+  NPr+   . NSg/C/P
+> The Vice     President of the United States    shall be       President of the Senate , but
+# D   NSg/J/P+ NSg       P  D+  VP/J   NPrPl/V3+ VXB   NSg/VLXB NSg       P  D+  NPr+   . NSg/C/P
 > shall have    no        Vote    , unless they be       equally divided .
 # VXB   NSg/VXB NSg/Dq/P+ NSg/VB+ . C      IPl+ NSg/VLXB R       VP/J    .
 >
 #
 > The Senate shall chuse their other    Officers , and  also a   President pro     tempore ,
-# D+  NPr+   VXB   ?     D$+   NSg/VB/J NPl/V3+  . VB/C R/C  D/P NSg/VB+   NSg/J/P ?       .
-> in        the Absence of the Vice        President , or    when    he       shall exercise the Office of
-# NPr/J/R/P D   N🅪Sg    P  D   NSg/VB/J/P+ NSg/VB+   . NPr/C NSg/I/C NPr/ISg+ VXB   N🅪Sg/VB  D   NSg/VB P
+# D+  NPr+   VXB   ?     D$+   NSg/VB/J NPl/V3+  . VB/C R/C  D/P NSg+      NSg/J/P ?       .
+> in        the Absence of the Vice     President , or    when    he       shall exercise the Office of
+# NPr/J/R/P D   N🅪Sg    P  D   NSg/J/P+ NSg+      . NPr/C NSg/I/C NPr/ISg+ VXB   N🅪Sg/VB  D   NSg/VB P
 > President of the United States    .
-# NSg/VB    P  D   VP/J   NPrPl/V3+ .
+# NSg       P  D   VP/J   NPrPl/V3+ .
 >
 #
 > The Senate shall have    the sole      Power      to try      all          Impeachments . When    sitting  for
 # D+  NPr+   VXB   NSg/VXB D+  NSg/VB/J+ N🅪Sg/VB/J+ P  NSg/VB/J NSg/I/J/C/Dq NPl          . NSg/I/C NSg/Vg/J R/C/P
 > that      Purpose  , they shall be       on  Oath    or    Affirmation . When    the President of the
-# I/C/Ddem+ N🅪Sg/VB+ . IPl+ VXB   NSg/VLXB J/P NSg/VB+ NPr/C NSg         . NSg/I/C D   NSg/VB    P  D+
+# I/C/Ddem+ N🅪Sg/VB+ . IPl+ VXB   NSg/VLXB J/P NSg/VB+ NPr/C NSg         . NSg/I/C D   NSg       P  D+
 > United States    is  tried , the Chief     Justice shall preside : And  no        Person  shall be
 # VP/J   NPrPl/V3+ VL3 VP/J  . D+  NSg/VB/J+ NPr🅪Sg+ VXB   VB      . VB/C NSg/Dq/P+ NSg/VB+ VXB   NSg/VLXB
 > convicted without the Concurrence of two thirds of the Members present  .
@@ -232,18 +232,18 @@
 #
 > The Times   , Places  and  Manner of holding Elections for   Senators
 # D+  NPl/V3+ . NPl/V3+ VB/C NSg    P  Nᴹ/Vg/J NPl+      R/C/P NPl
-> and  Representatives , shall be       prescribed in        each State    by    the Legislature
-# VB/C NPl+            . VXB   NSg/VLXB VP/J       NPr/J/R/P Dq   N🅪Sg/VB+ NSg/P D   NSg+
-> thereof ; but     the Congress may     at    any    time       by    Law      make   or    alter  such
-# R       . NSg/C/P D   NPr/VB+  NPr/VXB NSg/P I/R/Dq N🅪Sg/VB/J+ NSg/P N🅪Sg/VB+ NSg/VB NPr/C NSg/VB NSg/I
+> and  Representatives , shall be       prescribed in        each State    by the Legislature
+# VB/C NPl+            . VXB   NSg/VLXB VP/J       NPr/J/R/P Dq   N🅪Sg/VB+ P  D   NSg+
+> thereof ; but     the Congress may     at    any    time       by Law      make   or    alter  such
+# R       . NSg/C/P D   NPr+     NPr/VXB NSg/P I/R/Dq N🅪Sg/VB/J+ P  N🅪Sg/VB+ NSg/VB NPr/C NSg/VB NSg/I
 > Regulations , except as    to the Places of chusing Senators .
 # NPl+        . VB/C/P R/C/P P  D   NPl/V3 P  ?       NPl+     .
 >
 #
 > The Congress shall assemble at    least    once  in        every year , and  such   meeting    shall
-# D+  NPr/VB+  VXB   VB       NSg/P NSg/J/Dq NSg/C NPr/J/R/P Dq+   NSg+ . VB/C NSg/I+ N🅪Sg/Vg/J+ VXB
-> begin  at    noon    on  the 3 d         day    of January , unless they shall by    law      appoint a
-# NSg/VB NSg/P NSg/VB+ J/P D   # NPr/J/#r+ NPr🅪Sg P  NPr+    . C      IPl+ VXB   NSg/P N🅪Sg/VB+ VB      D/P+
+# D+  NPr+     VXB   VB       NSg/P NSg/J/Dq NSg/C NPr/J/R/P Dq+   NSg+ . VB/C NSg/I+ N🅪Sg/Vg/J+ VXB
+> begin  at    noon    on  the 3 d         day    of January , unless they shall by law      appoint a
+# NSg/VB NSg/P NSg/VB+ J/P D   # NPr/J/#r+ NPr🅪Sg P  NPr+    . C      IPl+ VXB   P  N🅪Sg/VB+ VB      D/P+
 > different day     .
 # NSg/J     NPr🅪Sg+ .
 >
@@ -281,7 +281,7 @@
 >
 #
 > Neither House   , during the Session of Congress , shall , without the Consent of
-# I/C     NPr/VB+ . VB/P   D   NSg/VB  P  NPr/VB+  . VXB   . C/P     D   N🅪Sg/VP P
+# I/C     NPr/VB+ . VB/P   D   NSg/VB  P  NPr+     . VXB   . C/P     D   N🅪Sg/VP P
 > the other    , adjourn for   more         than three days , nor   to any    other    Place    than that
 # D   NSg/VB/J . VB      R/C/P NPr/I/J/R/Dq C/P  NSg   NPl+ . NSg/C P  I/R/Dq NSg/VB/J N🅪Sg/VB+ C/P  I/C/Ddem+
 > in        which the two Houses  shall be       sitting  .
@@ -294,8 +294,8 @@
 #
 > The Senators and  Representatives shall receive a   Compensation
 # D   NPl      VB/C NPl+            VXB   NSg/VB  D/P N🅪Sg+
-> for   their Services , to be       ascertained by    Law      , and  paid out          of the Treasury of
-# R/C/P D$+   NPl/V3+  . P  NSg/VLXB VP/J        NSg/P N🅪Sg/VB+ . VB/C VP/J NSg/VB/J/R/P P  D   NPr      P
+> for   their Services , to be       ascertained by Law      , and  paid out          of the Treasury of
+# R/C/P D$+   NPl/V3+  . P  NSg/VLXB VP/J        P  N🅪Sg/VB+ . VB/C VP/J NSg/VB/J/R/P P  D   NPr      P
 > the United States    . They shall in        all           Cases   , except Treason , Felony and  Breach
 # D   VP/J   NPrPl/V3+ . IPl+ VXB   NPr/J/R/P NSg/I/J/C/Dq+ NPl/V3+ . VB/C/P NSg     . NSg    VB/C NSg/VB
 > of the Peace      , be       privileged from Arrest   during their Attendance at    the Session
@@ -341,7 +341,7 @@
 > Every Bill    which shall have    passed the House  of Representatives and  the Senate ,
 # Dq+   NPr/VB+ I/C+  VXB   NSg/VXB VP/J   D   NPr/VB P  NPl             VB/C D+  NPr+   .
 > shall , before it       become a    Law      , be       presented to the President of the United
-# VXB   . C/P    NPr/ISg+ VBPp   D/P+ N🅪Sg/VB+ . NSg/VLXB VP/J      P  D   NSg/VB    P  D+  VP/J
+# VXB   . C/P    NPr/ISg+ VBPp   D/P+ N🅪Sg/VB+ . NSg/VLXB VP/J      P  D   NSg       P  D+  VP/J
 > States    ; If    he       approve he       shall sign   it       , but     if    not     he       shall return it       , with his
 # NPrPl/V3+ . NSg/C NPr/ISg+ VB      NPr/ISg+ VXB   NSg/VB NPr/ISg+ . NSg/C/P NSg/C NSg/R/C NPr/ISg+ VXB   NSg/VB NPr/ISg+ . P    ISg/D$+
 > Objections to that      House   in        which it       shall have    originated , who    shall enter  the
@@ -350,22 +350,22 @@
 # NPl+       NSg/P NSg/J J/P D$+   NSg/VB/J+ . VB/C VB      P  VB         NPr/ISg+ . NSg/C P
 > such  Reconsideration two thirds of that     House   shall agree to pass   the Bill    , it
 # NSg/I N🅪Sg            NSg NPl/V3 P  I/C/Ddem NPr/VB+ VXB   VB    P  NSg/VB D   NPr/VB+ . NPr/ISg+
-> shall be       sent   , together with the Objections , to the other    House   , by    which it
-# VXB   NSg/VLXB NSg/VP . J        P    D   NPl+       . P  D   NSg/VB/J NPr/VB+ . NSg/P I/C+  NPr/ISg+
-> shall likewise be       reconsidered , and  if    approved by    two thirds of that     House   , it
-# VXB   R        NSg/VLXB VP/J         . VB/C NSg/C VP/J     NSg/P NSg NPl/V3 P  I/C/Ddem NPr/VB+ . NPr/ISg+
+> shall be       sent   , together with the Objections , to the other    House   , by which it
+# VXB   NSg/VLXB NSg/VP . J        P    D   NPl+       . P  D   NSg/VB/J NPr/VB+ . P  I/C+  NPr/ISg+
+> shall likewise be       reconsidered , and  if    approved by two thirds of that     House   , it
+# VXB   R        NSg/VLXB VP/J         . VB/C NSg/C VP/J     P  NSg NPl/V3 P  I/C/Ddem NPr/VB+ . NPr/ISg+
 > shall become a   Law      . But     in        all          such  Cases   the Votes  of both   Houses  shall be
 # VXB   VBPp   D/P N🅪Sg/VB+ . NSg/C/P NPr/J/R/P NSg/I/J/C/Dq NSg/I NPl/V3+ D   NPl/V3 P  I/C/Dq NPl/V3+ VXB   NSg/VLXB
-> determined by    yeas and  Nays   , and  the Names  of the Persons voting   for   and
-# VP/J       NSg/P NPl  VB/C NPl/V3 . VB/C D   NPl/V3 P  D   NPl/V3+ Nᴹ/Vg/J+ R/C/P VB/C
+> determined by yeas and  Nays   , and  the Names  of the Persons voting   for   and
+# VP/J       P  NPl  VB/C NPl/V3 . VB/C D   NPl/V3 P  D   NPl/V3+ Nᴹ/Vg/J+ R/C/P VB/C
 > against the Bill    shall be       entered on  the Journal  of each House   respectively . If
 # C/P     D   NPr/VB+ VXB   NSg/VLXB VP/J    J/P D   NSg/VB/J P  Dq   NPr/VB+ R            . NSg/C
-> any     Bill    shall not     be       returned by    the President within  ten Days ( Sundays
-# I/R/Dq+ NPr/VB+ VXB   NSg/R/C NSg/VLXB VP/J     NSg/P D   NSg/VB    NSg/J/P NSg NPl  . NPl/V3+
+> any     Bill    shall not     be       returned by the President within  ten Days ( Sundays
+# I/R/Dq+ NPr/VB+ VXB   NSg/R/C NSg/VLXB VP/J     P  D   NSg       NSg/J/P NSg NPl  . NPl/V3+
 > excepted ) after it       shall have    been   presented to him  , the Same shall be       a   Law     ,
 # VP/J     . P     NPr/ISg+ VXB   NSg/VXB VLPp/B VP/J      P  ISg+ . D   I/J  VXB   NSg/VLXB D/P N🅪Sg/VB .
-> in        like         Manner as    if    he       had signed it       , unless the Congress by    their Adjournment
-# NPr/J/R/P NSg/VB/J/C/P NSg+   R/C/P NSg/C NPr/ISg+ VP  VP/J   NPr/ISg+ . C      D+  NPr/VB+  NSg/P D$+   NSg
+> in        like         Manner as    if    he       had signed it       , unless the Congress by their Adjournment
+# NPr/J/R/P NSg/VB/J/C/P NSg+   R/C/P NSg/C NPr/ISg+ VP  VP/J   NPr/ISg+ . C      D+  NPr+     P  D$+   NSg
 > prevent its     Return , in        which Case       it       shall not     be       a   Law      .
 # VB      ISg/D$+ NSg/VB . NPr/J/R/P I/C+  NPr🅪Sg/VB+ NPr/ISg+ VXB   NSg/R/C NSg/VLXB D/P N🅪Sg/VB+ .
 >
@@ -375,11 +375,11 @@
 > House  of Representatives may     be       necessary ( except on  a   question of Adjournment )
 # NPr/VB P  NPl+            NPr/VXB NSg/VLXB NSg/J     . VB/C/P J/P D/P NSg/VB+  P  NSg         .
 > shall be       presented to the President of the United States    ; and  before the Same
-# VXB   NSg/VLXB VP/J      P  D   NSg/VB    P  D   VP/J   NPrPl/V3+ . VB/C C/P    D   I/J
-> shall take   Effect  , shall be       approved by    him  , or    being        disapproved by    him  , shall
-# VXB   NSg/VB NSg/VB+ . VXB   NSg/VLXB VP/J     NSg/P ISg+ . NPr/C N🅪Sg/VLg/J/C VP/J        NSg/P ISg+ . VXB
-> be       repassed by    two thirds of the Senate and  House  of Representatives , according
-# NSg/VLXB ?        NSg/P NSg NPl/V3 P  D   NPr+   VB/C NPr/VB P  NPl+            . Nᴹ/Vg/J
+# VXB   NSg/VLXB VP/J      P  D   NSg       P  D   VP/J   NPrPl/V3+ . VB/C C/P    D   I/J
+> shall take   Effect  , shall be       approved by him  , or    being        disapproved by him  , shall
+# VXB   NSg/VB NSg/VB+ . VXB   NSg/VLXB VP/J     P  ISg+ . NPr/C N🅪Sg/VLg/J/C VP/J        P  ISg+ . VXB
+> be       repassed by two thirds of the Senate and  House  of Representatives , according
+# NSg/VLXB ?        P  NSg NPl/V3 P  D   NPr+   VB/C NPr/VB P  NPl+            . Nᴹ/Vg/J
 > to the Rules  and  Limitations prescribed in        the Case      of a   Bill    .
 # P  D   NPl/V3 VB/C NPl+        VP/J       NPr/J/R/P D   NPr🅪Sg/VB P  D/P NPr/VB+ .
 >
@@ -389,7 +389,7 @@
 >
 #
 > The Congress shall have    Power      To lay        and  collect  Taxes   , Duties ,
-# D+  NPr/VB+  VXB   NSg/VXB N🅪Sg/VB/J+ P  NSg/VBPt/J VB/C NSg/VB/J NPl/V3+ . NPl+   .
+# D+  NPr+     VXB   NSg/VXB N🅪Sg/VB/J+ P  NSg/VBPt/J VB/C NSg/VB/J NPl/V3+ . NPl+   .
 > Imposts and  Excises , to pay      the Debts and  provide for   the common   Defence    and
 # NPl     VB/C NPl/V3  . P  NSg/VB/J D   NPl+  VB/C VB      R/C/P D   NSg/VB/J N🅪Sg/Comm+ VB/C
 > general  Welfare of the United States    ; but     all          Duties , Imposts and  Excises shall
@@ -458,8 +458,8 @@
 #
 >
 #
-> To promote the Progress of Science and  useful Arts    , by    securing for   limited
-# P  NSg/VB  D   Nᴹ/VB    P  N🅪Sg/VB VB/C J+     NPl/V3+ . NSg/P Nᴹ/Vg/J  R/C/P NSg/VP/J
+> To promote the Progress of Science and  useful Arts    , by securing for   limited
+# P  NSg/VB  D   Nᴹ/VB    P  N🅪Sg/VB VB/C J+     NPl/V3+ . P  Nᴹ/Vg/J  R/C/P NSg/VP/J
 > Times   to Authors and  Inventors the exclusive Right    to their respective Writings
 # NPl/V3+ P  NPl/V3  VB/C NPl       D   NSg/J     NPr/VB/J P  D$+   J          NPl/V3
 > and  Discoveries ;
@@ -542,8 +542,8 @@
 # NPrPl/V3+ . Nᴹ/Vg/J   P  D   NPrPl/V3+ R            . D   NSg         P  D   NPl/V3+  .
 > and  the Authority of training the Militia according to the discipline
 # VB/C D   N🅪Sg      P  Nᴹ/Vg/J+ D   NSg     Nᴹ/Vg/J   P  D   NSg/VB+
-> prescribed by    Congress ;
-# VP/J       NSg/P NPr/VB+  .
+> prescribed by Congress ;
+# VP/J       P  NPr+     .
 >
 #
 >
@@ -552,12 +552,12 @@
 #
 > To exercise exclusive Legislation in        all           Cases   whatsoever , over    such  District
 # P  N🅪Sg/VB  NSg/J     NSg+        NPr/J/R/P NSg/I/J/C/Dq+ NPl/V3+ I          . NSg/J/P NSg/I NSg/VB/J+
-> ( not     exceeding ten  Miles  square   ) as    may     , by    Cession of particular States    , and
-# . NSg/R/C Nᴹ/Vg/J   NSg+ NPrPl+ NSg/VB/J . R/C/P NPr/VXB . NSg/P NSg     P  NSg/J      NPrPl/V3+ . VB/C
+> ( not     exceeding ten  Miles  square   ) as    may     , by Cession of particular States    , and
+# . NSg/R/C Nᴹ/Vg/J   NSg+ NPrPl+ NSg/VB/J . R/C/P NPr/VXB . P  NSg     P  NSg/J      NPrPl/V3+ . VB/C
 > the Acceptance of Congress , become the Seat   of the Government of the United
-# D   N🅪Sg       P  NPr/VB+  . VBPp   D   NSg/VB P  D   N🅪Sg       P  D   VP/J
-> States    , and  to exercise like         Authority over    all          Places  purchased by    the Consent
-# NPrPl/V3+ . VB/C P  N🅪Sg/VB  NSg/VB/J/C/P N🅪Sg+     NSg/J/P NSg/I/J/C/Dq NPl/V3+ VP/J      NSg/P D   N🅪Sg/VP
+# D   N🅪Sg       P  NPr+     . VBPp   D   NSg/VB P  D   N🅪Sg       P  D   VP/J
+> States    , and  to exercise like         Authority over    all          Places  purchased by the Consent
+# NPrPl/V3+ . VB/C P  N🅪Sg/VB  NSg/VB/J/C/P N🅪Sg+     NSg/J/P NSg/I/J/C/Dq NPl/V3+ VP/J      P  D   N🅪Sg/VP
 > of the Legislature of the State    in        which the Same shall be       , for   the Erection of
 # P  D   NSg         P  D   N🅪Sg/VB+ NPr/J/R/P I/C+  D   I/J  VXB   NSg/VLXB . R/C/P D   NSg      P
 > Forts  , Magazines , Arsenals , dock    - Yards   , and  other    needful Buildings ; — And
@@ -570,8 +570,8 @@
 #
 > To make   all           Laws    which shall be       necessary and  proper for   carrying into
 # P  NSg/VB NSg/I/J/C/Dq+ NPl/V3+ I/C+  VXB   NSg/VLXB NSg/J     VB/C NSg/J  R/C/P Nᴹ/Vg/J  P
-> Execution the foregoing Powers    , and  all          other    Powers    vested by    this
-# N🅪Sg+     D   Nᴹ/Vg/J   NPrPl/V3+ . VB/C NSg/I/J/C/Dq NSg/VB/J NPrPl/V3+ VP/J   NSg/P I/Ddem
+> Execution the foregoing Powers    , and  all          other    Powers    vested by this
+# N🅪Sg+     D   Nᴹ/Vg/J   NPrPl/V3+ . VB/C NSg/I/J/C/Dq NSg/VB/J NPrPl/V3+ VP/J   P  I/Ddem
 > Constitution in        the Government of the United States    , or    in        any    Department or
 # NPr+         NPr/J/R/P D   N🅪Sg       P  D   VP/J   NPrPl/V3+ . NPr/C NPr/J/R/P I/R/Dq NSg        NPr/C
 > Officer thereof .
@@ -588,10 +588,10 @@
 #
 > The Migration or    Importation of such  Persons as    any    of the
 # D   NSg+      NPr/C N🅪Sg        P  NSg/I NPl/V3+ R/C/P I/R/Dq P  D
-> States    now       existing shall think  proper to admit , shall not     be       prohibited by    the
-# NPrPl/V3+ NSg/J/R/C Nᴹ/Vg/J  VXB   NSg/VB NSg/J  P  VB    . VXB   NSg/R/C NSg/VLXB VP/J       NSg/P D
+> States    now       existing shall think  proper to admit , shall not     be       prohibited by the
+# NPrPl/V3+ NSg/J/R/C Nᴹ/Vg/J  VXB   NSg/VB NSg/J  P  VB    . VXB   NSg/R/C NSg/VLXB VP/J       P  D
 > Congress prior to the Year one      thousand eight hundred and  eight , but     a   Tax     or
-# NPr/VB+  NSg/J P  D   NSg+ NSg/I/J+ NSg      NSg/J NSg     VB/C NSg/J . NSg/C/P D/P N🅪Sg/VB NPr/C
+# NPr+     NSg/J P  D   NSg+ NSg/I/J+ NSg      NSg/J NSg     VB/C NSg/J . NSg/C/P D/P N🅪Sg/VB NPr/C
 > duty  may     be       imposed on  such  Importation , not     exceeding ten dollars for   each
 # N🅪Sg+ NPr/VXB NSg/VLXB VP/J    J/P NSg/I N🅪Sg        . NSg/R/C Nᴹ/Vg/J   NSg NPl+    R/C/P Dq
 > Person  .
@@ -611,7 +611,7 @@
 > No       Capitation , or    other    direct , Tax      shall be       laid , unless in        Proportion to the
 # NSg/Dq/P NSg        . NPr/C NSg/VB/J VB/J   . N🅪Sg/VB+ VXB   NSg/VLXB VP/J . C      NPr/J/R/P NSg/VB+    P  D
 > Census  or    Enumeration herein before directed to be       taken . Congress shall have
-# NSg/VB+ NPr/C N🅪Sg        R      C/P    VP/J     P  NSg/VLXB VPp/J . NPr/VB+  VXB   NSg/VXB
+# NSg/VB+ NPr/C N🅪Sg        R      C/P    VP/J     P  NSg/VLXB VPp/J . NPr+     VXB   NSg/VXB
 > power      to lay        and  collect  taxes   on  incomes , from whatever source   derived ,
 # N🅪Sg/VB/J+ P  NSg/VBPt/J VB/C NSg/VB/J NPl/V3+ J/P NPl/V3+ . P    NSg/I/J+ N🅪Sg/VB+ VP/J    .
 > without apportionment among the several States    , and  without regard  to any
@@ -624,8 +624,8 @@
 # NSg/Dq/P N🅪Sg/VB NPr/C N🅪Sg+ VXB   NSg/VLXB VP/J J/P NPl/V3+  VP/J     P    I/R/Dq N🅪Sg/VB+ .
 >
 #
-> No        Preference shall be       given       by    any    Regulation of Commerce or    Revenue to the
-# NSg/Dq/P+ NSg/VB+    VXB   NSg/VLXB NSg/VPp/J/P NSg/P I/R/Dq N🅪Sg/J     P  Nᴹ/VB    NPr/C NSg+    P  D
+> No        Preference shall be       given       by any    Regulation of Commerce or    Revenue to the
+# NSg/Dq/P+ NSg/VB+    VXB   NSg/VLXB NSg/VPp/J/P P  I/R/Dq N🅪Sg/J     P  Nᴹ/VB    NPr/C NSg+    P  D
 > Ports  of one     State    over    those  of another : nor   shall Vessels bound    to , or    from ,
 # NPl/V3 P  NSg/I/J N🅪Sg/VB+ NSg/J/P I/Ddem P  I/D     . NSg/C VXB   NPl/V3+ NSg/VP/J P  . NPr/C P    .
 > one      State    , be       obliged to enter  , clear    , or    pay      Duties in        another .
@@ -634,30 +634,30 @@
 #
 > No        Money   shall be       drawn from the Treasury , but     in        Consequence of Appropriations
 # NSg/Dq/P+ N🅪Sg/J+ VXB   NSg/VLXB VPp/J P    D   NPr      . NSg/C/P NPr/J/R/P NSg/VB      P  +
-> made by    Law      ; and  a   regular Statement and  Account of the Receipts and
-# VP   NSg/P N🅪Sg/VB+ . VB/C D/P NSg/J   NSg/VB/J+ VB/C NSg/VB  P  D   NPl/V3+  VB/C
+> made by Law      ; and  a   regular Statement and  Account of the Receipts and
+# VP   P  N🅪Sg/VB+ . VB/C D/P NSg/J   NSg/VB/J+ VB/C NSg/VB  P  D   NPl/V3+  VB/C
 > Expenditures of all          public  Money   shall be       published from time       to time      .
 # NPl          P  NSg/I/J/C/Dq Nᴹ/VB/J N🅪Sg/J+ VXB   NSg/VLXB VP/J      P    N🅪Sg/VB/J+ P  N🅪Sg/VB/J .
 >
 #
-> No       Title   of Nobility shall be       granted by    the United States    : And  no       Person
-# NSg/Dq/P NSg/VB+ P  NSg      VXB   NSg/VLXB VP/J    NSg/P D   VP/J   NPrPl/V3+ . VB/C NSg/Dq/P NSg/VB+
+> No       Title   of Nobility shall be       granted by the United States    : And  no       Person
+# NSg/Dq/P NSg/VB+ P  NSg      VXB   NSg/VLXB VP/J    P  D   VP/J   NPrPl/V3+ . VB/C NSg/Dq/P NSg/VB+
 > holding any    Office of Profit      or    Trust     under   them     , shall , without the Consent of
 # Nᴹ/Vg/J I/R/Dq NSg/VB P  N🅪Sg/VBP/J+ NPr/C N🅪Sg/VB/J NSg/J/P NSg/IPl+ . VXB   . C/P     D   N🅪Sg/VP P
 > the Congress , accept   of any    present  , Emolument , Office  , or    Title   , of any    kind
-# D   NPr/VB+  . NSg/VB/J P  I/R/Dq NSg/VB/J . NSg       . NSg/VB+ . NPr/C NSg/VB+ . P  I/R/Dq NSg/J+
+# D   NPr+     . NSg/VB/J P  I/R/Dq NSg/VB/J . NSg       . NSg/VB+ . NPr/C NSg/VB+ . P  I/R/Dq NSg/J+
 > whatever , from any    King      , Prince    , or    foreign State    .
 # NSg/I/J+ . P    I/R/Dq NPr/VB/J+ . NPr/VB/J+ . NPr/C NSg/J   N🅪Sg/VB+ .
 >
 #
 > The right    of citizens of the United States    to vote   in        any    primary  or    other
 # D   NPr/VB/J P  NPl      P  D+  VP/J   NPrPl/V3+ P  NSg/VB NPr/J/R/P I/R/Dq NSg/VB/J NPr/C NSg/VB/J
-> election for   President or    Vice        President , for   electors for   President or    Vice
-# NSg      R/C/P NSg/VB    NPr/C NSg/VB/J/P+ NSg/VB+   . R/C/P NPl      R/C/P NSg/VB    NPr/C NSg/VB/J/P+
+> election for   President or    Vice     President , for   electors for   President or    Vice
+# NSg      R/C/P NSg       NPr/C NSg/J/P+ NSg+      . R/C/P NPl      R/C/P NSg       NPr/C NSg/J/P+
 > President , or    for   Senator or    Representative in        Congress , shall not     be       denied or
-# NSg/VB+   . NPr/C R/C/P NSg     NPr/C NSg/J+         NPr/J/R/P NPr/VB+  . VXB   NSg/R/C NSg/VLXB VP/J   NPr/C
-> abridged by    the United States    or    any    State    by    reason  of failure to pay      any    poll
-# VP/J     NSg/P D   VP/J   NPrPl/V3+ NPr/C I/R/Dq N🅪Sg/VB+ NSg/P N🅪Sg/VB P  N🅪Sg+   P  NSg/VB/J I/R/Dq NSg/VB/J+
+# NSg+      . NPr/C R/C/P NSg     NPr/C NSg/J+         NPr/J/R/P NPr+     . VXB   NSg/R/C NSg/VLXB VP/J   NPr/C
+> abridged by the United States    or    any    State    by reason  of failure to pay      any    poll
+# VP/J     P  D   VP/J   NPrPl/V3+ NPr/C I/R/Dq N🅪Sg/VB+ P  N🅪Sg/VB P  N🅪Sg+   P  NSg/VB/J I/R/Dq NSg/VB/J+
 > tax     or    other    tax      .
 # N🅪Sg/VB NPr/C NSg/VB/J N🅪Sg/VB+ .
 >
@@ -679,21 +679,21 @@
 >
 #
 > No        State    shall , without the Consent of the Congress , lay        any    Imposts or    Duties
-# NSg/Dq/P+ N🅪Sg/VB+ VXB   . C/P     D   N🅪Sg/VP P  D+  NPr/VB+  . NSg/VBPt/J I/R/Dq NPl     NPr/C NPl+
+# NSg/Dq/P+ N🅪Sg/VB+ VXB   . C/P     D   N🅪Sg/VP P  D+  NPr+     . NSg/VBPt/J I/R/Dq NPl     NPr/C NPl+
 > on  Imports or    Exports , except what   may     be       absolutely necessary for   executing
 # J/P NPl/V3  NPr/C NPl/V3+ . VB/C/P NSg/I+ NPr/VXB NSg/VLXB R          NSg/J     R/C/P Nᴹ/Vg/J
 > it's inspection Laws    : and  the net       Produce of all          Duties and  Imposts , laid by
-# +    N🅪Sg+      NPl/V3+ . VB/C D   NSg/VB/J+ Nᴹ/VB   P  NSg/I/J/C/Dq NPl+   VB/C NPl     . VP/J NSg/P
+# +    N🅪Sg+      NPl/V3+ . VB/C D   NSg/VB/J+ Nᴹ/VB   P  NSg/I/J/C/Dq NPl+   VB/C NPl     . VP/J P
 > any    State    on  Imports or    Exports , shall be       for   the Use     of the Treasury of the
 # I/R/Dq N🅪Sg/VB+ J/P NPl/V3  NPr/C NPl/V3+ . VXB   NSg/VLXB R/C/P D   N🅪Sg/VB P  D   NPr      P  D
 > United States    ; and  all          such  Laws    shall be       subject  to the Revision and  Controul
 # VP/J   NPrPl/V3+ . VB/C NSg/I/J/C/Dq NSg/I NPl/V3+ VXB   NSg/VLXB NSg/VB/J P  D   NSg/VB+  VB/C ?
 > of the Congress .
-# P  D   NPr/VB+  .
+# P  D   NPr+     .
 >
 #
 > No        State    shall , without the Consent of Congress , lay        any    Duty of Tonnage , keep
-# NSg/Dq/P+ N🅪Sg/VB+ VXB   . C/P     D   N🅪Sg/VP P  NPr/VB+  . NSg/VBPt/J I/R/Dq N🅪Sg P  NSg+    . NSg/VB
+# NSg/Dq/P+ N🅪Sg/VB+ VXB   . C/P     D   N🅪Sg/VP P  NPr+     . NSg/VBPt/J I/R/Dq N🅪Sg P  NSg+    . NSg/VB
 > Troops  , or    Ships  of War      in        time      of Peace      , enter  into any    Agreement or    Compact
 # NPl/V3+ . NPr/C NPl/V3 P  N🅪Sg/VB+ NPr/J/R/P N🅪Sg/VB/J P  NPr🅪Sg/VB+ . NSg/VB P    I/R/Dq N🅪Sg+     NPr/C NSg/VB/J
 > with another State    , or    with a    foreign Power      , or    engage in        War      , unless actually
@@ -711,13 +711,13 @@
 >
 #
 > The executive Power      shall be       vested in        a   President of the
-# D+  NSg/J+    N🅪Sg/VB/J+ VXB   NSg/VLXB VP/J   NPr/J/R/P D/P NSg/VB    P  D
+# D+  NSg/J+    N🅪Sg/VB/J+ VXB   NSg/VLXB VP/J   NPr/J/R/P D/P NSg       P  D
 > United States   of America . He       shall hold     his     Office  during the Term     of four
 # VP/J   NPrPl/V3 P  NPr+    . NPr/ISg+ VXB   NSg/VB/J ISg/D$+ NSg/VB+ VB/P   D   NSg/VB/J P  NSg+
 > Years ending  at    noon    on  the 20th day    of January , and  , together with the Vice
-# NPl+  Nᴹ/Vg/J NSg/P NSg/VB+ J/P D   #    NPr🅪Sg P  NPr+    . VB/C . J        P    D+  NSg/VB/J/P+
+# NPl+  Nᴹ/Vg/J NSg/P NSg/VB+ J/P D   #    NPr🅪Sg P  NPr+    . VB/C . J        P    D+  NSg/J/P+
 > President , chosen   for   the same Term      , be       elected  , as    follows
-# NSg/VB+   . Nᴹ/VPp/J R/C/P D+  I/J+ NSg/VB/J+ . NSg/VLXB NSg/VP/J . R/C/P NPl/V3
+# NSg+      . Nᴹ/VPp/J R/C/P D+  I/J+ NSg/VB/J+ . NSg/VLXB NSg/VP/J . R/C/P NPl/V3
 >
 #
 > Each State    shall appoint , in        such  Manner as    the Legislature thereof may     direct ,
@@ -725,7 +725,7 @@
 > a   Number      of Electors , equal    to the whole Number     of Senators and  Representatives
 # D/P N🅪Sg/VB/JC+ P  NPl      . NSg/VB/J P  D   NSg/J N🅪Sg/VB/JC P  NPl      VB/C NPl+
 > to which the State    may     be       entitled in        the Congress : but     no       Senator or
-# P  I/C+  D   N🅪Sg/VB+ NPr/VXB NSg/VLXB VP/J     NPr/J/R/P D   NPr/VB+  . NSg/C/P NSg/Dq/P NSg     NPr/C
+# P  I/C+  D   N🅪Sg/VB+ NPr/VXB NSg/VLXB VP/J     NPr/J/R/P D   NPr+     . NSg/C/P NSg/Dq/P NSg     NPr/C
 > Representative , or    Person  holding an  Office of Trust     or    Profit      under   the United
 # NSg/J+         . NPr/C NSg/VB+ Nᴹ/Vg/J D/P NSg/VB P  N🅪Sg/VB/J NPr/C N🅪Sg/VBP/J+ NSg/J/P D   VP/J
 > States    , shall be       appointed an  Elector .
@@ -738,90 +738,90 @@
 #
 > The Electors shall meet     in        their respective states    , and  vote
 # D   NPl      VXB   NSg/VB/J NPr/J/R/P D$+   J          NPrPl/V3+ . VB/C NSg/VB+
-> by    ballot for   President and  Vice        - President , one     of whom , at    least    , shall not     be
-# NSg/P NSg/VB R/C/P NSg/VB    VB/C NSg/VB/J/P+ . NSg/VB+   . NSg/I/J P  I+   . NSg/P NSg/J/Dq . VXB   NSg/R/C NSg/VLXB
+> by ballot for   President and  Vice     - President , one     of whom , at    least    , shall not     be
+# P  NSg/VB R/C/P NSg       VB/C NSg/J/P+ . NSg+      . NSg/I/J P  I+   . NSg/P NSg/J/Dq . VXB   NSg/R/C NSg/VLXB
 > an  inhabitant of the same state    with themselves ; they shall name   in        their
 # D/P NSg/J      P  D   I/J  N🅪Sg/VB+ P    IPl+       . IPl+ VXB   NSg/VB NPr/J/R/P D$+
 > ballots the person  voted for   as    President , and  in        distinct ballots the person
-# NPl/V3  D   NSg/VB+ VP/J  R/C/P R/C/P NSg/VB+   . VB/C NPr/J/R/P VB/J     NPl/V3  D   NSg/VB+
-> voted for   as    Vice        - President , and  they shall make   distinct lists  of all          persons
-# VP/J  R/C/P R/C/P NSg/VB/J/P+ . NSg/VB+   . VB/C IPl+ VXB   NSg/VB VB/J     NPl/V3 P  NSg/I/J/C/Dq NPl/V3+
-> voted for   as    President , and  all          persons voted for   as    Vice        - President and  of the
-# VP/J  R/C/P R/C/P NSg/VB+   . VB/C NSg/I/J/C/Dq NPl/V3+ VP/J  R/C/P R/C/P NSg/VB/J/P+ . NSg/VB    VB/C P  D
+# NPl/V3  D   NSg/VB+ VP/J  R/C/P R/C/P NSg+      . VB/C NPr/J/R/P VB/J     NPl/V3  D   NSg/VB+
+> voted for   as    Vice     - President , and  they shall make   distinct lists  of all          persons
+# VP/J  R/C/P R/C/P NSg/J/P+ . NSg+      . VB/C IPl+ VXB   NSg/VB VB/J     NPl/V3 P  NSg/I/J/C/Dq NPl/V3+
+> voted for   as    President , and  all          persons voted for   as    Vice     - President and  of the
+# VP/J  R/C/P R/C/P NSg+      . VB/C NSg/I/J/C/Dq NPl/V3+ VP/J  R/C/P R/C/P NSg/J/P+ . NSg       VB/C P  D
 > number     of votes   for   each , which lists   they shall sign    and  certify , and  transmit
 # N🅪Sg/VB/JC P  NPl/V3+ R/C/P Dq   . I/C+  NPl/V3+ IPl+ VXB   NSg/VB+ VB/C VB      . VB/C VB
 > sealed to the seat   of the government of the United States    , directed to the
 # VP/J   P  D   NSg/VB P  D   N🅪Sg       P  D   VP/J   NPrPl/V3+ . VP/J     P  D
 > President of the Senate ; — The President of the Senate shall , in        the presence of
-# NSg/VB    P  D   NPr+   . . D   NSg/VB    P  D   NPr+   VXB   . NPr/J/R/P D   N🅪Sg/VB  P
+# NSg       P  D   NPr+   . . D   NSg       P  D   NPr+   VXB   . NPr/J/R/P D   N🅪Sg/VB  P
 > the Senate and  House  of Representatives , open     all          the certificates and  the
 # D   NPr+   VB/C NPr/VB P  NPl+            . NSg/VB/J NSg/I/J/C/Dq D   NPl/V3+      VB/C D
 > votes   shall then      be       counted ; — The person  having  the greatest Number     of votes   for
 # NPl/V3+ VXB   NSg/J/R/C NSg/VLXB VP/J    . . D   NSg/VB+ Nᴹ/Vg/J D   JS       N🅪Sg/VB/JC P  NPl/V3+ R/C/P
 > President , shall be       the President , if    such  number      be       a   majority of the whole
-# NSg/VB+   . VXB   NSg/VLXB D   NSg/VB+   . NSg/C NSg/I N🅪Sg/VB/JC+ NSg/VLXB D/P NSg      P  D   NSg/J
+# NSg+      . VXB   NSg/VLXB D   NSg+      . NSg/C NSg/I N🅪Sg/VB/JC+ NSg/VLXB D/P NSg      P  D   NSg/J
 > number      of Electors appointed ; and  if    no       person  have    such  majority , then      from
 # N🅪Sg/VB/JC+ P  NPl      VP/J      . VB/C NSg/C NSg/Dq/P NSg/VB+ NSg/VXB NSg/I NSg+     . NSg/J/R/C P
 > the persons having  the highest numbers   not     exceeding three on  the list   of those
 # D   NPl/V3+ Nᴹ/Vg/J D   JS      NPrPl/V3+ NSg/R/C Nᴹ/Vg/J   NSg   J/P D   NSg/VB P  I/Ddem
 > voted for   as    President , the House  of Representatives shall choose   immediately ,
-# VP/J+ R/C/P R/C/P NSg/VB+   . D   NPr/VB P  NPl+            VXB   NSg/VB/C R           .
-> by    ballot  , the President . But     in        choosing the President , the votes   shall be
-# NSg/P NSg/VB+ . D   NSg/VB+   . NSg/C/P NPr/J/R/P Nᴹ/Vg/J  D+  NSg/VB+   . D+  NPl/V3+ VXB   NSg/VLXB
-> taken by    states    , the representation from each state    having  one      vote    ; a   quorum
-# VPp/J NSg/P NPrPl/V3+ . D   NSg            P    Dq+  N🅪Sg/VB+ Nᴹ/Vg/J NSg/I/J+ NSg/VB+ . D/P NSg
+# VP/J+ R/C/P R/C/P NSg+      . D   NPr/VB P  NPl+            VXB   NSg/VB/C R           .
+> by ballot  , the President . But     in        choosing the President , the votes   shall be
+# P  NSg/VB+ . D   NSg+      . NSg/C/P NPr/J/R/P Nᴹ/Vg/J  D+  NSg+      . D+  NPl/V3+ VXB   NSg/VLXB
+> taken by states    , the representation from each state    having  one      vote    ; a   quorum
+# VPp/J P  NPrPl/V3+ . D   NSg            P    Dq+  N🅪Sg/VB+ Nᴹ/Vg/J NSg/I/J+ NSg/VB+ . D/P NSg
 > for   this   purpose  shall consist of a   member or    members from two - thirds of the
 # R/C/P I/Ddem N🅪Sg/VB+ VXB   NSg/VB  P  D/P NSg/VB NPr/C NPl/V3+ P    NSg . NPl/V3 P  D
 > states    , and  a   majority of all          the states    shall be       necessary to a   choice  . [ If    ,
 # NPrPl/V3+ . VB/C D/P NSg      P  NSg/I/J/C/Dq D   NPrPl/V3+ VXB   NSg/VLXB NSg/J     P  D/P N🅪Sg/J+ . . NSg/C .
 > at    the time       fixed for   the beginning of the term     of the President , the President
-# NSg/P D+  N🅪Sg/VB/J+ VP/J  R/C/P D   NSg/Vg/J  P  D   NSg/VB/J P  D+  NSg/VB+   . D+  NSg/VB+
-> elect    shall have    died , the Vice        President elect    shall become President . If    a
-# NSg/VB/J VXB   NSg/VXB VP/J . D   NSg/VB/J/P+ NSg/VB+   NSg/VB/J VXB   VBPp   NSg/VB+   . NSg/C D/P+
+# NSg/P D+  N🅪Sg/VB/J+ VP/J  R/C/P D   NSg/Vg/J  P  D   NSg/VB/J P  D+  NSg+      . D+  NSg+
+> elect    shall have    died , the Vice     President elect    shall become President . If    a
+# NSg/VB/J VXB   NSg/VXB VP/J . D   NSg/J/P+ NSg+      NSg/VB/J VXB   VBPp   NSg+      . NSg/C D/P+
 > President shall not     have    been   chosen   before the time       fixed for   the beginning of
-# NSg/VB+   VXB   NSg/R/C NSg/VXB VLPp/B Nᴹ/VPp/J C/P    D+  N🅪Sg/VB/J+ VP/J  R/C/P D   NSg/Vg/J  P
+# NSg+      VXB   NSg/R/C NSg/VXB VLPp/B Nᴹ/VPp/J C/P    D+  N🅪Sg/VB/J+ VP/J  R/C/P D   NSg/Vg/J  P
 > his     term      , or    if    the President elect    shall have    failed to qualify , then      the Vice
-# ISg/D$+ NSg/VB/J+ . NPr/C NSg/C D+  NSg/VB+   NSg/VB/J VXB   NSg/VXB VP/J   P  NSg/VB  . NSg/J/R/C D   NSg/VB/J/P+
+# ISg/D$+ NSg/VB/J+ . NPr/C NSg/C D+  NSg+      NSg/VB/J VXB   NSg/VXB VP/J   P  NSg/VB  . NSg/J/R/C D   NSg/J/P+
 > President elect    shall act     as    President until a   President shall have    qualified ;
-# NSg/VB+   NSg/VB/J VXB   NPr/VB+ R/C/P NSg/VB+   C/P   D/P NSg/VB+   VXB   NSg/VXB VP/J      .
-> and  the Congress may     by    law      provide for   the case       wherein neither a   President
-# VB/C D   NPr/VB+  NPr/VXB NSg/P N🅪Sg/VB+ VB      R/C/P D   NPr🅪Sg/VB+ C       I/C     D/P NSg/VB+
-> elect    nor   a   Vice        President elect    shall have    qualified , declaring who    shall then
-# NSg/VB/J NSg/C D/P NSg/VB/J/P+ NSg/VB+   NSg/VB/J VXB   NSg/VXB VP/J      . Nᴹ/Vg/J   NPr/I+ VXB   NSg/J/R/C
+# NSg+      NSg/VB/J VXB   NPr/VB+ R/C/P NSg+      C/P   D/P NSg+      VXB   NSg/VXB VP/J      .
+> and  the Congress may     by law      provide for   the case       wherein neither a   President
+# VB/C D   NPr+     NPr/VXB P  N🅪Sg/VB+ VB      R/C/P D   NPr🅪Sg/VB+ C       I/C     D/P NSg+
+> elect    nor   a   Vice     President elect    shall have    qualified , declaring who    shall then
+# NSg/VB/J NSg/C D/P NSg/J/P+ NSg+      NSg/VB/J VXB   NSg/VXB VP/J      . Nᴹ/Vg/J   NPr/I+ VXB   NSg/J/R/C
 > act     as    President , or    the manner in        which one     who    is  to act    shall be       selected ,
-# NPr/VB+ R/C/P NSg/VB+   . NPr/C D   NSg+   NPr/J/R/P I/C+  NSg/I/J NPr/I+ VL3 P  NPr/VB VXB   NSg/VLXB VP/J     .
-> and  such  person  shall act     accordingly until a   President or    Vice        President shall
-# VB/C NSg/I NSg/VB+ VXB   NPr/VB+ R           C/P   D/P NSg/VB    NPr/C NSg/VB/J/P+ NSg/VB+   VXB
-> have    qualified . The Congress may     by    law      provide for   the case      of the death  of any
-# NSg/VXB VP/J      . D+  NPr/VB+  NPr/VXB NSg/P N🅪Sg/VB+ VB      R/C/P D   NPr🅪Sg/VB P  D   NPr🅪Sg P  I/R/Dq
+# NPr/VB+ R/C/P NSg+      . NPr/C D   NSg+   NPr/J/R/P I/C+  NSg/I/J NPr/I+ VL3 P  NPr/VB VXB   NSg/VLXB VP/J     .
+> and  such  person  shall act     accordingly until a   President or    Vice     President shall
+# VB/C NSg/I NSg/VB+ VXB   NPr/VB+ R           C/P   D/P NSg       NPr/C NSg/J/P+ NSg+      VXB
+> have    qualified . The Congress may     by law      provide for   the case      of the death  of any
+# NSg/VXB VP/J      . D+  NPr+     NPr/VXB P  N🅪Sg/VB+ VB      R/C/P D   NPr🅪Sg/VB P  D   NPr🅪Sg P  I/R/Dq
 > of the persons from whom the House  of Representatives may     choose   a    President
-# P  D   NPl/V3+ P    I+   D   NPr/VB P  NPl+            NPr/VXB NSg/VB/C D/P+ NSg/VB+
+# P  D   NPl/V3+ P    I+   D   NPr/VB P  NPl+            NPr/VXB NSg/VB/C D/P+ NSg+
 > whenever the right    of choice  shall have    devolved upon them     , and  for   the case      of
 # C        D   NPr/VB/J P  N🅪Sg/J+ VXB   NSg/VXB VP/J     P    NSg/IPl+ . VB/C R/C/P D   NPr🅪Sg/VB P
 > the death  of any    of the persons from whom the Senate may     choose   a   Vice
-# D   NPr🅪Sg P  I/R/Dq P  D   NPl/V3+ P    I+   D   NPr+   NPr/VXB NSg/VB/C D/P NSg/VB/J/P+
+# D   NPr🅪Sg P  I/R/Dq P  D   NPl/V3+ P    I+   D   NPr+   NPr/VXB NSg/VB/C D/P NSg/J/P+
 > President whenever the right    of choice  shall have    devolved upon them     . ] The
-# NSg/VB+   C        D   NPr/VB/J P  N🅪Sg/J+ VXB   NSg/VXB VP/J     P    NSg/IPl+ . . D+
-> person  having  the greatest number     of votes   as    Vice        - President , shall be       the
-# NSg/VB+ Nᴹ/Vg/J D   JS       N🅪Sg/VB/JC P  NPl/V3+ R/C/P NSg/VB/J/P+ . NSg/VB+   . VXB   NSg/VLXB D
-> Vice        - President , if    such   number      be       a   majority of the whole number     of Electors
-# NSg/VB/J/P+ . NSg/VB+   . NSg/C NSg/I+ N🅪Sg/VB/JC+ NSg/VLXB D/P NSg      P  D   NSg/J N🅪Sg/VB/JC P  NPl
+# NSg+      C        D   NPr/VB/J P  N🅪Sg/J+ VXB   NSg/VXB VP/J     P    NSg/IPl+ . . D+
+> person  having  the greatest number     of votes   as    Vice     - President , shall be       the
+# NSg/VB+ Nᴹ/Vg/J D   JS       N🅪Sg/VB/JC P  NPl/V3+ R/C/P NSg/J/P+ . NSg+      . VXB   NSg/VLXB D
+> Vice     - President , if    such   number      be       a   majority of the whole number     of Electors
+# NSg/J/P+ . NSg+      . NSg/C NSg/I+ N🅪Sg/VB/JC+ NSg/VLXB D/P NSg      P  D   NSg/J N🅪Sg/VB/JC P  NPl
 > appointed , and  if    no       person  have    a   majority , then      from the two highest numbers
 # VP/J      . VB/C NSg/C NSg/Dq/P NSg/VB+ NSg/VXB D/P NSg+     . NSg/J/R/C P    D   NSg JS      NPrPl/V3+
-> on  the list    , the Senate shall choose   the Vice        - President ; a   quorum for   the
-# J/P D   NSg/VB+ . D   NPr+   VXB   NSg/VB/C D   NSg/VB/J/P+ . NSg/VB+   . D/P NSg    R/C/P D
+> on  the list    , the Senate shall choose   the Vice     - President ; a   quorum for   the
+# J/P D   NSg/VB+ . D   NPr+   VXB   NSg/VB/C D   NSg/J/P+ . NSg+      . D/P NSg    R/C/P D
 > purpose  shall consist of two - thirds of the whole number     of Senators , and  a
 # N🅪Sg/VB+ VXB   NSg/VB  P  NSg . NPl/V3 P  D   NSg/J N🅪Sg/VB/JC P  NPl+     . VB/C D/P
 > majority of the whole number      shall be       necessary to a   choice  . But     no        person
 # NSg      P  D   NSg/J N🅪Sg/VB/JC+ VXB   NSg/VLXB NSg/J     P  D/P N🅪Sg/J+ . NSg/C/P NSg/Dq/P+ NSg/VB+
 > constitutionally ineligible to the office of President shall be       eligible to
-# R                NSg/J      P  D   NSg/VB P  NSg/VB+   VXB   NSg/VLXB NSg/J    P
-> that     of Vice        - President of the United States    .
-# I/C/Ddem P  NSg/VB/J/P+ . NSg/VB    P  D   VP/J   NPrPl/V3+ .
+# R                NSg/J      P  D   NSg/VB P  NSg+      VXB   NSg/VLXB NSg/J    P
+> that     of Vice     - President of the United States    .
+# I/C/Ddem P  NSg/J/P+ . NSg       P  D   VP/J   NPrPl/V3+ .
 >
 #
 > The Congress may     determine the Time      of chusing the Electors , and  the Day     on
-# D+  NPr/VB+  NPr/VXB VB        D   N🅪Sg/VB/J P  ?       D   NPl      . VB/C D   NPr🅪Sg+ J/P
+# D+  NPr+     NPr/VXB VB        D   N🅪Sg/VB/J P  ?       D   NPl      . VB/C D   NPr🅪Sg+ J/P
 > which they shall give   their Votes   ; which Day     shall be       the same throughout the
 # I/C+  IPl+ VXB   NSg/VB D$+   NPl/V3+ . I/C+  NPr🅪Sg+ VXB   NSg/VLXB D   I/J  P          D
 > United States    .
@@ -837,7 +837,7 @@
 > United States    , at    the time      of the Adoption of this    Constitution , shall be
 # VP/J   NPrPl/V3+ . NSg/P D   N🅪Sg/VB/J P  D   N🅪Sg     P  I/Ddem+ NPr+         . VXB   NSg/VLXB
 > eligible to the Office of President ; neither shall any     Person  be       eligible to
-# NSg/J    P  D   NSg/VB P  NSg/VB+   . I/C     VXB   I/R/Dq+ NSg/VB+ NSg/VLXB NSg/J    P
+# NSg/J    P  D   NSg/VB P  NSg+      . I/C     VXB   I/R/Dq+ NSg/VB+ NSg/VLXB NSg/J    P
 > that     Office  who    shall not     have    attained to the Age     of thirty five Years , and
 # I/C/Ddem NSg/VB+ NPr/I+ VXB   NSg/R/C NSg/VXB VP/J     P  D   N🅪Sg/VB P  NSg    NSg  NPl+  . VB/C
 > been   fourteen Years a   Resident within  the United States    .
@@ -845,23 +845,23 @@
 >
 #
 > No        person  shall be       elected  to the office of the President more         than twice , and
-# NSg/Dq/P+ NSg/VB+ VXB   NSg/VLXB NSg/VP/J P  D   NSg/VB P  D+  NSg/VB+   NPr/I/J/R/Dq C/P  R     . VB/C
+# NSg/Dq/P+ NSg/VB+ VXB   NSg/VLXB NSg/VP/J P  D   NSg/VB P  D+  NSg+      NPr/I/J/R/Dq C/P  R     . VB/C
 > no        person  who    has held the office of President , or    acted as    President , for   more
-# NSg/Dq/P+ NSg/VB+ NPr/I+ V3  VP   D   NSg/VB P  NSg/VB+   . NPr/C VP/J  R/C/P NSg/VB+   . R/C/P NPr/I/J/R/Dq
+# NSg/Dq/P+ NSg/VB+ NPr/I+ V3  VP   D   NSg/VB P  NSg+      . NPr/C VP/J  R/C/P NSg+      . R/C/P NPr/I/J/R/Dq
 > than two years of a    term      to which some      other     person  was  elected  President shall
-# C/P  NSg NPl   P  D/P+ NSg/VB/J+ P  I/C+  I/J/R/Dq+ NSg/VB/J+ NSg/VB+ VLPt NSg/VP/J NSg/VB+   VXB
+# C/P  NSg NPl   P  D/P+ NSg/VB/J+ P  I/C+  I/J/R/Dq+ NSg/VB/J+ NSg/VB+ VLPt NSg/VP/J NSg+      VXB
 > be       elected  to the office of the President more         than once  . But     this    article
-# NSg/VLXB NSg/VP/J P  D   NSg/VB P  D+  NSg/VB+   NPr/I/J/R/Dq C/P  NSg/C . NSg/C/P I/Ddem+ NSg/VB+
+# NSg/VLXB NSg/VP/J P  D   NSg/VB P  D+  NSg+      NPr/I/J/R/Dq C/P  NSg/C . NSg/C/P I/Ddem+ NSg/VB+
 > shall not     apply to any     person  holding the office of President when    this    article
-# VXB   NSg/R/C VB/J  P  I/R/Dq+ NSg/VB+ Nᴹ/Vg/J D   NSg/VB P  NSg/VB+   NSg/I/C I/Ddem+ NSg/VB+
-> was  proposed by    the Congress , and  shall not     prevent any     person  who    may     be
-# VLPt VP/J     NSg/P D+  NPr/VB+  . VB/C VXB   NSg/R/C VB      I/R/Dq+ NSg/VB+ NPr/I+ NPr/VXB NSg/VLXB
+# VXB   NSg/R/C VB/J  P  I/R/Dq+ NSg/VB+ Nᴹ/Vg/J D   NSg/VB P  NSg+      NSg/I/C I/Ddem+ NSg/VB+
+> was  proposed by the Congress , and  shall not     prevent any     person  who    may     be
+# VLPt VP/J     P  D+  NPr+     . VB/C VXB   NSg/R/C VB      I/R/Dq+ NSg/VB+ NPr/I+ NPr/VXB NSg/VLXB
 > holding the office of President , or    acting  as    President , during the term      within
-# Nᴹ/Vg/J D   NSg/VB P  NSg/VB+   . NPr/C Nᴹ/Vg/J R/C/P NSg/VB+   . VB/P   D   NSg/VB/J+ NSg/J/P
+# Nᴹ/Vg/J D   NSg/VB P  NSg+      . NPr/C Nᴹ/Vg/J R/C/P NSg+      . VB/P   D   NSg/VB/J+ NSg/J/P
 > which this    article becomes operative from holding the office of President or
-# I/C+  I/Ddem+ NSg/VB+ V3      NSg/J+    P    Nᴹ/Vg/J D   NSg/VB P  NSg/VB+   NPr/C
+# I/C+  I/Ddem+ NSg/VB+ V3      NSg/J+    P    Nᴹ/Vg/J D   NSg/VB P  NSg+      NPr/C
 > acting  as    President during the remainder of such   term      .
-# Nᴹ/Vg/J R/C/P NSg/VB+   VB/P   D   NSg/VB/J  P  NSg/I+ NSg/VB/J+ .
+# Nᴹ/Vg/J R/C/P NSg+      VB/P   D   NSg/VB/J  P  NSg/I+ NSg/VB/J+ .
 >
 #
 >              SubSection 3 .
@@ -869,75 +869,75 @@
 >
 #
 > In        case      of the removal of the President from office  or    of his
-# NPr/J/R/P NPr🅪Sg/VB P  D   NSg     P  D   NSg/VB+   P    NSg/VB+ NPr/C P  ISg/D$+
-> death  or    resignation , the Vice        President shall become President .
-# NPr🅪Sg NPr/C NSg+        . D+  NSg/VB/J/P+ NSg/VB+   VXB   VBPp   NSg/VB+   .
+# NPr/J/R/P NPr🅪Sg/VB P  D   NSg     P  D   NSg+      P    NSg/VB+ NPr/C P  ISg/D$+
+> death  or    resignation , the Vice     President shall become President .
+# NPr🅪Sg NPr/C NSg+        . D+  NSg/J/P+ NSg+      VXB   VBPp   NSg+      .
 >
 #
-> Whenever there is  a   vacancy in        the office of the Vice        President , the President
-# C        R+    VL3 D/P N🅪Sg+   NPr/J/R/P D   NSg/VB P  D+  NSg/VB/J/P+ NSg/VB+   . D+  NSg/VB+
-> shall nominate a    Vice        President who    shall take   office  upon confirmation by    a
-# VXB   VB/J     D/P+ NSg/VB/J/P+ NSg/VB+   NPr/I+ VXB   NSg/VB NSg/VB+ P    N🅪Sg+        NSg/P D/P
+> Whenever there is  a   vacancy in        the office of the Vice     President , the President
+# C        R+    VL3 D/P N🅪Sg+   NPr/J/R/P D   NSg/VB P  D+  NSg/J/P+ NSg+      . D+  NSg+
+> shall nominate a    Vice     President who    shall take   office  upon confirmation by a
+# VXB   VB/J     D/P+ NSg/J/P+ NSg+      NPr/I+ VXB   NSg/VB NSg/VB+ P    N🅪Sg+        P  D/P
 > majority vote   of both   Houses of Congress .
-# NSg+     NSg/VB P  I/C/Dq NPl/V3 P  NPr/VB+  .
+# NSg+     NSg/VB P  I/C/Dq NPl/V3 P  NPr+     .
 >
 #
 > Whenever the President transmits to the President pro     tempore of the Senate and
-# C        D+  NSg/VB+   V3        P  D   NSg/VB+   NSg/J/P ?       P  D   NPr+   VB/C
+# C        D+  NSg+      V3        P  D   NSg+      NSg/J/P ?       P  D   NPr+   VB/C
 > the Speaker of the House  of Representatives his     written declaration that      he       is
 # D   NSg     P  D   NPr/VB P  NPl+            ISg/D$+ VPp/J   NSg+        I/C/Ddem+ NPr/ISg+ VL3
 > unable   to discharge the powers    and  duties of his     office  , and  until he       transmits
 # NSg/VB/J P  N🅪Sg/VB   D   NPrPl/V3+ VB/C NPl    P  ISg/D$+ NSg/VB+ . VB/C C/P   NPr/ISg+ V3
 > to them     a   written declaration to the contrary  , such  powers   and  duties shall be
 # P  NSg/IPl+ D/P VPp/J   NSg+        P  D   NSg/VB/J+ . NSg/I NPrPl/V3 VB/C NPl+   VXB   NSg/VLXB
-> discharged by    the Vice        President as    Acting  President .
-# VP/J       NSg/P D   NSg/VB/J/P+ NSg/VB+   R/C/P Nᴹ/Vg/J NSg/VB+   .
+> discharged by the Vice     President as    Acting  President .
+# VP/J       P  D   NSg/J/P+ NSg+      R/C/P Nᴹ/Vg/J NSg+      .
 >
 #
-> Whenever the Vice        President and  a   majority of either the principal officers of
-# C        D   NSg/VB/J/P+ NSg/VB+   VB/C D/P NSg      P  I/C    D   NSg/J     NPl/V3   P
-> the executive departments or    of such  other     body    as    Congress may     by    law      provide ,
-# D   NSg/J     NPl+        NPr/C P  NSg/I NSg/VB/J+ NSg/VB+ R/C/P NPr/VB+  NPr/VXB NSg/P N🅪Sg/VB+ VB      .
+> Whenever the Vice     President and  a   majority of either the principal officers of
+# C        D   NSg/J/P+ NSg+      VB/C D/P NSg      P  I/C    D   NSg/J     NPl/V3   P
+> the executive departments or    of such  other     body    as    Congress may     by law      provide ,
+# D   NSg/J     NPl+        NPr/C P  NSg/I NSg/VB/J+ NSg/VB+ R/C/P NPr+     NPr/VXB P  N🅪Sg/VB+ VB      .
 > transmit to the President pro     tempore of the Senate and  the Speaker of the
-# VB       P  D+  NSg/VB+   NSg/J/P ?       P  D   NPr+   VB/C D   NSg     P  D
+# VB       P  D+  NSg+      NSg/J/P ?       P  D   NPr+   VB/C D   NSg     P  D
 > House  of Representatives their written declaration that     the President is  unable
-# NPr/VB P  NPl+            D$+   VPp/J   NSg+        I/C/Ddem D   NSg/VB+   VL3 NSg/VB/J
-> to discharge the powers    and  duties of his     office  , the Vice        President shall
-# P  N🅪Sg/VB   D   NPrPl/V3+ VB/C NPl    P  ISg/D$+ NSg/VB+ . D   NSg/VB/J/P+ NSg/VB+   VXB
+# NPr/VB P  NPl+            D$+   VPp/J   NSg+        I/C/Ddem D   NSg+      VL3 NSg/VB/J
+> to discharge the powers    and  duties of his     office  , the Vice     President shall
+# P  N🅪Sg/VB   D   NPrPl/V3+ VB/C NPl    P  ISg/D$+ NSg/VB+ . D   NSg/J/P+ NSg+      VXB
 > immediately assume the powers    and  duties of the office  as    Acting  President .
-# R           VB     D   NPrPl/V3+ VB/C NPl    P  D   NSg/VB+ R/C/P Nᴹ/Vg/J NSg/VB+   .
+# R           VB     D   NPrPl/V3+ VB/C NPl    P  D   NSg/VB+ R/C/P Nᴹ/Vg/J NSg+      .
 >
 #
 > Thereafter , when    the President transmits to the President pro     tempore of the
-# NSg        . NSg/I/C D+  NSg/VB+   V3        P  D   NSg/VB+   NSg/J/P ?       P  D
+# NSg        . NSg/I/C D+  NSg+      V3        P  D   NSg+      NSg/J/P ?       P  D
 > Senate and  the Speaker of the House  of Representatives his     written declaration
 # NPr+   VB/C D   NSg     P  D   NPr/VB P  NPl+            ISg/D$+ VPp/J   NSg+
 > that     no       inability exists , he       shall resume the powers    and  duties of his     office
 # I/C/Ddem NSg/Dq/P N🅪Sg+     V3     . NPr/ISg+ VXB   NSg/VB D   NPrPl/V3+ VB/C NPl    P  ISg/D$+ NSg/VB+
-> unless the Vice        President and  a   majority of either the principal officers of
-# C      D   NSg/VB/J/P+ NSg/VB+   VB/C D/P NSg      P  I/C    D   NSg/J     NPl/V3   P
-> the executive department or    of such  other    body    as    Congress may     by    law      provide ,
-# D   NSg/J     NSg+       NPr/C P  NSg/I NSg/VB/J NSg/VB+ R/C/P NPr/VB+  NPr/VXB NSg/P N🅪Sg/VB+ VB      .
+> unless the Vice     President and  a   majority of either the principal officers of
+# C      D   NSg/J/P+ NSg+      VB/C D/P NSg      P  I/C    D   NSg/J     NPl/V3   P
+> the executive department or    of such  other    body    as    Congress may     by law      provide ,
+# D   NSg/J     NSg+       NPr/C P  NSg/I NSg/VB/J NSg/VB+ R/C/P NPr+     NPr/VXB P  N🅪Sg/VB+ VB      .
 > transmit within  four days to the President pro     tempore of the Senate and  the
-# VB       NSg/J/P NSg  NPl+ P  D   NSg/VB+   NSg/J/P ?       P  D   NPr+   VB/C D
+# VB       NSg/J/P NSg  NPl+ P  D   NSg+      NSg/J/P ?       P  D   NPr+   VB/C D
 > Speaker of the House  of Representatives their written declaration that     the
 # NSg     P  D   NPr/VB P  NPl+            D$+   VPp/J   NSg+        I/C/Ddem D
 > President is  unable   to discharge the powers    and  duties of his     office  . Thereupon
-# NSg/VB+   VL3 NSg/VB/J P  N🅪Sg/VB   D   NPrPl/V3+ VB/C NPl    P  ISg/D$+ NSg/VB+ . R
+# NSg+      VL3 NSg/VB/J P  N🅪Sg/VB   D   NPrPl/V3+ VB/C NPl    P  ISg/D$+ NSg/VB+ . R
 > Congress shall decide the issue   , assembling within  forty - eight hours for   that
-# NPr/VB+  VXB   VB     D   NSg/VB+ . Nᴹ/Vg/J    NSg/J/P NSg/J . NSg/J NPl+  R/C/P I/C/Ddem
+# NPr+     VXB   VB     D   NSg/VB+ . Nᴹ/Vg/J    NSg/J/P NSg/J . NSg/J NPl+  R/C/P I/C/Ddem
 > purpose  if    not     in        session . If    the Congress , within  twenty - one     days after
-# N🅪Sg/VB+ NSg/C NSg/R/C NPr/J/R/P NSg/VB+ . NSg/C D+  NPr/VB+  . NSg/J/P NSg    . NSg/I/J NPl  P
+# N🅪Sg/VB+ NSg/C NSg/R/C NPr/J/R/P NSg/VB+ . NSg/C D+  NPr+     . NSg/J/P NSg    . NSg/I/J NPl  P
 > receipt of the latter written declaration , or    , if    Congress is  not     in        session ,
-# NSg/VB  P  D+  NSg/J+ VPp/J   NSg+        . NPr/C . NSg/C NPr/VB+  VL3 NSg/R/C NPr/J/R/P NSg/VB+ .
+# NSg/VB  P  D+  NSg/J+ VPp/J   NSg+        . NPr/C . NSg/C NPr+     VL3 NSg/R/C NPr/J/R/P NSg/VB+ .
 > within  twenty - one     days after Congress is  required to assemble , determines by
-# NSg/J/P NSg    . NSg/I/J NPl  P     NPr/VB+  VL3 VP/J     P  VB       . V3         NSg/P
+# NSg/J/P NSg    . NSg/I/J NPl  P     NPr+     VL3 VP/J     P  VB       . V3         P
 > two - thirds vote   of both   Houses  that     the President is  unable   to discharge the
-# NSg . NPl/V3 NSg/VB P  I/C/Dq NPl/V3+ I/C/Ddem D+  NSg/VB+   VL3 NSg/VB/J P  N🅪Sg/VB   D
-> powers   and  duties of his     office  , the Vice        President shall continue to discharge
-# NPrPl/V3 VB/C NPl    P  ISg/D$+ NSg/VB+ . D+  NSg/VB/J/P+ NSg/VB+   VXB   NSg/VB   P  N🅪Sg/VB
+# NSg . NPl/V3 NSg/VB P  I/C/Dq NPl/V3+ I/C/Ddem D+  NSg+      VL3 NSg/VB/J P  N🅪Sg/VB   D
+> powers   and  duties of his     office  , the Vice     President shall continue to discharge
+# NPrPl/V3 VB/C NPl    P  ISg/D$+ NSg/VB+ . D+  NSg/J/P+ NSg+      VXB   NSg/VB   P  N🅪Sg/VB
 > the same as    Acting  President ; otherwise , the President shall resume the powers
-# D   I/J  R/C/P Nᴹ/Vg/J NSg/VB+   . J/R/C     . D+  NSg/VB+   VXB   NSg/VB D   NPrPl/V3
+# D   I/J  R/C/P Nᴹ/Vg/J NSg+      . J/R/C     . D+  NSg+      VXB   NSg/VB D   NPrPl/V3
 > and  duties of his     office  .
 # VB/C NPl    P  ISg/D$+ NSg/VB+ .
 >
@@ -947,7 +947,7 @@
 >
 #
 > The President shall , at    stated Times   , receive for   his
-# D+  NSg/VB+   VXB   . NSg/P VP/J   NPl/V3+ . NSg/VB  R/C/P ISg/D$+
+# D+  NSg+      VXB   . NSg/P VP/J   NPl/V3+ . NSg/VB  R/C/P ISg/D$+
 > Services , a    Compensation , which shall neither be       encreased nor   diminished
 # NPl/V3+  . D/P+ N🅪Sg+        . I/C+  VXB   I/C     NSg/VLXB ?         NSg/C VP/J
 > during the Period    for   which he       shall have    been   elected  , and  he       shall not
@@ -963,7 +963,7 @@
 > Oath    or    Affirmation : - - " I       do  solemnly swear    ( or    affirm ) that     I       will    faithfully
 # NSg/VB+ NPr/C NSg         . . . . ISg/#r+ VXB R        NSg/VB/J . NPr/C VB     . I/C/Ddem ISg/#r+ NPr/VXB R
 > execute the Office of President of the United States    , and  will    to the best       of
-# VB      D   NSg/VB P  NSg/VB    P  D   VP/J   NPrPl/V3+ . VB/C NPr/VXB P  D   NPr/VXB/JS P
+# VB      D   NSg/VB P  NSg       P  D   VP/J   NPrPl/V3+ . VB/C NPr/VXB P  D   NPr/VXB/JS P
 > my  Ability , preserve , protect and  defend the Constitution of the United
 # D$+ N🅪Sg+   . NSg/VB   . VB      VB/C NSg/VB D   NPr          P  D   VP/J
 > States    . "
@@ -977,23 +977,23 @@
 > The District  constituting the seat   of Government of the
 # D+  NSg/VB/J+ Nᴹ/Vg/J      D   NSg/VB P  N🅪Sg       P  D
 > United States    shall appoint in        such  manner as    the Congress may     direct :
-# VP/J   NPrPl/V3+ VXB   VB      NPr/J/R/P NSg/I NSg+   R/C/P D   NPr/VB+  NPr/VXB VB/J   .
+# VP/J   NPrPl/V3+ VXB   VB      NPr/J/R/P NSg/I NSg+   R/C/P D   NPr+     NPr/VXB VB/J   .
 >
 #
-> A   number     of electors of President and  Vice        President equal    to the whole number
-# D/P N🅪Sg/VB/JC P  NPl      P  NSg/VB    VB/C NSg/VB/J/P+ NSg/VB+   NSg/VB/J P  D   NSg/J N🅪Sg/VB/JC
+> A   number     of electors of President and  Vice     President equal    to the whole number
+# D/P N🅪Sg/VB/JC P  NPl      P  NSg       VB/C NSg/J/P+ NSg+      NSg/VB/J P  D   NSg/J N🅪Sg/VB/JC
 > of Senators and  Representatives in        Congress to which the District  would be
-# P  NPl+     VB/C NPl+            NPr/J/R/P NPr/VB+  P  I/C+  D   NSg/VB/J+ VXB   NSg/VLXB
+# P  NPl+     VB/C NPl+            NPr/J/R/P NPr+     P  I/C+  D   NSg/VB/J+ VXB   NSg/VLXB
 > entitled if    it       were a   State    , but     in        no       event   more         than the least    populous
 # VP/J     NSg/C NPr/ISg+ VLPt D/P N🅪Sg/VB+ . NSg/C/P NPr/J/R/P NSg/Dq/P NSg/VB+ NPr/I/J/R/Dq C/P  D   NSg/J/Dq J
-> State    ; they shall be       in        addition to those  appointed by    the States    , but     they
-# N🅪Sg/VB+ . IPl+ VXB   NSg/VLXB NPr/J/R/P NSg+     P  I/Ddem VP/J+     NSg/P D   NPrPl/V3+ . NSg/C/P IPl+
+> State    ; they shall be       in        addition to those  appointed by the States    , but     they
+# N🅪Sg/VB+ . IPl+ VXB   NSg/VLXB NPr/J/R/P NSg+     P  I/Ddem VP/J+     P  D   NPrPl/V3+ . NSg/C/P IPl+
 > shall be       considered , for   the purposes of the election of President and  Vice
-# VXB   NSg/VLXB VP/J       . R/C/P D   NPl/V3   P  D   NSg      P  NSg/VB    VB/C NSg/VB/J/P+
-> President , to be       electors appointed by    a   State    ; and  they shall meet     in        the
-# NSg/VB+   . P  NSg/VLXB NPl      VP/J      NSg/P D/P N🅪Sg/VB+ . VB/C IPl+ VXB   NSg/VB/J NPr/J/R/P D
-> District  and  perform such  duties as    provided by    this   article of the
-# NSg/VB/J+ VB/C VB      NSg/I NPl+   R/C/P VP/J/C   NSg/P I/Ddem NSg/VB  P  D
+# VXB   NSg/VLXB VP/J       . R/C/P D   NPl/V3   P  D   NSg      P  NSg       VB/C NSg/J/P+
+> President , to be       electors appointed by a   State    ; and  they shall meet     in        the
+# NSg+      . P  NSg/VLXB NPl      VP/J      P  D/P N🅪Sg/VB+ . VB/C IPl+ VXB   NSg/VB/J NPr/J/R/P D
+> District  and  perform such  duties as    provided by this   article of the
+# NSg/VB/J+ VB/C VB      NSg/I NPl+   R/C/P VP/J/C   P  I/Ddem NSg/VB  P  D
 > Constitution .
 # NPr+         .
 >
@@ -1003,7 +1003,7 @@
 >
 #
 > The President shall be       Commander in        Chief    of the Army and  Navy
-# D+  NSg/VB+   VXB   NSg/VLXB NSg       NPr/J/R/P NSg/VB/J P  D   NSg  VB/C N🅪Sg/J
+# D+  NSg+      VXB   NSg/VLXB NSg       NPr/J/R/P NSg/VB/J P  D   NSg  VB/C N🅪Sg/J
 > of the United States    , and  of the Militia of the several States    , when    called
 # P  D+  VP/J   NPrPl/V3+ . VB/C P  D   NSg     P  D   J/Dq    NPrPl/V3+ . NSg/I/C VP/J
 > into the actual Service of the United States    ; he       may     require the Opinion , in
@@ -1018,30 +1018,30 @@
 # NPrPl/V3+ . VB/C/P NPr/J/R/P NPl/V3+ P  N🅪Sg        .
 >
 #
-> He       shall have    Power      , by    and  with the Advice and  Consent of the Senate , to make
-# NPr/ISg+ VXB   NSg/VXB N🅪Sg/VB/J+ . NSg/P VB/C P    D+  Nᴹ+    VB/C N🅪Sg/VP P  D+  NPr+   . P  NSg/VB
+> He       shall have    Power      , by and  with the Advice and  Consent of the Senate , to make
+# NPr/ISg+ VXB   NSg/VXB N🅪Sg/VB/J+ . P  VB/C P    D+  Nᴹ+    VB/C N🅪Sg/VP P  D+  NPr+   . P  NSg/VB
 > Treaties , provided two thirds of the Senators present   concur ; and  he       shall
 # NPl/V3+  . VP/J/C   NSg NPl/V3 P  D+  NPl+     NSg/VB/J+ VB+    . VB/C NPr/ISg+ VXB
-> nominate , and  by    and  with the Advice and  Consent of the Senate , shall appoint
-# VB/J     . VB/C NSg/P VB/C P    D   Nᴹ+    VB/C N🅪Sg/VP P  D   NPr+   . VXB   VB
+> nominate , and  by and  with the Advice and  Consent of the Senate , shall appoint
+# VB/J     . VB/C P  VB/C P    D   Nᴹ+    VB/C N🅪Sg/VP P  D   NPr+   . VXB   VB
 > Ambassadors , other    public  Ministers and  Consuls , Judges   of the supreme  Court      ,
 # NPl+        . NSg/VB/J Nᴹ/VB/J NPl/V3+   VB/C NPl     . NPrPl/V3 P  D   NSg/VB/J N🅪Sg/VB/J+ .
 > and  all          other    Officers of the United States    , whose Appointments are not     herein
 # VB/C NSg/I/J/C/Dq NSg/VB/J NPl/V3   P  D   VP/J   NPrPl/V3+ . I+    NPl+         VLB NSg/R/C R
-> otherwise provided for   , and  which shall be       established by    Law      : but     the Congress
-# J/R/C     VP/J/C   R/C/P . VB/C I/C+  VXB   NSg/VLXB VP/J        NSg/P N🅪Sg/VB+ . NSg/C/P D   NPr/VB+
-> may     by    Law      vest   the Appointment of such  inferior Officers , as    they think
-# NPr/VXB NSg/P N🅪Sg/VB+ NSg/VB D   NSg         P  NSg/I NSg/J    NPl/V3+  . R/C/P IPl+ NSg/VB
+> otherwise provided for   , and  which shall be       established by Law      : but     the Congress
+# J/R/C     VP/J/C   R/C/P . VB/C I/C+  VXB   NSg/VLXB VP/J        P  N🅪Sg/VB+ . NSg/C/P D   NPr+
+> may     by Law      vest   the Appointment of such  inferior Officers , as    they think
+# NPr/VXB P  N🅪Sg/VB+ NSg/VB D   NSg         P  NSg/I NSg/J    NPl/V3+  . R/C/P IPl+ NSg/VB
 > proper , in        the President alone , in        the Courts of Law      , or    in        the Heads  of
-# NSg/J  . NPr/J/R/P D   NSg/VB+   J     . NPr/J/R/P D   NPl/V3 P  N🅪Sg/VB+ . NPr/C NPr/J/R/P D   NPl/V3 P
+# NSg/J  . NPr/J/R/P D   NSg+      J     . NPr/J/R/P D   NPl/V3 P  N🅪Sg/VB+ . NPr/C NPr/J/R/P D   NPl/V3 P
 > Departments .
 # NPl+        .
 >
 #
 > The President shall have    Power      to fill   up         all          Vacancies that      may     happen during
-# D+  NSg/VB+   VXB   NSg/VXB N🅪Sg/VB/J+ P  NSg/VB NSg/VB/J/P NSg/I/J/C/Dq NPl       I/C/Ddem+ NPr/VXB VB     VB/P
-> the Recess   of the Senate , by    granting Commissions which shall expire at    the End
-# D   NSg/VB/J P  D   NPr+   . NSg/P Nᴹ/Vg/J+ NPl/V3+     I/C+  VXB   VB     NSg/P D   NSg/VB
+# D+  NSg+      VXB   NSg/VXB N🅪Sg/VB/J+ P  NSg/VB NSg/VB/J/P NSg/I/J/C/Dq NPl       I/C/Ddem+ NPr/VXB VB     VB/P
+> the Recess   of the Senate , by granting Commissions which shall expire at    the End
+# D   NSg/VB/J P  D   NPr+   . P  Nᴹ/Vg/J+ NPl/V3+     I/C+  VXB   VB     NSg/P D   NSg/VB
 > of their next    Session .
 # P  D$+   NSg/J/P NSg/VB+ .
 >
@@ -1049,7 +1049,7 @@
 > No        soldier   shall , in        time      of peace      be       quartered in        any     house   , without the
 # NSg/Dq/P+ NSg/VB/J+ VXB   . NPr/J/R/P N🅪Sg/VB/J P  NPr🅪Sg/VB+ NSg/VLXB VP/J      NPr/J/R/P I/R/Dq+ NPr/VB+ . C/P     D
 > consent of the owner , nor   in        time      of war      , but     in        a    manner to be       prescribed by
-# N🅪Sg/VP P  D+  NSg+  . NSg/C NPr/J/R/P N🅪Sg/VB/J P  N🅪Sg/VB+ . NSg/C/P NPr/J/R/P D/P+ NSg+   P  NSg/VLXB VP/J       NSg/P
+# N🅪Sg/VP P  D+  NSg+  . NSg/C NPr/J/R/P N🅪Sg/VB/J P  N🅪Sg/VB+ . NSg/C/P NPr/J/R/P D/P+ NSg+   P  NSg/VLXB VP/J       P
 > law      .
 # N🅪Sg/VB+ .
 >
@@ -1059,7 +1059,7 @@
 >
 #
 > He       shall from time       to time      give   to the Congress Information of
-# NPr/ISg+ VXB   P    N🅪Sg/VB/J+ P  N🅪Sg/VB/J NSg/VB P  D   NPr/VB+  Nᴹ          P
+# NPr/ISg+ VXB   P    N🅪Sg/VB/J+ P  N🅪Sg/VB/J NSg/VB P  D   NPr+     Nᴹ          P
 > the State   of the Union     , and  recommend to their Consideration such   Measures as
 # D   N🅪Sg/VB P  D+  NPr/VB/J+ . VB/C NSg/VB    P  D$+   N🅪Sg+         NSg/I+ NPl/V3+  R/C/P
 > he       shall judge   necessary and  expedient ; he       may     , on  extraordinary Occasions ,
@@ -1080,8 +1080,8 @@
 # HeadingStart NSg/VB+ . # .
 >
 #
-> The President , Vice        President and  all          civil Officers of the
-# D+  NSg/VB+   . NSg/VB/J/P+ NSg/VB+   VB/C NSg/I/J/C/Dq J     NPl/V3   P  D+
+> The President , Vice     President and  all          civil Officers of the
+# D+  NSg+      . NSg/J/P+ NSg+      VB/C NSg/I/J/C/Dq J     NPl/V3   P  D+
 > United States    , shall be       removed from Office  on  Impeachment for   , and  Conviction
 # VP/J   NPrPl/V3+ . VXB   NSg/VLXB VP/J    P    NSg/VB+ J/P N🅪Sg        R/C/P . VB/C N🅪Sg+
 > of , Treason , Bribery , or    other    high       Crimes  and  Misdemeanors .
@@ -1099,7 +1099,7 @@
 > The judicial Power     of the United States    , shall be       vested in
 # D   NSg/J    N🅪Sg/VB/J P  D+  VP/J   NPrPl/V3+ . VXB   NSg/VLXB VP/J   NPr/J/R/P
 > one     supreme  Court      , and  in        such  inferior Courts  as    the Congress may     from time       to
-# NSg/I/J NSg/VB/J N🅪Sg/VB/J+ . VB/C NPr/J/R/P NSg/I NSg/J+   NPl/V3+ R/C/P D+  NPr/VB+  NPr/VXB P    N🅪Sg/VB/J+ P
+# NSg/I/J NSg/VB/J N🅪Sg/VB/J+ . VB/C NPr/J/R/P NSg/I NSg/J+   NPl/V3+ R/C/P D+  NPr+     NPr/VXB P    N🅪Sg/VB/J+ P
 > time      ordain and  establish . The Judges    , both   of the supreme  and  inferior Courts  ,
 # N🅪Sg/VB/J VB     VB/C VB        . D+  NPrPl/V3+ . I/C/Dq P  D   NSg/VB/J VB/C NSg/J+   NPl/V3+ .
 > shall hold     their Offices during good      Behaviour  , and  shall , at    stated Times   ,
@@ -1141,17 +1141,17 @@
 > have    appellate Jurisdiction , both   as    to Law     and  Fact , with such  Exceptions , and
 # NSg/VXB J         N🅪Sg+        . I/C/Dq R/C/P P  N🅪Sg/VB VB/C NSg+ . P    NSg/I NPl+       . VB/C
 > under   such  Regulations as    the Congress shall make   .
-# NSg/J/P NSg/I NPl+        R/C/P D   NPr/VB+  VXB   NSg/VB .
+# NSg/J/P NSg/I NPl+        R/C/P D   NPr+     VXB   NSg/VB .
 >
 #
-> The Trial    of all           Crimes  , except in        Cases   of Impeachment , shall be       by    Jury      ; and
-# D   NSg/VB/J P  NSg/I/J/C/Dq+ NPl/V3+ . VB/C/P NPr/J/R/P NPl/V3+ P  N🅪Sg        . VXB   NSg/VLXB NSg/P NSg/VB/J+ . VB/C
+> The Trial    of all           Crimes  , except in        Cases   of Impeachment , shall be       by Jury      ; and
+# D   NSg/VB/J P  NSg/I/J/C/Dq+ NPl/V3+ . VB/C/P NPr/J/R/P NPl/V3+ P  N🅪Sg        . VXB   NSg/VLXB P  NSg/VB/J+ . VB/C
 > such  Trial     shall be       held in        the State    where   the said Crimes  shall have    been
 # NSg/I NSg/VB/J+ VXB   NSg/VLXB VP   NPr/J/R/P D   N🅪Sg/VB+ NSg/R/C D   VP/J NPl/V3+ VXB   NSg/VXB VLPp/B
 > committed ; but     when    not     committed within  any    State    , the Trial     shall be       at    such
 # VP/J      . NSg/C/P NSg/I/C NSg/R/C VP/J      NSg/J/P I/R/Dq N🅪Sg/VB+ . D   NSg/VB/J+ VXB   NSg/VLXB NSg/P NSg/I
-> Place   or    Places  as    the Congress may     by    Law      have    directed .
-# N🅪Sg/VB NPr/C NPl/V3+ R/C/P D   NPr/VB+  NPr/VXB NSg/P N🅪Sg/VB+ NSg/VXB VP/J     .
+> Place   or    Places  as    the Congress may     by Law      have    directed .
+# N🅪Sg/VB NPr/C NPl/V3+ R/C/P D   NPr+     NPr/VXB P  N🅪Sg/VB+ NSg/VXB VP/J     .
 >
 #
 >              Section . 3 .
@@ -1169,7 +1169,7 @@
 >
 #
 > The Congress shall have    Power      to declare the Punishment of Treason , but     no
-# D+  NPr/VB+  VXB   NSg/VXB N🅪Sg/VB/J+ P  VB      D   N🅪Sg       P  NSg     . NSg/C/P NSg/Dq/P
+# D+  NPr+     VXB   NSg/VXB N🅪Sg/VB/J+ P  VB      D   N🅪Sg       P  NSg     . NSg/C/P NSg/Dq/P
 > Attainder of Treason shall work     Corruption of Blood  , or    Forfeiture except
 # NSg       P  NSg     VXB   N🅪Sg/VB+ N🅪Sg       P  Nᴹ/VB+ . NPr/C NSg        VB/C/P
 > during the Life    of the Person  attainted .
@@ -1185,7 +1185,7 @@
 > papers  , and  effects , against unreasonable searches and  seizures , shall not     be
 # NPl/V3+ . VB/C NPl/V3+ . C/P     J            NPl/V3   VB/C NPl/V3+  . VXB   NSg/R/C NSg/VLXB
 > violated , and  no       warrants shall issue   , but     upon probable cause     , supported by
-# VP/J     . VB/C NSg/Dq/P NPl/V3+  VXB   NSg/VB+ . NSg/C/P P    NSg/J    N🅪Sg/VB/C . VP/J      NSg/P
+# VP/J     . VB/C NSg/Dq/P NPl/V3+  VXB   NSg/VB+ . NSg/C/P P    NSg/J    N🅪Sg/VB/C . VP/J      P
 > oath    or    affirmation , and  particularly describing the place    to be       searched , and
 # NSg/VB+ NPr/C NSg         . VB/C R            Nᴹ/Vg/J    D   N🅪Sg/VB+ P  NSg/VLXB VP/J     . VB/C
 > the persons or    things to be       seized .
@@ -1212,12 +1212,12 @@
 #
 > In        all          criminal prosecutions , the accused shall enjoy the right    to a   speedy and
 # NPr/J/R/P NSg/I/J/C/Dq NSg/J    NPl          . D+  VP/J+   VXB   VB    D   NPr/VB/J P  D/P VB/J   VB/C
-> public  trial     , by    an  impartial jury     of the state    and  district  wherein the crime
-# Nᴹ/VB/J NSg/VB/J+ . NSg/P D/P J         NSg/VB/J P  D   N🅪Sg/VB+ VB/C NSg/VB/J+ C       D   N🅪Sg/VB+
+> public  trial     , by an  impartial jury     of the state    and  district  wherein the crime
+# Nᴹ/VB/J NSg/VB/J+ . P  D/P J         NSg/VB/J P  D   N🅪Sg/VB+ VB/C NSg/VB/J+ C       D   N🅪Sg/VB+
 > shall have    been   committed , which district  shall have    been   previously
 # VXB   NSg/VXB VLPp/B VP/J      . I/C+  NSg/VB/J+ VXB   NSg/VXB VLPp/B R
-> ascertained by    law      , and  to be       informed of the nature   and  cause     of the
-# VP/J        NSg/P N🅪Sg/VB+ . VB/C P  NSg/VLXB VP/J     P  D   N🅪Sg/VB+ VB/C N🅪Sg/VB/C P  D
+> ascertained by law      , and  to be       informed of the nature   and  cause     of the
+# VP/J        P  N🅪Sg/VB+ . VB/C P  NSg/VLXB VP/J     P  D   N🅪Sg/VB+ VB/C N🅪Sg/VB/C P  D
 > accusation ; to be       confronted with the witnesses against him  ; to have    compulsory
 # N🅪Sg       . P  NSg/VLXB VP/J       P    D   NPl/V3+   C/P     ISg+ . P  NSg/VXB NSg/J
 > process for   obtaining witnesses in        his     favor       , and  to have    the assistance of
@@ -1228,8 +1228,8 @@
 #
 > In        suits  at    common    law      , where   the value    in        controversy shall exceed twenty
 # NPr/J/R/P NPl/V3 NSg/P NSg/VB/J+ N🅪Sg/VB+ . NSg/R/C D   N🅪Sg/VB+ NPr/J/R/P N🅪Sg+       VXB   VB     NSg+
-> dollars , the right    of trial     by    jury      shall be       preserved , and  no        fact tried by    a
-# NPl+    . D   NPr/VB/J P  NSg/VB/J+ NSg/P NSg/VB/J+ VXB   NSg/VLXB VP/J      . VB/C NSg/Dq/P+ NSg+ VP/J  NSg/P D/P+
+> dollars , the right    of trial     by jury      shall be       preserved , and  no        fact tried by a
+# NPl+    . D   NPr/VB/J P  NSg/VB/J+ P  NSg/VB/J+ VXB   NSg/VLXB VP/J      . VB/C NSg/Dq/P+ NSg+ VP/J  P  D/P+
 > jury      , shall be       otherwise reexamined in        any    court     of the United States    , than
 # NSg/VB/J+ . VXB   NSg/VLXB J/R/C     VP/J       NPr/J/R/P I/R/Dq N🅪Sg/VB/J P  D   VP/J   NPrPl/V3+ . C/P
 > according to the rules  of the common   law      .
@@ -1254,8 +1254,8 @@
 # NSg/VB/J NPr🅪Sg VB/C NSg/VB+ VXB   NSg/VLXB NSg/VPp/J/P NPr/J/R/P Dq   N🅪Sg/VB+ P  D
 > public  Acts     , Records , and  judicial Proceedings of every other     State    . And  the
 # Nᴹ/VB/J NPrPl/V3 . NPl/V3+ . VB/C NSg/J    NPl         P  Dq+   NSg/VB/J+ N🅪Sg/VB+ . VB/C D+
-> Congress may     by    general  Laws    prescribe the Manner in        which such  Acts      , Records
-# NPr/VB+  NPr/VXB NSg/P NSg/VB/J NPl/V3+ VB        D+  NSg+   NPr/J/R/P I/C+  NSg/I NPrPl/V3+ . NPl/V3
+> Congress may     by general  Laws    prescribe the Manner in        which such  Acts      , Records
+# NPr+     NPr/VXB P  NSg/VB/J NPl/V3+ VB        D+  NSg+   NPr/J/R/P I/C+  NSg/I NPrPl/V3+ . NPl/V3
 > and  Proceedings shall be       proved , and  the Effect  thereof .
 # VB/C NPl+        VXB   NSg/VLXB VP/J   . VB/C D+  NSg/VB+ R       .
 >
@@ -1282,8 +1282,8 @@
 #
 > The right    of citizens of the United States    , who    are eighteen years of age      or
 # D   NPr/VB/J P  NPl      P  D+  VP/J   NPrPl/V3+ . NPr/I+ VLB NSg      NPl   P  N🅪Sg/VB+ NPr/C
-> older , to vote   shall not     be       denied or    abridged by    the United States    or    by    any
-# JC    . P  NSg/VB VXB   NSg/R/C NSg/VLXB VP/J   NPr/C VP/J     NSg/P D   VP/J   NPrPl/V3+ NPr/C NSg/P I/R/Dq
+> older , to vote   shall not     be       denied or    abridged by the United States    or    by any
+# JC    . P  NSg/VB VXB   NSg/R/C NSg/VLXB VP/J   NPr/C VP/J     P  D   VP/J   NPrPl/V3+ NPr/C P  I/R/Dq
 > State    on  account of age      , sex     , race     , color         , or    previous condition of servitude .
 # N🅪Sg/VB+ J/P NSg/VB  P  N🅪Sg/VB+ . NSg/VB+ . N🅪Sg/VB+ . N🅪Sg/VB/J/Am+ . NPr/C NSg/J    N🅪Sg/VB+  P  NSg       .
 >
@@ -1318,20 +1318,20 @@
 # HeadingStart NSg/VB+ . # .
 >
 #
-> New    States    may     be       admitted by    the Congress into this    Union     ; but
-# NSg/J+ NPrPl/V3+ NPr/VXB NSg/VLXB VP/J     NSg/P D+  NPr/VB+  P    I/Ddem+ NPr/VB/J+ . NSg/C/P
+> New    States    may     be       admitted by the Congress into this    Union     ; but
+# NSg/J+ NPrPl/V3+ NPr/VXB NSg/VLXB VP/J     P  D+  NPr+     P    I/Ddem+ NPr/VB/J+ . NSg/C/P
 > no        new    State    shall be       formed or    erected within  the Jurisdiction of any     other
 # NSg/Dq/P+ NSg/J+ N🅪Sg/VB+ VXB   NSg/VLXB VP/J   NPr/C VP/J    NSg/J/P D   N🅪Sg         P  I/R/Dq+ NSg/VB/J+
-> State    ; nor   any     State    be       formed by    the Junction of two or    more         States    , or    Parts
-# N🅪Sg/VB+ . NSg/C I/R/Dq+ N🅪Sg/VB+ NSg/VLXB VP/J   NSg/P D   NSg/VB   P  NSg NPr/C NPr/I/J/R/Dq NPrPl/V3+ . NPr/C NPl/V3
+> State    ; nor   any     State    be       formed by the Junction of two or    more         States    , or    Parts
+# N🅪Sg/VB+ . NSg/C I/R/Dq+ N🅪Sg/VB+ NSg/VLXB VP/J   P  D   NSg/VB   P  NSg NPr/C NPr/I/J/R/Dq NPrPl/V3+ . NPr/C NPl/V3
 > of States    , without the Consent of the Legislatures of the States    concerned as
 # P  NPrPl/V3+ . C/P     D   N🅪Sg/VP P  D   NPl          P  D   NPrPl/V3+ VP/J      R/C/P
 > well       as    of the Congress .
-# NSg/VB/J/R R/C/P P  D   NPr/VB+  .
+# NSg/VB/J/R R/C/P P  D   NPr+     .
 >
 #
 > The Congress shall have    Power      to dispose of and  make   all          needful Rules  and
-# D+  NPr/VB+  VXB   NSg/VXB N🅪Sg/VB/J+ P  NSg/VB  P  VB/C NSg/VB NSg/I/J/C/Dq NSg/J   NPl/V3 VB/C
+# D+  NPr+     VXB   NSg/VXB N🅪Sg/VB/J+ P  NSg/VB  P  VB/C NSg/VB NSg/I/J/C/Dq NSg/J   NPl/V3 VB/C
 > Regulations respecting the Territory or    other    Property belonging to the United
 # NPl+        Nᴹ/Vg/J    D   N🅪Sg+     NPr/C NSg/VB/J NSg/VB+  N🅪Sg/Vg/J P  D   VP/J
 > States    ; and  nothing  in        this   Constitution shall be       so          construed as    to Prejudice
@@ -1360,8 +1360,8 @@
 #
 > The validity of the public  debt of the United States    ,
 # D   NSg      P  D   Nᴹ/VB/J N🅪Sg P  D+  VP/J   NPrPl/V3+ .
-> authorized by    law      , including debts incurred for   payment of pensions and
-# VP/J       NSg/P N🅪Sg/VB+ . Nᴹ/Vg/J   NPl+  VP       R/C/P N🅪Sg    P  NPl/V3   VB/C
+> authorized by law      , including debts incurred for   payment of pensions and
+# VP/J       P  N🅪Sg/VB+ . Nᴹ/Vg/J   NPl+  VP       R/C/P N🅪Sg    P  NPl/V3   VB/C
 > bounties for   services in        suppressing insurrection or    rebellion , shall not     be
 # NPl/V3   R/C/P NPl/V3+  NPr/J/R/P Nᴹ/Vg/J     N🅪Sg         NPr/C N🅪Sg+     . VXB   NSg/R/C NSg/VLXB
 > questioned . But     neither the United States    nor   any     State    shall assume or    pay      any
@@ -1379,21 +1379,21 @@
 >
 #
 > The Congress , whenever two thirds of both   Houses  shall deem   it       necessary , shall
-# D+  NPr/VB+  . C        NSg NPl/V3 P  I/C/Dq NPl/V3+ VXB   NSg/VB NPr/ISg+ NSg/J     . VXB
+# D+  NPr+     . C        NSg NPl/V3 P  I/C/Dq NPl/V3+ VXB   NSg/VB NPr/ISg+ NSg/J     . VXB
 > propose Amendments to this    Constitution , or    , on  the Application of the
 # NSg/VB  NPl+       P  I/Ddem+ NPr+         . NPr/C . J/P D   NSg         P  D
 > Legislatures of two thirds of the several States    , shall call   a   Convention for
 # NPl          P  NSg NPl/V3 P  D   J/Dq    NPrPl/V3+ . VXB   NSg/VB D/P N🅪Sg+      R/C/P
 > proposing Amendments , which , in        either Case       , shall be       valid to all          Intents and
 # Nᴹ/Vg/J   NPl+       . I/C+  . NPr/J/R/P I/C    NPr🅪Sg/VB+ . VXB   NSg/VLXB J     P  NSg/I/J/C/Dq NPl     VB/C
-> Purposes , as    Part     of this   Constitution , when    ratified by    the Legislatures of
-# NPl/V3+  . R/C/P NSg/VB/J P  I/Ddem NPr+         . NSg/I/C VP/J     NSg/P D   NPl          P
-> three fourths of the several States    , or    by    Conventions in        three fourths
-# NSg   NSg     P  D   J/Dq    NPrPl/V3+ . NPr/C NSg/P NPl+        NPr/J/R/P NSg   NSg
-> thereof , as    the one      or    the other    Mode of Ratification may     be       proposed by    the
-# R       . R/C/P D   NSg/I/J+ NPr/C D   NSg/VB/J NSg  P  NSg+         NPr/VXB NSg/VLXB VP/J     NSg/P D
+> Purposes , as    Part     of this   Constitution , when    ratified by the Legislatures of
+# NPl/V3+  . R/C/P NSg/VB/J P  I/Ddem NPr+         . NSg/I/C VP/J     P  D   NPl          P
+> three fourths of the several States    , or    by Conventions in        three fourths
+# NSg   NSg     P  D   J/Dq    NPrPl/V3+ . NPr/C P  NPl+        NPr/J/R/P NSg   NSg
+> thereof , as    the one      or    the other    Mode of Ratification may     be       proposed by the
+# R       . R/C/P D   NSg/I/J+ NPr/C D   NSg/VB/J NSg  P  NSg+         NPr/VXB NSg/VLXB VP/J     P  D
 > Congress ; Provided that     no       Amendment which may     be       made prior to the Year One
-# NPr/VB+  . VP/J/C   I/C/Ddem NSg/Dq/P NSg+      I/C+  NPr/VXB NSg/VLXB VP   NSg/J P  D   NSg+ NSg/I/J+
+# NPr+     . VP/J/C   I/C/Ddem NSg/Dq/P NSg+      I/C+  NPr/VXB NSg/VLXB VP   NSg/J P  D   NSg+ NSg/I/J+
 > thousand eight hundred and  eight shall in        any    Manner affect the first and
 # NSg      NSg/J NSg     VB/C NSg/J VXB+  NPr/J/R/P I/R/Dq NSg+   NSg/VB D   NSg/J VB/C
 > fourth   Clauses in        the Ninth    Section of the first Article ; and  that     no       State    ,
@@ -1430,8 +1430,8 @@
 # D   NPl      VB/C NPl+            C/P    VP/J      . VB/C D   NPl/V3  P  D+
 > several State    Legislatures , and  all          executive and  judicial Officers , both   of
 # J/Dq+   N🅪Sg/VB+ NPl          . VB/C NSg/I/J/C/Dq NSg/J     VB/C NSg/J    NPl/V3+  . I/C/Dq P
-> the United States    and  of the several States    , shall be       bound    by    Oath    or
-# D   VP/J   NPrPl/V3+ VB/C P  D   J/Dq    NPrPl/V3+ . VXB   NSg/VLXB NSg/VP/J NSg/P NSg/VB+ NPr/C
+> the United States    and  of the several States    , shall be       bound    by Oath    or
+# D   VP/J   NPrPl/V3+ VB/C P  D   J/Dq    NPrPl/V3+ . VXB   NSg/VLXB NSg/VP/J P  NSg/VB+ NPr/C
 > Affirmation , to support this   Constitution ; but     no       religious Test    shall ever be
 # NSg         . P  N🅪Sg/VB I/Ddem NPr+         . NSg/C/P NSg/Dq/P NSg/J     NSg/VB+ VXB   J/R  NSg/VLXB
 > required as    a   Qualification to any    Office  or    public  Trust     under   the United
@@ -1452,14 +1452,14 @@
 #
 > The enumeration in        the Constitution , of certain rights  , shall
 # D   N🅪Sg        NPr/J/R/P D   NPr+         . P  I/J     NPl/V3+ . VXB
-> not     be       construed to deny or    disparage others  retained by    the people  .
-# NSg/R/C NSg/VLXB VP/J      P  VB   NPr/C NSg/VB    NPl/V3+ VP/J     NSg/P D   NPl/VB+ .
+> not     be       construed to deny or    disparage others  retained by the people  .
+# NSg/R/C NSg/VLXB VP/J      P  VB   NPr/C NSg/VB    NPl/V3+ VP/J     P  D   NPl/VB+ .
 >
 #
-> The powers    not     delegated to the United States    by    the Constitution , nor
-# D+  NPrPl/V3+ NSg/R/C VP/J      P  D   VP/J   NPrPl/V3+ NSg/P D   NPr+         . NSg/C
-> prohibited by    it       to the states    , are reserved to the states    respectively , or    to
-# VP/J       NSg/P NPr/ISg+ P  D   NPrPl/V3+ . VLB VP/J     P  D   NPrPl/V3+ R            . NPr/C P
+> The powers    not     delegated to the United States    by the Constitution , nor
+# D+  NPrPl/V3+ NSg/R/C VP/J      P  D   VP/J   NPrPl/V3+ P  D   NPr+         . NSg/C
+> prohibited by it       to the states    , are reserved to the states    respectively , or    to
+# VP/J       P  NPr/ISg+ P  D   NPrPl/V3+ . VLB VP/J     P  D   NPrPl/V3+ R            . NPr/C P
 > the people  .
 # D   NPl/VB+ .
 >
@@ -1488,8 +1488,8 @@
 # NPr/VB+ .
 >
 #
-> done      in        Convention by    the Unanimous Consent of the States    present  the
-# NSg/VPp/J NPr/J/R/P N🅪Sg+      NSg/P D   J         N🅪Sg/VP P  D+  NPrPl/V3+ NSg/VB/J D
+> done      in        Convention by the Unanimous Consent of the States    present  the
+# NSg/VPp/J NPr/J/R/P N🅪Sg+      P  D   J         N🅪Sg/VP P  D+  NPrPl/V3+ NSg/VB/J D
 > Seventeenth Day    of September in        the Year of our Lord      one     thousand seven hundred
 # NSg/J       NPr🅪Sg P  NPr+      NPr/J/R/P D   NSg  P  D$+ NPr/VB/J+ NSg/I/J NSg      NSg   NSg
 > and  Eighty seven and  of the Independence of the United States   of America the

--- a/harper-core/tests/text/tagged/The Constitution of the United States.md
+++ b/harper-core/tests/text/tagged/The Constitution of the United States.md
@@ -82,8 +82,8 @@
 #
 > No        Person  shall be       a    Representative who    shall not     have    attained to the Age     of
 # NSg/Dq/P+ NSg/VB+ VXB   NSg/VLXB D/P+ NSg/J+         NPr/I+ VXB   NSg/R/C NSg/VXB VP/J     P  D   N🅪Sg/VB P
-> twenty five Years , and  been     seven Years a   Citizen of the United States    , and  who
-# NSg    NSg  NPl+  . VB/C NSg/VLPp NSg   NPl+  D/P NSg     P  D   VP/J   NPrPl/V3+ . VB/C NPr/I+
+> twenty five Years , and  been   seven Years a   Citizen of the United States    , and  who
+# NSg    NSg  NPl+  . VB/C VLPp/B NSg   NPl+  D/P NSg     P  D   VP/J   NPrPl/V3+ . VB/C NPr/I+
 > shall not     , when    elected  , be       an  Inhabitant of that     State    in        which he       shall be
 # VXB   NSg/R/C . NSg/I/C NSg/VP/J . NSg/VLXB D/P NSg/J      P  I/C/Ddem N🅪Sg/VB+ NPr/J/R/P I/C+  NPr/ISg+ VXB   NSg/VLXB
 > chosen   .
@@ -184,8 +184,8 @@
 #
 > No        Person  shall be       a    Senator who    shall not     have    attained to the Age     of thirty
 # NSg/Dq/P+ NSg/VB+ VXB   NSg/VLXB D/P+ NSg+    NPr/I+ VXB   NSg/R/C NSg/VXB VP/J     P  D   N🅪Sg/VB P  NSg
-> Years , and  been     nine Years a   Citizen of the United States    , and  who    shall not     ,
-# NPl+  . VB/C NSg/VLPp NSg  NPl+  D/P NSg     P  D   VP/J   NPrPl/V3+ . VB/C NPr/I+ VXB   NSg/R/C .
+> Years , and  been   nine Years a   Citizen of the United States    , and  who    shall not     ,
+# NPl+  . VB/C VLPp/B NSg  NPl+  D/P NSg     P  D   VP/J   NPrPl/V3+ . VB/C NPr/I+ VXB   NSg/R/C .
 > when    elected  , be       an  Inhabitant of that     State    for   which he       shall be       chosen   .
 # NSg/I/C NSg/VP/J . NSg/VLXB D/P NSg/J      P  I/C/Ddem N🅪Sg/VB+ R/C/P I/C+  NPr/ISg+ VXB   NSg/VLXB Nᴹ/VPp/J .
 >
@@ -312,8 +312,8 @@
 # NSg/Dq/P NSg     NPr/C NSg/J+         VXB   . VB/P   D+  N🅪Sg/VB/J+ R/C/P I/C+  NPr/ISg+ VLPt NSg/VP/J .
 > be       appointed to any    civil Office  under   the Authority of the United States    ,
 # NSg/VLXB VP/J      P  I/R/Dq J+    NSg/VB+ NSg/J/P D   N🅪Sg      P  D+  VP/J   NPrPl/V3+ .
-> which shall have    been     created , or    the Emoluments whereof shall have    been
-# I/C+  VXB   NSg/VXB NSg/VLPp VP/J    . NPr/C D   NPl        C       VXB   NSg/VXB NSg/VLPp
+> which shall have    been   created , or    the Emoluments whereof shall have    been
+# I/C+  VXB   NSg/VXB VLPp/B VP/J    . NPr/C D   NPl        C       VXB   NSg/VXB VLPp/B
 > encreased during such  time       ; and  no       Person  holding any    Office  under   the United
 # ?         VB/P   NSg/I N🅪Sg/VB/J+ . VB/C NSg/Dq/P NSg/VB+ Nᴹ/Vg/J I/R/Dq NSg/VB+ NSg/J/P D   VP/J
 > States    , shall be       a   Member of either House   during his     Continuance in        Office  . No
@@ -362,8 +362,8 @@
 # C/P     D   NPr/VB+ VXB   NSg/VLXB VP/J    J/P D   NSg/VB/J P  Dq   NPr/VB+ R            . NSg/C
 > any     Bill    shall not     be       returned by    the President within  ten Days ( Sundays
 # I/R/Dq+ NPr/VB+ VXB   NSg/R/C NSg/VLXB VP/J     NSg/P D   NSg/VB    NSg/J/P NSg NPl  . NPl/V3+
-> excepted ) after it       shall have    been     presented to him  , the Same shall be       a   Law     ,
-# VP/J     . P     NPr/ISg+ VXB   NSg/VXB NSg/VLPp VP/J      P  ISg+ . D   I/J  VXB   NSg/VLXB D/P N🅪Sg/VB .
+> excepted ) after it       shall have    been   presented to him  , the Same shall be       a   Law     ,
+# VP/J     . P     NPr/ISg+ VXB   NSg/VXB VLPp/B VP/J      P  ISg+ . D   I/J  VXB   NSg/VLXB D/P N🅪Sg/VB .
 > in        like         Manner as    if    he       had signed it       , unless the Congress by    their Adjournment
 # NPr/J/R/P NSg/VB/J/C/P NSg+   R/C/P NSg/C NPr/ISg+ VP  VP/J   NPr/ISg+ . C      D+  NPr/VB+  NSg/P D$+   NSg
 > prevent its     Return , in        which Case       it       shall not     be       a   Law      .
@@ -778,8 +778,8 @@
 # NSg/P D+  N🅪Sg/VB/J+ VP/J  R/C/P D   NSg/Vg/J  P  D   NSg/VB/J P  D+  NSg/VB+   . D+  NSg/VB+
 > elect    shall have    died , the Vice        President elect    shall become President . If    a
 # NSg/VB/J VXB   NSg/VXB VP/J . D   NSg/VB/J/P+ NSg/VB+   NSg/VB/J VXB   VBPp   NSg/VB+   . NSg/C D/P+
-> President shall not     have    been     chosen   before the time       fixed for   the beginning of
-# NSg/VB+   VXB   NSg/R/C NSg/VXB NSg/VLPp Nᴹ/VPp/J C/P    D+  N🅪Sg/VB/J+ VP/J  R/C/P D   NSg/Vg/J  P
+> President shall not     have    been   chosen   before the time       fixed for   the beginning of
+# NSg/VB+   VXB   NSg/R/C NSg/VXB VLPp/B Nᴹ/VPp/J C/P    D+  N🅪Sg/VB/J+ VP/J  R/C/P D   NSg/Vg/J  P
 > his     term      , or    if    the President elect    shall have    failed to qualify , then      the Vice
 # ISg/D$+ NSg/VB/J+ . NPr/C NSg/C D+  NSg/VB+   NSg/VB/J VXB   NSg/VXB VP/J   P  NSg/VB  . NSg/J/R/C D   NSg/VB/J/P+
 > President elect    shall act     as    President until a   President shall have    qualified ;
@@ -840,8 +840,8 @@
 # NSg/J    P  D   NSg/VB P  NSg/VB+   . I/C     VXB   I/R/Dq+ NSg/VB+ NSg/VLXB NSg/J    P
 > that     Office  who    shall not     have    attained to the Age     of thirty five Years , and
 # I/C/Ddem NSg/VB+ NPr/I+ VXB   NSg/R/C NSg/VXB VP/J     P  D   N🅪Sg/VB P  NSg    NSg  NPl+  . VB/C
-> been     fourteen Years a   Resident within  the United States    .
-# NSg/VLPp NSg      NPl+  D/P NSg/J+   NSg/J/P D   VP/J   NPrPl/V3+ .
+> been   fourteen Years a   Resident within  the United States    .
+# VLPp/B NSg      NPl+  D/P NSg/J+   NSg/J/P D   VP/J   NPrPl/V3+ .
 >
 #
 > No        person  shall be       elected  to the office of the President more         than twice , and
@@ -950,8 +950,8 @@
 # D+  NSg/VB+   VXB   . NSg/P VP/J   NPl/V3+ . NSg/VB  R/C/P ISg/D$+
 > Services , a    Compensation , which shall neither be       encreased nor   diminished
 # NPl/V3+  . D/P+ N🅪Sg+        . I/C+  VXB   I/C     NSg/VLXB ?         NSg/C VP/J
-> during the Period    for   which he       shall have    been     elected  , and  he       shall not
-# VB/P   D   NSg/VB/J+ R/C/P I/C+  NPr/ISg+ VXB   NSg/VXB NSg/VLPp NSg/VP/J . VB/C NPr/ISg+ VXB   NSg/R/C
+> during the Period    for   which he       shall have    been   elected  , and  he       shall not
+# VB/P   D   NSg/VB/J+ R/C/P I/C+  NPr/ISg+ VXB   NSg/VXB VLPp/B NSg/VP/J . VB/C NPr/ISg+ VXB   NSg/R/C
 > receive within  that     Period    any    other    Emolument from the United States    , or    any
 # NSg/VB  NSg/J/P I/C/Ddem NSg/VB/J+ I/R/Dq NSg/VB/J NSg       P    D   VP/J   NPrPl/V3+ . NPr/C I/R/Dq
 > of them     .
@@ -1147,7 +1147,7 @@
 > The Trial    of all           Crimes  , except in        Cases   of Impeachment , shall be       by    Jury      ; and
 # D   NSg/VB/J P  NSg/I/J/C/Dq+ NPl/V3+ . VB/C/P NPr/J/R/P NPl/V3+ P  N🅪Sg        . VXB   NSg/VLXB NSg/P NSg/VB/J+ . VB/C
 > such  Trial     shall be       held in        the State    where   the said Crimes  shall have    been
-# NSg/I NSg/VB/J+ VXB   NSg/VLXB VP   NPr/J/R/P D   N🅪Sg/VB+ NSg/R/C D   VP/J NPl/V3+ VXB   NSg/VXB NSg/VLPp
+# NSg/I NSg/VB/J+ VXB   NSg/VLXB VP   NPr/J/R/P D   N🅪Sg/VB+ NSg/R/C D   VP/J NPl/V3+ VXB   NSg/VXB VLPp/B
 > committed ; but     when    not     committed within  any    State    , the Trial     shall be       at    such
 # VP/J      . NSg/C/P NSg/I/C NSg/R/C VP/J      NSg/J/P I/R/Dq N🅪Sg/VB+ . D   NSg/VB/J+ VXB   NSg/VLXB NSg/P NSg/I
 > Place   or    Places  as    the Congress may     by    Law      have    directed .
@@ -1214,8 +1214,8 @@
 # NPr/J/R/P NSg/I/J/C/Dq NSg/J    NPl          . D+  VP/J+   VXB   VB    D   NPr/VB/J P  D/P VB/J   VB/C
 > public  trial     , by    an  impartial jury     of the state    and  district  wherein the crime
 # Nᴹ/VB/J NSg/VB/J+ . NSg/P D/P J         NSg/VB/J P  D   N🅪Sg/VB+ VB/C NSg/VB/J+ C       D   N🅪Sg/VB+
-> shall have    been     committed , which district  shall have    been     previously
-# VXB   NSg/VXB NSg/VLPp VP/J      . I/C+  NSg/VB/J+ VXB   NSg/VXB NSg/VLPp R
+> shall have    been   committed , which district  shall have    been   previously
+# VXB   NSg/VXB VLPp/B VP/J      . I/C+  NSg/VB/J+ VXB   NSg/VXB VLPp/B R
 > ascertained by    law      , and  to be       informed of the nature   and  cause     of the
 # VP/J        NSg/P N🅪Sg/VB+ . VB/C P  NSg/VLXB VP/J     P  D   N🅪Sg/VB+ VB/C N🅪Sg/VB/C P  D
 > accusation ; to be       confronted with the witnesses against him  ; to have    compulsory
@@ -1300,8 +1300,8 @@
 #
 > Neither slavery nor   involuntary servitude , except as    a   punishment for   crime
 # I/C     NSg/J+  NSg/C J           NSg       . VB/C/P R/C/P D/P N🅪Sg       R/C/P N🅪Sg/VB+
-> whereof the party     shall have    been     duly convicted , shall exist within  the United
-# C       D   NSg/VB/J+ VXB   NSg/VXB NSg/VLPp R    VP/J      . VXB   VB    NSg/J/P D   VP/J
+> whereof the party     shall have    been   duly convicted , shall exist within  the United
+# C       D   NSg/VB/J+ VXB   NSg/VXB VLPp/B R    VP/J      . VXB   VB    NSg/J/P D   VP/J
 > States    , or    any    place    subject   to their jurisdiction . No        Person  held to Service
 # NPrPl/V3+ . NPr/C I/R/Dq N🅪Sg/VB+ NSg/VB/J+ P  D$+   N🅪Sg+        . NSg/Dq/P+ NSg/VB+ VP   P  NSg/VB
 > or    Labour          in        one      State    , under   the Laws    thereof , escaping into another , shall ,

--- a/harper-core/tests/text/tagged/The Great Gatsby.md
+++ b/harper-core/tests/text/tagged/The Great Gatsby.md
@@ -12,8 +12,8 @@
 #
 > In        my  younger and  more         vulnerable years my  father  gave me       some      advice that      I’ve
 # NPr/J/R/P D$+ NSg/JC  VB/C NPr/I/J/R/Dq J+         NPl+  D$+ NPr/VB+ VPt  NPr/ISg+ I/J/R/Dq+ Nᴹ+    I/C/Ddem+ K
-> been     turning over    in        my  mind    ever since .
-# NSg/VLPp Nᴹ/Vg/J NSg/J/P NPr/J/R/P D$+ NSg/VB+ J/R  C/P   .
+> been   turning over    in        my  mind    ever since .
+# VLPp/B Nᴹ/Vg/J NSg/J/P NPr/J/R/P D$+ NSg/VB+ J/R  C/P   .
 >
 #
 > “ Whenever you    feel     like         criticising   any     one      , ” he       told me       , “ just remember that
@@ -22,8 +22,8 @@
 # NSg/I/J/C/Dq D   NPl/VB NPr/J/R/P I/Ddem+ NSg/VB+ VXB     VP  D+  NPl/V3+    I/C/Ddem+ K      VP  . .
 >
 #
-> He       didn’t say    any    more         , but     we’ve always been     unusually communicative in        a
-# NPr/ISg+ VXPt   NSg/VB I/R/Dq NPr/I/J/R/Dq . NSg/C/P K     R      NSg/VLPp R         J             NPr/J/R/P D/P
+> He       didn’t say    any    more         , but     we’ve always been   unusually communicative in        a
+# NPr/ISg+ VXPt   NSg/VB I/R/Dq NPr/I/J/R/Dq . NSg/C/P K     R      VLPp/B R         J             NPr/J/R/P D/P
 > reserved way    , and  I       understood that     he       meant a   great deal      more         than that      . In
 # VP/J     NSg/J+ . VB/C ISg/#r+ VP/J       I/C/Ddem NPr/ISg+ VP    D/P NSg/J NSg/VB/J+ NPr/I/J/R/Dq C/P  I/C/Ddem+ . NPr/J/R/P
 > consequence , I’m inclined to reserve all          judgments , a   habit   that      has opened up
@@ -94,8 +94,8 @@
 # NPl/V3+ VB/C NPr/VB/J/P . VP/J   NPl      P  NPl+ .
 >
 #
-> My  family  have    been     prominent , well       - to - do  people in        this   Middle   Western city for
-# D$+ N🅪Sg/J+ NSg/VXB NSg/VLPp NSg/J     . NSg/VB/J/R . P  . VXB NPl/VB NPr/J/R/P I/Ddem NSg/VB/J NPr/J   NSg  R/C/P
+> My  family  have    been   prominent , well       - to - do  people in        this   Middle   Western city for
+# D$+ N🅪Sg/J+ NSg/VXB VLPp/B NSg/J     . NSg/VB/J/R . P  . VXB NPl/VB NPr/J/R/P I/Ddem NSg/VB/J NPr/J   NSg  R/C/P
 > three generations . The Carraways are something of a   clan , and  we   have    a
 # NSg+  NPl+        . D   ?         VLB NSg/I/J   P  D/P NSg+ . VB/C IPl+ NSg/VXB D/P
 > tradition that      we’re descended from the Dukes  of Buccleuch , but     the actual
@@ -246,8 +246,8 @@
 # NPr/VB/J/R . R/C/P ISg/#r+ VXPt   VB   NSg+ . NPr    . NPr/ISg+ VLPt D/P NSg+    VP/J      NSg/P D/P NSg/J
 > of that     name    . My  own       house   was  an  eyesore , but     it       was  a   small    eyesore , and  it
 # P  I/C/Ddem NSg/VB+ . D$+ NSg/VB/J+ NPr/VB+ VLPt D/P NSg     . NSg/C/P NPr/ISg+ VLPt D/P NPr/VB/J NSg     . VB/C NPr/ISg+
-> had been     overlooked , so          I       had a   view   of the water    , a   partial  view   of my
-# VP  NSg/VLPp VP/J       . NSg/I/J/R/C ISg/#r+ VP  D/P NSg/VB P  D   N🅪Sg/VB+ . D/P NSg/VB/J NSg/VB P  D$+
+> had been   overlooked , so          I       had a   view   of the water    , a   partial  view   of my
+# VP  VLPp/B VP/J       . NSg/I/J/R/C ISg/#r+ VP  D/P NSg/VB P  D   N🅪Sg/VB+ . D/P NSg/VB/J NSg/VB P  D$+
 > neighbor’s lawn    , and  the consoling proximity of millionaires — all          for   eighty
 # NSg$/Am    NSg/VB+ . VB/C D   Nᴹ/Vg/J   Nᴹ        P  NPl          . NSg/I/J/C/Dq R/C/P NSg
 > dollars a   month  .
@@ -266,8 +266,8 @@
 # VP/J  NSg NPl+ P    NSg/IPl+ NPr/J/R/P NPr+    .
 >
 #
-> Her     husband , among various physical accomplishments , had been     one     of the most
-# ISg/D$+ NSg/VB+ . P     J+      NSg/J+   NPl+            . VP  NSg/VLPp NSg/I/J P  D   NSg/I/J/R/Dq
+> Her     husband , among various physical accomplishments , had been   one     of the most
+# ISg/D$+ NSg/VB+ . P     J+      NSg/J+   NPl+            . VP  VLPp/B NSg/I/J P  D   NSg/I/J/R/Dq
 > powerful ends    that      ever played football at    New    Haven   — a   national figure  in        a    way    ,
 # J        NPl/V3+ I/C/Ddem+ J/R  VP/J   NSg/VB+  NSg/P NSg/J+ NSg/VB+ . D/P NSg/J    NSg/VB+ NPr/J/R/P D/P+ NSg/J+ .
 > one     of those   men  who    reach  such  an   acute     limited   excellence at    twenty - one     that
@@ -386,8 +386,8 @@
 # NSg/VP/J P    D   NPr/VB+ NSg/P NPr🅪Sg/VB/J NPrPl/V3+ NSg/P I/C    NSg/VB+ . D+  NPrPl/V3+ VLPt VB/J VB/C
 > gleaming white       against the fresh    grass      outside   that      seemed to grow a   little     way
 # Nᴹ/Vg/J  NPr🅪Sg/VB/J C/P     D   NSg/VB/J NPr🅪Sg/VB+ Nᴹ/VB/J/P I/C/Ddem+ VP/J   P  VB   D/P NPr/I/J/Dq NSg/J+
-> into the house   . A    breeze  blew      through the room       , blew      curtains in        at    one      end     and
-# P    D   NPr/VB+ . D/P+ NSg/VB+ NSg/VPt/J J/P     D+  N🅪Sg/VB/J+ . NSg/VPt/J NPl/V3+  NPr/J/R/P NSg/P NSg/I/J+ NSg/VB+ VB/C
+> into the house   . A    breeze  blew      through the room     , blew      curtains in        at    one      end     and
+# P    D   NPr/VB+ . D/P+ NSg/VB+ NSg/VPt/J J/P     D+  N🅪Sg/VB+ . NSg/VPt/J NPl/V3+  NPr/J/R/P NSg/P NSg/I/J+ NSg/VB+ VB/C
 > out          the other    like         pale      flags   , twisting them     up         toward the frosted wedding - cake
 # NSg/VB/J/R/P D   NSg/VB/J NSg/VB/J/C/P NSg/VB/J+ NPl/V3+ . Nᴹ/Vg/J  NSg/IPl+ NSg/VB/J/P J/P    D   VP/J    NSg/Vg+ . N🅪Sg/VB
 > of the ceiling , and  then      rippled over    the wine     - colored     rug       , making  a   shadow    on
@@ -396,20 +396,20 @@
 # NPr/ISg+ R/C/P N🅪Sg/VB+ NPl/VX3 J/P D   NSg+ .
 >
 #
-> The only  completely stationary object  in        the room       was  an  enormous couch   on  which
-# D   J/R/C R          NSg/J      NSg/VB+ NPr/J/R/P D   N🅪Sg/VB/J+ VLPt D/P J        NSg/VB+ J/P I/C+
+> The only  completely stationary object  in        the room     was  an  enormous couch   on  which
+# D   J/R/C R          NSg/J      NSg/VB+ NPr/J/R/P D   N🅪Sg/VB+ VLPt D/P J        NSg/VB+ J/P I/C+
 > two young    women were buoyed up         as    though upon an  anchored balloon . They were
 # NSg NPr/VB/J NPl+  VLPt VP/J   NSg/VB/J/P R/C/P C      P    D/P VP/J     NSg/VB+ . IPl+ VLPt
 > both   in        white       , and  their dresses were rippling and  fluttering as    if    they had
 # I/C/Dq NPr/J/R/P NPr🅪Sg/VB/J . VB/C D$+   NPl/V3+ VLPt Nᴹ/Vg/J  VB/C Nᴹ/Vg/J    R/C/P NSg/C IPl+ VP
-> just been     blown back     in        after a   short      flight     around the house   . I       must    have    stood
-# J/R  NSg/VLPp VPp/J NSg/VB/J NPr/J/R/P P     D/P NPr/VB/J/P N🅪Sg/VB/J+ J/P    D   NPr/VB+ . ISg/#r+ NSg/VXB NSg/VXB VP
+> just been   blown back     in        after a   short      flight     around the house   . I       must    have    stood
+# J/R  VLPp/B VPp/J NSg/VB/J NPr/J/R/P P     D/P NPr/VB/J/P N🅪Sg/VB/J+ J/P    D   NPr/VB+ . ISg/#r+ NSg/VXB NSg/VXB VP
 > for   a    few       moments listening to the whip   and  snap     of the curtains and  the groan
 # R/C/P D/P+ NSg/I/Dq+ NPl+    Nᴹ/Vg/J   P  D   NSg/VB VB/C NSg/VB/J P  D   NPl/V3+  VB/C D   NSg/VB
 > of a   picture on  the wall    . Then      there was  a    boom    as    Tom     Buchanan shut      the rear
 # P  D/P NSg/VB+ J/P D   NPr/VB+ . NSg/J/R/C R+    VLPt D/P+ NSg/VB+ R/C/P NPr/VB+ NPr+     NSg/VBP/J D+  NSg/VB/J+
-> windows   and  the caught wind     died out          about the room       , and  the curtains and  the
-# NPrPl/V3+ VB/C D   VP/J   N🅪Sg/VB+ VP/J NSg/VB/J/R/P J/P   D+  N🅪Sg/VB/J+ . VB/C D   NPl/V3   VB/C D
+> windows   and  the caught wind     died out          about the room     , and  the curtains and  the
+# NPrPl/V3+ VB/C D   VP/J   N🅪Sg/VB+ VP/J NSg/VB/J/R/P J/P   D+  N🅪Sg/VB+ . VB/C D   NPl/V3   VB/C D
 > rugs   and  the two  young     women ballooned slowly to the floor   .
 # NPl/V3 VB/C D+  NSg+ NPr/VB/J+ NPl+  VP/J      R      P  D   NSg/VB+ .
 >
@@ -430,8 +430,8 @@
 # D+  NSg/VB/J+ NSg/VB+ . NPr+  . VP   D/P NSg/VB+ P  NSg/VB . ISg+ VP/J   R        NSg/VB/J P
 > a    conscientious expression — then      she  laughed , an  absurd , charming little      laugh   ,
 # D/P+ J+            N🅪Sg+      . NSg/J/R/C ISg+ VP/J    . D/P NSg/J  . Nᴹ/Vg/J+ NPr/I/J/Dq+ NSg/VB+ .
-> and  I       laughed too and  came      forward  into the room       .
-# VB/C ISg/#r+ VP/J    R   VB/C NSg/VPt/P NSg/VB/J P    D+  N🅪Sg/VB/J+ .
+> and  I       laughed too and  came      forward  into the room     .
+# VB/C ISg/#r+ VP/J    R   VB/C NSg/VPt/P NSg/VB/J P    D+  N🅪Sg/VB+ .
 >
 #
 > “ I’m p         - paralyzed with happiness . ”
@@ -522,8 +522,8 @@
 # . NSg/VB/J/R . ISgPl+ NSg/I/VXB P  NSg/VB ISg/D$+ . K     . .
 >
 #
-> Tom     Buchanan , who    had been     hovering restlessly about the room       , stopped and
-# NPr/VB+ NPr+     . NPr/I+ VP  NSg/VLPp Nᴹ/Vg/J  R          J/P   D   N🅪Sg/VB/J+ . VP/J    VB/C
+> Tom     Buchanan , who    had been   hovering restlessly about the room     , stopped and
+# NPr/VB+ NPr+     . NPr/I+ VP  VLPp/B Nᴹ/Vg/J  R          J/P   D   N🅪Sg/VB+ . VP/J    VB/C
 > rested his     hand    on  my  shoulder .
 # VP/J   ISg/D$+ NSg/VB+ J/P D$+ NSg/VB+  .
 >
@@ -566,22 +566,22 @@
 #
 > At    this    point   Miss   Baker said : “ Absolutely ! ” with such  suddenness that     I
 # NSg/P I/Ddem+ NSg/VB+ NSg/VB NPr+  VP/J . . R          . . P    NSg/I Nᴹ         I/C/Ddem ISg/#r+
-> started — it       was  the first word    she  had uttered since I       came      into the room       .
-# VP/J    . NPr/ISg+ VLPt D   NSg/J NSg/VB+ ISg+ VP  VP/J    C/P   ISg/#r+ NSg/VPt/P P    D   N🅪Sg/VB/J+ .
+> started — it       was  the first word    she  had uttered since I       came      into the room     .
+# VP/J    . NPr/ISg+ VLPt D   NSg/J NSg/VB+ ISg+ VP  VP/J    C/P   ISg/#r+ NSg/VPt/P P    D   N🅪Sg/VB+ .
 > Evidently it       surprised her     as    much         as    it       did  me       , for   she  yawned and  with a
 # R         NPr/ISg+ VP/J      ISg/D$+ R/C/P NSg/I/J/R/Dq R/C/P NPr/ISg+ VXPt NPr/ISg+ . R/C/P ISg+ VP/J   VB/C P    D/P
-> series of rapid , deft movements stood up         into the room       .
-# NSgPl  P  NSg/J . J    NPl+      VP    NSg/VB/J/P P    D   N🅪Sg/VB/J+ .
+> series of rapid , deft movements stood up         into the room     .
+# NSgPl  P  NSg/J . J    NPl+      VP    NSg/VB/J/P P    D   N🅪Sg/VB+ .
 >
 #
-> “ I’m stiff    , ” she  complained , “ I’ve been     lying   on  that     sofa    for   as    long     as    I       can
-# . K   NSg/VB/J . . ISg+ VP/J       . . K    NSg/VLPp Nᴹ/Vg/J J/P I/C/Ddem NSg/VB+ R/C/P R/C/P NPr/VB/J R/C/P ISg/#r+ NPr/VXB
+> “ I’m stiff    , ” she  complained , “ I’ve been   lying   on  that     sofa    for   as    long     as    I       can
+# . K   NSg/VB/J . . ISg+ VP/J       . . K    VLPp/B Nᴹ/Vg/J J/P I/C/Ddem NSg/VB+ R/C/P R/C/P NPr/VB/J R/C/P ISg/#r+ NPr/VXB
 > remember . ”
 # NSg/VB   . .
 >
 #
-> “ Don’t look   at    me       , ” Daisy retorted , “ ‘ I’ve been     trying  to get    you    to New   York
-# . VXB   NSg/VB NSg/P NPr/ISg+ . . NPr+  VP/J     . . . K    NSg/VLPp Nᴹ/Vg/J P  NSg/VB ISgPl+ P  NSg/J NPr+
+> “ Don’t look   at    me       , ” Daisy retorted , “ ‘ I’ve been   trying  to get    you    to New   York
+# . VXB   NSg/VB NSg/P NPr/ISg+ . . NPr+  VP/J     . . . K    VLPp/B Nᴹ/Vg/J P  NSg/VB ISgPl+ P  NSg/J NPr+
 > all          afternoon . ”
 # NSg/I/J/C/Dq N🅪Sg+     . .
 >
@@ -634,8 +634,8 @@
 #
 > Before I       could   reply   that      he       was  my  neighbor     dinner   was  announced ; wedging his
 # C/P    ISg/#r+ NSg/VXB NSg/VB+ I/C/Ddem+ NPr/ISg+ VLPt D$+ NSg/VB/J/Am+ N🅪Sg/VB+ VLPt VP/J      . Nᴹ/Vg/J ISg/D$+
-> tense    arm       imperatively under   mine      , Tom     Buchanan compelled me       from the room       as
-# NSg/VB/J NSg/VB/J+ R            NSg/J/P NSg/I/VB+ . NPr/VB+ NPr+     VP/J      NPr/ISg+ P    D   N🅪Sg/VB/J+ R/C/P
+> tense    arm       imperatively under   mine      , Tom     Buchanan compelled me       from the room     as
+# NSg/VB/J NSg/VB/J+ R            NSg/J/P NSg/I/VB+ . NPr/VB+ NPr+     VP/J      NPr/ISg+ P    D   N🅪Sg/VB+ R/C/P
 > though he       were moving  a   checker to another square   .
 # C      NPr/ISg+ VLPt Nᴹ/Vg/J D/P NSg/VB  P  I/D     NSg/VB/J .
 >
@@ -748,8 +748,8 @@
 # . NSg/VB/J/R . K    D/P+ NSg/VB/J NSg/VB+ . VB/C NSg/I+    NSg/I/VXB P  NSg/VBP NPr/ISg+ . D+  NSg+ VL3 NSg/C IPl+ VXB
 > look   out          the white       race     will    be       — will    be       utterly submerged . It’s all           scientific
 # NSg/VB NSg/VB/J/R/P D   NPr🅪Sg/VB/J N🅪Sg/VB+ NPr/VXB NSg/VLXB . NPr/VXB NSg/VLXB R       VP/J      . K    NSg/I/J/C/Dq+ J
-> stuff  ; it’s been     proved . ”
-# Nᴹ/VB+ . K    NSg/VLPp VP/J   . .
+> stuff  ; it’s been   proved . ”
+# Nᴹ/VB+ . K    VLPp/B VP/J   . .
 >
 #
 > “ Tom’s getting very profound , ” said Daisy , with an  expression of unthoughtful
@@ -868,10 +868,10 @@
 #
 > Miss   Baker and  I       exchanged a    short       glance  consciously devoid of meaning    . I       was
 # NSg/VB NPr+  VB/C ISg/#r+ VP/J      D/P+ NPr/VB/J/P+ NSg/VB+ R           VB/J   P  N🅪Sg/Vg/J+ . ISg/#r+ VLPt
-> about to speak  when    she  sat      up         alertly and  said “ Sh ! ” in        a    warning    voice   . A
-# J/P   P  NSg/VB NSg/I/C ISg+ NSg/VP/J NSg/VB/J/P R       VB/C VP/J . W? . . NPr/J/R/P D/P+ N🅪Sg/Vg/J+ NSg/VB+ . D/P
-> subdued impassioned murmur was  audible  in        the room       beyond , and  Miss   Baker leaned
-# VP/J    J           NSg/VB VLPt NSg/VB/J NPr/J/R/P D   N🅪Sg/VB/J+ NSg/P  . VB/C NSg/VB NPr+  VP/J
+> about to speak  when    she  sat    up         alertly and  said “ Sh ! ” in        a    warning    voice   . A
+# J/P   P  NSg/VB NSg/I/C ISg+ NSg/VP NSg/VB/J/P R       VB/C VP/J . W? . . NPr/J/R/P D/P+ N🅪Sg/Vg/J+ NSg/VB+ . D/P
+> subdued impassioned murmur was  audible  in        the room     beyond , and  Miss   Baker leaned
+# VP/J    J           NSg/VB VLPt NSg/VB/J NPr/J/R/P D   N🅪Sg/VB+ NSg/P  . VB/C NSg/VB NPr+  VP/J
 > forward  unashamed , trying  to hear . The murmur trembled on  the verge  of
 # NSg/VB/J J         . Nᴹ/Vg/J P  VB   . D   NSg/VB VP/J     J/P D   NSg/VB P
 > coherence , sank down        , mounted excitedly , and  then      ceased altogether .
@@ -928,8 +928,8 @@
 # . NPr/ISg+ VXB      NSg/VLXB VP/J   . . VP/J  NPr+  P    NSg/VB/J ?      .
 >
 #
-> She  sat      down        , glanced searchingly at    Miss   Baker and  then      at    me       , and  continued :
-# ISg+ NSg/VP/J N🅪Sg/VB/J/P . VP/J    R           NSg/P NSg/VB NPr+  VB/C NSg/J/R/C NSg/P NPr/ISg+ . VB/C VP/J      .
+> She  sat    down        , glanced searchingly at    Miss   Baker and  then      at    me       , and  continued :
+# ISg+ NSg/VP N🅪Sg/VB/J/P . VP/J    R           NSg/P NSg/VB NPr+  VB/C NSg/J/R/C NSg/P NPr/ISg+ . VB/C VP/J      .
 > “ I       looked outdoors for   a   minute    , and  it’s very romantic outdoors . There’s a   bird
 # . ISg/#r+ VP/J   NSg/R    R/C/P D/P NSg/VB/J+ . VB/C K    J/R  NSg/J    NSg/R    . K       D/P NPr/VB/J+
 > on  the lawn    that      I       think  must    be       a   nightingale come       over    on  the Cunard or    White
@@ -972,8 +972,8 @@
 # D/P NSg/VB P      D/P R         NSg/J    NSg/VB+ . NSg/VB/C/P . Nᴹ/Vg/J P  NSg/VB R
 > interested and  a   little     deaf     , I       followed Daisy around a   chain   of connecting
 # VP/J       VB/C D/P NPr/I/J/Dq NSg/VB/J . ISg/#r+ VP/J     NPr+  J/P    D/P N🅪Sg/VB P  Nᴹ/Vg/J
-> verandas    to the porch in        front     . In        its     deep   gloom  we   sat      down        side      by    side      on  a
-# NPl/NoAm/Br P  D   NSg+  NPr/J/R/P NSg/VB/J+ . NPr/J/R/P ISg/D$+ NSg/J+ Nᴹ/VB+ IPl+ NSg/VP/J N🅪Sg/VB/J/P NSg/VB/J+ NSg/P NSg/VB/J+ J/P D/P
+> verandas    to the porch in        front     . In        its     deep   gloom  we   sat    down        side      by    side      on  a
+# NPl/NoAm/Br P  D   NSg+  NPr/J/R/P NSg/VB/J+ . NPr/J/R/P ISg/D$+ NSg/J+ Nᴹ/VB+ IPl+ NSg/VP N🅪Sg/VB/J/P NSg/VB/J+ NSg/P NSg/VB/J+ J/P D/P
 > wicker settee .
 # NSg/JC NSg    .
 >
@@ -1040,8 +1040,8 @@
 #
 > “ You    see    I       think  everything’s terrible anyhow , ” she  went    on  in        a   convinced way    .
 # . ISgPl+ NSg/VB ISg/#r+ NSg/VB NSg$         J        J      . . ISg+ NSg/VPt J/P NPr/J/R/P D/P VP/J      NSg/J+ .
-> “ Everybody thinks so          — the most         advanced people  . And  I       know . I’ve been     everywhere
-# . NSg/I+    NPl/V3 NSg/I/J/R/C . D   NSg/I/J/R/Dq VP/J+    NPl/VB+ . VB/C ISg/#r+ VB   . K    NSg/VLPp Nᴹ/R
+> “ Everybody thinks so          — the most         advanced people  . And  I       know . I’ve been   everywhere
+# . NSg/I+    NPl/V3 NSg/I/J/R/C . D   NSg/I/J/R/Dq VP/J+    NPl/VB+ . VB/C ISg/#r+ VB   . K    VLPp/B Nᴹ/R
 > and  seen    everything and  done      everything . ” Her     eyes    flashed around her     in        a
 # VB/C NSg/VPp NSg/I/VB+  VB/C NSg/VPp/J NSg/I/VB+  . . ISg/D$+ NPl/V3+ VP/J    J/P    ISg/D$+ NPr/J/R/P D/P
 > defiant way    , rather     like         Tom’s , and  she  laughed with thrilling scorn   .
@@ -1054,8 +1054,8 @@
 # D+  NSg/VB/J+ ISg/D$+ NSg/VB+ NSg/VPt/J NSg/VB/J/P . Nᴹ/Vg/J P  VB     D$+ NSg+      . D$+ N🅪Sg+  . ISg/#r+
 > felt      the basic insincerity of what   she  had said . It       made me       uneasy   , as    though
 # N🅪Sg/VP/J D   NPr/J Nᴹ          P  NSg/I+ ISg+ VP  VP/J . NPr/ISg+ VP   NPr/ISg+ NSg/VB/J . R/C/P C
-> the whole  evening    had been     a   trick    of some      sort    to exact a   contributary emotion
-# D+  NSg/J+ N🅪Sg/Vg/J+ VP  NSg/VLPp D/P NSg/VB/J P  I/J/R/Dq+ NSg/VB+ P  VB/J  D/P ?            N🅪Sg+
+> the whole  evening    had been   a   trick    of some      sort    to exact a   contributary emotion
+# D+  NSg/J+ N🅪Sg/Vg/J+ VP  VLPp/B D/P NSg/VB/J P  I/J/R/Dq+ NSg/VB+ P  VB/J  D/P ?            N🅪Sg+
 > from me       . I       waited , and  sure enough , in        a    moment she  looked at    me       with an
 # P    NPr/ISg+ . ISg/#r+ VP/J   . VB/C J    NSg/I  . NPr/J/R/P D/P+ NSg+   ISg+ VP/J   NSg/P NPr/ISg+ P    D/P+
 > absolute smirk     on  her     lovely face    , as    if    she  had asserted her     membership in        a
@@ -1064,8 +1064,8 @@
 # NPr/VB/J/R VP/J          NSg/VB/J N🅪Sg    P  I/C+  ISg+ VB/C NPr/VB+ VP/J     .
 >
 #
-> Inside  , the crimson   room       bloomed with light      . Tom     and  Miss   Baker sat      at    either
-# NSg/J/P . D+  NSg/VB/J+ N🅪Sg/VB/J+ VP/J    P    N🅪Sg/VB/J+ . NPr/VB+ VB/C NSg/VB NPr+  NSg/VP/J NSg/P I/C
+> Inside  , the crimson   room     bloomed with light      . Tom     and  Miss   Baker sat    at    either
+# NSg/J/P . D+  NSg/VB/J+ N🅪Sg/VB+ VP/J    P    N🅪Sg/VB/J+ . NPr/VB+ VB/C NSg/VB NPr+  NSg/VP NSg/P I/C
 > end    of the long      couch   and  she  read    aloud to him  from the Saturday Evening
 # NSg/VB P  D+  NPr/VB/J+ NSg/VB+ VB/C ISg+ NSg/VBP J     P  ISg+ P    D+  NSg/VB+  N🅪Sg/Vg/J+
 > Post         — the words   , murmurous and  uninflected , running   together in        a   soothing tune    .
@@ -1245,7 +1245,7 @@
 > there were no       such  intentions in        her     head      . As    for   Tom     , the fact that      he       “ had
 # R+    VLPt NSg/Dq/P NSg/I NPl/V3+    NPr/J/R/P ISg/D$+ NPr/VB/J+ . R/C/P R/C/P NPr/VB+ . D+  NSg+ I/C/Ddem+ NPr/ISg+ . VP
 > some     woman  in        New    York ” was  really less    surprising than that     he       had been
-# I/J/R/Dq NSg/VB NPr/J/R/P NSg/J+ NPr+ . VLPt R      J/R/C/P Nᴹ/Vg/J    C/P  I/C/Ddem NPr/ISg+ VP  NSg/VLPp
+# I/J/R/Dq NSg/VB NPr/J/R/P NSg/J+ NPr+ . VLPt R      J/R/C/P Nᴹ/Vg/J    C/P  I/C/Ddem NPr/ISg+ VP  VLPp/B
 > depressed by    a    book    . Something was  making  him  nibble at    the edge   of stale     ideas
 # VP/J      NSg/P D/P+ NSg/VB+ . NSg/I/J+  VLPt Nᴹ/Vg/J ISg+ NSg/VB NSg/P D   NSg/VB P  NSg/VB/J+ NPl+
 > as    if    his     sturdy physical egotism no       longer nourished his     peremptory heart    .
@@ -1254,10 +1254,10 @@
 #
 > Already it       was  deep  summer    on  roadhouse roofs   and  in        front     of wayside garages ,
 # R       NPr/ISg+ VLPt NSg/J NPr🅪Sg/VB J/P NSg+      NPl/V3+ VB/C NPr/J/R/P NSg/VB/J+ P  NSg/J   NPl/V3  .
-> where   new   red    gaspumps sat      out          in        pools  of light      , and  when    I       reached my  estate
-# NSg/R/C NSg/J N🅪Sg/J ?        NSg/VP/J NSg/VB/J/R/P NPr/J/R/P NPl/V3 P  N🅪Sg/VB/J+ . VB/C NSg/I/C ISg/#r+ VP/J    D$+ NSg/VB/J+
-> at    West      Egg      I       ran the car  under   its     shed    and  sat      for   a   while       on  an  abandoned
-# NSg/P NPr/VB/J+ N🅪Sg/VB+ ISg/#r+ VPt D   NSg+ NSg/J/P ISg/D$+ NSg/VP+ VB/C NSg/VP/J R/C/P D/P NSg/VB/C/P+ J/P D/P VP/J
+> where   new   red    gaspumps sat    out          in        pools  of light      , and  when    I       reached my  estate
+# NSg/R/C NSg/J N🅪Sg/J ?        NSg/VP NSg/VB/J/R/P NPr/J/R/P NPl/V3 P  N🅪Sg/VB/J+ . VB/C NSg/I/C ISg/#r+ VP/J    D$+ NSg/VB/J+
+> at    West      Egg      I       ran the car  under   its     shed    and  sat    for   a   while       on  an  abandoned
+# NSg/P NPr/VB/J+ N🅪Sg/VB+ ISg/#r+ VPt D   NSg+ NSg/J/P ISg/D$+ NSg/VP+ VB/C NSg/VP R/C/P D/P NSg/VB/C/P+ J/P D/P VP/J
 > grass      roller in        the yard    . The wind     had blown off        , leaving a   loud  , bright   night    ,
 # NPr🅪Sg/VB+ NSg/VB NPr/J/R/P D   NSg/VB+ . D+  N🅪Sg/VB+ VP  VPp/J NSg/VB/J/P . Nᴹ/Vg/J D/P NSg/J . NPr/VB/J N🅪Sg/VB+ .
 > with wings   beating in        the trees   and  a   persistent organ  sound      as    the full     bellows
@@ -1288,8 +1288,8 @@
 # NSg/VB/J N🅪Sg/VB+ NPr/J/R/P D/P J       NSg/J+ . VB/C . NSg/VB/J R/C/P ISg/#r+ VLPt P    ISg+ . ISg/#r+ NSg/VXB NSg/VXB VB/J  NPr/ISg+
 > was  trembling . Involuntarily I       glanced seaward — and  distinguished nothing  except
 # VLPt Nᴹ/Vg/J   . R             ISg/#r+ VP/J    NSg/J   . VB/C VP/J          NSg/I/J+ VB/C/P
-> a   single   green       light      , minute    and  far      away , that      might    have    been     the end    of a
-# D/P NSg/VB/J NPr🅪Sg/VB/J N🅪Sg/VB/J+ . NSg/VB/J+ VB/C NSg/VB/J VB/J . I/C/Ddem+ Nᴹ/VXB/J NSg/VXB NSg/VLPp D   NSg/VB P  D/P
+> a   single   green       light      , minute    and  far      away , that      might    have    been   the end    of a
+# D/P NSg/VB/J NPr🅪Sg/VB/J N🅪Sg/VB/J+ . NSg/VB/J+ VB/C NSg/VB/J VB/J . I/C/Ddem+ Nᴹ/VXB/J NSg/VXB VLPp/B D   NSg/VB P  D/P
 > dock    . When    I       looked once  more         for   Gatsby he       had vanished , and  I       was  alone again
 # NSg/VB+ . NSg/I/C ISg/#r+ VP/J   NSg/C NPr/I/J/R/Dq R/C/P NPr    NPr/ISg+ VP  VP/J     . VB/C ISg/#r+ VLPt J     P
 > in        the unquiet darkness .
@@ -1532,8 +1532,8 @@
 #
 > So          Tom     Buchanan and  his     girl    and  I       went    up         together to New    York — or    not     quite
 # NSg/I/J/R/C NPr/VB+ NPr+     VB/C ISg/D$+ NSg/VB+ VB/C ISg/#r+ NSg/VPt NSg/VB/J/P J        P  NSg/J+ NPr+ . NPr/C NSg/R/C R
-> together , for   Mrs  . Wilson sat      discreetly in        another car  . Tom     deferred that      much
-# J        . R/C/P NPl+ . NPr+   NSg/VP/J R          NPr/J/R/P I/D     NSg+ . NPr/VB+ NSg/VP/J I/C/Ddem+ NSg/I/J/R/Dq
+> together , for   Mrs  . Wilson sat    discreetly in        another car  . Tom     deferred that      much
+# J        . R/C/P NPl+ . NPr+   NSg/VP R          NPr/J/R/P I/D     NSg+ . NPr/VB+ NSg/VP/J I/C/Ddem+ NSg/I/J/R/Dq
 > to the sensibilities of those  East   Eggers who    might    be       on  the train   .
 # P  D   NPl           P  I/Ddem NPr/J+ ?      NPr/I+ Nᴹ/VXB/J NSg/VLXB J/P D   NSg/VB+ .
 >
@@ -1636,8 +1636,8 @@
 #
 > We   drove   over    to Fifth     Avenue , warm     and  soft  , almost pastoral , on  the summer
 # IPl+ NSg/VPt NSg/J/P P  NSg/VB/J+ NSg+   . NSg/VB/J VB/C NSg/J . R      NSg/J    . J/P D   NPr🅪Sg/VB+
-> Sunday  afternoon . I       wouldn’t have    been     surprised to see    a   great flock  of white
-# NSg/VB+ N🅪Sg+     . ISg/#r+ VXB      NSg/VXB NSg/VLPp VP/J      P  NSg/VB D/P NSg/J NSg/VB P  NPr🅪Sg/VB/J
+> Sunday  afternoon . I       wouldn’t have    been   surprised to see    a   great flock  of white
+# NSg/VB+ N🅪Sg+     . ISg/#r+ VXB      NSg/VXB VLPp/B VP/J      P  NSg/VB D/P NSg/J NSg/VB P  NPr🅪Sg/VB/J
 > sheep  turn   the corner  .
 # NSgPl+ NSg/VB D   NSg/VB+ .
 >
@@ -1678,10 +1678,10 @@
 # NSg/VB+  . . VB/C . P  NSg/VB+ . ISg/#r+ VP  P  NSg/VB NSg/VB/J/P D$+ NSg/VB+ . R   . .
 >
 #
-> The apartment was  on  the top       floor   — a   small    living     - room      , a   small    dining   - room      , a
-# D+  NSg+      VLPt J/P D   NSg/VB/J+ NSg/VB+ . D/P NPr/VB/J N🅪Sg/Vg/J+ . N🅪Sg/VB/J . D/P NPr/VB/J Nᴹ/Vg/J+ . N🅪Sg/VB/J . D/P+
-> small     bedroom , and  a    bath    . The living     - room       was  crowded to the doors  with a   set
-# NPr/VB/J+ NSg+    . VB/C D/P+ NSg/VB+ . D+  N🅪Sg/Vg/J+ . N🅪Sg/VB/J+ VLPt VP/J    P  D   NPl/V3 P    D/P NPr/VBP/J
+> The apartment was  on  the top       floor   — a   small    living     - room    , a   small    dining   - room    , a
+# D+  NSg+      VLPt J/P D   NSg/VB/J+ NSg/VB+ . D/P NPr/VB/J N🅪Sg/Vg/J+ . N🅪Sg/VB . D/P NPr/VB/J Nᴹ/Vg/J+ . N🅪Sg/VB . D/P+
+> small     bedroom , and  a    bath    . The living     - room     was  crowded to the doors  with a   set
+# NPr/VB/J+ NSg+    . VB/C D/P+ NSg/VB+ . D+  N🅪Sg/Vg/J+ . N🅪Sg/VB+ VLPt VP/J    P  D   NPl/V3 P    D/P NPr/VBP/J
 > of tapestried furniture entirely too large for   it       , so          that      to move   about was  to
 # P  J          Nᴹ+       R        R   NSg/J R/C/P NPr/ISg+ . NSg/I/J/R/C I/C/Ddem+ P  NSg/VB J/P   VLPt P
 > stumble continually over    scenes of ladies  swinging in        the gardens of Versailles .
@@ -1690,8 +1690,8 @@
 # D+  J/R/C+ NSg/VB+ VLPt D/P NSg/J/P . VP/J     NSg/VB+    . R          D/P NSg/VB NSg/Vg/J J/P D/P
 > blurred rock       . Looked at    from a    distance , however , the hen    resolved itself into a
 # VP/J    NPr🅪Sg/VB+ . VP/J   NSg/P P    D/P+ N🅪Sg/VB+ . C       . D   NSg/VB VP/J     ISg+   P    D/P
-> bonnet , and  the countenance of a   stout     old   lady    beamed down        into the room       .
-# NSg/VB . VB/C D   NSg/VB      P  D/P NPr/VB/J+ NSg/J NPr/VB+ VP/J   N🅪Sg/VB/J/P P    D   N🅪Sg/VB/J+ .
+> bonnet , and  the countenance of a   stout     old   lady    beamed down        into the room     .
+# NSg/VB . VB/C D   NSg/VB      P  D/P NPr/VB/J+ NSg/J NPr/VB+ VP/J   N🅪Sg/VB/J/P P    D   N🅪Sg/VB+ .
 > Several old   copies of Town Tattle lay        on  the table   together with a   copy   of
 # J/Dq    NSg/J NPl/V3 P  NSg+ NSg/VB NSg/VBPt/J J/P D   NSg/VB+ J        P    D/P NSg/VB P
 > “ Simon Called Peter      , ” and  some     of the small    scandal  magazines of Broadway . Mrs  .
@@ -1708,8 +1708,8 @@
 # NSg+   NSg/VB+ .
 >
 #
-> I       have    been     drunk     just twice in        my  life     , and  the second    time       was  that     afternoon ;
-# ISg/#r+ NSg/VXB NSg/VLPp NSg/VPp/J J/R  R     NPr/J/R/P D$+ N🅪Sg/VB+ . VB/C D+  NSg/VB/J+ N🅪Sg/VB/J+ VLPt I/C/Ddem N🅪Sg+     .
+> I       have    been   drunk     just twice in        my  life     , and  the second    time       was  that     afternoon ;
+# ISg/#r+ NSg/VXB VLPp/B NSg/VPp/J J/R  R     NPr/J/R/P D$+ N🅪Sg/VB+ . VB/C D+  NSg/VB/J+ N🅪Sg/VB/J+ VLPt I/C/Ddem N🅪Sg+     .
 > so          everything that      happened has a   dim      , hazy  cast     over    it       , although until after
 # NSg/I/J/R/C NSg/I/VB+  I/C/Ddem+ VP/J     V3  D/P NSg/VB/J . NSg/J NSg/VB/J NSg/J/P NPr/ISg+ . C        C/P   P
 > eight o’clock the apartment was  full     of cheerful sun     . Sitting  on  Tom’s lap       Mrs  .
@@ -1718,8 +1718,8 @@
 # NPr+   VP/J   NSg/VB/J/P J/Dq    NPl/VB+ J/P D+  NSg/VB+   . NSg/J/R/C R+    VLPt NSg/Dq/P+ NPl/V3+    .
 > and  I       went    out          to buy    some     at    the drugstore on  the corner  . When    I       came      back     they
 # VB/C ISg/#r+ NSg/VPt NSg/VB/J/R/P P  NSg/VB I/J/R/Dq NSg/P D   NSg       J/P D   NSg/VB+ . NSg/I/C ISg/#r+ NSg/VPt/P NSg/VB/J IPl+
-> had both   disappeared , so          I       sat      down        discreetly in        the living     - room       and  read    a
-# VP  I/C/Dq VP/J        . NSg/I/J/R/C ISg/#r+ NSg/VP/J N🅪Sg/VB/J/P R          NPr/J/R/P D   N🅪Sg/Vg/J+ . N🅪Sg/VB/J+ VB/C NSg/VBP D/P
+> had both   disappeared , so          I       sat    down        discreetly in        the living     - room     and  read    a
+# VP  I/C/Dq VP/J        . NSg/I/J/R/C ISg/#r+ NSg/VP N🅪Sg/VB/J/P R          NPr/J/R/P D   N🅪Sg/Vg/J+ . N🅪Sg/VB+ VB/C NSg/VBP D/P
 > chapter of “ Simon Called Peter      ” — either it       was  terrible stuff  or    the whiskey
 # NSg/VB  P  . NPr+  VP/J   NPr/VB/JC+ . . I/C    NPr/ISg+ VLPt J        Nᴹ/VB+ NPr/C D   N🅪Sg
 > distorted things , because it       didn’t make   any    sense    to me       .
@@ -1738,8 +1738,8 @@
 # D+  NSg/VB+ . NPr+      . VLPt D/P J       . J       NSg/VB+ P  J/P   NSg    . P    D/P
 > solid , sticky   bob    of red    hair     , and  a   complexion powdered milky white       . Her
 # NSg/J . NSg/VB/J NPr/VB P  N🅪Sg/J N🅪Sg/VB+ . VB/C D/P NSg/VB+    VP/J     J     NPr🅪Sg/VB/J . ISg/D$+
-> eyebrows had been     plucked and  then      drawn on  again at    a   more         rakish angle   , but
-# NPl/V3+  VP  NSg/VLPp VP/J    VB/C NSg/J/R/C VPp/J J/P P     NSg/P D/P NPr/I/J/R/Dq J      NSg/VB+ . NSg/C/P
+> eyebrows had been   plucked and  then      drawn on  again at    a   more         rakish angle   , but
+# NPl/V3+  VP  VLPp/B VP/J    VB/C NSg/J/R/C VPp/J J/P P     NSg/P D/P NPr/I/J/R/Dq J      NSg/VB+ . NSg/C/P
 > the efforts of nature   toward the restoration of the old   alignment gave a   blurred
 # D   NPl/V3  P  N🅪Sg/VB+ J/P    D   NPr🅪Sg      P  D   NSg/J N🅪Sg+     VPt  D/P VP/J
 > air      to her     face    . When    she  moved about there was  an  incessant clicking as
@@ -1760,8 +1760,8 @@
 # NSg+ . NPr   VLPt D/P NSg/VB/J . NSg/J    NPr/VB+ P    D   NSg/VB/J P     . NPr/ISg+ VP  J/R  VP/J   . R/C/P
 > there was  a   white       spot     of lather on  his     cheekbone , and  he       was  most         respectful in
 # R+    VLPt D/P NPr🅪Sg/VB/J NSg/VB/J P  Nᴹ/VB  J/P ISg/D$+ NSg       . VB/C NPr/ISg+ VLPt NSg/I/J/R/Dq J          NPr/J/R/P
-> his     greeting to every one      in        the room       . He       informed me       that     he       was  in        the
-# ISg/D$+ Nᴹ/Vg/J+ P  Dq    NSg/I/J+ NPr/J/R/P D   N🅪Sg/VB/J+ . NPr/ISg+ VP/J     NPr/ISg+ I/C/Ddem NPr/ISg+ VLPt NPr/J/R/P D
+> his     greeting to every one      in        the room     . He       informed me       that     he       was  in        the
+# ISg/D$+ Nᴹ/Vg/J+ P  Dq    NSg/I/J+ NPr/J/R/P D   N🅪Sg/VB+ . NPr/ISg+ VP/J     NPr/ISg+ I/C/Ddem NPr/ISg+ VLPt NPr/J/R/P D
 > “ artistic game      , ” and  I       gathered later that     he       was  a   photographer and  had made
 # . J+       NSg/VB/J+ . . VB/C ISg/#r+ VP/J     JC    I/C/Ddem NPr/ISg+ VLPt D/P NSg          VB/C VP  VP
 > the dim      enlargement of Mrs  . Wilson’s mother    which hovered like         an  ectoplasm on
@@ -1770,24 +1770,24 @@
 # D   NPr/VB+ . ISg/D$+ NSg/VB/J+ VLPt NSg/VB/J . NSg/J   . VB/J     . VB/C NSg/J    . ISg+ VP   NPr/ISg+ P
 > pride  that      her     husband had photographed her     a   hundred and  twenty - seven times
 # Nᴹ/VB+ I/C/Ddem+ ISg/D$+ NSg/VB+ VP  VP/J         ISg/D$+ D/P NSg     VB/C NSg    . NSg   NPl/V3
-> since they had been     married  .
-# C/P   IPl+ VP  NSg/VLPp NSg/VP/J .
+> since they had been   married  .
+# C/P   IPl+ VP  VLPp/B NSg/VP/J .
 >
 #
 > Mrs  . Wilson had changed her     costume some      time       before , and  was  now       attired in        an
 # NPl+ . NPr+   VP  VP/J    ISg/D$+ NSg/VB  I/J/R/Dq+ N🅪Sg/VB/J+ C/P    . VB/C VLPt NSg/J/R/C VP/J    NPr/J/R/P D/P
 > elaborate afternoon dress  of cream      - colored     chiffon , which gave out          a   continual
 # VB/J      N🅪Sg+     NSg/VB P  N🅪Sg/VB/J+ . NSg/VP/J/Am NSg     . I/C+  VPt  NSg/VB/J/R/P D/P J
-> rustle as    she  swept about the room       . With the influence of the dress   her
-# NSg/VB R/C/P ISg+ VP/J  J/P   D   N🅪Sg/VB/J+ . P    D   N🅪Sg/VB   P  D+  NSg/VB+ ISg/D$+
-> personality had also undergone a    change   . The intense vitality that      had been     so
-# N🅪Sg+       VP  R/C  VPp       D/P+ N🅪Sg/VB+ . D+  J+      Nᴹ+      I/C/Ddem+ VP  NSg/VLPp NSg/I/J/R/C
+> rustle as    she  swept about the room     . With the influence of the dress   her
+# NSg/VB R/C/P ISg+ VP/J  J/P   D   N🅪Sg/VB+ . P    D   N🅪Sg/VB   P  D+  NSg/VB+ ISg/D$+
+> personality had also undergone a    change   . The intense vitality that      had been   so
+# N🅪Sg+       VP  R/C  VPp       D/P+ N🅪Sg/VB+ . D+  J+      Nᴹ+      I/C/Ddem+ VP  VLPp/B NSg/I/J/R/C
 > remarkable in        the garage  was  converted into impressive hauteur . Her     laughter ,
 # J          NPr/J/R/P D+  NSg/VB+ VLPt VP/J      P    J          NSg     . ISg/D$+ Nᴹ+      .
 > her     gestures , her     assertions became more         violently affected moment by    moment ,
 # ISg/D$+ NPl/V3+  . ISg/D$+ NSg+       VPt    NPr/I/J/R/Dq R         NSg/VP/J NSg+   NSg/P NSg+   .
-> and  as    she  expanded the room       grew smaller around her     , until she  seemed to be
-# VB/C R/C/P ISg+ VP/J     D+  N🅪Sg/VB/J+ VPt  NSg/JC  J/P    ISg/D$+ . C/P   ISg+ VP/J   P  NSg/VLXB
+> and  as    she  expanded the room     grew smaller around her     , until she  seemed to be
+# VB/C R/C/P ISg+ VP/J     D+  N🅪Sg/VB+ VPt  NSg/JC  J/P    ISg/D$+ . C/P   ISg+ VP/J   P  NSg/VLXB
 > revolving on  a   noisy , creaking pivot  through the smoky air      .
 # Nᴹ/Vg/J   J/P D/P J     . Nᴹ/Vg/J+ NSg/VB J/P     D   J     N🅪Sg/VB+ .
 >
@@ -1902,8 +1902,8 @@
 # . ?       NSg/VB+ . D   NSg+ . . .
 >
 #
-> The sister  Catherine sat      down        beside me       on  the couch   .
-# D+  NSg/VB+ NPr+      NSg/VP/J N🅪Sg/VB/J/P P      NPr/ISg+ J/P D+  NSg/VB+ .
+> The sister  Catherine sat    down        beside me       on  the couch   .
+# D+  NSg/VB+ NPr+      NSg/VP N🅪Sg/VB/J/P P      NPr/ISg+ J/P D+  NSg/VB+ .
 >
 #
 > “ Do  you    live down        on  Long      Island  , too , ” she  inquired .
@@ -2066,14 +2066,14 @@
 # D+  NSg/J+ N🅪Sg+     N🅪Sg/VB+ VP/J    NPr/J/R/P D   NSg/VB+ R/C/P D/P NSg+   NSg/VB/J/C/P D   N🅪Sg/VB/J N🅪Sg/VB/J P
 > the Mediterranean — then      the shrill   voice  of Mrs  . McKee called me       back     into the
 # D   NPr/J+        . NSg/J/R/C D   NSg/VB/J NSg/VB P  NPl+ . NPr   VP/J   NPr/ISg+ NSg/VB/J P    D
-> room       .
-# N🅪Sg/VB/J+ .
+> room     .
+# N🅪Sg/VB+ .
 >
 #
 > “ I       almost made a    mistake , too , ” she  declared vigorously . “ I       almost married  a
 # . ISg/#r+ R      VP   D/P+ NSg/VB+ . R   . . ISg+ VP/J     R          . . ISg/#r+ R      NSg/VP/J D/P
-> little     kyke who’d been     after me       for   years . I       knew he       was  below me       . Everybody
-# NPr/I/J/Dq ?    K     NSg/VLPp P     NPr/ISg+ R/C/P NPl+  . ISg/#r+ VPt  NPr/ISg+ VLPt P     NPr/ISg+ . NSg/I+
+> little     kyke who’d been   after me       for   years . I       knew he       was  below me       . Everybody
+# NPr/I/J/Dq ?    K     VLPp/B P     NPr/ISg+ R/C/P NPl+  . ISg/#r+ VPt  NPr/ISg+ VLPt P     NPr/ISg+ . NSg/I+
 > kept saying    to me       : ‘ Lucille , that      man’s    ’ way    below you    ! ’ But     if    I       hadn’t met
 # VP   N🅪Sg/Vg/J P  NPr/ISg+ . . NPr+    . I/C/Ddem+ NPr$/I/J . NSg/J+ P     ISgPl+ . . NSg/C/P NSg/C ISg/#r+ VPt    VP
 > Chester , he’d of got me       sure . ”
@@ -2139,7 +2139,7 @@
 >
 #
 > “ She  really ought     to get    away from him  , ” resumed Catherine to me       . “ They’ve been
-# . ISg+ R      NSg/I/VXB P  NSg/VB VB/J P    ISg+ . . VP/J    NPr+      P  NPr/ISg+ . . K       NSg/VLPp
+# . ISg+ R      NSg/I/VXB P  NSg/VB VB/J P    ISg+ . . VP/J    NPr+      P  NPr/ISg+ . . K       VLPp/B
 > living    over    that     garage  for   eleven years . And  Tom’s the first sweetie she  ever
 # N🅪Sg/Vg/J NSg/J/P I/C/Ddem NSg/VB+ R/C/P NSg    NPl+  . VB/C NPr$  D   NSg/J NSg     ISg+ J/R
 > had . ”
@@ -2196,8 +2196,8 @@
 # NSg/J   . . .
 >
 #
-> She  turned to Mrs . McKee and  the room       rang full     of her     artificial laughter .
-# ISg+ VP/J   P  NPl . NPr   VB/C D   N🅪Sg/VB/J+ VPt  NSg/VB/J P  ISg/D$+ J          Nᴹ+      .
+> She  turned to Mrs . McKee and  the room     rang full     of her     artificial laughter .
+# ISg+ VP/J   P  NPl . NPr   VB/C D   N🅪Sg/VB+ VPt  NSg/VB/J P  ISg/D$+ J          Nᴹ+      .
 >
 #
 > “ My  dear     , ” she  cried , “ I’m going   to give   you    this   dress   as    soon as    I’m through
@@ -2426,8 +2426,8 @@
 #
 > I       believe that     on  the first  night    I       went    to Gatsby’s house   I       was  one     of the few
 # ISg/#r+ VB      I/C/Ddem J/P D+  NSg/J+ N🅪Sg/VB+ ISg/#r+ NSg/VPt P  NPr$     NPr/VB+ ISg/#r+ VLPt NSg/I/J P  D   NSg/I/Dq
-> guests  who    had actually been     invited  . People  were not     invited  — they went    there .
-# NPl/V3+ NPr/I+ VP  R        NSg/VLPp NSg/VP/J . NPl/VB+ VLPt NSg/R/C NSg/VP/J . IPl+ NSg/VPt R     .
+> guests  who    had actually been   invited  . People  were not     invited  — they went    there .
+# NPl/V3+ NPr/I+ VP  R        VLPp/B NSg/VP/J . NPl/VB+ VLPt NSg/R/C NSg/VP/J . IPl+ NSg/VPt R     .
 > They got into automobiles which bore     them     out          to Long     Island  , and  somehow they
 # IPl+ VP  P    NPl/V3      I/C+  NSg/VBPt NSg/IPl+ NSg/VB/J/R/P P  NPr/VB/J NSg/VB+ . VB/C R       IPl+
 > ended up         at    Gatsby’s door    . Once  there they were introduced by    somebody who    knew
@@ -2442,8 +2442,8 @@
 # ISg/D$+ NSg/VB/J NSg/VB P  NSg+      .
 >
 #
-> I       had been     actually invited  . A   chauffeur in        a   uniform  of robin’s - egg      blue
-# ISg/#r+ VP  NSg/VLPp R        NSg/VP/J . D/P NSg/VB    NPr/J/R/P D/P NSg/VB/J P  NPr$    . N🅪Sg/VB+ N🅪Sg/VB/J
+> I       had been   actually invited  . A   chauffeur in        a   uniform  of robin’s - egg      blue
+# ISg/#r+ VP  VLPp/B R        NSg/VP/J . D/P NSg/VB    NPr/J/R/P D/P NSg/VB/J P  NPr$    . N🅪Sg/VB+ N🅪Sg/VB/J
 > crossed my  lawn    early   that     Saturday morning    with a   surprisingly formal note    from
 # VP/J    D$+ NSg/VB+ NSg/J/R I/C/Ddem NSg/VB+  N🅪Sg/Vg/J+ P    D/P R            NSg/J  NSg/VB+ P
 > his     employer : the honor       would be       entirely Gatsby’s , it       said , if    I       would attend
@@ -2545,7 +2545,7 @@
 > slender golden   arm       resting  in        mine      , we   descended the steps   and  sauntered about
 # J       NPr/VB/J NSg/VB/J+ Nᴹ/Vg/J+ NPr/J/R/P NSg/I/VB+ . IPl+ VP/J      D   NPl/V3+ VB/C VP/J      J/P
 > the garden    . A   tray   of cocktails floated at    us       through the twilight , and  we   sat
-# D   NSg/VB/J+ . D/P NSg/VB P  NPl/V3+   VP/J    NSg/P NPr/IPl+ J/P     D+  Nᴹ/VB/J+ . VB/C IPl+ NSg/VP/J
+# D   NSg/VB/J+ . D/P NSg/VB P  NPl/V3+   VP/J    NSg/P NPr/IPl+ J/P     D+  Nᴹ/VB/J+ . VB/C IPl+ NSg/VP
 > down        at    a   table   with the two  girls   in        yellow   and  three men  , each one      introduced
 # N🅪Sg/VB/J/P NSg/P D/P NSg/VB+ P    D+  NSg+ NPl/V3+ NPr/J/R/P NSg/VB/J VB/C NSg+  NPl+ . Dq   NSg/I/J+ VP/J
 > to us       as    Mr   . Mumble .
@@ -2776,8 +2776,8 @@
 #
 > “ I       was  brought by    a    woman   named Roosevelt , ” he       continued . “ Mrs  . Claud Roosevelt .
 # . ISg/#r+ VLPt VP      NSg/P D/P+ NSg/VB+ VP/J  NPr+      . . NPr/ISg+ VP/J      . . NPl+ . ?     NPr+      .
-> Do  you    know her     ? I       met her     somewhere last      night    . I’ve been     drunk     for   about a
-# VXB ISgPl+ VB   ISg/D$+ . ISg/#r+ VP  ISg/D$+ R         NSg/VB/J+ N🅪Sg/VB+ . K    NSg/VLPp NSg/VPp/J R/C/P J/P   D/P
+> Do  you    know her     ? I       met her     somewhere last      night    . I’ve been   drunk     for   about a
+# VXB ISgPl+ VB   ISg/D$+ . ISg/#r+ VP  ISg/D$+ R         NSg/VB/J+ N🅪Sg/VB+ . K    VLPp/B NSg/VPp/J R/C/P J/P   D/P
 > week   now       , and  I       thought it       might    sober me       up         to sit    in        a   library . ”
 # NSg/J+ NSg/J/R/C . VB/C ISg/#r+ N🅪Sg/VP NPr/ISg+ Nᴹ/VXB/J VB/J  NPr/ISg+ NSg/VB/J/P P  NSg/VB NPr/J/R/P D/P NSg+    . .
 >
@@ -2786,8 +2786,8 @@
 # . V3  NPr/ISg+ . .
 >
 #
-> “ A    little      bit      , I       think  . I       can’t tell   yet      . I’ve only  been     here an  hour . Did  I
-# . D/P+ NPr/I/J/Dq+ NSg/VPt+ . ISg/#r+ NSg/VB . ISg/#r+ VXB   NPr/VB NSg/VB/C . K    J/R/C NSg/VLPp J/R  D/P NSg+ . VXPt ISg/#r+
+> “ A    little      bit      , I       think  . I       can’t tell   yet      . I’ve only  been   here an  hour . Did  I
+# . D/P+ NPr/I/J/Dq+ NSg/VPt+ . ISg/#r+ NSg/VB . ISg/#r+ VXB   NPr/VB NSg/VB/C . K    J/R/C VLPp/B J/R  D/P NSg+ . VXPt ISg/#r+
 > tell   you    about the books   ? They’re real  . They’re — ”
 # NPr/VB ISgPl+ J/P   D+  NPl/V3+ . K       NSg/J . K       . .
 >
@@ -3102,16 +3102,16 @@
 #
 > I       was  alone and  it       was  almost two . For   some      time       confused and  intriguing sounds
 # ISg/#r+ VLPt J     VB/C NPr/ISg+ VLPt R      NSg . R/C/P I/J/R/Dq+ N🅪Sg/VB/J+ VP/J     VB/C Nᴹ/Vg/J    NPl/V3
-> had issued from a   long     , many       - windowed room       which overhung the terrace . Eluding
-# VP  VP/J   P    D/P NPr/VB/J . NSg/I/J/Dq . VP/J     N🅪Sg/VB/J+ I/C+  VP/J     D   NSg/VB+ . Nᴹ/Vg/J
+> had issued from a   long     , many       - windowed room     which overhung the terrace . Eluding
+# VP  VP/J   P    D/P NPr/VB/J . NSg/I/J/Dq . VP/J     N🅪Sg/VB+ I/C+  VP/J     D   NSg/VB+ . Nᴹ/Vg/J
 > Jordan’s undergraduate , who    was  now       engaged in        an  obstetrical conversation with
 # NPr$     NSg/J         . NPr/I+ VLPt NSg/J/R/C VP/J    NPr/J/R/P D/P J           N🅪Sg/VB+     P
 > two chorus  girls   , and  who    implored me       to join   him  , I       went    inside  .
 # NSg NSg/VB+ NPl/V3+ . VB/C NPr/I+ VP/J     NPr/ISg+ P  NSg/VB ISg+ . ISg/#r+ NSg/VPt NSg/J/P .
 >
 #
-> The large  room       was  full     of people  . One     of the girls   in        yellow   was  playing the
-# D+  NSg/J+ N🅪Sg/VB/J+ VLPt NSg/VB/J P  NPl/VB+ . NSg/I/J P  D+  NPl/V3+ NPr/J/R/P NSg/VB/J VLPt Nᴹ/Vg/J D+
+> The large  room     was  full     of people  . One     of the girls   in        yellow   was  playing the
+# D+  NSg/J+ N🅪Sg/VB+ VLPt NSg/VB/J P  NPl/VB+ . NSg/I/J P  D+  NPl/V3+ NPr/J/R/P NSg/VB/J VLPt Nᴹ/Vg/J D+
 > piano     , and  beside her     stood a   tall  , red    - haired young    lady   from a   famous chorus  ,
 # NSg/VB/J+ . VB/C P      ISg/D$+ VP    D/P NSg/J . N🅪Sg/J . VP/J   NPr/VB/J NPr/VB P    D/P VB/J   NSg/VB+ .
 > engaged in        song  . She  had drunk     a   quantity of champagne  , and  during the course of
@@ -3270,8 +3270,8 @@
 #
 > “ Good      night    . ” He       smiled — and  suddenly there seemed to be       a    pleasant significance
 # . NPr/VB/J+ N🅪Sg/VB+ . . NPr/ISg+ VP/J   . VB/C R        R+    VP/J   P  NSg/VLXB D/P+ NSg/J+   NSg+
-> in        having  been     among the last      to go       , as    if    he       had desired it       all           the time       . “ Good
-# NPr/J/R/P Nᴹ/Vg/J NSg/VLPp P     D+  NSg/VB/J+ P  NSg/VB/J . R/C/P NSg/C NPr/ISg+ VP  VP/J    NPr/ISg+ NSg/I/J/C/Dq+ D+  N🅪Sg/VB/J+ . . NPr/VB/J
+> in        having  been   among the last      to go       , as    if    he       had desired it       all           the time       . “ Good
+# NPr/J/R/P Nᴹ/Vg/J VLPp/B P     D+  NSg/VB/J+ P  NSg/VB/J . R/C/P NSg/C NPr/ISg+ VP  VP/J    NPr/ISg+ NSg/I/J/C/Dq+ D+  N🅪Sg/VB/J+ . . NPr/VB/J
 > night    , old    sport   . . . . Good      night    . ”
 # N🅪Sg/VB+ . NSg/J+ NSg/VB+ . . . . NPr/VB/J+ N🅪Sg/VB+ . .
 >
@@ -3290,8 +3290,8 @@
 # NSg/Vg  NSg/J        NSg+      P    N🅪Sg/J/P+ D/P NSg   J       NPl/V3     . C       . R/C/P
 > they had left     their cars blocking the road    , a   harsh , discordant din     from those
 # IPl+ VP  NPr/VP/J D$+   NPl+ Nᴹ/Vg/J  D+  N🅪Sg/J+ . D/P VB/J  . J          NSg/VB+ P    I/Ddem
-> in        the rear     had been     audible  for   some     time       , and  added to the already violent
-# NPr/J/R/P D   NSg/VB/J VP  NSg/VLPp NSg/VB/J R/C/P I/J/R/Dq N🅪Sg/VB/J+ . VB/C VP/J  P  D   R       NSg/VB/J
+> in        the rear     had been   audible  for   some     time       , and  added to the already violent
+# NPr/J/R/P D   NSg/VB/J VP  VLPp/B NSg/VB/J R/C/P I/J/R/Dq N🅪Sg/VB/J+ . VB/C VP/J  P  D   R       NSg/VB/J
 > confusion of the scene   .
 # N🅪Sg/VB   P  D   NSg/VB+ .
 >
@@ -3564,8 +3564,8 @@
 # NSg  . NSg/VB/J NSg/VB/J/P . D+  NSg+  VP/J       D   NPl/V3      P  D/P N🅪Sg/VB+ . NSg/J/R/C VP/J
 > away . A   caddy retracted his     statement , and  the only  other    witness admitted that
 # VB/J . D/P NSg   VP/J      ISg/D$+ NSg/VB/J+ . VB/C D   J/R/C NSg/VB/J NSg/VB+ VP/J     I/C/Ddem
-> he       might    have    been     mistaken . The incident and  the name    had remained together in
-# NPr/ISg+ Nᴹ/VXB/J NSg/VXB NSg/VLPp VPp/J    . D   NSg/J    VB/C D+  NSg/VB+ VP  VP/J     J        NPr/J/R/P
+> he       might    have    been   mistaken . The incident and  the name    had remained together in
+# NPr/ISg+ Nᴹ/VXB/J NSg/VXB VLPp/B VPp/J    . D   NSg/J    VB/C D+  NSg/VB+ VP  VP/J     J        NPr/J/R/P
 > my  mind    .
 # D$+ NSg/VB+ .
 >
@@ -3640,8 +3640,8 @@
 # NSg/VB/J . Nᴹ/Vg/J  VB/C NSg/VB/J P  NSg/J+   NPl/V3+ I/C/Ddem+ NPr/VB R/C/P NPl/V3+ J/P D$+ NPl/V3  . VB/C ISg/#r+
 > knew that     first I       had to get    myself definitely out          of that      tangle back     home      . I'd
 # VPt  I/C/Ddem NSg/J ISg/#r+ VP  P  NSg/VB ISg+   R          NSg/VB/J/R/P P  I/C/Ddem+ NSg/VB NSg/VB/J NSg/VB/J+ . +
-> been     writing letters once  a    week   and  signing them     : “ Love      , Nick    , ” and  all          I       could
-# NSg/VLPp Nᴹ/Vg/J NPl/V3+ NSg/C D/P+ NSg/J+ VB/C Nᴹ/Vg/J NSg/IPl+ . . NPr🅪Sg/VB . NPr/VB+ . . VB/C NSg/I/J/C/Dq ISg/#r+ NSg/VXB
+> been   writing letters once  a    week   and  signing them     : “ Love      , Nick    , ” and  all          I       could
+# VLPp/B Nᴹ/Vg/J NPl/V3+ NSg/C D/P+ NSg/J+ VB/C Nᴹ/Vg/J NSg/IPl+ . . NPr🅪Sg/VB . NPr/VB+ . . VB/C NSg/I/J/C/Dq ISg/#r+ NSg/VXB
 > think  of was  how   , when    that      certain girl    played tennis  , a   faint    mustache of
 # NSg/VB P  VLPt NSg/C . NSg/I/C I/C/Ddem+ I/J+    NSg/VB+ VP/J   NSg/VB+ . D/P NSg/VB/J NSg      P
 > perspiration appeared on  her     upper  lip     . Nevertheless there was  a    vague
@@ -3770,8 +3770,8 @@
 # NPr   ?          VP/J    R      P    NSg  NPl/V3+ . IPl+ VLPt R     R     D   I/J
 > ones in        physical person  , but     they were so          identical one     with another that     it
 # NPl  NPr/J/R/P NSg/J+   NSg/VB+ . NSg/C/P IPl+ VLPt NSg/I/J/R/C NSg/J     NSg/I/J P    I/D     I/C/Ddem NPr/ISg+
-> inevitably seemed they had been     there before . I       have    forgotten their
-# R          VP/J   IPl+ VP  NSg/VLPp R+    C/P    . ISg/#r+ NSg/VXB NSg/VPp/J D$+
+> inevitably seemed they had been   there before . I       have    forgotten their
+# R          VP/J   IPl+ VP  VLPp/B R+    C/P    . ISg/#r+ NSg/VXB NSg/VPp/J D$+
 > names   — Jaqueline , I       think  , or    else    Consuela , or    Gloria or    Judy or    June , and  their
 # NPl/V3+ . ?         . ISg/#r+ NSg/VB . NPr/C NSg/J/C ?        . NPr/C NPr    NPr/C NPr  NPr/C NPr+ . VB/C D$+
 > last     names   were either the melodious names  of flowers  and  months or    the sterner
@@ -3904,8 +3904,8 @@
 # P  NSg/VB NSg/P . . ISg/#r+ NPr/VLB/J D   NPr/VB P  I/J/R/Dq NSg/J   NPl/VB NPr/J/R/P D+  NSg/VB/J+ NPr/VB/J+ . NSg/I/J/C/Dq NSg/VB/J
 > now       . I       was  brought up         in        America but     educated at    Oxford , because all           my
 # NSg/J/R/C . ISg/#r+ VLPt VP      NSg/VB/J/P NPr/J/R/P NPr+    NSg/C/P VP/J     NSg/P NPr+   . C/P     NSg/I/J/C/Dq+ D$+
-> ancestors have    been     educated there for   many        years . It       is  a   family tradition . ”
-# NPl/V3+   NSg/VXB NSg/VLPp VP/J     R     R/C/P NSg/I/J/Dq+ NPl+  . NPr/ISg+ VL3 D/P N🅪Sg/J N🅪Sg/VB   . .
+> ancestors have    been   educated there for   many        years . It       is  a   family tradition . ”
+# NPl/V3+   NSg/VXB VLPp/B VP/J     R     R/C/P NSg/I/J/Dq+ NPl+  . NPr/ISg+ VL3 D/P N🅪Sg/J N🅪Sg/VB   . .
 >
 #
 > He       looked at    me       sideways — and  I       knew why    Jordan Baker had believed he       was  lying   .
@@ -4152,8 +4152,8 @@
 # NPr+   . VB/C ISg/#r+ VLPt NSg/VB/J I/C/Ddem D   N🅪Sg/VB P  NPr$     J        NSg+ VLPt VP/J     NPr/J/R/P
 > their sombre        holiday . As    we   crossed Blackwell’s Island  a   limousine passed us       ,
 # D$+   NSg/VB/J/Comm NPr/VB+ . R/C/P IPl+ VP/J    NPr$        NSg/VB+ D/P NSg       VP/J   NPr/IPl+ .
-> driven by    a   white       chauffeur , in        which sat      three modish negroes , two bucks  and  a
-# VPp/J  NSg/P D/P NPr🅪Sg/VB/J NSg/VB    . NPr/J/R/P I/C+  NSg/VP/J NSg   J      NPl     . NSg NPl/V3 VB/C D/P
+> driven by    a   white       chauffeur , in        which sat    three modish negroes , two bucks  and  a
+# VPp/J  NSg/P D/P NPr🅪Sg/VB/J NSg/VB    . NPr/J/R/P I/C+  NSg/VP NSg   J      NPl     . NSg NPl/V3 VB/C D/P
 > girl    . I       laughed aloud as    the yolks  of their eyeballs rolled toward us       in        haughty
 # NSg/VB+ . ISg/#r+ VP/J    J     R/C/P D   NPl/V3 P  D$+   NPl/V3+  VP/J   J/P    NPr/IPl+ NPr/J/R/P J
 > rivalry .
@@ -4266,8 +4266,8 @@
 #
 > “ ‘ Let     the bastards come       in        here if    they want   you    , Rosy     , but     don’t you    , so          help
 # . . NSg/VBP D   NPl/V3   NSg/VBPp/P NPr/J/R/P J/R  NSg/C IPl+ NSg/VB ISgPl+ . NSg/VB/J . NSg/C/P VXB   ISgPl+ . NSg/I/J/R/C NSg/VB
-> me       , move   outside   this   room       . ’
-# NPr/ISg+ . NSg/VB Nᴹ/VB/J/P I/Ddem N🅪Sg/VB/J+ . .
+> me       , move   outside   this   room     . ’
+# NPr/ISg+ . NSg/VB Nᴹ/VB/J/P I/Ddem N🅪Sg/VB+ . .
 >
 #
 > “ It       was  four o’clock in        the morning    then      , and  if    we’d of raised the blinds  we’d
@@ -4324,8 +4324,8 @@
 # D/P+ NSg/J+    NSg/VB+ VP/J    . VB/C NSg+ . ?         . NSg/Vg     D   NPr/I/J/R/Dq J
 > atmosphere of the old   Metropole , began to eat with ferocious delicacy . His     eyes    ,
 # N🅪Sg       P  D   NSg/J ?         . VPt   P  VB  P    J         NSg+     . ISg/D$+ NPl/V3+ .
-> meanwhile , roved very slowly all          around the room       — he       completed the arc       by    turning
-# NSg       . VP/J  J/R  R      NSg/I/J/C/Dq J/P    D   N🅪Sg/VB/J+ . NPr/ISg+ VP/J      D   NPr/VB/J+ NSg/P Nᴹ/Vg/J
+> meanwhile , roved very slowly all          around the room     — he       completed the arc       by    turning
+# NSg       . VP/J  J/R  R      NSg/I/J/C/Dq J/P    D   N🅪Sg/VB+ . NPr/ISg+ VP/J      D   NPr/VB/J+ NSg/P Nᴹ/Vg/J
 > to inspect the people  directly behind  . I       think  that      , except for   my  presence , he
 # P  VB      D   NPl/VB+ R/C      NSg/J/P . ISg/#r+ NSg/VB I/C/Ddem+ . VB/C/P R/C/P D$+ N🅪Sg/VB+ . NPr/ISg+
 > would have    taken one     short       glance  beneath our own       table   .
@@ -4356,8 +4356,8 @@
 # ISgPl+ VB   . VB/C K     R     VXB NSg/I/VB+ I/C/Ddem+ VPt    NSg/I/J/C/Dq NPr/VB/J . .
 >
 #
-> Suddenly he       looked at    his     watch  , jumped up         , and  hurried from the room       , leaving
-# R        NPr/ISg+ VP/J   NSg/P ISg/D$+ NSg/VB . VP/J   NSg/VB/J/P . VB/C VP/J    P    D+  N🅪Sg/VB/J+ . Nᴹ/Vg/J
+> Suddenly he       looked at    his     watch  , jumped up         , and  hurried from the room     , leaving
+# R        NPr/ISg+ VP/J   NSg/P ISg/D$+ NSg/VB . VP/J   NSg/VB/J/P . VB/C VP/J    P    D+  N🅪Sg/VB+ . Nᴹ/Vg/J
 > me       with Mr   . Wolfshiem at    the table   .
 # NPr/ISg+ P    NSg+ . ?         NSg/P D   NSg/VB+ .
 >
@@ -4410,8 +4410,8 @@
 # NSg/VB/J VB/C NSg/VB+ . . . NPr/ISg+ VP/J   . . ISg/#r+ NSg/VB K      Nᴹ/Vg/J NSg/P D$+ NSg/VB NPl/V3+ . .
 >
 #
-> I       hadn’t been     looking at    them     , but     I       did  now       . They were composed of oddly
-# ISg/#r+ VPt    NSg/VLPp Nᴹ/Vg/J NSg/P NSg/IPl+ . NSg/C/P ISg/#r+ VXPt NSg/J/R/C . IPl+ VLPt VP/J     P  R
+> I       hadn’t been   looking at    them     , but     I       did  now       . They were composed of oddly
+# ISg/#r+ VPt    VLPp/B Nᴹ/Vg/J NSg/P NSg/IPl+ . NSg/C/P ISg/#r+ VXPt NSg/J/R/C . IPl+ VLPt VP/J     P  R
 > familiar pieces of ivory     .
 # NSg/J    NPl/V3 P  NPr🅪Sg/J+ .
 >
@@ -4430,8 +4430,8 @@
 # J/P   NPl+  . NPr/ISg+ VXB   R     NSg/I/J/R/C NSg/I/J/R/Dq R/C/P NSg/VB NSg/P D/P NPr$     NSg/VB/J+ . .
 >
 #
-> When    the subject  of this   instinctive trust     returned to the table   and  sat      down
-# NSg/I/C D   NSg/VB/J P  I/Ddem J           N🅪Sg/VB/J VP/J     P  D   NSg/VB+ VB/C NSg/VP/J N🅪Sg/VB/J/P
+> When    the subject  of this   instinctive trust     returned to the table   and  sat    down
+# NSg/I/C D   NSg/VB/J P  I/Ddem J           N🅪Sg/VB/J VP/J     P  D   NSg/VB+ VB/C NSg/VP N🅪Sg/VB/J/P
 > Mr   . Wolfshiem drank   his     coffee     with a   jerk    and  got to his     feet .
 # NSg+ . ?         NSg/VPt ISg/D$+ N🅪Sg/VB/J+ P    D/P NSg/VB+ VB/C VP  P  ISg/D$+ NPl+ .
 >
@@ -4493,7 +4493,7 @@
 >
 #
 > The idea staggered me       . I       remembered , of course  , that     the World’s Series had been
-# D+  NSg+ VP/J      NPr/ISg+ . ISg/#r+ VP/J       . P  NSg/VB+ . I/C/Ddem D   NSg$    NSgPl+ VP  NSg/VLPp
+# D+  NSg+ VP/J      NPr/ISg+ . ISg/#r+ VP/J       . P  NSg/VB+ . I/C/Ddem D   NSg$    NSgPl+ VP  VLPp/B
 > fixed in        1919 , but     if    I       had thought of it       at    all          I       would have    thought of it       as    a
 # VP/J  NPr/J/R/P #    . NSg/C/P NSg/C ISg/#r+ VP  N🅪Sg/VP P  NPr/ISg+ NSg/P NSg/I/J/C/Dq ISg/#r+ VXB   NSg/VXB N🅪Sg/VP P  NPr/ISg+ R/C/P D/P
 > thing that      merely happened , the end    of some     inevitable chain    . It       never occurred
@@ -4522,8 +4522,8 @@
 #
 > I       insisted on  paying  the check     . As    the waiter  brought my  change   I       caught sight
 # ISg/#r+ VP/J     J/P Nᴹ/Vg/J D+  NSg/VB/J+ . R/C/P D+  NSg/VB+ VP      D$+ N🅪Sg/VB+ ISg/#r+ VP/J   N🅪Sg/VB
-> of Tom     Buchanan across the crowded room       .
-# P  NPr/VB+ NPr+     NSg/P  D+  VP/J+   N🅪Sg/VB/J+ .
+> of Tom     Buchanan across the crowded room     .
+# P  NPr/VB+ NPr+     NSg/P  D+  VP/J+   N🅪Sg/VB+ .
 >
 #
 > “ Come       along with me       for   a    minute    , ” I       said ; “ I’ve got to say    hello  to some     one      . ”
@@ -4534,8 +4534,8 @@
 # NSg/I/C NPr/ISg+ NSg/VPt NPr/IPl+ NPr/VB+ VP/J   NSg/VB/J/P VB/C VPt  N🅪Sg/J/P+ D/P NSg   NPl/V3+ NPr/J/R/P D$+ N🅪Sg+     .
 >
 #
-> “ Where’ve you    been     ? ” he       demanded eagerly . “ Daisy’s furious because you    haven’t
-# . ?        ISgPl+ NSg/VLPp . . NPr/ISg+ VP/J     R       . . NPr$    J       C/P     ISgPl+ VXB
+> “ Where’ve you    been   ? ” he       demanded eagerly . “ Daisy’s furious because you    haven’t
+# . ?        ISgPl+ VLPp/B . . NPr/ISg+ VP/J     R       . . NPr$    J       C/P     ISgPl+ VXB
 > called up         . ”
 # VP/J   NSg/VB/J/P . .
 >
@@ -4550,14 +4550,14 @@
 # NSg/J/P NPr$     NSg/VB+ .
 >
 #
-> “ How’ve you    been     , anyhow ? ” demanded Tom    of me       . “ How’d you    happen to come       up         this
-# . ?      ISgPl+ NSg/VLPp . J      . . VP/J     NPr/VB P  NPr/ISg+ . . K     ISgPl+ VB     P  NSg/VBPp/P NSg/VB/J/P I/Ddem
+> “ How’ve you    been   , anyhow ? ” demanded Tom    of me       . “ How’d you    happen to come       up         this
+# . ?      ISgPl+ VLPp/B . J      . . VP/J     NPr/VB P  NPr/ISg+ . . K     ISgPl+ VB     P  NSg/VBPp/P NSg/VB/J/P I/Ddem
 > far      to eat ? ”
 # NSg/VB/J P  VB  . .
 >
 #
-> “ I’ve been     having  lunch    with Mr   . Gatsby . ”
-# . K    NSg/VLPp Nᴹ/Vg/J N🅪Sg/VB+ P    NSg+ . NPr    . .
+> “ I’ve been   having  lunch    with Mr   . Gatsby . ”
+# . K    VLPp/B Nᴹ/Vg/J N🅪Sg/VB+ P    NSg+ . NPr    . .
 >
 #
 > I       turned toward Mr   . Gatsby , but     he       was  no       longer there .
@@ -4670,8 +4670,8 @@
 # NSg      NPl+    .
 >
 #
-> I       was  a   bridesmaid . I       came      into her     room       half      an   hour before the bridal dinner   ,
-# ISg/#r+ VLPt D/P NSg/VB     . ISg/#r+ NSg/VPt/P P    ISg/D$+ N🅪Sg/VB/J+ N🅪Sg/J/P+ D/P+ NSg+ C/P    D+  NSg/J+ N🅪Sg/VB+ .
+> I       was  a   bridesmaid . I       came      into her     room     half      an   hour before the bridal dinner   ,
+# ISg/#r+ VLPt D/P NSg/VB     . ISg/#r+ NSg/VPt/P P    ISg/D$+ N🅪Sg/VB+ N🅪Sg/J/P+ D/P+ NSg+ C/P    D+  NSg/J+ N🅪Sg/VB+ .
 > and  found  her     lying   on  her     bed        as    lovely as    the June night    in        her     flowered
 # VB/C NSg/VP ISg/D$+ Nᴹ/Vg/J J/P ISg/D$+ NSg/VBP/J+ R/C/P NSg/J  R/C/P D+  NPr+ N🅪Sg/VB+ NPr/J/R/P ISg/D$+ VP/J+
 > dress   — and  as    drunk     as    a    monkey  . She  had a   bottle of Sauterne in        one     hand   and  a
@@ -4720,8 +4720,8 @@
 # NSg/C/P ISg+ VXPt   NSg/VB I/D     NSg/VB+ . IPl+ VPt  ISg/D$+ NPl/V3  P  Nᴹ+     VB/C NSg/VBP NPr🅪Sg/VB+ J/P
 > her     forehead and  hooked her     back     into her     dress   , and  half     an   hour later , when    we
 # ISg/D$+ NSg+     VB/C VP/J   ISg/D$+ NSg/VB/J P    ISg/D$+ NSg/VB+ . VB/C N🅪Sg/J/P D/P+ NSg+ JC    . NSg/I/C IPl+
-> walked out          of the room       , the pearls  were around her     neck   and  the incident was
-# VP/J   NSg/VB/J/R/P P  D+  N🅪Sg/VB/J+ . D+  NPl/V3+ VLPt J/P    ISg/D$+ NSg/VB VB/C D+  NSg/J+   VLPt
+> walked out          of the room     , the pearls  were around her     neck   and  the incident was
+# VP/J   NSg/VB/J/R/P P  D+  N🅪Sg/VB+ . D+  NPl/V3+ VLPt J/P    ISg/D$+ NSg/VB VB/C D+  NSg/J+   VLPt
 > over    . Next     day     at    five o’clock she  married  Tom     Buchanan without so          much         as    a
 # NSg/J/P . NSg/J/P+ NPr🅪Sg+ NSg/P NSg  R       ISg+ NSg/VP/J NPr/VB+ NPr+     C/P     NSg/I/J/R/C NSg/I/J/R/Dq R/C/P D/P
 > shiver , and  started off        on  a   three months ’ trip      to the South     Seas .
@@ -4730,8 +4730,8 @@
 #
 > I       saw     them     in        Santa Barbara when    they came      back     , and  I       thought I’d never seen    a
 # ISg/#r+ NSg/VPt NSg/IPl+ NPr/J/R/P NPr+  NPr+    NSg/I/C IPl+ NSg/VPt/P NSg/VB/J . VB/C ISg/#r+ N🅪Sg/VP K   R     NSg/VPp D/P
-> girl    so          mad      about her     husband . If    he       left     the room      for   a    minute    she’d look
-# NSg/VB+ NSg/I/J/R/C NSg/VB/J J/P   ISg/D$+ NSg/VB+ . NSg/C NPr/ISg+ NPr/VP/J D   N🅪Sg/VB/J R/C/P D/P+ NSg/VB/J+ K     NSg/VB
+> girl    so          mad      about her     husband . If    he       left     the room    for   a    minute    she’d look
+# NSg/VB+ NSg/I/J/R/C NSg/VB/J J/P   ISg/D$+ NSg/VB+ . NSg/C NPr/ISg+ NPr/VP/J D   N🅪Sg/VB R/C/P D/P+ NSg/VB/J+ K     NSg/VB
 > around uneasily , and  say    : ‘ ‘ Where’s Tom     gone    ? ” and  wear   the most         abstracted
 # J/P    R        . VB/C NSg/VB . . . NSg$    NPr/VB+ VPp/J/P . . VB/C NSg/VB D   NSg/I/J/R/Dq VP/J
 > expression until she  saw     him  coming  in        the door    . She  used to sit    on  the sand
@@ -4776,8 +4776,8 @@
 # NSg/VB/J/R . J/P   NSg+ NPrPl+ J/P . ISg+ VP/J  D+  NSg/VB+ NPr    R/C/P D   NSg/J N🅪Sg/VB/J+ NPr/J/R/P
 > years . It       was  when    I       asked you    — do  you    remember ? — if    you    knew Gatsby in        West      Egg      .
 # NPl+  . NPr/ISg+ VLPt NSg/I/C ISg/#r+ VP/J  ISgPl+ . VXB ISgPl+ NSg/VB   . . NSg/C ISgPl+ VPt  NPr    NPr/J/R/P NPr/VB/J+ N🅪Sg/VB+ .
-> After you    had gone    home      she  came      into my  room       and  woke     me       up         , and  said : “ What
-# P     ISgPl+ VP  VPp/J/P NSg/VB/J+ ISg+ NSg/VPt/P P    D$+ N🅪Sg/VB/J+ VB/C NSg/VB/J NPr/ISg+ NSg/VB/J/P . VB/C VP/J . . NSg/I+
+> After you    had gone    home      she  came      into my  room     and  woke     me       up         , and  said : “ What
+# P     ISgPl+ VP  VPp/J/P NSg/VB/J+ ISg+ NSg/VPt/P P    D$+ N🅪Sg/VB+ VB/C NSg/VB/J NPr/ISg+ NSg/VB/J/P . VB/C VP/J . . NSg/I+
 > Gatsby ? ” and  when    I       described him  — I       was  half     asleep — she  said in        the strangest
 # NPr    . . VB/C NSg/I/C ISg/#r+ VP/J      ISg+ . ISg/#r+ VLPt N🅪Sg/J/P J      . ISg+ VP/J NPr/J/R/P D   JS
 > voice   that      it       must    be       the man     she  used to know . It       wasn’t until then      that     I
@@ -4820,8 +4820,8 @@
 # . NPr    NSg/VP I/C/Ddem NPr/VB+ NSg/I/J/R/C I/C/Ddem NPr+  VXB   NSg/VLXB J/R  NSg/P  D   NSg/VB/J+ . .
 >
 #
-> Then      it       had not     been     merely the stars   to which he       had aspired on  that     June
-# NSg/J/R/C NPr/ISg+ VP  NSg/R/C NSg/VLPp R      D+  NPl/V3+ P  I/C+  NPr/ISg+ VP  VP/J    J/P I/C/Ddem NPr+
+> Then      it       had not     been   merely the stars   to which he       had aspired on  that     June
+# NSg/J/R/C NPr/ISg+ VP  NSg/R/C VLPp/B R      D+  NPl/V3+ P  I/C+  NPr/ISg+ VP  VP/J    J/P I/C/Ddem NPr+
 > night    . He       came      alive to me       , delivered suddenly from the womb   of his     purposeless
 # N🅪Sg/VB+ . NPr/ISg+ NSg/VPt/P J     P  NPr/ISg+ . VP/J      R        P    D   NSg/VB P  ISg/D$+ J
 > splendor .
@@ -4978,8 +4978,8 @@
 # . D$+  N🅪Sg/VB+ NPl/V3 NSg/VB/J/C/P D   NSg$    NSg/VB/J . . ISg/#r+ VP/J .
 >
 #
-> “ Does    it       ? ” He       turned his     eyes    toward it       absently . “ I       have    been     glancing into
-# . NPl/VX3 NPr/ISg+ . . NPr/ISg+ VP/J   ISg/D$+ NPl/V3+ J/P    NPr/ISg+ R        . . ISg/#r+ NSg/VXB NSg/VLPp Nᴹ/Vg/J  P
+> “ Does    it       ? ” He       turned his     eyes    toward it       absently . “ I       have    been   glancing into
+# . NPl/VX3 NPr/ISg+ . . NPr/ISg+ VP/J   ISg/D$+ NPl/V3+ J/P    NPr/ISg+ R        . . ISg/#r+ NSg/VXB VLPp/B Nᴹ/Vg/J  P
 > some     of the rooms   . Let’s go       to Coney Island  , old   sport   . In        my  car  . ”
 # I/J/R/Dq P  D+  NPl/V3+ . NSg$  NSg/VB/J P  ?     NSg/VB+ . NSg/J NSg/VB+ . NPr/J/R/P D$+ NSg+ . .
 >
@@ -5092,8 +5092,8 @@
 #
 > I       realize      now       that     under   different circumstances that      conversation might    have
 # ISg/#r+ VB/Comm/NoAm NSg/J/R/C I/C/Ddem NSg/J/P NSg/J+    NPl/V3+       I/C/Ddem+ N🅪Sg/VB+     Nᴹ/VXB/J NSg/VXB
-> been     one     of the crises of my  life     . But     , because the offer   was  obviously and
-# NSg/VLPp NSg/I/J P  D   NPl    P  D$+ N🅪Sg/VB+ . NSg/C/P . C/P     D+  NSg/VB+ VLPt R         VB/C
+> been   one     of the crises of my  life     . But     , because the offer   was  obviously and
+# VLPp/B NSg/I/J P  D   NPl    P  D$+ N🅪Sg/VB+ . NSg/C/P . C/P     D+  NSg/VB+ VLPt R         VB/C
 > tactlessly for   a   service to be       rendered , I       had no       choice  except to cut       him  off
 # R          R/C/P D/P NSg/VB+ P  NSg/VLXB VP/J     . ISg/#r+ VP  NSg/Dq/P N🅪Sg/J+ VB/C/P P  NSg/VBP/J ISg+ NSg/VB/J/P
 > there .
@@ -5234,8 +5234,8 @@
 # . VXB   NSg/VLXB NSg/J . K    J/R  NSg NPl/V3+ P  NSg  . .
 >
 #
-> He       sat      down        miserably , as    if    I       had pushed him  , and  simultaneously there was  the
-# NPr/ISg+ NSg/VP/J N🅪Sg/VB/J/P R         . R/C/P NSg/C ISg/#r+ VP  VP/J   ISg+ . VB/C R              R+    VLPt D
+> He       sat    down        miserably , as    if    I       had pushed him  , and  simultaneously there was  the
+# NPr/ISg+ NSg/VP N🅪Sg/VB/J/P R         . R/C/P NSg/C ISg/#r+ VP  VP/J   ISg+ . VB/C R              R+    VLPt D
 > sound     of a    motor     turning into my  lane . We   both   jumped up         , and  , a   little     harrowed
 # N🅪Sg/VB/J P  D/P+ NSg/VB/J+ Nᴹ/Vg/J P    D$+ NPr+ . IPl+ I/C/Dq VP/J   NSg/VB/J/P . VB/C . D/P NPr/I/J/Dq VP/J
 > myself , I       went    out          into the yard    .
@@ -5290,8 +5290,8 @@
 # . ISg/#r+ VXB   NSg/VB NSg/I/J/R/C . . ISg+ VP/J R          . . NSg/VB . .
 >
 #
-> We   went    in        . To my  overwhelming surprise the living     - room       was  deserted .
-# IPl+ NSg/VPt NPr/J/R/P . P  D$+ Nᴹ/Vg/J+     NSg/VB+  D+  N🅪Sg/Vg/J+ . N🅪Sg/VB/J+ VLPt VP/J     .
+> We   went    in        . To my  overwhelming surprise the living     - room     was  deserted .
+# IPl+ NSg/VPt NPr/J/R/P . P  D$+ Nᴹ/Vg/J+     NSg/VB+  D+  N🅪Sg/Vg/J+ . N🅪Sg/VB+ VLPt VP/J     .
 >
 #
 > “ Well       , that’s funny , ” I       exclaimed .
@@ -5314,16 +5314,16 @@
 #
 > With his     hands   still      in        his     coat    pockets he       stalked by    me       into the hall , turned
 # P    ISg/D$+ NPl/V3+ NSg/VB/J/R NPr/J/R/P ISg/D$+ NSg/VB+ NPl/V3+ NPr/ISg+ VP/J    NSg/P NPr/ISg+ P    D+  NPr+ . VP/J
-> sharply as    if    he       were on  a    wire     , and  disappeared into the living     - room       . It       wasn’t
-# R       R/C/P NSg/C NPr/ISg+ VLPt J/P D/P+ N🅪Sg/VB+ . VB/C VP/J        P    D+  N🅪Sg/Vg/J+ . N🅪Sg/VB/J+ . NPr/ISg+ VPt
+> sharply as    if    he       were on  a    wire     , and  disappeared into the living     - room     . It       wasn’t
+# R       R/C/P NSg/C NPr/ISg+ VLPt J/P D/P+ N🅪Sg/VB+ . VB/C VP/J        P    D+  N🅪Sg/Vg/J+ . N🅪Sg/VB+ . NPr/ISg+ VPt
 > a   bit      funny . Aware of the loud  beating of my  own       heart    I       pulled the door    to
 # D/P NSg/VPt+ NSg/J . VB/J  P  D   NSg/J Nᴹ/Vg/J P  D$+ NSg/VB/J+ N🅪Sg/VB+ ISg/#r+ VP/J   D+  NSg/VB+ P
 > against the increasing rain     .
 # C/P     D+  Nᴹ/Vg/J    N🅪Sg/VB+ .
 >
 #
-> For   half      a    minute    there wasn’t a    sound      . Then      from the living     - room       I       heard a   sort
-# R/C/P N🅪Sg/J/P+ D/P+ NSg/VB/J+ R+    VPt    D/P+ N🅪Sg/VB/J+ . NSg/J/R/C P    D+  N🅪Sg/Vg/J+ . N🅪Sg/VB/J+ ISg/#r+ VP/J  D/P NSg/VB
+> For   half      a    minute    there wasn’t a    sound      . Then      from the living     - room     I       heard a   sort
+# R/C/P N🅪Sg/J/P+ D/P+ NSg/VB/J+ R+    VPt    D/P+ N🅪Sg/VB/J+ . NSg/J/R/C P    D+  N🅪Sg/Vg/J+ . N🅪Sg/VB+ ISg/#r+ VP/J  D/P NSg/VB
 > of choking murmur and  part     of a   laugh   , followed by    Daisy’s voice   on  a   clear
 # P  Nᴹ/Vg/J NSg/VB VB/C NSg/VB/J P  D/P NSg/VB+ . VP/J     NSg/P NPr$    NSg/VB+ J/P D/P NSg/VB/J
 > artificial note    :
@@ -5336,8 +5336,8 @@
 #
 > A    pause   ; it       endured horribly . I       had nothing  to do  in        the hall , so          I       went    into
 # D/P+ NSg/VB+ . NPr/ISg+ VP/J    R        . ISg/#r+ VP  NSg/I/J+ P  VXB NPr/J/R/P D+  NPr+ . NSg/I/J/R/C ISg/#r+ NSg/VPt P
-> the room       .
-# D+  N🅪Sg/VB/J+ .
+> the room     .
+# D+  N🅪Sg/VB+ .
 >
 #
 > Gatsby , his     hands   still      in        his     pockets , was  reclining against the mantelpiece in
@@ -5358,8 +5358,8 @@
 # NPl/V3+ VP/J   P    D/P NSg/J    NSg/VB+ NSg/P D/P NSg/VB+ . R       D+  NSg/VB+ VPt  I/Ddem+
 > moment to tilt   dangerously at    the pressure of his     head      , whereupon he       turned and
 # NSg+   P  NSg/VB R           NSg/P D   N🅪Sg/VB  P  ISg/D$+ NPr/VB/J+ . C         NPr/ISg+ VP/J   VB/C
-> caught it       with trembling fingers , and  set       it       back     in        place    . Then      he       sat      down        ,
-# VP/J   NPr/ISg+ P    Nᴹ/Vg/J   NPl/V3+ . VB/C NPr/VBP/J NPr/ISg+ NSg/VB/J NPr/J/R/P N🅪Sg/VB+ . NSg/J/R/C NPr/ISg+ NSg/VP/J N🅪Sg/VB/J/P .
+> caught it       with trembling fingers , and  set       it       back     in        place    . Then      he       sat    down        ,
+# VP/J   NPr/ISg+ P    Nᴹ/Vg/J   NPl/V3+ . VB/C NPr/VBP/J NPr/ISg+ NSg/VB/J NPr/J/R/P N🅪Sg/VB+ . NSg/J/R/C NPr/ISg+ NSg/VP N🅪Sg/VB/J/P .
 > rigidly , his     elbow   on  the arm      of the sofa    and  his     chin    in        his     hand    .
 # R       . ISg/D$+ NSg/VB+ J/P D   NSg/VB/J P  D   NSg/VB+ VB/C ISg/D$+ NPr/VB+ NPr/J/R/P ISg/D$+ NSg/VB+ .
 >
@@ -5466,8 +5466,8 @@
 #
 > He       raised his     hand    to stop   my  words   , looked at    me       with unforgettable reproach ,
 # NPr/ISg+ VP/J   ISg/D$+ NSg/VB+ P  NSg/VB D$+ NPl/V3+ . VP/J   NSg/P NPr/ISg+ P    J             NSg/VB   .
-> and  , opening the door    cautiously , went    back     into the other    room       .
-# VB/C . Nᴹ/Vg/J D   NSg/VB+ R          . NSg/VPt NSg/VB/J P    D   NSg/VB/J N🅪Sg/VB/J+ .
+> and  , opening the door    cautiously , went    back     into the other    room     .
+# VB/C . Nᴹ/Vg/J D   NSg/VB+ R          . NSg/VPt NSg/VB/J P    D   NSg/VB/J N🅪Sg/VB+ .
 >
 #
 > I       walked out          the back      way    — just as    Gatsby had when    he       had made his     nervous
@@ -5494,8 +5494,8 @@
 # N🅪Sg/J+ . NPr/ISg+ NSg/VPt P    D/P+ J+        NSg/VB+ . ISg/D$+ NPl+     NSg/VP ISg/D$+ NPr/VB+ P    D
 > black     wreath still      on  the door    . Americans , while      willing  , even       eager    , to be
 # N🅪Sg/VB/J NSg/VB NSg/VB/J/R J/P D   NSg/VB+ . NPrPl+    . NSg/VB/C/P NSg/Vg/J . NSg/VB/J/R NSg/VB/J . P  NSg/VLXB
-> serfs , have    always been     obstinate about being        peasantry .
-# NPl   . NSg/VXB R      NSg/VLPp J         J/P   N🅪Sg/VLg/J/C N🅪Sg      .
+> serfs , have    always been   obstinate about being        peasantry .
+# NPl   . NSg/VXB R      VLPp/B J         J/P   N🅪Sg/VLg/J/C N🅪Sg      .
 >
 #
 > After half      an   hour , the sun     shone again , and  the grocer’s automobile rounded
@@ -5521,7 +5521,7 @@
 > over    the stove   — but     I       don’t believe they heard a   sound      . They were sitting  at
 # NSg/J/P D+  NSg/VB+ . NSg/C/P ISg/#r+ VXB   VB      IPl+ VP/J  D/P N🅪Sg/VB/J+ . IPl+ VLPt NSg/Vg/J NSg/P
 > either end    of the couch   , looking at    each other    as    if    some      question had been
-# I/C    NSg/VB P  D+  NSg/VB+ . Nᴹ/Vg/J NSg/P Dq   NSg/VB/J R/C/P NSg/C I/J/R/Dq+ NSg/VB+  VP  NSg/VLPp
+# I/C    NSg/VB P  D+  NSg/VB+ . Nᴹ/Vg/J NSg/P Dq   NSg/VB/J R/C/P NSg/C I/J/R/Dq+ NSg/VB+  VP  VLPp/B
 > asked , or    was  in        the air      , and  every vestige of embarrassment was  gone    . Daisy’s
 # VP/J  . NPr/C VLPt NPr/J/R/P D+  N🅪Sg/VB+ . VB/C Dq    NSg     P  N🅪Sg+         VLPt VPp/J/P . NPr$
 > face    was  smeared with tears   , and  when    I       came      in        she  jumped up         and  began wiping
@@ -5530,8 +5530,8 @@
 # NSg/P NPr/ISg+ P    ISg/D$+ NSg+         C/P    D/P NSg/VB+ . NSg/C/P R+    VLPt D/P+ N🅪Sg/VB+ NPr/J/R/P NPr
 > that      was  simply confounding . He       literally glowed ; without a   word    or    a   gesture of
 # I/C/Ddem+ VLPt R      Nᴹ/Vg/J     . NPr/ISg+ R         VP/J   . C/P     D/P NSg/VB+ NPr/C D/P NSg/VB  P
-> exultation a   new   well       - being        radiated from him  and  filled the little     room       .
-# NSg        D/P NSg/J NSg/VB/J/R . N🅪Sg/VLg/J/C VP/J     P    ISg+ VB/C VP/J   D   NPr/I/J/Dq N🅪Sg/VB/J+ .
+> exultation a   new   well       - being        radiated from him  and  filled the little     room     .
+# NSg        D/P NSg/J NSg/VB/J/R . N🅪Sg/VLg/J/C VP/J     P    ISg+ VB/C VP/J   D   NPr/I/J/Dq N🅪Sg/VB+ .
 >
 #
 > “ Oh     , hello  , old    sport   , ” he       said , as    if    he       hadn’t seen    me       for   years . I       thought
@@ -5546,8 +5546,8 @@
 #
 > “ Has it       ? ” When    he       realized       what   I       was  talking about , that     there were
 # . V3  NPr/ISg+ . . NSg/I/C NPr/ISg+ VP/J/Comm/NoAm NSg/I+ ISg/#r+ VLPt Nᴹ/Vg/J J/P   . I/C/Ddem R+    VLPt
-> twinkle - bells  of sunshine in        the room       , he       smiled like         a   weather  man     , like         an
-# NSg/VB  . NPl/V3 P  Nᴹ/J+    NPr/J/R/P D   N🅪Sg/VB/J+ . NPr/ISg+ VP/J   NSg/VB/J/C/P D/P Nᴹ/VB/J+ NPr/VB+ . NSg/VB/J/C/P D/P
+> twinkle - bells  of sunshine in        the room     , he       smiled like         a   weather  man     , like         an
+# NSg/VB  . NPl/V3 P  Nᴹ/J+    NPr/J/R/P D   N🅪Sg/VB+ . NPr/ISg+ VP/J   NSg/VB/J/C/P D/P Nᴹ/VB/J+ NPr/VB+ . NSg/VB/J/C/P D/P
 > ecstatic patron of recurrent light      , and  repeated the news   to Daisy . “ What   do  you
 # NSg/J    NSg/VB P  NSg/J     N🅪Sg/VB/J+ . VB/C VP/J     D   Nᴹ/VB+ P  NPr   . . NSg/I+ VXB ISgPl+
 > think  of that      ? It’s stopped raining . ”
@@ -5614,12 +5614,12 @@
 # VB/J        NSg/VB+ .
 >
 #
-> “ Oh     , I’ve been     in        several things , ” he       corrected himself . “ I       was  in        the drug
-# . NPr/VB . K    NSg/VLPp NPr/J/R/P J/Dq    NPl+   . . NPr/ISg+ VP/J      ISg+    . . ISg/#r+ VLPt NPr/J/R/P D+  NSg/VB+
+> “ Oh     , I’ve been   in        several things , ” he       corrected himself . “ I       was  in        the drug
+# . NPr/VB . K    VLPp/B NPr/J/R/P J/Dq    NPl+   . . NPr/ISg+ VP/J      ISg+    . . ISg/#r+ VLPt NPr/J/R/P D+  NSg/VB+
 > business and  then      I       was  in        the oil      business . But     I’m not     in        either one     now       . ” He
 # N🅪Sg/J+  VB/C NSg/J/R/C ISg/#r+ VLPt NPr/J/R/P D+  N🅪Sg/VB+ N🅪Sg/J+  . NSg/C/P K   NSg/R/C NPr/J/R/P I/C    NSg/I/J NSg/J/R/C . . NPr/ISg+
-> looked at    me       with more          attention . “ Do  you    mean     you’ve been     thinking over    what   I
-# VP/J   NSg/P NPr/ISg+ P    NPr/I/J/R/Dq+ NSg+      . . VXB ISgPl+ NSg/VB/J K      NSg/VLPp Nᴹ/Vg/J  NSg/J/P NSg/I+ ISg/#r+
+> looked at    me       with more          attention . “ Do  you    mean     you’ve been   thinking over    what   I
+# VP/J   NSg/P NPr/ISg+ P    NPr/I/J/R/Dq+ NSg+      . . VXB ISgPl+ NSg/VB/J K      VLPp/B Nᴹ/Vg/J  NSg/J/P NSg/I+ ISg/#r+
 > proposed the other    night    ? ”
 # VP/J     D   NSg/VB/J N🅪Sg/VB+ . .
 >
@@ -5687,7 +5687,7 @@
 > had seen    him  wandering hungrily about the beach   that      morning    . Finally we   came      to
 # VP  NSg/VPp ISg+ Nᴹ/Vg/J   R        J/P   D+  NPr/VB+ I/C/Ddem+ N🅪Sg/Vg/J+ . R       IPl+ NSg/VPt/P P
 > Gatsby’s own      apartment , a   bedroom and  a   bath    , and  an  Adam’s study   , where   we   sat
-# NPr$     NSg/VB/J NSg+      . D/P NSg     VB/C D/P NSg/VB+ . VB/C D/P NPr$   NSg/VB+ . NSg/R/C IPl+ NSg/VP/J
+# NPr$     NSg/VB/J NSg+      . D/P NSg     VB/C D/P NSg/VB+ . VB/C D/P NPr$   NSg/VB+ . NSg/R/C IPl+ NSg/VP
 > down        and  drank   a   glass     of some     Chartreuse he       took from a   cupboard in        the wall    .
 # N🅪Sg/VB/J/P VB/C NSg/VPt D/P NPr🅪Sg/VB P  I/J/R/Dq NSg/J      NPr/ISg+ VPt  P    D/P NSg/VB+  NPr/J/R/P D   NPr/VB+ .
 >
@@ -5704,12 +5704,12 @@
 # R      VP/J    N🅪Sg/VB/J/P D/P N🅪Sg/VB/J P  NPl+   .
 >
 #
-> His     bedroom was  the simplest room      of all          — except where   the dresser was  garnished
-# ISg/D$+ NSg+    VLPt D   JS       N🅪Sg/VB/J P  NSg/I/J/C/Dq . VB/C/P NSg/R/C D+  NSg+    VLPt VP/J
+> His     bedroom was  the simplest room    of all          — except where   the dresser was  garnished
+# ISg/D$+ NSg+    VLPt D   JS       N🅪Sg/VB P  NSg/I/J/C/Dq . VB/C/P NSg/R/C D+  NSg+    VLPt VP/J
 > with a   toilet  set       of pure      dull gold     . Daisy took the brush  with delight    , and
 # P    D/P NSg/VB+ NPr/VBP/J P  NSg/VB/J+ VB/J Nᴹ/VB/J+ . NPr+  VPt  D   NSg/VB P    N🅪Sg/VB/J+ . VB/C
-> smoothed her     hair     , whereupon Gatsby sat      down        and  shaded his     eyes    and  began to
-# VP/J     ISg/D$+ N🅪Sg/VB+ . C         NPr    NSg/VP/J N🅪Sg/VB/J/P VB/C J      ISg/D$+ NPl/V3+ VB/C VPt   P
+> smoothed her     hair     , whereupon Gatsby sat    down        and  shaded his     eyes    and  began to
+# VP/J     ISg/D$+ N🅪Sg/VB+ . C         NPr    NSg/VP N🅪Sg/VB/J/P VB/C J      ISg/D$+ NPl/V3+ VB/C VPt   P
 > laugh  .
 # NSg/VB .
 >
@@ -5724,8 +5724,8 @@
 # NPr/ISg+ VP  VP/J   R       J/P     NSg+ NPrPl/V3+ VB/C VLPt Nᴹ/Vg/J  P    D/P NSg/VB/J . P
 > his     embarrassment and  his     unreasoning joy        he       was  consumed with wonder  at    her
 # ISg/D$+ N🅪Sg+         VB/C ISg/D$+ J           NPr🅪Sg/VB+ NPr/ISg+ VLPt VP/J     P    N🅪Sg/VB NSg/P ISg/D$+
-> presence . He       had been     full     of the idea so          long     , dreamed      it       right    through to the
-# N🅪Sg/VB+ . NPr/ISg+ VP  NSg/VLPp NSg/VB/J P  D+  NSg+ NSg/I/J/R/C NPr/VB/J . VP/J/NoAm/Au NPr/ISg+ NPr/VB/J J/P     P  D+
+> presence . He       had been   full     of the idea so          long     , dreamed      it       right    through to the
+# N🅪Sg/VB+ . NPr/ISg+ VP  VLPp/B NSg/VB/J P  D+  NSg+ NSg/I/J/R/C NPr/VB/J . VP/J/NoAm/Au NPr/ISg+ NPr/VB/J J/P     P  D+
 > end     , waited with his     teeth set       , so          to speak  , at    an  inconceivable pitch    of
 # NSg/VB+ . VP/J   P    ISg/D$+ NPl+  NPr/VBP/J . NSg/I/J/R/C P  NSg/VB . NSg/P D/P J             NSg/VB/J P
 > intensity . Now       , in        the reaction   , he       was  running   down        like         an  overwound clock   .
@@ -5798,8 +5798,8 @@
 # NSg/VB+ . ISg/D$+ NSg/VB P  VP/J      NPl/V3+ VP  VP/J       NSg/P NSg/I/J .
 >
 #
-> I       began to walk   about the room       , examining various indefinite objects in        the half
-# ISg/#r+ VPt   P  NSg/VB J/P   D+  N🅪Sg/VB/J+ . Nᴹ/Vg/J   J       NSg/J      NPl/V3  NPr/J/R/P D+  N🅪Sg/J/P+
+> I       began to walk   about the room     , examining various indefinite objects in        the half
+# ISg/#r+ VPt   P  NSg/VB J/P   D+  N🅪Sg/VB+ . Nᴹ/Vg/J   J       NSg/J      NPl/V3  NPr/J/R/P D+  N🅪Sg/J/P+
 > darkness . A   large photograph of an   elderly man     in        yachting costume attracted me       ,
 # Nᴹ+      . D/P NSg/J NSg/VB     P  D/P+ R+      NPr/VB+ NPr/J/R/P Nᴹ/Vg/J  NSg/VB  VP/J      NPr/ISg+ .
 > hung     on  the wall    over    his     desk    .
@@ -5880,8 +5880,8 @@
 # . ISg/#r+ VB   NSg/I+ K     VXB . . VP/J NPr    . . K     NSg/VXB ?            N🅪Sg/VB D   NSg/VB/J+ . .
 >
 #
-> He       went    out          of the room       calling “ Ewing ! ” and  returned in        a    few       minutes
-# NPr/ISg+ NSg/VPt NSg/VB/J/R/P P  D+  N🅪Sg/VB/J+ Nᴹ/Vg/J . NPr   . . VB/C VP/J     NPr/J/R/P D/P+ NSg/I/Dq+ NPl/V3+
+> He       went    out          of the room     calling “ Ewing ! ” and  returned in        a    few       minutes
+# NPr/ISg+ NSg/VPt NSg/VB/J/R/P P  D+  N🅪Sg/VB+ Nᴹ/Vg/J . NPr   . . VB/C VP/J     NPr/J/R/P D/P+ NSg/I/Dq+ NPl/V3+
 > accompanied by    an  embarrassed , slightly worn  young    man     , with shell      - rimmed
 # VP/J        NSg/P D/P VP/J        . R        VPp/J NPr/VB/J NPr/VB+ . P    NPr🅪Sg/VB+ . VP/J
 > glasses and  scanty blond    hair     . He       was  now       decently clothed in        a   “ sport   shirt   , ”
@@ -5896,8 +5896,8 @@
 #
 > “ I       was  asleep , ” cried Mr   . Klipspringer , in        a   spasm  of embarrassment . “ That      is  ,
 # . ISg/#r+ VLPt J      . . VP/J  NSg+ . ?            . NPr/J/R/P D/P NSg/VB P  N🅪Sg+         . . I/C/Ddem+ VL3 .
-> I’d been     asleep . Then      I       got up         . . . ”
-# K   NSg/VLPp J      . NSg/J/R/C ISg/#r+ VP  NSg/VB/J/P . . . .
+> I’d been   asleep . Then      I       got up         . . . ”
+# K   VLPp/B J      . NSg/J/R/C ISg/#r+ VP  NSg/VB/J/P . . . .
 >
 #
 > “ Klipspringer plays  the piano     , ” said Gatsby , cutting  him  off        . “ Don’t you    , Ewing ,
@@ -5916,12 +5916,12 @@
 # NPrPl/V3+ VP/J        R/C/P D+  NPr/VB+ VP/J   NSg/VB/J P  N🅪Sg/VB/J+ .
 >
 #
-> In        the music      - room       Gatsby turned on  a   solitary lamp    beside the piano     . He       lit
-# NPr/J/R/P D+  N🅪Sg/VB/J+ . N🅪Sg/VB/J+ NPr    VP/J   J/P D/P NSg/J    NSg/VB+ P      D   NSg/VB/J+ . NPr/ISg+ NSg/VP/J
-> Daisy’s cigarette from a   trembling match   , and  sat      down        with her     on  a   couch   far
-# NPr$    NSg/VB+   P    D/P Nᴹ/Vg/J   NSg/VB+ . VB/C NSg/VP/J N🅪Sg/VB/J/P P    ISg/D$+ J/P D/P NSg/VB+ NSg/VB/J
-> across the room       , where   there was  no       light      save       what   the gleaming floor   bounced
-# NSg/P  D   N🅪Sg/VB/J+ . NSg/R/C R+    VLPt NSg/Dq/P N🅪Sg/VB/J+ NSg/VB/C/P NSg/I+ D   Nᴹ/Vg/J  NSg/VB+ VP/J
+> In        the music      - room     Gatsby turned on  a   solitary lamp    beside the piano     . He       lit
+# NPr/J/R/P D+  N🅪Sg/VB/J+ . N🅪Sg/VB+ NPr    VP/J   J/P D/P NSg/J    NSg/VB+ P      D   NSg/VB/J+ . NPr/ISg+ NSg/VP/J
+> Daisy’s cigarette from a   trembling match   , and  sat    down        with her     on  a   couch   far
+# NPr$    NSg/VB+   P    D/P Nᴹ/Vg/J   NSg/VB+ . VB/C NSg/VP N🅪Sg/VB/J/P P    ISg/D$+ J/P D/P NSg/VB+ NSg/VB/J
+> across the room     , where   there was  no       light      save       what   the gleaming floor   bounced
+# NSg/P  D   N🅪Sg/VB+ . NSg/R/C R+    VLPt NSg/Dq/P N🅪Sg/VB/J+ NSg/VB/C/P NSg/I+ D   Nᴹ/Vg/J  NSg/VB+ VP/J
 > in        from the hall .
 # NPr/J/R/P P    D   NPr+ .
 >
@@ -5967,7 +5967,7 @@
 > back     into Gatsby’s face    , as    though a   faint    doubt    had occurred to him  as    to the
 # NSg/VB/J P    NPr$     NSg/VB+ . R/C/P C      D/P NSg/VB/J N🅪Sg/VB+ VP  VP       P  ISg+ R/C/P P  D
 > quality of his     present  happiness . Almost five years ! There must    have    been
-# N🅪Sg/J  P  ISg/D$+ NSg/VB/J Nᴹ+       . R      NSg+ NPl+  . R+    NSg/VXB NSg/VXB NSg/VLPp
+# N🅪Sg/J  P  ISg/D$+ NSg/VB/J Nᴹ+       . R      NSg+ NPl+  . R+    NSg/VXB NSg/VXB VLPp/B
 > moments even       that      afternoon when    Daisy tumbled short      of his     dreams  — not     through
 # NPl+    NSg/VB/J/R I/C/Ddem+ N🅪Sg+     NSg/I/C NPr+  VP/J    NPr/VB/J/P P  ISg/D$+ NPl/V3+ . NSg/R/C J/P
 > her     own       fault   , but     because of the colossal vitality of his     illusion . It       had gone
@@ -5996,8 +5996,8 @@
 # IPl+ VP  NSg/VPp/J NPr/ISg+ . NSg/C/P NPr+  VP/J    NSg/VB/J/P VB/C VP   NSg/VB/J/R/P ISg/D$+ NSg/VB+ . NPr    VXPt
 > know me       now       at    all          . I       looked once  more         at    them     and  they looked back     at    me       ,
 # VB   NPr/ISg+ NSg/J/R/C NSg/P NSg/I/J/C/Dq . ISg/#r+ VP/J   NSg/C NPr/I/J/R/Dq NSg/P NSg/IPl+ VB/C IPl+ VP/J   NSg/VB/J NSg/P NPr/ISg+ .
-> remotely , possessed by    intense life     . Then      I       went    out          of the room       and  down        the
-# R        . VP/J      NSg/P J+      N🅪Sg/VB+ . NSg/J/R/C ISg/#r+ NSg/VPt NSg/VB/J/R/P P  D+  N🅪Sg/VB/J+ VB/C N🅪Sg/VB/J/P D+
+> remotely , possessed by    intense life     . Then      I       went    out          of the room     and  down        the
+# R        . VP/J      NSg/P J+      N🅪Sg/VB+ . NSg/J/R/C ISg/#r+ NSg/VPt NSg/VB/J/R/P P  D+  N🅪Sg/VB+ VB/C N🅪Sg/VB/J/P D+
 > marble    steps   into the rain     , leaving them     there together .
 # NSg/VB/J+ NPl/V3+ P    D+  N🅪Sg/VB+ . Nᴹ/Vg/J NSg/IPl+ R+    J        .
 >
@@ -6054,8 +6054,8 @@
 # D   N🅪Sg/VB P  NSg       VB/C NSg/P D+  NSg/J+   NSg+   I/C/Ddem+ VP/J      D   NSg/Vg/J  P
 > his     career    — when    he       saw     Dan  Cody’s yacht   drop    anchor  over    the most         insidious flat
 # ISg/D$+ NSg/VB/J+ . NSg/I/C NPr/ISg+ NSg/VPt NPr+ NPr$   NSg/VB+ NSg/VB+ NSg/VB+ NSg/J/P D   NSg/I/J/R/Dq J         NSg/VB/J
-> on  Lake    Superior . It       was  James  Gatz who    had been     loafing along the beach   that
-# J/P NSg/VB+ NPr/J    . NPr/ISg+ VLPt NPrPl+ ?    NPr/I+ VP  NSg/VLPp Nᴹ/Vg/J P     D   NPr/VB+ I/C/Ddem+
+> on  Lake    Superior . It       was  James  Gatz who    had been   loafing along the beach   that
+# J/P NSg/VB+ NPr/J    . NPr/ISg+ VLPt NPrPl+ ?    NPr/I+ VP  VLPp/B Nᴹ/Vg/J P     D   NPr/VB+ I/C/Ddem+
 > afternoon in        a   torn green       jersey and  a   pair   of canvas  pants   , but     it       was  already
 # N🅪Sg      NPr/J/R/P D/P VB/J NPr🅪Sg/VB/J NPr+   VB/C D/P NSg/VB P  NSg/VB+ NPl/V3+ . NSg/C/P NPr/ISg+ VLPt R
 > Jay  Gatsby who    borrowed a   rowboat , pulled out          to the Tuolomee , and  informed Cody
@@ -6082,8 +6082,8 @@
 # NSg/J  P  VB     . VB/C P  I/Ddem N🅪Sg       NPr/ISg+ VLPt NSg/J    P  D   NSg/VB+ .
 >
 #
-> For   over    a    year he       had been     beating his     way    along the south     shore  of Lake
-# R/C/P NSg/J/P D/P+ NSg+ NPr/ISg+ VP  NSg/VLPp Nᴹ/Vg/J ISg/D$+ NSg/J+ P     D   NPr/VB/J+ NSg/VB P  NSg/VB+
+> For   over    a    year he       had been   beating his     way    along the south     shore  of Lake
+# R/C/P NSg/J/P D/P+ NSg+ NPr/ISg+ VP  VLPp/B Nᴹ/Vg/J ISg/D$+ NSg/J+ P     D   NPr/VB/J+ NSg/VB P  NSg/VB+
 > Superior as    a   clam     - digger and  a   salmon       - fisher or    in        any    other    capacity that
 # NPr/J    R/C/P D/P NSg/VB/J . NSg    VB/C D/P N🅪SgPl/VB/J+ . NPr+   NPr/C NPr/J/R/P I/R/Dq NSg/VB/J N🅪Sg/J+  I/C/Ddem+
 > brought him  food and  bed        . His     brown       , hardening body    lived naturally through the
@@ -6148,8 +6148,8 @@
 # NPr  NPr  . D   N🅪Sg/VB+  NSg/VB+ . VP/J   NSg+   NPr+ ?         P  ISg/D$+ N🅪Sg+    VB/C
 > sent   him  to sea in        a   yacht   , were common   property of the turgid journalism
 # NSg/VP ISg+ P  NSg NPr/J/R/P D/P NSg/VB+ . VLPt NSg/VB/J NSg/VB   P  D   J      Nᴹ+
-> of 1902 . He       had been     coasting along all          too hospitable shores  for   five years
-# P  #    . NPr/ISg+ VP  NSg/VLPp Nᴹ/Vg/J  P     NSg/I/J/C/Dq R   J          NPl/V3+ R/C/P NSg  NPl+
+> of 1902 . He       had been   coasting along all          too hospitable shores  for   five years
+# P  #    . NPr/ISg+ VP  VLPp/B Nᴹ/Vg/J  P     NSg/I/J/C/Dq R   J          NPl/V3+ R/C/P NSg  NPl+
 > when    he       turned up         as    James  Gatz’s destiny in        Little     Girl    Bay       .
 # NSg/I/C NPr/ISg+ VP/J   NSg/VB/J/P R/C/P NPrPl+ ?      N🅪Sg+   NPr/J/R/P NPr/I/J/Dq NSg/VB+ NSg/VB/J+ .
 >
@@ -6234,8 +6234,8 @@
 # VXPt   NSg/VB ISg+ NPr/C VB   ISg/D$+ NSg/VB+ J/P D   NSg/VB+ . R      ISg/#r+ VLPt NPr/J/R/P NSg/J NPr+ . NSg/Vg/J
 > around with Jordan and  trying  to ingratiate myself with her     senile aunt — but
 # J/P    P    NPr+   VB/C Nᴹ/Vg/J P  VB         ISg+   P    ISg/D$+ NSg/J  NSg+ . NSg/C/P
-> finally I       went    over    to his     house   one      Sunday  afternoon . I       hadn’t been     there two
-# R       ISg/#r+ NSg/VPt NSg/J/P P  ISg/D$+ NPr/VB+ NSg/I/J+ NSg/VB+ N🅪Sg+     . ISg/#r+ VPt    NSg/VLPp R+    NSg
+> finally I       went    over    to his     house   one      Sunday  afternoon . I       hadn’t been   there two
+# R       ISg/#r+ NSg/VPt NSg/J/P P  ISg/D$+ NPr/VB+ NSg/I/J+ NSg/VB+ N🅪Sg+     . ISg/#r+ VPt    VLPp/B R+    NSg
 > minutes when    somebody brought Tom     Buchanan in        for   a   drink   . I       was  startled ,
 # NPl/V3+ NSg/I/C NSg/I+   VP      NPr/VB+ NPr+     NPr/J/R/P R/C/P D/P NSg/VB+ . ISg/#r+ VLPt VP/J     .
 > naturally , but     the really surprising thing was  that     it       hadn’t happened before .
@@ -6244,8 +6244,8 @@
 #
 > They were a   party    of three on  horseback — Tom    and  a   man     named Sloane and  a   pretty
 # IPl+ VLPt D/P NSg/VB/J P  NSg   J/P Nᴹ        . NPr/VB VB/C D/P NPr/VB+ VP/J  NPr    VB/C D/P NSg/VB/J/R
-> woman   in        a   brown       riding   - habit   , who    had been     there previously .
-# NSg/VB+ NPr/J/R/P D/P NPr🅪Sg/VB/J Nᴹ/Vg/J+ . NSg/VB+ . NPr/I+ VP  NSg/VLPp R+    R          .
+> woman   in        a   brown       riding   - habit   , who    had been   there previously .
+# NSg/VB+ NPr/J/R/P D/P NPr🅪Sg/VB/J Nᴹ/Vg/J+ . NSg/VB+ . NPr/I+ VP  VLPp/B R+    R          .
 >
 #
 > “ I’m delighted to see    you    , ” said Gatsby , standing on  his     porch . “ I’m delighted
@@ -6259,7 +6259,7 @@
 >
 #
 > “ Sit    right    down        . Have    a   cigarette or    a    cigar . ” He       walked around the room
-# . NSg/VB NPr/VB/J N🅪Sg/VB/J/P . NSg/VXB D/P NSg/VB    NPr/C D/P+ NSg+  . . NPr/ISg+ VP/J   J/P    D+  N🅪Sg/VB/J+
+# . NSg/VB NPr/VB/J N🅪Sg/VB/J/P . NSg/VXB D/P NSg/VB    NPr/C D/P+ NSg+  . . NPr/ISg+ VP/J   J/P    D+  N🅪Sg/VB+
 > quickly , ringing bells  . “ I’ll have    something to drink  for   you    in        just a   minute    . ”
 # R       . Nᴹ/Vg/J NPl/V3 . . K    NSg/VXB NSg/I/J+  P  NSg/VB R/C/P ISgPl+ NPr/J/R/P J/R  D/P NSg/VB/J+ . .
 >
@@ -6382,8 +6382,8 @@
 # . NSg/VBPp/P P     . . NPr/ISg+ VP/J . NSg/C/P P  ISg/D$+ J/R/C .
 >
 #
-> “ I       mean     it       , ” she  insisted . “ I’d love      to have    you    . Lots   of room       . ”
-# . ISg/#r+ NSg/VB/J NPr/ISg+ . . ISg+ VP/J     . . K   NPr🅪Sg/VB P  NSg/VXB ISgPl+ . NPl/V3 P  N🅪Sg/VB/J+ . .
+> “ I       mean     it       , ” she  insisted . “ I’d love      to have    you    . Lots   of room     . ”
+# . ISg/#r+ NSg/VB/J NPr/ISg+ . . ISg+ VP/J     . . K   NPr🅪Sg/VB P  NSg/VXB ISgPl+ . NPl/V3 P  N🅪Sg/VB+ . .
 >
 #
 > Gatsby looked at    me       questioningly . He       wanted to go       , and  he       didn’t see    that     Mr   .
@@ -6472,8 +6472,8 @@
 # NPl/VB+ . NPr/C NSg/P NSg/J/Dq D   I/J  NSg/VB P  NPl/VB+ . D   I/J  N🅪Sg/VB   P  N🅪Sg/VB/J+ .
 > the same many       - colored     , many       - keyed commotion , but     I       felt      an  unpleasantness in        the
 # D   I/J  NSg/I/J/Dq . NSg/VP/J/Am . NSg/I/J/Dq . VP/J  N🅪Sg      . NSg/C/P ISg/#r+ N🅪Sg/VP/J D/P NSg            NPr/J/R/P D
-> air      , a   pervading harshness that      hadn’t been     there before . Or    perhaps I       had
-# N🅪Sg/VB+ . D/P Nᴹ/Vg/J   NSg       I/C/Ddem+ VPt    NSg/VLPp R+    C/P    . NPr/C NSg/R   ISg/#r+ VP
+> air      , a   pervading harshness that      hadn’t been   there before . Or    perhaps I       had
+# N🅪Sg/VB+ . D/P Nᴹ/Vg/J   NSg       I/C/Ddem+ VPt    VLPp/B R+    C/P    . NPr/C NSg/R   ISg/#r+ VP
 > merely grown used to it       , grown to accept   West      Egg      as    a    world   complete in        itself ,
 # R      VB/J  VP/J P  NPr/ISg+ . VB/J  P  NSg/VB/J NPr/VB/J+ N🅪Sg/VB+ R/C/P D/P+ NSg/VB+ NSg/VB/J NPr/J/R/P ISg+   .
 > with its     own      standards and  its     own       great  figures , second   to nothing  because it
@@ -6524,8 +6524,8 @@
 #
 > “ Perhaps you    know that      lady    , ” Gatsby indicated a   gorgeous , scarcely human    orchid
 # . NSg/R   ISgPl+ VB   I/C/Ddem+ NPr/VB+ . . NPr    VP/J      D/P J        . R        NSg/VB/J NSg/J
-> of a   woman   who    sat      in        state    under   a   white       - plum       tree    . Tom    and  Daisy stared , with
-# P  D/P NSg/VB+ NPr/I+ NSg/VP/J NPr/J/R/P N🅪Sg/VB+ NSg/J/P D/P NPr🅪Sg/VB/J . N🅪Sg/VB/J+ NSg/VB+ . NPr/VB VB/C NPr+  VP/J   . P
+> of a   woman   who    sat    in        state    under   a   white       - plum       tree    . Tom    and  Daisy stared , with
+# P  D/P NSg/VB+ NPr/I+ NSg/VP NPr/J/R/P N🅪Sg/VB+ NSg/J/P D/P NPr🅪Sg/VB/J . N🅪Sg/VB/J+ NSg/VB+ . NPr/VB VB/C NPr+  VP/J   . P
 > that      peculiarly unreal feeling   that     accompanies the recognition of a   hitherto
 # I/C/Ddem+ R          J      N🅪Sg/Vg/J I/C/Ddem V3          D   NSg         P  D/P J/R
 > ghostly celebrity of the movies .
@@ -6584,8 +6584,8 @@
 # NPr+  VB/C NPr    VP/J   . ISg/#r+ NSg/VB   N🅪Sg/VLg/J/C VP/J      NSg/P ISg/D$+ J        .
 > conservative fox     - trot   — I       had never seen    him  dance    before . Then      they sauntered
 # NSg/J        NPr/VB+ . NSg/VB . ISg/#r+ VP  R     NSg/VPp ISg+ N🅪Sg/VB+ C/P    . NSg/J/R/C IPl+ VP/J
-> over    to my  house   and  sat      on  the steps   for   half      an  hour , while      at    her     request I
-# NSg/J/P P  D$+ NPr/VB+ VB/C NSg/VP/J J/P D   NPl/V3+ R/C/P N🅪Sg/J/P+ D/P NSg+ . NSg/VB/C/P NSg/P ISg/D$+ NSg/VB+ ISg/#r+
+> over    to my  house   and  sat    on  the steps   for   half      an  hour , while      at    her     request I
+# NSg/J/P P  D$+ NPr/VB+ VB/C NSg/VP J/P D   NPl/V3+ R/C/P N🅪Sg/J/P+ D/P NSg+ . NSg/VB/C/P NSg/P ISg/D$+ NSg/VB+ ISg/#r+
 > remained watchfully in        the garden    . “ In        case       there’s a   fire      or    a   flood   , ” she
 # VP/J     R          NPr/J/R/P D   NSg/VB/J+ . . NPr/J/R/P NPr🅪Sg/VB+ K       D/P N🅪Sg/VB/J NPr/C D/P NSg/VB+ . . ISg+
 > explained , ‘ ‘ or    any    act    of God     . ”
@@ -6606,12 +6606,12 @@
 # K      D$+ NPr/I/J/Dq Nᴹ/VB/J+ NSg/VB+ . . . . . ISg+ VP/J   J/P    P     D/P+ NSg+   VB/C VP
 > me       the girl    was  “ common   but     pretty     , ” and  I       knew that     except for   the half      - hour
 # NPr/ISg+ D+  NSg/VB+ VLPt . NSg/VB/J NSg/C/P NSg/VB/J/R . . VB/C ISg/#r+ VPt  I/C/Ddem VB/C/P R/C/P D+  N🅪Sg/J/P+ . NSg+
-> she’d been     alone with Gatsby she  wasn’t having  a   good     time       .
-# K     NSg/VLPp J     P    NPr    ISg+ VPt    Nᴹ/Vg/J D/P NPr/VB/J N🅪Sg/VB/J+ .
+> she’d been   alone with Gatsby she  wasn’t having  a   good     time       .
+# K     VLPp/B J     P    NPr    ISg+ VPt    Nᴹ/Vg/J D/P NPr/VB/J N🅪Sg/VB/J+ .
 >
 #
-> We   were at    a   particularly tipsy table   . That      was  my  fault   — Gatsby had been     called
-# IPl+ VLPt NSg/P D/P R            J     NSg/VB+ . I/C/Ddem+ VLPt D$+ NSg/VB+ . NPr    VP  NSg/VLPp VP/J
+> We   were at    a   particularly tipsy table   . That      was  my  fault   — Gatsby had been   called
+# IPl+ VLPt NSg/P D/P R            J     NSg/VB+ . I/C/Ddem+ VLPt D$+ NSg/VB+ . NPr    VP  VLPp/B VP/J
 > to the phone   , and  I’d enjoyed these  same people  only  two weeks  before . But     what
 # P  D   NSg/VB+ . VB/C K   VP/J    I/Ddem I/J  NPl/VB+ J/R/C NSg NPrPl+ C/P    . NSg/C/P NSg/I+
 > had amused me       then      turned septic on  the air      now       .
@@ -6624,16 +6624,16 @@
 #
 > The girl    addressed was  trying  , unsuccessfully , to slump  against my  shoulder . At
 # D+  NSg/VB+ VP/J      VLPt Nᴹ/Vg/J . R              . P  NSg/VB C/P     D$+ NSg/VB+  . NSg/P
-> this    inquiry she  sat      up         and  opened her     eyes    .
-# I/Ddem+ NSg+    ISg+ NSg/VP/J NSg/VB/J/P VB/C VP/J   ISg/D$+ NPl/V3+ .
+> this    inquiry she  sat    up         and  opened her     eyes    .
+# I/Ddem+ NSg+    ISg+ NSg/VP NSg/VB/J/P VB/C VP/J   ISg/D$+ NPl/V3+ .
 >
 #
 > “ Wha ’ ? ”
 # . ?   . . .
 >
 #
-> A   massive and  lethargic woman   , who    had been     urging   Daisy to play    golf    with her
-# D/P NSg/J   VB/C J         NSg/VB+ . NPr/I+ VP  NSg/VLPp Nᴹ/Vg/J+ NPr+  P  N🅪Sg/VB NSg/VB+ P    ISg/D$+
+> A   massive and  lethargic woman   , who    had been   urging   Daisy to play    golf    with her
+# D/P NSg/J   VB/C J         NSg/VB+ . NPr/I+ VP  VLPp/B Nᴹ/Vg/J+ NPr+  P  N🅪Sg/VB NSg/VB+ P    ISg/D$+
 > at    the local club    to - morrow , spoke   in        Miss   Baedeker’s defence    :
 # NSg/P D   NSg/J NSg/VB+ P  . NPr/VB . NSg/VPt NPr/J/R/P NSg/VB NPr$       N🅪Sg/Comm+ .
 >
@@ -6682,8 +6682,8 @@
 # Nᴹ/Vg/J  D   Nᴹ/Vg/J+ . NSg/VB+ NSg      VB/C ISg/D$+ NSg/VB+ . IPl+ VLPt NSg/VB/J/R NSg/J/P D
 > white       - plum      tree   and  their faces   were touching  except for   a   pale     , thin     ray    of
 # NPr🅪Sg/VB/J . N🅪Sg/VB/J NSg/VB VB/C D$+   NPl/V3+ VLPt Nᴹ/Vg/J/P VB/C/P R/C/P D/P NSg/VB/J . NSg/VB/J NPr/VB P
-> moonlight between . It       occurred to me       that     he       had been     very slowly bending toward
-# N🅪Sg/VB+  NSg/P   . NPr/ISg+ VP       P  NPr/ISg+ I/C/Ddem NPr/ISg+ VP  NSg/VLPp J/R  R      Nᴹ/Vg/J J/P
+> moonlight between . It       occurred to me       that     he       had been   very slowly bending toward
+# N🅪Sg/VB+  NSg/P   . NPr/ISg+ VP       P  NPr/ISg+ I/C/Ddem NPr/ISg+ VP  VLPp/B J/R  R      Nᴹ/Vg/J J/P
 > her     all          evening    to attain this    proximity , and  even       while      I       watched I       saw     him
 # ISg/D$+ NSg/I/J/C/Dq N🅪Sg/Vg/J+ P  VB     I/Ddem+ Nᴹ+       . VB/C NSg/VB/J/R NSg/VB/C/P ISg/#r+ VP/J    ISg/#r+ NSg/VPt ISg+
 > stoop  one      ultimate  degree and  kiss   at    her     cheek   .
@@ -6708,12 +6708,12 @@
 # NPr/J/R/P D+  J/R+ N🅪Sg+      ISg+ VP/J   P  VB         .
 >
 #
-> I       sat      on  the front     steps   with them     while      they waited for   their car  . It       was  dark
-# ISg/#r+ NSg/VP/J J/P D+  NSg/VB/J+ NPl/V3+ P    NSg/IPl+ NSg/VB/C/P IPl+ VP/J   R/C/P D$+   NSg+ . NPr/ISg+ VLPt NSg/VB/J
+> I       sat    on  the front     steps   with them     while      they waited for   their car  . It       was  dark
+# ISg/#r+ NSg/VP J/P D+  NSg/VB/J+ NPl/V3+ P    NSg/IPl+ NSg/VB/C/P IPl+ VP/J   R/C/P D$+   NSg+ . NPr/ISg+ VLPt NSg/VB/J
 > here in        front     ; only  the bright   door    sent   ten square   feet of light      volleying out
 # J/R  NPr/J/R/P NSg/VB/J+ . J/R/C D   NPr/VB/J NSg/VB+ NSg/VP NSg NSg/VB/J NPl  P  N🅪Sg/VB/J+ Nᴹ/Vg/J   NSg/VB/J/R/P
 > into the soft  black     morning    . Sometimes a    shadow    moved against a   dressing - room
-# P    D   NSg/J N🅪Sg/VB/J N🅪Sg/Vg/J+ . R         D/P+ NSg/VB/J+ VP/J  C/P     D/P Nᴹ/Vg/J+ . N🅪Sg/VB/J
+# P    D   NSg/J N🅪Sg/VB/J N🅪Sg/Vg/J+ . R         D/P+ NSg/VB/J+ VP/J  C/P     D/P Nᴹ/Vg/J+ . N🅪Sg/VB
 > blind    above   , gave way    to another shadow    , an  indefinite procession of shadows ,
 # NSg/VB/J NSg/J/P . VPt  NSg/J+ P  I/D+    NSg/VB/J+ . D/P NSg/J      NSg/VB     P  NPl/V3+ .
 > who    rouged and  powdered in        an  invisible glass      .
@@ -6786,10 +6786,10 @@
 # N🅪Sg/VB/J+ P    D   N🅪Sg/VB+ .
 >
 #
-> “ Lots   of people  come       who    haven’t been     invited  , ” she  said suddenly . “ That     girl
-# . NPl/V3 P  NPl/VB+ NSg/VBPp/P NPr/I+ VXB     NSg/VLPp NSg/VP/J . . ISg+ VP/J R        . . I/C/Ddem NSg/VB+
-> hadn’t been     invited  . They simply force   their way    in        and  he’s too polite to
-# VPt    NSg/VLPp NSg/VP/J . IPl+ R      N🅪Sg/VB D$+   NSg/J+ NPr/J/R/P VB/C NPr$ R   VB/J   P
+> “ Lots   of people  come       who    haven’t been   invited  , ” she  said suddenly . “ That     girl
+# . NPl/V3 P  NPl/VB+ NSg/VBPp/P NPr/I+ VXB     VLPp/B NSg/VP/J . . ISg+ VP/J R        . . I/C/Ddem NSg/VB+
+> hadn’t been   invited  . They simply force   their way    in        and  he’s too polite to
+# VPt    VLPp/B NSg/VP/J . IPl+ R      N🅪Sg/VB D$+   NSg/J+ NPr/J/R/P VB/C NPr$ R   VB/J   P
 > object . ”
 # NSg/VB . .
 >
@@ -6924,16 +6924,16 @@
 # NPr/ISg+ VP/J   D/P+ NPr/VB+ J/P   D   NSg/VB/J/P . VB/C ISg/#r+ VP/J     I/C/Ddem NPr/ISg+ VP/J   P  N🅪Sg/VB/J
 > something , some     idea of himself perhaps , that      had gone    into loving   Daisy . His
 # NSg/I/J+  . I/J/R/Dq NSg  P  ISg+    NSg/R   . I/C/Ddem+ VP  VPp/J/P P    Nᴹ/Vg/J+ NPr+  . ISg/D$+
-> life     had been     confused and  disordered since then      , but     if    he       could   once  return to
-# N🅪Sg/VB+ VP  NSg/VLPp VP/J     VB/C VP/J       C/P   NSg/J/R/C . NSg/C/P NSg/C NPr/ISg+ NSg/VXB NSg/C NSg/VB P
+> life     had been   confused and  disordered since then      , but     if    he       could   once  return to
+# N🅪Sg/VB+ VP  VLPp/B VP/J     VB/C VP/J       C/P   NSg/J/R/C . NSg/C/P NSg/C NPr/ISg+ NSg/VXB NSg/C NSg/VB P
 > a   certain starting place    and  go       over    it       all          slowly , he       could   find   out          what   that
 # D/P I/J     Nᴹ/Vg/J+ N🅪Sg/VB+ VB/C NSg/VB/J NSg/J/P NPr/ISg+ NSg/I/J/C/Dq R      . NPr/ISg+ NSg/VXB NSg/VB NSg/VB/J/R/P NSg/I+ I/C/Ddem
 > thing was  . . . .
 # NSg+  VLPt . . . .
 >
 #
-> . . . One      autumn     night    , five years before , they had been     walking down        the street
-# . . . NSg/I/J+ NPr🅪Sg/VB+ N🅪Sg/VB+ . NSg+ NPl+  C/P    . IPl+ VP  NSg/VLPp Nᴹ/Vg/J N🅪Sg/VB/J/P D+  NSg/VB/J+
+> . . . One      autumn     night    , five years before , they had been   walking down        the street
+# . . . NSg/I/J+ NPr🅪Sg/VB+ N🅪Sg/VB+ . NSg+ NPl+  C/P    . IPl+ VP  VLPp/B Nᴹ/Vg/J N🅪Sg/VB/J/P D+  NSg/VB/J+
 > when    the leaves  were falling , and  they came      to a    place    where   there were no       trees
 # NSg/I/C D+  NPl/V3+ VLPt Nᴹ/Vg/J . VB/C IPl+ NSg/VPt/P P  D/P+ N🅪Sg/VB+ NSg/R/C R+    VLPt NSg/Dq/P NPl/V3
 > and  the sidewalk was  white       with moonlight . They stopped here and  turned toward
@@ -6960,8 +6960,8 @@
 # VPt  I/C/Ddem NSg/I/C NPr/ISg+ VP/J   I/Ddem+ NSg/VB+ . VB/C NSg/J   NSg/VB ISg/D$+ NSg/J       NPl/V3+ P
 > her     perishable breath     , his     mind    would never romp   again like         the mind   of God     . So
 # ISg/D$+ NSg/J      N🅪Sg/VB/J+ . ISg/D$+ NSg/VB+ VXB   R     NSg/VB P     NSg/VB/J/C/P D   NSg/VB P  NPr/VB+ . NSg/I/J/R/C
-> he       waited , listening for   a    moment longer to the tuning   - fork    that      had been     struck
-# NPr/ISg+ VP/J   . Nᴹ/Vg/J   R/C/P D/P+ NSg+   NSg/JC P  D+  Nᴹ/Vg/J+ . NSg/VB+ I/C/Ddem+ VP  NSg/VLPp VB
+> he       waited , listening for   a    moment longer to the tuning   - fork    that      had been   struck
+# NPr/ISg+ VP/J   . Nᴹ/Vg/J   R/C/P D/P+ NSg+   NSg/JC P  D+  Nᴹ/Vg/J+ . NSg/VB+ I/C/Ddem+ VP  VLPp/B VB
 > upon a    star    . Then      he       kissed her     . At    his     lips    ’ touch   she  blossomed for   him  like         a
 # P    D/P+ NSg/VB+ . NSg/J/R/C NPr/ISg+ VP/J   ISg/D$+ . NSg/P ISg/D$+ NPl/V3+ . N🅪Sg/VB ISg+ VP/J      R/C/P ISg+ NSg/VB/J/C/P D/P
 > flower  and  the incarnation was  complete .
@@ -7170,8 +7170,8 @@
 # P  N🅪Sg/VB+ .
 >
 #
-> The room       , shadowed well       with awnings , was  dark     and  cool     . Daisy and  Jordan lay
-# D+  N🅪Sg/VB/J+ . VP/J     NSg/VB/J/R P    NPl/V3  . VLPt NSg/VB/J VB/C NSg/VB/J . NPr   VB/C NPr+   NSg/VBPt/J
+> The room     , shadowed well       with awnings , was  dark     and  cool     . Daisy and  Jordan lay
+# D+  N🅪Sg/VB+ . VP/J     NSg/VB/J/R P    NPl/V3  . VLPt NSg/VB/J VB/C NSg/VB/J . NPr   VB/C NPr+   NSg/VBPt/J
 > upon an   enormous couch   , like         silver   idols weighing down        their own      white       dresses
 # P    D/P+ J+       NSg/VB+ . NSg/VB/J/C/P Nᴹ/VB/J+ NPl+  Nᴹ/Vg/J  N🅪Sg/VB/J/P D$+   NSg/VB/J NPr🅪Sg/VB/J NPl/V3+
 > against the singing breeze of the fans    .
@@ -7228,8 +7228,8 @@
 #
 > Tom     flung open      the door    , blocked out          its     space    for   a   moment with his     thick     body    ,
 # NPr/VB+ VB    NSg/VB/J+ D+  NSg/VB+ . VP/J    NSg/VB/J/R/P ISg/D$+ N🅪Sg/VB+ R/C/P D/P NSg+   P    ISg/D$+ NSg/VB/J+ NSg/VB+ .
-> and  hurried into the room       .
-# VB/C VP/J    P    D+  N🅪Sg/VB/J+ .
+> and  hurried into the room     .
+# VB/C VP/J    P    D+  N🅪Sg/VB+ .
 >
 #
 > “ Mr   . Gatsby ! ” He       put     out          his     broad , flat      hand    with well       - concealed dislike      . “ I’m
@@ -7242,8 +7242,8 @@
 # . NSg/VB NPr/IPl+ D/P+ NSg/J+ NSg/VB+ . . VP/J  NPr+  .
 >
 #
-> As    he       left     the room       again she  got up         and  went    over    to Gatsby and  pulled his     face
-# R/C/P NPr/ISg+ NPr/VP/J D+  N🅪Sg/VB/J+ P     ISg+ VP  NSg/VB/J/P VB/C NSg/VPt NSg/J/P P  NPr    VB/C VP/J   ISg/D$+ NSg/VB+
+> As    he       left     the room     again she  got up         and  went    over    to Gatsby and  pulled his     face
+# R/C/P NPr/ISg+ NPr/VP/J D+  N🅪Sg/VB+ P     ISg+ VP  NSg/VB/J/P VB/C NSg/VPt NSg/J/P P  NPr    VB/C VP/J   ISg/D$+ NSg/VB+
 > down        , kissing him  on  the mouth   .
 # N🅪Sg/VB/J/P . Nᴹ/Vg/J ISg+ J/P D   NSg/VB+ .
 >
@@ -7270,10 +7270,10 @@
 #
 > “ I       don’t care     ! ” cried Daisy , and  began to clog   on  the brick      fireplace . Then      she
 # . ISg/#r+ VXB   N🅪Sg/VB+ . . VP/J  NPr+  . VB/C VPt   P  NSg/VB J/P D+  N🅪Sg/VB/J+ NSg+      . NSg/J/R/C ISg+
-> remembered the heat   and  sat      down        guiltily on  the couch   just as    a   freshly
-# VP/J       D+  Nᴹ/VB+ VB/C NSg/VP/J N🅪Sg/VB/J/P R        J/P D+  NSg/VB+ J/R  R/C/P D/P R
-> laundered nurse   leading a   little     girl    came      into the room       .
-# VP/J      NSg/VB+ Nᴹ/Vg/J D/P NPr/I/J/Dq NSg/VB+ NSg/VPt/P P    D   N🅪Sg/VB/J+ .
+> remembered the heat   and  sat    down        guiltily on  the couch   just as    a   freshly
+# VP/J       D+  Nᴹ/VB+ VB/C NSg/VP N🅪Sg/VB/J/P R        J/P D+  NSg/VB+ J/R  R/C/P D/P R
+> laundered nurse   leading a   little     girl    came      into the room     .
+# VP/J      NSg/VB+ Nᴹ/Vg/J D/P NPr/I/J/Dq NSg/VB+ NSg/VPt/P P    D   N🅪Sg/VB+ .
 >
 #
 > “ Bles - sed pre      - cious , ” she  crooned , holding out          her     arms    . “ Come       to your own
@@ -7282,8 +7282,8 @@
 # NSg/VB/J+ I/C/Ddem+ NPl/V3 ISgPl+ . .
 >
 #
-> The child   , relinquished by    the nurse   , rushed across the room       and  rooted shyly
-# D+  NSg/VB+ . VP/J         NSg/P D+  NSg/VB+ . VP/J   NSg/P  D+  N🅪Sg/VB/J+ VB/C VP/J   R
+> The child   , relinquished by    the nurse   , rushed across the room     and  rooted shyly
+# D+  NSg/VB+ . VP/J         NSg/P D+  NSg/VB+ . VP/J   NSg/P  D+  N🅪Sg/VB+ VB/C VP/J   R
 > into her     mother’s dress   .
 # P    ISg/D$+ NSg$     NSg/VB+ .
 >
@@ -7334,8 +7334,8 @@
 # VP  D$+ N🅪Sg/VB VB/C N🅪Sg/VB P  D   NSg/VB+ . .
 >
 #
-> Daisy sat      back     upon the couch   . The nurse   took a    step    forward  and  held out          her
-# NPr+  NSg/VP/J NSg/VB/J P    D+  NSg/VB+ . D+  NSg/VB+ VPt  D/P+ NSg/VB+ NSg/VB/J VB/C VP   NSg/VB/J/R/P ISg/D$+
+> Daisy sat    back     upon the couch   . The nurse   took a    step    forward  and  held out          her
+# NPr+  NSg/VP NSg/VB/J P    D+  NSg/VB+ . D+  NSg/VB+ VPt  D/P+ NSg/VB+ NSg/VB/J VB/C VP   NSg/VB/J/R/P ISg/D$+
 > hand    .
 # NSg/VB+ .
 >
@@ -7414,8 +7414,8 @@
 # R/C/P J/P   D/P NSg+ . .
 >
 #
-> We   had luncheon in        the dining   - room       , darkened too against the heat   , and  drank
-# IPl+ VP  NSg/VB+  NPr/J/R/P D+  Nᴹ/Vg/J+ . N🅪Sg/VB/J+ . VP/J     R   C/P     D+  Nᴹ/VB+ . VB/C NSg/VPt
+> We   had luncheon in        the dining   - room     , darkened too against the heat   , and  drank
+# IPl+ VP  NSg/VB+  NPr/J/R/P D+  Nᴹ/Vg/J+ . N🅪Sg/VB+ . VP/J     R   C/P     D+  Nᴹ/VB+ . VB/C NSg/VPt
 > down        nervous gayety with the cold  ale   .
 # N🅪Sg/VB/J/P J       ?      P    D   NSg/J N🅪Sg+ .
 >
@@ -7698,8 +7698,8 @@
 # VPp/J/P JC     NSg/C K   VPp/J . . . .
 >
 #
-> “ Do  you    mean     you’ve been     to a   medium ? ” inquired Jordan humorously .
-# . VXB ISgPl+ NSg/VB/J K      NSg/VLPp P  D/P NSg/J  . . VP/J     NPr+   R          .
+> “ Do  you    mean     you’ve been   to a   medium ? ” inquired Jordan humorously .
+# . VXB ISgPl+ NSg/VB/J K      VLPp/B P  D/P NSg/J  . . VP/J     NPr+   R          .
 >
 #
 > “ What   ? ” Confused , he       stared at    us       as    we   laughed . “ A   medium ? ”
@@ -7710,8 +7710,8 @@
 # . J/P   NPr    . .
 >
 #
-> “ About Gatsby ! No       , I       haven’t . I       said I’d been     making  a   small    investigation of
-# . J/P   NPr    . NSg/Dq/P . ISg/#r+ VXB     . ISg/#r+ VP/J K   NSg/VLPp Nᴹ/Vg/J D/P NPr/VB/J N🅪Sg          P
+> “ About Gatsby ! No       , I       haven’t . I       said I’d been   making  a   small    investigation of
+# . J/P   NPr    . NSg/Dq/P . ISg/#r+ VXB     . ISg/#r+ VP/J K   VLPp/B Nᴹ/Vg/J D/P NPr/VB/J N🅪Sg          P
 > his     past       . ”
 # ISg/D$+ NSg/VB/J/P . .
 >
@@ -7774,8 +7774,8 @@
 # VB     D+  NSg/VB+ . .
 >
 #
-> “ I’m sick     , ” said Wilson without moving  . “ Been     sick     all           day     . ”
-# . K   NSg/VB/J . . VP/J NPr+   C/P     Nᴹ/Vg/J . . NSg/VLPp NSg/VB/J NSg/I/J/C/Dq+ NPr🅪Sg+ . .
+> “ I’m sick     , ” said Wilson without moving  . “ Been   sick     all           day     . ”
+# . K   NSg/VB/J . . VP/J NPr+   C/P     Nᴹ/Vg/J . . VLPp/B NSg/VB/J NSg/I/J/C/Dq+ NPr🅪Sg+ . .
 >
 #
 > “ What’s the matter   ? ”
@@ -7826,16 +7826,16 @@
 # . NSg/I+ VXB ISgPl+ NSg/VB N🅪Sg/J+ R/C/P . NSg/I/J/C/Dq P  D/P NSg/J  . .
 >
 #
-> “ I’ve been     here too long     . I       want   to get    away . My  wife      and  I       want   to go       West      . ”
-# . K    NSg/VLPp J/R  R   NPr/VB/J . ISg/#r+ NSg/VB P  NSg/VB VB/J . D$+ NSg/VB/J+ VB/C ISg/#r+ NSg/VB P  NSg/VB/J NPr/VB/J+ . .
+> “ I’ve been   here too long     . I       want   to get    away . My  wife      and  I       want   to go       West      . ”
+# . K    VLPp/B J/R  R   NPr/VB/J . ISg/#r+ NSg/VB P  NSg/VB VB/J . D$+ NSg/VB/J+ VB/C ISg/#r+ NSg/VB P  NSg/VB/J NPr/VB/J+ . .
 >
 #
 > “ Your wife      does    , ” exclaimed Tom     , startled .
 # . D$+  NSg/VB/J+ NPl/VX3 . . VP/J      NPr/VB+ . VP/J     .
 >
 #
-> “ She’s been     talking about it       for   ten years . ” He       rested for   a   moment against the
-# . K     NSg/VLPp Nᴹ/Vg/J J/P   NPr/ISg+ R/C/P NSg NPl+  . . NPr/ISg+ VP/J   R/C/P D/P NSg+   C/P     D+
+> “ She’s been   talking about it       for   ten years . ” He       rested for   a   moment against the
+# . K     VLPp/B Nᴹ/Vg/J J/P   NPr/ISg+ R/C/P NSg NPl+  . . NPr/ISg+ VP/J   R/C/P D/P NSg+   C/P     D+
 > pump    , shading his     eyes    . “ And  now       she’s going   whether she  wants  to or    not     . I’m
 # NSg/VB+ . Nᴹ/Vg/J ISg/D$+ NPl/V3+ . . VB/C NSg/J/R/C K     Nᴹ/Vg/J I/C     ISg+ NPl/V3 P  NPr/C NSg/R/C . K
 > going   to get    her     away . ”
@@ -7852,8 +7852,8 @@
 #
 > “ I       just got wised up         to something funny the last     two days , ” remarked Wilson .
 # . ISg/#r+ J/R  VP  VP/J  NSg/VB/J/P P  NSg/I/J+  NSg/J D   NSg/VB/J NSg NPl+ . . VP/J     NPr+   .
-> “ That’s why    I       want   to get    away . That’s why    I       been     bothering you    about the car  . ”
-# . K      NSg/VB ISg/#r+ NSg/VB P  NSg/VB VB/J . K      NSg/VB ISg/#r+ NSg/VLPp Nᴹ/Vg/J   ISgPl+ J/P   D   NSg+ . .
+> “ That’s why    I       want   to get    away . That’s why    I       been   bothering you    about the car  . ”
+# . K      NSg/VB ISg/#r+ NSg/VB P  NSg/VB VB/J . K      NSg/VB ISg/#r+ VLPp/B Nᴹ/Vg/J   ISgPl+ J/P   D   NSg+ . .
 >
 #
 > “ What   do  I       owe you    ? ”
@@ -7890,8 +7890,8 @@
 #
 > That      locality was  always vaguely disquieting , even       in        the broad glare    of
 # I/C/Ddem+ NSg      VLPt R      R       Nᴹ/Vg/J     . NSg/VB/J/R NPr/J/R/P D   NSg/J NSg/VB/J P
-> afternoon , and  now       I       turned my  head      as    though I       had been     warned of something
-# N🅪Sg+     . VB/C NSg/J/R/C ISg/#r+ VP/J   D$+ NPr/VB/J+ R/C/P C      ISg/#r+ VP  NSg/VLPp VP/J   P  NSg/I/J+
+> afternoon , and  now       I       turned my  head      as    though I       had been   warned of something
+# N🅪Sg+     . VB/C NSg/J/R/C ISg/#r+ VP/J   D$+ NPr/VB/J+ R/C/P C      ISg/#r+ VP  VLPp/B VP/J   P  NSg/I/J+
 > behind  . Over    the ashheaps the giant eyes   of Doctor  T. J. Eckleburg kept their
 # NSg/J/P . NSg/J/P D   ?        D   NSg/J NPl/V3 P  NSg/VB+ ?  ?  ?         VP   D$+
 > vigil  , but     I       perceived , after a   moment , that     other    eyes    were regarding us       with
@@ -7900,8 +7900,8 @@
 # NSg/J    Nᴹ+       P    J/R/C/P C/P  NSg    NPl+ VB/J .
 >
 #
-> In        one     of the windows   over    the garage  the curtains had been     moved aside a
-# NPr/J/R/P NSg/I/J P  D+  NPrPl/V3+ NSg/J/P D+  NSg/VB+ D+  NPl/V3+  VP  NSg/VLPp VP/J  NSg/J D/P
+> In        one     of the windows   over    the garage  the curtains had been   moved aside a
+# NPr/J/R/P NSg/I/J P  D+  NPrPl/V3+ NSg/J/P D+  NSg/VB+ D+  NPl/V3+  VP  VLPp/B VP/J  NSg/J D/P
 > little     , and  Myrtle Wilson was  peering down        at    the car  . So          engrossed was  she  that
 # NPr/I/J/Dq . VB/C NPr    NPr+   VLPt Nᴹ/Vg/J N🅪Sg/VB/J/P NSg/P D   NSg+ . NSg/I/J/R/C VP/J      VLPt ISg+ I/C/Ddem
 > she  had no       consciousness of being        observed , and  one     emotion after another crept
@@ -7991,7 +7991,7 @@
 >
 #
 > The prolonged and  tumultuous argument that      ended by    herding  us       into that     room
-# D   VP/J      VB/C J          N🅪Sg/VB+ I/C/Ddem+ VP/J  NSg/P Nᴹ/Vg/J+ NPr/IPl+ P    I/C/Ddem N🅪Sg/VB/J+
+# D   VP/J      VB/C J          N🅪Sg/VB+ I/C/Ddem+ VP/J  NSg/P Nᴹ/Vg/J+ NPr/IPl+ P    I/C/Ddem N🅪Sg/VB+
 > eludes me       , though I       have    a   sharp    physical memory that      , in        the course of it       , my
 # V3     NPr/ISg+ . C      ISg/#r+ NSg/VXB D/P NPr/VB/J NSg/J    N🅪Sg+  I/C/Ddem+ . NPr/J/R/P D   NSg/VB P  NPr/ISg+ . D$+
 > underwear kept climbing like         a   damp    snake   around my  legs    and  intermittent beads
@@ -8008,8 +8008,8 @@
 # N🅪Sg/VP . NPr/C VP/J      P  NSg/VB . I/C/Ddem IPl+ VLPt N🅪Sg/VLg/J/C J/R  NSg/J . . .
 >
 #
-> The room       was  large and  stifling , and  , though it       was  already four o’clock ,
-# D+  N🅪Sg/VB/J+ VLPt NSg/J VB/C Nᴹ/Vg/J  . VB/C . C      NPr/ISg+ VLPt R       NSg  R       .
+> The room     was  large and  stifling , and  , though it       was  already four o’clock ,
+# D+  N🅪Sg/VB+ VLPt NSg/J VB/C Nᴹ/Vg/J  . VB/C . C      NPr/ISg+ VLPt R       NSg  R       .
 > opening the windows   admitted only  a   gust   of hot      shrubbery from the Park    . Daisy
 # Nᴹ/Vg/J D   NPrPl/V3+ VP/J     J/R/C D/P NSg/VB P  NSg/VB/J NSg       P    D   NPr/VB+ . NPr+
 > went    to the mirror  and  stood with her     back     to us       , fixing  her     hair     .
@@ -8164,8 +8164,8 @@
 #
 > “ Well       , he       said he       knew you    . He       said he       was  raised in        Louisville . Asa Bird
 # . NSg/VB/J/R . NPr/ISg+ VP/J NPr/ISg+ VPt  ISgPl+ . NPr/ISg+ VP/J NPr/ISg+ VLPt VP/J   NPr/J/R/P NPr        . ?   NPr/VB/J+
-> brought him  around at    the last     minute    and  asked if    we   had room       for   him  . ”
-# VP      ISg+ J/P    NSg/P D   NSg/VB/J NSg/VB/J+ VB/C VP/J  NSg/C IPl+ VP  N🅪Sg/VB/J+ R/C/P ISg+ . .
+> brought him  around at    the last     minute    and  asked if    we   had room     for   him  . ”
+# VP      ISg+ J/P    NSg/P D   NSg/VB/J NSg/VB/J+ VB/C VP/J  NSg/C IPl+ VP  N🅪Sg/VB+ R/C/P ISg+ . .
 >
 #
 > Jordan smiled .
@@ -8376,12 +8376,12 @@
 #
 > “ Sit    down        , Daisy , ” Tom’s voice   groped unsuccessfully for   the paternal note    .
 # . NSg/VB N🅪Sg/VB/J/P . NPr+  . . NPr$  NSg/VB+ VP/J   R              R/C/P D   J        NSg/VB+ .
-> “ What’s been     going   on  ? I       want   to hear all          about it       . ”
-# . K      NSg/VLPp Nᴹ/Vg/J J/P . ISg/#r+ NSg/VB P  VB   NSg/I/J/C/Dq J/P   NPr/ISg+ . .
+> “ What’s been   going   on  ? I       want   to hear all          about it       . ”
+# . K      VLPp/B Nᴹ/Vg/J J/P . ISg/#r+ NSg/VB P  VB   NSg/I/J/C/Dq J/P   NPr/ISg+ . .
 >
 #
-> “ I       told you    what’s been     going   on  , ” said Gatsby . “ Going   on  for   five years — and  you
-# . ISg/#r+ VP   ISgPl+ K      NSg/VLPp Nᴹ/Vg/J J/P . . VP/J NPr    . . Nᴹ/Vg/J J/P R/C/P NSg+ NPl+  . VB/C ISgPl+
+> “ I       told you    what’s been   going   on  , ” said Gatsby . “ Going   on  for   five years — and  you
+# . ISg/#r+ VP   ISgPl+ K      VLPp/B Nᴹ/Vg/J J/P . . VP/J NPr    . . Nᴹ/Vg/J J/P R/C/P NSg+ NPl+  . VB/C ISgPl+
 > didn’t know . ”
 # VXPt   VB   . .
 >
@@ -8390,8 +8390,8 @@
 # NPr/VB+ VP/J   P  NPr   R       .
 >
 #
-> “ You’ve been     seeing     this   fellow for   five years ? ”
-# . K      NSg/VLPp NSg/Vg/J/C I/Ddem NSg    R/C/P NSg  NPl+  . .
+> “ You’ve been   seeing     this   fellow for   five years ? ”
+# . K      VLPp/B NSg/Vg/J/C I/Ddem NSg    R/C/P NSg  NPl+  . .
 >
 #
 > “ Not     seeing     , ” said Gatsby . “ No       , we   couldn’t meet     . But     both   of us       loved each
@@ -8438,8 +8438,8 @@
 #
 > “ You're revolting , ” said Daisy . She  turned to me       , and  her     voice   , dropping an
 # . +      Nᴹ/Vg/J   . . VP/J NPr+  . ISg+ VP/J   P  NPr/ISg+ . VB/C ISg/D$+ NSg/VB+ . NSg/Vg   D/P
-> octave   lower     , filled the room       with thrilling scorn   : “ Do  you    know why    we   left
-# NSg/VB/J NSg/VB/JC . VP/J   D   N🅪Sg/VB/J+ P    Nᴹ/Vg/J   NSg/VB+ . . VXB ISgPl+ VB   NSg/VB IPl+ NPr/VP/J
+> octave   lower     , filled the room     with thrilling scorn   : “ Do  you    know why    we   left
+# NSg/VB/J NSg/VB/JC . VP/J   D   N🅪Sg/VB+ P    Nᴹ/Vg/J   NSg/VB+ . . VXB ISgPl+ VB   NSg/VB IPl+ NPr/VP/J
 > Chicago ? I’m surprised that     they didn’t treat  you    to the story  of that     little
 # NPr+    . K   VP/J      I/C/Ddem IPl+ VXPt   NSg/VB ISgPl+ P  D   NSg/VB P  I/C/Ddem NPr/I/J/Dq
 > spree   . ”
@@ -8670,16 +8670,16 @@
 #
 > It       passed , and  he       began to talk    excitedly to Daisy , denying everything ,
 # NPr/ISg+ VP/J   . VB/C NPr/ISg+ VPt   P  N🅪Sg/VB R         P  NPr   . Nᴹ/Vg/J NSg/I/VB+  .
-> defending his     name    against accusations that      had not     been     made . But     with every
-# Nᴹ/Vg/J   ISg/D$+ NSg/VB+ C/P     NPl+        I/C/Ddem+ VP  NSg/R/C NSg/VLPp VP   . NSg/C/P P    Dq+
+> defending his     name    against accusations that      had not     been   made . But     with every
+# Nᴹ/Vg/J   ISg/D$+ NSg/VB+ C/P     NPl+        I/C/Ddem+ VP  NSg/R/C VLPp/B VP   . NSg/C/P P    Dq+
 > word    she  was  drawing   further and  further into herself , so          he       gave that      up         , and
 # NSg/VB+ ISg+ VLPt N🅪Sg/Vg/J VB/JC   VB/C VB/JC   P    ISg+    . NSg/I/J/R/C NPr/ISg+ VPt  I/C/Ddem+ NSg/VB/J/P . VB/C
 > only  the dead      dream     fought on  as    the afternoon slipped away , trying  to touch
 # J/R/C D+  NSg/VB/J+ NSg/VB/J+ VP     J/P R/C/P D+  N🅪Sg+     VP/J    VB/J . Nᴹ/Vg/J P  N🅪Sg/VB
 > what   was  no       longer tangible , struggling unhappily , undespairingly , toward that
 # NSg/I+ VLPt NSg/Dq/P NSg/JC NSg/J    . Nᴹ/Vg/J    R         . ?              . J/P    I/C/Ddem+
-> lost voice   across the room       .
-# VP/J NSg/VB+ NSg/P  D   N🅪Sg/VB/J+ .
+> lost voice   across the room     .
+# VP/J NSg/VB+ NSg/P  D   N🅪Sg/VB+ .
 >
 #
 > The voice   begged again to go       .
@@ -8800,12 +8800,12 @@
 # NSg/VB/J R     NSg/VB/C/P D   NPr🅪Sg+ P     P  . NPr/VB . VB/C NSg/J/R/C K     Nᴹ/Vg/J P  NSg/VB VB/J . .
 >
 #
-> Michaelis was  astonished ; they had been     neighbors for   four years , and  Wilson had
-# ?         VLPt VP/J       . IPl+ VP  NSg/VLPp NPl/V3/Am R/C/P NSg+ NPl+  . VB/C NPr+   VP
+> Michaelis was  astonished ; they had been   neighbors for   four years , and  Wilson had
+# ?         VLPt VP/J       . IPl+ VP  VLPp/B NPl/V3/Am R/C/P NSg+ NPl+  . VB/C NPr+   VP
 > never seemed faintly capable of such  a    statement . Generally he       was  one     of these
 # R     VP/J   R       J       P  NSg/I D/P+ NSg/VB/J+ . R         NPr/ISg+ VLPt NSg/I/J P  I/Ddem+
-> worn   - out          men  : when    he       wasn’t working , he       sat      on  a   chair   in        the doorway and
-# VPp/J+ . NSg/VB/J/R/P NPl+ . NSg/I/C NPr/ISg+ VPt    Nᴹ/Vg/J . NPr/ISg+ NSg/VP/J J/P D/P NSg/VB+ NPr/J/R/P D   NSg+    VB/C
+> worn   - out          men  : when    he       wasn’t working , he       sat    on  a   chair   in        the doorway and
+# VPp/J+ . NSg/VB/J/R/P NPl+ . NSg/I/C NPr/ISg+ VPt    Nᴹ/Vg/J . NPr/ISg+ NSg/VP J/P D/P NSg/VB+ NPr/J/R/P D   NSg+    VB/C
 > stared at    the people  and  the cars that      passed along the road    . When    any    one      spoke
 # VP/J   NSg/P D   NPl/VB+ VB/C D   NPl+ I/C/Ddem+ VP/J   P     D   N🅪Sg/J+ . NSg/I/C I/R/Dq NSg/I/J+ NSg/VPt
 > to him  he       invariably laughed in        an  agreeable , colorless way    . He       was  his     wife’s
@@ -8818,8 +8818,8 @@
 # NSg/I/J/R/C R         ?         VP/J  P  NSg/VB NSg/VB/J/R/P NSg/I+ VP  VP/J     . NSg/C/P NPr+   VXB
 > say    a   word    — instead he       began to throw  curious , suspicious glances at    his     visitor
 # NSg/VB D/P NSg/VB+ . R       NPr/ISg+ VPt   P  NSg/VB J       . J          NPl/V3+ NSg/P ISg/D$+ NSg+
-> and  ask    him  what   he’d been     doing   at    certain times   on  certain days . Just as    the
-# VB/C NSg/VB ISg+ NSg/I+ K    NSg/VLPp Nᴹ/Vg/J NSg/P I/J     NPl/V3+ J/P I/J+    NPl+ . J/R  R/C/P D
+> and  ask    him  what   he’d been   doing   at    certain times   on  certain days . Just as    the
+# VB/C NSg/VB ISg+ NSg/I+ K    VLPp/B Nᴹ/Vg/J NSg/P I/J     NPl/V3+ J/P I/J+    NPl+ . J/R  R/C/P D
 > latter was  getting uneasy   , some      workmen came      past       the door    bound    for   his
 # NSg/J  VLPt NSg/Vg  NSg/VB/J . I/J/R/Dq+ NPl+    NSg/VPt/P NSg/VB/J/P D+  NSg/VB+ NSg/VP/J R/C/P ISg/D$+
 > restaurant , and  Michaelis took the opportunity to get    away , intending to come
@@ -9084,8 +9084,8 @@
 #
 > “ Listen , ” said Tom     , shaking him  a   little     . “ I       just got here a    minute    ago , from
 # . NSg/VB . . VP/J NPr/VB+ . Nᴹ/Vg/J ISg+ D/P NPr/I/J/Dq . . ISg/#r+ J/R  VP  J/R  D/P+ NSg/VB/J+ J/P . P
-> New    York . I       was  bringing you    that     coupé we’ve been     talking about . That      yellow
-# NSg/J+ NPr+ . ISg/#r+ VLPt Nᴹ/Vg/J  ISgPl+ I/C/Ddem ?     K     NSg/VLPp Nᴹ/Vg/J J/P   . I/C/Ddem+ NSg/VB/J+
+> New    York . I       was  bringing you    that     coupé we’ve been   talking about . That      yellow
+# NSg/J+ NPr+ . ISg/#r+ VLPt Nᴹ/Vg/J  ISgPl+ I/C/Ddem ?     K     VLPp/B Nᴹ/Vg/J J/P   . I/C/Ddem+ NSg/VB/J+
 > car  I       was  driving this    afternoon wasn’t mine      — do  you    hear ? I       haven’t seen    it       all
 # NSg+ ISg/#r+ VLPt Nᴹ/Vg/J I/Ddem+ N🅪Sg+     VPt    NSg/I/VB+ . VXB ISgPl+ VB   . ISg/#r+ VXB     NSg/VPp NPr/ISg+ NSg/I/J/C/Dq
 > afternoon . ”
@@ -9124,8 +9124,8 @@
 # . K     NSg/VBPp/P NSg/VB/J/R P    NSg/J NPr+ . . ISg/#r+ VP/J .
 >
 #
-> Some     one     who    had been     driving a   little     behind  us       confirmed this    , and  the
-# I/J/R/Dq NSg/I/J NPr/I+ VP  NSg/VLPp Nᴹ/Vg/J D/P NPr/I/J/Dq NSg/J/P NPr/IPl+ VP/J      I/Ddem+ . VB/C D+
+> Some     one     who    had been   driving a   little     behind  us       confirmed this    , and  the
+# I/J/R/Dq NSg/I/J NPr/I+ VP  VLPp/B Nᴹ/Vg/J D/P NPr/I/J/Dq NSg/J/P NPr/IPl+ VP/J      I/Ddem+ . VB/C D+
 > policeman turned away .
 # NSg+      VP/J   VB/J .
 >
@@ -9144,8 +9144,8 @@
 # . NSg/C ?           NSg/VBPp/P J/R  VB/C NSg/VB P    ISg+ . . NPr/ISg+ VP      R               . NPr/ISg+
 > watched while      the two  men  standing closest glanced at    each other    and  went
 # VP/J    NSg/VB/C/P D+  NSg+ NPl+ Nᴹ/Vg/J  JS      VP/J    NSg/P Dq   NSg/VB/J VB/C NSg/VPt
-> unwillingly into the room       . Then      Tom     shut      the door    on  them     and  came      down        the
-# R           P    D+  N🅪Sg/VB/J+ . NSg/J/R/C NPr/VB+ NSg/VBP/J D+  NSg/VB+ J/P NSg/IPl+ VB/C NSg/VPt/P N🅪Sg/VB/J/P D+
+> unwillingly into the room     . Then      Tom     shut      the door    on  them     and  came      down        the
+# R           P    D+  N🅪Sg/VB+ . NSg/J/R/C NPr/VB+ NSg/VBP/J D+  NSg/VB+ J/P NSg/IPl+ VB/C NSg/VPt/P N🅪Sg/VB/J/P D+
 > single    step    , his     eyes    avoiding the table   . As    he       passed close    to me       he       whispered :
 # NSg/VB/J+ NSg/VB+ . ISg/D$+ NPl/V3+ Nᴹ/Vg/J  D+  NSg/VB+ . R/C/P NPr/ISg+ VP/J   NSg/VB/J P  NPr/ISg+ NPr/ISg+ VP/J      .
 > “ Let’s get    out          . ”
@@ -9156,8 +9156,8 @@
 # NSg/I/VB/J+ . R           . P    ISg/D$+ J+            NPl/V3+ Nᴹ/Vg/J  D+  NSg/J+ . IPl+ VP/J
 > through the still      gathering crowd   , passing a   hurried doctor , case       in        hand    , who
 # J/P     D   NSg/VB/J/R Nᴹ/Vg/J   NSg/VB+ . Nᴹ/Vg/J D/P VP/J    NSg/VB . NPr🅪Sg/VB+ NPr/J/R/P NSg/VB+ . NPr/I+
-> had been     sent   for   in        wild     hope      half      an   hour ago .
-# VP  NSg/VLPp NSg/VP R/C/P NPr/J/R/P NSg/VB/J NPr🅪Sg/VB N🅪Sg/J/P+ D/P+ NSg+ J/P .
+> had been   sent   for   in        wild     hope      half      an   hour ago .
+# VP  VLPp/B NSg/VP R/C/P NPr/J/R/P NSg/VB/J NPr🅪Sg/VB N🅪Sg/J/P+ D/P+ NSg+ J/P .
 >
 #
 > Tom     drove   slowly until we   were beyond the bend    — then      his     foot    came      down        hard     , and
@@ -9240,8 +9240,8 @@
 # R        I/C/Ddem+ VP/J     NPr+   R   . ISg+ NSg/VXB NSg/VXB NSg/VPp NSg/I/J+  P  I/Ddem+ NPr/J/R/P D$+
 > expression , for   she  turned abruptly away and  ran up         the porch steps   into the
 # N🅪Sg+      . R/C/P ISg+ VP/J   R        VB/J VB/C VPt NSg/VB/J/P D+  NSg+  NPl/V3+ P    D+
-> house   . I       sat      down        for   a   few       minutes with my  head      in        my  hands   , until I       heard the
-# NPr/VB+ . ISg/#r+ NSg/VP/J N🅪Sg/VB/J/P R/C/P D/P NSg/I/Dq+ NPl/V3+ P    D$+ NPr/VB/J+ NPr/J/R/P D$+ NPl/V3+ . C/P   ISg/#r+ VP/J  D+
+> house   . I       sat    down        for   a   few       minutes with my  head      in        my  hands   , until I       heard the
+# NPr/VB+ . ISg/#r+ NSg/VP N🅪Sg/VB/J/P R/C/P D/P NSg/I/Dq+ NPl/V3+ P    D$+ NPr/VB/J+ NPr/J/R/P D$+ NPl/V3+ . C/P   ISg/#r+ VP/J  D+
 > phone   taken up         inside  and  the butler’s voice   calling a   taxi    . Then      I       walked
 # NSg/VB+ VPp/J NSg/VB/J/P NSg/J/P VB/C D   NPr$     NSg/VB+ Nᴹ/Vg/J D/P NSg/VB+ . NSg/J/R/C ISg/#r+ VP/J
 > slowly down        the drive   away from the house   , intending to wait   by    the gate    .
@@ -9266,8 +9266,8 @@
 #
 > Somehow , that      seemed a   despicable occupation . For   all           I       knew he       was  going   to rob
 # R       . I/C/Ddem+ VP/J   D/P NSg/J      N🅪Sg+      . R/C/P NSg/I/J/C/Dq+ ISg/#r+ VPt  NPr/ISg+ VLPt Nᴹ/Vg/J P  NPr/VB+
-> the house   in        a    moment ; I       wouldn’t have    been     surprised to see    sinister faces   , the
-# D+  NPr/VB+ NPr/J/R/P D/P+ NSg+   . ISg/#r+ VXB      NSg/VXB NSg/VLPp VP/J      P  NSg/VB J        NPl/V3+ . D
+> the house   in        a    moment ; I       wouldn’t have    been   surprised to see    sinister faces   , the
+# D+  NPr/VB+ NPr/J/R/P D/P+ NSg+   . ISg/#r+ VXB      NSg/VXB VLPp/B VP/J      P  NSg/VB J        NPl/V3+ . D
 > faces  of “ Wolfshiem’s people  , ” behind  him  in        the dark     shrubbery .
 # NPl/V3 P  . ?           NPl/VB+ . . NSg/J/P ISg+ NPr/J/R/P D   NSg/VB/J NSg       .
 >
@@ -9366,8 +9366,8 @@
 # . K      NSg/VLXB NSg/I/J/C/Dq NPr/VB/J+ P  . NPr/VB . . NPr/ISg+ VP/J R         . . K   J/R  Nᴹ/Vg/J P  NSg/VB J/R
 > and  see    if    he       tries  to bother her     about that      unpleasantness this   afternoon .
 # VB/C NSg/VB NSg/C NPr/ISg+ NPl/V3 P  Nᴹ/VB  ISg/D$+ J/P   I/C/Ddem+ NSg            I/Ddem N🅪Sg+     .
-> She’s locked herself into her     room       , and  if    he       tries  any    brutality she’s going   to
-# K     VP/J   ISg+    P    ISg/D$+ N🅪Sg/VB/J+ . VB/C NSg/C NPr/ISg+ NPl/V3 I/R/Dq Nᴹ+       K     Nᴹ/Vg/J P
+> She’s locked herself into her     room     , and  if    he       tries  any    brutality she’s going   to
+# K     VP/J   ISg+    P    ISg/D$+ N🅪Sg/VB+ . VB/C NSg/C NPr/ISg+ NPl/V3 I/R/Dq Nᴹ+       K     Nᴹ/Vg/J P
 > turn   the light      out          and  on  again . ”
 # NSg/VB D   N🅪Sg/VB/J+ NSg/VB/J/R/P VB/C J/P P     . .
 >
@@ -9389,13 +9389,13 @@
 >
 #
 > A   new   point  of view    occurred to me       . Suppose Tom     found  out          that     Daisy had been
-# D/P NSg/J NSg/VB P  NSg/VB+ VP       P  NPr/ISg+ . VB      NPr/VB+ NSg/VP NSg/VB/J/R/P I/C/Ddem NPr+  VP  NSg/VLPp
+# D/P NSg/J NSg/VB P  NSg/VB+ VP       P  NPr/ISg+ . VB      NPr/VB+ NSg/VP NSg/VB/J/R/P I/C/Ddem NPr+  VP  VLPp/B
 > driving . He       might    think  he       saw     a    connection in        it       — he       might    think  anything  . I
 # Nᴹ/Vg/J . NPr/ISg+ Nᴹ/VXB/J NSg/VB NPr/ISg+ NSg/VPt D/P+ N🅪Sg+      NPr/J/R/P NPr/ISg+ . NPr/ISg+ Nᴹ/VXB/J NSg/VB NSg/I/VB+ . ISg/#r+
 > looked at    the house   ; there were two or    three bright   windows   down        - stairs and  the
 # VP/J   NSg/P D+  NPr/VB+ . R+    VLPt NSg NPr/C NSg   NPr/VB/J NPrPl/V3+ N🅪Sg/VB/J/P . NPl    VB/C D
-> pink      glow   from Daisy’s room       on  the second   floor   .
-# N🅪Sg/VB/J NSg/VB P    NPr$    N🅪Sg/VB/J+ J/P D   NSg/VB/J NSg/VB+ .
+> pink      glow   from Daisy’s room     on  the second   floor   .
+# N🅪Sg/VB/J NSg/VB P    NPr$    N🅪Sg/VB+ J/P D   NSg/VB/J NSg/VB+ .
 >
 #
 > “ You    wait   here , ” I       said . “ I’ll see    if    there’s any    sign   of a   commotion . ”
@@ -9404,10 +9404,10 @@
 #
 > I       walked back     along the border of the lawn    , traversed the gravel   softly , and
 # ISg/#r+ VP/J   NSg/VB/J P     D   NSg/VB P  D+  NSg/VB+ . VP/J      D+  Nᴹ/VB/J+ R      . VB/C
-> tiptoed up         the veranda      steps   . The drawing    - room       curtains were open     , and  I       saw
-# VP/J    NSg/VB/J/P D   NSg/NoAm/Br+ NPl/V3+ . D   N🅪Sg/Vg/J+ . N🅪Sg/VB/J+ NPl/V3+  VLPt NSg/VB/J . VB/C ISg/#r+ NSg/VPt
-> that     the room       was  empty    . Crossing the porch where   we   had dined that     June night
-# I/C/Ddem D+  N🅪Sg/VB/J+ VLPt NSg/VB/J . Nᴹ/Vg/J  D+  NSg+  NSg/R/C IPl+ VP  VP/J  I/C/Ddem NPr+ N🅪Sg/VB+
+> tiptoed up         the veranda      steps   . The drawing    - room     curtains were open     , and  I       saw
+# VP/J    NSg/VB/J/P D   NSg/NoAm/Br+ NPl/V3+ . D   N🅪Sg/Vg/J+ . N🅪Sg/VB+ NPl/V3+  VLPt NSg/VB/J . VB/C ISg/#r+ NSg/VPt
+> that     the room     was  empty    . Crossing the porch where   we   had dined that     June night
+# I/C/Ddem D+  N🅪Sg/VB+ VLPt NSg/VB/J . Nᴹ/Vg/J  D+  NSg+  NSg/R/C IPl+ VP  VP/J  I/C/Ddem NPr+ N🅪Sg/VB+
 > three months before , I       came      to a   small    rectangle of light      which I       guessed was
 # NSg+  NPl+   C/P    . ISg/#r+ NSg/VPt/P P  D/P NPr/VB/J NSg/J     P  N🅪Sg/VB/J+ I/C+  ISg/#r+ VP/J    VLPt
 > the pantry window  . The blind    was  drawn , but     I       found  a   rift    at    the sill   .
@@ -9504,12 +9504,12 @@
 # NPl/V3+  . NSg/C ISg/#r+ VP/J    P    D/P NSg/VB P  NSg/VB+ P    D   NPl/V3 P  D/P J/R     NSg/VB/J+ .
 > There was  an  inexplicable amount of dust   everywhere , and  the rooms   were musty    ,
 # R+    VLPt D/P J            NSg/VB P  Nᴹ/VB+ Nᴹ/R       . VB/C D   NPl/V3+ VLPt NSg/VB/J .
-> as    though they hadn’t been     aired for   many       days . I       found  the humidor on  an
-# R/C/P C      IPl+ VPt    NSg/VLPp VP/J  R/C/P NSg/I/J/Dq NPl+ . ISg/#r+ NSg/VP D   NSg     J/P D/P
+> as    though they hadn’t been   aired for   many       days . I       found  the humidor on  an
+# R/C/P C      IPl+ VPt    VLPp/B VP/J  R/C/P NSg/I/J/Dq NPl+ . ISg/#r+ NSg/VP D   NSg     J/P D/P
 > unfamiliar table   , with two stale    , dry      cigarettes inside  . Throwing open     the
 # NSg/J      NSg/VB+ . P    NSg NSg/VB/J . NSg/VB/J NPl/V3+    NSg/J/P . Nᴹ/Vg/J  NSg/VB/J D
-> French      windows  of the drawing    - room       , we   sat      smoking  out          into the darkness .
-# NPr🅪Sg/VB/J NPrPl/V3 P  D   N🅪Sg/Vg/J+ . N🅪Sg/VB/J+ . IPl+ NSg/VP/J Nᴹ/Vg/J+ NSg/VB/J/R/P P    D+  Nᴹ+      .
+> French      windows  of the drawing    - room     , we   sat    smoking  out          into the darkness .
+# NPr🅪Sg/VB/J NPrPl/V3 P  D   N🅪Sg/Vg/J+ . N🅪Sg/VB+ . IPl+ NSg/VP Nᴹ/Vg/J+ NSg/VB/J/R/P P    D+  Nᴹ+      .
 >
 #
 > “ You    ought     to go       away , ” I       said . “ It’s pretty     certain they'll trace   your car  . ”
@@ -9552,8 +9552,8 @@
 # J             VP/J   N🅪Sg/VB+ NSg/P   . NPr/ISg+ NSg/VP ISg/D$+ R          J         . NPr/ISg+ NSg/VPt P
 > her     house   , at    first with other    officers from Camp      Taylor , then      alone . It       amazed
 # ISg/D$+ NPr/VB+ . NSg/P NSg/J P    NSg/VB/J NPl/V3   P    NSg/VB/J+ NPr+   . NSg/J/R/C J     . NPr/ISg+ VP/J
-> him  — he       had never been     in        such  a    beautiful house   before . But     what   gave it       an  air
-# ISg+ . NPr/ISg+ VP  R     NSg/VLPp NPr/J/R/P NSg/I D/P+ NSg/J+    NPr/VB+ C/P    . NSg/C/P NSg/I+ VPt  NPr/ISg+ D/P N🅪Sg/VB
+> him  — he       had never been   in        such  a    beautiful house   before . But     what   gave it       an  air
+# ISg+ . NPr/ISg+ VP  R     VLPp/B NPr/J/R/P NSg/I D/P+ NSg/J+    NPr/VB+ C/P    . NSg/C/P NSg/I+ VPt  NPr/ISg+ D/P N🅪Sg/VB
 > of breathless intensity , was  that      Daisy lived there — it       was  as    casual a   thing to
 # P  J+         Nᴹ+       . VLPt I/C/Ddem+ NPr+  VP/J  R     . NPr/ISg+ VLPt R/C/P NSg/J  D/P NSg   P
 > her     as    his     tent    out          at    camp      was  to him  . There was  a   ripe     mystery about it       , a
@@ -9652,18 +9652,18 @@
 # VXB . .
 >
 #
-> On  the last      afternoon before he       went    abroad  , he       sat      with Daisy in        his     arms    for   a
-# J/P D+  NSg/VB/J+ N🅪Sg+     C/P    NPr/ISg+ NSg/VPt NSg/J/P . NPr/ISg+ NSg/VP/J P    NPr+  NPr/J/R/P ISg/D$+ NPl/V3+ R/C/P D/P
-> long     , silent time       . It       was  a   cold  fall    day    , with fire       in        the room      and  her     cheeks
-# NPr/VB/J . NSg/J+ N🅪Sg/VB/J+ . NPr/ISg+ VLPt D/P NSg/J N🅪Sg/VB NPr🅪Sg . P    N🅪Sg/VB/J+ NPr/J/R/P D   N🅪Sg/VB/J VB/C ISg/D$+ NPl/V3+
+> On  the last      afternoon before he       went    abroad  , he       sat    with Daisy in        his     arms    for   a
+# J/P D+  NSg/VB/J+ N🅪Sg+     C/P    NPr/ISg+ NSg/VPt NSg/J/P . NPr/ISg+ NSg/VP P    NPr+  NPr/J/R/P ISg/D$+ NPl/V3+ R/C/P D/P
+> long     , silent time       . It       was  a   cold  fall    day    , with fire       in        the room    and  her     cheeks
+# NPr/VB/J . NSg/J+ N🅪Sg/VB/J+ . NPr/ISg+ VLPt D/P NSg/J N🅪Sg/VB NPr🅪Sg . P    N🅪Sg/VB/J+ NPr/J/R/P D   N🅪Sg/VB VB/C ISg/D$+ NPl/V3+
 > flushed . Now       and  then      she  moved and  he       changed his     arm      a   little     , and  once  he
 # VP/J    . NSg/J/R/C VB/C NSg/J/R/C ISg+ VP/J  VB/C NPr/ISg+ VP/J    ISg/D$+ NSg/VB/J D/P NPr/I/J/Dq . VB/C NSg/C NPr/ISg+
 > kissed her     dark      shining hair     . The afternoon had made them     tranquil for   a    while       ,
 # VP/J   ISg/D$+ NSg/VB/J+ Nᴹ/Vg/J N🅪Sg/VB+ . D+  N🅪Sg+     VP  VP   NSg/IPl+ J        R/C/P D/P+ NSg/VB/C/P+ .
 > as    if    to give   them     a   deep  memory for   the long     parting   the next    day     promised .
 # R/C/P NSg/C P  NSg/VB NSg/IPl+ D/P NSg/J N🅪Sg+  R/C/P D   NPr/VB/J N🅪Sg/Vg/J D+  NSg/J/P NPr🅪Sg+ VP/J     .
-> They had never been     closer in        their month of love       , nor   communicated more
-# IPl+ VP  R     NSg/VLPp NSg/JC NPr/J/R/P D$+   NSg/J P  NPr🅪Sg/VB+ . NSg/C VP/J         NPr/I/J/R/Dq
+> They had never been   closer in        their month of love       , nor   communicated more
+# IPl+ VP  R     VLPp/B NSg/JC NPr/J/R/P D$+   NSg/J P  NPr🅪Sg/VB+ . NSg/C VP/J         NPr/I/J/R/Dq
 > profoundly one     with another , than when    she  brushed silent lips    against his
 # R          NSg/I/J P    I/D     . C/P  NSg/I/C ISg+ VP/J    NSg/J  NPl/V3+ C/P     ISg/D$+
 > coat’s shoulder or    when    he       touched the end    of her     fingers , gently , as    though she
@@ -9758,8 +9758,8 @@
 # VPt  NSg/I+ ISg+ VLPt N🅪Sg/Vg/J . .
 >
 #
-> He       sat      down        gloomily .
-# NPr/ISg+ NSg/VP/J N🅪Sg/VB/J/P R        .
+> He       sat    down        gloomily .
+# NPr/ISg+ NSg/VP N🅪Sg/VB/J/P R        .
 >
 #
 > “ Of course  she  might    have    loved him  just for   a    minute    , when    they were first
@@ -9804,8 +9804,8 @@
 # NPr/ISg+ NPr/VP/J N🅪Sg/Vg/J I/C/Ddem NSg/C NPr/ISg+ VP  VP/J     JC     . NPr/ISg+ Nᴹ/VXB/J NSg/VXB NSg/VP ISg/D$+ . I/C/Ddem NPr/ISg+
 > was  leaving her     behind  . The day     - coach   — he       was  penniless now       — was  hot      . He       went    out
 # VLPt Nᴹ/Vg/J ISg/D$+ NSg/J/P . D+  NPr🅪Sg+ . NSg/VB+ . NPr/ISg+ VLPt J         NSg/J/R/C . VLPt NSg/VB/J . NPr/ISg+ NSg/VPt NSg/VB/J/R/P
-> to the open     vestibule and  sat      down        on  a   folding  - chair   , and  the station slid away
-# P  D   NSg/VB/J NSg/VB    VB/C NSg/VP/J N🅪Sg/VB/J/P J/P D/P Nᴹ/Vg/J+ . NSg/VB+ . VB/C D   NSg/VB+ VP   VB/J
+> to the open     vestibule and  sat    down        on  a   folding  - chair   , and  the station slid away
+# P  D   NSg/VB/J NSg/VB    VB/C NSg/VP N🅪Sg/VB/J/P J/P D/P Nᴹ/Vg/J+ . NSg/VB+ . VB/C D   NSg/VB+ VP   VB/J
 > and  the backs  of unfamiliar buildings moved by    . Then      out          into the spring   fields    ,
 # VB/C D   NPl/V3 P  NSg/J      NPl/V3+   VP/J  NSg/P . NSg/J/R/C NSg/VB/J/R/P P    D+  N🅪Sg/VB+ NPrPl/V3+ .
 > where   a   yellow   trolley raced them     for   a   minute    with people  in        it       who    might    once
@@ -9908,20 +9908,20 @@
 # NSg/VB/J NSg/VB+ NSg/VBP J        . .
 >
 #
-> I’ve always been     glad     I       said that      . It       was  the only  compliment I       ever gave him  ,
-# K    R      NSg/VLPp NSg/VB/J ISg/#r+ VP/J I/C/Ddem+ . NPr/ISg+ VLPt D   J/R/C NSg/VB     ISg/#r+ J/R  VPt  ISg+ .
+> I’ve always been   glad     I       said that      . It       was  the only  compliment I       ever gave him  ,
+# K    R      VLPp/B NSg/VB/J ISg/#r+ VP/J I/C/Ddem+ . NPr/ISg+ VLPt D   J/R/C NSg/VB     ISg/#r+ J/R  VPt  ISg+ .
 > because I       disapproved of him  from beginning to end    . First he       nodded politely ,
 # C/P     ISg/#r+ VP/J        P  ISg+ P    NSg/Vg/J+ P  NSg/VB . NSg/J NPr/ISg+ VP     R        .
 > and  then      his     face    broke     into that     radiant and  understanding smile   , as    if    we’d
 # VB/C NSg/J/R/C ISg/D$+ NSg/VB+ NSg/VPt/J P    I/C/Ddem NSg/J   VB/C N🅪Sg/Vg/J+    NSg/VB+ . R/C/P NSg/C K
-> been     in        ecstatic cahoots on  that     fact all          the time       . His     gorgeous pink      rag    of a
-# NSg/VLPp NPr/J/R/P NSg/J    NPl/V3  J/P I/C/Ddem NSg+ NSg/I/J/C/Dq D   N🅪Sg/VB/J+ . ISg/D$+ J        N🅪Sg/VB/J NSg/VB P  D/P+
+> been   in        ecstatic cahoots on  that     fact all          the time       . His     gorgeous pink      rag    of a
+# VLPp/B NPr/J/R/P NSg/J    NPl/V3  J/P I/C/Ddem NSg+ NSg/I/J/C/Dq D   N🅪Sg/VB/J+ . ISg/D$+ J        N🅪Sg/VB/J NSg/VB P  D/P+
 > suit    made a   bright   spot     of color         against the white        steps   , and  I       thought of the
 # NSg/VB+ VP   D/P NPr/VB/J NSg/VB/J P  N🅪Sg/VB/J/Am+ C/P     D+  NPr🅪Sg/VB/J+ NPl/V3+ . VB/C ISg/#r+ N🅪Sg/VP P  D+
 > night    when    I       first came      to his     ancestral home      , three months before . The lawn    and
 # N🅪Sg/VB+ NSg/I/C ISg/#r+ NSg/J NSg/VPt/P P  ISg/D$+ NSg/J+    NSg/VB/J+ . NSg+  NPl+   C/P    . D+  NSg/VB+ VB/C
-> drive   had been     crowded with the faces  of those   who    guessed at    his     corruption — and
-# N🅪Sg/VB VP  NSg/VLPp VP/J    P    D   NPl/V3 P  I/Ddem+ NPr/I+ VP/J    NSg/P ISg/D$+ N🅪Sg+      . VB/C
+> drive   had been   crowded with the faces  of those   who    guessed at    his     corruption — and
+# N🅪Sg/VB VP  VLPp/B VP/J    P    D   NPl/V3 P  I/Ddem+ NPr/I+ VP/J    NSg/P ISg/D$+ N🅪Sg+      . VB/C
 > he       had stood on  those   steps   , concealing his     incorruptible dream     , as    he       waved
 # NPr/ISg+ VP  VP    J/P I/Ddem+ NPl/V3+ . Nᴹ/Vg/J    ISg/D$+ NSg/J         NSg/VB/J+ . R/C/P NPr/ISg+ VP/J
 > them     good     - by    .
@@ -9962,8 +9962,8 @@
 # NPr+        I/Ddem N🅪Sg+     . .
 >
 #
-> Probably it       had been     tactful to leave  Daisy’s house   , but     the act     annoyed me       , and
-# R        NPr/ISg+ VP  NSg/VLPp J       P  NSg/VB NPr$    NPr/VB+ . NSg/C/P D   NPr/VB+ VP/J    NPr/ISg+ . VB/C
+> Probably it       had been   tactful to leave  Daisy’s house   , but     the act     annoyed me       , and
+# R        NPr/ISg+ VP  VLPp/B J       P  NSg/VB NPr$    NPr/VB+ . NSg/C/P D   NPr/VB+ VP/J    NPr/ISg+ . VB/C
 > her     next    remark  made me       rigid .
 # ISg/D$+ NSg/J/P NSg/VB+ VP   NPr/ISg+ NSg/J .
 >
@@ -10094,10 +10094,10 @@
 # P     NPr/J/R/P ISg/D$+ Nᴹ/Vg/J  NSg/VB+ . ?         VP   D/P NSg/J  NSg/VB+ P  NSg/VB/J ISg+ .
 >
 #
-> “ How   long     have    you    been     married  , George ? Come       on  there , try      and  sit    still      a
-# . NSg/C NPr/VB/J NSg/VXB ISgPl+ NSg/VLPp NSg/VP/J . NPr+   . NSg/VBPp/P J/P R     . NSg/VB/J VB/C NSg/VB NSg/VB/J/R D/P
-> minute   and  answer  my  question . How   long     have    you    been     married  ? ”
-# NSg/VB/J VB/C NSg/VB+ D$+ NSg/VB+  . NSg/C NPr/VB/J NSg/VXB ISgPl+ NSg/VLPp NSg/VP/J . .
+> “ How   long     have    you    been   married  , George ? Come       on  there , try      and  sit    still      a
+# . NSg/C NPr/VB/J NSg/VXB ISgPl+ VLPp/B NSg/VP/J . NPr+   . NSg/VBPp/P J/P R     . NSg/VB/J VB/C NSg/VB NSg/VB/J/R D/P
+> minute   and  answer  my  question . How   long     have    you    been   married  ? ”
+# NSg/VB/J VB/C NSg/VB+ D$+ NSg/VB+  . NSg/C NPr/VB/J NSg/VXB ISgPl+ VLPp/B NSg/VP/J . .
 >
 #
 > “ Twelve years . ”
@@ -10116,20 +10116,20 @@
 # ?         VP/J  D/P NSg+ NSg/VB/J Nᴹ/Vg/J P     D   N🅪Sg/J+ Nᴹ/VB/J/P NPr/ISg+ VP/J    P  ISg+ NSg/VB/J/C/P
 > the car  that      hadn’t stopped a   few      hours before . He       didn’t like         to go       into the
 # D   NSg+ I/C/Ddem+ VPt    VP/J    D/P NSg/I/Dq NPl+  C/P    . NPr/ISg+ VXPt   NSg/VB/J/C/P P  NSg/VB/J P    D
-> garage  , because the work     bench   was  stained where   the body    had been     lying   , so          he
-# NSg/VB+ . C/P     D   N🅪Sg/VB+ NSg/VB+ VLPt VP/J    NSg/R/C D   NSg/VB+ VP  NSg/VLPp Nᴹ/Vg/J . NSg/I/J/R/C NPr/ISg+
+> garage  , because the work     bench   was  stained where   the body    had been   lying   , so          he
+# NSg/VB+ . C/P     D   N🅪Sg/VB+ NSg/VB+ VLPt VP/J    NSg/R/C D   NSg/VB+ VP  VLPp/B Nᴹ/Vg/J . NSg/I/J/R/C NPr/ISg+
 > moved uncomfortably around the office  — he       knew every object  in        it       before
 # VP/J  R             J/P    D   NSg/VB+ . NPr/ISg+ VPt  Dq    NSg/VB+ NPr/J/R/P NPr/ISg+ C/P
-> morning    — and  from time       to time      sat      down        beside Wilson trying  to keep   him  more
-# N🅪Sg/Vg/J+ . VB/C P    N🅪Sg/VB/J+ P  N🅪Sg/VB/J NSg/VP/J N🅪Sg/VB/J/P P      NPr+   Nᴹ/Vg/J P  NSg/VB ISg+ NPr/I/J/R/Dq
+> morning    — and  from time       to time      sat    down        beside Wilson trying  to keep   him  more
+# N🅪Sg/Vg/J+ . VB/C P    N🅪Sg/VB/J+ P  N🅪Sg/VB/J NSg/VP N🅪Sg/VB/J/P P      NPr+   Nᴹ/Vg/J P  NSg/VB ISg+ NPr/I/J/R/Dq
 > quiet     .
 # N🅪Sg/VB/J .
 >
 #
 > “ Have    you    got a    church     you    go       to sometimes , George ? Maybe   even       if    you    haven’t
 # . NSg/VXB ISgPl+ VP  D/P+ NPr🅪Sg/VB+ ISgPl+ NSg/VB/J P  R         . NPr+   . NSg/J/R NSg/VB/J/R NSg/C ISgPl+ VXB
-> been     there for   a   long     time       ? Maybe   I       could   call   up         the church     and  get    a   priest    to
-# NSg/VLPp R     R/C/P D/P NPr/VB/J N🅪Sg/VB/J+ . NSg/J/R ISg/#r+ NSg/VXB NSg/VB NSg/VB/J/P D+  NPr🅪Sg/VB+ VB/C NSg/VB D/P NSg/VB/J+ P
+> been   there for   a   long     time       ? Maybe   I       could   call   up         the church     and  get    a   priest    to
+# VLPp/B R     R/C/P D/P NPr/VB/J N🅪Sg/VB/J+ . NSg/J/R ISg/#r+ NSg/VXB NSg/VB NSg/VB/J/P D+  NPr🅪Sg/VB+ VB/C NSg/VB D/P NSg/VB/J+ P
 > come       over    and  he       could   talk    to you    , see    ? ”
 # NSg/VBPp/P NSg/J/P VB/C NPr/ISg+ NSg/VXB N🅪Sg/VB P  ISgPl+ . NSg/VB . .
 >
@@ -10224,8 +10224,8 @@
 # . ISg/#r+ NSg/VXB D/P NSg/J P  Nᴹ/Vg/J NSg/VB/J/R/P . .
 >
 #
-> “ You’re morbid , George , ” said his     friend    . “ This    has been     a   strain  to you    and  you
-# . K      J      . NPr+   . . VP/J ISg/D$+ NPr/VB/J+ . . I/Ddem+ V3  NSg/VLPp D/P N🅪Sg/VB P  ISgPl+ VB/C ISgPl+
+> “ You’re morbid , George , ” said his     friend    . “ This    has been   a   strain  to you    and  you
+# . K      J      . NPr+   . . VP/J ISg/D$+ NPr/VB/J+ . . I/Ddem+ V3  VLPp/B D/P N🅪Sg/VB P  ISgPl+ VB/C ISgPl+
 > don’t know what   you're saying    . You’d better      try       and  sit    quiet     till       morning    . ”
 # VXB   VB   NSg/I+ +      N🅪Sg/Vg/J . K     NSg/VXB/JC+ NSg/VB/J+ VB/C NSg/VB N🅪Sg/VB/J NSg/VB/C/P N🅪Sg/Vg/J+ . .
 >
@@ -10254,14 +10254,14 @@
 #
 > Michaelis had seen    this   too , but     it       hadn’t occurred to him  that     there was  any
 # ?         VP  NSg/VPp I/Ddem R   . NSg/C/P NPr/ISg+ VPt    VP       P  ISg+ I/C/Ddem R+    VLPt I/R/Dq
-> special  significance in        it       . He       believed that      Mrs  . Wilson had been     running   away
-# NSg/VB/J NSg+         NPr/J/R/P NPr/ISg+ . NPr/ISg+ VP/J     I/C/Ddem+ NPl+ . NPr+   VP  NSg/VLPp Nᴹ/Vg/J/P VB/J
+> special  significance in        it       . He       believed that      Mrs  . Wilson had been   running   away
+# NSg/VB/J NSg+         NPr/J/R/P NPr/ISg+ . NPr/ISg+ VP/J     I/C/Ddem+ NPl+ . NPr+   VP  VLPp/B Nᴹ/Vg/J/P VB/J
 > from her     husband , rather     than trying  to stop   any     particular car  .
 # P    ISg/D$+ NSg/VB+ . NPr/VB/J/R C/P  Nᴹ/Vg/J P  NSg/VB I/R/Dq+ NSg/J+     NSg+ .
 >
 #
-> “ How   could   she  of been     like         that      ? ”
-# . NSg/C NSg/VXB ISg+ P  NSg/VLPp NSg/VB/J/C/P I/C/Ddem+ . .
+> “ How   could   she  of been   like         that      ? ”
+# . NSg/C NSg/VXB ISg+ P  VLPp/B NSg/VB/J/C/P I/C/Ddem+ . .
 >
 #
 > “ She’s a    deep  one      , ” said Wilson , as    if    that      answered the question . “ Ah       - h      - h      — — — ”
@@ -10280,8 +10280,8 @@
 # I/Ddem+ VLPt D/P NSg/VB/J NPr🅪Sg/VB . NPr/ISg+ VLPt R      J    I/C/Ddem NPr+   VP  NSg/Dq/P NPr/VB/J+ . R+    VLPt
 > not     enough of him  for   his     wife      . He       was  glad     a   little     later when    he       noticed a
 # NSg/R/C NSg/I  P  ISg+ R/C/P ISg/D$+ NSg/VB/J+ . NPr/ISg+ VLPt NSg/VB/J D/P NPr/I/J/Dq JC    NSg/I/C NPr/ISg+ VP/J    D/P
-> change   in        the room       , a   blue       quickening by    the window  , and  realized       that      dawn
-# N🅪Sg/VB+ NPr/J/R/P D+  N🅪Sg/VB/J+ . D/P N🅪Sg/VB/J+ Nᴹ/Vg/J+   NSg/P D+  NSg/VB+ . VB/C VP/J/Comm/NoAm I/C/Ddem+ NPr🅪Sg/VB+
+> change   in        the room     , a   blue       quickening by    the window  , and  realized       that      dawn
+# N🅪Sg/VB+ NPr/J/R/P D+  N🅪Sg/VB+ . D/P N🅪Sg/VB/J+ Nᴹ/Vg/J+   NSg/P D+  NSg/VB+ . VB/C VP/J/Comm/NoAm I/C/Ddem+ NPr🅪Sg/VB+
 > wasn’t far      off        . About five o’clock it       was  blue      enough outside   to snap      off        the
 # VPt    NSg/VB/J NSg/VB/J/P . J/P   NSg  R       NPr/ISg+ VLPt N🅪Sg/VB/J NSg/I  Nᴹ/VB/J/P P  NSg/VB/J+ NSg/VB/J/P D+
 > light      .
@@ -10300,8 +10300,8 @@
 # NPr/ISg+ NSg/C/P ISg+ VXB      NSg/VB/J NPr/VB+ . ISg/#r+ VPt  ISg/D$+ P  D+  NSg/VB+ . . P    D/P+ N🅪Sg/VB+ NPr/ISg+ VP  NSg/VB/J/P
 > and  walked to the rear      window  and  leaned with his     face    pressed against it       — “ and  I
 # VB/C VP/J   P  D+  NSg/VB/J+ NSg/VB+ VB/C VP/J   P    ISg/D$+ NSg/VB+ VP/J    C/P     NPr/ISg+ . . VB/C ISg/#r+
-> said ‘ God     knows what   you’ve been     doing   , everything you’ve been     doing   . You    may
-# VP/J . NPr/VB+ V3    NSg/I+ K      NSg/VLPp Nᴹ/Vg/J . NSg/I/VB+  K      NSg/VLPp Nᴹ/Vg/J . ISgPl+ NPr/VXB
+> said ‘ God     knows what   you’ve been   doing   , everything you’ve been   doing   . You    may
+# VP/J . NPr/VB+ V3    NSg/I+ K      VLPp/B Nᴹ/Vg/J . NSg/I/VB+  K      VLPp/B Nᴹ/Vg/J . ISgPl+ NPr/VXB
 > fool     me       , but     you    can’t fool     God     ! ’ ”
 # NSg/VB/J NPr/ISg+ . NSg/C/P ISgPl+ VXB   NSg/VB/J NPr/VB+ . . .
 >
@@ -10320,8 +10320,8 @@
 #
 > “ That’s an  advertisement , ” Michaelis assured  him  . Something made him  turn   away
 # . K      D/P NSg           . . ?         NSg/VP/J ISg+ . NSg/I/J+  VP   ISg+ NSg/VB VB/J
-> from the window  and  look   back     into the room       . But     Wilson stood there a    long      time       ,
-# P    D+  NSg/VB+ VB/C NSg/VB NSg/VB/J P    D+  N🅪Sg/VB/J+ . NSg/C/P NPr+   VP    R+    D/P+ NPr/VB/J+ N🅪Sg/VB/J+ .
+> from the window  and  look   back     into the room     . But     Wilson stood there a    long      time       ,
+# P    D+  NSg/VB+ VB/C NSg/VB NSg/VB/J P    D+  N🅪Sg/VB+ . NSg/C/P NPr+   VP    R+    D/P+ NPr/VB/J+ N🅪Sg/VB/J+ .
 > his     face    close    to the window  pane   , nodding  into the twilight .
 # ISg/D$+ NSg/VB+ NSg/VB/J P  D+  NSg/VB+ NSg/VB . NSg/VP/J P    D   Nᴹ/VB/J+ .
 >
@@ -10342,8 +10342,8 @@
 # ISg/D$+ NPl+      . NPr/ISg+ VLPt J/P NSg/VB+ NSg/I/J/C/Dq D+  N🅪Sg/VB/J+ . VLPt R/Am      VP/J   P  NPr/VB/J
 > Roosevelt and  then      to Gad’s Hill    , where   he       bought a   sandwich  that      he       didn’t eat ,
 # NPr+      VB/C NSg/J/R/C P  ?     NPr/VB+ . NSg/R/C NPr/ISg+ NSg/VP D/P NSg/VB/J+ I/C/Ddem+ NPr/ISg+ VXPt   VB  .
-> and  a   cup    of coffee     . He       must    have    been     tired and  walking slowly , for   he       didn’t
-# VB/C D/P NSg/VB P  N🅪Sg/VB/J+ . NPr/ISg+ NSg/VXB NSg/VXB NSg/VLPp VP/J  VB/C Nᴹ/Vg/J R      . R/C/P NPr/ISg+ VXPt
+> and  a   cup    of coffee     . He       must    have    been   tired and  walking slowly , for   he       didn’t
+# VB/C D/P NSg/VB P  N🅪Sg/VB/J+ . NPr/ISg+ NSg/VXB NSg/VXB VLPp/B VP/J  VB/C Nᴹ/Vg/J R      . R/C/P NPr/ISg+ VXPt
 > reach  Gad’s Hill    until noon    . Thus far      there was  no       difficulty in        accounting for
 # NSg/VB ?     NPr/VB+ C/P   NSg/VB+ . NSg  NSg/VB/J R+    VLPt NSg/Dq/P N🅪Sg       NPr/J/R/P Nᴹ/Vg/J+   R/C/P
 > his     time       — there were boys    who    had seen    a    man     “ acting  sort    of crazy , ” and
@@ -10486,8 +10486,8 @@
 # P    VP/J       NPl/V3+ NSg/J/P I/C/Ddem+ VP/J      NSg/VB P  ISg+ . VB/C VB    I/C/Ddem ISg/D$+
 > sister  had never seen    Gatsby , that     her     sister  was  completely happy    with her
 # NSg/VB+ VP  R     NSg/VPp NPr    . I/C/Ddem ISg/D$+ NSg/VB+ VLPt R          NSg/VB/J P    ISg/D$+
-> husband , that     her     sister  had been     into no       mischief whatever . She  convinced
-# NSg/VB+ . I/C/Ddem ISg/D$+ NSg/VB+ VP  NSg/VLPp P    NSg/Dq/P NSg/VB+  NSg/I/J+ . ISg+ VP/J
+> husband , that     her     sister  had been   into no       mischief whatever . She  convinced
+# NSg/VB+ . I/C/Ddem ISg/D$+ NSg/VB+ VP  VLPp/B P    NSg/Dq/P NSg/VB+  NSg/I/J+ . ISg+ VP/J
 > herself of it       , and  cried into her     handkerchief , as    if    the very suggestion was
 # ISg+    P  NPr/ISg+ . VB/C VP/J  P    ISg/D$+ NSg+         . R/C/P NSg/C D+  J/R+ N🅪Sg+      VLPt
 > more         than she  could   endure . So          Wilson was  reduced to a    man     “ deranged by    grief  ”
@@ -10546,8 +10546,8 @@
 # . ISg/#r+ VXB   VB   . VXB   NSg/VB . .
 >
 #
-> I       wanted to get    somebody for   him  . I       wanted to go       into the room       where   he       lay        and
-# ISg/#r+ VP/J   P  NSg/VB NSg/I+   R/C/P ISg+ . ISg/#r+ VP/J   P  NSg/VB/J P    D+  N🅪Sg/VB/J+ NSg/R/C NPr/ISg+ NSg/VBPt/J VB/C
+> I       wanted to get    somebody for   him  . I       wanted to go       into the room     where   he       lay        and
+# ISg/#r+ VP/J   P  NSg/VB NSg/I+   R/C/P ISg+ . ISg/#r+ VP/J   P  NSg/VB/J P    D+  N🅪Sg/VB+ NSg/R/C NPr/ISg+ NSg/VBPt/J VB/C
 > reassure him  : “ I’ll get    somebody for   you    , Gatsby . Don’t worry   . Just trust     me       and
 # VB       ISg+ . . K    NSg/VB NSg/I+   R/C/P ISgPl+ . NPr    . VXB   N🅪Sg/VB . J/R  N🅪Sg/VB/J NPr/ISg+ VB/C
 > I’ll get    somebody for   you    — — — ”
@@ -10578,8 +10578,8 @@
 # . NSg/VB/J . K   J      NSg/Dq/P NSg$  R     . .
 >
 #
-> I       went    back     to the drawing    - room       and  thought for   an  instant  that     they were chance
-# ISg/#r+ NSg/VPt NSg/VB/J P  D+  N🅪Sg/Vg/J+ . N🅪Sg/VB/J+ VB/C N🅪Sg/VP R/C/P D/P NSg/VB/J I/C/Ddem IPl+ VLPt NPr/VB/J+
+> I       went    back     to the drawing    - room     and  thought for   an  instant  that     they were chance
+# ISg/#r+ NSg/VPt NSg/VB/J P  D+  N🅪Sg/Vg/J+ . N🅪Sg/VB+ VB/C N🅪Sg/VP R/C/P D/P NSg/VB/J I/C/Ddem IPl+ VLPt NPr/VB/J+
 > visitors , all          these   official people  who    suddenly filled it       . But     , though they
 # NPl+     . NSg/I/J/C/Dq I/Ddem+ NSg/J+   NPl/VB+ NPr/I+ R        VP/J   NPr/ISg+ . NSg/C/P . C      IPl+
 > drew    back     the sheet   and  looked at    Gatsby with shocked eyes    , his     protest
@@ -10622,8 +10622,8 @@
 # NPr/ISg+ C/P     NSg/IPl+ NSg/I/J/C/Dq .
 >
 #
-> Dear      Mr   . Carraway . This    has been     one     of the most         terrible shocks of my  life     to
-# NSg/VB/J+ NSg+ . ?        . I/Ddem+ V3  NSg/VLPp NSg/I/J P  D   NSg/I/J/R/Dq J        NPl    P  D$+ N🅪Sg/VB+ P
+> Dear      Mr   . Carraway . This    has been   one     of the most         terrible shocks of my  life     to
+# NSg/VB/J+ NSg+ . ?        . I/Ddem+ V3  VLPp/B NSg/I/J P  D   NSg/I/J/R/Dq J        NPl    P  D$+ N🅪Sg/VB+ P
 > me       I       hardly can     believe it       that     it       is  true     at    all          . Such  a   mad      act     as    that     man
 # NPr/ISg+ ISg/#r+ R      NPr/VXB VB      NPr/ISg+ I/C/Ddem NPr/ISg+ VL3 NSg/VB/J NSg/P NSg/I/J/C/Dq . NSg/I D/P NSg/VB/J NPr/VB+ R/C/P I/C/Ddem NPr/VB+
 > did  should make   us       all           think   . I       cannot  come       down        now       as    I       am        tied up         in        some
@@ -10674,8 +10674,8 @@
 # . NPr/VB P  D/P+ NSg/VB+ . NSg/VX3 NPr/ISg+ . NSg/VB D$+ N🅪Sg/VB+ . .
 >
 #
-> “ There haven’t been     any    wires   . ”
-# . R+    VXB     NSg/VLPp I/R/Dq NPl/V3+ . .
+> “ There haven’t been   any    wires   . ”
+# . R+    VXB     VLPp/B I/R/Dq NPl/V3+ . .
 >
 #
 > “ Young    Parke’s in        trouble  , ” he       said rapidly . “ They picked him  up         when    he       handed
@@ -10718,8 +10718,8 @@
 # NPl/V3+ NPr/ISg+ VPt   P  NSg/VB NSg/I/J/R/C R           NSg/P ISg/D$+ VB/J   NPr🅪Sg/VB/J/Am+ NPr/VB+ I/C/Ddem+ ISg/#r+ VP
 > difficulty in        getting off        his     coat    . He       was  on  the point  of collapse , so          I       took
 # N🅪Sg+      NPr/J/R/P NSg/Vg+ NSg/VB/J/P ISg/D$+ NSg/VB+ . NPr/ISg+ VLPt J/P D   NSg/VB P  N🅪Sg/VB+ . NSg/I/J/R/C ISg/#r+ VPt
-> him  into the music      room       and  made him  sit    down        while      I       sent   for   something to eat .
-# ISg+ P    D+  N🅪Sg/VB/J+ N🅪Sg/VB/J+ VB/C VP   ISg+ NSg/VB N🅪Sg/VB/J/P NSg/VB/C/P ISg/#r+ NSg/VP R/C/P NSg/I/J+  P  VB  .
+> him  into the music      room     and  made him  sit    down        while      I       sent   for   something to eat .
+# ISg+ P    D+  N🅪Sg/VB/J+ N🅪Sg/VB+ VB/C VP   ISg+ NSg/VB N🅪Sg/VB/J/P NSg/VB/C/P ISg/#r+ NSg/VP R/C/P NSg/I/J+  P  VB  .
 > But     he       wouldn’t eat , and  the glass     of milk     spilled from his     trembling hand    .
 # NSg/C/P NPr/ISg+ VXB      VB  . VB/C D   NPr🅪Sg/VB P  N🅪Sg/VB+ VP/J    P    ISg/D$+ Nᴹ/Vg/J   NSg/VB+ .
 >
@@ -10734,12 +10734,12 @@
 # . ISg/#r+ VXPt   VB   NSg/C P  NSg/VB ISgPl+ . .
 >
 #
-> His     eyes    , seeing     nothing  , moved ceaselessly about the room       .
-# ISg/D$+ NPl/V3+ . NSg/Vg/J/C NSg/I/J+ . VP/J  R           J/P   D+  N🅪Sg/VB/J+ .
+> His     eyes    , seeing     nothing  , moved ceaselessly about the room     .
+# ISg/D$+ NPl/V3+ . NSg/Vg/J/C NSg/I/J+ . VP/J  R           J/P   D+  N🅪Sg/VB+ .
 >
 #
-> “ It       was  a   madman , ” he       said . “ He       must    have    been     mad      . ”
-# . NPr/ISg+ VLPt D/P NSg    . . NPr/ISg+ VP/J . . NPr/ISg+ NSg/VXB NSg/VXB NSg/VLPp NSg/VB/J . .
+> “ It       was  a   madman , ” he       said . “ He       must    have    been   mad      . ”
+# . NPr/ISg+ VLPt D/P NSg    . . NPr/ISg+ VP/J . . NPr/ISg+ NSg/VXB NSg/VXB VLPp/B NSg/VB/J . .
 >
 #
 > “ Wouldn’t you    like         some     coffee     ? ” I       urged him  .
@@ -10758,8 +10758,8 @@
 # . NSg/VB/J/R . K   NSg/I/J/C/Dq NPr/VB/J NSg/J/R/C . NSg/R/C NSg/VXB IPl+ VP  NPr/VB+ . .
 >
 #
-> I       took him  into the drawing    - room       , where   his     son     lay        , and  left     him  there . Some
-# ISg/#r+ VPt  ISg+ P    D   N🅪Sg/Vg/J+ . N🅪Sg/VB/J+ . NSg/R/C ISg/D$+ NPr/VB+ NSg/VBPt/J . VB/C NPr/VP/J ISg+ R     . I/J/R/Dq+
+> I       took him  into the drawing    - room     , where   his     son     lay        , and  left     him  there . Some
+# ISg/#r+ VPt  ISg+ P    D   N🅪Sg/Vg/J+ . N🅪Sg/VB+ . NSg/R/C ISg/D$+ NPr/VB+ NSg/VBPt/J . VB/C NPr/VP/J ISg+ R     . I/J/R/Dq+
 > little      boys    had come       up         on  the steps   and  were looking into the hall ; when    I       told
 # NPr/I/J/Dq+ NPl/V3+ VP  NSg/VBPp/P NSg/VB/J/P J/P D+  NPl/V3+ VB/C VLPt Nᴹ/Vg/J P    D+  NPr+ . NSg/I/C ISg/#r+ VP
 > them     who    had arrived , they went    reluctantly away .
@@ -10778,8 +10778,8 @@
 # P  D   NPr+ VB/C D   NSg/J NPl/V3+ Nᴹ/Vg/J NSg/VB/J/R/P P    NPr/ISg+ P    NSg/VB/J NPl/V3+ . ISg/D$+ Nᴹ/VB+
 > began to be       mixed with an  awed pride  . I       helped him  to a    bedroom up         - stairs ; while
 # VPt   P  NSg/VLXB VP/J  P    D/P VP/J Nᴹ/VB+ . ISg/#r+ VP/J   ISg+ P  D/P+ NSg+    NSg/VB/J/P . NPl+   . NSg/VB/C/P
-> he       took off        his     coat    and  vest   I       told him  that     all          arrangements had been     deferred
-# NPr/ISg+ VPt  NSg/VB/J/P ISg/D$+ NSg/VB+ VB/C NSg/VB ISg/#r+ VP   ISg+ I/C/Ddem NSg/I/J/C/Dq NPl+         VP  NSg/VLPp NSg/VP/J
+> he       took off        his     coat    and  vest   I       told him  that     all          arrangements had been   deferred
+# NPr/ISg+ VPt  NSg/VB/J/P ISg/D$+ NSg/VB+ VB/C NSg/VB ISg/#r+ VP   ISg+ I/C/Ddem NSg/I/J/C/Dq NPl+         VP  VLPp/B NSg/VP/J
 > until he       came      .
 # C/P   NPr/ISg+ NSg/VPt/P .
 >
@@ -10820,8 +10820,8 @@
 # NPr/ISg+ VP/J    ISg/D$+ NPr/VB/J+ R            . VB/C ISg/#r+ VP     .
 >
 #
-> “ If    he’d of lived , he’d of been     a   great man     . A   man    like         James  J. Hill    . He’d of
-# . NSg/C K    P  VP/J+ . K    P  NSg/VLPp D/P NSg/J NPr/VB+ . D/P NPr/VB NSg/VB/J/C/P NPrPl+ ?  NPr/VB+ . K    P
+> “ If    he’d of lived , he’d of been   a   great man     . A   man    like         James  J. Hill    . He’d of
+# . NSg/C K    P  VP/J+ . K    P  VLPp/B D/P NSg/J NPr/VB+ . D/P NPr/VB NSg/VB/J/C/P NPrPl+ ?  NPr/VB+ . K    P
 > helped build  up         the country . ”
 # VP/J   NSg/VB NSg/VB/J/P D   NSg/J+  . .
 >
@@ -10853,7 +10853,7 @@
 > I       was  relieved too , for   that      seemed to promise another friend    at    Gatsby’s grave     .
 # ISg/#r+ VLPt VP/J     R   . R/C/P I/C/Ddem+ VP/J   P  NSg/VB  I/D+    NPr/VB/J+ NSg/P NPr$     NSg/VB/J+ .
 > I       didn’t want   it       to be       in        the papers  and  draw   a   sightseeing crowd   , so          I’d been
-# ISg/#r+ VXPt   NSg/VB NPr/ISg+ P  NSg/VLXB NPr/J/R/P D   NPl/V3+ VB/C NSg/VB D/P NSg/Vg+     NSg/VB+ . NSg/I/J/R/C K   NSg/VLPp
+# ISg/#r+ VXPt   NSg/VB NPr/ISg+ P  NSg/VLXB NPr/J/R/P D   NPl/V3+ VB/C NSg/VB D/P NSg/Vg+     NSg/VB+ . NSg/I/J/R/C K   VLPp/B
 > calling up         a   few      people  myself . They were hard     to find   .
 # Nᴹ/Vg/J NSg/VB/J/P D/P NSg/I/Dq NPl/VB+ ISg+   . IPl+ VLPt N🅪Sg/J/R P  NSg/VB .
 >
@@ -11362,8 +11362,8 @@
 # NPr/VB/J+ NPrPl/V3+ . D/P NPr/I/J/Dq J          P    Nᴹ/Vg/J NSg/VB/J/P NPr/J/R/P D   ?        NPr/VB NPr/J/R/P D/P
 > city where   dwellings are still      called through decades by    a   family’s name    . I       see
 # NSg+ NSg/R/C NPl/V3+   VLB NSg/VB/J/R VP/J   J/P     NPl+    NSg/P D/P NSg$     NSg/VB+ . ISg/#r+ NSg/VB
-> now       that     this    has been     a   story  of the West      , after all          — Tom     and  Gatsby , Daisy and
-# NSg/J/R/C I/C/Ddem I/Ddem+ V3  NSg/VLPp D/P NSg/VB P  D+  NPr/VB/J+ . P     NSg/I/J/C/Dq . NPr/VB+ VB/C NPr    . NPr   VB/C
+> now       that     this    has been   a   story  of the West      , after all          — Tom     and  Gatsby , Daisy and
+# NSg/J/R/C I/C/Ddem I/Ddem+ V3  VLPp/B D/P NSg/VB P  D+  NPr/VB/J+ . P     NSg/I/J/C/Dq . NPr/VB+ VB/C NPr    . NPr   VB/C
 > Jordan and  I       , were all          Westerners , and  perhaps we   possessed some     deficiency in
 # NPr+   VB/C ISg/#r+ . VLPt NSg/I/J/C/Dq +          . VB/C NSg/R   IPl+ VP/J      I/J/R/Dq NSg+       NPr/J/R/P
 > common   which made us       subtly unadaptable to Eastern life     .
@@ -11406,8 +11406,8 @@
 #
 > There was  one     thing to be       done      before I       left     , an  awkward , unpleasant thing that
 # R+    VLPt NSg/I/J NSg+  P  NSg/VLXB NSg/VPp/J C/P    ISg/#r+ NPr/VP/J . D/P NSg/J   . NSg/J+     NSg+  I/C/Ddem+
-> perhaps had better     have    been     let     alone . But     I       wanted to leave  things in        order
-# NSg/R   VP  NSg/VXB/JC NSg/VXB NSg/VLPp NSg/VBP J     . NSg/C/P ISg/#r+ VP/J   P  NSg/VB NPl+   NPr/J/R/P N🅪Sg/VB+
+> perhaps had better     have    been   let     alone . But     I       wanted to leave  things in        order
+# NSg/R   VP  NSg/VXB/JC NSg/VXB VLPp/B NSg/VBP J     . NSg/C/P ISg/#r+ VP/J   P  NSg/VB NPl+   NPr/J/R/P N🅪Sg/VB+
 > and  not     just trust     that     obliging and  indifferent sea  to sweep  my  refuse away . I
 # VB/C NSg/R/C J/R  N🅪Sg/VB/J I/C/Ddem Nᴹ/Vg/J  VB/C NSg/J       NSg+ P  NSg/VB D$+ NSg/VB VB/J . ISg/#r+
 > saw     Jordan Baker and  talked over    and  around what   had happened to us       together ,
@@ -11548,8 +11548,8 @@
 # . VB/C NSg/C ISgPl+ NSg/VB ISg/#r+ VXPt   NSg/VXB D$+ NSg/VB P  Nᴹ/Vg/J+  . NSg/VB J/R  . NSg/I/C ISg/#r+ NSg/VPt P
 > give   up         that     flat     and  saw     that     damn     box    of dog       biscuits sitting  there on  the
 # NSg/VB NSg/VB/J/P I/C/Ddem NSg/VB/J VB/C NSg/VPt I/C/Ddem NSg/VB/J NSg/VB P  NSg/VB/J+ NPl      NSg/Vg/J R     J/P D
-> sideboard , I       sat      down        and  cried like         a   baby      . By    God     it       was  awful — ”
-# NSg/VB    . ISg/#r+ NSg/VP/J N🅪Sg/VB/J/P VB/C VP/J  NSg/VB/J/C/P D/P NSg/VB/J+ . NSg/P NPr/VB+ NPr/ISg+ VLPt J     . .
+> sideboard , I       sat    down        and  cried like         a   baby      . By    God     it       was  awful — ”
+# NSg/VB    . ISg/#r+ NSg/VP N🅪Sg/VB/J/P VB/C VP/J  NSg/VB/J/C/P D/P NSg/VB/J+ . NSg/P NPr/VB+ NPr/ISg+ VLPt J     . .
 >
 #
 > I       couldn’t forgive him  or    like         him  , but     I       saw     that     what   he       had done      was  , to him  ,
@@ -11598,8 +11598,8 @@
 # ISg/D$+ N🅪Sg/VB . NSg/I/J+ N🅪Sg/VB+ ISg/#r+ VXPt VB   D/P+ N🅪Sg/VB/J+ NSg+ R     . VB/C NSg/VPt ISg/D$+ NPl/V3+ NSg/VB NSg/P
 > his     front     steps   . But     I       didn’t investigate . Probably it       was  some     final    guest  who
 # ISg/D$+ NSg/VB/J+ NPl/V3+ . NSg/C/P ISg/#r+ VXPt   VB          . R        NPr/ISg+ VLPt I/J/R/Dq NSg/VB/J NSg/VB NPr/I+
-> had been     away at    the ends   of the earth    and  didn’t know that     the party     was  over    .
-# VP  NSg/VLPp VB/J NSg/P D   NPl/V3 P  D+  NPrᴹ/VB+ VB/C VXPt   VB   I/C/Ddem D   NSg/VB/J+ VLPt NSg/J/P .
+> had been   away at    the ends   of the earth    and  didn’t know that     the party     was  over    .
+# VP  VLPp/B VB/J NSg/P D   NPl/V3 P  D+  NPrᴹ/VB+ VB/C VXPt   VB   I/C/Ddem D   NSg/VB/J+ VLPt NSg/J/P .
 >
 #
 > On  the last      night    , with my  trunk   packed and  my  car  sold   to the grocer , I       went
@@ -11636,8 +11636,8 @@
 # NPr/J/R/P N🅪Sg+   P    NSg/I/J+  VB/J         P  ISg/D$+ N🅪Sg/J+  R/C/P N🅪Sg/VB .
 >
 #
-> And  as    I       sat      there brooding on  the old   , unknown   world   , I       thought of Gatsby’s
-# VB/C R/C/P ISg/#r+ NSg/VP/J R     Nᴹ/Vg/J  J/P D   NSg/J . NSg/VB/J+ NSg/VB+ . ISg/#r+ N🅪Sg/VP P  NPr$
+> And  as    I       sat    there brooding on  the old   , unknown   world   , I       thought of Gatsby’s
+# VB/C R/C/P ISg/#r+ NSg/VP R     Nᴹ/Vg/J  J/P D   NSg/J . NSg/VB/J+ NSg/VB+ . ISg/#r+ N🅪Sg/VP P  NPr$
 > wonder  when    he       first picked out          the green       light      at    the end    of Daisy’s dock    . He
 # N🅪Sg/VB NSg/I/C NPr/ISg+ NSg/J VP/J   NSg/VB/J/R/P D   NPr🅪Sg/VB/J N🅪Sg/VB/J+ NSg/P D   NSg/VB P  NPr$    NSg/VB+ . NPr/ISg+
 > had come       a   long     way    to this    blue       lawn    , and  his     dream     must    have    seemed so          close

--- a/harper-core/tests/text/tagged/The Great Gatsby.md
+++ b/harper-core/tests/text/tagged/The Great Gatsby.md
@@ -2,8 +2,8 @@
 # HeadingStart D   NSg/J NPr
 >
 #
-> BY    F. SCOTT FITZGERALD
-# NSg/P ?  NPr+  NPr
+> BY F. SCOTT FITZGERALD
+# P  ?  NPr+  NPr
 >
 #
 >              CHAPTER I
@@ -38,14 +38,14 @@
 # R        VP/J    P  N🅪Sg/VLg/J/C D/P NSg+       . C/P     ISg/#r+ VLPt NSg/J P  D   NSg/VB/J NPl/V3
 > of wild     , unknown  men  . Most         of the confidences were unsought — frequently I       have
 # P  NSg/VB/J . NSg/VB/J NPl+ . NSg/I/J/R/Dq P  D   NPl         VLPt VP       . R          ISg/#r+ NSg/VXB
-> feigned sleep    , preoccupation , or    a   hostile levity when    I       realized       by    some
-# VP/J    N🅪Sg/VB+ . NSg           . NPr/C D/P NSg/J   Nᴹ     NSg/I/C ISg/#r+ VP/J/Comm/NoAm NSg/P I/J/R/Dq
+> feigned sleep    , preoccupation , or    a   hostile levity when    I       realized       by some
+# VP/J    N🅪Sg/VB+ . NSg           . NPr/C D/P NSg/J   Nᴹ     NSg/I/C ISg/#r+ VP/J/Comm/NoAm P  I/J/R/Dq
 > unmistakable sign    that     an  intimate revelation was  quivering on  the horizon ; for
 # J            NSg/VB+ I/C/Ddem D/P NSg/VB/J NPr        VLPt Nᴹ/Vg/J   J/P D   NSg+    . R/C/P
 > the intimate revelations of young    men  , or    at    least    the terms   in        which they
 # D   NSg/VB/J NPrPl       P  NPr/VB/J NPl+ . NPr/C NSg/P NSg/J/Dq D   NPl/V3+ NPr/J/R/P I/C+  IPl+
-> express  them     , are usually plagiaristic and  marred by    obvious suppressions .
-# NSg/VB/J NSg/IPl+ . VLB R       J            VB/C VP/J   NSg/P J       NPl          .
+> express  them     , are usually plagiaristic and  marred by obvious suppressions .
+# NSg/VB/J NSg/IPl+ . VLB R       J            VB/C VP/J   P  J       NPl          .
 > Reserving judgments is  a   matter  of infinite hope       . I       am        still      a   little     afraid of
 # Nᴹ/Vg/J   NPl+      VL3 D/P N🅪Sg/VB P  NSg/J    NPr🅪Sg/VB+ . ISg/#r+ NPr/VLB/J NSg/VB/J/R D/P NPr/I/J/Dq J      P
 > missing something if    I       forget that      , as    my  father  snobbishly suggested , and  I
@@ -210,8 +210,8 @@
 # I/C+  NPl/V3  ISg+   NSg/J NPr/J P  NSg/J NPr+ . VB/C NSg/R/C R+    VLB . P     NSg/VB/J
 > natural curiosities , two unusual formations of land       . Twenty miles  from the city
 # NSg/J   NPl         . NSg NSg/J   NPl        P  NPr🅪Sg/VB+ . NSg    NPrPl+ P    D+  NSg+
-> a   pair   of enormous eggs    , identical in        contour and  separated only  by    a   courtesy
-# D/P NSg/VB P  J+       NPl/V3+ . NSg/J     NPr/J/R/P NSg/VB  VB/C VP/J      J/R/C NSg/P D/P NSg/VB/J+
+> a   pair   of enormous eggs    , identical in        contour and  separated only  by a   courtesy
+# D/P NSg/VB P  J+       NPl/V3+ . NSg/J     NPr/J/R/P NSg/VB  VB/C VP/J      J/R/C P  D/P NSg/VB/J+
 > bay       , jut    out          into the most         domesticated body   of salt         water    in        the Western
 # NSg/VB/J+ . NSg/VB NSg/VB/J/R/P P    D   NSg/I/J/R/Dq VP/J         NSg/VB P  NPr🅪Sg/VB/J+ N🅪Sg/VB+ NPr/J/R/P D   NPr/J
 > hemisphere , the great wet      barnyard of Long     Island  Sound      . They are not     perfect
@@ -234,16 +234,16 @@
 # NSg/P   NSg/IPl+ . D$+ NPr/VB+ VLPt NSg/P D   J/R  NSg/VB P  D+  N🅪Sg/VB+ . J/R/C NSg   NPl/V3 P    D+
 > Sound      , and  squeezed between two  huge places  that      rented for   twelve or    fifteen
 # N🅪Sg/VB/J+ . VB/C VP/J     NSg/P   NSg+ J+   NPl/V3+ I/C/Ddem+ VP/J   R/C/P NSg    NPr/C NSg
-> thousand a    season  . The one     on  my  right    was  a   colossal affair by    any    standard — it
-# NSg+     D/P+ NSg/VB+ . D   NSg/I/J J/P D$+ NPr/VB/J VLPt D/P J        NSg    NSg/P I/R/Dq NSg/J    . NPr/ISg+
+> thousand a    season  . The one     on  my  right    was  a   colossal affair by any    standard — it
+# NSg+     D/P+ NSg/VB+ . D   NSg/I/J J/P D$+ NPr/VB/J VLPt D/P J        NSg    P  I/R/Dq NSg/J    . NPr/ISg+
 > was  a   factual imitation of some     Hôtel de   Ville in        Normandy , with a   tower   on  one
 # VLPt D/P NSg/J   N🅪Sg      P  I/J/R/Dq ?     NPr+ ?     NPr/J/R/P NPr      . P    D/P NSg/VB+ J/P NSg/I/J
 > side      , spanking new   under   a   thin     beard  of raw      ivy  , and  a   marble    swimming pool    ,
 # NSg/VB/J+ . Nᴹ/Vg/J  NSg/J NSg/J/P D/P NSg/VB/J NPr/VB P  NSg/VB/J NPr+ . VB/C D/P NSg/VB/J+ NSg/Vg   NSg/VB+ .
 > and  more         than forty acres of lawn   and  garden    . It       was  Gatsby’s mansion . Or    ,
 # VB/C NPr/I/J/R/Dq C/P  NSg/J NPl   P  NSg/VB VB/C NSg/VB/J+ . NPr/ISg+ VLPt NPr$     NSg+    . NPr/C .
-> rather     , as    I       didn’t know Mr   . Gatsby , it       was  a   mansion inhabited by    a   gentleman
-# NPr/VB/J/R . R/C/P ISg/#r+ VXPt   VB   NSg+ . NPr    . NPr/ISg+ VLPt D/P NSg+    VP/J      NSg/P D/P NSg/J
+> rather     , as    I       didn’t know Mr   . Gatsby , it       was  a   mansion inhabited by a   gentleman
+# NPr/VB/J/R . R/C/P ISg/#r+ VXPt   VB   NSg+ . NPr    . NPr/ISg+ VLPt D/P NSg+    VP/J      P  D/P NSg/J
 > of that     name    . My  own       house   was  an  eyesore , but     it       was  a   small    eyesore , and  it
 # P  I/C/Ddem NSg/VB+ . D$+ NSg/VB/J+ NPr/VB+ VLPt D/P NSg     . NSg/C/P NPr/ISg+ VLPt D/P NPr/VB/J NSg     . VB/C NPr/ISg+
 > had been   overlooked , so          I       had a   view   of the water    , a   partial  view   of my
@@ -310,8 +310,8 @@
 # NSg/VB/J P  D/P+ NSg+ . Nᴹ/Vg/J NSg/J/P NPr/VB+ . NPl/V3 VB/C N🅪Sg/VB/J+ NPl/V3 VB/C Nᴹ/Vg/J
 > gardens — finally when    it       reached the house   drifting up         the side      in        bright   vines
 # NPl/V3+ . R       NSg/I/C NPr/ISg+ VP/J    D+  NPr/VB+ Nᴹ/Vg/J  NSg/VB/J/P D+  NSg/VB/J+ NPr/J/R/P NPr/VB/J NPl
-> as    though from the momentum of its     run      . The front     was  broken by    a   line   of French
-# R/C/P C      P    D   N🅪Sg     P  ISg/D$+ NSg/VBPp . D+  NSg/VB/J+ VLPt VPp/J  NSg/P D/P NSg/VB P  NPr🅪Sg/VB/J+
+> as    though from the momentum of its     run      . The front     was  broken by a   line   of French
+# R/C/P C      P    D   N🅪Sg     P  ISg/D$+ NSg/VBPp . D+  NSg/VB/J+ VLPt VPp/J  P  D/P NSg/VB P  NPr🅪Sg/VB/J+
 > windows   , glowing now       with reflected gold     and  wide  open     to the warm      windy
 # NPrPl/V3+ . Nᴹ/Vg/J NSg/J/R/C P    VP/J      Nᴹ/VB/J+ VB/C NSg/J NSg/VB/J P  D+  NSg/VB/J+ NSg/J+
 > afternoon , and  Tom     Buchanan in        riding   clothes was  standing with his     legs    apart
@@ -366,8 +366,8 @@
 # . K    VP  D/P NPr/J N🅪Sg/VB+ J/R  . . NPr/ISg+ VP/J . ISg/D$+ NPl/V3+ Nᴹ/Vg/J  J/P   R          .
 >
 #
-> Turning me       around by    one      arm       , he       moved a    broad  flat      hand    along the front     vista   ,
-# Nᴹ/Vg/J NPr/ISg+ J/P    NSg/P NSg/I/J+ NSg/VB/J+ . NPr/ISg+ VP/J  D/P+ NSg/J+ NSg/VB/J+ NSg/VB+ P     D+  NSg/VB/J+ NSg/VB+ .
+> Turning me       around by one      arm       , he       moved a    broad  flat      hand    along the front     vista   ,
+# Nᴹ/Vg/J NPr/ISg+ J/P    P  NSg/I/J+ NSg/VB/J+ . NPr/ISg+ VP/J  D/P+ NSg/J+ NSg/VB/J+ NSg/VB+ P     D+  NSg/VB/J+ NSg/VB+ .
 > including in        its     sweep  a   sunken Italian garden   , a    half      acre of deep  , pungent
 # Nᴹ/Vg/J   NPr/J/R/P ISg/D$+ NSg/VB D/P VPp/J  N🅪Sg/J  NSg/VB/J . D/P+ N🅪Sg/J/P+ NSg  P  NSg/J . J
 > roses   , and  a   snub      - nosed motor     - boat    that      bumped the tide    offshore .
@@ -382,8 +382,8 @@
 #
 > We   walked through a    high        hallway into a   bright   rosy     - colored     space    , fragilely
 # IPl+ VP/J   J/P     D/P+ NSg/VB/J/R+ NSg+    P    D/P NPr/VB/J NSg/VB/J . NSg/VP/J/Am N🅪Sg/VB+ . R
-> bound    into the house   by    French      windows   at    either end     . The windows   were ajar and
-# NSg/VP/J P    D   NPr/VB+ NSg/P NPr🅪Sg/VB/J NPrPl/V3+ NSg/P I/C    NSg/VB+ . D+  NPrPl/V3+ VLPt VB/J VB/C
+> bound    into the house   by French      windows   at    either end     . The windows   were ajar and
+# NSg/VP/J P    D   NPr/VB+ P  NPr🅪Sg/VB/J NPrPl/V3+ NSg/P I/C    NSg/VB+ . D+  NPrPl/V3+ VLPt VB/J VB/C
 > gleaming white       against the fresh    grass      outside   that      seemed to grow a   little     way
 # Nᴹ/Vg/J  NPr🅪Sg/VB/J C/P     D   NSg/VB/J NPr🅪Sg/VB+ Nᴹ/VB/J/P I/C/Ddem+ VP/J   P  VB   D/P NPr/I/J/Dq NSg/J+
 > into the house   . A    breeze  blew      through the room     , blew      curtains in        at    one      end     and
@@ -422,8 +422,8 @@
 # NSg/C ISg+ VLPt Nᴹ/Vg/J   NSg/I/J+  J/P NPr/ISg+ I/C+  VLPt R     NSg/J  P  N🅪Sg/VB . NSg/C ISg+ NSg/VPt
 > me       out          of the corner of her     eyes    she  gave no       hint   of it       — indeed , I       was  almost
 # NPr/ISg+ NSg/VB/J/R/P P  D   NSg/VB P  ISg/D$+ NPl/V3+ ISg+ VPt  NSg/Dq/P NSg/VB P  NPr/ISg+ . R      . ISg/#r+ VLPt R
-> surprised into murmuring an  apology for   having  disturbed her     by    coming  in        .
-# VP/J      P    Nᴹ/Vg/J   D/P N🅪Sg+   R/C/P Nᴹ/Vg/J VP/J      ISg/D$+ NSg/P Nᴹ/Vg/J NPr/J/R/P .
+> surprised into murmuring an  apology for   having  disturbed her     by coming  in        .
+# VP/J      P    Nᴹ/Vg/J   D/P N🅪Sg+   R/C/P Nᴹ/Vg/J VP/J      ISg/D$+ P  Nᴹ/Vg/J NPr/J/R/P .
 >
 #
 > The other     girl    , Daisy , made an  attempt to rise   — she  leaned slightly forward  with
@@ -606,8 +606,8 @@
 # ISg/#r+ VP/J   NSg/P NSg/VB NPr+  . Nᴹ/Vg/J   NSg/I+ NPr/ISg+ VLPt ISg+ . VP  NSg/VPp/J . . ISg/#r+ VP/J    Nᴹ/Vg/J
 > at    her     . She  was  a   slender , small    - breasted girl    , with an  erect carriage , which
 # NSg/P ISg/D$+ . ISg+ VLPt D/P J       . NPr/VB/J . VP/J     NSg/VB+ . P    D/P VB/J  NSg      . I/C+
-> she  accentuated by    throwing her     body    backward at    the shoulders like         a   young
-# ISg+ VP/J        NSg/P Nᴹ/Vg/J  ISg/D$+ NSg/VB+ NSg/J    NSg/P D   NPl/V3+   NSg/VB/J/C/P D/P NPr/VB/J
+> she  accentuated by throwing her     body    backward at    the shoulders like         a   young
+# ISg+ VP/J        P  Nᴹ/Vg/J  ISg/D$+ NSg/VB+ NSg/J    NSg/P D   NPl/V3+   NSg/VB/J/C/P D/P NPr/VB/J
 > cadet . Her     gray            sun     - strained eyes    looked back     at    me       with polite reciprocal
 # NSg   . ISg/D$+ NPr🅪Sg/VB/J/Am+ NPr/VB+ . VP/J     NPl/V3+ VP/J   NSg/VB/J NSg/P NPr/ISg+ P    VB/J   NSg/J
 > curiosity out          of a   wan       , charming , discontented face    . It       occurred to me       now       that
@@ -726,8 +726,8 @@
 # NSg/C/P NPr/VB/J/R J          Nᴹ/VB/J . . VXB   ISgPl+ N🅪Sg/VB J/P   NPl/V3+ NPr/C NSg/I/J+  . .
 >
 #
-> I       meant nothing  in        particular by    this    remark  , but     it       was  taken up         in        an
-# ISg/#r+ VP    NSg/I/J+ NPr/J/R/P NSg/J      NSg/P I/Ddem+ NSg/VB+ . NSg/C/P NPr/ISg+ VLPt VPp/J NSg/VB/J/P NPr/J/R/P D/P+
+> I       meant nothing  in        particular by this    remark  , but     it       was  taken up         in        an
+# ISg/#r+ VP    NSg/I/J+ NPr/J/R/P NSg/J      P  I/Ddem+ NSg/VB+ . NSg/C/P NPr/ISg+ VLPt VPp/J NSg/VB/J/P NPr/J/R/P D/P+
 > unexpected way    .
 # NSg/J+     NSg/J+ .
 >
@@ -736,12 +736,12 @@
 # . NPr$           Nᴹ/Vg/J P  NPl/V3 . . NSg/VPt/J NSg/VB/J/R/P NPr/VB+ R         . . K    VPp/J  P  NSg/VLXB D/P
 > terrible pessimist about things . Have    you    read    ‘ The Rise   of the Colored     Empires ’
 # J        NSg       J/P   NPl+   . NSg/VXB ISgPl+ NSg/VBP . D   NSg/VB P  D+  NSg/VP/J/Am NPl+    .
-> by    this    man     Goddard ? ”
-# NSg/P I/Ddem+ NPr/VB+ NPr+    . .
+> by this    man     Goddard ? ”
+# P  I/Ddem+ NPr/VB+ NPr+    . .
 >
 #
-> “ Why    , no       , ” I       answered , rather     surprised by    his     tone       .
-# . NSg/VB . NSg/Dq/P . . ISg/#r+ VP/J     . NPr/VB/J/R VP/J      NSg/P ISg/D$+ N🅪Sg/I/VB+ .
+> “ Why    , no       , ” I       answered , rather     surprised by his     tone       .
+# . NSg/VB . NSg/Dq/P . . ISg/#r+ VP/J     . NPr/VB/J/R VP/J      P  ISg/D$+ N🅪Sg/I/VB+ .
 >
 #
 > “ Well       , it’s a    fine     book    , and  everybody ought     to read    it       . The idea is  if    we   don’t
@@ -775,7 +775,7 @@
 >
 #
 > “ You    ought     to live in        California — ” began Miss   Baker , but     Tom     interrupted her     by
-# . ISgPl+ NSg/I/VXB P  VB/J NPr/J/R/P NPr+       . . VPt   NSg/VB NPr+  . NSg/C/P NPr/VB+ VP/J        ISg/D$+ NSg/P
+# . ISgPl+ NSg/I/VXB P  VB/J NPr/J/R/P NPr+       . . VPt   NSg/VB NPr+  . NSg/C/P NPr/VB+ VP/J        ISg/D$+ P
 > shifting heavily in        his     chair   .
 # Nᴹ/Vg/J+ R       NPr/J/R/P ISg/D$+ NSg/VB+ .
 >
@@ -972,8 +972,8 @@
 # D/P NSg/VB P      D/P R         NSg/J    NSg/VB+ . NSg/VB/C/P . Nᴹ/Vg/J P  NSg/VB R
 > interested and  a   little     deaf     , I       followed Daisy around a   chain   of connecting
 # VP/J       VB/C D/P NPr/I/J/Dq NSg/VB/J . ISg/#r+ VP/J     NPr+  J/P    D/P N🅪Sg/VB P  Nᴹ/Vg/J
-> verandas    to the porch in        front     . In        its     deep   gloom  we   sat    down        side      by    side      on  a
-# NPl/NoAm/Br P  D   NSg+  NPr/J/R/P NSg/VB/J+ . NPr/J/R/P ISg/D$+ NSg/J+ Nᴹ/VB+ IPl+ NSg/VP N🅪Sg/VB/J/P NSg/VB/J+ NSg/P NSg/VB/J+ J/P D/P
+> verandas    to the porch in        front     . In        its     deep   gloom  we   sat    down        side      by side      on  a
+# NPl/NoAm/Br P  D   NSg+  NPr/J/R/P NSg/VB/J+ . NPr/J/R/P ISg/D$+ NSg/J+ Nᴹ/VB+ IPl+ NSg/VP N🅪Sg/VB/J/P NSg/VB/J+ P  NSg/VB/J+ J/P D/P
 > wicker settee .
 # NSg/JC NSg    .
 >
@@ -1200,8 +1200,8 @@
 #
 > I       said lightly that     I       had heard nothing  at    all          , and  a    few       minutes later I       got up
 # ISg/#r+ VP/J R       I/C/Ddem ISg/#r+ VP  VP/J  NSg/I/J+ NSg/P NSg/I/J/C/Dq . VB/C D/P+ NSg/I/Dq+ NPl/V3+ JC    ISg/#r+ VP  NSg/VB/J/P
-> to go       home      . They came      to the door    with me       and  stood side      by    side      in        a   cheerful
-# P  NSg/VB/J NSg/VB/J+ . IPl+ NSg/VPt/P P  D+  NSg/VB+ P    NPr/ISg+ VB/C VP    NSg/VB/J+ NSg/P NSg/VB/J+ NPr/J/R/P D/P J
+> to go       home      . They came      to the door    with me       and  stood side      by side      in        a   cheerful
+# P  NSg/VB/J NSg/VB/J+ . IPl+ NSg/VPt/P P  D+  NSg/VB+ P    NPr/ISg+ VB/C VP    NSg/VB/J+ P  NSg/VB/J+ NPr/J/R/P D/P J
 > square   of light      . As    I       started my  motor     Daisy peremptorily called : “ Wait   !
 # NSg/VB/J P  N🅪Sg/VB/J+ . R/C/P ISg/#r+ VP/J    D$+ NSg/VB/J+ NPr+  R            VP/J   . . NSg/VB .
 >
@@ -1220,8 +1220,8 @@
 # . K    D/P+ NSg/VB+ . K   R   NSg/VB/J . .
 >
 #
-> “ But     we   heard it       , ” insisted Daisy , surprising me       by    opening up         again in        a
-# . NSg/C/P IPl+ VP/J  NPr/ISg+ . . VP/J     NPr+  . Nᴹ/Vg/J    NPr/ISg+ NSg/P Nᴹ/Vg/J NSg/VB/J/P P     NPr/J/R/P D/P+
+> “ But     we   heard it       , ” insisted Daisy , surprising me       by opening up         again in        a
+# . NSg/C/P IPl+ VP/J  NPr/ISg+ . . VP/J     NPr+  . Nᴹ/Vg/J    NPr/ISg+ P  Nᴹ/Vg/J NSg/VB/J/P P     NPr/J/R/P D/P+
 > flower  - like         way    . “ We   heard it       from three people  , so          it       must    be       true     . ”
 # NSg/VB+ . NSg/VB/J/C/P NSg/J+ . . IPl+ VP/J  NPr/ISg+ P    NSg+  NPl/VB+ . NSg/I/J/R/C NPr/ISg+ NSg/VXB NSg/VLXB NSg/VB/J . .
 >
@@ -1246,8 +1246,8 @@
 # R+    VLPt NSg/Dq/P NSg/I NPl/V3+    NPr/J/R/P ISg/D$+ NPr/VB/J+ . R/C/P R/C/P NPr/VB+ . D+  NSg+ I/C/Ddem+ NPr/ISg+ . VP
 > some     woman  in        New    York ” was  really less    surprising than that     he       had been
 # I/J/R/Dq NSg/VB NPr/J/R/P NSg/J+ NPr+ . VLPt R      J/R/C/P Nᴹ/Vg/J    C/P  I/C/Ddem NPr/ISg+ VP  VLPp/B
-> depressed by    a    book    . Something was  making  him  nibble at    the edge   of stale     ideas
-# VP/J      NSg/P D/P+ NSg/VB+ . NSg/I/J+  VLPt Nᴹ/Vg/J ISg+ NSg/VB NSg/P D   NSg/VB P  NSg/VB/J+ NPl+
+> depressed by a    book    . Something was  making  him  nibble at    the edge   of stale     ideas
+# VP/J      P  D/P+ NSg/VB+ . NSg/I/J+  VLPt Nᴹ/Vg/J ISg+ NSg/VB NSg/P D   NSg/VB P  NSg/VB/J+ NPl+
 > as    if    his     sturdy physical egotism no       longer nourished his     peremptory heart    .
 # R/C/P NSg/C ISg/D$+ NSg/J  NSg/J    NSg     NSg/Dq/P NSg/JC VP/J+     ISg/D$+ NSg/J      N🅪Sg/VB+ .
 >
@@ -1336,14 +1336,14 @@
 # NSg     NPr/VBP/J NSg/IPl+ R+    P  VB     ISg/D$+ NSg/VB+  NPr/J/R/P D   NSg+    P  NPrPl/V3 . VB/C NSg/J/R/C
 > sank down        himself into eternal blindness , or    forgot them     and  moved away . But     his
 # VPt  N🅪Sg/VB/J/P ISg+    P    NSg/J   NSg+      . NPr/C VPt    NSg/IPl+ VB/C VP/J  VB/J . NSg/C/P ISg/D$+
-> eyes    , dimmed a   little     by    many       paintless days , under   sun    and  rain     , brood    on  over
-# NPl/V3+ . VP     D/P NPr/I/J/Dq NSg/P NSg/I/J/Dq J         NPl+ . NSg/J/P NPr/VB VB/C N🅪Sg/VB+ . NSg/VB/J J/P NSg/J/P
+> eyes    , dimmed a   little     by many       paintless days , under   sun    and  rain     , brood    on  over
+# NPl/V3+ . VP     D/P NPr/I/J/Dq P  NSg/I/J/Dq J         NPl+ . NSg/J/P NPr/VB VB/C N🅪Sg/VB+ . NSg/VB/J J/P NSg/J/P
 > the solemn dumping  ground     .
 # D   J      Nᴹ/Vg/J+ N🅪Sg/VB/J+ .
 >
 #
-> The valley of ashes   is  bounded on  one      side      by    a    small     foul      river   , and  , when    the
-# D   NSg/VB P  NPl/V3+ VL3 VP/J    J/P NSg/I/J+ NSg/VB/J+ NSg/P D/P+ NPr/VB/J+ NSg/VB/J+ NSg/VB+ . VB/C . NSg/I/C D
+> The valley of ashes   is  bounded on  one      side      by a    small     foul      river   , and  , when    the
+# D   NSg/VB P  NPl/V3+ VL3 VP/J    J/P NSg/I/J+ NSg/VB/J+ P  D/P+ NPr/VB/J+ NSg/VB/J+ NSg/VB+ . VB/C . NSg/I/C D
 > drawbridge is  up         to let     barges  through , the passengers on  waiting trains  can
 # NSg        VL3 NSg/VB/J/P P  NSg/VBP NPl/V3+ J/P     . D   NPl/V3+    J/P Nᴹ/Vg/J NPl/V3+ NPr/VXB
 > stare   at    the dismal scene   for   as    long     as    half      an  hour . There is  always a    halt
@@ -1362,8 +1362,8 @@
 # Nᴹ/Vg/J ISg/D$+ NSg/P D/P NSg/VB+ . VP/J      J/P   . NSg/Vg   P    I          NPr/ISg+ VPt  .
 > Though I       was  curious to see    her     , I       had no        desire   to meet     her     — but     I       did  . I       went
 # C      ISg/#r+ VLPt J       P  NSg/VB ISg/D$+ . ISg/#r+ VP  NSg/Dq/P+ N🅪Sg/VB+ P  NSg/VB/J ISg/D$+ . NSg/C/P ISg/#r+ VXPt . ISg/#r+ NSg/VPt
-> up         to New   York with Tom     on  the train   one      afternoon , and  when    we   stopped by    the
-# NSg/VB/J/P P  NSg/J NPr+ P    NPr/VB+ J/P D+  NSg/VB+ NSg/I/J+ N🅪Sg+     . VB/C NSg/I/C IPl+ VP/J    NSg/P D
+> up         to New   York with Tom     on  the train   one      afternoon , and  when    we   stopped by the
+# NSg/VB/J/P P  NSg/J NPr+ P    NPr/VB+ J/P D+  NSg/VB+ NSg/I/J+ N🅪Sg+     . VB/C NSg/I/C IPl+ VP/J    P  D
 > ashheaps he       jumped to his     feet and  , taking   hold     of my  elbow   , literally forced me
 # ?        NPr/ISg+ VP/J   P  ISg/D$+ NPl+ VB/C . NSg/Vg/J NSg/VB/J P  D$+ NSg/VB+ . R         VP/J   NPr/ISg+
 > from the car  .
@@ -1392,8 +1392,8 @@
 # NSg/VB/J+ NPr🅪Sg/VB+ . D/P NSg/VB P  NSg/VB/J+ NSg/VB/J+ NSg/VB/J+ Nᴹ/Vg/J     P  NPr/ISg+ . VB/C J          P
 > absolutely nothing  . One     of the three shops   it       contained was  for   rent     and  another
 # R          NSg/I/J+ . NSg/I/J P  D+  NSg+  NPl/V3+ NPr/ISg+ VP/J      VLPt R/C/P Nᴹ/VB/J+ VB/C I/D+
-> was  an  all          - night    restaurant , approached by    a   trail  of ashes   ; the third    was  a
-# VLPt D/P NSg/I/J/C/Dq . N🅪Sg/VB+ NSg+       . VP/J       NSg/P D/P NSg/VB P  NPl/V3+ . D   NSg/VB/J VLPt D/P
+> was  an  all          - night    restaurant , approached by a   trail  of ashes   ; the third    was  a
+# VLPt D/P NSg/I/J/C/Dq . N🅪Sg/VB+ NSg+       . VP/J       P  D/P NSg/VB P  NPl/V3+ . D   NSg/VB/J VLPt D/P
 > garage — Repairs . George B. Wilson . Cars bought and  sold   . — and  I       followed Tom
 # NSg/VB . NPl/V3+ . NPr+   ?  NPr+   . NPl+ NSg/VP VB/C NSg/VP . . VB/C ISg/#r+ VP/J     NPr/VB+
 > inside  .
@@ -1490,8 +1490,8 @@
 # . NSg/I/J/C/Dq NPr/VB/J . .
 >
 #
-> “ I’ll meet     you    by    the news   - stand  on  the lower     level     . ”
-# . K    NSg/VB/J ISgPl+ NSg/P D   Nᴹ/VB+ . NSg/VB J/P D   NSg/VB/JC NSg/VB/J+ . .
+> “ I’ll meet     you    by the news   - stand  on  the lower     level     . ”
+# . K    NSg/VB/J ISgPl+ P  D   Nᴹ/VB+ . NSg/VB J/P D   NSg/VB/JC NSg/VB/J+ . .
 >
 #
 > She  nodded and  moved away from him  just as    George Wilson emerged with two chairs
@@ -1586,8 +1586,8 @@
 #
 > The man     peered doubtfully into the basket  , plunged in        his     hand    and  drew    one     up         ,
 # D+  NPr/VB+ VP/J   R          P    D   NSg/VB+ . VP/J    NPr/J/R/P ISg/D$+ NSg/VB+ VB/C NPr/VPt NSg/I/J NSg/VB/J/P .
-> wriggling , by    the back     of the neck    .
-# Nᴹ/Vg/J   . NSg/P D   NSg/VB/J P  D   NSg/VB+ .
+> wriggling , by the back     of the neck    .
+# Nᴹ/Vg/J   . P  D   NSg/VB/J P  D   NSg/VB+ .
 >
 #
 > “ That’s no        police dog       , ” said Tom     .
@@ -1654,8 +1654,8 @@
 #
 > “ Come       on  , ” she  urged . “ I'll telephone my  sister  Catherine . She’s said to be       very
 # . NSg/VBPp/P J/P . . ISg+ VP/J  . . K    NSg/VB+   D$+ NSg/VB+ NPr+      . K     VP/J P  NSg/VLXB J/R
-> beautiful by    people  who    ought     to know . ”
-# NSg/J     NSg/P NPl/VB+ NPr/I+ NSg/I/VXB P  VB   . .
+> beautiful by people  who    ought     to know . ”
+# NSg/J     P  NPl/VB+ NPr/I+ NSg/I/VXB P  VB   . .
 >
 #
 > “ Well       , I’d like         to , but     — ”
@@ -1728,8 +1728,8 @@
 #
 > Just as    Tom     and  Myrtle ( after the first drink   Mrs  . Wilson and  I       called each
 # J/R  R/C/P NPr/VB+ VB/C NPr    . P     D   NSg/J NSg/VB+ NPl+ . NPr+   VB/C ISg/#r+ VP/J   Dq
-> other    by    our first  names   ) reappeared , company commenced to arrive at    the
-# NSg/VB/J NSg/P D$+ NSg/J+ NPl/V3+ . VP/J       . N🅪Sg+   VP/J      P  VB     NSg/P D
+> other    by our first  names   ) reappeared , company commenced to arrive at    the
+# NSg/VB/J P  D$+ NSg/J+ NPl/V3+ . VP/J       . N🅪Sg+   VP/J      P  VB     NSg/P D
 > apartment - door    .
 # NSg+      . NSg/VB+ .
 >
@@ -1784,8 +1784,8 @@
 # N🅪Sg+       VP  R/C  VPp       D/P+ N🅪Sg/VB+ . D+  J+      Nᴹ+      I/C/Ddem+ VP  VLPp/B NSg/I/J/R/C
 > remarkable in        the garage  was  converted into impressive hauteur . Her     laughter ,
 # J          NPr/J/R/P D+  NSg/VB+ VLPt VP/J      P    J          NSg     . ISg/D$+ Nᴹ+      .
-> her     gestures , her     assertions became more         violently affected moment by    moment ,
-# ISg/D$+ NPl/V3+  . ISg/D$+ NSg+       VPt    NPr/I/J/R/Dq R         NSg/VP/J NSg+   NSg/P NSg+   .
+> her     gestures , her     assertions became more         violently affected moment by moment ,
+# ISg/D$+ NPl/V3+  . ISg/D$+ NSg+       VPt    NPr/I/J/R/Dq R         NSg/VP/J NSg+   P  NSg+   .
 > and  as    she  expanded the room     grew smaller around her     , until she  seemed to be
 # VB/C R/C/P ISg+ VP/J     D+  N🅪Sg/VB+ VPt  NSg/JC  J/P    ISg/D$+ . C/P   ISg+ VP/J   P  NSg/VLXB
 > revolving on  a   noisy , creaking pivot  through the smoky air      .
@@ -1814,8 +1814,8 @@
 # . ISg/#r+ NSg/VB/J/C/P D$+  NSg/VB+ . . VP/J     NPl+ . NPr   . . ISg/#r+ NSg/VB K    J        . .
 >
 #
-> Mrs  . Wilson rejected the compliment by    raising her     eyebrow in        disdain .
-# NPl+ . NPr+   VP/J     D+  NSg/VB+    NSg/P Nᴹ/Vg/J ISg/D$+ NSg/VB  NPr/J/R/P Nᴹ/VB+  .
+> Mrs  . Wilson rejected the compliment by raising her     eyebrow in        disdain .
+# NPl+ . NPr+   VP/J     D+  NSg/VB+    P  Nᴹ/Vg/J ISg/D$+ NSg/VB  NPr/J/R/P Nᴹ/VB+  .
 >
 #
 > “ It’s just a   crazy old   thing , ” she  said . “ I       just slip   it       on  sometimes when    I
@@ -1942,8 +1942,8 @@
 # . K   VP/J   P  ISg+ . K   N🅪Sg/VB P  NSg/VXB ISg+ NSg/VB NSg/I/VB+ J/P NPr/ISg+ . .
 >
 #
-> This   absorbing information about my  neighbor     was  interrupted by    Mrs  . McKee’s
-# I/Ddem Nᴹ/Vg/J   Nᴹ          J/P   D$+ NSg/VB/J/Am+ VLPt VP/J        NSg/P NPl+ . NPr$
+> This   absorbing information about my  neighbor     was  interrupted by Mrs  . McKee’s
+# I/Ddem Nᴹ/Vg/J   Nᴹ          J/P   D$+ NSg/VB/J/Am+ VLPt VP/J        P  NPl+ . NPr$
 > pointing suddenly at    Catherine :
 # Nᴹ/Vg/J  R        NSg/P NPr+      .
 >
@@ -2052,8 +2052,8 @@
 # . NSg/VB/J NPr/VB/J . .
 >
 #
-> “ No       , we   just went    to Monte Carlo and  back     . We   went    by    way   of Marseilles . We   had
-# . NSg/Dq/P . IPl+ J/R  NSg/VPt P  NPr   NPr+  VB/C NSg/VB/J . IPl+ NSg/VPt NSg/P NSg/J P  NPr        . IPl+ VP
+> “ No       , we   just went    to Monte Carlo and  back     . We   went    by way   of Marseilles . We   had
+# . NSg/Dq/P . IPl+ J/R  NSg/VPt P  NPr   NPr+  VB/C NSg/VB/J . IPl+ NSg/VPt P  NSg/J P  NPr        . IPl+ VP
 > over    twelve hundred dollars when    we   started , but     we   got gyped out          of it       all          in
 # NSg/J/P NSg+   NSg+    NPl+    NSg/I/C IPl+ VP/J    . NSg/C/P IPl+ VP  ?     NSg/VB/J/R/P P  NPr/ISg+ NSg/I/J/C/Dq NPr/J/R/P
 > two days in        the private  rooms   . We   had an   awful time       getting back     , I       can     tell
@@ -2122,8 +2122,8 @@
 #
 > She  pointed suddenly at    me       , and  every one      looked at    me       accusingly . I       tried to
 # ISg+ VP/J    R        NSg/P NPr/ISg+ . VB/C Dq+   NSg/I/J+ VP/J   NSg/P NPr/ISg+ R          . ISg/#r+ VP/J  P
-> show   by    my  expression that      I       expected no        affection .
-# NSg/VB NSg/P D$+ N🅪Sg+      I/C/Ddem+ ISg/#r+ NSg/VP/J NSg/Dq/P+ Nᴹ+       .
+> show   by my  expression that      I       expected no        affection .
+# NSg/VB P  D$+ N🅪Sg+      I/C/Ddem+ ISg/#r+ NSg/VP/J NSg/Dq/P+ Nᴹ+       .
 >
 #
 > “ The only  crazy I       was  was  when    I       married  him  . I       knew right    away I       made a
@@ -2146,8 +2146,8 @@
 # VP  . .
 >
 #
-> The bottle of whiskey — a   second   one      — was  now       in        constant demand   by    all          present  ,
-# D   NSg/VB P  N🅪Sg    . D/P NSg/VB/J NSg/I/J+ . VLPt NSg/J/R/C NPr/J/R/P NSg/J    N🅪Sg/VB+ NSg/P NSg/I/J/C/Dq NSg/VB/J .
+> The bottle of whiskey — a   second   one      — was  now       in        constant demand   by all          present  ,
+# D   NSg/VB P  N🅪Sg    . D/P NSg/VB/J NSg/I/J+ . VLPt NSg/J/R/C NPr/J/R/P NSg/J    N🅪Sg/VB+ P  NSg/I/J/C/Dq NSg/VB/J .
 > excepting Catherine , who    “ felt      just as    good     on  nothing  at    all          . ” Tom     rang for   the
 # Nᴹ/Vg/J   NPr+      . NPr/I+ . N🅪Sg/VP/J J/R  R/C/P NPr/VB/J J/P NSg/I/J+ NSg/P NSg/I/J/C/Dq . . NPr/VB+ VPt  R/C/P D
 > janitor and  sent   him  for   some     celebrated sandwiches , which were a   complete
@@ -2164,8 +2164,8 @@
 # D$+   NSg/VB P  NSg/VB/J Nᴹ      P  D   NSg/J  NSg+    NPr/J/R/P D   Nᴹ/Vg/J   NPl/V3+ . VB/C
 > I       saw     him  too , looking up         and  wondering . I       was  within  and  without ,
 # ISg/#r+ NSg/VPt ISg+ R   . Nᴹ/Vg/J NSg/VB/J/P VB/C Nᴹ/Vg/J   . ISg/#r+ VLPt NSg/J/P VB/C C/P     .
-> simultaneously enchanted and  repelled by    the inexhaustible variety of life     .
-# R              VP/J      VB/C VP       NSg/P D   J             N🅪Sg    P  N🅪Sg/VB+ .
+> simultaneously enchanted and  repelled by the inexhaustible variety of life     .
+# R              VP/J      VB/C VP       P  D   J             N🅪Sg    P  N🅪Sg/VB+ .
 >
 #
 > Myrtle pulled her     chair   close    to mine      , and  suddenly her     warm     breath     poured over
@@ -2346,8 +2346,8 @@
 # P  ?        V3+    . R+    VLPt D/P NSg/VB+ NPr/J/R/P D+  NSg/VB+ I/C+  NSg/VXB NSg/VB  D
 > juice     of two hundred oranges in        half      an  hour if    a   little     button  was  pressed two
 # N🅪Sg/VB/J P  NSg NSg     NPl/V3  NPr/J/R/P N🅪Sg/J/P+ D/P NSg+ NSg/C D/P NPr/I/J/Dq NSg/VB+ VLPt VP/J    NSg
-> hundred times   by    a   butler’s thumb   .
-# NSg     NPl/V3+ NSg/P D/P NPr$     NSg/VB+ .
+> hundred times   by a   butler’s thumb   .
+# NSg     NPl/V3+ P  D/P NPr$     NSg/VB+ .
 >
 #
 > At    least    once  a   fortnight a   corps of caterers came      down        with several hundred
@@ -2368,8 +2368,8 @@
 # I/D     .
 >
 #
-> By    seven o’clock the orchestra has arrived , no       thin     five - piece   affair , but     a
-# NSg/P NSg   R       D+  NSg+      V3  VP/J    . NSg/Dq/P NSg/VB/J NSg  . NSg/VB+ NSg+   . NSg/C/P D/P
+> By seven o’clock the orchestra has arrived , no       thin     five - piece   affair , but     a
+# P  NSg   R       D+  NSg+      V3  VP/J    . NSg/Dq/P NSg/VB/J NSg  . NSg/VB+ NSg+   . NSg/C/P D/P
 > whole pitful of oboes and  trombones and  saxophones and  viols  and  cornets and
 # NSg/J ?      P  NPl   VB/C NPl/V3    VB/C NPl/V3     VB/C NPl/V3 VB/C NPl     VB/C
 > piccolos , and  low        and  high       drums   . The last     swimmers have    come       in        from the beach
@@ -2394,8 +2394,8 @@
 # D+  NPl/V3+ VB   NSg/JC   R/C/P D+  NPrᴹ/VB+ NPl/V3  VB/J P    D   NPr/VB+ . VB/C NSg/J/R/C D
 > orchestra is  playing yellow   cocktail  music      , and  the opera of voices  pitches a
 # NSg+      VL3 Nᴹ/Vg/J NSg/VB/J NSg/VB/J+ N🅪Sg/VB/J+ . VB/C D   NSg   P  NPl/V3+ NPl/V3+ D/P
-> key      higher . Laughter is  easier minute   by    minute    , spilled with prodigality ,
-# NPr/VB/J NSg/JC . Nᴹ+      VL3 NSg/JC NSg/VB/J NSg/P NSg/VB/J+ . VP/J    P    Nᴹ          .
+> key      higher . Laughter is  easier minute   by minute    , spilled with prodigality ,
+# NPr/VB/J NSg/JC . Nᴹ+      VL3 NSg/JC NSg/VB/J P  NSg/VB/J+ . VP/J    P    Nᴹ          .
 > tipped out          at    a   cheerful word    . The groups  change   more         swiftly , swell     with new
 # VP     NSg/VB/J/R/P NSg/P D/P J        NSg/VB+ . D+  NPl/V3+ N🅪Sg/VB+ NPr/I/J/R/Dq R       . NSg/VB/J+ P    NSg/J
 > arrivals , dissolve and  form     in        the same breath     ; already there are wanderers ,
@@ -2430,8 +2430,8 @@
 # NPl/V3+ NPr/I+ VP  R        VLPp/B NSg/VP/J . NPl/VB+ VLPt NSg/R/C NSg/VP/J . IPl+ NSg/VPt R     .
 > They got into automobiles which bore     them     out          to Long     Island  , and  somehow they
 # IPl+ VP  P    NPl/V3      I/C+  NSg/VBPt NSg/IPl+ NSg/VB/J/R/P P  NPr/VB/J NSg/VB+ . VB/C R       IPl+
-> ended up         at    Gatsby’s door    . Once  there they were introduced by    somebody who    knew
-# VP/J  NSg/VB/J/P NSg/P NPr$     NSg/VB+ . NSg/C R+    IPl+ VLPt VP/J       NSg/P NSg/I+   NPr/I+ VPt
+> ended up         at    Gatsby’s door    . Once  there they were introduced by somebody who    knew
+# VP/J  NSg/VB/J/P NSg/P NPr$     NSg/VB+ . NSg/C R+    IPl+ VLPt VP/J       P  NSg/I+   NPr/I+ VPt
 > Gatsby , and  after that     they conducted themselves according to the rules  of
 # NPr    . VB/C P     I/C/Ddem IPl+ VP/J      IPl+       Nᴹ/Vg/J   P  D   NPl/V3 P
 > behavior associated with an  amusement park    . Sometimes they came      and  went    without
@@ -2462,8 +2462,8 @@
 # VP/J     J/P    NPr/VB/J/R NSg/VB/J NSg/P Nᴹ/VB+ P     NPl/V3 VB/C NPl/V3 P  NPl/VB+ ISg/#r+ VXPt
 > know — though here and  there was  a   face    I       had noticed on  the commuting train   . I
 # VB   . C      J/R  VB/C R+    VLPt D/P NSg/VB+ ISg/#r+ VP  VP/J    J/P D   Nᴹ/Vg/J   NSg/VB+ . ISg/#r+
-> was  immediately struck by    the number      of young    Englishmen dotted about ; all          well
-# VLPt R           VB     NSg/P D   N🅪Sg/VB/JC+ P  NPr/VB/J NPl        VP/J   J/P   . NSg/I/J/C/Dq NSg/VB/J/R
+> was  immediately struck by the number      of young    Englishmen dotted about ; all          well
+# VLPt R           VB     P  D   N🅪Sg/VB/JC+ P  NPr/VB/J NPl        VP/J   J/P   . NSg/I/J/C/Dq NSg/VB/J/R
 > dressed , all          looking a   little     hungry , and  all          talking  in        low        , earnest   voices  to
 # VP/J    . NSg/I/J/C/Dq Nᴹ/Vg/J D/P NPr/I/J/Dq J      . VB/C NSg/I/J/C/Dq Nᴹ/Vg/J+ NPr/J/R/P NSg/VB/J/R . NPr/VB/J+ NPl/V3+ P
 > solid and  prosperous Americans . I       was  sure that     they were selling something :
@@ -2498,8 +2498,8 @@
 #
 > Welcome  or    not     , I       found  it       necessary to attach myself to some      one      before I
 # NSg/VB/J NPr/C NSg/R/C . ISg/#r+ NSg/VP NPr/ISg+ NSg/J     P  VB     ISg+   P  I/J/R/Dq+ NSg/I/J+ C/P    ISg/#r+
-> should begin  to address cordial remarks to the passers - by    .
-# VXB    NSg/VB P  NSg/VB  NSg/J   NPl/V3+ P  D   NPl     . NSg/P .
+> should begin  to address cordial remarks to the passers - by .
+# VXB    NSg/VB P  NSg/VB  NSg/J   NPl/V3+ P  D   NPl     . P  .
 >
 #
 > “ Hello  ! ” I       roared , advancing toward her     . My  voice   seemed unnaturally loud  across
@@ -2774,8 +2774,8 @@
 # NPr+   VP/J   NSg/P ISg+ R       . R          . C/P     Nᴹ/Vg/J   .
 >
 #
-> “ I       was  brought by    a    woman   named Roosevelt , ” he       continued . “ Mrs  . Claud Roosevelt .
-# . ISg/#r+ VLPt VP      NSg/P D/P+ NSg/VB+ VP/J  NPr+      . . NPr/ISg+ VP/J      . . NPl+ . ?     NPr+      .
+> “ I       was  brought by a    woman   named Roosevelt , ” he       continued . “ Mrs  . Claud Roosevelt .
+# . ISg/#r+ VLPt VP      P  D/P+ NSg/VB+ VP/J  NPr+      . . NPr/ISg+ VP/J      . . NPl+ . ?     NPr+      .
 > Do  you    know her     ? I       met her     somewhere last      night    . I’ve been   drunk     for   about a
 # VXB ISgPl+ VB   ISg/D$+ . ISg/#r+ VP  ISg/D$+ R         NSg/VB/J+ N🅪Sg/VB+ . K    VLPp/B NSg/VPp/J R/C/P J/P   D/P
 > week   now       , and  I       thought it       might    sober me       up         to sit    in        a   library . ”
@@ -2808,8 +2808,8 @@
 # R          . R           . VB/C Nᴹ/Vg/J NPr/J/R/P D   NPl/V3+ . VB/C D/P NSg/J N🅪Sg/VB/JC P  NSg/VB/J
 > girls   dancing individualistically or    relieving the orchestra for   a   moment of the
 # NPl/V3+ Nᴹ/Vg/J R                   NPr/C Nᴹ/Vg/J   D   NSg+      R/C/P D/P NSg    P  D
-> burden of the banjo  or    the traps  . By    midnight the hilarity had increased . A
-# NSg/VB P  D   NSg/VB NPr/C D   NPl/V3 . NSg/P NSg/J+   D   NSg      VP  VP/J      . D/P
+> burden of the banjo  or    the traps  . By midnight the hilarity had increased . A
+# NSg/VB P  D   NSg/VB NPr/C D   NPl/V3 . P  NSg/J+   D   NSg      VP  VP/J      . D/P
 > celebrated tenor had sung    in        Italian , and  a   notorious contralto had sung    in
 # VP/J       NSg/J VP  NPr/VPp NPr/J/R/P N🅪Sg/J  . VB/C D/P J         NSg       VP  NPr/VPp NPr/J/R/P
 > jazz    , and  between the numbers   people  were doing   ‘ ‘ stunts ” all          over    the garden    ,
@@ -3144,8 +3144,8 @@
 # ISg/#r+ VP/J   J/P    . NSg/I/J/R/Dq P  D+  Nᴹ/Vg/J   NPl+  VLPt NSg/J/R/C Nᴹ/Vg/J NPl/V3+ P    NPl+
 > said to be       their husbands . Even       Jordan’s party     , the quartet from East   Egg      , were
 # VP/J P  NSg/VLXB D$+   NPl/V3+  . NSg/VB/J/R NPr$     NSg/VB/J+ . D   NSg+    P    NPr/J+ N🅪Sg/VB+ . VLPt
-> rent     asunder by    dissension . One     of the men  was  talking with curious intensity to
-# Nᴹ/VB/J+ R       NSg/P NSg        . NSg/I/J P  D+  NPl+ VLPt Nᴹ/Vg/J P    J       Nᴹ+       P
+> rent     asunder by dissension . One     of the men  was  talking with curious intensity to
+# Nᴹ/VB/J+ R       P  NSg        . NSg/I/J P  D+  NPl+ VLPt Nᴹ/Vg/J P    J       Nᴹ+       P
 > a    young     actress , and  his     wife      , after attempting to laugh  at    the situation in        a
 # D/P+ NPr/VB/J+ NSg+    . VB/C ISg/D$+ NSg/VB/J+ . P     Nᴹ/Vg/J    P  NSg/VB NSg/P D+  NSg+      NPr/J/R/P D/P
 > dignified and  indifferent way    , broke     down        entirely and  resorted to flank
@@ -3158,8 +3158,8 @@
 #
 > The reluctance to go       home      was  not     confined to wayward men  . The hall was  at
 # D   NSg+       P  NSg/VB/J NSg/VB/J+ VLPt NSg/R/C VP/J     P  J       NPl+ . D+  NPr+ VLPt NSg/P
-> present  occupied by    two deplorably sober men  and  their highly indignant wives   .
-# NSg/VB/J VP/J     NSg/P NSg R          VB/J  NPl+ VB/C D$+   R      J         NPl/V3+ .
+> present  occupied by two deplorably sober men  and  their highly indignant wives   .
+# NSg/VB/J VP/J     P  NSg R          VB/J  NPl+ VB/C D$+   R      J         NPl/V3+ .
 > The wives   were sympathizing with each other    in        slightly raised voices  .
 # D+  NPl/V3+ VLPt Nᴹ/Vg/J      P    Dq   NSg/VB/J NPr/J/R/P R        VP/J   NPl/V3+ .
 >
@@ -3200,8 +3200,8 @@
 # NPr+  VB/C NPr    NSg/VPt/P NSg/VB/J/R/P J        . NPr/ISg+ VLPt N🅪Sg/Vg/J I/J/R/Dq NSg/VB/J+ NSg/VB+ P  ISg/D$+ . NSg/C/P D
 > eagerness in        his     manner tightened abruptly into formality as    several people
 # NSg       NPr/J/R/P ISg/D$+ NSg+   VP/J      R        P    NSg+      R/C/P J/Dq    NPl/VB+
-> approached him  to say    good     - by    .
-# VP/J       ISg+ P  NSg/VB NPr/VB/J . NSg/P .
+> approached him  to say    good     - by .
+# VP/J       ISg+ P  NSg/VB NPr/VB/J . P  .
 >
 #
 > Jordan’s party     were calling impatiently to her     from the porch , but     she  lingered
@@ -3368,14 +3368,14 @@
 # D   NSg/VB P  D   ?     VPp   R      NSg/VB/J . D+  NSg/VB+ . NPr/ISg+ VLPt NSg/J/R/C D/P NSg/VB+ . J
 > back     involuntarily , and  when    the door    had opened wide  there was  a   ghostly pause   .
 # NSg/VB/J R             . VB/C NSg/I/C D   NSg/VB+ VP  VP/J   NSg/J R+    VLPt D/P J/R     NSg/VB+ .
-> Then      , very gradually , part      by    part      , a   pale     , dangling individual stepped out          of
-# NSg/J/R/C . J/R  R         . NSg/VB/J+ NSg/P NSg/VB/J+ . D/P NSg/VB/J . Nᴹ/Vg/J  NSg/J      J       NSg/VB/J/R/P P
+> Then      , very gradually , part      by part      , a   pale     , dangling individual stepped out          of
+# NSg/J/R/C . J/R  R         . NSg/VB/J+ P  NSg/VB/J+ . D/P NSg/VB/J . Nᴹ/Vg/J  NSg/J      J       NSg/VB/J/R/P P
 > the wreck   , pawing  tentatively at    the ground     with a   large uncertain dancing shoe    .
 # D+  NSg/VB+ . Nᴹ/Vg/J R           NSg/P D+  N🅪Sg/VB/J+ P    D/P NSg/J I/J       Nᴹ/Vg/J NSg/VB+ .
 >
 #
-> Blinded by    the glare    of the headlights and  confused by    the incessant groaning of
-# VP/J    NSg/P D   NSg/VB/J P  D   NPl        VB/C VP/J     NSg/P D   J         Nᴹ/Vg/J  P
+> Blinded by the glare    of the headlights and  confused by the incessant groaning of
+# VP/J    P  D   NSg/VB/J P  D   NPl        VB/C VP/J     P  D   J         Nᴹ/Vg/J  P
 > the horns  , the apparition stood swaying for   a   moment before he       perceived the man
 # D   NPl/V3 . D   NSg+       VP    Nᴹ/Vg/J R/C/P D/P NSg+   C/P    NPr/ISg+ VP/J      D   NPr/VB+
 > in        the duster .
@@ -3422,8 +3422,8 @@
 #
 > At    least    a    dozen men  , some     of them     a   little     better     off        than he       was  , explained to
 # NSg/P NSg/J/Dq D/P+ NSg+  NPl+ . I/J/R/Dq P  NSg/IPl+ D/P NPr/I/J/Dq NSg/VXB/JC NSg/VB/J/P C/P  NPr/ISg+ VLPt . VP/J      P
-> him  that     wheel  and  car  were no       longer joined by    any     physical bond      .
-# ISg+ I/C/Ddem NSg/VB VB/C NSg+ VLPt NSg/Dq/P NSg/JC VP/J   NSg/P I/R/Dq+ NSg/J+   NPr/VB/J+ .
+> him  that     wheel  and  car  were no       longer joined by any     physical bond      .
+# ISg+ I/C/Ddem NSg/VB VB/C NSg+ VLPt NSg/Dq/P NSg/JC VP/J   P  I/R/Dq+ NSg/J+   NPr/VB/J+ .
 >
 #
 > “ Back     out          , ” he       suggested after a    moment . “ Put     her     in        reverse  . ”
@@ -3472,8 +3472,8 @@
 # NSg/I/J/R/Dq P  D+  N🅪Sg/VB/J+ ISg/#r+ VP/J   . NPr/J/R/P D+  NSg/J/R+ N🅪Sg/Vg/J+ D+  NPr/VB+ VPt   D$+ NSg/VB/J+ NSg/J
 > as    I       hurried down        the white       chasms of lower     New   York to the Probity Trust     . I
 # R/C/P ISg/#r+ VP/J    N🅪Sg/VB/J/P D   NPr🅪Sg/VB/J NPl    P  NSg/VB/JC NSg/J NPr+ P  D   Nᴹ      N🅪Sg/VB/J . ISg/#r+
-> knew the other    clerks and  young     bond      - salesmen by    their first names   , and  lunched
-# VPt  D   NSg/VB/J NPl/V3 VB/C NPr/VB/J+ NPr/VB/J+ . NPl      NSg/P D$+   NSg/J NPl/V3+ . VB/C VP/J
+> knew the other    clerks and  young     bond      - salesmen by their first names   , and  lunched
+# VPt  D   NSg/VB/J NPl/V3 VB/C NPr/VB/J+ NPr/VB/J+ . NPl      P  D$+   NSg/J NPl/V3+ . VB/C VP/J
 > with them     in        dark     , crowded restaurants on  little     pig     sausages and  mashed
 # P    NSg/IPl+ NPr/J/R/P NSg/VB/J . VP/J    NPl+        J/P NPr/I/J/Dq NSg/VB+ NPl/V3+  VB/C VP/J
 > potatoes and  coffee     . I       even       had a   short      affair with a    girl    who    lived in        Jersey
@@ -3760,8 +3760,8 @@
 # VB/C NPr    NPr+  VB/C D   ?         VB/C D   ?         VB/C D   ?      VB/C D
 > Scullys and  S. W. Belcher and  the Smirkes and  the young    Quinns , divorced now       ,
 # ?       VB/C ?  ?  ?       VB/C D   ?       VB/C D   NPr/VB/J ?      . VP/J     NSg/J/R/C .
-> and  Henry L. Palmetto , who    killed himself by    jumping in        front    of a   subway  train
-# VB/C NPr+  ?  NSg      . NPr/I+ VP/J   ISg+    NSg/P Nᴹ/Vg/J NPr/J/R/P NSg/VB/J P  D/P NSg/VB+ NSg/VB+
+> and  Henry L. Palmetto , who    killed himself by jumping in        front    of a   subway  train
+# VB/C NPr+  ?  NSg      . NPr/I+ VP/J   ISg+    P  Nᴹ/Vg/J NPr/J/R/P NSg/VB/J P  D/P NSg/VB+ NSg/VB+
 > in        Times   Square   .
 # NPr/J/R/P NPl/V3+ NSg/VB/J .
 >
@@ -3900,8 +3900,8 @@
 #
 > “ I’ll tell   you    God’s truth    . ” His     right     hand    suddenly ordered divine   retribution
 # . K    NPr/VB ISgPl+ NPr$  N🅪Sg/VB+ . . ISg/D$+ NPr/VB/J+ NSg/VB+ R        VP/J    NPr/VB/J NSg
-> to stand  by    . “ I       am        the son    of some     wealthy people in        the Middle    West      — all          dead
-# P  NSg/VB NSg/P . . ISg/#r+ NPr/VLB/J D   NPr/VB P  I/J/R/Dq NSg/J   NPl/VB NPr/J/R/P D+  NSg/VB/J+ NPr/VB/J+ . NSg/I/J/C/Dq NSg/VB/J
+> to stand  by . “ I       am        the son    of some     wealthy people in        the Middle    West      — all          dead
+# P  NSg/VB P  . . ISg/#r+ NPr/VLB/J D   NPr/VB P  I/J/R/Dq NSg/J   NPl/VB NPr/J/R/P D+  NSg/VB/J+ NPr/VB/J+ . NSg/I/J/C/Dq NSg/VB/J
 > now       . I       was  brought up         in        America but     educated at    Oxford , because all           my
 # NSg/J/R/C . ISg/#r+ VLPt VP      NSg/VB/J/P NPr/J/R/P NPr+    NSg/C/P VP/J     NSg/P NPr+   . C/P     NSg/I/J/C/Dq+ D$+
 > ancestors have    been   educated there for   many        years . It       is  a   family tradition . ”
@@ -4096,8 +4096,8 @@
 # D   J+    . NSg/VB/J NSg      . NPl+     . NSg/J/R/C D   NSg/VB P  NPl/V3+ VP/J   NSg/VB/J/R/P J/P I/C/Dq
 > sides  of us       , and  I       had a   glimpse of Mrs  . Wilson straining at    the garage  pump
 # NPl/V3 P  NPr/IPl+ . VB/C ISg/#r+ VP  D/P NSg/VB  P  NPl+ . NPr+   Nᴹ/Vg/J   NSg/P D+  NSg/VB+ NSg/VB+
-> with panting vitality as    we   went    by    .
-# P    Nᴹ/Vg/J Nᴹ+      R/C/P IPl+ NSg/VPt NSg/P .
+> with panting vitality as    we   went    by .
+# P    Nᴹ/Vg/J Nᴹ+      R/C/P IPl+ NSg/VPt P  .
 >
 #
 > With fenders spread   like         wings   we   scattered light      through half      Astoria — only
@@ -4142,18 +4142,18 @@
 # ISg/D$+ NSg/J NSg/VB/J NSg/VB  P  NSg/I/J/C/Dq D   N🅪Sg+   VB/C D   N🅪Sg/VB/J+ NPr/J/R/P D   NSg/VB+ .
 >
 #
-> A    dead      man     passed us       in        a   hearse heaped with blooms , followed by    two carriages
-# D/P+ NSg/VB/J+ NPr/VB+ VP/J   NPr/IPl+ NPr/J/R/P D/P NSg/VB VP/J   P    NPl/V3 . VP/J     NSg/P NSg NPl
-> with drawn blinds  , and  by    more         cheerful carriages for   friends   . The friends
-# P    VPp/J NPl/V3+ . VB/C NSg/P NPr/I/J/R/Dq J        NPl       R/C/P NPrPl/V3+ . D+  NPrPl/V3+
+> A    dead      man     passed us       in        a   hearse heaped with blooms , followed by two carriages
+# D/P+ NSg/VB/J+ NPr/VB+ VP/J   NPr/IPl+ NPr/J/R/P D/P NSg/VB VP/J   P    NPl/V3 . VP/J     P  NSg NPl
+> with drawn blinds  , and  by more         cheerful carriages for   friends   . The friends
+# P    VPp/J NPl/V3+ . VB/C P  NPr/I/J/R/Dq J        NPl       R/C/P NPrPl/V3+ . D+  NPrPl/V3+
 > looked out          at    us       with the tragic eyes    and  short      upper lips   of southeastern
 # VP/J   NSg/VB/J/R/P NSg/P NPr/IPl+ P    D+  NSg/J+ NPl/V3+ VB/C NPr/VB/J/P NSg/J NPl/V3 P  J+
 > Europe , and  I       was  glad     that     the sight   of Gatsby’s splendid car  was  included in
 # NPr+   . VB/C ISg/#r+ VLPt NSg/VB/J I/C/Ddem D   N🅪Sg/VB P  NPr$     J        NSg+ VLPt VP/J     NPr/J/R/P
 > their sombre        holiday . As    we   crossed Blackwell’s Island  a   limousine passed us       ,
 # D$+   NSg/VB/J/Comm NPr/VB+ . R/C/P IPl+ VP/J    NPr$        NSg/VB+ D/P NSg       VP/J   NPr/IPl+ .
-> driven by    a   white       chauffeur , in        which sat    three modish negroes , two bucks  and  a
-# VPp/J  NSg/P D/P NPr🅪Sg/VB/J NSg/VB    . NPr/J/R/P I/C+  NSg/VP NSg   J      NPl     . NSg NPl/V3 VB/C D/P
+> driven by a   white       chauffeur , in        which sat    three modish negroes , two bucks  and  a
+# VPp/J  P  D/P NPr🅪Sg/VB/J NSg/VB    . NPr/J/R/P I/C+  NSg/VP NSg   J      NPl     . NSg NPl/V3 VB/C D/P
 > girl    . I       laughed aloud as    the yolks  of their eyeballs rolled toward us       in        haughty
 # NSg/VB+ . ISg/#r+ VP/J    J     R/C/P D   NPl/V3 P  D$+   NPl/V3+  VP/J   J/P    NPr/IPl+ NPr/J/R/P J
 > rivalry .
@@ -4324,8 +4324,8 @@
 # D/P+ NSg/J+    NSg/VB+ VP/J    . VB/C NSg+ . ?         . NSg/Vg     D   NPr/I/J/R/Dq J
 > atmosphere of the old   Metropole , began to eat with ferocious delicacy . His     eyes    ,
 # N🅪Sg       P  D   NSg/J ?         . VPt   P  VB  P    J         NSg+     . ISg/D$+ NPl/V3+ .
-> meanwhile , roved very slowly all          around the room     — he       completed the arc       by    turning
-# NSg       . VP/J  J/R  R      NSg/I/J/C/Dq J/P    D   N🅪Sg/VB+ . NPr/ISg+ VP/J      D   NPr/VB/J+ NSg/P Nᴹ/Vg/J
+> meanwhile , roved very slowly all          around the room     — he       completed the arc       by turning
+# NSg       . VP/J  J/R  R      NSg/I/J/C/Dq J/P    D   N🅪Sg/VB+ . NPr/ISg+ VP/J      D   NPr/VB/J+ P  Nᴹ/Vg/J
 > to inspect the people  directly behind  . I       think  that      , except for   my  presence , he
 # P  VB      D   NPl/VB+ R/C      NSg/J/P . ISg/#r+ NSg/VB I/C/Ddem+ . VB/C/P R/C/P D$+ N🅪Sg/VB+ . NPr/ISg+
 > would have    taken one     short       glance  beneath our own       table   .
@@ -4590,8 +4590,8 @@
 #
 > The largest of the banners and  the largest of the lawns  belonged to Daisy Fay’s
 # D   JS      P  D+  NPl/V3+ VB/C D   JS      P  D   NPl/V3 VP/J     P  NPr   NPr$
-> house   . She  was  just eighteen , two  years older than me       , and  by    far      the most
-# NPr/VB+ . ISg+ VLPt J/R  NSg      . NSg+ NPl+  JC    C/P  NPr/ISg+ . VB/C NSg/P NSg/VB/J D   NSg/I/J/R/Dq
+> house   . She  was  just eighteen , two  years older than me       , and  by far      the most
+# NPr/VB+ . ISg+ VLPt J/R  NSg      . NSg+ NPl+  JC    C/P  NPr/ISg+ . VB/C P  NSg/VB/J D   NSg/I/J/R/Dq
 > popular of all          the young     girls   in        Louisville . She  dressed in        white       , and  had a
 # NSg/J   P  NSg/I/J/C/Dq D+  NPr/VB/J+ NPl/V3+ NPr/J/R/P NPr        . ISg+ VP/J    NPr/J/R/P NPr🅪Sg/VB/J . VB/C VP  D/P
 > little     white       roadster , and  all          day     long     the telephone rang in        her     house   and
@@ -4634,16 +4634,16 @@
 # VXPt   VB/Comm/NoAm NPr/ISg+ VLPt D   I/J  NPr/VB+ .
 >
 #
-> That      was  nineteen - seventeen . By    the next     year I       had a   few      beaux myself , and  I
-# I/C/Ddem+ VLPt NSg      . NSg       . NSg/P D+  NSg/J/P+ NSg+ ISg/#r+ VP  D/P NSg/I/Dq ?     ISg+   . VB/C ISg/#r+
+> That      was  nineteen - seventeen . By the next     year I       had a   few      beaux myself , and  I
+# I/C/Ddem+ VLPt NSg      . NSg       . P  D+  NSg/J/P+ NSg+ ISg/#r+ VP  D/P NSg/I/Dq ?     ISg+   . VB/C ISg/#r+
 > began to play    in        tournaments , so          I       didn’t see    Daisy very often . She  went    with a
 # VPt   P  N🅪Sg/VB NPr/J/R/P NPl         . NSg/I/J/R/C ISg/#r+ VXPt   NSg/VB NPr+  J/R  R     . ISg+ NSg/VPt P    D/P
 > slightly older crowd   — when    she  went    with anyone at    all          . Wild      rumors     were
 # R        JC+   NSg/VB+ . NSg/I/C ISg+ NSg/VPt P    NSg/I+ NSg/P NSg/I/J/C/Dq . NSg/VB/J+ NPl/V3/Am+ VLPt
 > circulating about her     — how   her     mother    had found  her     packing her     bag     one      winter
 # Nᴹ/Vg/J     J/P   ISg/D$+ . NSg/C ISg/D$+ NSg/VB/J+ VP  NSg/VP ISg/D$+ Nᴹ/Vg/J ISg/D$+ NSg/VB+ NSg/I/J+ N🅪Sg/VB+
-> night    to go       to New    York and  say    good     - by    to a    soldier   who    was  going   overseas . She
-# N🅪Sg/VB+ P  NSg/VB/J P  NSg/J+ NPr+ VB/C NSg/VB NPr/VB/J . NSg/P P  D/P+ NSg/VB/J+ NPr/I+ VLPt Nᴹ/Vg/J J/R      . ISg+
+> night    to go       to New    York and  say    good     - by to a    soldier   who    was  going   overseas . She
+# N🅪Sg/VB+ P  NSg/VB/J P  NSg/J+ NPr+ VB/C NSg/VB NPr/VB/J . P  P  D/P+ NSg/VB/J+ NPr/I+ VLPt Nᴹ/Vg/J J/R      . ISg+
 > was  effectually prevented , but     she  wasn’t on  speaking terms   with her     family  for
 # VLPt R           VP/J      . NSg/C/P ISg+ VPt    J/P Nᴹ/Vg/J  NPl/V3+ P    ISg/D$+ N🅪Sg/J+ R/C/P
 > several weeks  . After that     she  didn’t play    around with the soldiers any    more         , but
@@ -4654,8 +4654,8 @@
 # P    D   NSg+ NSg/P NSg/I/J/C/Dq .
 >
 #
-> By    the next     autumn     she  was  gay      again , gay      as    ever . She  had a   début after the
-# NSg/P D+  NSg/J/P+ NPr🅪Sg/VB+ ISg+ VLPt NPr/VB/J P     . NPr/VB/J R/C/P J/R  . ISg+ VP  D/P ?     P     D
+> By the next     autumn     she  was  gay      again , gay      as    ever . She  had a   début after the
+# P  D+  NSg/J/P+ NPr🅪Sg/VB+ ISg+ VLPt NPr/VB/J P     . NPr/VB/J R/C/P J/R  . ISg+ VP  D/P ?     P     D
 > armistice , and  in        February she  was  presumably engaged to a   man     from New   Orleans .
 # NPr🅪Sg    . VB/C NPr/J/R/P NPr+     ISg+ VLPt R          VP/J    P  D/P NPr/VB+ P    NSg/J NPr+    .
 > In        June she  married  Tom     Buchanan of Chicago , with more         pomp   and  circumstance
@@ -4736,8 +4736,8 @@
 # J/P    R        . VB/C NSg/VB . . . NSg$    NPr/VB+ VPp/J/P . . VB/C NSg/VB D   NSg/I/J/R/Dq VP/J
 > expression until she  saw     him  coming  in        the door    . She  used to sit    on  the sand
 # N🅪Sg+      C/P   ISg+ NSg/VPt ISg+ Nᴹ/Vg/J NPr/J/R/P D   NSg/VB+ . ISg+ VP/J P  NSg/VB J/P D   NSg/VB/J+
-> with his     head      in        her     lap       by    the hour , rubbing her     fingers over    his     eyes    and
-# P    ISg/D$+ NPr/VB/J+ NPr/J/R/P ISg/D$+ NSg/VB/J+ NSg/P D+  NSg+ . NSg/Vg  ISg/D$+ NPl/V3+ NSg/J/P ISg/D$+ NPl/V3+ VB/C
+> with his     head      in        her     lap       by the hour , rubbing her     fingers over    his     eyes    and
+# P    ISg/D$+ NPr/VB/J+ NPr/J/R/P ISg/D$+ NSg/VB/J+ P  D+  NSg+ . NSg/Vg  ISg/D$+ NPl/V3+ NSg/J/P ISg/D$+ NPl/V3+ VB/C
 > looking at    him  with unfathomable delight    . It       was  touching  to see    them
 # Nᴹ/Vg/J NSg/P ISg+ P    J+           N🅪Sg/VB/J+ . NPr/ISg+ VLPt Nᴹ/Vg/J/P P  NSg/VB NSg/IPl+
 > together — it       made you    laugh  in        a   hushed , fascinated way    . That      was  in        August    . A
@@ -5312,8 +5312,8 @@
 # R          P    D$+ NPl/V3+ .
 >
 #
-> With his     hands   still      in        his     coat    pockets he       stalked by    me       into the hall , turned
-# P    ISg/D$+ NPl/V3+ NSg/VB/J/R NPr/J/R/P ISg/D$+ NSg/VB+ NPl/V3+ NPr/ISg+ VP/J    NSg/P NPr/ISg+ P    D+  NPr+ . VP/J
+> With his     hands   still      in        his     coat    pockets he       stalked by me       into the hall , turned
+# P    ISg/D$+ NPl/V3+ NSg/VB/J/R NPr/J/R/P ISg/D$+ NSg/VB+ NPl/V3+ NPr/ISg+ VP/J    P  NPr/ISg+ P    D+  NPr+ . VP/J
 > sharply as    if    he       were on  a    wire     , and  disappeared into the living     - room     . It       wasn’t
 # R       R/C/P NSg/C NPr/ISg+ VLPt J/P D/P+ N🅪Sg/VB+ . VB/C VP/J        P    D+  N🅪Sg/Vg/J+ . N🅪Sg/VB+ . NPr/ISg+ VPt
 > a   bit      funny . Aware of the loud  beating of my  own       heart    I       pulled the door    to
@@ -5324,8 +5324,8 @@
 #
 > For   half      a    minute    there wasn’t a    sound      . Then      from the living     - room     I       heard a   sort
 # R/C/P N🅪Sg/J/P+ D/P+ NSg/VB/J+ R+    VPt    D/P+ N🅪Sg/VB/J+ . NSg/J/R/C P    D+  N🅪Sg/Vg/J+ . N🅪Sg/VB+ ISg/#r+ VP/J  D/P NSg/VB
-> of choking murmur and  part     of a   laugh   , followed by    Daisy’s voice   on  a   clear
-# P  Nᴹ/Vg/J NSg/VB VB/C NSg/VB/J P  D/P NSg/VB+ . VP/J     NSg/P NPr$    NSg/VB+ J/P D/P NSg/VB/J
+> of choking murmur and  part     of a   laugh   , followed by Daisy’s voice   on  a   clear
+# P  Nᴹ/Vg/J NSg/VB VB/C NSg/VB/J P  D/P NSg/VB+ . VP/J     P  NPr$    NSg/VB+ J/P D/P NSg/VB/J
 > artificial note    :
 # J          NSg/VB+ .
 >
@@ -5476,8 +5476,8 @@
 # NSg/VB  P  D   NPr/VB+ N🅪Sg/J/P+ D/P NSg+ C/P    . VB/C VPt R/C/P D/P J    N🅪Sg/VB/J VP/J    NSg/VB+ .
 > whose massed leaves  made a   fabric   against the rain     . Once  more         it       was  pouring ,
 # I+    VP/J   NPl/V3+ VP   D/P N🅪Sg/VB+ C/P     D   N🅪Sg/VB+ . NSg/C NPr/I/J/R/Dq NPr/ISg+ VLPt Nᴹ/Vg/J .
-> and  my  irregular lawn    , well       - shaved by    Gatsby’s gardener , abounded in        small    muddy
-# VB/C D$+ NSg/J     NSg/VB+ . NSg/VB/J/R . VP/J   NSg/P NPr$     NSg/JC   . VP/J     NPr/J/R/P NPr/VB/J NSg/VB/J
+> and  my  irregular lawn    , well       - shaved by Gatsby’s gardener , abounded in        small    muddy
+# VB/C D$+ NSg/J     NSg/VB+ . NSg/VB/J/R . VP/J   P  NPr$     NSg/JC   . VP/J     NPr/J/R/P NPr/VB/J NSg/VB/J
 > swamps and  prehistoric marshes . There was  nothing  to look   at    from under   the tree
 # NPl/V3 VB/C J           NPl+    . R+    VLPt NSg/I/J+ P  NSg/VB NSg/P P    NSg/J/P D+  NSg/VB+
 > except Gatsby’s enormous house   , so          I       stared at    it       , like         Kant at    his     church
@@ -5650,8 +5650,8 @@
 #
 > Instead of taking   the short      cut       along the Sound      we   went    down        to the road    and
 # R       P  NSg/Vg/J D   NPr/VB/J/P NSg/VBP/J P     D+  N🅪Sg/VB/J+ IPl+ NSg/VPt N🅪Sg/VB/J/P P  D+  N🅪Sg/J+ VB/C
-> entered by    the big   postern . With enchanting murmurs Daisy admired this   aspect   or
-# VP/J    NSg/P D   NSg/J ?       . P    Nᴹ/Vg/J    NPl/V3  NPr+  VP/J    I/Ddem N🅪Sg/VB+ NPr/C
+> entered by the big   postern . With enchanting murmurs Daisy admired this   aspect   or
+# VP/J    P  D   NSg/J ?       . P    Nᴹ/Vg/J    NPl/V3  NPr+  VP/J    I/Ddem N🅪Sg/VB+ NPr/C
 > that     of the feudal silhouette against the sky      , admired the gardens , the
 # I/C/Ddem P  D   J      NSg/VB+    C/P     D   N🅪Sg/VB+ . VP/J    D   NPl/V3+ . D
 > sparkling odor    of jonquils and  the frothy odor    of hawthorn and  plum       blossoms and
@@ -5746,8 +5746,8 @@
 # NPl+   NSg/P D   NSg/Vg/J  P  Dq+  NSg/VB+ . N🅪Sg/VB VB/C N🅪Sg/VB+ . .
 >
 #
-> He       took out          a   pile   of shirts  and  began throwing them     , one     by    one     , before us       ,
-# NPr/ISg+ VPt  NSg/VB/J/R/P D/P NSg/VB P  NPl/V3+ VB/C VPt   Nᴹ/Vg/J  NSg/IPl+ . NSg/I/J NSg/P NSg/I/J . C/P    NPr/IPl+ .
+> He       took out          a   pile   of shirts  and  began throwing them     , one     by one     , before us       ,
+# NPr/ISg+ VPt  NSg/VB/J/R/P D/P NSg/VB P  NPl/V3+ VB/C VPt   Nᴹ/Vg/J  NSg/IPl+ . NSg/I/J P  NSg/I/J . C/P    NPr/IPl+ .
 > shirts of sheer    linen  and  thick    silk    and  fine      flannel   , which lost their folds   as
 # NPl/V3 P  NSg/VB/J N🅪Sg/J VB/C NSg/VB/J N🅪Sg/VB VB/C NSg/VB/J+ NSg/VB/J+ . I/C+  VP/J D$+   NPl/V3+ R/C/P
 > they fell      and  covered the table   in        many       colored     disarray . While      we   admired he
@@ -5794,8 +5794,8 @@
 # VP/J      ISg+ P    NPr+  NPr/ISg+ VP  VP/J   J/R  NSg/VB/J/P P  ISg/D$+ . R      Nᴹ/Vg/J/P ISg/D$+ . NPr/ISg+
 > had seemed as    close    as    a   star   to the moon    . Now       it       was  again a   green       light     on  a
 # VP  VP/J   R/C/P NSg/VB/J R/C/P D/P NSg/VB P  D+  NPr/VB+ . NSg/J/R/C NPr/ISg+ VLPt P     D/P NPr🅪Sg/VB/J N🅪Sg/VB/J J/P D/P+
-> dock    . His     count  of enchanted objects had diminished by    one     .
-# NSg/VB+ . ISg/D$+ NSg/VB P  VP/J      NPl/V3+ VP  VP/J       NSg/P NSg/I/J .
+> dock    . His     count  of enchanted objects had diminished by one     .
+# NSg/VB+ . ISg/D$+ NSg/VB P  VP/J      NPl/V3+ VP  VP/J       P  NSg/I/J .
 >
 #
 > I       began to walk   about the room     , examining various indefinite objects in        the half
@@ -5840,8 +5840,8 @@
 # . NSg/VB NSg/P I/Ddem+ . . VP/J NPr    R       . . K      D/P NPr/VB P  NPl/V3+   . J/P   ISgPl+ . .
 >
 #
-> They stood side      by    side      examining it       . I       was  going   to ask    to see    the rubies when
-# IPl+ VP    NSg/VB/J+ NSg/P NSg/VB/J+ Nᴹ/Vg/J   NPr/ISg+ . ISg/#r+ VLPt Nᴹ/Vg/J P  NSg/VB P  NSg/VB D   NPl/V3 NSg/I/C
+> They stood side      by side      examining it       . I       was  going   to ask    to see    the rubies when
+# IPl+ VP    NSg/VB/J+ P  NSg/VB/J+ Nᴹ/Vg/J   NPr/ISg+ . ISg/#r+ VLPt Nᴹ/Vg/J P  NSg/VB P  NSg/VB D   NPl/V3 NSg/I/C
 > the phone   rang , and  Gatsby took up         the receiver .
 # D   NSg/VB+ VPt  . VB/C NPr    VPt  NSg/VB/J/P D   NSg+     .
 >
@@ -5882,8 +5882,8 @@
 #
 > He       went    out          of the room     calling “ Ewing ! ” and  returned in        a    few       minutes
 # NPr/ISg+ NSg/VPt NSg/VB/J/R/P P  D+  N🅪Sg/VB+ Nᴹ/Vg/J . NPr   . . VB/C VP/J     NPr/J/R/P D/P+ NSg/I/Dq+ NPl/V3+
-> accompanied by    an  embarrassed , slightly worn  young    man     , with shell      - rimmed
-# VP/J        NSg/P D/P VP/J        . R        VPp/J NPr/VB/J NPr/VB+ . P    NPr🅪Sg/VB+ . VP/J
+> accompanied by an  embarrassed , slightly worn  young    man     , with shell      - rimmed
+# VP/J        P  D/P VP/J        . R        VPp/J NPr/VB/J NPr/VB+ . P    NPr🅪Sg/VB+ . VP/J
 > glasses and  scanty blond    hair     . He       was  now       decently clothed in        a   “ sport   shirt   , ”
 # NPl/V3  VB/C J      NSg/VB/J N🅪Sg/VB+ . NPr/ISg+ VLPt NSg/J/R/C R        VP/J    NPr/J/R/P D/P . NSg/VB+ NSg/VB+ . .
 > open     at    the neck    , sneakers , and  duck    trousers of a   nebulous hue   .
@@ -5962,8 +5962,8 @@
 # NSg/VB . NPl+     . NPr/J/R/P D+  NSg+     . NPr/J/R/P NSg/P   N🅪Sg/VB/J+ . . . .
 >
 #
-> As    I       went    over    to say    good     - by    I       saw     that     the expression of bewilderment had come
-# R/C/P ISg/#r+ NSg/VPt NSg/J/P P  NSg/VB NPr/VB/J . NSg/P ISg/#r+ NSg/VPt I/C/Ddem D   N🅪Sg+      P  NSg          VP  NSg/VBPp/P
+> As    I       went    over    to say    good     - by I       saw     that     the expression of bewilderment had come
+# R/C/P ISg/#r+ NSg/VPt NSg/J/P P  NSg/VB NPr/VB/J . P  ISg/#r+ NSg/VPt I/C/Ddem D   N🅪Sg+      P  NSg          VP  NSg/VBPp/P
 > back     into Gatsby’s face    , as    though a   faint    doubt    had occurred to him  as    to the
 # NSg/VB/J P    NPr$     NSg/VB+ . R/C/P C      D/P NSg/VB/J N🅪Sg/VB+ VP  VP       P  ISg+ R/C/P P  D
 > quality of his     present  happiness . Almost five years ! There must    have    been
@@ -5996,8 +5996,8 @@
 # IPl+ VP  NSg/VPp/J NPr/ISg+ . NSg/C/P NPr+  VP/J    NSg/VB/J/P VB/C VP   NSg/VB/J/R/P ISg/D$+ NSg/VB+ . NPr    VXPt
 > know me       now       at    all          . I       looked once  more         at    them     and  they looked back     at    me       ,
 # VB   NPr/ISg+ NSg/J/R/C NSg/P NSg/I/J/C/Dq . ISg/#r+ VP/J   NSg/C NPr/I/J/R/Dq NSg/P NSg/IPl+ VB/C IPl+ VP/J   NSg/VB/J NSg/P NPr/ISg+ .
-> remotely , possessed by    intense life     . Then      I       went    out          of the room     and  down        the
-# R        . VP/J      NSg/P J+      N🅪Sg/VB+ . NSg/J/R/C ISg/#r+ NSg/VPt NSg/VB/J/R/P P  D+  N🅪Sg/VB+ VB/C N🅪Sg/VB/J/P D+
+> remotely , possessed by intense life     . Then      I       went    out          of the room     and  down        the
+# R        . VP/J      P  J+      N🅪Sg/VB+ . NSg/J/R/C ISg/#r+ NSg/VPt NSg/VB/J/R/P P  D+  N🅪Sg/VB+ VB/C N🅪Sg/VB/J/P D+
 > marble    steps   into the rain     , leaving them     there together .
 # NSg/VB/J+ NPl/V3+ P    D+  N🅪Sg/VB+ . Nᴹ/Vg/J NSg/IPl+ R+    J        .
 >
@@ -6032,8 +6032,8 @@
 #
 > It       was  a   random   shot     , and  yet      the reporter’s instinct was  right    . Gatsby’s
 # NPr/ISg+ VLPt D/P NSg/VB/J NSg/VP/J . VB/C NSg/VB/C D   NSg$       NSg/J+   VLPt NPr/VB/J . NPr$
-> notoriety , spread   about by    the hundreds who    had accepted his     hospitality and  so
-# Nᴹ        . N🅪Sg/VBP J/P   NSg/P D   NPl+     NPr/I+ VP  VP/J     ISg/D$+ Nᴹ+         VB/C NSg/I/J/R/C
+> notoriety , spread   about by the hundreds who    had accepted his     hospitality and  so
+# Nᴹ        . N🅪Sg/VBP J/P   P  D   NPl+     NPr/I+ VP  VP/J     ISg/D$+ Nᴹ+         VB/C NSg/I/J/R/C
 > become authorities upon his     past       , had increased all          summer     until he       fell      just
 # VBPp   NPl+        P    ISg/D$+ NSg/VB/J/P . VP  VP/J      NSg/I/J/C/Dq NPr🅪Sg/VB+ C/P   NPr/ISg+ NSg/VPt/J J/R
 > short      of being        news   . Contemporary legends such  as    the “ underground pipe    - line   to
@@ -6142,8 +6142,8 @@
 # N🅪Sg/VB/J+ I/C/Ddem+ VP   ISg+ NSg/I/J/Dq+ NPl/V3+ D/P NSg         NSg/VP ISg+ R          J      NSg/C/P J/P
 > the verge  of soft  - mindedness , and  , suspecting this    , an  infinite number     of women
 # D   NSg/VB P  NSg/J . Nᴹ+        . VB/C . Nᴹ/Vg/J    I/Ddem+ . D/P NSg/J    N🅪Sg/VB/JC P  NPl+
-> tried to separate him  from his     money   . The none too savory ramifications by    which
-# VP/J  P  NSg/VB/J ISg+ P    ISg/D$+ N🅪Sg/J+ . D+  I+   R   NSg/J  +             NSg/P I/C+
+> tried to separate him  from his     money   . The none too savory ramifications by which
+# VP/J  P  NSg/VB/J ISg+ P    ISg/D$+ N🅪Sg/J+ . D+  I+   R   NSg/J  +             P  I/C+
 > Ella Kaye , the newspaper woman   , played Madame de   Maintenon to his     weakness and
 # NPr  NPr  . D   N🅪Sg/VB+  NSg/VB+ . VP/J   NSg+   NPr+ ?         P  ISg/D$+ N🅪Sg+    VB/C
 > sent   him  to sea in        a   yacht   , were common   property of the turgid journalism
@@ -6178,8 +6178,8 @@
 # NPr/J/R/P NSg/VB NSg/VB+ . NSg/VB . NSg/VB+ . NPr/VB+   . VB/C NSg/VB/J/R ?      . R/C/P NPr+ NPr  VB/J
 > knew what   lavish   doings Dan  Cody drunk     might    soon be       about , and  he       provided for
 # VPt  NSg/I+ NSg/VB/J NPl/V3 NPr+ NPr  NSg/VPp/J Nᴹ/VXB/J J/R  NSg/VLXB J/P   . VB/C NPr/ISg+ VP/J/C   R/C/P
-> such  contingencies by    reposing more         and  more         trust     in        Gatsby . The arrangement
-# NSg/I NPl+          NSg/P Nᴹ/Vg/J  NPr/I/J/R/Dq VB/C NPr/I/J/R/Dq N🅪Sg/VB/J NPr/J/R/P NPr    . D+  NSg+
+> such  contingencies by reposing more         and  more         trust     in        Gatsby . The arrangement
+# NSg/I NPl+          P  Nᴹ/Vg/J  NPr/I/J/R/Dq VB/C NPr/I/J/R/Dq N🅪Sg/VB/J NPr/J/R/P NPr    . D+  NSg+
 > lasted five years , during which the boat    went    three times   around the Continent .
 # VP/J   NSg+ NPl+  . VB/P   I/C+  D+  NSg/VB+ NSg/VPt NSg   NPl/V3+ J/P    D+  NPr/J+    .
 > It       might    have    lasted indefinitely except for   the fact that      Ella Kaye came      on
@@ -6204,8 +6204,8 @@
 #
 > And  it       was  from Cody that     he       inherited money   — a   legacy of twenty - five thousand
 # VB/C NPr/ISg+ VLPt P    NPr  I/C/Ddem NPr/ISg+ VP/J      N🅪Sg/J+ . D/P NSg/J  P  NSg    . NSg  NSg
-> dollars . He       didn’t get    it       . He       never understood the legal  device      that      was  used
-# NPl+    . NPr/ISg+ VXPt   NSg/VB NPr/ISg+ . NPr/ISg+ R     VP/J       D+  NSg/J+ NSg/VB/J/P+ I/C/Ddem+ VLPt VP/J
+> dollars . He       didn’t get    it       . He       never understood the legal  device   that      was  used
+# NPl+    . NPr/ISg+ VXPt   NSg/VB NPr/ISg+ . NPr/ISg+ R     VP/J       D+  NSg/J+ NSg/J/P+ I/C/Ddem+ VLPt VP/J
 > against him  , but     what   remained of the millions went    intact to Ella Kaye . He       was
 # C/P     ISg+ . NSg/C/P NSg/I+ VP/J     P  D+  NPl+     NSg/VPt J      P  NPr  NPr  . NPr/ISg+ VLPt
 > left     with his     singularly appropriate education ; the vague    contour of Jay  Gatsby
@@ -6264,8 +6264,8 @@
 # R       . Nᴹ/Vg/J NPl/V3 . . K    NSg/VXB NSg/I/J+  P  NSg/VB R/C/P ISgPl+ NPr/J/R/P J/R  D/P NSg/VB/J+ . .
 >
 #
-> He       was  profoundly affected by    the fact that      Tom     was  there . But     he       would be
-# NPr/ISg+ VLPt R          NSg/VP/J NSg/P D+  NSg+ I/C/Ddem+ NPr/VB+ VLPt R     . NSg/C/P NPr/ISg+ VXB   NSg/VLXB
+> He       was  profoundly affected by the fact that      Tom     was  there . But     he       would be
+# NPr/ISg+ VLPt R          NSg/VP/J P  D+  NSg+ I/C/Ddem+ NPr/VB+ VLPt R     . NSg/C/P NPr/ISg+ VXB   NSg/VLXB
 > uneasy   anyhow until he       had given       them     something , realizing         in        a    vague     way    that
 # NSg/VB/J J      C/P   NPr/ISg+ VP  NSg/VPp/J/P NSg/IPl+ NSg/I/J+  . Nᴹ/Vg/J/Comm/NoAm NPr/J/R/P D/P+ NSg/VB/J+ NSg/J+ I/C/Ddem+
 > that      was  all          they came      for   . Mr   . Sloane wanted nothing  . A    lemonade ? No       , thanks  . A
@@ -6290,8 +6290,8 @@
 # . NSg  . .
 >
 #
-> Moved by    an   irresistible impulse , Gatsby turned to Tom     , who    had accepted the
-# VP/J  NSg/P D/P+ J+           NSg/VB+ . NPr    VP/J   P  NPr/VB+ . NPr/I+ VP  VP/J     D
+> Moved by an   irresistible impulse , Gatsby turned to Tom     , who    had accepted the
+# VP/J  P  D/P+ J+           NSg/VB+ . NPr    VP/J   P  NPr/VB+ . NPr/I+ VP  VP/J     D
 > introduction as    a   stranger   .
 # NSg+         R/C/P D/P NSg/VB/JC+ .
 >
@@ -6434,8 +6434,8 @@
 #
 > “ She  has a    big    dinner   party     and  he       won’t know a   soul     there . ” He       frowned . “ I
 # . ISg+ V3  D/P+ NSg/J+ N🅪Sg/VB+ NSg/VB/J+ VB/C NPr/ISg+ VXB   VB   D/P N🅪Sg/VB+ R     . . NPr/ISg+ VP/J    . . ISg/#r+
-> wonder  where   in        the devil   he       met Daisy . By    God     , I       may     be       old   - fashioned in        my
-# N🅪Sg/VB NSg/R/C NPr/J/R/P D+  NPr/VB+ NPr/ISg+ VP  NPr+  . NSg/P NPr/VB+ . ISg/#r+ NPr/VXB NSg/VLXB NSg/J . VP/J      NPr/J/R/P D$+
+> wonder  where   in        the devil   he       met Daisy . By God     , I       may     be       old   - fashioned in        my
+# N🅪Sg/VB NSg/R/C NPr/J/R/P D+  NPr/VB+ NPr/ISg+ VP  NPr+  . P  NPr/VB+ . ISg/#r+ NPr/VXB NSg/VLXB NSg/J . VP/J      NPr/J/R/P D$+
 > ideas , but     women run      around too much         these   days to suit   me       . They meet     all          kinds
 # NPl+  . NSg/C/P NPl+  NSg/VBPp J/P    R   NSg/I/J/R/Dq I/Ddem+ NPl+ P  NSg/VB NPr/ISg+ . IPl+ NSg/VB/J NSg/I/J/C/Dq NPl
 > of crazy  fish       . ”
@@ -6580,8 +6580,8 @@
 # NSg/VB NSg/P NSg/I/J/C/Dq I/Ddem VB/J   NPl/VB+ NPr/J/R/P . NPr/J/R/P NSg/VB+  . .
 >
 #
-> Daisy and  Gatsby danced . I       remember being        surprised by    his     graceful ,
-# NPr+  VB/C NPr    VP/J   . ISg/#r+ NSg/VB   N🅪Sg/VLg/J/C VP/J      NSg/P ISg/D$+ J        .
+> Daisy and  Gatsby danced . I       remember being        surprised by his     graceful ,
+# NPr+  VB/C NPr    VP/J   . ISg/#r+ NSg/VB   N🅪Sg/VLg/J/C VP/J      P  ISg/D$+ J        .
 > conservative fox     - trot   — I       had never seen    him  dance    before . Then      they sauntered
 # NSg/J        NPr/VB+ . NSg/VB . ISg/#r+ VP  R     NSg/VPp ISg+ N🅪Sg/VB+ C/P    . NSg/J/R/C IPl+ VP/J
 > over    to my  house   and  sat    on  the steps   for   half      an  hour , while      at    her     request I
@@ -6696,12 +6696,12 @@
 #
 > But     the rest    offended her     — and  inarguably , because it       wasn’t a   gesture but     an
 # NSg/C/P D+  NSg/VB+ VP/J     ISg/D$+ . VB/C ?          . C/P     NPr/ISg+ VPt    D/P NSg/VB+ NSg/C/P D/P
-> emotion . She  was  appalled by    West      Egg      , this   unprecedented “ place   ” that     Broadway
-# N🅪Sg+   . ISg+ VLPt VP/J     NSg/P NPr/VB/J+ N🅪Sg/VB+ . I/Ddem J             . N🅪Sg/VB . I/C/Ddem NPr/J+
-> had begotten upon a   Long     Island  fishing  village — appalled by    its     raw      vigor that
-# VP  VPp/J    P    D/P NPr/VB/J NSg/VB+ Nᴹ/Vg/J+ NSg+    . VP/J     NSg/P ISg/D$+ NSg/VB/J NSg+  I/C/Ddem+
-> chafed under   the old   euphemisms and  by    the too obtrusive fate    that      herded its
-# VP/J   NSg/J/P D   NSg/J NPl        VB/C NSg/P D   R   J         NSg/VB+ I/C/Ddem+ VP/J   ISg/D$+
+> emotion . She  was  appalled by West      Egg      , this   unprecedented “ place   ” that     Broadway
+# N🅪Sg+   . ISg+ VLPt VP/J     P  NPr/VB/J+ N🅪Sg/VB+ . I/Ddem J             . N🅪Sg/VB . I/C/Ddem NPr/J+
+> had begotten upon a   Long     Island  fishing  village — appalled by its     raw      vigor that
+# VP  VPp/J    P    D/P NPr/VB/J NSg/VB+ Nᴹ/Vg/J+ NSg+    . VP/J     P  ISg/D$+ NSg/VB/J NSg+  I/C/Ddem+
+> chafed under   the old   euphemisms and  by the too obtrusive fate    that      herded its
+# VP/J   NSg/J/P D   NSg/J NPl        VB/C P  D   R   J         NSg/VB+ I/C/Ddem+ VP/J   ISg/D$+
 > inhabitants along a   short      - cut       from nothing  to nothing  . She  saw     something awful
 # NPl+        P     D/P NPr/VB/J/P . NSg/VBP/J P    NSg/I/J+ P  NSg/I/J+ . ISg+ NSg/VPt NSg/I/J+  J
 > in        the very simplicity she  failed to understand .
@@ -7036,8 +7036,8 @@
 # D$+ NPr+ VP/J     NPr/ISg+ I/C/Ddem NPr    VP  VP/J      Dq    NSg/VB+ NPr/J/R/P ISg/D$+ NPr/VB D/P NSg/J+
 > ago and  replaced them     with half      a   dozen others  , who    never went    into West      Egg
 # J/P VB/C VP/J     NSg/IPl+ P    N🅪Sg/J/P+ D/P NSg   NPl/V3+ . NPr/I+ R     NSg/VPt P    NPr/VB/J+ N🅪Sg/VB+
-> Village to be       bribed by    the tradesmen , but     ordered moderate supplies over    the
-# NSg+    P  NSg/VLXB VP/J   NSg/P D   NPl       . NSg/C/P VP/J    NSg/VB/J NPl/V3+  NSg/J/P D
+> Village to be       bribed by the tradesmen , but     ordered moderate supplies over    the
+# NSg+    P  NSg/VLXB VP/J   P  D   NPl       . NSg/C/P VP/J    NSg/VB/J NPl/V3+  NSg/J/P D
 > telephone . The grocery boy     reported that     the kitchen looked like         a    pigsty , and
 # NSg/VB+   . D+  NSg/VB+ NSg/VB+ VP/J     I/C/Ddem D+  NSg/VB+ VP/J   NSg/VB/J/C/P D/P+ NSg+   . VB/C
 > the general  opinion in        the village was  that     the new   people  weren’t servants at
@@ -7120,10 +7120,10 @@
 #
 > I       picked it       up         with a    weary bend    and  handed it       back     to her     , holding it       at    arm’s
 # ISg/#r+ VP/J   NPr/ISg+ NSg/VB/J/P P    D/P+ VB/J+ NPr/VB+ VB/C VP/J   NPr/ISg+ NSg/VB/J P  ISg/D$+ . Nᴹ/Vg/J NPr/ISg+ NSg/P K
-> length   and  by    the extreme tip    of the corners to indicate that     I       had no       designs
-# N🅪Sg/VB+ VB/C NSg/P D   NSg/J   NSg/VB P  D   NPl/V3+ P  VB       I/C/Ddem ISg/#r+ VP  NSg/Dq/P NPl/V3+
-> upon it       — but     every one      near       by    , including the woman   , suspected me       just the same .
-# P    NPr/ISg+ . NSg/C/P Dq    NSg/I/J+ NSg/VB/J/P NSg/P . Nᴹ/Vg/J   D   NSg/VB+ . VP/J      NPr/ISg+ J/R  D   I/J  .
+> length   and  by the extreme tip    of the corners to indicate that     I       had no       designs
+# N🅪Sg/VB+ VB/C P  D   NSg/J   NSg/VB P  D   NPl/V3+ P  VB       I/C/Ddem ISg/#r+ VP  NSg/Dq/P NPl/V3+
+> upon it       — but     every one      near       by , including the woman   , suspected me       just the same .
+# P    NPr/ISg+ . NSg/C/P Dq    NSg/I/J+ NSg/VB/J/P P  . Nᴹ/Vg/J   D   NSg/VB+ . VP/J      NPr/ISg+ J/R  D   I/J  .
 >
 #
 > “ Hot      ! ” said the conductor to familiar faces   . “ Some      weather  ! . . . Hot      ! . . .
@@ -7282,8 +7282,8 @@
 # NSg/VB/J+ I/C/Ddem+ NPl/V3 ISgPl+ . .
 >
 #
-> The child   , relinquished by    the nurse   , rushed across the room     and  rooted shyly
-# D+  NSg/VB+ . VP/J         NSg/P D+  NSg/VB+ . VP/J   NSg/P  D+  N🅪Sg/VB+ VB/C VP/J   R
+> The child   , relinquished by the nurse   , rushed across the room     and  rooted shyly
+# D+  NSg/VB+ . VP/J         P  D+  NSg/VB+ . VP/J   NSg/P  D+  N🅪Sg/VB+ VB/C VP/J   R
 > into her     mother’s dress   .
 # P    ISg/D$+ NSg$     NSg/VB+ .
 >
@@ -7344,8 +7344,8 @@
 # . NSg/VBPp/P . ?     . .
 >
 #
-> “ Good     - by    , sweetheart ! ”
-# . NPr/VB/J . NSg/P . NSg        . .
+> “ Good     - by , sweetheart ! ”
+# . NPr/VB/J . P  . NSg        . .
 >
 #
 > With a   reluctant backward glance the well       - disciplined child  held to her     nurse’s
@@ -7592,8 +7592,8 @@
 # . .
 >
 #
-> Tom     came      out          of the house   wrapping a    quart     bottle  in        a    towel   , followed by    Daisy
-# NPr/VB+ NSg/VPt/P NSg/VB/J/R/P P  D+  NPr/VB+ N🅪Sg/Vg+ D/P+ NSg/VB/J+ NSg/VB+ NPr/J/R/P D/P+ NSg/VB+ . VP/J     NSg/P NPr
+> Tom     came      out          of the house   wrapping a    quart     bottle  in        a    towel   , followed by Daisy
+# NPr/VB+ NSg/VPt/P NSg/VB/J/R/P P  D+  NPr/VB+ N🅪Sg/Vg+ D/P+ NSg/VB/J+ NSg/VB+ NPr/J/R/P D/P+ NSg/VB+ . VP/J     P  NPr
 > and  Jordan wearing small    tight hats   of metallic cloth and  carrying light      capes
 # VB/C NPr+   Nᴹ/Vg/J NPr/VB/J VB/J  NPl/V3 P  NSg/J+   NSg+  VB/C Nᴹ/Vg/J  N🅪Sg/VB/J+ NPl/V3+
 > over    their arms    .
@@ -7842,8 +7842,8 @@
 # Nᴹ/Vg/J P  NSg/VB ISg/D$+ VB/J . .
 >
 #
-> The coupé flashed by    us       with a   flurry of dust   and  the flash    of a   waving  hand    .
-# D   ?     VP/J    NSg/P NPr/IPl+ P    D/P NSg/VB P  Nᴹ/VB+ VB/C D   NSg/VB/J P  D/P Nᴹ/Vg/J NSg/VB+ .
+> The coupé flashed by us       with a   flurry of dust   and  the flash    of a   waving  hand    .
+# D   ?     VP/J    P  NPr/IPl+ P    D/P NSg/VB P  Nᴹ/VB+ VB/C D   NSg/VB/J P  D/P Nᴹ/Vg/J NSg/VB+ .
 >
 #
 > “ What   do  I       owe you    ? ” demanded Tom     harshly .
@@ -7990,8 +7990,8 @@
 # P  D/P NSg+  NPr/J/R/P D   NSg+  NSg+  .
 >
 #
-> The prolonged and  tumultuous argument that      ended by    herding  us       into that     room
-# D   VP/J      VB/C J          N🅪Sg/VB+ I/C/Ddem+ VP/J  NSg/P Nᴹ/Vg/J+ NPr/IPl+ P    I/C/Ddem N🅪Sg/VB+
+> The prolonged and  tumultuous argument that      ended by herding  us       into that     room
+# D   VP/J      VB/C J          N🅪Sg/VB+ I/C/Ddem+ VP/J  P  Nᴹ/Vg/J+ NPr/IPl+ P    I/C/Ddem N🅪Sg/VB+
 > eludes me       , though I       have    a   sharp    physical memory that      , in        the course of it       , my
 # V3     NPr/ISg+ . C      ISg/#r+ NSg/VXB D/P NPr/VB/J NSg/J    N🅪Sg+  I/C/Ddem+ . NPr/J/R/P D   NSg/VB P  NPr/ISg+ . D$+
 > underwear kept climbing like         a   damp    snake   around my  legs    and  intermittent beads
@@ -8034,8 +8034,8 @@
 #
 > “ The thing to do  is  to forget about the heat   , ” said Tom     impatiently . “ You    make
 # . D+  NSg+  P  VXB VL3 P  VB     J/P   D+  Nᴹ/VB+ . . VP/J NPr/VB+ R           . . ISgPl+ NSg/VB
-> it       ten  times   worse     by    crabbing about it       . ”
-# NPr/ISg+ NSg+ NPl/V3+ NSg/VB/JC NSg/P NSg/Vg   J/P   NPr/ISg+ . .
+> it       ten  times   worse     by crabbing about it       . ”
+# NPr/ISg+ NSg+ NPl/V3+ NSg/VB/JC P  NSg/Vg   J/P   NPr/ISg+ . .
 >
 #
 > He       unrolled the bottle of whiskey from the towel   and  put     it       on  the table   .
@@ -8136,8 +8136,8 @@
 #
 > The music      had died down        as    the ceremony began and  now       a    long      cheer   floated in        at
 # D+  N🅪Sg/VB/J+ VP  VP/J N🅪Sg/VB/J/P R/C/P D+  N🅪Sg+    VPt   VB/C NSg/J/R/C D/P+ NPr/VB/J+ NSg/VB+ VP/J    NPr/J/R/P NSg/P
-> the window  , followed by    intermittent cries  of “ Yea   — ea — ea ! ” and  finally by    a
-# D+  NSg/VB+ . VP/J     NSg/P NSg/J        NPl/V3 P  . NSg/C . ?  . ?  . . VB/C R       NSg/P D/P
+> the window  , followed by intermittent cries  of “ Yea   — ea — ea ! ” and  finally by a
+# D+  NSg/VB+ . VP/J     P  NSg/J        NPl/V3 P  . NSg/C . ?  . ?  . . VB/C R       P  D/P
 > burst  of jazz    as    the dancing began .
 # NSg/VB P  NSg/VB+ R/C/P D   Nᴹ/Vg/J VPt   .
 >
@@ -8173,7 +8173,7 @@
 >
 #
 > “ He       was  probably bumming his     way    home      . He       told me       he       was  president of your class
-# . NPr/ISg+ VLPt R        Vg      ISg/D$+ NSg/J+ NSg/VB/J+ . NPr/ISg+ VP   NPr/ISg+ NPr/ISg+ VLPt NSg/VB    P  D$+  N🅪Sg/VB/J+
+# . NPr/ISg+ VLPt R        Vg      ISg/D$+ NSg/J+ NSg/VB/J+ . NPr/ISg+ VP   NPr/ISg+ NPr/ISg+ VLPt NSg       P  D$+  N🅪Sg/VB/J+
 > at    Yale . ”
 # NSg/P NPr+ . .
 >
@@ -8187,15 +8187,15 @@
 >
 #
 > “ First  place    , we   didn’t have    any    president — — — ”
-# . NSg/J+ N🅪Sg/VB+ . IPl+ VXPt   NSg/VXB I/R/Dq NSg/VB+   . . . .
+# . NSg/J+ N🅪Sg/VB+ . IPl+ VXPt   NSg/VXB I/R/Dq NSg+      . . . .
 >
 #
 > Gatsby’s foot    beat      a   short      , restless tattoo and  Tom     eyed him  suddenly .
 # NPr$     NSg/VB+ N🅪Sg/VB/J D/P NPr/VB/J/P . J        NSg/VB VB/C NPr/VB+ VP/J ISg+ R        .
 >
 #
-> “ By    the way    , Mr   . Gatsby , I       understand you’re an  Oxford man     . ”
-# . NSg/P D   NSg/J+ . NSg+ . NPr    . ISg/#r+ VB         K      D/P NPr+   NPr/VB+ . .
+> “ By the way    , Mr   . Gatsby , I       understand you’re an  Oxford man     . ”
+# . P  D   NSg/J+ . NSg+ . NPr    . ISg/#r+ VB         K      D/P NPr+   NPr/VB+ . .
 >
 #
 > “ Not     exactly . ”
@@ -8220,8 +8220,8 @@
 #
 > Another pause   . A    waiter  knocked and  came      in        with crushed mint     and  ice        but     the
 # I/D+    NSg/VB+ . D/P+ NSg/VB+ VP/J    VB/C NSg/VPt/P NPr/J/R/P P    VP/J    NSg/VB/J VB/C NPr🅪Sg/VB+ NSg/C/P D
-> silence was  unbroken by    his     “ thank  you    ” and  the soft  closing of the door    . This
-# NSg/VB+ VLPt J        NSg/P ISg/D$+ . NSg/VB ISgPl+ . VB/C D   NSg/J Nᴹ/Vg/J P  D   NSg/VB+ . I/Ddem+
+> silence was  unbroken by his     “ thank  you    ” and  the soft  closing of the door    . This
+# NSg/VB+ VLPt J        P  ISg/D$+ . NSg/VB ISgPl+ . VB/C D   NSg/J Nᴹ/Vg/J P  D   NSg/VB+ . I/Ddem+
 > tremendous detail     was  to be       cleared up         at    last     .
 # J+         N🅪Sg/VB/J+ VLPt P  NSg/VLXB VP/J    NSg/VB/J/P NSg/P NSg/VB/J .
 >
@@ -8294,8 +8294,8 @@
 # . NSg/I/VB/J+ . N🅪Sg/VB+ . . VP/J     NPr/VB+ R             . . ISg/#r+ VB      D+  NSg/JS+ NSg+  VL3 P
 > sit    back     and  let     Mr   . Nobody from Nowhere make   love      to your wife      . Well       , if    that’s
 # NSg/VB NSg/VB/J VB/C NSg/VBP NSg+ . NSg/I+ P    NSg/J   NSg/VB NPr🅪Sg/VB P  D$+  NSg/VB/J+ . NSg/VB/J/R . NSg/C K
-> the idea you    can     count  me       out          . . . . Nowadays people  begin  by    sneering at    family
-# D+  NSg+ ISgPl+ NPr/VXB NSg/VB NPr/ISg+ NSg/VB/J/R/P . . . . NSg      NPl/VB+ NSg/VB NSg/P Nᴹ/Vg/J  NSg/P N🅪Sg/J+
+> the idea you    can     count  me       out          . . . . Nowadays people  begin  by sneering at    family
+# D+  NSg+ ISgPl+ NPr/VXB NSg/VB NPr/ISg+ NSg/VB/J/R/P . . . . NSg      NPl/VB+ NSg/VB P  Nᴹ/Vg/J  NSg/P N🅪Sg/J+
 > life    and  family  institutions , and  next    they’ll throw  everything overboard and
 # N🅪Sg/VB VB/C N🅪Sg/J+ +            . VB/C NSg/J/P K       NSg/VB NSg/I/VB+  VB/J      VB/C
 > have    intermarriage between black     and  white       . ”
@@ -8912,8 +8912,8 @@
 #
 > He       reached up         on  tiptoes and  peered over    a   circle of heads   into the garage  ,
 # NPr/ISg+ VP/J    NSg/VB/J/P J/P NPl/V3  VB/C VP/J   NSg/J/P D/P NSg/VB P  NPl/V3+ P    D   NSg/VB+ .
-> which was  lit      only  by    a   yellow   light      in        a   swinging metal      basket  overhead . Then
-# I/C+  VLPt NSg/VP/J J/R/C NSg/P D/P NSg/VB/J N🅪Sg/VB/J+ NPr/J/R/P D/P Nᴹ/Vg/J  N🅪Sg/VB/J+ NSg/VB+ NSg/J/P+ . NSg/J/R/C
+> which was  lit      only  by a   yellow   light      in        a   swinging metal      basket  overhead . Then
+# I/C+  VLPt NSg/VP/J J/R/C P  D/P NSg/VB/J N🅪Sg/VB/J+ NPr/J/R/P D/P Nᴹ/Vg/J  N🅪Sg/VB/J+ NSg/VB+ NSg/J/P+ . NSg/J/R/C
 > he       made a   harsh sound      in        his     throat  , and  with a   violent  thrusting movement of
 # NPr/ISg+ VP   D/P VB/J  N🅪Sg/VB/J+ NPr/J/R/P ISg/D$+ NSg/VB+ . VB/C P    D/P NSg/VB/J Nᴹ/Vg/J+  N🅪Sg     P
 > his     powerful arms    pushed his     way    through .
@@ -8930,8 +8930,8 @@
 #
 > Myrtle Wilson’s body    , wrapped in        a   blanket   , and  then      in        another blanket   , as
 # NPr    NPr$     NSg/VB+ . VP/J    NPr/J/R/P D/P NSg/VB/J+ . VB/C NSg/J/R/C NPr/J/R/P I/D     NSg/VB/J+ . R/C/P
-> though she  suffered from a   chill      in        the hot      night    , lay        on  a   work     - table   by    the
-# C      ISg+ VP/J     P    D/P N🅪Sg/VB/J+ NPr/J/R/P D   NSg/VB/J N🅪Sg/VB+ . NSg/VBPt/J J/P D/P N🅪Sg/VB+ . NSg/VB+ NSg/P D
+> though she  suffered from a   chill      in        the hot      night    , lay        on  a   work     - table   by the
+# C      ISg+ VP/J     P    D/P N🅪Sg/VB/J+ NPr/J/R/P D   NSg/VB/J N🅪Sg/VB+ . NSg/VBPt/J J/P D/P N🅪Sg/VB+ . NSg/VB+ P  D
 > wall    , and  Tom     , with his     back     to us       , was  bending over    it       , motionless . Next    to him
 # NPr/VB+ . VB/C NPr/VB+ . P    ISg/D$+ NSg/VB/J P  NPr/IPl+ . VLPt Nᴹ/Vg/J NSg/J/P NPr/ISg+ . J          . NSg/J/P P  ISg+
 > stood a    motorcycle policeman taking   down        names   with much         sweat   and  correction in
@@ -8948,8 +8948,8 @@
 # Nᴹ/Vg/J    . P    N🅪Sg/VB/J+ P  N🅪Sg/VB/J . P  NSg/VBPt/J D/P+ NSg/VB+ J/P ISg/D$+ NSg/VB+  . NSg/C/P NPr+   I/C
 > heard nor   saw     . His     eyes    would drop    slowly from the swinging light      to the laden
 # VP/J  NSg/C NSg/VPt . ISg/D$+ NPl/V3+ VXB   NSg/VB+ R      P    D   Nᴹ/Vg/J  N🅪Sg/VB/J+ P  D+  VB/J+
-> table   by    the wall    , and  then      jerk    back     to the light      again , and  he       gave out
-# NSg/VB+ NSg/P D+  NPr/VB+ . VB/C NSg/J/R/C NSg/VB+ NSg/VB/J P  D+  N🅪Sg/VB/J+ P     . VB/C NPr/ISg+ VPt  NSg/VB/J/R/P
+> table   by the wall    , and  then      jerk    back     to the light      again , and  he       gave out
+# NSg/VB+ P  D+  NPr/VB+ . VB/C NSg/J/R/C NSg/VB+ NSg/VB/J P  D+  N🅪Sg/VB/J+ P     . VB/C NPr/ISg+ VPt  NSg/VB/J/R/P
 > incessantly his     high       , horrible call    :
 # R           ISg/D$+ NSg/VB/J/R . NSg/J    NSg/VB+ .
 >
@@ -9068,8 +9068,8 @@
 # Nᴹ/Vg/J  NPr/VB+ . ISg/#r+ NSg/VPt D   NSg/VB P  N🅪Sg/VB+ NSg/VB/J P  ISg/D$+ NSg/VB+  VB      NSg/J/P ISg/D$+
 > coat    . He       walked quickly over    to Wilson and  , standing in        front    of him  seized him  ,
 # NSg/VB+ . NPr/ISg+ VP/J   R       NSg/J/P P  NPr+   VB/C . Nᴹ/Vg/J  NPr/J/R/P NSg/VB/J P  ISg+ VP/J   ISg+ .
-> firmly by    the upper  arms    .
-# R      NSg/P D+  NSg/J+ NPl/V3+ .
+> firmly by the upper  arms    .
+# R      P  D+  NSg/J+ NPl/V3+ .
 >
 #
 > “ You've got to pull   yourself together , ” he       said with soothing gruffness .
@@ -9244,14 +9244,14 @@
 # NPr/VB+ . ISg/#r+ NSg/VP N🅪Sg/VB/J/P R/C/P D/P NSg/I/Dq+ NPl/V3+ P    D$+ NPr/VB/J+ NPr/J/R/P D$+ NPl/V3+ . C/P   ISg/#r+ VP/J  D+
 > phone   taken up         inside  and  the butler’s voice   calling a   taxi    . Then      I       walked
 # NSg/VB+ VPp/J NSg/VB/J/P NSg/J/P VB/C D   NPr$     NSg/VB+ Nᴹ/Vg/J D/P NSg/VB+ . NSg/J/R/C ISg/#r+ VP/J
-> slowly down        the drive   away from the house   , intending to wait   by    the gate    .
-# R      N🅪Sg/VB/J/P D   N🅪Sg/VB VB/J P    D+  NPr/VB+ . Nᴹ/Vg/J   P  NSg/VB NSg/P D+  NSg/VB+ .
+> slowly down        the drive   away from the house   , intending to wait   by the gate    .
+# R      N🅪Sg/VB/J/P D   N🅪Sg/VB VB/J P    D+  NPr/VB+ . Nᴹ/Vg/J   P  NSg/VB P  D+  NSg/VB+ .
 >
 #
 > I       hadn’t gone    twenty yards   when    I       heard my  name    and  Gatsby stepped from between
 # ISg/#r+ VPt    VPp/J/P NSg    NPl/V3+ NSg/I/C ISg/#r+ VP/J  D$+ NSg/VB+ VB/C NPr    J       P    NSg/P
-> two bushes  into the path    . I       must    have    felt      pretty     weird    by    that      time       , because I
-# NSg NPl/V3+ P    D   NSg/VB+ . ISg/#r+ NSg/VXB NSg/VXB N🅪Sg/VP/J NSg/VB/J/R NSg/VB/J NSg/P I/C/Ddem+ N🅪Sg/VB/J+ . C/P     ISg/#r+
+> two bushes  into the path    . I       must    have    felt      pretty     weird    by that      time       , because I
+# NSg NPl/V3+ P    D   NSg/VB+ . ISg/#r+ NSg/VXB NSg/VXB N🅪Sg/VP/J NSg/VB/J/R NSg/VB/J P  I/C/Ddem+ N🅪Sg/VB/J+ . C/P     ISg/#r+
 > could   think  of nothing  except the luminosity of his     pink      suit    under   the moon    .
 # NSg/VXB NSg/VB P  NSg/I/J+ VB/C/P D   Nᴹ         P  ISg/D$+ N🅪Sg/VB/J NSg/VB+ NSg/J/P D   NPr/VB+ .
 >
@@ -9302,14 +9302,14 @@
 # NPr/ISg+ NSg/VPt R/C/P NSg/C NPr$    N🅪Sg/VB/J+ VLPt D   J/R/C NSg+  I/C/Ddem+ VP/J     .
 >
 #
-> “ I       got to West      Egg      by    a    side      road    , ” he       went    on  , “ and  left     the car  in        my  garage  .
-# . ISg/#r+ VP  P  NPr/VB/J+ N🅪Sg/VB+ NSg/P D/P+ NSg/VB/J+ N🅪Sg/J+ . . NPr/ISg+ NSg/VPt J/P . . VB/C NPr/VP/J D+  NSg+ NPr/J/R/P D$+ NSg/VB+ .
+> “ I       got to West      Egg      by a    side      road    , ” he       went    on  , “ and  left     the car  in        my  garage  .
+# . ISg/#r+ VP  P  NPr/VB/J+ N🅪Sg/VB+ P  D/P+ NSg/VB/J+ N🅪Sg/J+ . . NPr/ISg+ NSg/VPt J/P . . VB/C NPr/VP/J D+  NSg+ NPr/J/R/P D$+ NSg/VB+ .
 > I       don’t think  anybody saw     us       , but     of course  I       can’t be       sure . ”
 # ISg/#r+ VXB   NSg/VB NSg/I+  NSg/VPt NPr/IPl+ . NSg/C/P P  NSg/VB+ ISg/#r+ VXB   NSg/VLXB J    . .
 >
 #
-> I       disliked him  so          much         by    this    time       that      I       didn’t find   it       necessary to tell   him
-# ISg/#r+ VP/J     ISg+ NSg/I/J/R/C NSg/I/J/R/Dq NSg/P I/Ddem+ N🅪Sg/VB/J+ I/C/Ddem+ ISg/#r+ VXPt   NSg/VB NPr/ISg+ NSg/J     P  NPr/VB ISg+
+> I       disliked him  so          much         by this    time       that      I       didn’t find   it       necessary to tell   him
+# ISg/#r+ VP/J     ISg+ NSg/I/J/R/C NSg/I/J/R/Dq P  I/Ddem+ N🅪Sg/VB/J+ I/C/Ddem+ ISg/#r+ VXPt   NSg/VB NPr/ISg+ NSg/J     P  NPr/VB ISg+
 > he       was  wrong      .
 # NPr/ISg+ VLPt NSg/VB/J/R .
 >
@@ -9574,8 +9574,8 @@
 # Nᴹ/Vg/J   D   N🅪Sg/VB+ P    D   NPl/V3+ VB/C NPl/V3 P  NSg/VB/J/R NSg/J   NPl+     .
 >
 #
-> But     he       knew that     he       was  in        Daisy’s house   by    a   colossal accident . However
-# NSg/C/P NPr/ISg+ VPt  I/C/Ddem NPr/ISg+ VLPt NPr/J/R/P NPr$    NPr/VB+ NSg/P D/P J        NSg/J+   . C
+> But     he       knew that     he       was  in        Daisy’s house   by a   colossal accident . However
+# NSg/C/P NPr/ISg+ VPt  I/C/Ddem NPr/ISg+ VLPt NPr/J/R/P NPr$    NPr/VB+ P  D/P J        NSg/J+   . C
 > glorious might    be       his     future as    Jay  Gatsby , he       was  at    present  a   penniless young
 # J        Nᴹ/VXB/J NSg/VLXB ISg/D$+ NSg/J+ R/C/P NPr+ NPr    . NPr/ISg+ VLPt NSg/P NSg/VB/J D/P J         NPr/VB/J
 > man     without a   past       , and  at    any    moment the invisible cloak  of his     uniform  might
@@ -9703,7 +9703,7 @@
 > gray            tea      hour there were always rooms  that      throbbed incessantly with this   low        ,
 # NPr🅪Sg/VB/J/Am+ N🅪Sg/VB+ NSg+ R+    VLPt R      NPl/V3 I/C/Ddem+ VP       R           P    I/Ddem NSg/VB/J/R .
 > sweet    fever   , while      fresh    faces   drifted here and  there like         rose      petals blown by
-# NPr/VB/J NSg/VB+ . NSg/VB/C/P NSg/VB/J NPl/V3+ VP/J    J/R  VB/C R+    NSg/VB/J/C/P NPr/VPt/J NPl/V3 VPp/J NSg/P
+# NPr/VB/J NSg/VB+ . NSg/VB/C/P NSg/VB/J NPl/V3+ VP/J    J/R  VB/C R+    NSg/VB/J/C/P NPr/VPt/J NPl/V3 VPp/J P
 > the sad      horns  around the floor   .
 # D   NSg/VB/J NPl/V3 J/P    D   NSg/VB+ .
 >
@@ -9718,8 +9718,8 @@
 # VP/J    P     Nᴹ/Vg/J NPl     J/P D   NSg/VB+ P      ISg/D$+ NSg/VBP/J+ . VB/C NSg/I/J/C/Dq D+  N🅪Sg/VB/J+
 > something within  her     was  crying  for   a    decision . She  wanted her     life     shaped now       ,
 # NSg/I/J+  NSg/J/P ISg/D$+ VLPt Nᴹ/Vg/J R/C/P D/P+ NSg/VB+  . ISg+ VP/J   ISg/D$+ N🅪Sg/VB+ VP/J   NSg/J/R/C .
-> immediately — and  the decision must    be       made by    some      force    — of love       , of money   , of
-# R           . VB/C D+  NSg/VB+  NSg/VXB NSg/VLXB VP   NSg/P I/J/R/Dq+ N🅪Sg/VB+ . P  NPr🅪Sg/VB+ . P  N🅪Sg/J+ . P
+> immediately — and  the decision must    be       made by some      force    — of love       , of money   , of
+# R           . VB/C D+  NSg/VB+  NSg/VXB NSg/VLXB VP   P  I/J/R/Dq+ N🅪Sg/VB+ . P  NPr🅪Sg/VB+ . P  N🅪Sg/J+ . P
 > unquestionable practicality — that      was  close    at    hand    .
 # J              NSg          . I/C/Ddem+ VLPt NSg/VB/J NSg/P NSg/VB+ .
 >
@@ -9806,8 +9806,8 @@
 # VLPt Nᴹ/Vg/J ISg/D$+ NSg/J/P . D+  NPr🅪Sg+ . NSg/VB+ . NPr/ISg+ VLPt J         NSg/J/R/C . VLPt NSg/VB/J . NPr/ISg+ NSg/VPt NSg/VB/J/R/P
 > to the open     vestibule and  sat    down        on  a   folding  - chair   , and  the station slid away
 # P  D   NSg/VB/J NSg/VB    VB/C NSg/VP N🅪Sg/VB/J/P J/P D/P Nᴹ/Vg/J+ . NSg/VB+ . VB/C D   NSg/VB+ VP   VB/J
-> and  the backs  of unfamiliar buildings moved by    . Then      out          into the spring   fields    ,
-# VB/C D   NPl/V3 P  NSg/J      NPl/V3+   VP/J  NSg/P . NSg/J/R/C NSg/VB/J/R/P P    D+  N🅪Sg/VB+ NPrPl/V3+ .
+> and  the backs  of unfamiliar buildings moved by . Then      out          into the spring   fields    ,
+# VB/C D   NPl/V3 P  NSg/J      NPl/V3+   VP/J  P  . NSg/J/R/C NSg/VB/J/R/P P    D+  N🅪Sg/VB+ NPrPl/V3+ .
 > where   a   yellow   trolley raced them     for   a   minute    with people  in        it       who    might    once
 # NSg/R/C D/P NSg/VB/J NSg/VB  VP/J  NSg/IPl+ R/C/P D/P NSg/VB/J+ P    NPl/VB+ NPr/J/R/P NPr/ISg+ NPr/I+ Nᴹ/VXB/J NSg/C
 > have    seen    the pale     magic     of her     face    along the casual street    .
@@ -9822,8 +9822,8 @@
 # VP  VPp/J ISg/D$+ N🅪Sg/VB/J+ . NPr/ISg+ VP/J      NSg/VB/J/R/P ISg/D$+ NSg/VB+ R           R/C/P NSg/C P  NSg/VB J/R/C
 > a   wisp   of air      , to save       a   fragment of the spot      that      she  had made lovely for   him  .
 # D/P NSg/VB P  N🅪Sg/VB+ . P  NSg/VB/C/P D/P NSg/VB   P  D   NSg/VB/J+ I/C/Ddem+ ISg+ VP  VP   NSg/J  R/C/P ISg+ .
-> But     it       was  all          going   by    too fast       now       for   his     blurred eyes    and  he       knew that     he
-# NSg/C/P NPr/ISg+ VLPt NSg/I/J/C/Dq Nᴹ/Vg/J NSg/P R   NSg/VB/J/R NSg/J/R/C R/C/P ISg/D$+ VP/J    NPl/V3+ VB/C NPr/ISg+ VPt  I/C/Ddem NPr/ISg+
+> But     it       was  all          going   by too fast       now       for   his     blurred eyes    and  he       knew that     he
+# NSg/C/P NPr/ISg+ VLPt NSg/I/J/C/Dq Nᴹ/Vg/J P  R   NSg/VB/J/R NSg/J/R/C R/C/P ISg/D$+ VP/J    NPl/V3+ VB/C NPr/ISg+ VPt  I/C/Ddem NPr/ISg+
 > had lost that     part     of it       , the freshest and  the best       , forever .
 # VP  VP/J I/C/Ddem NSg/VB/J P  NPr/ISg+ . D   JS       VB/C D   NPr/VXB/JS . NSg/J   .
 >
@@ -9892,8 +9892,8 @@
 # . ISg/#r+ VB      NSg/I/J/R/C . .
 >
 #
-> “ Well       , good     - by    . ”
-# . NSg/VB/J/R . NPr/VB/J . NSg/P . .
+> “ Well       , good     - by . ”
+# . NSg/VB/J/R . NPr/VB/J . P  . .
 >
 #
 > We   shook     hands   and  I       started away . Just before I       reached the hedge   I       remembered
@@ -9924,8 +9924,8 @@
 # N🅪Sg/VB VP  VLPp/B VP/J    P    D   NPl/V3 P  I/Ddem+ NPr/I+ VP/J    NSg/P ISg/D$+ N🅪Sg+      . VB/C
 > he       had stood on  those   steps   , concealing his     incorruptible dream     , as    he       waved
 # NPr/ISg+ VP  VP    J/P I/Ddem+ NPl/V3+ . Nᴹ/Vg/J    ISg/D$+ NSg/J         NSg/VB/J+ . R/C/P NPr/ISg+ VP/J
-> them     good     - by    .
-# NSg/IPl+ NPr/VB/J . NSg/P .
+> them     good     - by .
+# NSg/IPl+ NPr/VB/J . P  .
 >
 #
 > I       thanked him  for   his     hospitality . We   were always thanking him  for   that      — I       and
@@ -9934,8 +9934,8 @@
 # D+  NPl/V3+ .
 >
 #
-> “ Good     - by    , ” I       called . “ I       enjoyed breakfast , Gatsby . ”
-# . NPr/VB/J . NSg/P . . ISg/#r+ VP/J   . . ISg/#r+ VP/J    N🅪Sg/VB+  . NPr    . .
+> “ Good     - by , ” I       called . “ I       enjoyed breakfast , Gatsby . ”
+# . NPr/VB/J . P  . . ISg/#r+ VP/J   . . ISg/#r+ VP/J    N🅪Sg/VB+  . NPr    . .
 >
 #
 > Up         in        the city , I       tried for   a   while       to list   the quotations on  an  interminable
@@ -10280,8 +10280,8 @@
 # I/Ddem+ VLPt D/P NSg/VB/J NPr🅪Sg/VB . NPr/ISg+ VLPt R      J    I/C/Ddem NPr+   VP  NSg/Dq/P NPr/VB/J+ . R+    VLPt
 > not     enough of him  for   his     wife      . He       was  glad     a   little     later when    he       noticed a
 # NSg/R/C NSg/I  P  ISg+ R/C/P ISg/D$+ NSg/VB/J+ . NPr/ISg+ VLPt NSg/VB/J D/P NPr/I/J/Dq JC    NSg/I/C NPr/ISg+ VP/J    D/P
-> change   in        the room     , a   blue       quickening by    the window  , and  realized       that      dawn
-# N🅪Sg/VB+ NPr/J/R/P D+  N🅪Sg/VB+ . D/P N🅪Sg/VB/J+ Nᴹ/Vg/J+   NSg/P D+  NSg/VB+ . VB/C VP/J/Comm/NoAm I/C/Ddem+ NPr🅪Sg/VB+
+> change   in        the room     , a   blue       quickening by the window  , and  realized       that      dawn
+# N🅪Sg/VB+ NPr/J/R/P D+  N🅪Sg/VB+ . D/P N🅪Sg/VB/J+ Nᴹ/Vg/J+   P  D+  NSg/VB+ . VB/C VP/J/Comm/NoAm I/C/Ddem+ NPr🅪Sg/VB+
 > wasn’t far      off        . About five o’clock it       was  blue      enough outside   to snap      off        the
 # VPt    NSg/VB/J NSg/VB/J/P . J/P   NSg  R       NPr/ISg+ VLPt N🅪Sg/VB/J NSg/I  Nᴹ/VB/J/P P  NSg/VB/J+ NSg/VB/J/P D+
 > light      .
@@ -10326,8 +10326,8 @@
 # ISg/D$+ NSg/VB+ NSg/VB/J P  D+  NSg/VB+ NSg/VB . NSg/VP/J P    D   Nᴹ/VB/J+ .
 >
 #
-> By    six o’clock Michaelis was  worn  out          , and  grateful for   the sound     of a    car
-# NSg/P NSg R       ?         VLPt VPp/J NSg/VB/J/R/P . VB/C J        R/C/P D   N🅪Sg/VB/J P  D/P+ NSg+
+> By six o’clock Michaelis was  worn  out          , and  grateful for   the sound     of a    car
+# P  NSg R       ?         VLPt VPp/J NSg/VB/J/R/P . VB/C J        R/C/P D   N🅪Sg/VB/J P  D/P+ NSg+
 > stopping outside   . It       was  one     of the watchers of the night    before who    had
 # NSg/Vg   Nᴹ/VB/J/P . NPr/ISg+ VLPt NSg/I/J P  D   NPl      P  D+  N🅪Sg/VB+ C/P    NPr/I+ VP
 > promised to come       back     , so          he       cooked breakfast for   three , which he       and  the other
@@ -10358,10 +10358,10 @@
 # Nᴹ/Vg/J P    NSg/VB+ P  NSg/VB R          . Nᴹ/Vg/J   R/C/P D/P NSg/VB/J NSg+ . J/P D+  NSg/VB/J+
 > hand    , no        garage  man     who    had seen    him  ever came      forward  , and  perhaps he       had an
 # NSg/VB+ . NSg/Dq/P+ NSg/VB+ NPr/VB+ NPr/I+ VP  NSg/VPp ISg+ J/R  NSg/VPt/P NSg/VB/J . VB/C NSg/R   NPr/ISg+ VP  D/P
-> easier , surer way   of finding out          what   he       wanted to know . By    half      - past       two he       was
-# NSg/JC . JC    NSg/J P  Nᴹ/Vg/J NSg/VB/J/R/P NSg/I+ NPr/ISg+ VP/J   P  VB   . NSg/P N🅪Sg/J/P+ . NSg/VB/J/P NSg NPr/ISg+ VLPt
-> in        West      Egg      , where   he       asked some      one      the way    to Gatsby’s house   . So          by    that      time
-# NPr/J/R/P NPr/VB/J+ N🅪Sg/VB+ . NSg/R/C NPr/ISg+ VP/J  I/J/R/Dq+ NSg/I/J+ D   NSg/J+ P  NPr$     NPr/VB+ . NSg/I/J/R/C NSg/P I/C/Ddem+ N🅪Sg/VB/J+
+> easier , surer way   of finding out          what   he       wanted to know . By half      - past       two he       was
+# NSg/JC . JC    NSg/J P  Nᴹ/Vg/J NSg/VB/J/R/P NSg/I+ NPr/ISg+ VP/J   P  VB   . P  N🅪Sg/J/P+ . NSg/VB/J/P NSg NPr/ISg+ VLPt
+> in        West      Egg      , where   he       asked some      one      the way    to Gatsby’s house   . So          by that      time
+# NPr/J/R/P NPr/VB/J+ N🅪Sg/VB+ . NSg/R/C NPr/ISg+ VP/J  I/J/R/Dq+ NSg/I/J+ D   NSg/J+ P  NPr$     NPr/VB+ . NSg/I/J/R/C P  I/C/Ddem+ N🅪Sg/VB/J+
 > he       knew Gatsby’s name    .
 # NPr/ISg+ VPt  NPr$     NSg/VB+ .
 >
@@ -10458,8 +10458,8 @@
 # NPr🅪Sg+ . J/R/C R/C/P D/P J       NSg/VB P  Nᴹ/VB  VB/C NPl           VB/C N🅪Sg/VB+  NPl+ NPr/J/R/P
 > and  out          of Gatsby’s front     door    . A    rope    stretched across the main     gate   and  a
 # VB/C NSg/VB/J/R/P P  NPr$     NSg/VB/J+ NSg/VB+ . D/P+ NSg/VB+ VP/J      NSg/P  D   NSg/VB/J NSg/VB VB/C D/P+
-> policeman by    it       kept out          the curious , but     little      boys    soon discovered that     they
-# NSg+      NSg/P NPr/ISg+ VP   NSg/VB/J/R/P D   J       . NSg/C/P NPr/I/J/Dq+ NPl/V3+ J/R  VP/J       I/C/Ddem IPl+
+> policeman by it       kept out          the curious , but     little      boys    soon discovered that     they
+# NSg+      P  NPr/ISg+ VP   NSg/VB/J/R/P D   J       . NSg/C/P NPr/I/J/Dq+ NPl/V3+ J/R  VP/J       I/C/Ddem IPl+
 > could   enter  through my  yard    , and  there were always a   few      of them     clustered
 # NSg/VXB NSg/VB J/P     D$+ NSg/VB+ . VB/C R+    VLPt R      D/P NSg/I/Dq P  NSg/IPl+ VP/J
 > open     - mouthed about the pool    . Some     one     with a    positive manner , perhaps a
@@ -10490,8 +10490,8 @@
 # NSg/VB+ . I/C/Ddem ISg/D$+ NSg/VB+ VP  VLPp/B P    NSg/Dq/P NSg/VB+  NSg/I/J+ . ISg+ VP/J
 > herself of it       , and  cried into her     handkerchief , as    if    the very suggestion was
 # ISg+    P  NPr/ISg+ . VB/C VP/J  P    ISg/D$+ NSg+         . R/C/P NSg/C D+  J/R+ N🅪Sg+      VLPt
-> more         than she  could   endure . So          Wilson was  reduced to a    man     “ deranged by    grief  ”
-# NPr/I/J/R/Dq C/P  ISg+ NSg/VXB VB     . NSg/I/J/R/C NPr+   VLPt VP/J    P  D/P+ NPr/VB+ . VP/J     NSg/P Nᴹ/VB+ .
+> more         than she  could   endure . So          Wilson was  reduced to a    man     “ deranged by grief  ”
+# NPr/I/J/R/Dq C/P  ISg+ NSg/VXB VB     . NSg/I/J/R/C NPr+   VLPt VP/J    P  D/P+ NPr/VB+ . VP/J     P  Nᴹ/VB+ .
 > in        order    that     the case       might    remain in        its     simplest form     . And  it       rested there .
 # NPr/J/R/P N🅪Sg/VB+ I/C/Ddem D   NPr🅪Sg/VB+ Nᴹ/VXB/J NSg/VB NPr/J/R/P ISg/D$+ JS       N🅪Sg/VB+ . VB/C NPr/ISg+ VP/J   R     .
 >
@@ -10556,8 +10556,8 @@
 #
 > Meyer Wolfshiem’s name    wasn’t in        the phone   book    . The butler gave me       his     office
 # NPr   ?           NSg/VB+ VPt    NPr/J/R/P D   NSg/VB+ NSg/VB+ . D   NPr/VB VPt  NPr/ISg+ ISg/D$+ NSg/VB+
-> address on  Broadway , and  I       called Information , but     by    the time       I       had the number
-# NSg/VB+ J/P NPr/J+   . VB/C ISg/#r+ VP/J   Nᴹ+         . NSg/C/P NSg/P D   N🅪Sg/VB/J+ ISg/#r+ VP  D   N🅪Sg/VB/JC+
+> address on  Broadway , and  I       called Information , but     by the time       I       had the number
+# NSg/VB+ J/P NPr/J+   . VB/C ISg/#r+ VP/J   Nᴹ+         . NSg/C/P P  D   N🅪Sg/VB/J+ ISg/#r+ VP  D   N🅪Sg/VB/JC+
 > it       was  long     after five , and  no       one      answered the phone   .
 # NPr/ISg+ VLPt NPr/VB/J P     NSg  . VB/C NSg/Dq/P NSg/I/J+ VP/J     D   NSg/VB+ .
 >
@@ -10630,8 +10630,8 @@
 # VXPt VXB    NSg/VB NPr/IPl+ NSg/I/J/C/Dq+ NSg/VB+ . ISg/#r+ NSg/VXB NSg/VBPp/P N🅪Sg/VB/J/P NSg/J/R/C R/C/P ISg/#r+ NPr/VLB/J VP/J NSg/VB/J/P NPr/J/R/P I/J/R/Dq
 > very important business and  cannot  get    mixed up         in        this   thing now       . If    there is
 # J/R  J         N🅪Sg/J+  VB/C NSg/VXB NSg/VB VP/J  NSg/VB/J/P NPr/J/R/P I/Ddem NSg+  NSg/J/R/C . NSg/C R+    VL3
-> anything  I       can     do  a   little     later let     me       know in        a   letter  by    Edgar . I       hardly know
-# NSg/I/VB+ ISg/#r+ NPr/VXB VXB D/P NPr/I/J/Dq JC    NSg/VBP NPr/ISg+ VB   NPr/J/R/P D/P NSg/VB+ NSg/P NPr+  . ISg/#r+ R      VB
+> anything  I       can     do  a   little     later let     me       know in        a   letter  by Edgar . I       hardly know
+# NSg/I/VB+ ISg/#r+ NPr/VXB VXB D/P NPr/I/J/Dq JC    NSg/VBP NPr/ISg+ VB   NPr/J/R/P D/P NSg/VB+ P  NPr+  . ISg/#r+ R      VB
 > where   I       am        when    I       hear about a    thing like         this    and  am        completely knocked down
 # NSg/R/C ISg/#r+ NPr/VLB/J NSg/I/C ISg/#r+ VB   J/P   D/P+ NSg+  NSg/VB/J/C/P I/Ddem+ VB/C NPr/VLB/J R          VP/J    N🅪Sg/VB/J/P
 > and  out          .
@@ -10694,8 +10694,8 @@
 # NPr$     NSg/VB/J . .
 >
 #
-> There was  a   long     silence on  the other    end    of the wire     , followed by    an
-# R+    VLPt D/P NPr/VB/J NSg/VB+ J/P D   NSg/VB/J NSg/VB P  D+  N🅪Sg/VB+ . VP/J     NSg/P D/P+
+> There was  a   long     silence on  the other    end    of the wire     , followed by an
+# R+    VLPt D/P NPr/VB/J NSg/VB+ J/P D   NSg/VB/J NSg/VB P  D+  N🅪Sg/VB+ . VP/J     P  D/P+
 > exclamation . . . then      a    quick    squawk  as    the connection was  broken .
 # NSg+        . . . NSg/J/R/C D/P+ NSg/VB/J NSg/VB+ R/C/P D+  N🅪Sg+      VLPt VPp/J  .
 >
@@ -11206,8 +11206,8 @@
 # NSg/VB/C/P . #    . VP/J    NSg/VB/J/R/P . . #    NSg NSg/J+ NSg/VLXB NSg/VXB/JC P  NPl/V3
 >
 #
-> “ I       come       across this   book    by    accident , ” said the old    man     . “ It       just shows  you    ,
-# . ISg/#r+ NSg/VBPp/P NSg/P  I/Ddem NSg/VB+ NSg/P NSg/J+   . . VP/J D+  NSg/J+ NPr/VB+ . . NPr/ISg+ J/R  NPl/V3 ISgPl+ .
+> “ I       come       across this   book    by accident , ” said the old    man     . “ It       just shows  you    ,
+# . ISg/#r+ NSg/VBPp/P NSg/P  I/Ddem NSg/VB+ P  NSg/J+   . . VP/J D+  NSg/J+ NPr/VB+ . . NPr/ISg+ J/R  NPl/V3 ISgPl+ .
 > don’t it       ? ”
 # VXB   NPr/ISg+ . .
 >
@@ -11287,7 +11287,7 @@
 >
 #
 > We   straggled down        quickly through the rain     to the cars . Owl     - eyes    spoke   to me       by
-# IPl+ VP/J      N🅪Sg/VB/J/P R       J/P     D   N🅪Sg/VB+ P  D   NPl+ . NSg/VB+ . NPl/V3+ NSg/VPt P  NPr/ISg+ NSg/P
+# IPl+ VP/J      N🅪Sg/VB/J/P R       J/P     D   N🅪Sg/VB+ P  D   NPl+ . NSg/VB+ . NPl/V3+ NSg/VPt P  NPr/ISg+ P
 > the gate    .
 # D+  NSg/VB+ .
 >
@@ -11300,8 +11300,8 @@
 # . I/C     NSg/VXB NSg/I+  NSg/J/C . .
 >
 #
-> “ Go       on  ! ” He       started . “ Why    , my  God     ! they used to go       there by    the hundreds . ”
-# . NSg/VB/J J/P . . NPr/ISg+ VP/J    . . NSg/VB . D$+ NPr/VB+ . IPl+ VP/J P  NSg/VB/J R     NSg/P D+  NPl+     . .
+> “ Go       on  ! ” He       started . “ Why    , my  God     ! they used to go       there by the hundreds . ”
+# . NSg/VB/J J/P . . NPr/ISg+ VP/J    . . NSg/VB . D$+ NPr/VB+ . IPl+ VP/J P  NSg/VB/J R     P  D+  NPl+     . .
 >
 #
 > He       took off        his     glasses and  wiped them     again , outside   and  in        .
@@ -11320,8 +11320,8 @@
 # NPr/J/R/P D+  NSg/J+ NSg/VB/J+ NPr/VB/J+ NSg/VB/J+ NSg/VB+ NSg/P NSg R       P  D/P+ NPr+     N🅪Sg/Vg/J+ . P    D/P+
 > few       Chicago friends   , already caught up         into their own       holiday gayeties , to bid
 # NSg/I/Dq+ NPr+    NPrPl/V3+ . R       VP/J   NSg/VB/J/P P    D$+   NSg/VB/J+ NPr/VB+ ?        . P  NSg/VBP
-> them     a   hasty good     - by    . I       remember the fur          coats  of the girls   returning from Miss
-# NSg/IPl+ D/P J     NPr/VB/J . NSg/P . ISg/#r+ NSg/VB   D   N🅪Sg/VB/C/P+ NPl/V3 P  D+  NPl/V3+ Nᴹ/Vg/J   P    NSg/VB
+> them     a   hasty good     - by . I       remember the fur          coats  of the girls   returning from Miss
+# NSg/IPl+ D/P J     NPr/VB/J . P  . ISg/#r+ NSg/VB   D   N🅪Sg/VB/C/P+ NPl/V3 P  D+  NPl/V3+ Nᴹ/Vg/J   P    NSg/VB
 > This    - or    - That’s and  the chatter of frozen breath     and  the hands   waving  overhead as
 # I/Ddem+ . NPr/C . K      VB/C D   NSg/VB  P  VB/J   N🅪Sg/VB/J+ VB/C D   NPl/V3+ Nᴹ/Vg/J NSg/J/P+ R/C/P
 > we   caught sight   of old   acquaintances , and  the matchings of invitations : “ Are you
@@ -11340,8 +11340,8 @@
 # NSg/I/C IPl+ VP/J   NSg/VB/J/R/P P    D+  N🅪Sg/VB+ N🅪Sg/VB+ VB/C D+  NSg/J+ NPr🅪Sg/VB+ . D$+ NPr🅪Sg/VB+ . VPt   P
 > stretch out          beside us       and  twinkle against the windows   , and  the dim      lights of
 # N🅪Sg/VB NSg/VB/J/R/P P      NPr/IPl+ VB/C NSg/VB  C/P     D   NPrPl/V3+ . VB/C D   NSg/VB/J NPl/V3 P
-> small    Wisconsin stations moved by    , a   sharp    wild     brace  came      suddenly into the
-# NPr/VB/J NPr+      +        VP/J  NSg/P . D/P NPr/VB/J NSg/VB/J NSg/VB NSg/VPt/P R        P    D
+> small    Wisconsin stations moved by , a   sharp    wild     brace  came      suddenly into the
+# NPr/VB/J NPr+      +        VP/J  P  . D/P NPr/VB/J NSg/VB/J NSg/VB NSg/VPt/P R        P    D
 > air      . We   drew    in        deep  breaths of it       as    we   walked back     from dinner   through the
 # N🅪Sg/VB+ . IPl+ NPr/VPt NPr/J/R/P NSg/J NPl     P  NPr/ISg+ R/C/P IPl+ VP/J   NSg/VB/J P    N🅪Sg/VB+ J/P     D
 > cold  vestibules , unutterably aware of our identity with this   country for   one
@@ -11354,14 +11354,14 @@
 # K      D$+ NSg/VB/J NPr/VB/J+ . NSg/R/C D   NSg/J+ NPr/C D   NPl      NPr/C D   VP/J NSg/VB+ NPl+  . NSg/C/P
 > the thrilling returning trains of my  youth , and  the street    lamps  and  sleigh
 # D   Nᴹ/Vg/J   Nᴹ/Vg/J   NPl/V3 P  D$+ NSg+  . VB/C D   NSg/VB/J+ NPl/V3 VB/C NSg/VB/J+
-> bells  in        the frosty dark     and  the shadows of holly wreaths thrown by    lighted
-# NPl/V3 NPr/J/R/P D   J      NSg/VB/J VB/C D   NPl/V3  P  NPr+  NPl/VB  VPp/J  NSg/P VP/J
+> bells  in        the frosty dark     and  the shadows of holly wreaths thrown by lighted
+# NPl/V3 NPr/J/R/P D   J      NSg/VB/J VB/C D   NPl/V3  P  NPr+  NPl/VB  VPp/J  P  VP/J
 > windows   on  the snow       . I       am        part     of that      , a   little     solemn with the feel     of those
 # NPrPl/V3+ J/P D   NPr🅪Sg/VB+ . ISg/#r+ NPr/VLB/J NSg/VB/J P  I/C/Ddem+ . D/P NPr/I/J/Dq J      P    D   NSg/I/VB P  I/Ddem+
 > long      winters   , a   little     complacent from growing up         in        the Carraway house  in        a
 # NPr/VB/J+ NPrPl/V3+ . D/P NPr/I/J/Dq J          P    Nᴹ/Vg/J NSg/VB/J/P NPr/J/R/P D   ?        NPr/VB NPr/J/R/P D/P
-> city where   dwellings are still      called through decades by    a   family’s name    . I       see
-# NSg+ NSg/R/C NPl/V3+   VLB NSg/VB/J/R VP/J   J/P     NPl+    NSg/P D/P NSg$     NSg/VB+ . ISg/#r+ NSg/VB
+> city where   dwellings are still      called through decades by a   family’s name    . I       see
+# NSg+ NSg/R/C NPl/V3+   VLB NSg/VB/J/R VP/J   J/P     NPl+    P  D/P NSg$     NSg/VB+ . ISg/#r+ NSg/VB
 > now       that     this    has been   a   story  of the West      , after all          — Tom     and  Gatsby , Daisy and
 # NSg/J/R/C I/C/Ddem I/Ddem+ V3  VLPp/B D/P NSg/VB P  D+  NPr/VB/J+ . P     NSg/I/J/C/Dq . NPr/VB+ VB/C NPr    . NPr   VB/C
 > Jordan and  I       , were all          Westerners , and  perhaps we   possessed some     deficiency in
@@ -11378,8 +11378,8 @@
 # J            NPl/V3       I/C+  VP/J   J/R/C D   NPl+     VB/C D   J/R  NSg/J . NSg/VB/J/R
 > then      it       had always for   me       a   quality of distortion . West      Egg      , especially , still
 # NSg/J/R/C NPr/ISg+ VP  R      R/C/P NPr/ISg+ D/P N🅪Sg/J  P  NSg+       . NPr/VB/J+ N🅪Sg/VB+ . R          . NSg/VB/J/R
-> figures in        my  more         fantastic dreams  . I       see    it       as    a   night    scene  by    El Greco : a
-# NPl/V3+ NPr/J/R/P D$+ NPr/I/J/R/Dq NSg/J+    NPl/V3+ . ISg/#r+ NSg/VB NPr/ISg+ R/C/P D/P N🅪Sg/VB+ NSg/VB NSg/P ?  ?     . D/P+
+> figures in        my  more         fantastic dreams  . I       see    it       as    a   night    scene  by El Greco : a
+# NPl/V3+ NPr/J/R/P D$+ NPr/I/J/R/Dq NSg/J+    NPl/V3+ . ISg/#r+ NSg/VB NPr/ISg+ R/C/P D/P N🅪Sg/VB+ NSg/VB P  ?  ?     . D/P+
 > hundred houses  , at    once  conventional and  grotesque , crouching under   a   sullen   ,
 # NSg+    NPl/V3+ . NSg/P NSg/C NSg/J        VB/C NSg/J     . Nᴹ/Vg/J   NSg/J/P D/P NSg/VB/J .
 > overhanging sky      and  a   lustreless moon    . In        the foreground four solemn men in
@@ -11432,8 +11432,8 @@
 # NPr/VB/J+ . NSg/C/P ISg/#r+ VP/J      P  NSg/VLXB VP/J      . R/C/P J/R  D/P+ NSg/VB/J+ ISg/#r+ VP/J     NSg/C ISg/#r+ VPt
 > making  a   mistake , then      I       thought it       all          over    again quickly and  got up         to say
 # Nᴹ/Vg/J D/P NSg/VB+ . NSg/J/R/C ISg/#r+ N🅪Sg/VP NPr/ISg+ NSg/I/J/C/Dq NSg/J/P P     R       VB/C VP  NSg/VB/J/P P  NSg/VB
-> good     - by    .
-# NPr/VB/J . NSg/P .
+> good     - by .
+# NPr/VB/J . P  .
 >
 #
 > “ Nevertheless you    did  throw  me       over    , ” said Jordan suddenly . ‘ ‘ You    threw me       over
@@ -11548,8 +11548,8 @@
 # . VB/C NSg/C ISgPl+ NSg/VB ISg/#r+ VXPt   NSg/VXB D$+ NSg/VB P  Nᴹ/Vg/J+  . NSg/VB J/R  . NSg/I/C ISg/#r+ NSg/VPt P
 > give   up         that     flat     and  saw     that     damn     box    of dog       biscuits sitting  there on  the
 # NSg/VB NSg/VB/J/P I/C/Ddem NSg/VB/J VB/C NSg/VPt I/C/Ddem NSg/VB/J NSg/VB P  NSg/VB/J+ NPl      NSg/Vg/J R     J/P D
-> sideboard , I       sat    down        and  cried like         a   baby      . By    God     it       was  awful — ”
-# NSg/VB    . ISg/#r+ NSg/VP N🅪Sg/VB/J/P VB/C VP/J  NSg/VB/J/C/P D/P NSg/VB/J+ . NSg/P NPr/VB+ NPr/ISg+ VLPt J     . .
+> sideboard , I       sat    down        and  cried like         a   baby      . By God     it       was  awful — ”
+# NSg/VB    . ISg/#r+ NSg/VP N🅪Sg/VB/J/P VB/C VP/J  NSg/VB/J/C/P D/P NSg/VB/J+ . P  NPr/VB+ NPr/ISg+ VLPt J     . .
 >
 #
 > I       couldn’t forgive him  or    like         him  , but     I       saw     that     what   he       had done      was  , to him  ,
@@ -11606,8 +11606,8 @@
 # J/P D+  NSg/VB/J+ N🅪Sg/VB+ . P    D$+ NSg/VB+ VP/J   VB/C D$+ NSg+ NSg/VP P  D   NSg/VB . ISg/#r+ NSg/VPt
 > over    and  looked at    that     huge incoherent failure of a   house   once  more         . On  the
 # NSg/J/P VB/C VP/J   NSg/P I/C/Ddem J    J          N🅪Sg    P  D/P NPr/VB+ NSg/C NPr/I/J/R/Dq . J/P D+
-> white        steps   an  obscene word    , scrawled by    some     boy     with a   piece  of brick      , stood
-# NPr🅪Sg/VB/J+ NPl/V3+ D/P VB/J    NSg/VB+ . VP/J     NSg/P I/J/R/Dq NSg/VB+ P    D/P NSg/VB P  N🅪Sg/VB/J+ . VP
+> white        steps   an  obscene word    , scrawled by some     boy     with a   piece  of brick      , stood
+# NPr🅪Sg/VB/J+ NPl/V3+ D/P VB/J    NSg/VB+ . VP/J     P  I/J/R/Dq NSg/VB+ P    D/P NSg/VB P  N🅪Sg/VB/J+ . VP
 > out          clearly in        the moonlight , and  I       erased it       , drawing   my  shoe    raspingly along
 # NSg/VB/J/R/P R       NPr/J/R/P D   N🅪Sg/VB+  . VB/C ISg/#r+ VP/J   NPr/ISg+ . N🅪Sg/Vg/J D$+ NSg/VB+ ?         P
 > the stone          . Then      I       wandered down        to the beach   and  sprawled out          on  the sand      .
@@ -11650,8 +11650,8 @@
 # NSg/VB/J NPrPl/V3 P  D+  Nᴹ/VB/J+ VP/J   J/P NSg/J/P D+  N🅪Sg/VB+ .
 >
 #
-> Gatsby believed in        the green       light      , the orgastic future that      year by    year
-# NPr    VP/J     NPr/J/R/P D   NPr🅪Sg/VB/J N🅪Sg/VB/J+ . D   ?        NSg/J+ I/C/Ddem+ NSg  NSg/P NSg+
+> Gatsby believed in        the green       light      , the orgastic future that      year by year
+# NPr    VP/J     NPr/J/R/P D   NPr🅪Sg/VB/J N🅪Sg/VB/J+ . D   ?        NSg/J+ I/C/Ddem+ NSg  P  NSg+
 > recedes before us       . It       eluded us       then      , but     that’s no        matter   — to - morrow we   will    run
 # V3      C/P    NPr/IPl+ . NPr/ISg+ VP/J   NPr/IPl+ NSg/J/R/C . NSg/C/P K      NSg/Dq/P+ N🅪Sg/VB+ . P  . NPr/VB IPl+ NPr/VXB NSg/VBPp
 > faster , stretch  out          our arms    farther . . . . And  one      fine      morning    — — —


### PR DESCRIPTION
# Issues 

Fixes #3960

# Description

Besides the words from issue #3960 most of these turned up while testing my new `posslq` tool where common pairs of POSes turn up many surprising results with words we don't think of primarily as those POSes. I'm removing POSes that are too obscure, archaic, dialectal, nonstandard, obsolete, or marginal.

-en - remove pronoun flag
+untoasted
-afterthought - verb sense too marginal
-besought - past tense and participle
-bethought - past tense and participle
-forethought - verb sense too marginal
-methought - past tense
-nought - verb sense too marginal
-outfought - past tense and participle
-overwrought - verb sense too marginal
-rethought - past tense and participle
-been - remove dialectal noun
-sat - remove abbreviation adj
-room - remove dialectal/obsolete adj
-hare - remove regional adj, obsolete verb
-president - remove verb POS
-by - remove noun POS - alt. of "bye"
-congress - remove verb POS
-vice - remove verb POS

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
