### PR TITLE
fix(obsidian-plugin): guard setting tab updates before state is ready

### DIFF
--- a/packages/obsidian-plugin/src/HarperSettingTab.ts
+++ b/packages/obsidian-plugin/src/HarperSettingTab.ts
@@ -37,6 +37,7 @@ export class HarperSettingTab extends PluginSettingTab {
 	}
 
 	updateSettings() {
+		if (this.state == null) return;
 		this.settings = undefined;
 		this.state.getSettings().then((v) => {
 			this.settings = v;
@@ -46,6 +47,7 @@ export class HarperSettingTab extends PluginSettingTab {
 	}
 
 	updateDescriptions() {
+		if (this.state == null) return;
 		this.state.getDescriptionHTML().then((v) => {
 			this.descriptionsHTML = v;
 			this.rerenderLintSettings();
@@ -53,6 +55,7 @@ export class HarperSettingTab extends PluginSettingTab {
 	}
 
 	updateDefaults() {
+		if (this.state == null) return;
 		this.state.getDefaultLintConfig().then((v) => {
 			this.defaultLintConfig = v as unknown as Record<string, boolean>;
 			this.updateToggleAllRulesButton();
@@ -61,6 +64,7 @@ export class HarperSettingTab extends PluginSettingTab {
 	}
 
 	updateStructuredConfig() {
+		if (this.state == null) return;
 		this.state.getStructuredLintConfig().then((v) => {
 			this.structuredLintConfig = v;
 			this.rerenderLintSettings();


### PR DESCRIPTION
> **AI disclosure**: This PR was prepared with the assistance of an AI agent, per AGENT_POLICY.md.

# Issues

Fixes #3540

# Description

Obsidian 1.13 renders a plugin's setting tab immediately when `addSettingTab` is called, before `onLayoutReady` has had a chance to construct `State`. As a result, `HarperSettingTab.updateSettings`, `updateDescriptions`, `updateDefaults` and `updateStructuredConfig` dereference `this.state` before it exists, throwing a `TypeError` and failing to load the plugin entirely.

This PR adds an early return when `this.state` is null in all four methods, mirroring the existing guard already present in `update()`. Once state is ready, behavior is unchanged.

# How Has This Been Tested

Verified locally with Obsidian 1.13.4 (Windows):
- With the patch, the plugin loads without the "failed to load" error and the settings page renders normally.
- Reverting the patch restores the failure (controlled A/B test).

No automated test was added: the failure is a UI timing race that requires a running Obsidian instance to reproduce. Happy to add a test if maintainers suggest a suitable harness.

# AI Disclosure

- [x] I used an AI agent interactively.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes (see note above)
- [x] I have considered splitting this into smaller pull requests.