### PR TITLE
chore: dictionary curation

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -18591,7 +18591,7 @@ commodious/JY
 commoditize/VdSG
 commodity/~NSg
 commodore/~NSg
-common/~JY^>pNVU
+common/~JY^>pVU
 common's
 commonality/NwgS
 commonalty/Ng
@@ -19603,11 +19603,11 @@ cottonwood/~NSg
 cottony/J
 cotyledon/NgS
 couch/~NgSVdG
-couchette/NS
+couchette/NSg
 cougar/~NSg
-cough/~VdGNg
-coughs/NV
-could/~NA
+cough/~VdGN0g
+coughs/N9Vh
+could/~A
 could've/V
 couldn't/~VA
 couldn't've/VA†
@@ -28504,7 +28504,7 @@ herd/~NgSVd>GZ
 herder/~NgS
 herdsman/N9g
 herdsmen/N9
-here/~JR            # removed `N` marginal noun sense complicates linting
+here/~R             # removed `N` marginal noun sense complicates linting
 here's
 hereabout/S
 hereafter/~NSgJ
@@ -31656,7 +31656,7 @@ kinetically/Ry
 kinetics/~Ng
 kinfolk/NSg
 kinfolks/Ng
-king/~NgSVY
+king/~NgSV
 kingdom/~NSg
 kingfisher/~NSg
 kingly/J>^
@@ -41545,7 +41545,7 @@ quayside/NS
 queasily/Ry
 queasiness/Ng
 queasy/J^>p
-queen/~NgSVGdY
+queen/~NgSVGd
 queenly/J>^
 queer/~J^Y>pNgSVGd
 queerness/Ng
@@ -44784,7 +44784,8 @@ setsquare/S
 sett/NSVG>BzZ
 settee/NgS
 setter/NgV
-setting/~NwgSV6J
+setting/~N0wgV6J
+settings/N9
 settle/~VGdSNrU
 settle's
 settlement/~N0gr
@@ -52829,8 +52830,8 @@ welterweight/~JNSg
 wen/~NgCI
 wench/NgSV
 wend/VdGSN
-went/~VtN
-wept/V
+went/~Vt
+wept/VtT
 were/~Vlt
 weren't/Vt
 werewolf/~N0g

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -12846,7 +12846,7 @@ anxious/~JYp
 anxiousness/Nmg
 any/~IRDq           # removed `5` adjective. it's determiner/pronoun/adverb only
 anybody/~ISg
-anyhow/~J
+anyhow/~R
 anymore/~
 anyone/~Ig
 anyplace/

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -4092,7 +4092,7 @@ Goteborg/g
 Goth/NOgJ
 Gotham/Og
 Gothic/ONSgJ
-Goths/N
+Goths/N9
 Gouda/ONSg
 Gould/Og
 Gounod/g
@@ -8215,7 +8215,7 @@ Pliocene/JOgS       # geological period
 Plutarch/ONg
 Pluto/Og
 Plymouth/ONg
-Plymouths/9
+Plymouths/ON9
 Pm/                 # Promethium
 Po/                 # Polonium
 Pocahontas/ONg
@@ -9003,8 +9003,8 @@ Saab/ONg            # car brand
 Saar/Og
 Saarinen/g
 Saatchi/Og
-Sabbath/Ng
-Sabbaths/N
+Sabbath/N0g
+Sabbaths/N9
 Sabik/Og
 Sabin/Og
 Sabina/Og
@@ -10684,8 +10684,8 @@ Visa/ONg
 Visalia/Og
 Visayans/Ng
 Vishnu/Og
-Visigoth/Ng
-Visigoths/N
+Visigoth/N0g
+Visigoths/N9
 Vistula/Og
 Vitim/Og
 Vito/g
@@ -14054,8 +14054,8 @@ bandsman/N0g
 bandsmen/N9
 bandstand/~NSg
 bandwagon/NSg
-bandwidth/~N
-bandwidths/N
+bandwidth/~N0wg
+bandwidths/N9
 bandy/~Vd>GSJ^N
 bane/~NSgV
 baneful/J
@@ -14252,7 +14252,7 @@ bastion/~NgV
 bat/~NSgV
 batch/~NgSVdGJ
 bate/VGdSNKre
-bath/~NgSVGd>Z
+bath/~N0gSVbGd>Z
 bathe/VNg
 bather/Ng
 bathetic/J
@@ -14262,7 +14262,7 @@ bathmat/NgS
 bathos/Ng
 bathrobe/NSg
 bathroom/~NSgV
-baths/~NV
+baths/~N9Vh
 bathtub/~NgS
 bathwater/Nm
 bathyscaphe/NSg
@@ -14497,8 +14497,8 @@ behaviourist/NSg!@_₹
 behead/VdS
 beheading/NgS
 beheld/V
-behemoth/Ng
-behemoths/N
+behemoth/N0g
+behemoths/N9
 behest/~NgSV
 behind/~PJNgS
 behindhand/J
@@ -14809,8 +14809,8 @@ billing/~V6Ng
 billingsgate/NgV
 billion/~SgH
 billionaire/~NSg
-billionth/JNg
-billionths/N
+billionth/JN0g
+billionths/N9
 billow/NgSVGd
 billowy/J
 billy/~NSg
@@ -14913,14 +14913,14 @@ birdsong/Nmg
 birdwatcher/NSg
 birdying/V
 biretta/NSg
-birth/~NgJ>VGdZ
+birth/~N0gJ>VGdZ
 birthday/~NgSV
 birther/NgV
 birthmark/NgS
 birthplace/~NgS
 birthrate/NgS
 birthright/~NgS
-births/~Nr
+births/~N9r
 birthstone/NSg
 biscuit/~NSg
 bisect/VdGSN
@@ -14975,8 +14975,8 @@ bl/~dG
 blab/VSNg
 blabbed/VtT
 blabber/VdGSN
-blabbermouth/Ng
-blabbermouths/N
+blabbermouth/N0g
+blabbermouths/N9
 blabbing/V6N
 black/~J^Y>pNwgSVGdXn
 black magic/Ng
@@ -15458,8 +15458,8 @@ boot's
 bootable/J
 bootblack/NSgV
 bootee/NgS
-booth/~Ng
-booths/~N
+booth/~N0g
+booths/~N9
 bootlace/NS
 bootleg/~VSNgJ
 bootlegged/VtT
@@ -15705,8 +15705,8 @@ breadbox/NgS
 breadcrumb/NgSV
 breadfruit/NwSg
 breadline/NgS
-breadth/~Ng
-breadths/N
+breadth/~N0g
+breadths/N9
 breadwinner/NSg
 break/~VbG>SNgBZ
 break out/V
@@ -16255,8 +16255,8 @@ bygone/JNSg
 bylaw/NSg
 byline/NSgV
 bypass/~NgSVGdB
-bypath/Ng
-bypaths/N
+bypath/N0g
+bypaths/N9
 byplay/Ng
 byproduct/~NgS
 byre/NS
@@ -17480,8 +17480,8 @@ chihuahua/~NSg
 chilblain/NSg
 child/~NgV
 childbearing/NgJ
-childbirth/~Nmg
-childbirths/N
+childbirth/~N0mg
+childbirths/N9
 childcare/Nmg
 childhood/~NSg
 childish/~JYp
@@ -18057,14 +18057,14 @@ closeup/NSg
 closing/~NgJV
 closure/~NSgVE
 clot/~NgSV
-cloth/~NgS
+cloth/~N0wgS
 clothe/VdSGU
 clotheshorse/NgS
 clothesline/NSgV
 clothespin/NSgV
 clothier/NgS
 clothing/~VNmg
-cloths/~N
+cloths/~N9
 clotted/VtTJ
 clotting/V6N
 cloture/NSgV
@@ -18601,8 +18601,8 @@ commonplace/~JNgSV
 commons/~NV
 commonsense/JN
 commonweal/NgH
-commonwealth/~Ng
-commonwealths/N
+commonwealth/~N0g
+commonwealths/N9
 commotion/~NwSg
 communal/~JY
 commune/~NSgVdGXn
@@ -19595,8 +19595,8 @@ cottar/NSg
 cotter/~NSgV
 cotter pin/NgS
 cotton/~NwSgJVGd
-cottonmouth/Ng
-cottonmouths/N
+cottonmouth/N0g
+cottonmouths/N9
 cottonseed/NwgS
 cottontail/NgS
 cottonwood/~NSg
@@ -20666,7 +20666,7 @@ dearness/Ng
 dearth/N0gV
 dearths/N9
 deary/NSg
-death/~Nw☁gS
+death/~N0w☁gS
 death knell/NgS
 deathbed/~NSg
 deathblow/NgS
@@ -22752,7 +22752,7 @@ earplug/NSgV
 earring/NSg
 earshot/Ng
 earsplitting/J
-earth/~ONmVdGU
+earth/~ON0wVdGU
 earth's
 earthbound/J
 earthen/~JV
@@ -22761,7 +22761,7 @@ earthiness/Nmg
 earthling/NgS
 earthly/~J>^NgSRy
 earthquake/~NSgV
-earths/~NVU
+earths/~N9VU
 earthshaking/J
 earthward/JS
 earthwork/~NgS
@@ -22981,12 +22981,12 @@ eigenvalue/~NS
 eigenvector/NS
 eight/~NSgJ
 eighteen/~SgH
-eighteenth/~JNg
-eighteenths/N
-eighth/~JNgV
+eighteenth/~JN0g
+eighteenths/N9
+eighth/~JN0gV
 eighths/N9Vh
-eightieth/JNg
-eightieths/N
+eightieth/JN0g
+eightieths/N9
 eighty/~SgH
 einsteinium/Nmg
 eisteddfod/~NS
@@ -23090,10 +23090,10 @@ elev
 elevate/~VdSGJXn
 elevation/~Nwg
 elevator/~NgSV
-eleven/~NSgH
-elevens/NS
-eleventh/~JNg
-elevenths/N
+eleven/~N0SgH
+elevens/N9S
+eleventh/~JN0g
+elevenths/N9
 elf/~NgV
 elfin/NJ
 elfish/J
@@ -24987,12 +24987,12 @@ fiesta/~NSgV
 fife/~NgSV>Z
 fifer/Ng
 fifteen/~NgSH
-fifteenth/~JNg
-fifteenths/N
-fifth/~JYNgV
-fifths/~N
-fiftieth/~JNg
-fiftieths/N
+fifteenth/~JN0g
+fifteenths/N9
+fifth/~JYN0gV
+fifths/~N9
+fiftieth/~JN0g
+fiftieths/N9
 fifty/~NSgH
 fig/~NSgVL
 fight/~V>GSNgZ
@@ -25157,8 +25157,8 @@ first time/NgS
 first-time/J
 firstborn/~NSgJ
 firsthand/~JR
-firth/~Ng
-firths/N
+firth/~N0g
+firths/N9
 fiscal/~JYNgS
 fish/~Nw09gSVd>GZ   # singular and plural, also has a plural in -s
 fishbowl/~NSg
@@ -25635,8 +25635,8 @@ footloose/J
 footman/N0g
 footmen/N9
 footnote/~NgSVGd
-footpath/~Ng
-footpaths/~N
+footpath/~N0g
+footpaths/~N9
 footplate/NSV
 footprint/~NSg
 footrace/NgS
@@ -25894,8 +25894,8 @@ foursquare/JN
 fourteen/~SgH
 fourteenth/~JN0g
 fourteenths/N9
-fourth/~JYNgV
-fourths/~N
+fourth/~JYN0gV
+fourths/~N9
 fowl/~NgSVdGJ
 fox/~NgSVGd
 foxfire/Ng
@@ -26866,8 +26866,8 @@ girlishness/Nmg
 girly/JN
 giro/~NSV
 girt/NgSVdGJ
-girth/NwgSV
-girths/N
+girth/N0wgSV
+girths/N9
 GIS/N # Geographic Information System
 gist/NgSV
 git/~NOgSV
@@ -27118,8 +27118,8 @@ goldfield/NS
 goldfinch/NgS
 goldfish/~NgS09     # singular and plural, also has a plural in -s
 goldmine/NSg
-goldsmith/~Ng
-goldsmiths/~N
+goldsmith/~N0g
+goldsmiths/~N9
 golem/NSg
 golf/~NgSVd>GZ
 golfer/~Ng
@@ -27199,7 +27199,7 @@ gossiper/Ng
 gossipy/J
 got/~VtT
 gotcha/NS
-goths/~N
+goths/~N9
 gotta/~V†
 gotten/~VTJ
 gouache/NSV
@@ -27697,8 +27697,8 @@ gunrunning/Ng
 gunship/NgS
 gunshot/~NgS
 gunslinger/~NSg
-gunsmith/Ng
-gunsmiths/N
+gunsmith/N0g
+gunsmiths/N9
 gunsmoke/Nmg
 gunwale/NgS
 guppy/NSg
@@ -27833,8 +27833,8 @@ hailstorm/NgS
 hair/~NwgSVd
 hairball/NgS
 hairband/NS
-hairbreadth/Ng
-hairbreadths/N
+hairbreadth/N0g
+hairbreadths/N9
 hairbrush/NgSV
 haircloth/Ng
 haircut/~NSgV
@@ -27850,8 +27850,8 @@ hairline/NSgJ
 hairnet/NSg
 hairpiece/NgS
 hairpin/~NSg
-hairsbreadth/Ng
-hairsbreadths/N
+hairsbreadth/N0g
+hairsbreadths/N9
 hairsplitter/NSg
 hairsplitting/NgV
 hairspray/NwSV
@@ -28307,9 +28307,9 @@ heartbroken/~J
 heartburn/~Ng
 hearten/VSGdE
 heartfelt/~J
-hearth/~Ng
+hearth/~N0g
 hearthrug/NS
-hearths/~N
+hearths/~N9
 hearthstone/NSgV
 heartily/Ry
 heartiness/Ng
@@ -28331,13 +28331,13 @@ heat's
 heated/~VtTJU
 heatedly/Ry
 heater/~NSg
-heath/~Ng>nX
+heath/~N0g>nX
 heathen/~JNg
 heathendom/Ng
 heathenish/J
 heathenism/Nmg
 heather/~NmgJ
-heaths/N
+heaths/N9
 heating/~NmgJV6
 heatproof/JV
 heatstroke/Ng
@@ -29316,8 +29316,8 @@ hutch/NgSV
 huzzah/NgVdG
 huzzahs/N
 hwy/~N
-hyacinth/Ng
-hyacinths/N
+hyacinth/N0g
+hyacinths/N9
 hybrid/~NSgJ
 hybridisation/NwSg!_₹
 hybridise/VdSG!_₹
@@ -31272,8 +31272,8 @@ jobless/Jp
 joblessness/Ng
 jobseeker/NgS
 jobshare/NSV
-jobsworth/N
-jobsworths/N
+jobsworth/N0
+jobsworths/N9
 jock/~NgSV
 jockey/~NSgVGd
 jockstrap/NgS
@@ -31832,7 +31832,7 @@ labour-intensive/J!@_₹
 labourer/Ng!@_₹
 laboursaving/J!@_₹
 laburnum/NgS
-labyrinth/~NgV
+labyrinth/~N0gV
 labyrinthine/J
 labyrinths/N9Vh
 lac/~Ng
@@ -32047,11 +32047,11 @@ latent/~JYNgS
 lateral/~JYNgSVdG
 latest/~JNg
 latex/~Ng
-lath/NgSVd>GZ
+lath/N0gSVd>GZ
 lathe/~VNg
 lather/NmgVGd
 lathery/J
-laths/N
+laths/N9
 latices/9
 latish/J
 latitude/~NgS
@@ -32816,8 +32816,8 @@ locket/NgS
 lockfile/NgS
 lockjaw/Ng
 lockout/~NgS
-locksmith/~Ng
-locksmiths/N
+locksmith/~N0g
+locksmiths/N9
 lockstep/Ng
 lockup/NgS
 loco/~JNSV
@@ -33450,8 +33450,8 @@ mammary/JN
 mammogram/NgS
 mammography/Nmg
 mammon/Og
-mammoth/~N9gJ
-mammoths/~N0
+mammoth/~N0gJ
+mammoths/~N9
 mammy/NSg
 man/~NSVU           # removed pron: not a pronoun, dialectal, adj: marginal, proper noun: ? - complicates lint heuristics
 man child/Ng
@@ -33779,7 +33779,7 @@ mathematisation/Ng!_₹
 mathematise/VdSG!_₹
 mathematization/Ng
 mathematize/VSdG
-maths/NVh!_₹
+maths/N0Vh!_₹
 matinee/NSgV
 mating/~JNgV6
 matins/Ng
@@ -33969,12 +33969,12 @@ megabucks/Ng
 megabyte/NgS
 megachurch/NgS
 megacycle/NSg
-megadeath/Ng
-megadeaths/N
+megadeath/N0g
+megadeaths/N9
 megagram/NS
 megahertz/Ng
 megajoule/NS
-megalith/N9g
+megalith/N0g
 megalithic/~J
 megaliths/N9
 megalomania/Ng
@@ -34465,8 +34465,8 @@ milling/~NgV6
 million/~SHg
 millionaire/~NSg
 millionairess/NS
-millionth/JNg
-millionths/N
+millionth/JN0g
+millionths/N9
 millipede/NSg
 millisecond/NSg
 millivolt/NSg
@@ -35020,9 +35020,9 @@ monogramming/V6
 monograph/~NgV
 monographs/~N
 monolingual/~JNgS
-monolith/~NgV
+monolith/~N0gV
 monolithic/~JQ
-monoliths/N
+monoliths/N9
 monologist/NSg
 monologue/~NSgV
 monomania/Nmg
@@ -35067,7 +35067,7 @@ monstrance/NSgr
 monstrosity/NSg
 monstrous/~JY
 montage/~NSgV
-month/~NgY
+month/~N0gY
 monthly/~JNSgR8
 months/~N9
 monument/~NgSV
@@ -35189,7 +35189,7 @@ mote/NSVKeXvn
 mote's
 motel/~NSgV
 motet/NSg
-moth/~NgV
+moth/~N0gV
 mothball/NgSVGd
 mother/~NgSVdGY
 motherboard/~NSg
@@ -35236,7 +35236,7 @@ motorization/Ng
 motorize/VdSG
 motorman/N0g
 motormen/N9
-motormouth/NgV
+motormouth/N0gV
 motormouths/N9Vh
 motorsport/NgS
 motorway/~NSg
@@ -36125,15 +36125,15 @@ nine/~NgS
 ninepin/NgS
 ninepins/Ng
 nineteen/~SgH
-nineteenth/~JNg
-nineteenths/N
-ninetieth/JNg
-ninetieths/N
+nineteenth/~JN0g
+nineteenths/N9
+ninetieth/JN0g
+ninetieths/N9
 ninety/~SHg
 ninja/~NSg09JV      # singular and plural, also has a plural in -s
 ninny/NSg
-ninth/~JNgV
-ninths/N
+ninth/~JN0gV
+ninths/N9
 niobium/~Nmg
 nip/~VSNg
 nipped/VtT
@@ -37412,9 +37412,9 @@ ostensibly/~Ry
 ostentation/Ng
 ostentatious/JY
 osteoarthritis/~Ng
-osteopath/NgS
+osteopath/N0gS
 osteopathic/J
-osteopaths/N
+osteopaths/N9
 osteopathy/Ng
 osteoporosis/Ng
 ostler/NS
@@ -37728,8 +37728,8 @@ overgrew/V
 overground/~JNV
 overgrow/VSGH
 overgrown/~JV
-overgrowth/Nmg
-overgrowths/9
+overgrowth/Nw0g
+overgrowths/N9
 overhand/JNgSVd
 overhang/~VGSNg
 overhasty/J
@@ -39744,8 +39744,8 @@ pliant/JY
 pliers/Ng
 plight/~NSgVdG
 plimsoll/NS
-plinth/Ng
-plinths/N
+plinth/N0g
+plinths/N9
 plod/NSVb
 plodded/VtT
 plodder/NgS
@@ -41172,7 +41172,7 @@ psychometric/J
 psychometrician/NSg
 psychoneuroses/N
 psychoneurosis/Ng
-psychopath/Ng
+psychopath/N0g
 psychopathic/JN
 psychopathology/N
 psychopaths/N9
@@ -44403,7 +44403,7 @@ secessionist/~NgSJ
 seclude/VGdS
 seclusion/~Nwg
 seclusive/JN
-second/~JY>NSgVGdLZ
+second/~JY>N0SgVGdLZ
 second-degree/J
 secondarily/R       # ordinal/sentence adverb
 secondary/~JNSg
@@ -45421,8 +45421,8 @@ silty/J^>
 silver/~NmgSJVGd
 silverfish/N09gS    # singular and plural, also has a plural in -s
 silverish/J
-silversmith/Ng
-silversmiths/N
+silversmith/N0g
+silversmiths/N9
 silverware/~Nmg
 silvery/~J
 sim/~NSgV
@@ -45950,10 +45950,10 @@ smoky/~J>^p
 smolder/VGdSNg
 smooch/NgSVdG
 smoochy/J
-smooth/~JY^>pNVdG
+smooth/~JY^>pN0VdG
 smoothie/NwgS
 smoothness/Ng
-smooths/NVh
+smooths/N9Vh
 smorgasbord/NSg
 smote/V
 smother/VGdSNg
@@ -46161,9 +46161,9 @@ socioeconomic/~JQ
 sociological/~JY
 sociologist/~NSg
 sociology/~Nmg
-sociopath/Ng
+sociopath/N0g
 sociopathic/J
-sociopaths/N
+sociopaths/N9
 sociopathy/NwgS
 sociopolitical/J
 sock/~NgSVdGJ
@@ -47274,8 +47274,8 @@ stile/NSgV
 stiletto/NSgV
 still/~J^RNSVGd
 still's
-stillbirth/Ng
-stillbirths/N
+stillbirth/Nwg
+stillbirths/N9
 stillborn/~JN
 stilled/JVtT
 stiller/~JN
@@ -48314,9 +48314,9 @@ swashbuckling/Jg
 swastika/NSg
 swat/~VSNg
 swatch/NgSV
-swath/NgSGd<
-swathe/NgV!@_₹
-swaths/N<
+swath/N0gSGd<
+swathe/N0gV!@_₹
+swaths/N9<
 swatted/VtT
 swatter/NSgVdG
 swatting/V6N
@@ -48519,7 +48519,7 @@ synthesiser/~NgS!_₹
 synthesize/~VGd>SZ
 synthesizer/~NgS
 synthetic/~JNSgQ
-synths/N9V
+synths/N9
 syphilis/~Nmg
 syphilitic/JNSg
 syringe/NSgVdG
@@ -49354,10 +49354,10 @@ thirstily/Ry
 thirstiness/Nmg
 thirsty/~J^>pN
 thirteen/~SgH
-thirteenth/~JNg
-thirteenths/N
-thirtieth/JNg
-thirtieths/N
+thirteenth/~JN0g
+thirteenths/N9
+thirtieth/JN0g
+thirtieths/N9
 thirty/~NSgH
 this/~IDM
 thistle/~NgS
@@ -49390,8 +49390,8 @@ thoughtless/JYp
 thoughtlessness/Nmg
 thousand/~NgSH
 thousandfold/J
-thousandth/JNg
-thousandths/N
+thousandth/JN0g
+thousandths/N9
 thraldom/Ng!_₹
 thrall/NSgJVdG
 thralldom/Ng
@@ -49634,8 +49634,8 @@ tinpot/JN
 tinsel/NSgJVGd
 tinselled/VtT!@_₹
 tinselling/V6!@_₹
-tinsmith/NSg
-tinsmiths/N
+tinsmith/N0g
+tinsmiths/N9
 tint/~NgSVdG
 tintinnabulation/NgS
 tintype/NgSV
@@ -49762,8 +49762,8 @@ tolerant/~JYi
 tolerate/~VGdSn
 toleration/~Ng
 toll/~NgSVdG
-tollbooth/Ng
-tollbooths/N
+tollbooth/N0g
+tollbooths/N9
 tollgate/NSgV
 tollway/NSg
 toluene/NSg
@@ -49994,8 +49994,8 @@ townsmen/9
 townspeople/~N9g
 townswoman/Ng
 townswomen/9
-towpath/Ng
-towpaths/N
+towpath/N0g
+towpaths/N9
 towrope/NSg
 toxaemia/Ng!_₹
 toxemia/Ng
@@ -50401,8 +50401,8 @@ trilby/NSg
 trill/NSgVGdJ
 trillion/~NSgH
 trillionaire/NSg
-trillionth/JNg
-trillionths/N
+trillionth/JN0g
+trillionths/N9
 trillium/Nmg
 trilobite/~NSg
 trilogy/~NSg
@@ -50738,8 +50738,8 @@ tweezers/~Ng
 twelfth/~JN0g
 twelfths/N9
 twelve/~NSg
-twelvemonth/Ng
-twelvemonths/N
+twelvemonth/N0g
+twelvemonths/N9
 twentieth/~JN0g
 twentieths/N9
 twenty/~NSgH
@@ -51084,8 +51084,8 @@ undermanned/VtTJ
 undermentioned/J
 undermine/~VGdS
 undermost/J
-underneath/~PJNg
-underneaths/N
+underneath/~PJN0g
+underneaths/N9
 undernourished/J
 undernourishment/Ng
 underpaid/J
@@ -52648,8 +52648,8 @@ wave/~VGd>SNgZ
 waveband/NS
 waveform/~N
 wavefront/NSg
-wavelength/~Ng
-wavelengths/~N
+wavelength/~N0g
+wavelengths/~N9
 wavelet/NSg
 wavelike/J
 wavenumber/NgS
@@ -53081,8 +53081,8 @@ widget/NS
 widow/~NSgVd>GZ
 widower/~Ng
 widowhood/~Nmg
-width/~Nwg
-widths/~N
+width/~N0wg
+widths/~N9
 wield/~Vd>GSNZ
 wielder/Ng
 wiener/~NSg
@@ -53748,10 +53748,10 @@ your/~D5
 yours/~I
 yourself/~Ia2F.     # I~pronoun a~personal 2~person F~reflexive
 yourselves/~Ia2F:   # I~pronoun a~personal 2~person :~plural F~reflexive
-youth/~Ng
+youth/~N0g
 youthful/~JYp
 youthfulness/Ng
-youths/~9
+youths/~N9
 yow/N
 yowie/NgS           # Australian mythological creature
 yowl/NgSVdG

--- a/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
+++ b/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
@@ -106,8 +106,8 @@
 # N🅪Sg/VB/J/P . N🅪Sg/VB/J/P . N🅪Sg/VB/J/P . VXB   D+  N🅪Sg/VB+ R     NSg/VBPp/P P  D/P+ NSg/VB+ . . ISg/#r+ N🅪Sg/VB NSg/C NSg/I/J/Dq+ NPrPl+
 > I’ve fallen by this   time       ? ” she  said aloud . “ I       must    be       getting somewhere near       the
 # K    VPp/J  P  I/Ddem N🅪Sg/VB/J+ . . ISg+ VP/J J     . . ISg/#r+ NSg/VXB NSg/VLXB NSg/Vg  R         NSg/VB/J/P D
-> centre      of the earth    . Let     me       see    : that      would be       four thousand miles  down        , I
-# NSg/VB/Comm P  D+  NPrᴹ/VB+ . NSg/VBP NPr/ISg+ NSg/VB . I/C/Ddem+ VXB   NSg/VLXB NSg+ NSg+     NPrPl+ N🅪Sg/VB/J/P . ISg/#r+
+> centre      of the earth      . Let     me       see    : that      would be       four thousand miles  down        , I
+# NSg/VB/Comm P  D+  NPr🅪Sg/VB+ . NSg/VBP NPr/ISg+ NSg/VB . I/C/Ddem+ VXB   NSg/VLXB NSg+ NSg+     NPrPl+ N🅪Sg/VB/J/P . ISg/#r+
 > think  — ” ( for   , you    see    , Alice had learnt several things of this    sort    in        her
 # NSg/VB . . . R/C/P . ISgPl+ NSg/VB . NPr+  VP  VB     J/Dq    NPl    P  I/Ddem+ NSg/VB+ NPr/J/R/P ISg/D$+
 > lessons in        the schoolroom , and  though this    was  not     a   very good     opportunity for
@@ -122,8 +122,8 @@
 # VLPt . NPr/C NSg+      I/C    . NSg/C/P N🅪Sg/VP IPl+ VLPt NPr/J NSg/J NPl/V3 P  NSg/VB . .
 >
 #
-> Presently she  began again . “ I       wonder  if    I       shall fall     right    through the earth    !
-# R         ISg+ VPt   P     . . ISg/#r+ N🅪Sg/VB NSg/C ISg/#r+ VXB   N🅪Sg/VB+ NPr/VB/J J/P     D+  NPrᴹ/VB+ .
+> Presently she  began again . “ I       wonder  if    I       shall fall     right    through the earth      !
+# R         ISg+ VPt   P     . . ISg/#r+ N🅪Sg/VB NSg/C ISg/#r+ VXB   N🅪Sg/VB+ NPr/VB/J J/P     D+  NPr🅪Sg/VB+ .
 > How   funny it’ll seem to come       out          among the people  that      walk   with their heads
 # NSg/C NSg/J K     VB   P  NSg/VBPp/P NSg/VB/J/R/P P     D   NPl/VB+ I/C/Ddem+ NSg/VB P    D$+   NPl/V3+
 > downward ! The Antipathies , I       think  — ” ( she  was  rather     glad     there was  no       one
@@ -2362,8 +2362,8 @@
 # . I/C+  VXB   NSg/R/C NSg/VLXB D/P+ N🅪Sg/VB+  . . VP/J NPr+  . NPr/I+ N🅪Sg/VP/J J/R  NSg/VB/J P  NSg/VB D/P
 > opportunity of showing off        a   little     of her     knowledge . “ Just think  of what   work
 # N🅪Sg        P  Nᴹ/Vg/J NSg/VB/J/P D/P NPr/I/J/Dq P  ISg/D$+ Nᴹ+       . . J/R  NSg/VB P  NSg/I+ N🅪Sg/VB+
-> it       would make   with the day    and  night    ! You    see    the earth    takes  twenty - four hours
-# NPr/ISg+ VXB   NSg/VB P    D   NPr🅪Sg VB/C N🅪Sg/VB+ . ISgPl+ NSg/VB D+  NPrᴹ/VB+ NPl/V3 NSg    . NSg  NPl
+> it       would make   with the day    and  night    ! You    see    the earth      takes  twenty - four hours
+# NPr/ISg+ VXB   NSg/VB P    D   NPr🅪Sg VB/C N🅪Sg/VB+ . ISgPl+ NSg/VB D+  NPr🅪Sg/VB+ NPl/V3 NSg    . NSg  NPl
 > to turn   round      on  its     axis — ”
 # P  NSg/VB NSg/VB/J/P J/P ISg/D$+ NPr+ . .
 >
@@ -4298,8 +4298,8 @@
 # . ISgPl+ NSg/I/VXB P  NSg/VLXB J       P  ISg+     R/C/P Nᴹ/Vg/J NSg/I+ D/P+ NSg/VB/J+ NSg/VB+  . . VP/J
 > the Gryphon ; and  then      they both   sat    silent and  looked at    poor     Alice , who    felt
 # D   ?       . VB/C NSg/J/R/C IPl+ I/C/Dq NSg/VP NSg/J  VB/C VP/J   NSg/P NSg/VB/J NPr+  . NPr/I+ N🅪Sg/VP/J
-> ready    to sink   into the earth    . At    last     the Gryphon said to the Mock     Turtle  ,
-# NSg/VB/J P  NSg/VB P    D   NPrᴹ/VB+ . NSg/P NSg/VB/J D   ?       VP/J P  D   NSg/VB/J NSg/VB+ .
+> ready    to sink   into the earth      . At    last     the Gryphon said to the Mock     Turtle  ,
+# NSg/VB/J P  NSg/VB P    D   NPr🅪Sg/VB+ . NSg/P NSg/VB/J D   ?       VP/J P  D   NSg/VB/J NSg/VB+ .
 > “ Drive   on  , old   fellow ! Don’t be       all          day     about it       ! ” and  he       went    on  in        these
 # . N🅪Sg/VB J/P . NSg/J NSg    . VXB   NSg/VLXB NSg/I/J/C/Dq NPr🅪Sg+ J/P   NPr/ISg+ . . VB/C NPr/ISg+ NSg/VPt J/P NPr/J/R/P I/Ddem+
 > words   :

--- a/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
+++ b/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
@@ -24,8 +24,8 @@
 # P  D/P NSg/VB+ . . N🅪Sg/VP NPr+  . C/P     NPl/V3   NPr/C NPl/V3+       . .
 >
 #
-> So          she  was  considering in        her     own       mind    ( as    well       as    she  could   , for   the hot       day
-# NSg/I/J/R/C ISg+ VLPt Nᴹ/Vg/J     NPr/J/R/P ISg/D$+ NSg/VB/J+ NSg/VB+ . R/C/P NSg/VB/J/R R/C/P ISg+ NSg/VXB . R/C/P D+  NSg/VB/J+ NPr🅪Sg+
+> So          she  was  considering in        her     own       mind    ( as    well       as    she  could , for   the hot       day
+# NSg/I/J/R/C ISg+ VLPt Nᴹ/Vg/J     NPr/J/R/P ISg/D$+ NSg/VB/J+ NSg/VB+ . R/C/P NSg/VB/J/R R/C/P ISg+ VXB   . R/C/P D+  NSg/VB/J+ NPr🅪Sg+
 > made her     feel     very sleepy and  stupid ) , whether the pleasure of making  a
 # VP   ISg/D$+ NSg/I/VB J/R  NSg/J  VB/C NSg/J  . . I/C     D   NSg/VB   P  Nᴹ/Vg/J D/P+
 > daisy - chain    would be       worth    the trouble of getting up         and  picking the daisies ,
@@ -56,14 +56,14 @@
 # N🅪Sg/VB/J/P D/P NSg/J NSg/VB+ . NSg/VB+ NSg/J/P D   NSg/VB+ .
 >
 #
-> In        another moment down        went    Alice after it       , never once  considering how   in        the
-# NPr/J/R/P I/D+    NSg+   N🅪Sg/VB/J/P NSg/VPt NPr+  P     NPr/ISg+ . R     NSg/C Nᴹ/Vg/J     NSg/C NPr/J/R/P D+
+> In        another moment down        went Alice after it       , never once  considering how   in        the
+# NPr/J/R/P I/D+    NSg+   N🅪Sg/VB/J/P VPt  NPr+  P     NPr/ISg+ . R     NSg/C Nᴹ/Vg/J     NSg/C NPr/J/R/P D+
 > world   she  was  to get    out          again .
 # NSg/VB+ ISg+ VLPt P  NSg/VB NSg/VB/J/R/P P     .
 >
 #
-> The rabbit  - hole    went    straight   on  like         a   tunnel for   some      way    , and  then      dipped
-# D+  NSg/VB+ . NSg/VB+ NSg/VPt NSg/VB/J/R J/P NSg/VB/J/C/P D/P NSg/VB R/C/P I/J/R/Dq+ NSg/J+ . VB/C NSg/J/R/C VP/J
+> The rabbit  - hole    went straight   on  like         a   tunnel for   some      way    , and  then      dipped
+# D+  NSg/VB+ . NSg/VB+ VPt  NSg/VB/J/R J/P NSg/VB/J/C/P D/P NSg/VB R/C/P I/J/R/Dq+ NSg/J+ . VB/C NSg/J/R/C VP/J
 > suddenly down        , so          suddenly that     Alice had not     a   moment to think  about stopping
 # R        N🅪Sg/VB/J/P . NSg/I/J/R/C R        I/C/Ddem NPr+  VP  NSg/R/C D/P NSg    P  NSg/VB J/P   NSg/Vg
 > herself before she  found  herself falling down        a   very deep  well       .
@@ -72,14 +72,14 @@
 #
 > Either the well       was  very deep  , or    she  fell      very slowly , for   she  had plenty  of
 # I/C    D   NSg/VB/J/R VLPt J/R  NSg/J . NPr/C ISg+ NSg/VPt/J J/R  R      . R/C/P ISg+ VP  NSg/I/J P
-> time       as    she  went    down        to look   about her     and  to wonder  what   was  going   to happen
-# N🅪Sg/VB/J+ R/C/P ISg+ NSg/VPt N🅪Sg/VB/J/P P  NSg/VB J/P   ISg/D$+ VB/C P  N🅪Sg/VB NSg/I+ VLPt Nᴹ/Vg/J P  VB
+> time       as    she  went down        to look   about her     and  to wonder  what   was  going   to happen
+# N🅪Sg/VB/J+ R/C/P ISg+ VPt  N🅪Sg/VB/J/P P  NSg/VB J/P   ISg/D$+ VB/C P  N🅪Sg/VB NSg/I+ VLPt Nᴹ/Vg/J P  VB
 > next    . First , she  tried to look   down        and  make   out          what   she  was  coming  to , but     it
 # NSg/J/P . NSg/J . ISg+ VP/J  P  NSg/VB N🅪Sg/VB/J/P VB/C NSg/VB NSg/VB/J/R/P NSg/I+ ISg+ VLPt Nᴹ/Vg/J P  . NSg/C/P NPr/ISg+
 > was  too dark     to see    anything  ; then      she  looked at    the sides  of the well       , and
 # VLPt R   NSg/VB/J P  NSg/VB NSg/I/VB+ . NSg/J/R/C ISg+ VP/J   NSg/P D   NPl/V3 P  D   NSg/VB/J/R . VB/C
 > noticed that     they were filled with cupboards and  book    - shelves ; here and  there
-# VP/J    I/C/Ddem IPl+ VLPt VP/J   P    NPl/V3    VB/C NSg/VB+ . NPl/V3+ . J/R  VB/C R+
+# VP/J    I/C/Ddem IPl+ VLPt VP/J   P    NPl/V3    VB/C NSg/VB+ . NPl/V3+ . R    VB/C R+
 > she  saw     maps   and  pictures hung     upon pegs   . She  took down        a    jar     from one     of the
 # ISg+ NSg/VPt NPl/V3 VB/C NPl/V3+  NPr/VP/J P    NPl/V3 . ISg+ VPt  N🅪Sg/VB/J/P D/P+ NSg/VB+ P    NSg/I/J P  D+
 > shelves as    she  passed ; it       was  labelled  “ ORANGE      MARMALADE ” , but     to her     great
@@ -134,8 +134,8 @@
 # NSg/VXB P  NSg/VB NSg/IPl+ NSg/I+ D   NSg/VB P  D   NSg/J+  VL3 . ISgPl+ VB   . VB     . NSg/VB . VL3
 > this   New   Zealand or    Australia ? ” ( and  she  tried to curtsey as    she  spoke   — fancy
 # I/Ddem NSg/J NPr     NPr/C NPr+      . . . VB/C ISg+ VP/J  P  ?       R/C/P ISg+ NSg/VPt . NSg/VB/J
-> curtseying as    you’re falling through the air      ! Do  you    think  you    could   manage it       ? )
-# ?          R/C/P K      Nᴹ/Vg/J J/P     D   N🅪Sg/VB+ . VXB ISgPl+ NSg/VB ISgPl+ NSg/VXB NSg/VB NPr/ISg+ . .
+> curtseying as    you’re falling through the air      ! Do  you    think  you    could manage it       ? )
+# ?          R/C/P K      Nᴹ/Vg/J J/P     D   N🅪Sg/VB+ . VXB ISgPl+ NSg/VB ISgPl+ VXB   NSg/VB NPr/ISg+ . .
 > “ And  what   an   ignorant little      girl    she’ll think  me       for   asking  ! No       , it’ll never do
 # . VB/C NSg/I+ D/P+ NSg/J+   NPr/I/J/Dq+ NSg/VB+ K      NSg/VB NPr/ISg+ R/C/P Nᴹ/Vg/J . NSg/Dq/P . K     R     VXB
 > to ask    : perhaps I       shall see    it       written up         somewhere . ”
@@ -149,11 +149,11 @@
 > cat       . ) “ I       hope      they’ll remember her     saucer of milk     at    tea      - time       . Dinah my  dear     ! I
 # NSg/VB/J+ . . . ISg/#r+ NPr🅪Sg/VB K       NSg/VB   ISg/D$+ NSg/VB P  N🅪Sg/VB+ NSg/P N🅪Sg/VB+ . N🅪Sg/VB/J+ . NPr   D$+ NSg/VB/J . ISg/#r+
 > wish   you    were down        here with me       ! There are no       mice   in        the air      , I’m afraid , but
-# NSg/VB ISgPl+ VLPt N🅪Sg/VB/J/P J/R  P    NPr/ISg+ . R+    VLB NSg/Dq/P NPl/VB NPr/J/R/P D+  N🅪Sg/VB+ . K   J      . NSg/C/P
+# NSg/VB ISgPl+ VLPt N🅪Sg/VB/J/P R    P    NPr/ISg+ . R+    VLB NSg/Dq/P NPl/VB NPr/J/R/P D+  N🅪Sg/VB+ . K   J      . NSg/C/P
 > you    might    catch  a   bat     , and  that’s very like         a   mouse   , you    know . But     do  cats    eat
 # ISgPl+ Nᴹ/VXB/J NSg/VB D/P NSg/VB+ . VB/C K      J/R  NSg/VB/J/C/P D/P NSg/VB+ . ISgPl+ VB   . NSg/C/P VXB NPl/V3+ VB
-> bats   , I       wonder  ? ” And  here Alice began to get    rather     sleepy , and  went    on  saying
-# NPl/V3 . ISg/#r+ N🅪Sg/VB . . VB/C J/R  NPr+  VPt   P  NSg/VB NPr/VB/J/R NSg/J  . VB/C NSg/VPt J/P N🅪Sg/Vg/J
+> bats   , I       wonder  ? ” And  here Alice began to get    rather     sleepy , and  went on  saying
+# NPl/V3 . ISg/#r+ N🅪Sg/VB . . VB/C R    NPr+  VPt   P  NSg/VB NPr/VB/J/R NSg/J  . VB/C VPt  J/P N🅪Sg/Vg/J
 > to herself , in        a   dreamy sort   of way    , “ Do  cats    eat bats   ? Do  cats    eat bats   ? ” and
 # P  ISg+    . NPr/J/R/P D/P J      NSg/VB P  NSg/J+ . . VXB NPl/V3+ VB  NPl/V3 . VXB NPl/V3+ VB  NPl/V3 . . VB/C
 > sometimes , “ Do  bats   eat cats    ? ” for   , you    see    , as    she  couldn’t answer  either
@@ -176,8 +176,8 @@
 # VP/J   NSg/VB/J/P . NSg/C/P NPr/ISg+ VLPt NSg/I/J/C/Dq NSg/VB/J NSg/J/P  . C/P    ISg/D$+ VLPt I/D     NPr/VB/J NSg/VB/J .
 > and  the White        Rabbit  was  still      in        sight    , hurrying down        it       . There was  not     a
 # VB/C D+  NPr🅪Sg/VB/J+ NSg/VB+ VLPt NSg/VB/J/R NPr/J/R/P N🅪Sg/VB+ . Nᴹ/Vg/J  N🅪Sg/VB/J/P NPr/ISg+ . R+    VLPt NSg/R/C D/P
-> moment to be       lost : away went    Alice like         the wind     , and  was  just in        time       to hear
-# NSg+   P  NSg/VLXB VP/J . VB/J NSg/VPt NPr+  NSg/VB/J/C/P D+  N🅪Sg/VB+ . VB/C VLPt J/R  NPr/J/R/P N🅪Sg/VB/J+ P  VB
+> moment to be       lost : away went Alice like         the wind     , and  was  just in        time       to hear
+# NSg+   P  NSg/VLXB VP/J . VB/J VPt  NPr+  NSg/VB/J/C/P D+  N🅪Sg/VB+ . VB/C VLPt J/R  NPr/J/R/P N🅪Sg/VB/J+ P  VB
 > it       say    , as    it       turned a    corner  , “ Oh     my  ears    and  whiskers , how   late  it’s getting ! ”
 # NPr/ISg+ NSg/VB . R/C/P NPr/ISg+ VP/J   D/P+ NSg/VB+ . . NPr/VB D$+ NPl/V3+ VB/C NPl      . NSg/C NSg/J K    NSg/Vg  . .
 > She  was  close    behind  it       when    she  turned the corner  , but     the Rabbit  was  no       longer
@@ -222,12 +222,12 @@
 # JS        NSg/VB/J+ ISgPl+ J/R  NSg/VPt . NSg/C ISg+ VP/J   P  NSg/VB NSg/VB/J/R/P P  I/C/Ddem+ NSg/VB/J+ NPr+ . VB/C
 > wander about among those  beds   of bright    flowers   and  those  cool     fountains , but
 # NSg/VB J/P   P     I/Ddem NPl/V3 P  NPr/VB/J+ NPrPl/V3+ VB/C I/Ddem NSg/VB/J NPl/V3    . NSg/C/P
-> she  could   not     even       get    her     head      through the doorway ; “ and  even       if    my  head      would
-# ISg+ NSg/VXB NSg/R/C NSg/VB/J/R NSg/VB ISg/D$+ NPr/VB/J+ J/P     D   NSg+    . . VB/C NSg/VB/J/R NSg/C D$+ NPr/VB/J+ VXB
+> she  could not     even       get    her     head      through the doorway ; “ and  even       if    my  head      would
+# ISg+ VXB   NSg/R/C NSg/VB/J/R NSg/VB ISg/D$+ NPr/VB/J+ J/P     D   NSg+    . . VB/C NSg/VB/J/R NSg/C D$+ NPr/VB/J+ VXB
 > go       through , ” thought poor     Alice , “ it       would be       of very little     use     without my
 # NSg/VB/J J/P     . . N🅪Sg/VP NSg/VB/J NPr+  . . NPr/ISg+ VXB   NSg/VLXB P  J/R  NPr/I/J/Dq N🅪Sg/VB C/P     D$+
-> shoulders . Oh     , how   I       wish   I       could   shut      up         like         a    telescope ! I       think  I       could   , if
-# NPl/V3+   . NPr/VB . NSg/C ISg/#r+ NSg/VB ISg/#r+ NSg/VXB NSg/VBP/J NSg/VB/J/P NSg/VB/J/C/P D/P+ NSg/VB+   . ISg/#r+ NSg/VB ISg/#r+ NSg/VXB . NSg/C
+> shoulders . Oh     , how   I       wish   I       could shut      up         like         a    telescope ! I       think  I       could , if
+# NPl/V3+   . NPr/VB . NSg/C ISg/#r+ NSg/VB ISg/#r+ VXB   NSg/VBP/J NSg/VB/J/P NSg/VB/J/C/P D/P+ NSg/VB+   . ISg/#r+ NSg/VB ISg/#r+ VXB   . NSg/C
 > I       only  knew how   to begin  . ” For   , you    see    , so          many       out          - of - the - way   things had
 # ISg/#r+ J/R/C VPt  NSg/C P  NSg/VB . . R/C/P . ISgPl+ NSg/VB . NSg/I/J/R/C NSg/I/J/Dq NSg/VB/J/R/P . P  . D   . NSg/J NPl+   VP
 > happened lately , that     Alice had begun to think  that     very few       things indeed were
@@ -236,14 +236,14 @@
 # R      NSg/J      .
 >
 #
-> There seemed to be       no       use     in        waiting  by the little      door    , so          she  went    back     to the
-# R+    VP/J   P  NSg/VLXB NSg/Dq/P N🅪Sg/VB NPr/J/R/P Nᴹ/Vg/J+ P  D+  NPr/I/J/Dq+ NSg/VB+ . NSg/I/J/R/C ISg+ NSg/VPt NSg/VB/J P  D+
+> There seemed to be       no       use     in        waiting  by the little      door    , so          she  went back     to the
+# R+    VP/J   P  NSg/VLXB NSg/Dq/P N🅪Sg/VB NPr/J/R/P Nᴹ/Vg/J+ P  D+  NPr/I/J/Dq+ NSg/VB+ . NSg/I/J/R/C ISg+ VPt  NSg/VB/J P  D+
 > table   , half      hoping  she  might    find   another key      on  it       , or    at    any    rate    a   book   of
 # NSg/VB+ . N🅪Sg/J/P+ Nᴹ/Vg/J ISg+ Nᴹ/VXB/J NSg/VB I/D     NPr/VB/J J/P NPr/ISg+ . NPr/C NSg/P I/R/Dq NSg/VB+ D/P NSg/VB P
 > rules   for   shutting people  up         like         telescopes : this   time       she  found  a   little
 # NPl/V3+ R/C/P NSg/Vg   NPl/VB+ NSg/VB/J/P NSg/VB/J/C/P NPl/V3     . I/Ddem N🅪Sg/VB/J+ ISg+ NSg/VP D/P NPr/I/J/Dq
 > bottle  on  it       , ( “ which certainly was  not     here before , ” said Alice , ) and  round      the
-# NSg/VB+ J/P NPr/ISg+ . . . I/C+  R         VLPt NSg/R/C J/R  C/P    . . VP/J NPr+  . . VB/C NSg/VB/J/P D
+# NSg/VB+ J/P NPr/ISg+ . . . I/C+  R         VLPt NSg/R/C R    C/P    . . VP/J NPr+  . . VB/C NSg/VB/J/P D
 > neck   of the bottle  was  a   paper      label   , with the words   “ DRINK   ME       , ” beautifully
 # NSg/VB P  D   NSg/VB+ VLPt D/P N🅪Sg/VB/J+ NSg/VB+ . P    D   NPl/V3+ . NSg/VB+ NPr/ISg+ . . R
 > printed on  it       in        large letters .
@@ -298,18 +298,18 @@
 # NSg        . NSg/VB/J/C/P D/P+ NSg/VB+ . ISg/#r+ N🅪Sg/VB NSg/I+ ISg/#r+ VXB    NSg/VLXB NSg/VB/J/C/P NSg/J/R/C . . VB/C ISg+ VP/J
 > to fancy    what   the flame    of a    candle  is  like         after the candle  is  blown out          , for
 # P  NSg/VB/J NSg/I+ D   NSg/VB/J P  D/P+ NSg/VB+ VL3 NSg/VB/J/C/P P     D+  NSg/VB+ VL3 VPp/J NSg/VB/J/R/P . R/C/P
-> she  could   not     remember ever having  seen    such   a    thing .
-# ISg+ NSg/VXB NSg/R/C NSg/VB   J/R  Nᴹ/Vg/J NSg/VPp NSg/I+ D/P+ NSg+  .
+> she  could not     remember ever having  seen    such   a    thing .
+# ISg+ VXB   NSg/R/C NSg/VB   J/R  Nᴹ/Vg/J NSg/VPp NSg/I+ D/P+ NSg+  .
 >
 #
 > After a    while       , finding that     nothing  more         happened , she  decided  on  going   into the
 # P     D/P+ NSg/VB/C/P+ . Nᴹ/Vg/J I/C/Ddem NSg/I/J+ NPr/I/J/R/Dq VP/J     . ISg+ NSg/VP/J J/P Nᴹ/Vg/J P    D+
 > garden    at    once  ; but     , alas  for   poor      Alice ! when    she  got to the door    , she  found
 # NSg/VB/J+ NSg/P NSg/C . NSg/C/P . NPrPl R/C/P NSg/VB/J+ NPr+  . NSg/I/C ISg+ VP  P  D+  NSg/VB+ . ISg+ NSg/VP
-> she  had forgotten the little     golden   key      , and  when    she  went    back     to the table   for
-# ISg+ VP  NSg/VPp/J D   NPr/I/J/Dq NPr/VB/J NPr/VB/J . VB/C NSg/I/C ISg+ NSg/VPt NSg/VB/J P  D+  NSg/VB+ R/C/P
-> it       , she  found  she  could   not     possibly reach  it       : she  could   see    it       quite plainly
-# NPr/ISg+ . ISg+ NSg/VP ISg+ NSg/VXB NSg/R/C R        NSg/VB NPr/ISg+ . ISg+ NSg/VXB NSg/VB NPr/ISg+ R     R
+> she  had forgotten the little     golden   key      , and  when    she  went back     to the table   for
+# ISg+ VP  NSg/VPp/J D   NPr/I/J/Dq NPr/VB/J NPr/VB/J . VB/C NSg/I/C ISg+ VPt  NSg/VB/J P  D+  NSg/VB+ R/C/P
+> it       , she  found  she  could not     possibly reach  it       : she  could see    it       quite plainly
+# NPr/ISg+ . ISg+ NSg/VP ISg+ VXB   NSg/R/C R        NSg/VB NPr/ISg+ . ISg+ VXB   NSg/VB NPr/ISg+ R     R
 > through the glass      , and  she  tried her     best       to climb  up         one     of the legs   of the
 # J/P     D   NPr🅪Sg/VB+ . VB/C ISg+ VP/J  ISg/D$+ NPr/VXB/JS P  NSg/VB NSg/VB/J/P NSg/I/J P  D   NPl/V3 P  D
 > table   , but     it       was  too slippery ; and  when    she  had tired herself out          with trying  ,
@@ -362,8 +362,8 @@
 # I/Ddem R         V3      NSg/I/C NSg/I/J V3   N🅪Sg/VB+ . NSg/C/P NPr+  VP  VP  NSg/I/J/R/C NSg/I/J/R/Dq P    D
 > way   of expecting nothing  but     out          - of - the - way   things to happen , that     it       seemed
 # NSg/J P  Nᴹ/Vg/J   NSg/I/J+ NSg/C/P NSg/VB/J/R/P . P  . D   . NSg/J NPl    P  VB     . I/C/Ddem NPr/ISg+ VP/J
-> quite dull and  stupid for   life     to go       on  in        the common    way    .
-# R     VB/J VB/C NSg/J  R/C/P N🅪Sg/VB+ P  NSg/VB/J J/P NPr/J/R/P D+  NSg/VB/J+ NSg/J+ .
+> quite dull and  stupid for   life     to go       on  in        the common way    .
+# R     VB/J VB/C NSg/J  R/C/P N🅪Sg/VB+ P  NSg/VB/J J/P NPr/J/R/P D+  VB/J+  NSg/J+ .
 >
 #
 > So          she  set       to work    , and  very soon finished off        the cake     .
@@ -396,8 +396,8 @@
 # NPr/VB/J+ . .
 >
 #
-> And  she  went    on  planning to herself how   she  would manage it       . “ They must    go       by
-# VB/C ISg+ NSg/VPt J/P NSg/Vg   P  ISg+    NSg/C ISg+ VXB   NSg/VB NPr/ISg+ . . IPl+ NSg/VXB NSg/VB/J P
+> And  she  went on  planning to herself how   she  would manage it       . “ They must    go       by
+# VB/C ISg+ VPt  J/P NSg/Vg   P  ISg+    NSg/C ISg+ VXB   NSg/VB NPr/ISg+ . . IPl+ NSg/VXB NSg/VB/J P
 > the carrier , ” she  thought ; “ and  how   funny it’ll seem , sending presents to one’s
 # D+  NPr+    . . ISg+ N🅪Sg/VP . . VB/C NSg/C NSg/J K     VB   . Nᴹ/Vg/J NPl/V3+  P  NSg$
 > own      feet ! And  how   odd    the directions will    look   !
@@ -420,8 +420,8 @@
 # NSg/VB/J/P P  D+  NSg/VB/J+ NSg/VB+ .
 >
 #
-> Poor      Alice ! It       was  as    much         as    she  could   do  , lying   down        on  one      side      , to look
-# NSg/VB/J+ NPr+  . NPr/ISg+ VLPt R/C/P NSg/I/J/R/Dq R/C/P ISg+ NSg/VXB VXB . Nᴹ/Vg/J N🅪Sg/VB/J/P J/P NSg/I/J+ NSg/VB/J+ . P  NSg/VB
+> Poor      Alice ! It       was  as    much         as    she  could do  , lying   down        on  one      side      , to look
+# NSg/VB/J+ NPr+  . NPr/ISg+ VLPt R/C/P NSg/I/J/R/Dq R/C/P ISg+ VXB   VXB . Nᴹ/Vg/J N🅪Sg/VB/J/P J/P NSg/I/J+ NSg/VB/J+ . P  NSg/VB
 > through into the garden    with one      eye     ; but     to get    through was  more         hopeless than
 # J/P     P    D   NSg/VB/J+ P    NSg/I/J+ NSg/VB+ . NSg/C/P P  NSg/VB J/P     VLPt NPr/I/J/R/Dq J        C/P
 > ever : she  sat    down        and  began to cry    again .
@@ -432,8 +432,8 @@
 # . ISgPl+ NSg/I/VXB P  NSg/VLXB J       P  ISg+     . . VP/J NPr+  . . D/P NSg/J NSg/VB+ NSg/VB/J/C/P ISgPl+ . . . ISg+
 > might    well       say    this    ) , “ to go       on  crying  in        this    way    ! Stop   this    moment , I       tell
 # Nᴹ/VXB/J NSg/VB/J/R NSg/VB I/Ddem+ . . . P  NSg/VB/J J/P Nᴹ/Vg/J NPr/J/R/P I/Ddem+ NSg/J+ . NSg/VB I/Ddem+ NSg+   . ISg/#r+ NPr/VB
-> you    ! ” But     she  went    on  all          the same , shedding gallons of tears   , until there was  a
-# ISgPl+ . . NSg/C/P ISg+ NSg/VPt J/P NSg/I/J/C/Dq D   I/J  . NSg/Vg   NPl     P  NPl/V3+ . C/P   R+    VLPt D/P
+> you    ! ” But     she  went on  all          the same , shedding gallons of tears   , until there was  a
+# ISgPl+ . . NSg/C/P ISg+ VPt  J/P NSg/I/J/C/Dq D   I/J  . NSg/Vg   NPl     P  NPl/V3+ . C/P   R+    VLPt D/P
 > large pool    all          round      her     , about four inches  deep  and  reaching half      down        the
 # NSg/J NSg/VB+ NSg/I/J/C/Dq NSg/VB/J/P ISg/D$+ . J/P   NSg  NPl/V3+ NSg/J VB/C Nᴹ/Vg/J  N🅪Sg/J/P+ N🅪Sg/VB/J/P D
 > hall .
@@ -456,16 +456,16 @@
 # P  I/R/Dq+ NSg/I/J+ . NSg/I/J/R/C . NSg/I/C D+  NSg/VB+ NSg/VPt/P NSg/VB/J/P ISg/D$+ . ISg+ VPt   . NPr/J/R/P D/P NSg/VB/J/R . J+    NSg/VB+ .
 > “ If    you    please , sir     — ” The Rabbit  started violently , dropped the white        kid     gloves
 # . NSg/C ISgPl+ VB     . NPr/VB+ . . D+  NSg/VB+ VP/J    R         . VP/J    D+  NPr🅪Sg/VB/J+ NSg/VB+ NPl/V3
-> and  the fan     , and  skurried away into the darkness as    hard     as    he       could   go       .
-# VB/C D+  NSg/VB+ . VB/C ?        VB/J P    D   Nᴹ+      R/C/P N🅪Sg/J/R R/C/P NPr/ISg+ NSg/VXB NSg/VB/J .
+> and  the fan     , and  skurried away into the darkness as    hard     as    he       could go       .
+# VB/C D+  NSg/VB+ . VB/C ?        VB/J P    D   Nᴹ+      R/C/P N🅪Sg/J/R R/C/P NPr/ISg+ VXB   NSg/VB/J .
 >
 #
 > Alice took up         the fan    and  gloves  , and  , as    the hall was  very hot      , she  kept
 # NPr+  VPt  NSg/VB/J/P D   NSg/VB VB/C NPl/V3+ . VB/C . R/C/P D+  NPr+ VLPt J/R  NSg/VB/J . ISg+ VP
-> fanning herself all          the time       she  went    on  talking : “ Dear     , dear     ! How   queer
-# NSg/Vg  ISg+    NSg/I/J/C/Dq D   N🅪Sg/VB/J+ ISg+ NSg/VPt J/P Nᴹ/Vg/J . . NSg/VB/J . NSg/VB/J . NSg/C NSg/VB/J
-> everything is  to - day     ! And  yesterday things went    on  just as    usual . I       wonder  if
-# NSg/I/VB+  VL3 P  . NPr🅪Sg+ . VB/C NSg+      NPl+   NSg/VPt J/P J/R  R/C/P NSg/J . ISg/#r+ N🅪Sg/VB NSg/C
+> fanning herself all          the time       she  went on  talking : “ Dear     , dear     ! How   queer
+# NSg/Vg  ISg+    NSg/I/J/C/Dq D   N🅪Sg/VB/J+ ISg+ VPt  J/P Nᴹ/Vg/J . . NSg/VB/J . NSg/VB/J . NSg/C NSg/VB/J
+> everything is  to - day     ! And  yesterday things went on  just as    usual . I       wonder  if
+# NSg/I/VB+  VL3 P  . NPr🅪Sg+ . VB/C NSg+      NPl+   VPt  J/P J/R  R/C/P NSg/J . ISg/#r+ N🅪Sg/VB NSg/C
 > I’ve been   changed in        the night    ? Let     me       think  : was  I       the same when    I       got up         this
 # K    VLPp/B VP/J    NPr/J/R/P D   N🅪Sg/VB+ . NSg/VBP NPr/ISg+ NSg/VB . VLPt ISg/#r+ D   I/J  NSg/I/C ISg/#r+ VP  NSg/VB/J/P I/Ddem+
 > morning    ? I       almost think  I       can     remember feeling   a   little     different . But     if    I’m
@@ -474,8 +474,8 @@
 # NSg/R/C D   I/J  . D   NSg/J/P NSg/VB+  VL3 . NPr/I+ NPr/J/R/P D   NSg/VB+ NPr/VLB/J ISg/#r+ . NSg/I/VB . K      D   NSg/J
 > puzzle ! ” And  she  began thinking over    all           the children she  knew that      were of the
 # NSg/VB . . VB/C ISg+ VPt   Nᴹ/Vg/J  NSg/J/P NSg/I/J/C/Dq+ D+  NPl+     ISg+ VPt  I/C/Ddem+ VLPt P  D+
-> same age      as    herself , to see    if    she  could   have    been   changed for   any    of them     .
-# I/J+ N🅪Sg/VB+ R/C/P ISg+    . P  NSg/VB NSg/C ISg+ NSg/VXB NSg/VXB VLPp/B VP/J    R/C/P I/R/Dq P  NSg/IPl+ .
+> same age      as    herself , to see    if    she  could have    been   changed for   any    of them     .
+# I/J+ N🅪Sg/VB+ R/C/P ISg+    . P  NSg/VB NSg/C ISg+ VXB   NSg/VXB VLPp/B VP/J    R/C/P I/R/Dq P  NSg/IPl+ .
 >
 #
 > “ I’m sure I’m not     Ada  , ” she  said , “ for   her     hair     goes   in        such  long     ringlets , and
@@ -518,24 +518,24 @@
 #
 > “ I’m sure those   are not     the right    words   , ” said poor     Alice , and  her     eyes    filled
 # . K   J    I/Ddem+ VLB NSg/R/C D   NPr/VB/J NPl/V3+ . . VP/J NSg/VB/J NPr+  . VB/C ISg/D$+ NPl/V3+ VP/J
-> with tears   again as    she  went    on  , “ I       must    be       Mabel after all          , and  I       shall have    to
-# P    NPl/V3+ P     R/C/P ISg+ NSg/VPt J/P . . ISg/#r+ NSg/VXB NSg/VLXB NPr   P     NSg/I/J/C/Dq . VB/C ISg/#r+ VXB   NSg/VXB P
+> with tears   again as    she  went on  , “ I       must    be       Mabel after all          , and  I       shall have    to
+# P    NPl/V3+ P     R/C/P ISg+ VPt  J/P . . ISg/#r+ NSg/VXB NSg/VLXB NPr   P     NSg/I/J/C/Dq . VB/C ISg/#r+ VXB   NSg/VXB P
 > go       and  live in        that     poky  little     house   , and  have    next    to no       toys    to play    with ,
 # NSg/VB/J VB/C VB/J NPr/J/R/P I/C/Ddem NSg/J NPr/I/J/Dq NPr/VB+ . VB/C NSg/VXB NSg/J/P P  NSg/Dq/P NPl/V3+ P  N🅪Sg/VB P    .
 > and  oh     ! ever so          many       lessons to learn  ! No       , I’ve made up         my  mind    about it       ; if    I’m
 # VB/C NPr/VB . J/R  NSg/I/J/R/C NSg/I/J/Dq NPl/V3+ P  NSg/VB . NSg/Dq/P . K    VP   NSg/VB/J/P D$+ NSg/VB+ J/P   NPr/ISg+ . NSg/C K
 > Mabel , I’ll stay     down        here ! It’ll be       no       use     their putting their heads   down        and
-# NPr   . K    NSg/VB/J N🅪Sg/VB/J/P J/R  . K     NSg/VLXB NSg/Dq/P N🅪Sg/VB D$+   Nᴹ/Vg/J D$+   NPl/V3+ N🅪Sg/VB/J/P VB/C
+# NPr   . K    NSg/VB/J N🅪Sg/VB/J/P R    . K     NSg/VLXB NSg/Dq/P N🅪Sg/VB D$+   Nᴹ/Vg/J D$+   NPl/V3+ N🅪Sg/VB/J/P VB/C
 > saying    ‘ Come       up         again , dear     ! ’ I       shall only  look   up         and  say    ‘ Who    am        I       then      ? Tell
 # N🅪Sg/Vg/J . NSg/VBPp/P NSg/VB/J/P P     . NSg/VB/J . . ISg/#r+ VXB   J/R/C NSg/VB NSg/VB/J/P VB/C NSg/VB . NPr/I+ NPr/VLB/J ISg/#r+ NSg/J/R/C . NPr/VB
 > me       that     first , and  then      , if    I       like         being        that      person  , I’ll come       up         : if    not     , I’ll
 # NPr/ISg+ I/C/Ddem NSg/J . VB/C NSg/J/R/C . NSg/C ISg/#r+ NSg/VB/J/C/P N🅪Sg/VLg/J/C I/C/Ddem+ NSg/VB+ . K    NSg/VBPp/P NSg/VB/J/P . NSg/C NSg/R/C . K
 > stay     down        here till       I’m somebody else    ’ — but     , oh     dear     ! ” cried Alice , with a   sudden
-# NSg/VB/J N🅪Sg/VB/J/P J/R  NSg/VB/C/P K   NSg/I+   NSg/J/C . . NSg/C/P . NPr/VB NSg/VB/J . . VP/J  NPr+  . P    D/P NSg/J
+# NSg/VB/J N🅪Sg/VB/J/P R    NSg/VB/C/P K   NSg/I+   NSg/J/C . . NSg/C/P . NPr/VB NSg/VB/J . . VP/J  NPr+  . P    D/P NSg/J
 > burst  of tears   , “ I       do  wish   they would put     their heads   down        ! I       am        so          very tired
 # NSg/VB P  NPl/V3+ . . ISg/#r+ VXB NSg/VB IPl+ VXB   NSg/VBP D$+   NPl/V3+ N🅪Sg/VB/J/P . ISg/#r+ NPr/VLB/J NSg/I/J/R/C J/R  VP/J
 > of being        all          alone here ! ”
-# P  N🅪Sg/VLg/J/C NSg/I/J/C/Dq J     J/R  . .
+# P  N🅪Sg/VLg/J/C NSg/I/J/C/Dq J     R    . .
 >
 #
 > As    she  said this    she  looked down        at    her     hands   , and  was  surprised to see    that     she
@@ -544,10 +544,10 @@
 # VP  NSg/VBP J/P NSg/I/J P  D   NSg$     NPr/I/J/Dq NPr🅪Sg/VB/J NSg/VB+ NPl/V3+ NSg/VB/C/P ISg+ VLPt Nᴹ/Vg/J .
 > “ How   can     I       have    done      that      ? ” she  thought . “ I       must    be       growing small    again . ” She
 # . NSg/C NPr/VXB ISg/#r+ NSg/VXB NSg/VPp/J I/C/Ddem+ . . ISg+ N🅪Sg/VP . . ISg/#r+ NSg/VXB NSg/VLXB Nᴹ/Vg/J NPr/VB/J P     . . ISg+
-> got up         and  went    to the table   to measure herself by it       , and  found  that      , as    nearly
-# VP  NSg/VB/J/P VB/C NSg/VPt P  D+  NSg/VB+ P  NSg/VB  ISg+    P  NPr/ISg+ . VB/C NSg/VP I/C/Ddem+ . R/C/P R
-> as    she  could   guess  , she  was  now       about two  feet high       , and  was  going   on  shrinking
-# R/C/P ISg+ NSg/VXB NSg/VB . ISg+ VLPt NSg/J/R/C J/P   NSg+ NPl+ NSg/VB/J/R . VB/C VLPt Nᴹ/Vg/J J/P Nᴹ/Vg/J
+> got up         and  went to the table   to measure herself by it       , and  found  that      , as    nearly
+# VP  NSg/VB/J/P VB/C VPt  P  D+  NSg/VB+ P  NSg/VB  ISg+    P  NPr/ISg+ . VB/C NSg/VP I/C/Ddem+ . R/C/P R
+> as    she  could guess  , she  was  now       about two  feet high       , and  was  going   on  shrinking
+# R/C/P ISg+ VXB   NSg/VB . ISg+ VLPt NSg/J/R/C J/P   NSg+ NPl+ NSg/VB/J/R . VB/C VLPt Nᴹ/Vg/J J/P Nᴹ/Vg/J
 > rapidly : she  soon found  out          that     the cause     of this    was  the fan    she  was  holding ,
 # R       . ISg+ J/R  NSg/VP NSg/VB/J/R/P I/C/Ddem D   N🅪Sg/VB/C P  I/Ddem+ VLPt D+  NSg/VB ISg+ VLPt Nᴹ/Vg/J .
 > and  she  dropped it       hastily , just in        time       to avoid shrinking away altogether .
@@ -585,7 +585,7 @@
 > spades , then      a   row    of lodging    houses  , and  behind  them     a   railway station . )
 # NPl/V3 . NSg/J/R/C D/P NSg/VB P  N🅪Sg/Vg/J+ NPl/V3+ . VB/C NSg/J/P NSg/IPl+ D/P NSg+    NSg/VB+ . .
 > However , she  soon made out          that     she  was  in        the pool   of tears   which she  had wept
-# C       . ISg+ J/R  VP   NSg/VB/J/R/P I/C/Ddem ISg+ VLPt NPr/J/R/P D   NSg/VB P  NPl/V3+ I/C+  ISg+ VP  VB
+# C       . ISg+ J/R  VP   NSg/VB/J/R/P I/C/Ddem ISg+ VLPt NPr/J/R/P D   NSg/VB P  NPl/V3+ I/C+  ISg+ VP  VP
 > when    she  was  nine feet high       .
 # NSg/I/C ISg+ VLPt NSg  NPl  NSg/VB/J/R .
 >
@@ -613,11 +613,11 @@
 > “ Would it       be       of any     use      , now       , ” thought Alice , “ to speak  to this    mouse   ?
 # . VXB   NPr/ISg+ NSg/VLXB P  I/R/Dq+ N🅪Sg/VB+ . NSg/J/R/C . . N🅪Sg/VP NPr+  . . P  NSg/VB P  I/Ddem+ NSg/VB+ .
 > Everything is  so          out          - of - the - way   down        here , that     I       should think  very likely it
-# NSg/I/VB+  VL3 NSg/I/J/R/C NSg/VB/J/R/P . P  . D   . NSg/J N🅪Sg/VB/J/P J/R  . I/C/Ddem ISg/#r+ VXB    NSg/VB J/R  NSg/J  NPr/ISg+
+# NSg/I/VB+  VL3 NSg/I/J/R/C NSg/VB/J/R/P . P  . D   . NSg/J N🅪Sg/VB/J/P R    . I/C/Ddem ISg/#r+ VXB    NSg/VB J/R  NSg/J  NPr/ISg+
 > can     talk    : at    any     rate    , there’s no        harm     in        trying  . ” So          she  began : “ O       Mouse   , do
 # NPr/VXB N🅪Sg/VB . NSg/P I/R/Dq+ NSg/VB+ . K       NSg/Dq/P+ N🅪Sg/VB+ NPr/J/R/P Nᴹ/Vg/J . . NSg/I/J/R/C ISg+ VPt   . . NPr/J/P NSg/VB+ . VXB
 > you    know the way    out          of this    pool    ? I       am        very tired of swimming about here , O
-# ISgPl+ VB   D+  NSg/J+ NSg/VB/J/R/P P  I/Ddem+ NSg/VB+ . ISg/#r+ NPr/VLB/J J/R  VP/J  P  NSg/Vg   J/P   J/R  . NPr/J/P
+# ISgPl+ VB   D+  NSg/J+ NSg/VB/J/R/P P  I/Ddem+ NSg/VB+ . ISg/#r+ NPr/VLB/J J/R  VP/J  P  NSg/Vg   J/P   R    . NPr/J/P
 > Mouse   ! ” ( Alice thought this    must    be       the right    way   of speaking to a    mouse   : she
 # NSg/VB+ . . . NPr+  N🅪Sg/VP I/Ddem+ NSg/VXB NSg/VLXB D   NPr/VB/J NSg/J P  Nᴹ/Vg/J  P  D/P+ NSg/VB+ . ISg+
 > had never done      such  a    thing before , but     she  remembered having  seen    in        her
@@ -654,10 +654,10 @@
 #
 > “ Well       , perhaps not     , ” said Alice in        a    soothing tone       : “ don’t be       angry about it       .
 # . NSg/VB/J/R . NSg/R   NSg/R/C . . VP/J NPr+  NPr/J/R/P D/P+ Nᴹ/Vg/J+ N🅪Sg/I/VB+ . . VXB   NSg/VLXB VB/J  J/P   NPr/ISg+ .
-> And  yet      I       wish   I       could   show   you    our cat       Dinah : I       think  you’d take   a   fancy     to
-# VB/C NSg/VB/C ISg/#r+ NSg/VB ISg/#r+ NSg/VXB NSg/VB ISgPl+ D$+ NSg/VB/J+ NPr   . ISg/#r+ NSg/VB K     NSg/VB D/P NSg/VB/J+ P
-> cats   if    you    could   only  see    her     . She  is  such  a   dear     quiet     thing , ” Alice went    on  ,
-# NPl/V3 NSg/C ISgPl+ NSg/VXB J/R/C NSg/VB ISg/D$+ . ISg+ VL3 NSg/I D/P NSg/VB/J N🅪Sg/VB/J NSg   . . NPr+  NSg/VPt J/P .
+> And  yet      I       wish   I       could show   you    our cat       Dinah : I       think  you’d take   a   fancy     to
+# VB/C NSg/VB/C ISg/#r+ NSg/VB ISg/#r+ VXB   NSg/VB ISgPl+ D$+ NSg/VB/J+ NPr   . ISg/#r+ NSg/VB K     NSg/VB D/P NSg/VB/J+ P
+> cats   if    you    could only  see    her     . She  is  such  a   dear     quiet     thing , ” Alice went on  ,
+# NPl/V3 NSg/C ISgPl+ VXB   J/R/C NSg/VB ISg/D$+ . ISg+ VL3 NSg/I D/P NSg/VB/J N🅪Sg/VB/J NSg   . . NPr+  VPt  J/P .
 > half      to herself , as    she  swam lazily about in        the pool    , “ and  she  sits   purring so
 # N🅪Sg/J/P+ P  ISg+    . R/C/P ISg+ VPt  R      J/P   NPr/J/R/P D+  NSg/VB+ . . VB/C ISg+ NPl/V3 Nᴹ/Vg/J NSg/I/J/R/C
 > nicely by the fire       , licking her     paws    and  washing her     face    — and  she  is  such  a   nice
@@ -684,8 +684,8 @@
 # . ISg/#r+ VXB   R      . . VP/J NPr+  . NPr/J/R/P D/P NSg/J NSg/VB+ P  N🅪Sg/VB D   NSg/VB/J P
 > conversation . “ Are you    — are you    fond     — of — of dogs    ? ” The Mouse   did  not     answer  , so
 # N🅪Sg/VB+     . . VLB ISgPl+ . VLB ISgPl+ NSg/VB/J . P  . P  NPl/V3+ . . D+  NSg/VB+ VXPt NSg/R/C NSg/VB+ . NSg/I/J/R/C
-> Alice went    on  eagerly : “ There is  such  a   nice  little     dog       near       our house   I       should
-# NPr+  NSg/VPt J/P R       . . R+    VL3 NSg/I D/P NPr/J NPr/I/J/Dq NSg/VB/J+ NSg/VB/J/P D$+ NPr/VB+ ISg/#r+ VXB
+> Alice went on  eagerly : “ There is  such  a   nice  little     dog       near       our house   I       should
+# NPr+  VPt  J/P R       . . R+    VL3 NSg/I D/P NPr/J NPr/I/J/Dq NSg/VB/J+ NSg/VB/J/P D$+ NPr/VB+ ISg/#r+ VXB
 > like         to show   you    ! A   little     bright   - eyed terrier , you    know , with oh     , such  long
 # NSg/VB/J/C/P P  NSg/VB ISgPl+ . D/P NPr/I/J/Dq NPr/VB/J . VP/J NSg     . ISgPl+ VB   . P    NPr/VB . NSg/I NPr/VB/J
 > curly   brown       hair     ! And  it’ll fetch  things when    you    throw  them     , and  it’ll sit    up
@@ -698,10 +698,10 @@
 # NSg/VB/J D/P NSg     NPl/V3+ . NPr/ISg+ NPl/V3 NPr/ISg+ NPl/V3 NSg/I/J/C/Dq+ D+  NPl/V3+ VB/C . NPr/VB NSg/VB/J . . VP/J  NPr+
 > in        a   sorrowful tone       , “ I’m afraid I’ve offended it       again ! ” For   the Mouse   was
 # NPr/J/R/P D/P J         N🅪Sg/I/VB+ . . K   J      K    VP/J     NPr/ISg+ P     . . R/C/P D+  NSg/VB+ VLPt
-> swimming away from her     as    hard     as    it       could   go       , and  making  quite a   commotion in
-# NSg/Vg   VB/J P    ISg/D$+ R/C/P N🅪Sg/J/R R/C/P NPr/ISg+ NSg/VXB NSg/VB/J . VB/C Nᴹ/Vg/J R     D/P N🅪Sg      NPr/J/R/P
-> the pool    as    it       went    .
-# D   NSg/VB+ R/C/P NPr/ISg+ NSg/VPt .
+> swimming away from her     as    hard     as    it       could go       , and  making  quite a   commotion in
+# NSg/Vg   VB/J P    ISg/D$+ R/C/P N🅪Sg/J/R R/C/P NPr/ISg+ VXB   NSg/VB/J . VB/C Nᴹ/Vg/J R     D/P N🅪Sg      NPr/J/R/P
+> the pool    as    it       went .
+# D   NSg/VB+ R/C/P NPr/ISg+ VPt  .
 >
 #
 > So          she  called softly after it       , “ Mouse   dear     ! Do  come       back     again , and  we   won’t
@@ -818,8 +818,8 @@
 # R         D/P NSg/VB NPr/C D/P NSg/VB+ . D+  NSg/VB+  VL3 . NSg/I+ VXPt D   NSg        NSg/VB . .
 >
 #
-> The Mouse   did  not     notice this    question , but     hurriedly went    on  , “ ‘ — found  it
-# D+  NSg/VB+ VXPt NSg/R/C NSg/VB I/Ddem+ NSg/VB+  . NSg/C/P R         NSg/VPt J/P . . . . NSg/VP NPr/ISg+
+> The Mouse   did  not     notice this    question , but     hurriedly went on  , “ ‘ — found  it
+# D+  NSg/VB+ VXPt NSg/R/C NSg/VB I/Ddem+ NSg/VB+  . NSg/C/P R         VPt  J/P . . . . NSg/VP NPr/ISg+
 > advisable to go       with Edgar Atheling to meet     William and  offer  him  the crown     .
 # J         P  NSg/VB/J P    NPr+  ?        P  NSg/VB/J NPr+    VB/C NSg/VB ISg+ D   NSg/VB/J+ .
 > William’s conduct at    first was  moderate . But     the insolence of his     Normans — ’ How
@@ -875,7 +875,7 @@
 > doesn’t matter   , ” it       said , ) and  then      all          the party     were placed along the course  ,
 # VX3     N🅪Sg/VB+ . . NPr/ISg+ VP/J . . VB/C NSg/J/R/C NSg/I/J/C/Dq D   NSg/VB/J+ VLPt VP/J   P     D   NSg/VB+ .
 > here and  there . There was  no       “ One      , two , three , and  away , ” but     they began running
-# J/R  VB/C R     . R+    VLPt NSg/Dq/P . NSg/I/J+ . NSg . NSg   . VB/C VB/J . . NSg/C/P IPl+ VPt   Nᴹ/Vg/J/P
+# R    VB/C R     . R+    VLPt NSg/Dq/P . NSg/I/J+ . NSg . NSg   . VB/C VB/J . . NSg/C/P IPl+ VPt   Nᴹ/Vg/J/P
 > when    they liked , and  left     off        when    they liked , so          that     it       was  not     easy     to know
 # NSg/I/C IPl+ VP/J  . VB/C NPr/VP/J NSg/VB/J/P NSg/I/C IPl+ VP/J  . NSg/I/J/R/C I/C/Ddem NPr/ISg+ VLPt NSg/R/C NSg/VB/J P  VB
 > when    the race     was  over    . However , when    they had been   running   half      an   hour or    so          ,
@@ -886,8 +886,8 @@
 # IPl+ NSg/I/J/C/Dq VP/J    NSg/VB/J/P NPr/ISg+ . Nᴹ/Vg/J . VB/C Nᴹ/Vg/J . . NSg/C/P NPr/I+ V3  NSgPl/VP . .
 >
 #
-> This    question the Dodo could   not     answer  without a   great deal     of thought  , and  it
-# I/Ddem+ NSg/VB+  D   NSg  NSg/VXB NSg/R/C NSg/VB+ C/P     D/P NSg/J NSg/VB/J P  N🅪Sg/VP+ . VB/C NPr/ISg+
+> This    question the Dodo could not     answer  without a   great deal     of thought  , and  it
+# I/Ddem+ NSg/VB+  D   NSg  VXB   NSg/R/C NSg/VB+ C/P     D/P NSg/J NSg/VB/J P  N🅪Sg/VP+ . VB/C NPr/ISg+
 > sat    for   a   long     time       with one     finger  pressed upon its     forehead ( the position in
 # NSg/VP R/C/P D/P NPr/VB/J N🅪Sg/VB/J+ P    NSg/I/J NSg/VB+ VP/J    P    ISg/D$+ NSg      . D   NSg/VB+  NPr/J/R/P
 > which you    usually see    Shakespeare , in        the pictures of him  ) , while      the rest
@@ -924,8 +924,8 @@
 #
 > “ Of course  , ” the Dodo replied very gravely . “ What   else    have    you    got in        your
 # . P  NSg/VB+ . . D   NSg  VP/J    J/R  R       . . NSg/I+ NSg/J/C NSg/VXB ISgPl+ VP  NPr/J/R/P D$+
-> pocket    ? ” he       went    on  , turning to Alice .
-# NSg/VB/J+ . . NPr/ISg+ NSg/VPt J/P . Nᴹ/Vg/J P  NPr+  .
+> pocket    ? ” he       went on  , turning to Alice .
+# NSg/VB/J+ . . NPr/ISg+ VPt  J/P . Nᴹ/Vg/J P  NPr+  .
 >
 #
 > “ Only  a   thimble , ” said Alice sadly .
@@ -933,7 +933,7 @@
 >
 #
 > “ Hand    it       over    here , ” said the Dodo .
-# . NSg/VB+ NPr/ISg+ NSg/J/P J/R  . . VP/J D   NSg  .
+# . NSg/VB+ NPr/ISg+ NSg/J/P R    . . VP/J D   NSg  .
 >
 #
 > Then      they all          crowded round      her     once  more         , while      the Dodo solemnly presented the
@@ -946,16 +946,16 @@
 #
 > Alice thought the whole  thing very absurd , but     they all          looked so          grave    that     she
 # NPr+  N🅪Sg/VP D+  NSg/J+ NSg+  J/R  NSg/J  . NSg/C/P IPl+ NSg/I/J/C/Dq VP/J   NSg/I/J/R/C NSg/VB/J I/C/Ddem ISg+
-> did  not     dare    to laugh  ; and  , as    she  could   not     think  of anything  to say    , she
-# VXPt NSg/R/C NPr/VXB P  NSg/VB . VB/C . R/C/P ISg+ NSg/VXB NSg/R/C NSg/VB P  NSg/I/VB+ P  NSg/VB . ISg+
-> simply bowed , and  took the thimble , looking as    solemn as    she  could   .
-# R      VP/J  . VB/C VPt  D   NSg/VB  . Nᴹ/Vg/J R/C/P J      R/C/P ISg+ NSg/VXB .
+> did  not     dare    to laugh  ; and  , as    she  could not     think  of anything  to say    , she
+# VXPt NSg/R/C NPr/VXB P  NSg/VB . VB/C . R/C/P ISg+ VXB   NSg/R/C NSg/VB P  NSg/I/VB+ P  NSg/VB . ISg+
+> simply bowed , and  took the thimble , looking as    solemn as    she  could .
+# R      VP/J  . VB/C VPt  D   NSg/VB  . Nᴹ/Vg/J R/C/P J      R/C/P ISg+ VXB   .
 >
 #
 > The next     thing was  to eat the comfits : this   caused some     noise   and  confusion , as
 # D+  NSg/J/P+ NSg+  VLPt P  VB  D   NPl/V3  . I/Ddem VP/J   I/J/R/Dq N🅪Sg/VB VB/C N🅪Sg/VB+  . R/C/P
-> the large birds   complained that     they could   not     taste    theirs , and  the small    ones
-# D   NSg/J NPl/V3+ VP/J       I/C/Ddem IPl+ NSg/VXB NSg/R/C NSg/VB/J I+     . VB/C D   NPr/VB/J NPl+
+> the large birds   complained that     they could not     taste    theirs , and  the small    ones
+# D   NSg/J NPl/V3+ VP/J       I/C/Ddem IPl+ VXB   NSg/R/C NSg/VB/J I+     . VB/C D   NPr/VB/J NPl+
 > choked and  had to be       patted on  the back     . However , it       was  over    at    last     , and  they
 # VP/J   VB/C VP  P  NSg/VLXB VP     J/P D   NSg/VB/J . C       . NPr/ISg+ VLPt NSg/J/P NSg/P NSg/VB/J . VB/C IPl+
 > sat    down        again in        a    ring    , and  begged the Mouse   to tell   them     something more         .
@@ -1065,7 +1065,7 @@
 >
 #
 > “ I       wish   I       had our Dinah here , I       know I       do  ! ” said Alice aloud , addressing nobody
-# . ISg/#r+ NSg/VB ISg/#r+ VP  D$+ NPr   J/R  . ISg/#r+ VB   ISg/#r+ VXB . . VP/J NPr+  J     . Nᴹ/Vg/J    NSg/I+
+# . ISg/#r+ NSg/VB ISg/#r+ VP  D$+ NPr   R    . ISg/#r+ VB   ISg/#r+ VXB . . VP/J NPr+  J     . Nᴹ/Vg/J    NSg/I+
 > in        particular . “ She’d soon fetch  it       back     ! ”
 # NPr/J/R/P NSg/J      . . K     J/R  NSg/VB NPr/ISg+ NSg/VB/J . .
 >
@@ -1078,8 +1078,8 @@
 # NPr+  VP/J    R       . R/C/P ISg+ VLPt R      NSg/VB/J P  N🅪Sg/VB J/P   ISg/D$+ NPr/VB/J+ . . NPr$
 > our cat       . And  she’s such  a   capital one      for   catching mice    you    can’t think  ! And  oh     ,
 # D$+ NSg/VB/J+ . VB/C K     NSg/I D/P N🅪Sg/J+ NSg/I/J+ R/C/P Nᴹ/Vg/J  NPl/VB+ ISgPl+ VXB   NSg/VB . VB/C NPr/VB .
-> I       wish   you    could   see    her     after the birds   ! Why    , she’ll eat a   little     bird      as    soon
-# ISg/#r+ NSg/VB ISgPl+ NSg/VXB NSg/VB ISg/D$+ P     D+  NPl/V3+ . NSg/VB . K      VB  D/P NPr/I/J/Dq NPr/VB/J+ R/C/P J/R
+> I       wish   you    could see    her     after the birds   ! Why    , she’ll eat a   little     bird      as    soon
+# ISg/#r+ NSg/VB ISgPl+ VXB   NSg/VB ISg/D$+ P     D+  NPl/V3+ . NSg/VB . K      VB  D/P NPr/I/J/Dq NPr/VB/J+ R/C/P J/R
 > as    look   at    it       ! ”
 # R/C/P NSg/VB NSg/P NPr/ISg+ . .
 >
@@ -1101,9 +1101,9 @@
 > “ I       wish   I       hadn’t mentioned Dinah ! ” she  said to herself in        a   melancholy tone       .
 # . ISg/#r+ NSg/VB ISg/#r+ VPt    VP/J      NPr   . . ISg+ VP/J P  ISg+    NPr/J/R/P D/P NSg/J      N🅪Sg/I/VB+ .
 > “ Nobody seems to like         her     , down        here , and  I’m sure she’s the best       cat       in        the
-# . NSg/I+ V3    P  NSg/VB/J/C/P ISg/D$+ . N🅪Sg/VB/J/P J/R  . VB/C K   J    K     D   NPr/VXB/JS NSg/VB/J+ NPr/J/R/P D
+# . NSg/I+ V3    P  NSg/VB/J/C/P ISg/D$+ . N🅪Sg/VB/J/P R    . VB/C K   J    K     D   NPr/VXB/JS NSg/VB/J+ NPr/J/R/P D
 > world   ! Oh     , my  dear     Dinah ! I       wonder  if    I       shall ever see    you    any    more         ! ” And  here
-# NSg/VB+ . NPr/VB . D$+ NSg/VB/J NPr   . ISg/#r+ N🅪Sg/VB NSg/C ISg/#r+ VXB   J/R  NSg/VB ISgPl+ I/R/Dq NPr/I/J/R/Dq . . VB/C J/R
+# NSg/VB+ . NPr/VB . D$+ NSg/VB/J NPr   . ISg/#r+ N🅪Sg/VB NSg/C ISg/#r+ VXB   J/R  NSg/VB ISgPl+ I/R/Dq NPr/I/J/R/Dq . . VB/C R
 > poor      Alice began to cry    again , for   she  felt      very lonely and  low        - spirited . In        a
 # NSg/VB/J+ NPr+  VPt   P  NSg/VB P     . R/C/P ISg+ N🅪Sg/VP/J J/R  J/R    VB/C NSg/VB/J/R . VP/J     . NPr/J/R/P D/P
 > little     while      , however , she  again heard a   little     pattering of footsteps in        the
@@ -1120,8 +1120,8 @@
 #
 > It       was  the White       Rabbit , trotting slowly back     again , and  looking anxiously about
 # NPr/ISg+ VLPt D   NPr🅪Sg/VB/J NSg/VB . NSg/Vg/J R      NSg/VB/J P     . VB/C Nᴹ/Vg/J R         J/P
-> as    it       went    , as    if    it       had lost something ; and  she  heard it       muttering to itself
-# R/C/P NPr/ISg+ NSg/VPt . R/C/P NSg/C NPr/ISg+ VP  VP/J NSg/I/J+  . VB/C ISg+ VP/J  NPr/ISg+ Nᴹ/Vg/J   P  ISg+
+> as    it       went , as    if    it       had lost something ; and  she  heard it       muttering to itself
+# R/C/P NPr/ISg+ VPt  . R/C/P NSg/C NPr/ISg+ VP  VP/J NSg/I/J+  . VB/C ISg+ VP/J  NPr/ISg+ Nᴹ/Vg/J   P  ISg+
 > “ The Duchess ! The Duchess ! Oh     my  dear      paws    ! Oh     my  fur          and  whiskers ! She’ll get
 # . D   NSg/VB  . D   NSg/VB  . NPr/VB D$+ NSg/VB/J+ NPl/V3+ . NPr/VB D$+ N🅪Sg/VB/C/P+ VB/C NPl      . K      NSg/VB
 > me       executed , as    sure as    ferrets are ferrets ! Where   can     I       have    dropped them     , I
@@ -1138,10 +1138,10 @@
 # VP  VP/J     R          .
 >
 #
-> Very soon the Rabbit  noticed Alice , as    she  went    hunting about , and  called out          to
-# J/R  J/R  D+  NSg/VB+ VP/J    NPr+  . R/C/P ISg+ NSg/VPt Nᴹ/Vg/J J/P   . VB/C VP/J   NSg/VB/J/R/P P
+> Very soon the Rabbit  noticed Alice , as    she  went hunting about , and  called out          to
+# J/R  J/R  D+  NSg/VB+ VP/J    NPr+  . R/C/P ISg+ VPt  Nᴹ/Vg/J J/P   . VB/C VP/J   NSg/VB/J/R/P P
 > her     in        an   angry tone       , “ Why    , Mary Ann    , what   are you    doing   out          here ? Run      home      this
-# ISg/D$+ NPr/J/R/P D/P+ VB/J+ N🅪Sg/I/VB+ . . NSg/VB . NPr+ NPr/J+ . NSg/I+ VLB ISgPl+ Nᴹ/Vg/J NSg/VB/J/R/P J/R  . NSg/VBPp NSg/VB/J+ I/Ddem+
+# ISg/D$+ NPr/J/R/P D/P+ VB/J+ N🅪Sg/I/VB+ . . NSg/VB . NPr+ NPr/J+ . NSg/I+ VLB ISgPl+ Nᴹ/Vg/J NSg/VB/J/R/P R    . NSg/VBPp NSg/VB/J+ I/Ddem+
 > moment , and  fetch  me       a   pair   of gloves and  a    fan     ! Quick    , now       ! ” And  Alice was  so
 # NSg+   . VB/C NSg/VB NPr/ISg+ D/P NSg/VB P  NPl/V3 VB/C D/P+ NSg/VB+ . NSg/VB/J . NSg/J/R/C . . VB/C NPr+  VLPt NSg/I/J/R/C
 > much         frightened that     she  ran off        at    once  in        the direction it       pointed to , without
@@ -1158,8 +1158,8 @@
 # NPl/V3+ . I/C/Ddem+ VL3 . NSg/C ISg/#r+ NPr/VXB NSg/VB NSg/IPl+ . . R/C/P ISg+ VP/J I/Ddem+ . ISg+ NSg/VPt/P P    D/P+ J+
 > little      house   , on  the door   of which was  a   bright   brass     plate  with the name    “ W.
 # NPr/I/J/Dq+ NPr/VB+ . J/P D   NSg/VB P  I/C+  VLPt D/P NPr/VB/J N🅪Sg/VB/J NSg/VB P    D+  NSg/VB+ . ?
-> RABBIT  , ” engraved upon it       . She  went    in        without knocking , and  hurried upstairs ,
-# NSg/VB+ . . VP/J     P    NPr/ISg+ . ISg+ NSg/VPt NPr/J/R/P C/P     Nᴹ/Vg/J  . VB/C VP/J    NSg/J    .
+> RABBIT  , ” engraved upon it       . She  went in        without knocking , and  hurried upstairs ,
+# NSg/VB+ . . VP/J     P    NPr/ISg+ . ISg+ VPt  NPr/J/R/P C/P     Nᴹ/Vg/J  . VB/C VP/J    NSg/J    .
 > in        great  fear     lest she  should meet     the real   Mary Ann    , and  be       turned out          of the
 # NPr/J/R/P NSg/J+ N🅪Sg/VB+ JS   ISg+ VXB    NSg/VB/J D+  NSg/J+ NPr+ NPr/J+ . VB/C NSg/VLXB VP/J   NSg/VB/J/R/P P  D+
 > house   before she  had found  the fan    and  gloves  .
@@ -1171,11 +1171,11 @@
 > I       suppose Dinah’ll be       sending me       on  messages next    ! ” And  she  began fancying the
 # ISg/#r+ VB      ?        NSg/VLXB Nᴹ/Vg/J NPr/ISg+ J/P NPl/V3+  NSg/J/P . . VB/C ISg+ VPt   Nᴹ/Vg/J  D
 > sort   of thing that      would happen : “ ‘ Miss   Alice ! Come       here directly , and  get    ready
-# NSg/VB P  NSg+  I/C/Ddem+ VXB   VB     . . . NSg/VB NPr+  . NSg/VBPp/P J/R  R/C      . VB/C NSg/VB NSg/VB/J
+# NSg/VB P  NSg+  I/C/Ddem+ VXB   VB     . . . NSg/VB NPr+  . NSg/VBPp/P R    R/C      . VB/C NSg/VB NSg/VB/J
 > for   your walk    ! ’ ‘ Coming  in        a    minute    , nurse   ! But     I’ve got to see    that     the mouse
 # R/C/P D$+  NSg/VB+ . . . Nᴹ/Vg/J NPr/J/R/P D/P+ NSg/VB/J+ . NSg/VB+ . NSg/C/P K    VP  P  NSg/VB I/C/Ddem D   NSg/VB+
-> doesn’t get    out          . ’ Only  I       don’t think  , ” Alice went    on  , “ that      they’d let     Dinah
-# VX3     NSg/VB NSg/VB/J/R/P . . J/R/C ISg/#r+ VXB   NSg/VB . . NPr+  NSg/VPt J/P . . I/C/Ddem+ K      NSg/VBP NPr
+> doesn’t get    out          . ’ Only  I       don’t think  , ” Alice went on  , “ that      they’d let     Dinah
+# VX3     NSg/VB NSg/VB/J/R/P . . J/R/C ISg/#r+ VXB   NSg/VB . . NPr+  VPt  J/P . . I/C/Ddem+ K      NSg/VBP NPr
 > stop   in        the house   if    it       began ordering people  about like         that      ! ”
 # NSg/VB NPr/J/R/P D   NPr/VB+ NSg/C NPr/ISg+ VPt   Nᴹ/Vg/J  NPl/VB+ J/P   NSg/VB/J/C/P I/C/Ddem+ . .
 >
@@ -1212,14 +1212,14 @@
 # VXB   NSg/VB NSg/VB/J/R/P NSg/P D   NSg/VB+ . ISg/#r+ VXB NSg/VB ISg/#r+ VPt    NSg/VPp/J R     NSg/I/J/R/C NSg/I/J/R/Dq . .
 >
 #
-> Alas  ! it       was  too late  to wish   that      ! She  went    on  growing , and  growing , and  very
-# NPrPl . NPr/ISg+ VLPt R   NSg/J P  NSg/VB I/C/Ddem+ . ISg+ NSg/VPt J/P Nᴹ/Vg/J . VB/C Nᴹ/Vg/J . VB/C J/R
+> Alas  ! it       was  too late  to wish   that      ! She  went on  growing , and  growing , and  very
+# NPrPl . NPr/ISg+ VLPt R   NSg/J P  NSg/VB I/C/Ddem+ . ISg+ VPt  J/P Nᴹ/Vg/J . VB/C Nᴹ/Vg/J . VB/C J/R
 > soon had to kneel down        on  the floor   : in        another minute    there was  not     even       room
 # J/R  VP  P  VB    N🅪Sg/VB/J/P J/P D   NSg/VB+ . NPr/J/R/P I/D     NSg/VB/J+ R+    VLPt NSg/R/C NSg/VB/J/R N🅪Sg/VB+
 > for   this    , and  she  tried the effect  of lying   down        with one     elbow   against the
 # R/C/P I/Ddem+ . VB/C ISg+ VP/J  D   NSg/VB+ P  Nᴹ/Vg/J N🅪Sg/VB/J/P P    NSg/I/J NSg/VB+ C/P     D
-> door    , and  the other    arm       curled round      her     head      . Still      she  went    on  growing , and  ,
-# NSg/VB+ . VB/C D   NSg/VB/J NSg/VB/J+ VP/J   NSg/VB/J/P ISg/D$+ NPr/VB/J+ . NSg/VB/J/R ISg+ NSg/VPt J/P Nᴹ/Vg/J . VB/C .
+> door    , and  the other    arm       curled round      her     head      . Still      she  went on  growing , and  ,
+# NSg/VB+ . VB/C D   NSg/VB/J NSg/VB/J+ VP/J   NSg/VB/J/P ISg/D$+ NPr/VB/J+ . NSg/VB/J/R ISg+ VPt  J/P Nᴹ/Vg/J . VB/C .
 > as    a    last      resource , she  put     one     arm       out          of the window  , and  one      foot    up         the
 # R/C/P D/P+ NSg/VB/J+ N🅪Sg/VB+ . ISg+ NSg/VBP NSg/I/J NSg/VB/J+ NSg/VB/J/R/P P  D+  NSg/VB+ . VB/C NSg/I/J+ NSg/VB+ NSg/VB/J/P D+
 > chimney , and  said to herself “ Now       I       can     do  no       more         , whatever happens . What   will
@@ -1249,13 +1249,13 @@
 > When    I       used to read    fairy  - tales   , I       fancied that     kind  of thing never happened ,
 # NSg/I/C ISg/#r+ VP/J P  NSg/VBP NSg/J+ . NPl/V3+ . ISg/#r+ VP/J    I/C/Ddem NSg/J P  NSg+  R     VP/J     .
 > and  now       here I       am        in        the middle   of one     ! There ought     to be       a   book    written about
-# VB/C NSg/J/R/C J/R  ISg/#r+ NPr/VLB/J NPr/J/R/P D   NSg/VB/J P  NSg/I/J . R+    NSg/I/VXB P  NSg/VLXB D/P NSg/VB+ VPp/J   J/P
+# VB/C NSg/J/R/C R    ISg/#r+ NPr/VLB/J NPr/J/R/P D   NSg/VB/J P  NSg/I/J . R+    NSg/I/VXB P  NSg/VLXB D/P NSg/VB+ VPp/J   J/P
 > me       , that     there ought     ! And  when    I       grow up         , I’ll write  one     — but     I’m grown up         now       , ”
 # NPr/ISg+ . I/C/Ddem R+    NSg/I/VXB . VB/C NSg/I/C ISg/#r+ VB   NSg/VB/J/P . K    NSg/VB NSg/I/J . NSg/C/P K   VB/J  NSg/VB/J/P NSg/J/R/C . .
 > she  added in        a   sorrowful tone       ; “ at    least    there’s no       room     to grow up         any    more
 # ISg+ VP/J  NPr/J/R/P D/P J         N🅪Sg/I/VB+ . . NSg/P NSg/J/Dq K       NSg/Dq/P N🅪Sg/VB+ P  VB   NSg/VB/J/P I/R/Dq NPr/I/J/R/Dq
 > here . ”
-# J/R  . .
+# R    . .
 >
 #
 > “ But     then      , ” thought Alice , “ shall I       never get    any    older than I       am        now       ? That’ll
@@ -1269,13 +1269,13 @@
 > “ Oh     , you    foolish Alice ! ” she  answered herself . “ How   can     you    learn  lessons in
 # . NPr/VB . ISgPl+ J+      NPr+  . . ISg+ VP/J     ISg+    . . NSg/C NPr/VXB ISgPl+ NSg/VB NPl/V3+ NPr/J/R/P
 > here ? Why    , there’s hardly room     for   you    , and  no       room     at    all          for   any
-# J/R  . NSg/VB . K       R      N🅪Sg/VB+ R/C/P ISgPl+ . VB/C NSg/Dq/P N🅪Sg/VB+ NSg/P NSg/I/J/C/Dq R/C/P I/R/Dq
+# R    . NSg/VB . K       R      N🅪Sg/VB+ R/C/P ISgPl+ . VB/C NSg/Dq/P N🅪Sg/VB+ NSg/P NSg/I/J/C/Dq R/C/P I/R/Dq
 > lesson  - books   ! ”
 # NSg/VB+ . NPl/V3+ . .
 >
 #
-> And  so          she  went    on  , taking   first  one      side      and  then      the other    , and  making  quite a
-# VB/C NSg/I/J/R/C ISg+ NSg/VPt J/P . NSg/Vg/J NSg/J+ NSg/I/J+ NSg/VB/J+ VB/C NSg/J/R/C D   NSg/VB/J . VB/C Nᴹ/Vg/J R     D/P
+> And  so          she  went on  , taking   first  one      side      and  then      the other    , and  making  quite a
+# VB/C NSg/I/J/R/C ISg+ VPt  J/P . NSg/Vg/J NSg/J+ NSg/I/J+ NSg/VB/J+ VB/C NSg/J/R/C D   NSg/VB/J . VB/C Nᴹ/Vg/J R     D/P
 > conversation of it       altogether ; but     after a    few       minutes she  heard a    voice
 # N🅪Sg/VB      P  NPr/ISg+ NSg        . NSg/C/P P     D/P+ NSg/I/Dq+ NPl/V3+ ISg+ VP/J  D/P+ NSg/VB+
 > outside   , and  stopped to listen .
@@ -1319,13 +1319,13 @@
 > Next    came      an   angry voice   — the Rabbit’s — “ Pat       ! Pat       ! Where   are you    ? ” And  then      a
 # NSg/J/P NSg/VPt/P D/P+ VB/J+ NSg/VB+ . D   NSg$     . . NPr/VB/J+ . NPr/VB/J+ . NSg/R/C VLB ISgPl+ . . VB/C NSg/J/R/C D/P+
 > voice   she  had never heard before , “ Sure then      I’m here ! Digging for   apples , yer
-# NSg/VB+ ISg+ VP  R     VP/J  C/P    . . J    NSg/J/R/C K   J/R  . NSg/Vg  R/C/P NPl    . +
+# NSg/VB+ ISg+ VP  R     VP/J  C/P    . . J    NSg/J/R/C K   R    . NSg/Vg  R/C/P NPl    . +
 > honour        ! ”
 # N🅪Sg/VB/Comm+ . .
 >
 #
 > “ Digging for   apples , indeed ! ” said the Rabbit  angrily . “ Here ! Come       and  help   me
-# . NSg/Vg  R/C/P NPl    . R      . . VP/J D+  NSg/VB+ R       . . J/R  . NSg/VBPp/P VB/C NSg/VB NPr/ISg+
+# . NSg/Vg  R/C/P NPl    . R      . . VP/J D+  NSg/VB+ R       . . R    . NSg/VBPp/P VB/C NSg/VB NPr/ISg+
 > out          of this    ! ” ( Sounds of more         broken glass      . )
 # NSg/VB/J/R/P P  I/Ddem+ . . . NPl/V3 P  NPr/I/J/R/Dq VPp/J  NPr🅪Sg/VB+ . .
 >
@@ -1350,8 +1350,8 @@
 # . NSg/VB/J/R . K    VP  NSg/Dq/P N🅪Sg/J+  R     . NSg/P I/R/Dq NSg/VB+ . NSg/VB/J VB/C NSg/VB NPr/ISg+ VB/J . .
 >
 #
-> There was  a    long      silence after this    , and  Alice could   only  hear whispers now       and
-# R+    VLPt D/P+ NPr/VB/J+ NSg/VB+ P     I/Ddem+ . VB/C NPr+  NSg/VXB J/R/C VB   NPl/V3   NSg/J/R/C VB/C
+> There was  a    long      silence after this    , and  Alice could only  hear whispers now       and
+# R+    VLPt D/P+ NPr/VB/J+ NSg/VB+ P     I/Ddem+ . VB/C NPr+  VXB   J/R/C VB   NPl/V3   NSg/J/R/C VB/C
 > then      ; such  as    , “ Sure , I       don’t like         it       , yer honour        , at    all          , at    all          ! ” “ Do  as    I
 # NSg/J/R/C . NSg/I R/C/P . . J    . ISg/#r+ VXB   NSg/VB/J/C/P NPr/ISg+ . +   N🅪Sg/VB/Comm+ . NSg/P NSg/I/J/C/Dq . NSg/P NSg/I/J/C/Dq . . . VXB R/C/P ISg/#r+
 > tell   you    , you    coward   ! ” and  at    last     she  spread   out          her     hand    again , and  made
@@ -1362,8 +1362,8 @@
 # NPl/V3 P  VPp/J  NPr🅪Sg/VB+ . . NSg/I+ D/P N🅪Sg/VB/JC P  N🅪Sg+    . NPl/V3+ R+    NSg/VXB NSg/VLXB . .
 > thought Alice . “ I       wonder  what   they’ll do  next    ! As    for    pulling me       out          of the
 # N🅪Sg/VP NPr+  . . ISg/#r+ N🅪Sg/VB NSg/I+ K       VXB NSg/J/P . R/C/P R/C/P+ Nᴹ/Vg/J NPr/ISg+ NSg/VB/J/R/P P  D+
-> window  , I       only  wish   they could   ! I’m sure I       don’t want   to stay     in        here any
-# NSg/VB+ . ISg/#r+ J/R/C NSg/VB IPl+ NSg/VXB . K   J    ISg/#r+ VXB   NSg/VB P  NSg/VB/J NPr/J/R/P J/R  I/R/Dq
+> window  , I       only  wish   they could ! I’m sure I       don’t want   to stay     in        here any
+# NSg/VB+ . ISg/#r+ J/R/C NSg/VB IPl+ VXB   . K   J    ISg/#r+ VXB   NSg/VB P  NSg/VB/J NPr/J/R/P R    I/R/Dq
 > longer ! ”
 # NSg/JC . .
 >
@@ -1375,11 +1375,11 @@
 > she  made out          the words   : “ Where’s the other    ladder  ? — Why    , I       hadn’t to bring but
 # ISg+ VP   NSg/VB/J/R/P D   NPl/V3+ . . NSg$    D   NSg/VB/J NSg/VB+ . . NSg/VB . ISg/#r+ VPt    P  VB    NSg/C/P
 > one     ; Bill’s got the other    — Bill    ! fetch  it       here , lad ! — Here , put     ’ em       up         at    this
-# NSg/I/J . NPr$   VP  D   NSg/VB/J . NPr/VB+ . NSg/VB NPr/ISg+ J/R  . NSg . . J/R  . NSg/VBP . NSg/I/J+ NSg/VB/J/P NSg/P I/Ddem+
+# NSg/I/J . NPr$   VP  D   NSg/VB/J . NPr/VB+ . NSg/VB NPr/ISg+ R    . NSg . . R    . NSg/VBP . NSg/I/J+ NSg/VB/J/P NSg/P I/Ddem+
 > corner  — No       , tie     ’ em       together first — they don’t reach  half      high       enough yet      — Oh     !
 # NSg/VB+ . NSg/Dq/P . NSg/VB+ . NSg/I/J+ J        NSg/J . IPl+ VXB   NSg/VB N🅪Sg/J/P+ NSg/VB/J/R NSg/I  NSg/VB/C . NPr/VB .
 > they’ll do  well       enough ; don’t be       particular — Here , Bill    ! catch  hold     of this
-# K       VXB NSg/VB/J/R NSg/I  . VXB   NSg/VLXB NSg/J      . J/R  . NPr/VB+ . NSg/VB NSg/VB/J P  I/Ddem+
+# K       VXB NSg/VB/J/R NSg/I  . VXB   NSg/VLXB NSg/J      . R    . NPr/VB+ . NSg/VB NSg/VB/J P  I/Ddem+
 > rope    — Will    the roof    bear      ? — Mind    that     loose     slate     — Oh     , it’s coming  down        ! Heads
 # NSg/VB+ . NPr/VXB D+  NSg/VB+ NSg/VB/J+ . . NSg/VB+ I/C/Ddem NSg/VB/J+ NSg/VB/J+ . NPr/VB . K    Nᴹ/Vg/J N🅪Sg/VB/J/P . NPl/V3+
 > below ! ” ( a    loud   crash     ) — “ Now       , who    did  that      ? — It       was  Bill    , I       fancy    — Who’s to go       down
@@ -1387,7 +1387,7 @@
 > the chimney ? — Nay      , I       shan’t ! You    do  it       ! — That     I       won’t , then      ! — Bill’s to go
 # D   NSg/VB+ . . NSg/VB/J . ISg/#r+ VXB    . ISgPl+ VXB NPr/ISg+ . . I/C/Ddem ISg/#r+ VXB   . NSg/J/R/C . . NPr$   P  NSg/VB/J
 > down        — Here , Bill    ! the master    says   you’re to go       down        the chimney ! ”
-# N🅪Sg/VB/J/P . J/R  . NPr/VB+ . D+  NPr/VB/J+ NPl/V3 K      P  NSg/VB/J N🅪Sg/VB/J/P D   NSg/VB+ . .
+# N🅪Sg/VB/J/P . R    . NPr/VB+ . D+  NPr/VB/J+ NPl/V3 K      P  NSg/VB/J N🅪Sg/VB/J/P D   NSg/VB+ . .
 >
 #
 > “ Oh     ! So          Bill’s got to come       down        the chimney , has he       ? ” said Alice to herself .
@@ -1400,8 +1400,8 @@
 # NPr/I/J/Dq . .
 >
 #
-> She  drew    her     foot    as    far      down        the chimney as    she  could   , and  waited till       she
-# ISg+ NPr/VPt ISg/D$+ NSg/VB+ R/C/P NSg/VB/J N🅪Sg/VB/J/P D+  NSg/VB+ R/C/P ISg+ NSg/VXB . VB/C VP/J   NSg/VB/C/P ISg+
+> She  drew    her     foot    as    far      down        the chimney as    she  could , and  waited till       she
+# ISg+ NPr/VPt ISg/D$+ NSg/VB+ R/C/P NSg/VB/J N🅪Sg/VB/J/P D+  NSg/VB+ R/C/P ISg+ VXB   . VB/C VP/J   NSg/VB/C/P ISg+
 > heard a    little      animal ( she  couldn’t guess  of what   sort    it       was  ) scratching and
 # VP/J  D/P+ NPr/I/J/Dq+ NSg/J+ . ISg+ VXB      NSg/VB P  NSg/I+ NSg/VB+ NPr/ISg+ VLPt . Nᴹ/Vg/J    VB/C
 > scrambling about in        the chimney close    above   her     : then      , saying    to herself “ This
@@ -1436,8 +1436,8 @@
 #
 > “ We   must    burn   the house   down        ! ” said the Rabbit’s voice   ; and  Alice called out          as
 # . IPl+ NSg/VXB NSg/VB D+  NPr/VB+ N🅪Sg/VB/J/P . . VP/J D   NSg$     NSg/VB+ . VB/C NPr+  VP/J   NSg/VB/J/R/P R/C/P
-> loud  as    she  could   , “ If    you    do  , I’ll set       Dinah at    you    ! ”
-# NSg/J R/C/P ISg+ NSg/VXB . . NSg/C ISgPl+ VXB . K    NPr/VBP/J NPr   NSg/P ISgPl+ . .
+> loud  as    she  could , “ If    you    do  , I’ll set       Dinah at    you    ! ”
+# NSg/J R/C/P ISg+ VXB   . . NSg/C ISgPl+ VXB . K    NPr/VBP/J NPr   NSg/P ISgPl+ . .
 >
 #
 > There was  a    dead      silence instantly , and  Alice thought to herself , “ I       wonder  what
@@ -1482,8 +1482,8 @@
 # Nᴹ/Vg/J Nᴹ/VB/J/P . D   NSg/VB/J NPr/I/J/Dq NSg    . NPr/VB+ . VLPt NPr/J/R/P D   NSg/VB/J . N🅪Sg/VLg/J/C VP   NSg/VB/J/P
 > by two guinea - pigs    , who    were giving  it       something out          of a   bottle  . They all          made
 # P  NSg NPr+   . NPl/V3+ . NPr/I+ VLPt Nᴹ/Vg/J NPr/ISg+ NSg/I/J+  NSg/VB/J/R/P P  D/P NSg/VB+ . IPl+ NSg/I/J/C/Dq VP
-> a   rush      at    Alice the moment she  appeared ; but     she  ran off        as    hard     as    she  could   ,
-# D/P NPr/VB/J+ NSg/P NPr+  D+  NSg+   ISg+ VP/J     . NSg/C/P ISg+ VPt NSg/VB/J/P R/C/P N🅪Sg/J/R R/C/P ISg+ NSg/VXB .
+> a   rush      at    Alice the moment she  appeared ; but     she  ran off        as    hard     as    she  could ,
+# D/P NPr/VB/J+ NSg/P NPr+  D+  NSg+   ISg+ VP/J     . NSg/C/P ISg+ VPt NSg/VB/J/P R/C/P N🅪Sg/J/R R/C/P ISg+ VXB   .
 > and  soon found  herself safe     in        a    thick     wood         .
 # VB/C J/R  NSg/VP ISg+    NSg/VB/J NPr/J/R/P D/P+ NSg/VB/J+ NPr🅪Sg/VB/J+ .
 >
@@ -1678,8 +1678,8 @@
 # . NSg/VB . . VP/J D   NSg/VB      .
 >
 #
-> Here was  another puzzling question ; and  as    Alice could   not     think  of any     good
-# J/R  VLPt I/D+    Nᴹ/Vg/J+ NSg/VB+  . VB/C R/C/P NPr+  NSg/VXB NSg/R/C NSg/VB P  I/R/Dq+ NPr/VB/J+
+> Here was  another puzzling question ; and  as    Alice could not     think  of any     good
+# R    VLPt I/D+    Nᴹ/Vg/J+ NSg/VB+  . VB/C R/C/P NPr+  VXB   NSg/R/C NSg/VB P  I/R/Dq+ NPr/VB/J+
 > reason   , and  as    the Caterpillar seemed to be       in        a   very unpleasant state   of mind    ,
 # N🅪Sg/VB+ . VB/C R/C/P D   NSg/VB      VP/J   P  NSg/VLXB NPr/J/R/P D/P J/R  NSg/J      N🅪Sg/VB P  NSg/VB+ .
 > she  turned away .
@@ -1700,8 +1700,8 @@
 # . NSg/VB D$+  NSg/VB/JC+ . . VP/J D   NSg/VB      .
 >
 #
-> “ Is  that     all          ? ” said Alice , swallowing down        her     anger  as    well       as    she  could   .
-# . VL3 I/C/Ddem NSg/I/J/C/Dq . . VP/J NPr+  . Nᴹ/Vg/J    N🅪Sg/VB/J/P ISg/D$+ Nᴹ/VB+ R/C/P NSg/VB/J/R R/C/P ISg+ NSg/VXB .
+> “ Is  that     all          ? ” said Alice , swallowing down        her     anger  as    well       as    she  could .
+# . VL3 I/C/Ddem NSg/I/J/C/Dq . . VP/J NPr+  . Nᴹ/Vg/J    N🅪Sg/VB/J/P ISg/D$+ Nᴹ/VB+ R/C/P NSg/VB/J/R R/C/P ISg+ VXB   .
 >
 #
 > “ No       , ” said the Caterpillar .
@@ -1880,8 +1880,8 @@
 # NSg D   NSg/VB      VPt  D   NSg    NSg/VB/J/R/P P  ISg/D$+ NSg/VB+ VB/C VP/J   NSg/C NPr/C R     .
 > and  shook     itself . Then      it       got down        off        the mushroom  , and  crawled away in        the
 # VB/C NSg/VPt/J ISg+   . NSg/J/R/C NPr/ISg+ VP  N🅪Sg/VB/J/P NSg/VB/J/P D   N🅪Sg/VB/J . VB/C VP/J    VB/J NPr/J/R/P D
-> grass      , merely remarking as    it       went    , “ One     side      will    make   you    grow taller , and  the
-# NPr🅪Sg/VB+ . R      Nᴹ/Vg/J   R/C/P NPr/ISg+ NSg/VPt . . NSg/I/J NSg/VB/J+ NPr/VXB NSg/VB ISgPl+ VB   JC     . VB/C D
+> grass      , merely remarking as    it       went , “ One     side      will    make   you    grow taller , and  the
+# NPr🅪Sg/VB+ . R      Nᴹ/Vg/J   R/C/P NPr/ISg+ VPt  . . NSg/I/J NSg/VB/J+ NPr/VXB NSg/VB ISgPl+ VB   JC     . VB/C D
 > other    side      will    make   you    grow shorter . ”
 # NSg/VB/J NSg/VB/J+ NPr/VXB NSg/VB ISgPl+ VB   NSg/JC  . .
 >
@@ -1930,8 +1930,8 @@
 # . NSg/VBPp/P . D$+ NPr$   NSg/VB/J NSg/P NSg/VB/J . . VP/J NPr+  NPr/J/R/P D/P N🅪Sg/I/VB P  N🅪Sg/VB/J+ . I/C+  VP/J
 > into alarm    in        another moment , when    she  found  that     her     shoulders were nowhere to
 # P    N🅪Sg/VB+ NPr/J/R/P I/D+    NSg+   . NSg/I/C ISg+ NSg/VP I/C/Ddem ISg/D$+ NPl/V3+   VLPt NSg/J   P
-> be       found  : all          she  could   see    , when    she  looked down        , was  an  immense length  of
-# NSg/VLXB NSg/VP . NSg/I/J/C/Dq ISg+ NSg/VXB NSg/VB . NSg/I/C ISg+ VP/J   N🅪Sg/VB/J/P . VLPt D/P NSg/J   N🅪Sg/VB P
+> be       found  : all          she  could see    , when    she  looked down        , was  an  immense length  of
+# NSg/VLXB NSg/VP . NSg/I/J/C/Dq ISg+ VXB   NSg/VB . NSg/I/C ISg+ VP/J   N🅪Sg/VB/J/P . VLPt D/P NSg/J   N🅪Sg/VB P
 > neck    , which seemed to rise   like         a    stalk   out          of a   sea of green        leaves  that      lay
 # NSg/VB+ . I/C+  VP/J   P  NSg/VB NSg/VB/J/C/P D/P+ NSg/VB+ NSg/VB/J/R/P P  D/P NSg P  NPr🅪Sg/VB/J+ NPl/V3+ I/C/Ddem+ NSg/VBPt/J
 > far      below her     .
@@ -1986,8 +1986,8 @@
 #
 > “ I’ve tried the roots  of trees   , and  I’ve tried banks     , and  I’ve tried hedges , ”
 # . K    VP/J  D   NPl/V3 P  NPl/V3+ . VB/C K    VP/J  NPrPl/V3+ . VB/C K    VP/J  NPl/V3 . .
-> the Pigeon  went    on  , without attending to her     ; “ but     those  serpents ! There’s no
-# D   NSg/VB+ NSg/VPt J/P . C/P     Nᴹ/Vg/J   P  ISg/D$+ . . NSg/C/P I/Ddem NPl/V3   . K       NSg/Dq/P
+> the Pigeon  went on  , without attending to her     ; “ but     those  serpents ! There’s no
+# D   NSg/VB+ VPt  J/P . C/P     Nᴹ/Vg/J   P  ISg/D$+ . . NSg/C/P I/Ddem NPl/V3   . K       NSg/Dq/P
 > pleasing them     ! ”
 # Nᴹ/Vg/J  NSg/IPl+ . .
 >
@@ -2078,8 +2078,8 @@
 #
 > “ Well       , be       off        , then      ! ” said the Pigeon  in        a    sulky  tone       , as    it       settled down        again
 # . NSg/VB/J/R . NSg/VLXB NSg/VB/J/P . NSg/J/R/C . . VP/J D   NSg/VB+ NPr/J/R/P D/P+ NSg/J+ N🅪Sg/I/VB+ . R/C/P NPr/ISg+ VP/J    N🅪Sg/VB/J/P P
-> into its     nest    . Alice crouched down        among the trees   as    well       as    she  could   , for   her
-# P    ISg/D$+ NSg/VB+ . NPr+  VP/J     N🅪Sg/VB/J/P P     D+  NPl/V3+ R/C/P NSg/VB/J/R R/C/P ISg+ NSg/VXB . R/C/P ISg/D$+
+> into its     nest    . Alice crouched down        among the trees   as    well       as    she  could , for   her
+# P    ISg/D$+ NSg/VB+ . NPr+  VP/J     N🅪Sg/VB/J/P P     D+  NPl/V3+ R/C/P NSg/VB/J/R R/C/P ISg+ VXB   . R/C/P ISg/D$+
 > neck    kept getting entangled among the branches , and  every now       and  then      she  had
 # NSg/VB+ VP   NSg/Vg  VP/J      P     D   NPl/V3+  . VB/C Dq    NSg/J/R/C VB/C NSg/J/R/C ISg+ VP
 > to stop   and  untwist it       . After a    while       she  remembered that     she  still      held the
@@ -2142,12 +2142,12 @@
 # D+  N🅪SgPl/VB+ . NSg     VPt   P  Nᴹ/Vg/J   P    NSg/J/P ISg/D$+ NSg/VB/J D/P NSg/J NSg/VB+ . R      R/C/P
 > large as    himself , and  this   he       handed over    to the other    , saying    , in        a   solemn
 # NSg/J R/C/P ISg+    . VB/C I/Ddem NPr/ISg+ VP/J   NSg/J/P P  D   NSg/VB/J . N🅪Sg/Vg/J . NPr/J/R/P D/P J
-> tone       , “ For   the Duchess . An  invitation from the Queen     to play    croquet . ” The
-# N🅪Sg/I/VB+ . . R/C/P D   NSg/VB  . D/P NSg+       P    D+  NPr/VB/J+ P  N🅪Sg/VB NSg/VB  . . D
+> tone       , “ For   the Duchess . An  invitation from the Queen   to play    croquet . ” The
+# N🅪Sg/I/VB+ . . R/C/P D   NSg/VB  . D/P NSg+       P    D+  NPr/VB+ P  N🅪Sg/VB NSg/VB  . . D
 > Frog   - Footman repeated , in        the same solemn tone       , only  changing the order   of the
 # NSg/VB . NSg     VP/J     . NPr/J/R/P D   I/J  J      N🅪Sg/I/VB+ . J/R/C Nᴹ/Vg/J  D   N🅪Sg/VB P  D
-> words   a   little     , “ From the Queen     . An   invitation for   the Duchess to play    croquet . ”
-# NPl/V3+ D/P NPr/I/J/Dq . . P    D   NPr/VB/J+ . D/P+ NSg+       R/C/P D   NSg/VB  P  N🅪Sg/VB NSg/VB  . .
+> words   a   little     , “ From the Queen   . An   invitation for   the Duchess to play    croquet . ”
+# NPl/V3+ D/P NPr/I/J/Dq . . P    D   NPr/VB+ . D/P+ NSg+       R/C/P D   NSg/VB  P  N🅪Sg/VB NSg/VB  . .
 >
 #
 > Then      they both   bowed low        , and  their curls  got entangled together .
@@ -2164,16 +2164,16 @@
 # D   N🅪Sg/VB+ .
 >
 #
-> Alice went    timidly up         to the door    , and  knocked .
-# NPr+  NSg/VPt R       NSg/VB/J/P P  D   NSg/VB+ . VB/C VP/J    .
+> Alice went timidly up         to the door    , and  knocked .
+# NPr+  VPt  R       NSg/VB/J/P P  D   NSg/VB+ . VB/C VP/J    .
 >
 #
 > “ There’s no       sort   of use     in        knocking , ” said the Footman , “ and  that      for   two
 # . K       NSg/Dq/P NSg/VB P  N🅪Sg/VB NPr/J/R/P Nᴹ/Vg/J+ . . VP/J D   NSg     . . VB/C I/C/Ddem+ R/C/P NSg
 > reasons . First , because I’m on  the same side     of the door    as    you    are ; secondly ,
 # NPl/V3+ . NSg/J . C/P     K   J/P D   I/J  NSg/VB/J P  D   NSg/VB+ R/C/P ISgPl+ VLB . R        .
-> because they’re making  such  a   noise    inside  , no       one      could   possibly hear you    . ” And
-# C/P     K       Nᴹ/Vg/J NSg/I D/P N🅪Sg/VB+ NSg/J/P . NSg/Dq/P NSg/I/J+ NSg/VXB R        VB   ISgPl+ . . VB/C
+> because they’re making  such  a   noise    inside  , no       one      could possibly hear you    . ” And
+# C/P     K       Nᴹ/Vg/J NSg/I D/P N🅪Sg/VB+ NSg/J/P . NSg/Dq/P NSg/I/J+ VXB   R        VB   ISgPl+ . . VB/C
 > certainly there was  a   most         extraordinary noise   going   on  within  — a   constant
 # R         R+    VLPt D/P NSg/I/J/R/Dq NSg/J         N🅪Sg/VB Nᴹ/Vg/J J/P NSg/J/P . D/P NSg/J
 > howling and  sneezing , and  every now       and  then      a   great crash     , as    if    a   dish    or
@@ -2186,12 +2186,12 @@
 # . VB     . NSg/J/R/C . . VP/J NPr+  . . NSg/C NPr/VLB/J ISg/#r+ P  NSg/VB NPr/J/R/P . .
 >
 #
-> “ There might    be       some     sense   in        your knocking , ” the Footman went    on  without
-# . R+    Nᴹ/VXB/J NSg/VLXB I/J/R/Dq N🅪Sg/VB NPr/J/R/P D$+  Nᴹ/Vg/J  . . D   NSg     NSg/VPt J/P C/P
+> “ There might    be       some     sense   in        your knocking , ” the Footman went on  without
+# . R+    Nᴹ/VXB/J NSg/VLXB I/J/R/Dq N🅪Sg/VB NPr/J/R/P D$+  Nᴹ/Vg/J  . . D   NSg     VPt  J/P C/P
 > attending to her     , “ if    we   had the door    between us       . For   instance , if    you    were
 # Nᴹ/Vg/J   P  ISg/D$+ . . NSg/C IPl+ VP  D   NSg/VB+ NSg/P   NPr/IPl+ . R/C/P NSg/VB+  . NSg/C ISgPl+ VLPt
-> inside  , you    might    knock  , and  I       could   let     you    out          , you    know . ” He       was  looking up
-# NSg/J/P . ISgPl+ Nᴹ/VXB/J NSg/VB . VB/C ISg/#r+ NSg/VXB NSg/VBP ISgPl+ NSg/VB/J/R/P . ISgPl+ VB   . . NPr/ISg+ VLPt Nᴹ/Vg/J NSg/VB/J/P
+> inside  , you    might    knock  , and  I       could let     you    out          , you    know . ” He       was  looking up
+# NSg/J/P . ISgPl+ Nᴹ/VXB/J NSg/VB . VB/C ISg/#r+ VXB   NSg/VBP ISgPl+ NSg/VB/J/R/P . ISgPl+ VB   . . NPr/ISg+ VLPt Nᴹ/Vg/J NSg/VB/J/P
 > into the sky      all           the time       he       was  speaking , and  this    Alice thought decidedly
 # P    D+  N🅪Sg/VB+ NSg/I/J/C/Dq+ D+  N🅪Sg/VB/J+ NPr/ISg+ VLPt Nᴹ/Vg/J  . VB/C I/Ddem+ NPr+  N🅪Sg/VP R
 > uncivil . “ But     perhaps he       can’t help   it       , ” she  said to herself ; “ his     eyes    are so
@@ -2203,7 +2203,7 @@
 >
 #
 > “ I       shall sit    here , ” the Footman remarked , “ till       tomorrow — ”
-# . ISg/#r+ VXB   NSg/VB J/R  . . D   NSg     VP/J     . . NSg/VB/C/P NSg+     . .
+# . ISg/#r+ VXB   NSg/VB R    . . D   NSg     VP/J     . . NSg/VB/C/P NSg+     . .
 >
 #
 > At    this    moment the door   of the house   opened , and  a    large  plate   came      skimming
@@ -2241,7 +2241,7 @@
 > The Footman seemed to think  this   a   good     opportunity for   repeating his     remark  ,
 # D   NSg     VP/J   P  NSg/VB I/Ddem D/P NPr/VB/J N🅪Sg+       R/C/P Nᴹ/Vg/J   ISg/D$+ NSg/VB+ .
 > with variations . “ I       shall sit    here , ” he       said , “ on  and  off        , for   days and  days . ”
-# P    NPl        . . ISg/#r+ VXB   NSg/VB J/R  . . NPr/ISg+ VP/J . . J/P VB/C NSg/VB/J/P . R/C/P NPl  VB/C NPl+ . .
+# P    NPl        . . ISg/#r+ VXB   NSg/VB R    . . NPr/ISg+ VP/J . . J/P VB/C NSg/VB/J/P . R/C/P NPl  VB/C NPl+ . .
 >
 #
 > “ But     what   am        I       to do  ? ” said Alice .
@@ -2254,8 +2254,8 @@
 #
 > “ Oh     , there’s no       use     in        talking  to him  , ” said Alice desperately : “ he’s perfectly
 # . NPr/VB . K       NSg/Dq/P N🅪Sg/VB NPr/J/R/P Nᴹ/Vg/J+ P  ISg+ . . VP/J NPr+  R           . . NPr$ R
-> idiotic ! ” And  she  opened the door    and  went    in        .
-# J       . . VB/C ISg+ VP/J   D+  NSg/VB+ VB/C NSg/VPt NPr/J/R/P .
+> idiotic ! ” And  she  opened the door    and  went in        .
+# J       . . VB/C ISg+ VP/J   D+  NSg/VB+ VB/C VPt  NPr/J/R/P .
 >
 #
 > The door    led      right    into a    large  kitchen , which was  full     of smoke    from one      end     to
@@ -2270,8 +2270,8 @@
 #
 > “ There’s certainly too much         pepper   in        that     soup     ! ” Alice said to herself , as    well
 # . K       R         R   NSg/I/J/R/Dq N🅪Sg/VB+ NPr/J/R/P I/C/Ddem N🅪Sg/VB+ . . NPr+  VP/J P  ISg+    . R/C/P NSg/VB/J/R
-> as    she  could   for   sneezing .
-# R/C/P ISg+ NSg/VXB R/C/P Nᴹ/Vg/J  .
+> as    she  could for   sneezing .
+# R/C/P ISg+ VXB   R/C/P Nᴹ/Vg/J  .
 >
 #
 > There was  certainly too much         of it       in        the air      . Even       the Duchess sneezed
@@ -2302,14 +2302,14 @@
 # ISg+ VP/J D   NSg/VB/J NSg/VB P    NSg/I+ NSg/J+ Nᴹ/VB+   I/C/Ddem+ NPr+  R     VP/J   . NSg/C/P
 > she  saw     in        another moment that      it       was  addressed to the baby      , and  not     to her     , so
 # ISg+ NSg/VPt NPr/J/R/P I/D+    NSg+   I/C/Ddem+ NPr/ISg+ VLPt VP/J      P  D+  NSg/VB/J+ . VB/C NSg/R/C P  ISg/D$+ . NSg/I/J/R/C
-> she  took courage , and  went    on  again : —
-# ISg+ VPt  NSg/VB+ . VB/C NSg/VPt J/P P     . .
+> she  took courage , and  went on  again : —
+# ISg+ VPt  NSg/VB+ . VB/C VPt  J/P P     . .
 >
 #
 > “ I       didn’t know that     Cheshire cats    always grinned ; in        fact , I       didn’t know that
 # . ISg/#r+ VXPt   VB   I/C/Ddem NPr      NPl/V3+ R      VP      . NPr/J/R/P NSg+ . ISg/#r+ VXPt   VB   I/C/Ddem
-> cats    could   grin    . ”
-# NPl/V3+ NSg/VXB NSg/VB+ . .
+> cats    could grin    . ”
+# NPl/V3+ VXB   NSg/VB+ . .
 >
 #
 > “ They all          can     , ” said the Duchess ; “ and  most         of ’ em       do  . ”
@@ -2376,12 +2376,12 @@
 # NPr+  VP/J    NPr/VB/J/R R         NSg/P D+  NPr/VB+ . P  NSg/VB NSg/C ISg+ VP    P  NSg/VB D+
 > hint    ; but     the cook    was  busily stirring the soup     , and  seemed not     to be       listening ,
 # NSg/VB+ . NSg/C/P D+  NPr/VB+ VLPt R      NSg/Vg/J D+  N🅪Sg/VB+ . VB/C VP/J   NSg/R/C P  NSg/VLXB Nᴹ/Vg/J   .
-> so          she  went    on  again : “ Twenty - four hours , I       think  ; or    is  it       twelve ? I       — ”
-# NSg/I/J/R/C ISg+ NSg/VPt J/P P     . . NSg    . NSg  NPl+  . ISg/#r+ NSg/VB . NPr/C VL3 NPr/ISg+ NSg    . ISg/#r+ . .
+> so          she  went on  again : “ Twenty - four hours , I       think  ; or    is  it       twelve ? I       — ”
+# NSg/I/J/R/C ISg+ VPt  J/P P     . . NSg    . NSg  NPl+  . ISg/#r+ NSg/VB . NPr/C VL3 NPr/ISg+ NSg    . ISg/#r+ . .
 >
 #
-> “ Oh     , don’t bother me       , ” said the Duchess ; “ I       never could   abide figures ! ” And  with
-# . NPr/VB . VXB   Nᴹ/VB  NPr/ISg+ . . VP/J D   NSg/VB  . . ISg/#r+ R     NSg/VXB VB    NPl/V3+ . . VB/C P
+> “ Oh     , don’t bother me       , ” said the Duchess ; “ I       never could abide figures ! ” And  with
+# . NPr/VB . VXB   Nᴹ/VB  NPr/ISg+ . . VP/J D   NSg/VB  . . ISg/#r+ R     VXB   VB    NPl/V3+ . . VB/C P
 > that     she  began nursing her     child   again , singing a   sort    of lullaby to it       as    she
 # I/C/Ddem ISg+ VPt   Nᴹ/Vg/J ISg/D$+ NSg/VB+ P     . Nᴹ/Vg/J D/P NSg/VB+ P  NSg/VB  P  NPr/ISg+ R/C/P ISg+
 > did  so          , and  giving  it       a   violent  shake   at    the end    of every line    :
@@ -2405,7 +2405,7 @@
 > While      the Duchess sang    the second   verse  of the song  , she  kept tossing the baby
 # NSg/VB/C/P D   NSg/VB  NPr/VPt D   NSg/VB/J NSg/VB P  D   N🅪Sg+ . ISg+ VP   Nᴹ/Vg/J D   NSg/VB/J+
 > violently up         and  down        , and  the poor     little     thing howled so          , that     Alice could
-# R         NSg/VB/J/P VB/C N🅪Sg/VB/J/P . VB/C D   NSg/VB/J NPr/I/J/Dq NSg+  VP/J   NSg/I/J/R/C . I/C/Ddem NPr+  NSg/VXB
+# R         NSg/VB/J/P VB/C N🅪Sg/VB/J/P . VB/C D   NSg/VB/J NPr/I/J/Dq NSg+  VP/J   NSg/I/J/R/C . I/C/Ddem NPr+  VXB
 > hardly hear the words   : —
 # R      VB   D   NPl/V3+ . .
 >
@@ -2425,13 +2425,13 @@
 >
 #
 > “ Here ! you    may     nurse  it       a    bit      , if    you    like         ! ” the Duchess said to Alice , flinging
-# . J/R  . ISgPl+ NPr/VXB NSg/VB NPr/ISg+ D/P+ NSg/VPt+ . NSg/C ISgPl+ NSg/VB/J/C/P . . D   NSg/VB  VP/J P  NPr+  . Nᴹ/Vg/J
+# . R    . ISgPl+ NPr/VXB NSg/VB NPr/ISg+ D/P+ NSg/VPt+ . NSg/C ISgPl+ NSg/VB/J/C/P . . D   NSg/VB  VP/J P  NPr+  . Nᴹ/Vg/J
 > the baby      at    her     as    she  spoke   . “ I       must    go       and  get    ready    to play    croquet with the
 # D   NSg/VB/J+ NSg/P ISg/D$+ R/C/P ISg+ NSg/VPt . . ISg/#r+ NSg/VXB NSg/VB/J VB/C NSg/VB NSg/VB/J P  N🅪Sg/VB NSg/VB  P    D+
-> Queen     , ” and  she  hurried out          of the room     . The cook   threw a   frying  - pan      after her
-# NPr/VB/J+ . . VB/C ISg+ VP/J    NSg/VB/J/R/P P  D   N🅪Sg/VB+ . D   NPr/VB VPt   D/P Nᴹ/Vg/J . NPr/VB/J P     ISg/D$+
-> as    she  went    out          , but     it       just missed her     .
-# R/C/P ISg+ NSg/VPt NSg/VB/J/R/P . NSg/C/P NPr/ISg+ J/R  VP/J   ISg/D$+ .
+> Queen   , ” and  she  hurried out          of the room     . The cook   threw a   frying  - pan      after her
+# NPr/VB+ . . VB/C ISg+ VP/J    NSg/VB/J/R/P P  D   N🅪Sg/VB+ . D   NPr/VB VPt   D/P Nᴹ/Vg/J . NPr/VB/J P     ISg/D$+
+> as    she  went out          , but     it       just missed her     .
+# R/C/P ISg+ VPt  NSg/VB/J/R/P . NSg/C/P NPr/ISg+ J/R  VP/J   ISg/D$+ .
 >
 #
 > Alice caught the baby     with some      difficulty , as    it       was  a   queer    - shaped little
@@ -2444,8 +2444,8 @@
 # N🅪Sg/VB/J+ . NSg/VB+ NSg/I/C ISg+ VP/J   NPr/ISg+ . VB/C VP   Nᴹ/Vg/J  ISg+   NSg/VB/J/P VB/C Nᴹ/Vg/J
 > itself out          again , so          that      altogether , for   the first minute    or    two , it       was  as
 # ISg+   NSg/VB/J/R/P P     . NSg/I/J/R/C I/C/Ddem+ NSg        . R/C/P D   NSg/J NSg/VB/J+ NPr/C NSg . NPr/ISg+ VLPt R/C/P
-> much         as    she  could   do  to hold     it       .
-# NSg/I/J/R/Dq R/C/P ISg+ NSg/VXB VXB P  NSg/VB/J NPr/ISg+ .
+> much         as    she  could do  to hold     it       .
+# NSg/I/J/R/Dq R/C/P ISg+ VXB   VXB P  NSg/VB/J NPr/ISg+ .
 >
 #
 > As    soon as    she  had made out          the proper way   of nursing it       , ( which was  to twist  it
@@ -2468,8 +2468,8 @@
 #
 > The baby      grunted again , and  Alice looked very anxiously into its     face    to see
 # D+  NSg/VB/J+ VP/J    P     . VB/C NPr+  VP/J   J/R  R         P    ISg/D$+ NSg/VB+ P  NSg/VB
-> what   was  the matter   with it       . There could   be       no        doubt    that      it       had a   very turn   - up
-# NSg/I+ VLPt D   N🅪Sg/VB+ P    NPr/ISg+ . R+    NSg/VXB NSg/VLXB NSg/Dq/P+ N🅪Sg/VB+ I/C/Ddem+ NPr/ISg+ VP  D/P J/R  NSg/VB . NSg/VB/J/P
+> what   was  the matter   with it       . There could be       no        doubt    that      it       had a   very turn   - up
+# NSg/I+ VLPt D   N🅪Sg/VB+ P    NPr/ISg+ . R+    VXB   NSg/VLXB NSg/Dq/P+ N🅪Sg/VB+ I/C/Ddem+ NPr/ISg+ VP  D/P J/R  NSg/VB . NSg/VB/J/P
 > nose    , much         more         like         a   snout  than a   real  nose    ; also its     eyes    were getting
 # NSg/VB+ . NSg/I/J/R/Dq NPr/I/J/R/Dq NSg/VB/J/C/P D/P NSg/VB C/P  D/P NSg/J NSg/VB+ . R/C  ISg/D$+ NPl/V3+ VLPt NSg/Vg
 > extremely small    for   a   baby      : altogether Alice did  not     like         the look   of the thing
@@ -2486,16 +2486,16 @@
 # NPr+  . R         . . K    NSg/VXB NSg/I/J+ NPr/I/J/R/Dq P  VXB P    ISgPl+ . NSg/VB+ NSg/J/R/C . . D+  NSg/VB/J+
 > little      thing sobbed again ( or    grunted , it       was  impossible to say    which ) , and  they
 # NPr/I/J/Dq+ NSg+  VP     P     . NPr/C VP/J    . NPr/ISg+ VLPt NSg/J      P  NSg/VB I/C+  . . VB/C IPl+
-> went    on  for   some     while      in        silence .
-# NSg/VPt J/P R/C/P I/J/R/Dq NSg/VB/C/P NPr/J/R/P NSg/VB+ .
+> went on  for   some     while      in        silence .
+# VPt  J/P R/C/P I/J/R/Dq NSg/VB/C/P NPr/J/R/P NSg/VB+ .
 >
 #
 > Alice was  just beginning to think  to herself , “ Now       , what   am        I       to do  with this
 # NPr+  VLPt J/R  NSg/Vg/J  P  NSg/VB P  ISg+    . . NSg/J/R/C . NSg/I+ NPr/VLB/J ISg/#r+ P  VXB P    I/Ddem+
 > creature when    I       get    it       home      ? ” when    it       grunted again , so          violently , that     she
 # NSg+     NSg/I/C ISg/#r+ NSg/VB NPr/ISg+ NSg/VB/J+ . . NSg/I/C NPr/ISg+ VP/J    P     . NSg/I/J/R/C R         . I/C/Ddem ISg+
-> looked down        into its     face    in        some     alarm    . This    time       there could   be       no       mistake
-# VP/J   N🅪Sg/VB/J/P P    ISg/D$+ NSg/VB+ NPr/J/R/P I/J/R/Dq N🅪Sg/VB+ . I/Ddem+ N🅪Sg/VB/J+ R+    NSg/VXB NSg/VLXB NSg/Dq/P NSg/VB
+> looked down        into its     face    in        some     alarm    . This    time       there could be       no       mistake
+# VP/J   N🅪Sg/VB/J/P P    ISg/D$+ NSg/VB+ NPr/J/R/P I/J/R/Dq N🅪Sg/VB+ . I/Ddem+ N🅪Sg/VB/J+ R+    VXB   NSg/VLXB NSg/Dq/P NSg/VB
 > about it       : it       was  neither more         nor   less    than a    pig     , and  she  felt      that     it       would be
 # J/P   NPr/ISg+ . NPr/ISg+ VLPt I/C     NPr/I/J/R/Dq NSg/C J/R/C/P C/P  D/P+ NSg/VB+ . VB/C ISg+ N🅪Sg/VP/J I/C/Ddem NPr/ISg+ VXB   NSg/VLXB
 > quite absurd for   her     to carry  it       further .
@@ -2530,10 +2530,10 @@
 # . NPr      NSg  . . ISg+ VPt   . NPr/VB/J/R R       . R/C/P ISg+ VXPt NSg/R/C NSg/P NSg/I/J/C/Dq VB+  I/C
 > it       would like         the name    : however , it       only  grinned a   little     wider . “ Come       , it’s
 # NPr/ISg+ VXB   NSg/VB/J/C/P D   NSg/VB+ . C       . NPr/ISg+ J/R/C VP      D/P NPr/I/J/Dq JC    . . NSg/VBPp/P . K
-> pleased so          far      , ” thought Alice , and  she  went    on  . “ Would you    tell   me       , please ,
-# VP/J    NSg/I/J/R/C NSg/VB/J . . N🅪Sg/VP NPr+  . VB/C ISg+ NSg/VPt J/P . . VXB   ISgPl+ NPr/VB NPr/ISg+ . VB     .
+> pleased so          far      , ” thought Alice , and  she  went on  . “ Would you    tell   me       , please ,
+# VP/J    NSg/I/J/R/C NSg/VB/J . . N🅪Sg/VP NPr+  . VB/C ISg+ VPt  J/P . . VXB   ISgPl+ NPr/VB NPr/ISg+ . VB     .
 > which way    I       ought     to go       from here ? ”
-# I/C+  NSg/J+ ISg/#r+ NSg/I/VXB P  NSg/VB/J P    J/R  . .
+# I/C+  NSg/J+ ISg/#r+ NSg/I/VXB P  NSg/VB/J P    R    . .
 >
 #
 > “ That      depends a    good      deal      on  where   you    want   to get    to , ” said the Cat       .
@@ -2556,10 +2556,10 @@
 # . NPr/VB . K      J    P  VXB I/C/Ddem+ . . VP/J D   NSg/VB/J+ . . NSg/C ISgPl+ J/R/C NSg/VB NPr/VB/J NSg/I  . .
 >
 #
-> Alice felt      that     this    could   not     be       denied , so          she  tried another question . “ What
-# NPr+  N🅪Sg/VP/J I/C/Ddem I/Ddem+ NSg/VXB NSg/R/C NSg/VLXB VP/J   . NSg/I/J/R/C ISg+ VP/J  I/D+    NSg/VB+  . . NSg/I+
+> Alice felt      that     this    could not     be       denied , so          she  tried another question . “ What
+# NPr+  N🅪Sg/VP/J I/C/Ddem I/Ddem+ VXB   NSg/R/C NSg/VLXB VP/J   . NSg/I/J/R/C ISg+ VP/J  I/D+    NSg/VB+  . . NSg/I+
 > sort   of people  live about here ? ”
-# NSg/VB P  NPl/VB+ VB/J J/P   J/R  . .
+# NSg/VB P  NPl/VB+ VB/J J/P   R    . .
 >
 #
 > “ In        that      direction , ” the Cat       said , waving  its     right     paw     round      , “ lives a   Hatter :
@@ -2575,7 +2575,7 @@
 >
 #
 > “ Oh     , you    can’t help   that      , ” said the Cat       : “ we’re all          mad      here . I’m mad      . You’re
-# . NPr/VB . ISgPl+ VXB   NSg/VB I/C/Ddem+ . . VP/J D   NSg/VB/J+ . . K     NSg/I/J/C/Dq NSg/VB/J J/R  . K   NSg/VB/J . K
+# . NPr/VB . ISgPl+ VXB   NSg/VB I/C/Ddem+ . . VP/J D   NSg/VB/J+ . . K     NSg/I/J/C/Dq NSg/VB/J R    . K   NSg/VB/J . K
 > mad      . ”
 # NSg/VB/J . .
 >
@@ -2585,11 +2585,11 @@
 >
 #
 > “ You    must    be       , ” said the Cat       , “ or    you    wouldn’t have    come       here . ”
-# . ISgPl+ NSg/VXB NSg/VLXB . . VP/J D+  NSg/VB/J+ . . NPr/C ISgPl+ VXB      NSg/VXB NSg/VBPp/P J/R  . .
+# . ISgPl+ NSg/VXB NSg/VLXB . . VP/J D+  NSg/VB/J+ . . NPr/C ISgPl+ VXB      NSg/VXB NSg/VBPp/P R    . .
 >
 #
-> Alice didn’t think  that      proved it       at    all          ; however , she  went    on  “ And  how   do  you
-# NPr+  VXPt   NSg/VB I/C/Ddem+ VP/J   NPr/ISg+ NSg/P NSg/I/J/C/Dq . C       . ISg+ NSg/VPt J/P . VB/C NSg/C VXB ISgPl+
+> Alice didn’t think  that      proved it       at    all          ; however , she  went on  “ And  how   do  you
+# NPr+  VXPt   NSg/VB I/C/Ddem+ VP/J   NPr/ISg+ NSg/P NSg/I/J/C/Dq . C       . ISg+ VPt  J/P . VB/C NSg/C VXB ISgPl+
 > know that     you’re mad      ? ”
 # VB   I/C/Ddem K      NSg/VB/J . .
 >
@@ -2602,8 +2602,8 @@
 # . ISg/#r+ VB      NSg/I/J/R/C . . VP/J NPr+  .
 >
 #
-> “ Well       , then      , ” the Cat       went    on  , “ you    see    , a    dog       growls when    it’s angry , and  wags
-# . NSg/VB/J/R . NSg/J/R/C . . D+  NSg/VB/J+ NSg/VPt J/P . . ISgPl+ NSg/VB . D/P+ NSg/VB/J+ NPl/V3 NSg/I/C K    VB/J  . VB/C NPl/V3
+> “ Well       , then      , ” the Cat       went on  , “ you    see    , a    dog       growls when    it’s angry , and  wags
+# . NSg/VB/J/R . NSg/J/R/C . . D+  NSg/VB/J+ VPt  J/P . . ISgPl+ NSg/VB . D/P+ NSg/VB/J+ NPl/V3 NSg/I/C K    VB/J  . VB/C NPl/V3
 > its     tail      when    it’s pleased . Now       I       growl  when    I’m pleased , and  wag    my  tail      when
 # ISg/D$+ NSg/VB/J+ NSg/I/C K    VP/J    . NSg/J/R/C ISg/#r+ NSg/VB NSg/I/C K   VP/J    . VB/C NSg/VB D$+ NSg/VB/J+ NSg/I/C
 > I’m angry . Therefore I’m mad      . ”
@@ -2615,7 +2615,7 @@
 >
 #
 > “ Call   it       what   you    like         , ” said the Cat       . “ Do  you    play    croquet with the Queen
-# . NSg/VB NPr/ISg+ NSg/I+ ISgPl+ NSg/VB/J/C/P . . VP/J D+  NSg/VB/J+ . . VXB ISgPl+ N🅪Sg/VB NSg/VB  P    D   NPr/VB/J+
+# . NSg/VB NPr/ISg+ NSg/I+ ISgPl+ NSg/VB/J/C/P . . VP/J D+  NSg/VB/J+ . . VXB ISgPl+ N🅪Sg/VB NSg/VB  P    D   NPr/VB+
 > to - day     ? ”
 # P  . NPr🅪Sg+ . .
 >
@@ -2796,8 +2796,8 @@
 # . R       NSg/I/J/R/C . . VP/J NPr+  .
 >
 #
-> “ Then      you    should say    what   you    mean     , ” the March   Hare went    on  .
-# . NSg/J/R/C ISgPl+ VXB    NSg/VB NSg/I+ ISgPl+ NSg/VB/J . . D+  NPr/VB+ NSg+ NSg/VPt J/P .
+> “ Then      you    should say    what   you    mean     , ” the March   Hare went on  .
+# . NSg/J/R/C ISgPl+ VXB    NSg/VB NSg/I+ ISgPl+ NSg/VB/J . . D+  NPr/VB+ NSg+ VPt  J/P .
 >
 #
 > “ I       do  , ” Alice hastily replied ; “ at    least    — at    least    I       mean     what   I       say    — that’s the
@@ -2827,11 +2827,11 @@
 >
 #
 > “ It       is  the same thing with you    , ” said the Hatter , and  here the conversation
-# . NPr/ISg+ VL3 D   I/J  NSg   P    ISgPl+ . . VP/J D   NSg/VB . VB/C J/R  D   N🅪Sg/VB+
+# . NPr/ISg+ VL3 D   I/J  NSg   P    ISgPl+ . . VP/J D   NSg/VB . VB/C R    D   N🅪Sg/VB+
 > dropped , and  the party     sat    silent for   a   minute    , while      Alice thought over    all          she
 # VP/J    . VB/C D   NSg/VB/J+ NSg/VP NSg/J  R/C/P D/P NSg/VB/J+ . NSg/VB/C/P NPr+  N🅪Sg/VP NSg/J/P NSg/I/J/C/Dq ISg+
-> could   remember about ravens and  writing - desks   , which wasn’t much         .
-# NSg/VXB NSg/VB   J/P   NPl/V3 VB/C Nᴹ/Vg/J . NPl/V3+ . I/C+  VPt    NSg/I/J/R/Dq .
+> could remember about ravens and  writing - desks   , which wasn’t much         .
+# VXB   NSg/VB   J/P   NPl/V3 VB/C Nᴹ/Vg/J . NPl/V3+ . I/C+  VPt    NSg/I/J/R/Dq .
 >
 #
 > The Hatter was  the first  to break  the silence . “ What   day    of the month  is  it       ? ” he
@@ -2866,8 +2866,8 @@
 #
 > The March   Hare took the watch  and  looked at    it       gloomily : then      he       dipped it       into
 # D+  NPr/VB+ NSg+ VPt  D   NSg/VB VB/C VP/J   NSg/P NPr/ISg+ R        . NSg/J/R/C NPr/ISg+ VP/J   NPr/ISg+ P
-> his     cup    of tea      , and  looked at    it       again : but     he       could   think  of nothing  better     to
-# ISg/D$+ NSg/VB P  N🅪Sg/VB+ . VB/C VP/J   NSg/P NPr/ISg+ P     . NSg/C/P NPr/ISg+ NSg/VXB NSg/VB P  NSg/I/J+ NSg/VXB/JC P
+> his     cup    of tea      , and  looked at    it       again : but     he       could think  of nothing  better     to
+# ISg/D$+ NSg/VB P  N🅪Sg/VB+ . VB/C VP/J   NSg/P NPr/ISg+ P     . NSg/C/P NPr/ISg+ VXB   NSg/VB P  NSg/I/J+ NSg/VXB/JC P
 > say    than his     first remark  , “ It       was  the best       butter  , you    know . ”
 # NSg/VB C/P  ISg/D$+ NSg/J NSg/VB+ . . NPr/ISg+ VLPt D   NPr/VXB/JS NSg/VB+ . ISgPl+ VB   . .
 >
@@ -2900,8 +2900,8 @@
 # NPr+  N🅪Sg/VP/J R          VP/J    . D   NSg$     NSg/VB+ VP/J   P  NSg/VXB NSg/Dq/P NSg/VB P
 > meaning    in        it       , and  yet      it       was  certainly English      . “ I       don’t quite understand you    , ”
 # N🅪Sg/Vg/J+ NPr/J/R/P NPr/ISg+ . VB/C NSg/VB/C NPr/ISg+ VLPt R         NPr🅪Sg/VB/J+ . . ISg/#r+ VXB   R     VB         ISgPl+ . .
-> she  said , as    politely as    she  could   .
-# ISg+ VP/J . R/C/P R        R/C/P ISg+ NSg/VXB .
+> she  said , as    politely as    she  could .
+# ISg+ VP/J . R/C/P R        R/C/P ISg+ VXB   .
 >
 #
 > “ The Dormouse is  asleep again , ” said the Hatter , and  he       poured a   little     hot      tea
@@ -2982,8 +2982,8 @@
 # NSg/VLXB J      R/C/P NPr/ISg+ . ISgPl+ VB   . .
 >
 #
-> “ Not     at    first , perhaps , ” said the Hatter : “ but     you    could   keep   it       to half     - past
-# . NSg/R/C NSg/P NSg/J . NSg/R   . . VP/J D   NSg/VB . . NSg/C/P ISgPl+ NSg/VXB NSg/VB NPr/ISg+ P  N🅪Sg/J/P . NSg/VB/J/P
+> “ Not     at    first , perhaps , ” said the Hatter : “ but     you    could keep   it       to half     - past
+# . NSg/R/C NSg/P NSg/J . NSg/R   . . VP/J D   NSg/VB . . NSg/C/P ISgPl+ VXB   NSg/VB NPr/ISg+ P  N🅪Sg/J/P . NSg/VB/J/P
 > one     as    long     as    you    liked . ”
 # NSg/I/J R/C/P NPr/VB/J R/C/P ISgPl+ VP/J  . .
 >
@@ -2994,10 +2994,10 @@
 #
 > The Hatter shook     his     head      mournfully . “ Not     I       ! ” he       replied . “ We   quarrelled last
 # D   NSg/VB NSg/VPt/J ISg/D$+ NPr/VB/J+ R          . . NSg/R/C ISg/#r+ . . NPr/ISg+ VP/J    . . IPl+ VP/Comm    NSg/VB/J
-> March   — just before he       went    mad      , you    know — ” ( pointing with his     tea      spoon   at    the
-# NPr/VB+ . J/R  C/P    NPr/ISg+ NSg/VPt NSg/VB/J . ISgPl+ VB   . . . Nᴹ/Vg/J  P    ISg/D$+ N🅪Sg/VB+ NSg/VB+ NSg/P D
-> March   Hare , ) “ — it       was  at    the great concert given       by the Queen    of Hearts  , and  I
-# NPr/VB+ NSg+ . . . . NPr/ISg+ VLPt NSg/P D   NSg/J NSg/VB+ NSg/VPp/J/P P  D   NPr/VB/J P  NPl/V3+ . VB/C ISg/#r+
+> March   — just before he       went mad      , you    know — ” ( pointing with his     tea      spoon   at    the
+# NPr/VB+ . J/R  C/P    NPr/ISg+ VPt  NSg/VB/J . ISgPl+ VB   . . . Nᴹ/Vg/J  P    ISg/D$+ N🅪Sg/VB+ NSg/VB+ NSg/P D
+> March   Hare , ) “ — it       was  at    the great concert given       by the Queen  of Hearts  , and  I
+# NPr/VB+ NSg+ . . . . NPr/ISg+ VLPt NSg/P D   NSg/J NSg/VB+ NSg/VPp/J/P P  D   NPr/VB P  NPl/V3+ . VB/C ISg/#r+
 > had to sing
 # VP  P  NSg/VB/J
 >
@@ -3023,15 +3023,15 @@
 >
 #
 > Here the Dormouse shook     itself , and  began singing in        its     sleep    “ Twinkle ,
-# J/R  D   NSg      NSg/VPt/J ISg+   . VB/C VPt   Nᴹ/Vg/J NPr/J/R/P ISg/D$+ N🅪Sg/VB+ . NSg/VB  .
-> twinkle , twinkle , twinkle — ” and  went    on  so          long     that     they had to pinch  it       to
-# NSg/VB  . NSg/VB  . NSg/VB  . . VB/C NSg/VPt J/P NSg/I/J/R/C NPr/VB/J I/C/Ddem IPl+ VP  P  NSg/VB NPr/ISg+ P
+# R    D   NSg      NSg/VPt/J ISg+   . VB/C VPt   Nᴹ/Vg/J NPr/J/R/P ISg/D$+ N🅪Sg/VB+ . NSg/VB  .
+> twinkle , twinkle , twinkle — ” and  went on  so          long     that     they had to pinch  it       to
+# NSg/VB  . NSg/VB  . NSg/VB  . . VB/C VPt  J/P NSg/I/J/R/C NPr/VB/J I/C/Ddem IPl+ VP  P  NSg/VB NPr/ISg+ P
 > make   it       stop   .
 # NSg/VB NPr/ISg+ NSg/VB .
 >
 #
 > “ Well       , I’d hardly finished the first verse  , ” said the Hatter , “ when    the Queen
-# . NSg/VB/J/R . K   R      VP/J     D   NSg/J NSg/VB . . VP/J D   NSg/VB . . NSg/I/C D   NPr/VB/J+
+# . NSg/VB/J/R . K   R      VP/J     D   NSg/J NSg/VB . . VP/J D   NSg/VB . . NSg/I/C D   NPr/VB+
 > jumped up         and  bawled out          , ‘ He’s murdering the time       ! Off        with his     head      ! ’ ”
 # VP/J   NSg/VB/J/P VB/C VP/J   NSg/VB/J/R/P . . NPr$ Nᴹ/Vg/J+  D   N🅪Sg/VB/J+ . NSg/VB/J/P P    ISg/D$+ NPr/VB/J+ . . .
 >
@@ -3040,8 +3040,8 @@
 # . NSg/C R          NPr/VB/J+ . . VP/J      NPr+  .
 >
 #
-> “ And  ever since that      , ” the Hatter went    on  in        a   mournful tone       , “ he       won’t do  a
-# . VB/C J/R  C/P   I/C/Ddem+ . . D   NSg/VB NSg/VPt J/P NPr/J/R/P D/P J        N🅪Sg/I/VB+ . . NPr/ISg+ VXB   VXB D/P
+> “ And  ever since that      , ” the Hatter went on  in        a   mournful tone       , “ he       won’t do  a
+# . VB/C J/R  C/P   I/C/Ddem+ . . D   NSg/VB VPt  J/P NPr/J/R/P D/P J        N🅪Sg/I/VB+ . . NPr/ISg+ VXB   VXB D/P
 > thing I       ask    ! It’s always six o’clock now       . ”
 # NSg+  ISg/#r+ NSg/VB . K    R      NSg R       NSg/J/R/C . .
 >
@@ -3049,7 +3049,7 @@
 > A    bright    idea came      into Alice’s head      . “ Is  that     the reason   so          many       tea      - things are
 # D/P+ NPr/VB/J+ NSg+ NSg/VPt/P P    NPr$    NPr/VB/J+ . . VL3 I/C/Ddem D+  N🅪Sg/VB+ NSg/I/J/R/C NSg/I/J/Dq N🅪Sg/VB+ . NPl+   VLB
 > put     out          here ? ” she  asked .
-# NSg/VBP NSg/VB/J/R/P J/R  . . ISg+ VP/J  .
+# NSg/VBP NSg/VB/J/R/P R    . . ISg+ VP/J  .
 >
 #
 > “ Yes    , that’s it       , ” said the Hatter with a   sigh   : “ it’s always tea      - time       , and  we’ve
@@ -3136,8 +3136,8 @@
 #
 > Alice tried to fancy    to herself what   such  an  extraordinary way   of living    would
 # NPr+  VP/J  P  NSg/VB/J P  ISg+    NSg/I+ NSg/I D/P NSg/J         NSg/J P  N🅪Sg/Vg/J VXB
-> be       like         , but     it       puzzled her     too much         , so          she  went    on  : “ But     why    did  they live at
-# NSg/VLXB NSg/VB/J/C/P . NSg/C/P NPr/ISg+ VP/J    ISg/D$+ R   NSg/I/J/R/Dq . NSg/I/J/R/C ISg+ NSg/VPt J/P . . NSg/C/P NSg/VB VXPt IPl+ VB/J NSg/P
+> be       like         , but     it       puzzled her     too much         , so          she  went on  : “ But     why    did  they live at
+# NSg/VLXB NSg/VB/J/C/P . NSg/C/P NPr/ISg+ VP/J    ISg/D$+ R   NSg/I/J/R/Dq . NSg/I/J/R/C ISg+ VPt  J/P . . NSg/C/P NSg/VB VXPt IPl+ VB/J NSg/P
 > the bottom   of a    well        ? ”
 # D   NSg/VB/J P  D/P+ NSg/VB/J/R+ . .
 >
@@ -3182,8 +3182,8 @@
 #
 > “ There’s no        such  thing ! ” Alice was  beginning very angrily , but     the Hatter and
 # . K       NSg/Dq/P+ NSg/I NSg+  . . NPr+  VLPt NSg/Vg/J+ J/R  R       . NSg/C/P D   NSg/VB VB/C
-> the March   Hare went    “ Sh ! sh ! ” and  the Dormouse sulkily remarked , “ If    you    can’t
-# D   NPr/VB+ NSg+ NSg/VPt . W? . W? . . VB/C D   NSg      R       VP/J     . . NSg/C ISgPl+ VXB
+> the March   Hare went “ Sh ! sh ! ” and  the Dormouse sulkily remarked , “ If    you    can’t
+# D   NPr/VB+ NSg+ VPt  . W? . W? . . VB/C D   NSg      R       VP/J     . . NSg/C ISgPl+ VXB
 > be       civil , you’d better     finish the story   for   yourself . ”
 # NSg/VLXB J     . K     NSg/VXB/JC NSg/VB D   NSg/VB+ R/C/P ISg+     . .
 >
@@ -3232,8 +3232,8 @@
 #
 > “ You    can     draw   water   out          of a    water    - well       , ” said the Hatter ; “ so          I       should think
 # . ISgPl+ NPr/VXB NSg/VB N🅪Sg/VB NSg/VB/J/R/P P  D/P+ N🅪Sg/VB+ . NSg/VB/J/R . . VP/J D   NSg/VB . . NSg/I/J/R/C ISg/#r+ VXB    NSg/VB
-> you    could   draw   treacle out          of a   treacle - well       — eh   , stupid ? ”
-# ISgPl+ NSg/VXB NSg/VB Nᴹ/VB   NSg/VB/J/R/P P  D/P Nᴹ/VB   . NSg/VB/J/R . VB/J . NSg/J  . .
+> you    could draw   treacle out          of a   treacle - well       — eh   , stupid ? ”
+# ISgPl+ VXB   NSg/VB Nᴹ/VB   NSg/VB/J/R/P P  D/P Nᴹ/VB   . NSg/VB/J/R . VB/J . NSg/J  . .
 >
 #
 > “ But     they were in        the well       , ” Alice said to the Dormouse , not     choosing to notice
@@ -3252,8 +3252,8 @@
 # N🅪Sg/VB/J+ C/P     Nᴹ/Vg/J      NPr/ISg+ .
 >
 #
-> “ They were learning to draw   , ” the Dormouse went    on  , yawning and  rubbing its
-# . IPl+ VLPt Nᴹ/Vg/J  P  NSg/VB . . D   NSg      NSg/VPt J/P . Nᴹ/Vg/J VB/C NSg/Vg  ISg/D$+
+> “ They were learning to draw   , ” the Dormouse went on  , yawning and  rubbing its
+# . IPl+ VLPt Nᴹ/Vg/J  P  NSg/VB . . D   NSg      VPt  J/P . Nᴹ/Vg/J VB/C NSg/Vg  ISg/D$+
 > eyes    , for   it       was  getting very sleepy ; “ and  they drew    all          manner of
 # NPl/V3+ . R/C/P NPr/ISg+ VLPt NSg/Vg  J/R  NSg/J  . . VB/C IPl+ NPr/VPt NSg/I/J/C/Dq NSg    P
 > things — everything that      begins with an  M           — ”
@@ -3276,8 +3276,8 @@
 # D   NSg      VP  VP/J   ISg/D$+ NPl/V3+ P  I/Ddem N🅪Sg/VB/J+ . VB/C VLPt Nᴹ/Vg/J NSg/VB/J/P P    D/P NSg/VB .
 > but     , on  being        pinched by the Hatter , it       woke     up         again with a   little     shriek , and
 # NSg/C/P . J/P N🅪Sg/VLg/J/C VP/J    P  D   NSg/VB . NPr/ISg+ NSg/VB/J NSg/VB/J/P P     P    D/P NPr/I/J/Dq NSg/VB . VB/C
-> went    on  : “ — that      begins with an  M           , such  as    mouse   - traps  , and  the moon    , and  memory ,
-# NSg/VPt J/P . . . I/C/Ddem+ NPl/V3 P    D/P NPr/VB/J/#r . NSg/I R/C/P NSg/VB+ . NPl/V3 . VB/C D   NPr/VB+ . VB/C N🅪Sg+  .
+> went on  : “ — that      begins with an  M           , such  as    mouse   - traps  , and  the moon    , and  memory ,
+# VPt  J/P . . . I/C/Ddem+ NPl/V3 P    D/P NPr/VB/J/#r . NSg/I R/C/P NSg/VB+ . NPl/V3 . VB/C D   NPr/VB+ . VB/C N🅪Sg+  .
 > and  muchness — you    know you    say    things are “ much         of a   muchness ” — did  you    ever see
 # VB/C NSg      . ISgPl+ VB   ISgPl+ NSg/VB NPl+   VLB . NSg/I/J/R/Dq P  D/P NSg      . . VXPt ISgPl+ J/R  NSg/VB
 > such  a   thing as    a   drawing   of a   muchness ? ”
@@ -3292,8 +3292,8 @@
 # . NSg/J/R/C ISgPl+ VXB       N🅪Sg/VB . . VP/J D   NSg/VB .
 >
 #
-> This   piece  of rudeness was  more         than Alice could   bear      : she  got up         in        great
-# I/Ddem NSg/VB P  NSg+     VLPt NPr/I/J/R/Dq C/P  NPr+  NSg/VXB NSg/VB/J+ . ISg+ VP  NSg/VB/J/P NPr/J/R/P NSg/J+
+> This   piece  of rudeness was  more         than Alice could bear      : she  got up         in        great
+# I/Ddem NSg/VB P  NSg+     VLPt NPr/I/J/R/Dq C/P  NPr+  VXB   NSg/VB/J+ . ISg+ VP  NSg/VB/J/P NPr/J/R/P NSg/J+
 > disgust , and  walked off        ; the Dormouse fell      asleep instantly , and  neither of the
 # Nᴹ/VB+  . VB/C VP/J   NSg/VB/J/P . D   NSg      NSg/VPt/J J      R         . VB/C I/C     P  D
 > others  took the least    notice of her     going   , though she  looked back     once  or    twice ,
@@ -3314,8 +3314,8 @@
 # J/R  R/C/P ISg+ VP/J I/Ddem+ . ISg+ VP/J    I/C/Ddem NSg/I/J P  D+  NPl/V3+ VP  D/P+ NSg/VB+ Nᴹ/Vg/J
 > right    into it       . “ That’s very curious ! ” she  thought . “ But     everything’s curious
 # NPr/VB/J P    NPr/ISg+ . . K      J/R  J       . . ISg+ N🅪Sg/VP . . NSg/C/P NSg$         J+
-> today  . I       think  I       may     as    well       go       in        at    once  . ” And  in        she  went    .
-# NSg/J+ . ISg/#r+ NSg/VB ISg/#r+ NPr/VXB R/C/P NSg/VB/J/R NSg/VB/J NPr/J/R/P NSg/P NSg/C . . VB/C NPr/J/R/P ISg+ NSg/VPt .
+> today  . I       think  I       may     as    well       go       in        at    once  . ” And  in        she  went .
+# NSg/J+ . ISg/#r+ NSg/VB ISg/#r+ NPr/VXB R/C/P NSg/VB/J/R NSg/VB/J NPr/J/R/P NSg/P NSg/C . . VB/C NPr/J/R/P ISg+ VPt  .
 >
 #
 > Once  more         she  found  herself in        the long      hall , and  close    to the little      glass
@@ -3324,8 +3324,8 @@
 # NSg/VB+ . . NSg/J/R/C . K    NSg/VB NSg/VXB/JC I/Ddem N🅪Sg/VB/J+ . . ISg+ VP/J P  ISg+    . VB/C VPt   P
 > taking   the little     golden   key      , and  unlocking the door    that      led      into the garden    .
 # NSg/Vg/J D   NPr/I/J/Dq NPr/VB/J NPr/VB/J . VB/C Nᴹ/Vg/J   D   NSg/VB+ I/C/Ddem+ NSg/VP/J P    D   NSg/VB/J+ .
-> Then      she  went    to work    nibbling at    the mushroom  ( she  had kept a   piece  of it       in
-# NSg/J/R/C ISg+ NSg/VPt P  N🅪Sg/VB Nᴹ/Vg/J  NSg/P D   N🅪Sg/VB/J . ISg+ VP  VP   D/P NSg/VB P  NPr/ISg+ NPr/J/R/P
+> Then      she  went to work    nibbling at    the mushroom  ( she  had kept a   piece  of it       in
+# NSg/J/R/C ISg+ VPt  P  N🅪Sg/VB Nᴹ/Vg/J  NSg/P D   N🅪Sg/VB/J . ISg+ VP  VP   D/P NSg/VB P  NPr/ISg+ NPr/J/R/P
 > her     pocket    ) till       she  was  about a   foot    high       : then      she  walked down        the little
 # ISg/D$+ NSg/VB/J+ . NSg/VB/C/P ISg+ VLPt J/P   D/P NSg/VB+ NSg/VB/J/R . NSg/J/R/C ISg+ VP/J   N🅪Sg/VB/J/P D   NPr/I/J/Dq
 > passage   : and  then      — she  found  herself at    last     in        the beautiful garden    , among the
@@ -3342,8 +3342,8 @@
 # D/P NSg/J NPr/VPt/J+ . NSg/VB VP    NSg/VB/J/P D   NSg/VB   P  D+  NSg/VB/J+ . D+  NPl/V3+ Nᴹ/Vg/J J/P NPr/ISg+
 > were white       , but     there were three gardeners at    it       , busily painting   them     red    .
 # VLPt NPr🅪Sg/VB/J . NSg/C/P R+    VLPt NSg+  NPl+      NSg/P NPr/ISg+ . R      N🅪Sg/Vg/J+ NSg/IPl+ N🅪Sg/J .
-> Alice thought this   a   very curious thing , and  she  went    nearer to watch  them     , and
-# NPr+  N🅪Sg/VP I/Ddem D/P J/R  J+      NSg+  . VB/C ISg+ NSg/VPt NSg/JC P  NSg/VB NSg/IPl+ . VB/C
+> Alice thought this   a   very curious thing , and  she  went nearer to watch  them     , and
+# NPr+  N🅪Sg/VP I/Ddem D/P J/R  J+      NSg+  . VB/C ISg+ VPt  NSg/JC P  NSg/VB NSg/IPl+ . VB/C
 > just as    she  came      up         to them     she  heard one     of them     say    , “ Look   out          now       , Five !
 # J/R  R/C/P ISg+ NSg/VPt/P NSg/VB/J/P P  NSg/IPl+ ISg+ VP/J  NSg/I/J P  NSg/IPl+ NSg/VB . . NSg/VB NSg/VB/J/R/P NSg/J/R/C . NSg  .
 > Don’t go       splashing paint    over    me       like         that      ! ”
@@ -3360,8 +3360,8 @@
 # NPl/V3+ . .
 >
 #
-> “ You’d better     not     talk    ! ” said Five . “ I       heard the Queen     say    only  yesterday you
-# . K     NSg/VXB/JC NSg/R/C N🅪Sg/VB . . VP/J NSg  . . ISg/#r+ VP/J  D+  NPr/VB/J+ NSg/VB J/R/C NSg       ISgPl+
+> “ You’d better     not     talk    ! ” said Five . “ I       heard the Queen   say    only  yesterday you
+# . K     NSg/VXB/JC NSg/R/C N🅪Sg/VB . . VP/J NSg  . . ISg/#r+ VP/J  D+  NPr/VB+ NSg/VB J/R/C NSg       ISgPl+
 > deserved to be       beheaded ! ”
 # VP/J     P  NSg/VLXB VP/J     . .
 >
@@ -3399,19 +3399,19 @@
 > Five and  Seven said nothing  , but     looked at    Two . Two began in        a    low         voice   , “ Why
 # NSg  VB/C NSg   VP/J NSg/I/J+ . NSg/C/P VP/J   NSg/P NSg . NSg VPt   NPr/J/R/P D/P+ NSg/VB/J/R+ NSg/VB+ . . NSg/VB
 > the fact is  , you    see    , Miss   , this   here ought     to have    been   a   red    rose      - tree    , and  we
-# D+  NSg+ VL3 . ISgPl+ NSg/VB . NSg/VB . I/Ddem J/R  NSg/I/VXB P  NSg/VXB VLPp/B D/P N🅪Sg/J NPr/VPt/J . NSg/VB+ . VB/C IPl+
-> put     a   white       one      in        by mistake ; and  if    the Queen     was  to find   it       out          , we   should
-# NSg/VBP D/P NPr🅪Sg/VB/J NSg/I/J+ NPr/J/R/P P  NSg/VB+ . VB/C NSg/C D+  NPr/VB/J+ VLPt P  NSg/VB NPr/ISg+ NSg/VB/J/R/P . IPl+ VXB
+# D+  NSg+ VL3 . ISgPl+ NSg/VB . NSg/VB . I/Ddem R    NSg/I/VXB P  NSg/VXB VLPp/B D/P N🅪Sg/J NPr/VPt/J . NSg/VB+ . VB/C IPl+
+> put     a   white       one      in        by mistake ; and  if    the Queen   was  to find   it       out          , we   should
+# NSg/VBP D/P NPr🅪Sg/VB/J NSg/I/J+ NPr/J/R/P P  NSg/VB+ . VB/C NSg/C D+  NPr/VB+ VLPt P  NSg/VB NPr/ISg+ NSg/VB/J/R/P . IPl+ VXB
 > all          have    our heads   cut       off        , you    know . So          you    see    , Miss   , we’re doing   our best       ,
 # NSg/I/J/C/Dq NSg/VXB D$+ NPl/V3+ NSg/VBP/J NSg/VB/J/P . ISgPl+ VB   . NSg/I/J/R/C ISgPl+ NSg/VB . NSg/VB . K     Nᴹ/Vg/J D$+ NPr/VXB/JS .
 > afore she  comes  , to — ” At    this   moment Five , who    had been   anxiously looking across
 # R/C/P ISg+ NPl/V3 . P  . . NSg/P I/Ddem NSg+   NSg  . NPr/I+ VP  VLPp/B R         Nᴹ/Vg/J NSg/P
-> the garden    , called out          “ The Queen     ! The Queen     ! ” and  the three gardeners instantly
-# D   NSg/VB/J+ . VP/J   NSg/VB/J/R/P . D   NPr/VB/J+ . D+  NPr/VB/J+ . . VB/C D+  NSg+  NPl+      R
+> the garden    , called out          “ The Queen   ! The Queen   ! ” and  the three gardeners instantly
+# D   NSg/VB/J+ . VP/J   NSg/VB/J/R/P . D   NPr/VB+ . D+  NPr/VB+ . . VB/C D+  NSg+  NPl+      R
 > threw themselves flat     upon their faces   . There was  a   sound     of many        footsteps , and
 # VPt   IPl+       NSg/VB/J P    D$+   NPl/V3+ . R+    VLPt D/P N🅪Sg/VB/J P  NSg/I/J/Dq+ NPl+      . VB/C
-> Alice looked round      , eager    to see    the Queen     .
-# NPr+  VP/J   NSg/VB/J/P . NSg/VB/J P  NSg/VB D+  NPr/VB/J+ .
+> Alice looked round      , eager    to see    the Queen   .
+# NPr+  VP/J   NSg/VB/J/P . NSg/VB/J P  NSg/VB D+  NPr/VB+ .
 >
 #
 > First came      ten  soldiers carrying clubs   ; these   were all          shaped like         the three
@@ -3428,20 +3428,20 @@
 # IPl+ VLPt NSg/I/J/C/Dq VP/J       P    NPl/V3+ . NSg/J/P NSg/VPt/P D+  NPl/V3+ . R      NPl/V3+ VB/C
 > Queens   , and  among them     Alice recognised the White       Rabbit  : it       was  talking in        a
 # NPrPl/V3 . VB/C P     NSg/IPl+ NPr+  VP/J/Au/Br D   NPr🅪Sg/VB/J NSg/VB+ . NPr/ISg+ VLPt Nᴹ/Vg/J NPr/J/R/P D/P
-> hurried nervous manner , smiling at    everything that      was  said , and  went    by without
-# VP/J+   J+      NSg+   . Nᴹ/Vg/J NSg/P NSg/I/VB+  I/C/Ddem+ VLPt VP/J . VB/C NSg/VPt P  C/P
+> hurried nervous manner , smiling at    everything that      was  said , and  went by without
+# VP/J+   J+      NSg+   . Nᴹ/Vg/J NSg/P NSg/I/VB+  I/C/Ddem+ VLPt VP/J . VB/C VPt  P  C/P
 > noticing her     . Then      followed the Knave of Hearts  , carrying the King’s crown     on  a
 # Nᴹ/Vg/J  ISg/D$+ . NSg/J/R/C VP/J     D   NSg   P  NPl/V3+ . Nᴹ/Vg/J  D   NPr$   NSg/VB/J+ J/P D/P
 > crimson  velvet   cushion ; and  , last     of all          this   grand procession , came      THE KING
-# NSg/VB/J Nᴹ/VB/J+ NSg/VB+ . VB/C . NSg/VB/J P  NSg/I/J/C/Dq I/Ddem NSg/J NSg/VB+    . NSg/VPt/P D   NPr/VB/J+
-> AND  QUEEN     OF HEARTS  .
-# VB/C NPr/VB/J+ P  NPl/V3+ .
+# NSg/VB/J Nᴹ/VB/J+ NSg/VB+ . VB/C . NSg/VB/J P  NSg/I/J/C/Dq I/Ddem NSg/J NSg/VB+    . NSg/VPt/P D   NPr/VB+
+> AND  QUEEN   OF HEARTS  .
+# VB/C NPr/VB+ P  NPl/V3+ .
 >
 #
 > Alice was  rather     doubtful whether she  ought     not     to lie    down        on  her     face    like         the
 # NPr+  VLPt NPr/VB/J/R NSg/J    I/C     ISg+ NSg/I/VXB NSg/R/C P  NPr/VB N🅪Sg/VB/J/P J/P ISg/D$+ NSg/VB+ NSg/VB/J/C/P D
-> three gardeners , but     she  could   not     remember ever having  heard of such  a   rule    at
-# NSg   NPl+      . NSg/C/P ISg+ NSg/VXB NSg/R/C NSg/VB   J/R  Nᴹ/Vg/J VP/J  P  NSg/I D/P NSg/VB+ NSg/P
+> three gardeners , but     she  could not     remember ever having  heard of such  a   rule    at
+# NSg   NPl+      . NSg/C/P ISg+ VXB   NSg/R/C NSg/VB   J/R  Nᴹ/Vg/J VP/J  P  NSg/I D/P NSg/VB+ NSg/P
 > processions ; “ and  besides , what   would be       the use     of a   procession , ” thought she  ,
 # NPl         . . VB/C R/P     . NSg/I+ VXB   NSg/VLXB D   N🅪Sg/VB P  D/P NSg/VB+    . . N🅪Sg/VP ISg+ .
 > “ if    people  had all           to lie    down        upon their faces   , so          that     they couldn’t see    it       ? ”
@@ -3452,16 +3452,16 @@
 #
 > When    the procession came      opposite to Alice , they all          stopped and  looked at    her     ,
 # NSg/I/C D+  NSg/VB+    NSg/VPt/P NSg/J/P  P  NPr+  . IPl+ NSg/I/J/C/Dq VP/J    VB/C VP/J   NSg/P ISg/D$+ .
-> and  the Queen     said severely “ Who    is  this    ? ” She  said it       to the Knave of Hearts  ,
-# VB/C D+  NPr/VB/J+ VP/J R        . NPr/I+ VL3 I/Ddem+ . . ISg+ VP/J NPr/ISg+ P  D   NSg   P  NPl/V3+ .
+> and  the Queen   said severely “ Who    is  this    ? ” She  said it       to the Knave of Hearts  ,
+# VB/C D+  NPr/VB+ VP/J R        . NPr/I+ VL3 I/Ddem+ . . ISg+ VP/J NPr/ISg+ P  D   NSg   P  NPl/V3+ .
 > who    only  bowed and  smiled in        reply   .
 # NPr/I+ J/R/C VP/J  VB/C VP/J   NPr/J/R/P NSg/VB+ .
 >
 #
-> “ Idiot  ! ” said the Queen     , tossing her     head      impatiently ; and  , turning to Alice ,
-# . NSg/J+ . . VP/J D+  NPr/VB/J+ . Nᴹ/Vg/J ISg/D$+ NPr/VB/J+ R           . VB/C . Nᴹ/Vg/J P  NPr+  .
-> she  went    on  , “ What’s your name    , child   ? ”
-# ISg+ NSg/VPt J/P . . K      D$+  NSg/VB+ . NSg/VB+ . .
+> “ Idiot  ! ” said the Queen   , tossing her     head      impatiently ; and  , turning to Alice ,
+# . NSg/J+ . . VP/J D+  NPr/VB+ . Nᴹ/Vg/J ISg/D$+ NPr/VB/J+ R           . VB/C . Nᴹ/Vg/J P  NPr+  .
+> she  went on  , “ What’s your name    , child   ? ”
+# ISg+ VPt  J/P . . K      D$+  NSg/VB+ . NSg/VB+ . .
 >
 #
 > “ My  name    is  Alice , so          please your Majesty , ” said Alice very politely ; but     she
@@ -3472,12 +3472,12 @@
 # J      P  NSg/IPl+ . .
 >
 #
-> “ And  who    are these  ? ” said the Queen     , pointing to the three gardeners who    were
-# . VB/C NPr/I+ VLB I/Ddem . . VP/J D+  NPr/VB/J+ . Nᴹ/Vg/J  P  D+  NSg+  NPl+      NPr/I+ VLPt
+> “ And  who    are these  ? ” said the Queen   , pointing to the three gardeners who    were
+# . VB/C NPr/I+ VLB I/Ddem . . VP/J D+  NPr/VB+ . Nᴹ/Vg/J  P  D+  NSg+  NPl+      NPr/I+ VLPt
 > lying   round      the rose       - tree    ; for   , you    see    , as    they were lying   on  their faces   , and
 # Nᴹ/Vg/J NSg/VB/J/P D   NPr/VPt/J+ . NSg/VB+ . R/C/P . ISgPl+ NSg/VB . R/C/P IPl+ VLPt Nᴹ/Vg/J J/P D$+   NPl/V3+ . VB/C
-> the pattern   on  their backs   was  the same as    the rest   of the pack    , she  could   not
-# D+  NSg/VB/J+ J/P D$+   NPl/V3+ VLPt D   I/J  R/C/P D   NSg/VB P  D+  NSg/VB+ . ISg+ NSg/VXB NSg/R/C
+> the pattern   on  their backs   was  the same as    the rest   of the pack    , she  could not
+# D+  NSg/VB/J+ J/P D$+   NPl/V3+ VLPt D   I/J  R/C/P D   NSg/VB P  D+  NSg/VB+ . ISg+ VXB   NSg/R/C
 > tell   whether they were gardeners , or    soldiers , or    courtiers , or    three of her     own
 # NPr/VB I/C     IPl+ VLPt NPl       . NPr/C NPl/V3+  . NPr/C NPl       . NPr/C NSg   P  ISg/D$+ NSg/VB/J
 > children .
@@ -3490,42 +3490,42 @@
 # P  NSg/I/VB+ . .
 >
 #
-> The Queen     turned crimson  with fury  , and  , after glaring at    her     for   a   moment like
-# D+  NPr/VB/J+ VP/J   NSg/VB/J P    N🅪Sg+ . VB/C . P     Nᴹ/Vg/J NSg/P ISg/D$+ R/C/P D/P NSg+   NSg/VB/J/C/P
+> The Queen   turned crimson  with fury  , and  , after glaring at    her     for   a   moment like
+# D+  NPr/VB+ VP/J   NSg/VB/J P    N🅪Sg+ . VB/C . P     Nᴹ/Vg/J NSg/P ISg/D$+ R/C/P D/P NSg+   NSg/VB/J/C/P
 > a    wild      beast     , screamed “ Off        with her     head      ! Off        — ”
 # D/P+ NSg/VB/J+ NSg/VB/J+ . VP/J     . NSg/VB/J/P P    ISg/D$+ NPr/VB/J+ . NSg/VB/J/P . .
 >
 #
-> “ Nonsense ! ” said Alice , very loudly and  decidedly , and  the Queen     was  silent .
-# . Nᴹ/VB/J+ . . VP/J NPr+  . J/R  R      VB/C R         . VB/C D   NPr/VB/J+ VLPt NSg/J  .
+> “ Nonsense ! ” said Alice , very loudly and  decidedly , and  the Queen   was  silent .
+# . Nᴹ/VB/J+ . . VP/J NPr+  . J/R  R      VB/C R         . VB/C D   NPr/VB+ VLPt NSg/J  .
 >
 #
-> The King      laid his     hand    upon her     arm       , and  timidly said “ Consider , my  dear     : she  is
-# D+  NPr/VB/J+ VP/J ISg/D$+ NSg/VB+ P    ISg/D$+ NSg/VB/J+ . VB/C R       VP/J . VB       . D$+ NSg/VB/J . ISg+ VL3
+> The King    laid his     hand    upon her     arm       , and  timidly said “ Consider , my  dear     : she  is
+# D+  NPr/VB+ VP/J ISg/D$+ NSg/VB+ P    ISg/D$+ NSg/VB/J+ . VB/C R       VP/J . VB       . D$+ NSg/VB/J . ISg+ VL3
 > only  a   child   ! ”
 # J/R/C D/P NSg/VB+ . .
 >
 #
-> The Queen     turned angrily away from him  , and  said to the Knave “ Turn   them     over    ! ”
-# D+  NPr/VB/J+ VP/J   R       VB/J P    ISg+ . VB/C VP/J P  D   NSg   . NSg/VB NSg/IPl+ NSg/J/P . .
+> The Queen   turned angrily away from him  , and  said to the Knave “ Turn   them     over    ! ”
+# D+  NPr/VB+ VP/J   R       VB/J P    ISg+ . VB/C VP/J P  D   NSg   . NSg/VB NSg/IPl+ NSg/J/P . .
 >
 #
 > The Knave did  so          , very carefully , with one     foot    .
 # D   NSg   VXPt NSg/I/J/R/C . J/R  R         . P    NSg/I/J NSg/VB+ .
 >
 #
-> “ Get    up         ! ” said the Queen     , in        a   shrill   , loud  voice   , and  the three gardeners
-# . NSg/VB NSg/VB/J/P . . VP/J D+  NPr/VB/J+ . NPr/J/R/P D/P NSg/VB/J . NSg/J NSg/VB+ . VB/C D+  NSg+  NPl+
-> instantly jumped up         , and  began bowing  to the King      , the Queen     , the royal
-# R         VP/J   NSg/VB/J/P . VB/C VPt   Nᴹ/Vg/J P  D   NPr/VB/J+ . D   NPr/VB/J+ . D   NPr/J
+> “ Get    up         ! ” said the Queen   , in        a   shrill   , loud  voice   , and  the three gardeners
+# . NSg/VB NSg/VB/J/P . . VP/J D+  NPr/VB+ . NPr/J/R/P D/P NSg/VB/J . NSg/J NSg/VB+ . VB/C D+  NSg+  NPl+
+> instantly jumped up         , and  began bowing  to the King    , the Queen   , the royal
+# R         VP/J   NSg/VB/J/P . VB/C VPt   Nᴹ/Vg/J P  D   NPr/VB+ . D   NPr/VB+ . D   NPr/J
 > children , and  everybody else    .
 # NPl+     . VB/C NSg/I+    NSg/J/C .
 >
 #
-> “ Leave  off        that      ! ” screamed the Queen     . “ You    make   me       giddy    . ” And  then      , turning to
-# . NSg/VB NSg/VB/J/P I/C/Ddem+ . . VP/J     D+  NPr/VB/J+ . . ISgPl+ NSg/VB NPr/ISg+ NSg/VB/J . . VB/C NSg/J/R/C . Nᴹ/Vg/J P
-> the rose       - tree    , she  went    on  , “ What   have    you    been   doing   here ? ”
-# D+  NPr/VPt/J+ . NSg/VB+ . ISg+ NSg/VPt J/P . . NSg/I+ NSg/VXB ISgPl+ VLPp/B Nᴹ/Vg/J J/R  . .
+> “ Leave  off        that      ! ” screamed the Queen   . “ You    make   me       giddy    . ” And  then      , turning to
+# . NSg/VB NSg/VB/J/P I/C/Ddem+ . . VP/J     D+  NPr/VB+ . . ISgPl+ NSg/VB NPr/ISg+ NSg/VB/J . . VB/C NSg/J/R/C . Nᴹ/Vg/J P
+> the rose       - tree    , she  went on  , “ What   have    you    been   doing   here ? ”
+# D+  NPr/VPt/J+ . NSg/VB+ . ISg+ VPt  J/P . . NSg/I+ NSg/VXB ISgPl+ VLPp/B Nᴹ/Vg/J R    . .
 >
 #
 > “ May     it       please your Majesty , ” said Two , in        a   very humble   tone       , going   down        on  one
@@ -3534,8 +3534,8 @@
 # NSg/VB+ R/C/P NPr/ISg+ NSg/VPt . . IPl+ VLPt Nᴹ/Vg/J . .
 >
 #
-> “ I       see    ! ” said the Queen     , who    had meanwhile been   examining the roses   . “ Off        with
-# . ISg/#r+ NSg/VB . . VP/J D+  NPr/VB/J+ . NPr/I+ VP  NSg       VLPp/B Nᴹ/Vg/J   D+  NPl/V3+ . . NSg/VB/J/P P
+> “ I       see    ! ” said the Queen   , who    had meanwhile been   examining the roses   . “ Off        with
+# . ISg/#r+ NSg/VB . . VP/J D+  NPr/VB+ . NPr/I+ VP  NSg       VLPp/B Nᴹ/Vg/J   D+  NPl/V3+ . . NSg/VB/J/P P
 > their heads   ! ” and  the procession moved on  , three of the soldiers remaining
 # D$+   NPl/V3+ . . VB/C D+  NSg/VB+    VP/J  J/P . NSg   P  D+  NPl/V3+  Nᴹ/Vg/J
 > behind  to execute the unfortunate gardeners , who    ran to Alice for   protection .
@@ -3550,8 +3550,8 @@
 # R/C/P NSg/IPl+ . VB/C NSg/J/R/C R       VP/J    NSg/VB/J/P P     D+  NPl/V3+ .
 >
 #
-> “ Are their heads   off        ? ” shouted the Queen     .
-# . VLB D$+   NPl/V3+ NSg/VB/J/P . . VP/J    D+  NPr/VB/J+ .
+> “ Are their heads   off        ? ” shouted the Queen   .
+# . VLB D$+   NPl/V3+ NSg/VB/J/P . . VP/J    D+  NPr/VB+ .
 >
 #
 > “ Their heads   are gone    , if    it       please your Majesty ! ” the soldiers shouted in
@@ -3560,8 +3560,8 @@
 # NSg/VB+ .
 >
 #
-> “ That’s right    ! ” shouted the Queen     . “ Can     you    play    croquet ? ”
-# . K      NPr/VB/J . . VP/J    D+  NPr/VB/J+ . . NPr/VXB ISgPl+ N🅪Sg/VB NSg/VB  . .
+> “ That’s right    ! ” shouted the Queen   . “ Can     you    play    croquet ? ”
+# . K      NPr/VB/J . . VP/J    D+  NPr/VB+ . . NPr/VXB ISgPl+ N🅪Sg/VB NSg/VB  . .
 >
 #
 > The soldiers were silent , and  looked at    Alice , as    the question was  evidently
@@ -3574,8 +3574,8 @@
 # . NPl/VB . . VP/J    NPr+  .
 >
 #
-> “ Come       on  , then      ! ” roared the Queen     , and  Alice joined the procession , wondering
-# . NSg/VBPp/P J/P . NSg/J/R/C . . VP/J   D+  NPr/VB/J+ . VB/C NPr+  VP/J   D+  NSg/VB+    . Nᴹ/Vg/J
+> “ Come       on  , then      ! ” roared the Queen   , and  Alice joined the procession , wondering
+# . NSg/VBPp/P J/P . NSg/J/R/C . . VP/J   D+  NPr/VB+ . VB/C NPr+  VP/J   D+  NSg/VB+    . Nᴹ/Vg/J
 > very much         what   would happen next    .
 # J/R  NSg/I/J/R/Dq NSg/I+ VXB   VB     NSg/J/P .
 >
@@ -3614,14 +3614,14 @@
 #
 > “ She  boxed the Queen’s ears    — ” the Rabbit  began . Alice gave a   little     scream of
 # . ISg+ VP/J  D   NPr$    NPl/V3+ . . D   NSg/VB+ VPt   . NPr+  VPt  D/P NPr/I/J/Dq NSg/VB P
-> laughter . “ Oh     , hush    ! ” the Rabbit  whispered in        a    frightened tone       . “ The Queen     will
-# Nᴹ+      . . NPr/VB . NSg/VB+ . . D+  NSg/VB+ VP/J      NPr/J/R/P D/P+ VP/J       N🅪Sg/I/VB+ . . D+  NPr/VB/J+ NPr/VXB
-> hear you    ! You    see    , she  came      rather     late  , and  the Queen     said — ”
-# VB   ISgPl+ . ISgPl+ NSg/VB . ISg+ NSg/VPt/P NPr/VB/J/R NSg/J . VB/C D+  NPr/VB/J+ VP/J . .
+> laughter . “ Oh     , hush    ! ” the Rabbit  whispered in        a    frightened tone       . “ The Queen   will
+# Nᴹ+      . . NPr/VB . NSg/VB+ . . D+  NSg/VB+ VP/J      NPr/J/R/P D/P+ VP/J       N🅪Sg/I/VB+ . . D+  NPr/VB+ NPr/VXB
+> hear you    ! You    see    , she  came      rather     late  , and  the Queen   said — ”
+# VB   ISgPl+ . ISgPl+ NSg/VB . ISg+ NSg/VPt/P NPr/VB/J/R NSg/J . VB/C D+  NPr/VB+ VP/J . .
 >
 #
-> “ Get    to your places  ! ” shouted the Queen     in        a   voice  of thunder , and  people  began
-# . NSg/VB P  D$+  NPl/V3+ . . VP/J    D+  NPr/VB/J+ NPr/J/R/P D/P NSg/VB P  NSg/VB+ . VB/C NPl/VB+ VPt
+> “ Get    to your places  ! ” shouted the Queen   in        a   voice  of thunder , and  people  began
+# . NSg/VB P  D$+  NPl/V3+ . . VP/J    D+  NPr/VB+ NPr/J/R/P D/P NSg/VB P  NSg/VB+ . VB/C NPl/VB+ VPt
 > running   about in        all           directions , tumbling up         against each other    ; however , they
 # Nᴹ/Vg/J/P J/P   NPr/J/R/P NSg/I/J/C/Dq+ NPl+       . Nᴹ/Vg/J  NSg/VB/J/P C/P     Dq   NSg/VB/J . C       . IPl+
 > got settled down        in        a    minute    or    two , and  the game      began . Alice thought she  had
@@ -3646,8 +3646,8 @@
 # VP/J         NSg/VB/J/R/P . VB/C VLPt Nᴹ/Vg/J P  NSg/VB D   NSg/VB+  D/P NSg/VB/J+ P    ISg/D$+ NPr/VB/J+ . NPr/ISg+
 > would twist  itself round      and  look   up         in        her     face    , with such  a   puzzled expression
 # VXB   NSg/VB ISg+   NSg/VB/J/P VB/C NSg/VB NSg/VB/J/P NPr/J/R/P ISg/D$+ NSg/VB+ . P    NSg/I D/P VP/J    N🅪Sg+
-> that      she  could   not     help   bursting out          laughing : and  when    she  had got its     head
-# I/C/Ddem+ ISg+ NSg/VXB NSg/R/C NSg/VB Nᴹ/Vg/J  NSg/VB/J/R/P Nᴹ/Vg/J  . VB/C NSg/I/C ISg+ VP  VP  ISg/D$+ NPr/VB/J+
+> that      she  could not     help   bursting out          laughing : and  when    she  had got its     head
+# I/C/Ddem+ ISg+ VXB   NSg/R/C NSg/VB Nᴹ/Vg/J  NSg/VB/J/R/P Nᴹ/Vg/J  . VB/C NSg/I/C ISg+ VP  VP  ISg/D$+ NPr/VB/J+
 > down        , and  was  going   to begin  again , it       was  very provoking to find   that     the
 # N🅪Sg/VB/J/P . VB/C VLPt Nᴹ/Vg/J P  NSg/VB P     . NPr/ISg+ VLPt J/R  Nᴹ/Vg/J   P  NSg/VB I/C/Ddem D
 > hedgehog had unrolled itself , and  was  in        the act     of crawling away : besides all
@@ -3664,26 +3664,26 @@
 #
 > The players all           played at    once  without waiting for   turns  , quarrelling all          the
 # D+  NPl+    NSg/I/J/C/Dq+ VP/J+  NSg/P NSg/C C/P     Nᴹ/Vg/J R/C/P NPl/V3 . Nᴹ/Vg/Comm  NSg/I/J/C/Dq D
-> while      , and  fighting for   the hedgehogs ; and  in        a   very short      time       the Queen     was  in
-# NSg/VB/C/P . VB/C Nᴹ/Vg/J  R/C/P D   NPl/V3    . VB/C NPr/J/R/P D/P J/R  NPr/VB/J/P N🅪Sg/VB/J+ D   NPr/VB/J+ VLPt NPr/J/R/P
-> a   furious passion  , and  went    stamping about , and  shouting “ Off        with his     head      ! ” or
-# D/P J       NPrᴹ/VB+ . VB/C NSg/VPt NSg      J/P   . VB/C Nᴹ/Vg/J+ . NSg/VB/J/P P    ISg/D$+ NPr/VB/J+ . . NPr/C
+> while      , and  fighting for   the hedgehogs ; and  in        a   very short      time       the Queen   was  in
+# NSg/VB/C/P . VB/C Nᴹ/Vg/J  R/C/P D   NPl/V3    . VB/C NPr/J/R/P D/P J/R  NPr/VB/J/P N🅪Sg/VB/J+ D   NPr/VB+ VLPt NPr/J/R/P
+> a   furious passion  , and  went stamping about , and  shouting “ Off        with his     head      ! ” or
+# D/P J       NPrᴹ/VB+ . VB/C VPt  NSg      J/P   . VB/C Nᴹ/Vg/J+ . NSg/VB/J/P P    ISg/D$+ NPr/VB/J+ . . NPr/C
 > “ Off        with her     head      ! ” about once  in        a    minute    .
 # . NSg/VB/J/P P    ISg/D$+ NPr/VB/J+ . . J/P   NSg/C NPr/J/R/P D/P+ NSg/VB/J+ .
 >
 #
 > Alice began to feel     very uneasy   : to be       sure , she  had not     as    yet      had any    dispute
 # NPr+  VPt   P  NSg/I/VB J/R  NSg/VB/J . P  NSg/VLXB J    . ISg+ VP  NSg/R/C R/C/P NSg/VB/C VP  I/R/Dq NSg/VB+
-> with the Queen     , but     she  knew that     it       might    happen any     minute    , “ and  then      , ”
-# P    D+  NPr/VB/J+ . NSg/C/P ISg+ VPt  I/C/Ddem NPr/ISg+ Nᴹ/VXB/J VB     I/R/Dq+ NSg/VB/J+ . . VB/C NSg/J/R/C . .
+> with the Queen   , but     she  knew that     it       might    happen any     minute    , “ and  then      , ”
+# P    D+  NPr/VB+ . NSg/C/P ISg+ VPt  I/C/Ddem NPr/ISg+ Nᴹ/VXB/J VB     I/R/Dq+ NSg/VB/J+ . . VB/C NSg/J/R/C . .
 > thought she  , “ what   would become of me       ? They’re dreadfully fond     of beheading
 # N🅪Sg/VP ISg+ . . NSg/I+ VXB   VBPp   P  NPr/ISg+ . K       R          NSg/VB/J P  NSg
 > people  here ; the great wonder   is  , that      there’s any    one      left     alive ! ”
-# NPl/VB+ J/R  . D   NSg/J N🅪Sg/VB+ VL3 . I/C/Ddem+ K       I/R/Dq NSg/I/J+ NPr/VP/J J     . .
+# NPl/VB+ R    . D   NSg/J N🅪Sg/VB+ VL3 . I/C/Ddem+ K       I/R/Dq NSg/I/J+ NPr/VP/J J     . .
 >
 #
 > She  was  looking about for   some     way   of escape   , and  wondering whether she  could
-# ISg+ VLPt Nᴹ/Vg/J J/P   R/C/P I/J/R/Dq NSg/J P  N🅪Sg/VB+ . VB/C Nᴹ/Vg/J   I/C     ISg+ NSg/VXB
+# ISg+ VLPt Nᴹ/Vg/J J/P   R/C/P I/J/R/Dq NSg/J P  N🅪Sg/VB+ . VB/C Nᴹ/Vg/J   I/C     ISg+ VXB
 > get    away without being        seen    , when    she  noticed a   curious appearance in        the air      :
 # NSg/VB VB/J C/P     N🅪Sg/VLg/J/C NSg/VPp . NSg/I/C ISg+ VP/J    D/P J       NSg        NPr/J/R/P D+  N🅪Sg/VB+ .
 > it       puzzled her     very much         at    first , but     , after watching it       a    minute    or    two , she
@@ -3730,24 +3730,24 @@
 # J/R  NSg/J/R/C . J/R/C NPr/ISg+ VPt VB/J NSg/I/C NPr/ISg+ NSg/VPt NSg/I/VB+ Nᴹ/Vg/J . .
 >
 #
-> “ How   do  you    like         the Queen     ? ” said the Cat       in        a    low         voice   .
-# . NSg/C VXB ISgPl+ NSg/VB/J/C/P D+  NPr/VB/J+ . . VP/J D   NSg/VB/J+ NPr/J/R/P D/P+ NSg/VB/J/R+ NSg/VB+ .
+> “ How   do  you    like         the Queen   ? ” said the Cat       in        a    low         voice   .
+# . NSg/C VXB ISgPl+ NSg/VB/J/C/P D+  NPr/VB+ . . VP/J D   NSg/VB/J+ NPr/J/R/P D/P+ NSg/VB/J/R+ NSg/VB+ .
 >
 #
 > “ Not     at    all          , ” said Alice : “ she’s so          extremely — ” Just then      she  noticed that     the
 # . NSg/R/C NSg/P NSg/I/J/C/Dq . . VP/J NPr+  . . K     NSg/I/J/R/C R         . . J/R  NSg/J/R/C ISg+ VP/J    I/C/Ddem D
-> Queen     was  close    behind  her     , listening : so          she  went    on  , “ — likely to win    , that
-# NPr/VB/J+ VLPt NSg/VB/J NSg/J/P ISg/D$+ . Nᴹ/Vg/J   . NSg/I/J/R/C ISg+ NSg/VPt J/P . . . NSg/J  P  NSg/VB . I/C/Ddem
+> Queen   was  close    behind  her     , listening : so          she  went on  , “ — likely to win    , that
+# NPr/VB+ VLPt NSg/VB/J NSg/J/P ISg/D$+ . Nᴹ/Vg/J   . NSg/I/J/R/C ISg+ VPt  J/P . . . NSg/J  P  NSg/VB . I/C/Ddem
 > it’s hardly worth    while      finishing the game      . ”
 # K    R      NSg/VB/J NSg/VB/C/P Nᴹ/Vg/J   D   NSg/VB/J+ . .
 >
 #
-> The Queen     smiled and  passed on  .
-# D+  NPr/VB/J+ VP/J   VB/C VP/J   J/P .
+> The Queen   smiled and  passed on  .
+# D+  NPr/VB+ VP/J   VB/C VP/J   J/P .
 >
 #
-> “ Who    are you    talking to ? ” said the King      , going   up         to Alice , and  looking at    the
-# . NPr/I+ VLB ISgPl+ Nᴹ/Vg/J P  . . VP/J D+  NPr/VB/J+ . Nᴹ/Vg/J NSg/VB/J/P P  NPr+  . VB/C Nᴹ/Vg/J NSg/P D
+> “ Who    are you    talking to ? ” said the King    , going   up         to Alice , and  looking at    the
+# . NPr/I+ VLB ISgPl+ Nᴹ/Vg/J P  . . VP/J D+  NPr/VB+ . Nᴹ/Vg/J NSg/VB/J/P P  NPr+  . VB/C Nᴹ/Vg/J NSg/P D
 > Cat’s head     with great curiosity .
 # NSg$  NPr/VB/J P    NSg/J NSg+      .
 >
@@ -3756,8 +3756,8 @@
 # . K    D/P NPr/VB/J P  NSg/I/VB+ . D/P NPr      NSg/VB/J+ . . VP/J NPr+  . . VB    NPr/ISg+ P  VB        NPr/ISg+ . .
 >
 #
-> “ I       don’t like         the look   of it       at    all          , ” said the King      : “ however , it       may     kiss   my
-# . ISg/#r+ VXB   NSg/VB/J/C/P D   NSg/VB P  NPr/ISg+ NSg/P NSg/I/J/C/Dq . . VP/J D   NPr/VB/J+ . . C       . NPr/ISg+ NPr/VXB NSg/VB D$+
+> “ I       don’t like         the look   of it       at    all          , ” said the King    : “ however , it       may     kiss   my
+# . ISg/#r+ VXB   NSg/VB/J/C/P D   NSg/VB P  NPr/ISg+ NSg/P NSg/I/J/C/Dq . . VP/J D   NPr/VB+ . . C       . NPr/ISg+ NPr/VXB NSg/VB D$+
 > hand    if    it       likes  . ”
 # NSg/VB+ NSg/C NPr/ISg+ NPl/V3 . .
 >
@@ -3766,34 +3766,34 @@
 # . K   NPr/VB/J/R NSg/R/C . . D   NSg/VB/J+ VP/J     .
 >
 #
-> “ Don’t be       impertinent , ” said the King      , “ and  don’t look   at    me       like         that      ! ” He       got
-# . VXB   NSg/VLXB NSg/J       . . VP/J D   NPr/VB/J+ . . VB/C VXB   NSg/VB NSg/P NPr/ISg+ NSg/VB/J/C/P I/C/Ddem+ . . NPr/ISg+ VP
+> “ Don’t be       impertinent , ” said the King    , “ and  don’t look   at    me       like         that      ! ” He       got
+# . VXB   NSg/VLXB NSg/J       . . VP/J D   NPr/VB+ . . VB/C VXB   NSg/VB NSg/P NPr/ISg+ NSg/VB/J/C/P I/C/Ddem+ . . NPr/ISg+ VP
 > behind  Alice as    he       spoke   .
 # NSg/J/P NPr+  R/C/P NPr/ISg+ NSg/VPt .
 >
 #
-> “ A    cat       may     look   at    a    king      , ” said Alice . “ I’ve read    that     in        some     book    , but     I
-# . D/P+ NSg/VB/J+ NPr/VXB NSg/VB NSg/P D/P+ NPr/VB/J+ . . VP/J NPr+  . . K    NSg/VBP I/C/Ddem NPr/J/R/P I/J/R/Dq NSg/VB+ . NSg/C/P ISg/#r+
+> “ A    cat       may     look   at    a    king    , ” said Alice . “ I’ve read    that     in        some     book    , but     I
+# . D/P+ NSg/VB/J+ NPr/VXB NSg/VB NSg/P D/P+ NPr/VB+ . . VP/J NPr+  . . K    NSg/VBP I/C/Ddem NPr/J/R/P I/J/R/Dq NSg/VB+ . NSg/C/P ISg/#r+
 > don’t remember where   . ”
 # VXB   NSg/VB   NSg/R/C . .
 >
 #
-> “ Well       , it       must    be       removed , ” said the King      very decidedly , and  he       called the
-# . NSg/VB/J/R . NPr/ISg+ NSg/VXB NSg/VLXB VP/J    . . VP/J D+  NPr/VB/J+ J/R  R         . VB/C NPr/ISg+ VP/J   D
-> Queen     , who    was  passing at    the moment , “ My  dear     ! I       wish   you    would have    this    cat
-# NPr/VB/J+ . NPr/I+ VLPt Nᴹ/Vg/J NSg/P D   NSg+   . . D$+ NSg/VB/J . ISg/#r+ NSg/VB ISgPl+ VXB   NSg/VXB I/Ddem+ NSg/VB/J+
+> “ Well       , it       must    be       removed , ” said the King    very decidedly , and  he       called the
+# . NSg/VB/J/R . NPr/ISg+ NSg/VXB NSg/VLXB VP/J    . . VP/J D+  NPr/VB+ J/R  R         . VB/C NPr/ISg+ VP/J   D
+> Queen   , who    was  passing at    the moment , “ My  dear     ! I       wish   you    would have    this    cat
+# NPr/VB+ . NPr/I+ VLPt Nᴹ/Vg/J NSg/P D   NSg+   . . D$+ NSg/VB/J . ISg/#r+ NSg/VB ISgPl+ VXB   NSg/VXB I/Ddem+ NSg/VB/J+
 > removed ! ”
 # VP/J    . .
 >
 #
-> The Queen     had only  one     way   of settling all           difficulties , great or    small    . “ Off
-# D+  NPr/VB/J+ VP  J/R/C NSg/I/J NSg/J P  Nᴹ/Vg/J  NSg/I/J/C/Dq+ NPl+         . NSg/J NPr/C NPr/VB/J . . NSg/VB/J/P
+> The Queen   had only  one     way   of settling all           difficulties , great or    small    . “ Off
+# D+  NPr/VB+ VP  J/R/C NSg/I/J NSg/J P  Nᴹ/Vg/J  NSg/I/J/C/Dq+ NPl+         . NSg/J NPr/C NPr/VB/J . . NSg/VB/J/P
 > with his     head      ! ” she  said , without even       looking round      .
 # P    ISg/D$+ NPr/VB/J+ . . ISg+ VP/J . C/P     NSg/VB/J/R Nᴹ/Vg/J NSg/VB/J/P .
 >
 #
-> “ I’ll fetch  the executioner myself , ” said the King      eagerly , and  he       hurried off        .
-# . K    NSg/VB D   NSg         ISg+   . . VP/J D   NPr/VB/J+ R       . VB/C NPr/ISg+ VP/J    NSg/VB/J/P .
+> “ I’ll fetch  the executioner myself , ” said the King    eagerly , and  he       hurried off        .
+# . K    NSg/VB D   NSg         ISg+   . . VP/J D   NPr/VB+ R       . VB/C NPr/ISg+ VP/J    NSg/VB/J/P .
 >
 #
 > Alice thought she  might    as    well       go       back     , and  see    how   the game      was  going   on  , as
@@ -3805,7 +3805,7 @@
 > their turns  , and  she  did  not     like         the look   of things at    all          , as    the game      was  in
 # D$+   NPl/V3 . VB/C ISg+ VXPt NSg/R/C NSg/VB/J/C/P D   NSg/VB P  NPl+   NSg/P NSg/I/J/C/Dq . R/C/P D+  NSg/VB/J+ VLPt NPr/J/R/P
 > such   confusion that      she  never knew whether it       was  her     turn   or    not     . So          she  went
-# NSg/I+ N🅪Sg/VB+  I/C/Ddem+ ISg+ R     VPt  I/C     NPr/ISg+ VLPt ISg/D$+ NSg/VB NPr/C NSg/R/C . NSg/I/J/R/C ISg+ NSg/VPt
+# NSg/I+ N🅪Sg/VB+  I/C/Ddem+ ISg+ R     VPt  I/C     NPr/ISg+ VLPt ISg/D$+ NSg/VB NPr/C NSg/R/C . NSg/I/J/R/C ISg+ VPt
 > in        search  of her     hedgehog .
 # NPr/J/R/P N🅪Sg/VB P  ISg/D$+ NSg/VB+  .
 >
@@ -3816,8 +3816,8 @@
 # D/P+ J+        N🅪Sg+       R/C/P Nᴹ/Vg/J    NSg/I/J P  NSg/IPl+ P    D   NSg/VB/J . D   J/R/C
 > difficulty was  , that     her     flamingo was  gone    across to the other    side     of the
 # N🅪Sg+      VLPt . I/C/Ddem ISg/D$+ NSg/J    VLPt VPp/J/P NSg/P  P  D   NSg/VB/J NSg/VB/J P  D
-> garden    , where   Alice could   see    it       trying  in        a   helpless sort   of way    to fly      up         into
-# NSg/VB/J+ . NSg/R/C NPr+  NSg/VXB NSg/VB NPr/ISg+ Nᴹ/Vg/J NPr/J/R/P D/P J        NSg/VB P  NSg/J+ P  NSg/VB/J NSg/VB/J/P P
+> garden    , where   Alice could see    it       trying  in        a   helpless sort   of way    to fly      up         into
+# NSg/VB/J+ . NSg/R/C NPr+  VXB   NSg/VB NPr/ISg+ Nᴹ/Vg/J NPr/J/R/P D/P J        NSg/VB P  NSg/J+ P  NSg/VB/J NSg/VB/J/P P
 > a   tree    .
 # D/P NSg/VB+ .
 >
@@ -3828,8 +3828,8 @@
 # VB/C I/C/Dq D   NPl/V3    VLPt NSg/VB/J/R/P P  N🅪Sg/VB+ . . NSg/C/P NPr/ISg+ VX3     N🅪Sg/VB+ NSg/I/J/R/Dq . . N🅪Sg/VP
 > Alice , “ as    all          the arches are gone    from this   side     of the ground     . ” So          she  tucked
 # NPr+  . . R/C/P NSg/I/J/C/Dq D   NPl/V3 VLB VPp/J/P P    I/Ddem NSg/VB/J P  D   N🅪Sg/VB/J+ . . NSg/I/J/R/C ISg+ VP/J
-> it       away under   her     arm       , that     it       might    not     escape  again , and  went    back     for   a
-# NPr/ISg+ VB/J NSg/J/P ISg/D$+ NSg/VB/J+ . I/C/Ddem NPr/ISg+ Nᴹ/VXB/J NSg/R/C N🅪Sg/VB P     . VB/C NSg/VPt NSg/VB/J R/C/P D/P
+> it       away under   her     arm       , that     it       might    not     escape  again , and  went back     for   a
+# NPr/ISg+ VB/J NSg/J/P ISg/D$+ NSg/VB/J+ . I/C/Ddem NPr/ISg+ Nᴹ/VXB/J NSg/R/C N🅪Sg/VB P     . VB/C VPt  NSg/VB/J R/C/P D/P
 > little     more         conversation with her     friend    .
 # NPr/I/J/Dq NPr/I/J/R/Dq N🅪Sg/VB      P    ISg/D$+ NPr/VB/J+ .
 >
@@ -3838,8 +3838,8 @@
 # NSg/I/C ISg+ VP  NSg/VB/J P  D   NPr      NSg/VB/J+ . ISg+ VLPt VP/J      P  NSg/VB R     D/P NSg/J
 > crowd   collected round      it       : there was  a   dispute going   on  between the executioner ,
 # NSg/VB+ VP/J      NSg/VB/J/P NPr/ISg+ . R+    VLPt D/P NSg/VB+ Nᴹ/Vg/J J/P NSg/P   D   NSg         .
-> the King      , and  the Queen     , who    were all          talking  at    once  , while      all          the rest    were
-# D   NPr/VB/J+ . VB/C D   NPr/VB/J+ . NPr/I+ VLPt NSg/I/J/C/Dq Nᴹ/Vg/J+ NSg/P NSg/C . NSg/VB/C/P NSg/I/J/C/Dq D   NSg/VB+ VLPt
+> the King    , and  the Queen   , who    were all          talking  at    once  , while      all          the rest    were
+# D   NPr/VB+ . VB/C D   NPr/VB+ . NPr/I+ VLPt NSg/I/J/C/Dq Nᴹ/Vg/J+ NSg/P NSg/C . NSg/VB/C/P NSg/I/J/C/Dq D   NSg/VB+ VLPt
 > quite silent , and  looked very uncomfortable .
 # R     NSg/J  . VB/C VP/J   J/R  J             .
 >
@@ -3860,8 +3860,8 @@
 # VB/C NPr/ISg+ VPt    Nᴹ/Vg/J P  NSg/VB NSg/P ISg/D$+ N🅪Sg/VB/J P  N🅪Sg/VB+ .
 >
 #
-> The King’s argument was  , that     anything  that      had a   head      could   be       beheaded , and
-# D   NPr$   N🅪Sg/VB+ VLPt . I/C/Ddem NSg/I/VB+ I/C/Ddem+ VP  D/P NPr/VB/J+ NSg/VXB NSg/VLXB VP/J     . VB/C
+> The King’s argument was  , that     anything  that      had a   head      could be       beheaded , and
+# D   NPr$   N🅪Sg/VB+ VLPt . I/C/Ddem NSg/I/VB+ I/C/Ddem+ VP  D/P NPr/VB/J+ VXB   NSg/VLXB VP/J     . VB/C
 > that     you    weren’t to talk    nonsense .
 # I/C/Ddem ISgPl+ VPt     P  N🅪Sg/VB Nᴹ/VB/J+ .
 >
@@ -3874,26 +3874,26 @@
 # VP   D+  NSg/J+ NSg/VB/J+ NSg/VB NSg/I/J/R/C NSg/VB/J+ VB/C J       . .
 >
 #
-> Alice could   think  of nothing  else    to say    but     “ It       belongs to the Duchess : you’d
-# NPr+  NSg/VXB NSg/VB P  NSg/I/J+ NSg/J/C P  NSg/VB NSg/C/P . NPr/ISg+ V3      P  D   NSg/VB  . K
+> Alice could think  of nothing  else    to say    but     “ It       belongs to the Duchess : you’d
+# NPr+  VXB   NSg/VB P  NSg/I/J+ NSg/J/C P  NSg/VB NSg/C/P . NPr/ISg+ V3      P  D   NSg/VB  . K
 > better     ask    her     about it       . ”
 # NSg/VXB/JC NSg/VB ISg/D$+ J/P   NPr/ISg+ . .
 >
 #
-> “ She’s in        prison  , ” the Queen     said to the executioner : “ fetch  her     here . ” And  the
-# . K     NPr/J/R/P NSg/VB+ . . D   NPr/VB/J+ VP/J P  D   NSg         . . NSg/VB ISg/D$+ J/R  . . VB/C D
-> executioner went     off        like         an  arrow   .
-# NSg         NSg/VPt+ NSg/VB/J/P NSg/VB/J/C/P D/P NSg/VB+ .
+> “ She’s in        prison  , ” the Queen   said to the executioner : “ fetch  her     here . ” And  the
+# . K     NPr/J/R/P NSg/VB+ . . D   NPr/VB+ VP/J P  D   NSg         . . NSg/VB ISg/D$+ R    . . VB/C D
+> executioner went off        like         an  arrow   .
+# NSg         VPt+ NSg/VB/J/P NSg/VB/J/C/P D/P NSg/VB+ .
 >
 #
 > The Cat’s head      began fading  away the moment he       was  gone    , and  , by the time       he       had
 # D   NSg$  NPr/VB/J+ VPt   Nᴹ/Vg/J VB/J D   NSg+   NPr/ISg+ VLPt VPp/J/P . VB/C . P  D   N🅪Sg/VB/J+ NPr/ISg+ VP
-> come       back     with the Duchess , it       had entirely disappeared ; so          the King      and  the
-# NSg/VBPp/P NSg/VB/J P    D   NSg/VB  . NPr/ISg+ VP  R        VP/J        . NSg/I/J/R/C D   NPr/VB/J+ VB/C D
+> come       back     with the Duchess , it       had entirely disappeared ; so          the King    and  the
+# NSg/VBPp/P NSg/VB/J P    D   NSg/VB  . NPr/ISg+ VP  R        VP/J        . NSg/I/J/R/C D   NPr/VB+ VB/C D
 > executioner ran wildly up         and  down        looking for   it       , while      the rest   of the party
 # NSg         VPt R      NSg/VB/J/P VB/C N🅪Sg/VB/J/P Nᴹ/Vg/J R/C/P NPr/ISg+ . NSg/VB/C/P D   NSg/VB P  D   NSg/VB/J+
-> went    back     to the game      .
-# NSg/VPt NSg/VB/J P  D   NSg/VB/J+ .
+> went back     to the game      .
+# VPt  NSg/VB/J P  D   NSg/VB/J+ .
 >
 #
 >              CHAPTER IX : The Mock     Turtle’s Story
@@ -3920,8 +3920,8 @@
 # . NSg/I/C K   D/P NSg/VB  . . ISg+ VP/J P  ISg+    . . NSg/R/C NPr/J/R/P D/P J/R  NSg/J   N🅪Sg/I/VB+ C      . .
 > “ I       won’t have    any    pepper   in        my  kitchen at    all          . Soup     does    very well       without — Maybe
 # . ISg/#r+ VXB   NSg/VXB I/R/Dq N🅪Sg/VB+ NPr/J/R/P D$+ NSg/VB+ NSg/P NSg/I/J/C/Dq . N🅪Sg/VB+ NPl/VX3 J/R  NSg/VB/J/R C/P     . NSg/J/R
-> it’s always pepper  that      makes  people  hot      - tempered , ” she  went    on  , very much
-# K    R      N🅪Sg/VB I/C/Ddem+ NPl/V3 NPl/VB+ NSg/VB/J . VP/J     . . ISg+ NSg/VPt J/P . J/R  NSg/I/J/R/Dq
+> it’s always pepper  that      makes  people  hot      - tempered , ” she  went on  , very much
+# K    R      N🅪Sg/VB I/C/Ddem+ NPl/V3 NPl/VB+ NSg/VB/J . VP/J     . . ISg+ VPt  J/P . J/R  NSg/I/J/R/Dq
 > pleased at    having  found  out          a   new   kind  of rule    , “ and  vinegar that      makes  them
 # VP/J    NSg/P Nᴹ/Vg/J NSg/VP NSg/VB/J/R/P D/P NSg/J NSg/J P  NSg/VB+ . . VB/C NSg/VB+ I/C/Ddem+ NPl/V3 NSg/IPl+
 > sour     — and  camomile that      makes  them     bitter   — and  — and  barley - sugar   and  such  things
@@ -3958,8 +3958,8 @@
 # J/R  NSg/VB/J . VB/C R        . C/P     ISg+ VLPt R       D   NPr/VB/J N🅪Sg+  P  NSg/VB ISg/D$+
 > chin    upon Alice’s shoulder , and  it       was  an  uncomfortably sharp    chin    . However , she
 # NPr/VB+ P    NPr$    NSg/VB+  . VB/C NPr/ISg+ VLPt D/P R             NPr/VB/J NPr/VB+ . C       . ISg+
-> did  not     like         to be       rude , so          she  bore     it       as    well       as    she  could   .
-# VXPt NSg/R/C NSg/VB/J/C/P P  NSg/VLXB J    . NSg/I/J/R/C ISg+ NSg/VBPt NPr/ISg+ R/C/P NSg/VB/J/R R/C/P ISg+ NSg/VXB .
+> did  not     like         to be       rude , so          she  bore     it       as    well       as    she  could .
+# VXPt NSg/R/C NSg/VB/J/C/P P  NSg/VLXB J    . NSg/I/J/R/C ISg+ NSg/VBPt NPr/ISg+ R/C/P NSg/VB/J/R R/C/P ISg+ VXB   .
 >
 #
 > “ The game’s going   on  rather     better     now       , ” she  said , by way   of keeping up         the
@@ -4029,7 +4029,7 @@
 > “ Of course  it       is  , ” said the Duchess , who    seemed ready    to agree to everything
 # . P  NSg/VB+ NPr/ISg+ VL3 . . VP/J D   NSg/VB  . NPr/I+ VP/J   NSg/VB/J P  VB    P  NSg/I/VB+
 > that     Alice said ; “ there’s a   large mustard - mine      near       here . And  the moral    of that
-# I/C/Ddem NPr+  VP/J . . K       D/P NSg/J Nᴹ/J    . NSg/I/VB+ NSg/VB/J/P J/R  . VB/C D   NSg/VB/J P  I/C/Ddem+
+# I/C/Ddem NPr+  VP/J . . K       D/P NSg/J Nᴹ/J    . NSg/I/VB+ NSg/VB/J/P R    . VB/C D   NSg/VB/J P  I/C/Ddem+
 > is  — ‘ The more         there is  of mine      , the less    there is  of yours . ’ ”
 # VL3 . . D   NPr/I/J/R/Dq R     VL3 P  NSg/I/VB+ . D   J/R/C/P R     VL3 P  I+    . . .
 >
@@ -4058,8 +4058,8 @@
 # NPr/ISg+ VPp/J   N🅪Sg/VB/J/P . NSg/C/P ISg/#r+ VXB   R     NSg/VB NPr/ISg+ R/C/P ISgPl+ NSg/VB NPr/ISg+ . .
 >
 #
-> “ That’s nothing  to what   I       could   say    if    I       chose   , ” the Duchess replied , in        a
-# . K      NSg/I/J+ P  NSg/I+ ISg/#r+ NSg/VXB NSg/VB NSg/C ISg/#r+ NSg/VPt . . D   NSg/VB  VP/J    . NPr/J/R/P D/P
+> “ That’s nothing  to what   I       could say    if    I       chose   , ” the Duchess replied , in        a
+# . K      NSg/I/J+ P  NSg/I+ ISg/#r+ VXB   NSg/VB NSg/C ISg/#r+ NSg/VPt . . D   NSg/VB  VP/J    . NPr/J/R/P D/P
 > pleased tone       .
 # VP/J    N🅪Sg/I/VB+ .
 >
@@ -4095,11 +4095,11 @@
 >
 #
 > But     here , to Alice’s great  surprise , the Duchess’s voice   died away , even       in        the
-# NSg/C/P J/R  . P  NPr$    NSg/J+ NSg/VB+  . D   NSg$      NSg/VB+ VP/J VB/J . NSg/VB/J/R NPr/J/R/P D
+# NSg/C/P R    . P  NPr$    NSg/J+ NSg/VB+  . D   NSg$      NSg/VB+ VP/J VB/J . NSg/VB/J/R NPr/J/R/P D
 > middle   of her     favourite     word    ‘ moral    , ’ and  the arm       that      was  linked into hers
 # NSg/VB/J P  ISg/D$+ NSg/VB/J/Comm NSg/VB+ . NSg/VB/J . . VB/C D   NSg/VB/J+ I/C/Ddem+ VLPt VP/J   P    ISg+
-> began to tremble . Alice looked up         , and  there stood the Queen     in        front    of them     ,
-# VPt   P  NSg/VB  . NPr+  VP/J   NSg/VB/J/P . VB/C R+    VP    D   NPr/VB/J+ NPr/J/R/P NSg/VB/J P  NSg/IPl+ .
+> began to tremble . Alice looked up         , and  there stood the Queen   in        front    of them     ,
+# VPt   P  NSg/VB  . NPr+  VP/J   NSg/VB/J/P . VB/C R+    VP    D   NPr/VB+ NPr/J/R/P NSg/VB/J P  NSg/IPl+ .
 > with her     arms    folded , frowning like         a   thunderstorm .
 # P    ISg/D$+ NPl/V3+ VP/J   . Nᴹ/Vg/J  NSg/VB/J/C/P D/P NSg          .
 >
@@ -4108,8 +4108,8 @@
 # . D/P+ NSg/VB/J+ NPr🅪Sg+ . D$+  N🅪Sg/I+ . . D   NSg/VB  VPt   NPr/J/R/P D/P NSg/VB/J/R . J    NSg/VB+ .
 >
 #
-> “ Now       , I       give   you    fair      warning    , ” shouted the Queen     , stamping on  the ground     as    she
-# . NSg/J/R/C . ISg/#r+ NSg/VB ISgPl+ NSg/VB/J+ N🅪Sg/Vg/J+ . . VP/J    D+  NPr/VB/J+ . NSg      J/P D+  N🅪Sg/VB/J+ R/C/P ISg+
+> “ Now       , I       give   you    fair      warning    , ” shouted the Queen   , stamping on  the ground     as    she
+# . NSg/J/R/C . ISg/#r+ NSg/VB ISgPl+ NSg/VB/J+ N🅪Sg/Vg/J+ . . VP/J    D+  NPr/VB+ . NSg      J/P D+  N🅪Sg/VB/J+ R/C/P ISg+
 > spoke   ; “ either you    or    your head      must    be       off        , and  that      in        about half      no        time       !
 # NSg/VPt . . I/C    ISgPl+ NPr/C D$+  NPr/VB/J+ NSg/VXB NSg/VLXB NSg/VB/J/P . VB/C I/C/Ddem+ NPr/J/R/P J/P   N🅪Sg/J/P+ NSg/Dq/P+ N🅪Sg/VB/J+ .
 > Take   your choice  ! ”
@@ -4120,8 +4120,8 @@
 # D   NSg/VB  VPt  ISg/D$+ N🅪Sg/J+ . VB/C VLPt VPp/J/P NPr/J/R/P D/P NSg+   .
 >
 #
-> “ Let’s go       on  with the game      , ” the Queen     said to Alice ; and  Alice was  too much
-# . NSg$  NSg/VB/J J/P P    D   NSg/VB/J+ . . D   NPr/VB/J+ VP/J P  NPr+  . VB/C NPr+  VLPt R   NSg/I/J/R/Dq
+> “ Let’s go       on  with the game      , ” the Queen   said to Alice ; and  Alice was  too much
+# . NSg$  NSg/VB/J J/P P    D   NSg/VB/J+ . . D   NPr/VB+ VP/J P  NPr+  . VB/C NPr+  VLPt R   NSg/I/J/R/Dq
 > frightened to say    a   word    , but     slowly followed her     back     to the croquet - ground     .
 # VP/J       P  NSg/VB D/P NSg/VB+ . NSg/C/P R      VP/J     ISg/D$+ NSg/VB/J P  D   NSg/VB  . N🅪Sg/VB/J+ .
 >
@@ -4130,26 +4130,26 @@
 # D+  NSg/VB/J+ NPl/V3+ VP  VPp/J N🅪Sg/VB   P  D   NPr$    N🅪Sg+   . VB/C VLPt Nᴹ/Vg/J NPr/J/R/P
 > the shade    : however , the moment they saw     her     , they hurried back     to the game      , the
 # D   N🅪Sg/VB+ . C       . D   NSg+   IPl+ NSg/VPt ISg/D$+ . IPl+ VP/J    NSg/VB/J P  D   NSg/VB/J+ . D
-> Queen     merely remarking that     a   moment’s delay       would cost       them     their lives .
-# NPr/VB/J+ R      Nᴹ/Vg/J   I/C/Ddem D/P NSg$     NSg/VBPt/J+ VXB   N🅪Sg/VBP/J NSg/IPl+ D$+   V3+   .
+> Queen   merely remarking that     a   moment’s delay       would cost       them     their lives .
+# NPr/VB+ R      Nᴹ/Vg/J   I/C/Ddem D/P NSg$     NSg/VBPt/J+ VXB   N🅪Sg/VBP/J NSg/IPl+ D$+   V3+   .
 >
 #
-> All           the time       they were playing the Queen     never left     off        quarrelling with the
-# NSg/I/J/C/Dq+ D+  N🅪Sg/VB/J+ IPl+ VLPt Nᴹ/Vg/J D+  NPr/VB/J+ R     NPr/VP/J NSg/VB/J/P Nᴹ/Vg/Comm  P    D
+> All           the time       they were playing the Queen   never left     off        quarrelling with the
+# NSg/I/J/C/Dq+ D+  N🅪Sg/VB/J+ IPl+ VLPt Nᴹ/Vg/J D+  NPr/VB+ R     NPr/VP/J NSg/VB/J/P Nᴹ/Vg/Comm  P    D
 > other    players , and  shouting “ Off        with his     head      ! ” or    “ Off        with her     head      ! ” Those
 # NSg/VB/J NPl+    . VB/C Nᴹ/Vg/J+ . NSg/VB/J/P P    ISg/D$+ NPr/VB/J+ . . NPr/C . NSg/VB/J/P P    ISg/D$+ NPr/VB/J+ . . I/Ddem+
 > whom she  sentenced were taken into custody by the soldiers , who   of course  had to
 # I+   ISg+ VP/J      VLPt VPp/J P    Nᴹ+     P  D   NPl/V3+  . NPr/I P  NSg/VB+ VP  P
 > leave  off        being        arches to do  this    , so          that      by the end    of half      an  hour or    so
 # NSg/VB NSg/VB/J/P N🅪Sg/VLg/J/C NPl/V3 P  VXB I/Ddem+ . NSg/I/J/R/C I/C/Ddem+ P  D   NSg/VB P  N🅪Sg/J/P+ D/P NSg+ NPr/C NSg/I/J/R/C
-> there were no       arches left     , and  all          the players , except the King      , the Queen     , and
-# R+    VLPt NSg/Dq/P NPl/V3 NPr/VP/J . VB/C NSg/I/J/C/Dq D   NPl+    . VB/C/P D   NPr/VB/J+ . D   NPr/VB/J+ . VB/C
+> there were no       arches left     , and  all          the players , except the King    , the Queen   , and
+# R+    VLPt NSg/Dq/P NPl/V3 NPr/VP/J . VB/C NSg/I/J/C/Dq D   NPl+    . VB/C/P D   NPr/VB+ . D   NPr/VB+ . VB/C
 > Alice , were in        custody and  under   sentence of execution .
 # NPr+  . VLPt NPr/J/R/P Nᴹ+     VB/C NSg/J/P NSg/VB   P  N🅪Sg+     .
 >
 #
-> Then      the Queen     left      off        , quite out          of breath     , and  said to Alice , “ Have    you    seen
-# NSg/J/R/C D+  NPr/VB/J+ NPr/VP/J+ NSg/VB/J/P . R     NSg/VB/J/R/P P  N🅪Sg/VB/J+ . VB/C VP/J P  NPr+  . . NSg/VXB ISgPl+ NSg/VPp
+> Then      the Queen   left      off        , quite out          of breath     , and  said to Alice , “ Have    you    seen
+# NSg/J/R/C D+  NPr/VB+ NPr/VP/J+ NSg/VB/J/P . R     NSg/VB/J/R/P P  N🅪Sg/VB/J+ . VB/C VP/J P  NPr+  . . NSg/VXB ISgPl+ NSg/VPp
 > the Mock      Turtle  yet      ? ”
 # D+  NSg/VB/J+ NSg/VB+ NSg/VB/C . .
 >
@@ -4158,32 +4158,32 @@
 # . NSg/Dq/P . . VP/J NPr+  . . ISg/#r+ VXB   NSg/VB/J/R VB   NSg/I+ D/P NSg/VB/J NSg/VB+ VL3 . .
 >
 #
-> “ It’s the thing Mock      Turtle  Soup     is  made from , ” said the Queen     .
-# . K    D+  NSg+  NSg/VB/J+ NSg/VB+ N🅪Sg/VB+ VL3 VP   P    . . VP/J D   NPr/VB/J+ .
+> “ It’s the thing Mock      Turtle  Soup     is  made from , ” said the Queen   .
+# . K    D+  NSg+  NSg/VB/J+ NSg/VB+ N🅪Sg/VB+ VL3 VP   P    . . VP/J D   NPr/VB+ .
 >
 #
 > “ I       never saw     one     , or    heard of one     , ” said Alice .
 # . ISg/#r+ R     NSg/VPt NSg/I/J . NPr/C VP/J  P  NSg/I/J . . VP/J NPr+  .
 >
 #
-> “ Come       on  , then      , ” said the Queen     , “ and  he       shall tell   you    his     history . ”
-# . NSg/VBPp/P J/P . NSg/J/R/C . . VP/J D+  NPr/VB/J+ . . VB/C NPr/ISg+ VXB   NPr/VB ISgPl+ ISg/D$+ N🅪Sg+   . .
+> “ Come       on  , then      , ” said the Queen   , “ and  he       shall tell   you    his     history . ”
+# . NSg/VBPp/P J/P . NSg/J/R/C . . VP/J D+  NPr/VB+ . . VB/C NPr/ISg+ VXB   NPr/VB ISgPl+ ISg/D$+ N🅪Sg+   . .
 >
 #
-> As    they walked off        together , Alice heard the King      say    in        a    low         voice   , to the
-# R/C/P IPl+ VP/J   NSg/VB/J/P J        . NPr+  VP/J  D+  NPr/VB/J+ NSg/VB NPr/J/R/P D/P+ NSg/VB/J/R+ NSg/VB+ . P  D+
+> As    they walked off        together , Alice heard the King    say    in        a    low         voice   , to the
+# R/C/P IPl+ VP/J   NSg/VB/J/P J        . NPr+  VP/J  D+  NPr/VB+ NSg/VB NPr/J/R/P D/P+ NSg/VB/J/R+ NSg/VB+ . P  D+
 > company generally , “ You    are all          pardoned . ” “ Come       , that’s a    good     thing ! ” she  said
 # N🅪Sg+   R         . . ISgPl+ VLB NSg/I/J/C/Dq VP/J     . . . NSg/VBPp/P . K      D/P+ NPr/VB/J NSg+  . . ISg+ VP/J
 > to herself , for   she  had felt      quite unhappy  at    the number     of executions the Queen
-# P  ISg+    . R/C/P ISg+ VP  N🅪Sg/VP/J R     NSg/VB/J NSg/P D   N🅪Sg/VB/JC P  NPl+       D+  NPr/VB/J+
+# P  ISg+    . R/C/P ISg+ VP  N🅪Sg/VP/J R     NSg/VB/J NSg/P D   N🅪Sg/VB/JC P  NPl+       D+  NPr/VB+
 > had ordered .
 # VP  VP/J    .
 >
 #
 > They very soon came      upon a   Gryphon , lying   fast       asleep in        the sun     . ( If    you    don’t
 # IPl+ J/R  J/R  NSg/VPt/P P    D/P ?       . Nᴹ/Vg/J NSg/VB/J/R J      NPr/J/R/P D   NPr/VB+ . . NSg/C ISgPl+ VXB
-> know what   a   Gryphon is  , look   at    the picture . ) “ Up         , lazy      thing ! ” said the Queen     ,
-# VB   NSg/I+ D/P ?       VL3 . NSg/VB NSg/P D   NSg/VB+ . . . NSg/VB/J/P . NSg/VB/J+ NSg+  . . VP/J D+  NPr/VB/J+ .
+> know what   a   Gryphon is  , look   at    the picture . ) “ Up         , lazy      thing ! ” said the Queen   ,
+# VB   NSg/I+ D/P ?       VL3 . NSg/VB NSg/P D   NSg/VB+ . . . NSg/VB/J/P . NSg/VB/J+ NSg+  . . VP/J D+  NPr/VB+ .
 > “ and  take   this    young    lady    to see    the Mock      Turtle  , and  to hear his     history . I
 # . VB/C NSg/VB I/Ddem+ NPr/VB/J NPr/VB+ P  NSg/VB D+  NSg/VB/J+ NSg/VB+ . VB/C P  VB   ISg/D$+ N🅪Sg+   . ISg/#r+
 > must    go       back     and  see    after some      executions I       have    ordered ; ” and  she  walked off        ,
@@ -4192,12 +4192,12 @@
 # Nᴹ/Vg/J NPr+  J     P    D   ?       . NPr+  VXPt NSg/R/C R     NSg/VB/J/C/P D   NSg/VB P  D+
 > creature , but     on  the whole she  thought it       would be       quite as    safe     to stay     with it
 # NSg+     . NSg/C/P J/P D+  NSg/J ISg+ N🅪Sg/VP NPr/ISg+ VXB   NSg/VLXB R     R/C/P NSg/VB/J P  NSg/VB/J P    NPr/ISg+
-> as    to go       after that     savage    Queen     : so          she  waited .
-# R/C/P P  NSg/VB/J P     I/C/Ddem NPr/VB/J+ NPr/VB/J+ . NSg/I/J/R/C ISg+ VP/J   .
+> as    to go       after that     savage    Queen   : so          she  waited .
+# R/C/P P  NSg/VB/J P     I/C/Ddem NPr/VB/J+ NPr/VB+ . NSg/I/J/R/C ISg+ VP/J   .
 >
 #
-> The Gryphon sat    up         and  rubbed its     eyes    : then      it       watched the Queen     till       she  was
-# D   ?       NSg/VP NSg/VB/J/P VB/C VP/J   ISg/D$+ NPl/V3+ . NSg/J/R/C NPr/ISg+ VP/J    D   NPr/VB/J+ NSg/VB/C/P ISg+ VLPt
+> The Gryphon sat    up         and  rubbed its     eyes    : then      it       watched the Queen   till       she  was
+# D   ?       NSg/VP NSg/VB/J/P VB/C VP/J   ISg/D$+ NPl/V3+ . NSg/J/R/C NPr/ISg+ VP/J    D   NPr/VB+ NSg/VB/C/P ISg+ VLPt
 > out          of sight    : then      it       chuckled . “ What   fun     ! ” said the Gryphon , half      to itself ,
 # NSg/VB/J/R/P P  N🅪Sg/VB+ . NSg/J/R/C NPr/ISg+ VP/J     . . NSg/I+ Nᴹ/VB/J . . VP/J D   ?       . N🅪Sg/J/P+ P  ISg+   .
 > half      to Alice .
@@ -4214,8 +4214,8 @@
 # NSg/I+ . ISgPl+ VB   . NSg/VBPp/P J/P . .
 >
 #
-> “ Everybody says   ‘ come       on  ! ’ here , ” thought Alice , as    she  went    slowly after it       : “ I
-# . NSg/I+    NPl/V3 . NSg/VBPp/P J/P . . J/R  . . N🅪Sg/VP NPr+  . R/C/P ISg+ NSg/VPt R      P     NPr/ISg+ . . ISg/#r+
+> “ Everybody says   ‘ come       on  ! ’ here , ” thought Alice , as    she  went slowly after it       : “ I
+# . NSg/I+    NPl/V3 . NSg/VBPp/P J/P . . R    . . N🅪Sg/VP NPr+  . R/C/P ISg+ VPt  R      P     NPr/ISg+ . . ISg/#r+
 > never was  so          ordered about in        all           my  life     , never ! ”
 # R     VLPt NSg/I/J/R/C VP/J    J/P   NPr/J/R/P NSg/I/J/C/Dq+ D$+ N🅪Sg/VB+ . R     . .
 >
@@ -4223,7 +4223,7 @@
 > They had not     gone    far      before they saw     the Mock     Turtle  in        the distance , sitting
 # IPl+ VP  NSg/R/C VPp/J/P NSg/VB/J C/P    IPl+ NSg/VPt D   NSg/VB/J NSg/VB+ NPr/J/R/P D+  N🅪Sg/VB+ . NSg/Vg/J
 > sad      and  lonely on  a   little     ledge  of rock       , and  , as    they came      nearer , Alice could
-# NSg/VB/J VB/C J/R    J/P D/P NPr/I/J/Dq NSg/VB P  NPr🅪Sg/VB+ . VB/C . R/C/P IPl+ NSg/VPt/P NSg/JC . NPr+  NSg/VXB
+# NSg/VB/J VB/C J/R    J/P D/P NPr/I/J/Dq NSg/VB P  NPr🅪Sg/VB+ . VB/C . R/C/P IPl+ NSg/VPt/P NSg/JC . NPr+  VXB
 > hear him  sighing as    if    his     heart    would break   . She  pitied him  deeply . “ What   is
 # VB   ISg+ Nᴹ/Vg/J R/C/P NSg/C ISg/D$+ N🅪Sg/VB+ VXB   NSg/VB+ . ISg+ VP/J   ISg+ R      . . NSg/I+ VL3
 > his     sorrow  ? ” she  asked the Gryphon , and  the Gryphon answered , very nearly in        the
@@ -4234,14 +4234,14 @@
 # VB   . NSg/VBPp/P J/P . .
 >
 #
-> So          they went    up         to the Mock      Turtle  , who    looked at    them     with large eyes   full     of
-# NSg/I/J/R/C IPl+ NSg/VPt NSg/VB/J/P P  D+  NSg/VB/J+ NSg/VB+ . NPr/I+ VP/J   NSg/P NSg/IPl+ P    NSg/J NPl/V3 NSg/VB/J P
+> So          they went up         to the Mock      Turtle  , who    looked at    them     with large eyes   full     of
+# NSg/I/J/R/C IPl+ VPt  NSg/VB/J/P P  D+  NSg/VB/J+ NSg/VB+ . NPr/I+ VP/J   NSg/P NSg/IPl+ P    NSg/J NPl/V3 NSg/VB/J P
 > tears   , but     said nothing  .
 # NPl/V3+ . NSg/C/P VP/J NSg/I/J+ .
 >
 #
 > “ This   here young     lady    , ” said the Gryphon , “ she  wants  for   to know your history ,
-# . I/Ddem J/R  NPr/VB/J+ NPr/VB+ . . VP/J D   ?       . . ISg+ NPl/V3 R/C/P P  VB   D$+  N🅪Sg+   .
+# . I/Ddem R    NPr/VB/J+ NPr/VB+ . . VP/J D   ?       . . ISg+ NPl/V3 R/C/P P  VB   D$+  N🅪Sg+   .
 > she  do  . ”
 # ISg+ VXB . .
 >
@@ -4270,16 +4270,16 @@
 # NSg         P  . ?       . . P    D   ?       . VB/C D   NSg/J    NSg/VB/J NSg/Vg/J P
 > the Mock     Turtle  . Alice was  very nearly getting up         and  saying    , “ Thank  you    , sir     ,
 # D   NSg/VB/J NSg/VB+ . NPr+  VLPt J/R  R      NSg/Vg  NSg/VB/J/P VB/C N🅪Sg/Vg/J . . NSg/VB ISgPl+ . NPr/VB+ .
-> for   your interesting story   , ” but     she  could   not     help   thinking there must    be       more
-# R/C/P D$+  Vg/J+       NSg/VB+ . . NSg/C/P ISg+ NSg/VXB NSg/R/C NSg/VB Nᴹ/Vg/J  R+    NSg/VXB NSg/VLXB NPr/I/J/R/Dq
+> for   your interesting story   , ” but     she  could not     help   thinking there must    be       more
+# R/C/P D$+  Vg/J+       NSg/VB+ . . NSg/C/P ISg+ VXB   NSg/R/C NSg/VB Nᴹ/Vg/J  R+    NSg/VXB NSg/VLXB NPr/I/J/R/Dq
 > to come       , so          she  sat    still      and  said nothing  .
 # P  NSg/VBPp/P . NSg/I/J/R/C ISg+ NSg/VP NSg/VB/J/R VB/C VP/J NSg/I/J+ .
 >
 #
-> “ When    we   were little     , ” the Mock      Turtle  went    on  at    last     , more         calmly , though
-# . NSg/I/C IPl+ VLPt NPr/I/J/Dq . . D+  NSg/VB/J+ NSg/VB+ NSg/VPt J/P NSg/P NSg/VB/J . NPr/I/J/R/Dq R      . C
-> still      sobbing  a   little     now       and  then      , “ we   went    to school  in        the sea  . The master
-# NSg/VB/J/R NSg/Vg/J D/P NPr/I/J/Dq NSg/J/R/C VB/C NSg/J/R/C . . IPl+ NSg/VPt P  N🅪Sg/VB NPr/J/R/P D   NSg+ . D+  NPr/VB/J+
+> “ When    we   were little     , ” the Mock      Turtle  went on  at    last     , more         calmly , though
+# . NSg/I/C IPl+ VLPt NPr/I/J/Dq . . D+  NSg/VB/J+ NSg/VB+ VPt  J/P NSg/P NSg/VB/J . NPr/I/J/R/Dq R      . C
+> still      sobbing  a   little     now       and  then      , “ we   went to school  in        the sea  . The master
+# NSg/VB/J/R NSg/Vg/J D/P NPr/I/J/Dq NSg/J/R/C VB/C NSg/J/R/C . . IPl+ VPt  P  N🅪Sg/VB NPr/J/R/P D   NSg+ . D+  NPr/VB/J+
 > was  an  old   Turtle — we   used to call   him  Tortoise — ”
 # VLPt D/P NSg/J NSg/VB . IPl+ VP/J P  NSg/VB ISg+ NSg+     . .
 >
@@ -4300,14 +4300,14 @@
 # D   ?       . VB/C NSg/J/R/C IPl+ I/C/Dq NSg/VP NSg/J  VB/C VP/J   NSg/P NSg/VB/J NPr+  . NPr/I+ N🅪Sg/VP/J
 > ready    to sink   into the earth      . At    last     the Gryphon said to the Mock     Turtle  ,
 # NSg/VB/J P  NSg/VB P    D   NPr🅪Sg/VB+ . NSg/P NSg/VB/J D   ?       VP/J P  D   NSg/VB/J NSg/VB+ .
-> “ Drive   on  , old   fellow ! Don’t be       all          day     about it       ! ” and  he       went    on  in        these
-# . N🅪Sg/VB J/P . NSg/J NSg    . VXB   NSg/VLXB NSg/I/J/C/Dq NPr🅪Sg+ J/P   NPr/ISg+ . . VB/C NPr/ISg+ NSg/VPt J/P NPr/J/R/P I/Ddem+
+> “ Drive   on  , old   fellow ! Don’t be       all          day     about it       ! ” and  he       went on  in        these
+# . N🅪Sg/VB J/P . NSg/J NSg    . VXB   NSg/VLXB NSg/I/J/C/Dq NPr🅪Sg+ J/P   NPr/ISg+ . . VB/C NPr/ISg+ VPt  J/P NPr/J/R/P I/Ddem+
 > words   :
 # NPl/V3+ .
 >
 #
-> “ Yes    , we   went    to school  in        the sea  , though you    mayn’t believe it       — ”
-# . NPl/VB . IPl+ NSg/VPt P  N🅪Sg/VB NPr/J/R/P D+  NSg+ . C      ISgPl+ VXB    VB      NPr/ISg+ . .
+> “ Yes    , we   went to school  in        the sea  , though you    mayn’t believe it       — ”
+# . NPl/VB . IPl+ VPt  P  N🅪Sg/VB NPr/J/R/P D+  NSg+ . C      ISgPl+ VXB    VB      NPr/ISg+ . .
 >
 #
 > “ I       never said I       didn’t ! ” interrupted Alice .
@@ -4318,14 +4318,14 @@
 # . ISgPl+ VXPt . . VP/J D+  NSg/VB/J+ NSg/VB+ .
 >
 #
-> “ Hold     your tongue   ! ” added the Gryphon , before Alice could   speak  again . The Mock
-# . NSg/VB/J D$+  N🅪Sg/VB+ . . VP/J  D   ?       . C/P    NPr+  NSg/VXB NSg/VB P     . D+  NSg/VB/J+
-> Turtle  went    on  .
-# NSg/VB+ NSg/VPt J/P .
+> “ Hold     your tongue   ! ” added the Gryphon , before Alice could speak  again . The Mock
+# . NSg/VB/J D$+  N🅪Sg/VB+ . . VP/J  D   ?       . C/P    NPr+  VXB   NSg/VB P     . D+  NSg/VB/J+
+> Turtle  went on  .
+# NSg/VB+ VPt  J/P .
 >
 #
-> “ We   had the best       of educations — in        fact , we   went    to school  every day     — ”
-# . IPl+ VP  D   NPr/VXB/JS P  NPl        . NPr/J/R/P NSg+ . IPl+ NSg/VPt P  N🅪Sg/VB Dq    NPr🅪Sg+ . .
+> “ We   had the best       of educations — in        fact , we   went to school  every day     — ”
+# . IPl+ VP  D   NPr/VXB/JS P  NPl        . NPr/J/R/P NSg+ . IPl+ VPt  P  N🅪Sg/VB Dq    NPr🅪Sg+ . .
 >
 #
 > “ I’ve been   to a   day     - school   , too , ” said Alice ; “ you    needn’t be       so          proud as    all
@@ -4396,8 +4396,8 @@
 # . NPl/VB . . VP/J NPr+  R          . . NPr/ISg+ NPl/V3 . P  . NSg/VB . NSg/I/VB+ . NSg/JC   . .
 >
 #
-> “ Well       , then      , ” the Gryphon went    on  , “ if    you    don’t know what   to uglify is  , you    are
-# . NSg/VB/J/R . NSg/J/R/C . . D   ?       NSg/VPt J/P . . NSg/C ISgPl+ VXB   VB   NSg/I+ P  ?      VL3 . ISgPl+ VLB
+> “ Well       , then      , ” the Gryphon went on  , “ if    you    don’t know what   to uglify is  , you    are
+# . NSg/VB/J/R . NSg/J/R/C . . D   ?       VPt  J/P . . NSg/C ISgPl+ VXB   VB   NSg/I+ P  ?      VL3 . ISgPl+ VLB
 > a   simpleton . ”
 # D/P NSg       . .
 >
@@ -4428,14 +4428,14 @@
 # D   ?       R     VB     NPr/ISg+ . .
 >
 #
-> “ Hadn’t time       , ” said the Gryphon : “ I       went    to the Classics master    , though . He       was
-# . VPt    N🅪Sg/VB/J+ . . VP/J D   ?       . . ISg/#r+ NSg/VPt P  D   N🅪Pl+    NPr/VB/J+ . C      . NPr/ISg+ VLPt
+> “ Hadn’t time       , ” said the Gryphon : “ I       went to the Classics master    , though . He       was
+# . VPt    N🅪Sg/VB/J+ . . VP/J D   ?       . . ISg/#r+ VPt  P  D   N🅪Pl+    NPr/VB/J+ . C      . NPr/ISg+ VLPt
 > an  old   crab   , he       was  . ”
 # D/P NSg/J NSg/VB . NPr/ISg+ VLPt . .
 >
 #
-> “ I       never went    to him  , ” the Mock      Turtle  said with a   sigh   : “ he       taught Laughing and
-# . ISg/#r+ R     NSg/VPt P  ISg+ . . D+  NSg/VB/J+ NSg/VB+ VP/J P    D/P NSg/VB . . NPr/ISg+ VP     Nᴹ/Vg/J  VB/C
+> “ I       never went to him  , ” the Mock      Turtle  said with a   sigh   : “ he       taught Laughing and
+# . ISg/#r+ R     VPt  P  ISg+ . . D+  NSg/VB/J+ NSg/VB+ VP/J P    D/P NSg/VB . . NPr/ISg+ VP     Nᴹ/Vg/J  VB/C
 > Grief  , they used to say    . ”
 # Nᴹ/VB+ . IPl+ VP/J P  NSg/VB . .
 >
@@ -4476,8 +4476,8 @@
 # . P  NSg/VB+ NPr/ISg+ VLPt . . VP/J D+  NSg/VB/J+ NSg/VB+ .
 >
 #
-> “ And  how   did  you    manage on  the twelfth ? ” Alice went    on  eagerly .
-# . VB/C NSg/C VXPt ISgPl+ NSg/VB J/P D   NSg/J   . . NPr+  NSg/VPt J/P R       .
+> “ And  how   did  you    manage on  the twelfth ? ” Alice went on  eagerly .
+# . VB/C NSg/C VXPt ISgPl+ NSg/VB J/P D   NSg/J   . . NPr+  VPt  J/P R       .
 >
 #
 > “ That’s enough about lessons , ” the Gryphon interrupted in        a   very decided  tone       :
@@ -4498,8 +4498,8 @@
 # NSg/VB+ . . I/J  R/C/P NSg/C NPr/ISg+ VP  D/P+ N🅪Sg/VB/J+ NPr/J/R/P ISg/D$+ NSg/VB+ . . VP/J D   ?       . VB/C NPr/ISg+ NPr/VBP/J P
 > work    shaking him  and  punching him  in        the back     . At    last     the Mock      Turtle  recovered
 # N🅪Sg/VB Nᴹ/Vg/J ISg+ VB/C Nᴹ/Vg/J  ISg+ NPr/J/R/P D   NSg/VB/J . NSg/P NSg/VB/J D+  NSg/VB/J+ NSg/VB+ VP/J
-> his     voice   , and  , with tears   running   down        his     cheeks  , he       went    on  again : —
-# ISg/D$+ NSg/VB+ . VB/C . P    NPl/V3+ Nᴹ/Vg/J/P N🅪Sg/VB/J/P ISg/D$+ NPl/V3+ . NPr/ISg+ NSg/VPt J/P P     . .
+> his     voice   , and  , with tears   running   down        his     cheeks  , he       went on  again : —
+# ISg/D$+ NSg/VB+ . VB/C . P    NPl/V3+ Nᴹ/Vg/J/P N🅪Sg/VB/J/P ISg/D$+ NPl/V3+ . NPr/ISg+ VPt  J/P P     . .
 >
 #
 > “ You    may     not     have    lived much         under   the sea  — ” ( “ I       haven’t , ” said Alice ) — “ and
@@ -4546,8 +4546,8 @@
 # . . N🅪Sg/VB+ NPl/V3   . VB/C NSg/VB NPr/J/R/P I/J  N🅪Sg/VB+ . . VP/J      D   ?       .
 >
 #
-> “ Then      , you    know , ” the Mock      Turtle  went    on  , “ you    throw  the — ”
-# . NSg/J/R/C . ISgPl+ VB   . . D+  NSg/VB/J+ NSg/VB+ NSg/VPt J/P . . ISgPl+ NSg/VB D   . .
+> “ Then      , you    know , ” the Mock      Turtle  went on  , “ you    throw  the — ”
+# . NSg/J/R/C . ISgPl+ VB   . . D+  NSg/VB/J+ NSg/VB+ VPt  J/P . . ISgPl+ NSg/VB D   . .
 >
 #
 > “ The lobsters ! ” shouted the Gryphon , with a   bound     into the air      .
@@ -4630,10 +4630,10 @@
 # VB/C NSg/VB NPr/IPl+ . P    D   NPl/V3   . NSg/VB/J/R/P P  NSg . . NSg/C/P D   NSg/VB VP/J    . R   NSg/VB/J .
 > too far      ! ” and  gave a   look   askance — Said he       thanked the whiting      kindly , but     he
 # R   NSg/VB/J . . VB/C VPt  D/P NSg/VB VB/J    . VP/J NPr/ISg+ VP/J    D   N🅪SgPl/Vg/J+ J/R    . NSg/C/P NPr/ISg+
-> would not     join   the dance    . Would not     , could   not     , would not     , could   not     , would
-# VXB   NSg/R/C NSg/VB D   N🅪Sg/VB+ . VXB   NSg/R/C . NSg/VXB NSg/R/C . VXB   NSg/R/C . NSg/VXB NSg/R/C . VXB
-> not     join   the dance    . Would not     , could   not     , would not     , could   not     , could   not     join
-# NSg/R/C NSg/VB D+  N🅪Sg/VB+ . VXB   NSg/R/C . NSg/VXB NSg/R/C . VXB   NSg/R/C . NSg/VXB NSg/R/C . NSg/VXB NSg/R/C NSg/VB
+> would not     join   the dance    . Would not     , could not     , would not     , could not     , would
+# VXB   NSg/R/C NSg/VB D   N🅪Sg/VB+ . VXB   NSg/R/C . VXB   NSg/R/C . VXB   NSg/R/C . VXB   NSg/R/C . VXB
+> not     join   the dance    . Would not     , could not     , would not     , could not     , could not     join
+# NSg/R/C NSg/VB D+  N🅪Sg/VB+ . VXB   NSg/R/C . VXB   NSg/R/C . VXB   NSg/R/C . VXB   NSg/R/C . VXB   NSg/R/C NSg/VB
 > the dance    .
 # D+  N🅪Sg/VB+ .
 >
@@ -4685,7 +4685,7 @@
 > off        in        the sea  . But     they have    their tails   in        their mouths  ; and  the reason   is  — ”
 # NSg/VB/J/P NPr/J/R/P D   NSg+ . NSg/C/P IPl+ NSg/VXB D$+   NPl/V3+ NPr/J/R/P D$+   NPl/V3+ . VB/C D+  N🅪Sg/VB+ VL3 . .
 > here the Mock      Turtle  yawned and  shut      his     eyes    . — “ Tell   her     about the reason   and
-# J/R  D+  NSg/VB/J+ NSg/VB+ VP/J   VB/C NSg/VBP/J ISg/D$+ NPl/V3+ . . . NPr/VB ISg/D$+ J/P   D+  N🅪Sg/VB+ VB/C
+# R    D+  NSg/VB/J+ NSg/VB+ VP/J   VB/C NSg/VBP/J ISg/D$+ NPl/V3+ . . . NPr/VB ISg/D$+ J/P   D+  N🅪Sg/VB+ VB/C
 > all          that      , ” he       said to the Gryphon .
 # NSg/I/J/C/Dq I/C/Ddem+ . . NPr/ISg+ VP/J P  D   ?       .
 >
@@ -4738,8 +4738,8 @@
 # . K       NSg/VPp/J P    Nᴹ/Vg/J  . ISg/#r+ VB      . .
 >
 #
-> “ Boots  and  shoes   under   the sea  , ” the Gryphon went    on  in        a   deep  voice   , “ are done
-# . NPl/V3 VB/C NPl/V3+ NSg/J/P D+  NSg+ . . D   ?       NSg/VPt J/P NPr/J/R/P D/P NSg/J NSg/VB+ . . VLB NSg/VPp/J
+> “ Boots  and  shoes   under   the sea  , ” the Gryphon went on  in        a   deep  voice   , “ are done
+# . NPl/V3 VB/C NPl/V3+ NSg/J/P D+  NSg+ . . D   ?       VPt  J/P NPr/J/R/P D/P NSg/J NSg/VB+ . . VLB NSg/VPp/J
 > with a   whiting      . Now       you    know . ”
 # P    D/P N🅪SgPl/Vg/J+ . NSg/J/R/C ISgPl+ VB   . .
 >
@@ -4750,8 +4750,8 @@
 #
 > “ Soles   and  eels   , of course  , ” the Gryphon replied rather     impatiently : “ any    shrimp
 # . NPl/V3+ VB/C NPl/V3 . P  NSg/VB+ . . D   ?       VP/J    NPr/VB/J/R R           . . I/R/Dq N🅪SgPl/VB+
-> could   have    told you    that      . ”
-# NSg/VXB NSg/VXB VP   ISgPl+ I/C/Ddem+ . .
+> could have    told you    that      . ”
+# VXB   NSg/VXB VP   ISgPl+ I/C/Ddem+ . .
 >
 #
 > “ If    I’d been   the whiting      , ” said Alice , whose thoughts were still      running   on  the
@@ -4788,8 +4788,8 @@
 # ?       VP/J  . NSg/VBPp/P . NSg$  VB   I/J/R/Dq P  D$+  NPl/V3+    . .
 >
 #
-> “ I       could   tell   you    my  adventures — beginning from this    morning    , ” said Alice a
-# . ISg/#r+ NSg/VXB NPr/VB ISgPl+ D$+ NPl/V3+    . NSg/Vg/J+ P    I/Ddem+ N🅪Sg/Vg/J+ . . VP/J NPr+  D/P
+> “ I       could tell   you    my  adventures — beginning from this    morning    , ” said Alice a
+# . ISg/#r+ VXB   NPr/VB ISgPl+ D$+ NPl/V3+    . NSg/Vg/J+ P    I/Ddem+ N🅪Sg/Vg/J+ . . VP/J NPr+  D/P
 > little     timidly : “ but     it’s no       use     going   back     to yesterday , because I       was  a
 # NPr/I/J/Dq R       . . NSg/C/P K    NSg/Dq/P N🅪Sg/VB Nᴹ/Vg/J NSg/VB/J P  NSg       . C/P     ISg/#r+ VLPt D/P
 > different person  then      . ”
@@ -4812,8 +4812,8 @@
 # NPr🅪Sg/VB/J+ NSg/VB+ . ISg+ VLPt D/P NPr/I/J/Dq J       J/P   NPr/ISg+ J/R  NSg/P NSg/J . D+  NSg+ NPl+
 > got so          close    to her     , one     on  each side      , and  opened their eyes   and  mouths  so          very
 # VP  NSg/I/J/R/C NSg/VB/J P  ISg/D$+ . NSg/I/J J/P Dq+  NSg/VB/J+ . VB/C VP/J   D$+   NPl/V3 VB/C NPl/V3+ NSg/I/J/R/C J/R
-> wide  , but     she  gained courage as    she  went    on  . Her     listeners were perfectly quiet
-# NSg/J . NSg/C/P ISg+ VP/J   NSg/VB+ R/C/P ISg+ NSg/VPt J/P . ISg/D$+ +         VLPt R         N🅪Sg/VB/J
+> wide  , but     she  gained courage as    she  went on  . Her     listeners were perfectly quiet
+# NSg/J . NSg/C/P ISg+ VP/J   NSg/VB+ R/C/P ISg+ VPt  J/P . ISg/D$+ +         VLPt R         N🅪Sg/VB/J
 > till       she  got to the part      about her     repeating “ You    are old   , Father  William , ” to
 # NSg/VB/C/P ISg+ VP  P  D+  NSg/VB/J+ J/P   ISg/D$+ Nᴹ/Vg/J   . ISgPl+ VLB NSg/J . NPr/VB+ NPr+    . . P
 > the Caterpillar , and  the words   all          coming  different , and  then      the Mock     Turtle
@@ -4869,7 +4869,7 @@
 >
 #
 > “ Well       , I       never heard it       before , ” said the Mock      Turtle  ; “ but     it       sounds uncommon
-# . NSg/VB/J/R . ISg/#r+ R     VP/J  NPr/ISg+ C/P    . . VP/J D+  NSg/VB/J+ NSg/VB+ . . NSg/C/P NPr/ISg+ NPl/V3 NSg/VB/J+
+# . NSg/VB/J/R . ISg/#r+ R     VP/J  NPr/ISg+ C/P    . . VP/J D+  NSg/VB/J+ NSg/VB+ . . NSg/C/P NPr/ISg+ NPl/V3 VB/J+
 > nonsense . ”
 # Nᴹ/VB/J+ . .
 >
@@ -4888,8 +4888,8 @@
 # . ISg+ VXB   VB      NPr/ISg+ . . VP/J D   ?       R       . . NSg/VB/J J/P P    D   NSg/J/P NSg/VB . .
 >
 #
-> “ But     about his     toes    ? ” the Mock      Turtle  persisted . “ How   could   he       turn   them     out
-# . NSg/C/P J/P   ISg/D$+ NPl/V3+ . . D+  NSg/VB/J+ NSg/VB+ VP/J      . . NSg/C NSg/VXB NPr/ISg+ NSg/VB NSg/IPl+ NSg/VB/J/R/P
+> “ But     about his     toes    ? ” the Mock      Turtle  persisted . “ How   could he       turn   them     out
+# . NSg/C/P J/P   ISg/D$+ NPl/V3+ . . D+  NSg/VB/J+ NSg/VB+ VP/J      . . NSg/C VXB   NPr/ISg+ NSg/VB NSg/IPl+ NSg/VB/J/R/P
 > with his     nose    , you    know ? ”
 # P    ISg/D$+ NSg/VB+ . ISgPl+ VB   . .
 >
@@ -4908,8 +4908,8 @@
 #
 > Alice did  not     dare    to disobey , though she  felt      sure it       would all          come       wrong      , and
 # NPr+  VXPt NSg/R/C NPr/VXB P  VB      . C      ISg+ N🅪Sg/VP/J J    NPr/ISg+ VXB   NSg/I/J/C/Dq NSg/VBPp/P NSg/VB/J/R . VB/C
-> she  went    on  in        a   trembling voice   : —
-# ISg+ NSg/VPt J/P NPr/J/R/P D/P Nᴹ/Vg/J   NSg/VB+ . .
+> she  went on  in        a   trembling voice   : —
+# ISg+ VPt  J/P NPr/J/R/P D/P Nᴹ/Vg/J   NSg/VB+ . .
 >
 #
 > “ I       passed by his     garden    , and  marked , with one      eye     , How   the Owl     and  the Panther
@@ -4944,8 +4944,8 @@
 # NSg/VB/J P  VXB NSg/I/J/R/C .
 >
 #
-> “ Shall we   try      another figure of the Lobster   Quadrille ? ” the Gryphon went    on  . “ Or
-# . VXB   IPl+ NSg/VB/J I/D     NSg/VB P  D+  NSg/VB/J+ NSg/VB/J  . . D   ?       NSg/VPt J/P . . NPr/C
+> “ Shall we   try      another figure of the Lobster   Quadrille ? ” the Gryphon went on  . “ Or
+# . VXB   IPl+ NSg/VB/J I/D     NSg/VB P  D+  NSg/VB/J+ NSg/VB/J  . . D   ?       VPt  J/P . . NPr/C
 > would you    like         the Mock      Turtle  to sing     you    a    song  ? ”
 # VXB   ISgPl+ NSg/VB/J/C/P D+  NSg/VB/J+ NSg/VB+ P  NSg/VB/J ISgPl+ D/P+ N🅪Sg+ . .
 >
@@ -5012,14 +5012,14 @@
 # HeadingStart NSg/VB+ NSg/#r . NPr/I+ NSg/VPt D   NPl/V3 .
 >
 #
-> The King     and  Queen    of Hearts  were seated on  their throne when    they arrived , with
-# D   NPr/VB/J VB/C NPr/VB/J P  NPl/V3+ VLPt VP/J   J/P D$+   NSg/VB NSg/I/C IPl+ VP/J    . P
+> The King   and  Queen  of Hearts  were seated on  their throne when    they arrived , with
+# D   NPr/VB VB/C NPr/VB P  NPl/V3+ VLPt VP/J   J/P D$+   NSg/VB NSg/I/C IPl+ VP/J    . P
 > a   great crowd   assembled about them     — all          sorts  of little     birds  and  beasts  , as    well
 # D/P NSg/J NSg/VB+ VP/J      J/P   NSg/IPl+ . NSg/I/J/C/Dq NPl/V3 P  NPr/I/J/Dq NPl/V3 VB/C NPl/V3+ . R/C/P NSg/VB/J/R
 > as    the whole pack   of cards   : the Knave was  standing before them     , in        chains  , with
 # R/C/P D   NSg/J NSg/VB P  NPl/V3+ . D   NSg   VLPt Nᴹ/Vg/J  C/P    NSg/IPl+ . NPr/J/R/P NPl/V3+ . P
-> a   soldier   on  each side      to guard   him  ; and  near       the King      was  the White       Rabbit  ,
-# D/P NSg/VB/J+ J/P Dq   NSg/VB/J+ P  NSg/VB+ ISg+ . VB/C NSg/VB/J/P D   NPr/VB/J+ VLPt D   NPr🅪Sg/VB/J NSg/VB+ .
+> a   soldier   on  each side      to guard   him  ; and  near       the King    was  the White       Rabbit  ,
+# D/P NSg/VB/J+ J/P Dq   NSg/VB/J+ P  NSg/VB+ ISg+ . VB/C NSg/VB/J/P D   NPr/VB+ VLPt D   NPr🅪Sg/VB/J NSg/VB+ .
 > with a   trumpet in        one     hand    , and  a   scroll of parchment in        the other    . In        the very
 # P    D/P NSg/VB+ NPr/J/R/P NSg/I/J NSg/VB+ . VB/C D/P NSg/VB P  N🅪Sg+     NPr/J/R/P D   NSg/VB/J . NPr/J/R/P D   J/R
 > middle   of the court      was  a   table  , with a   large dish   of tarts  upon it       : they looked
@@ -5044,8 +5044,8 @@
 # NSg/VB+ . .
 >
 #
-> The judge   , by the way    , was  the King      ; and  as    he       wore his     crown     over    the wig     ,
-# D+  NSg/VB+ . P  D+  NSg/J+ . VLPt D+  NPr/VB/J+ . VB/C R/C/P NPr/ISg+ VPt  ISg/D$+ NSg/VB/J+ NSg/J/P D+  NSg/VB+ .
+> The judge   , by the way    , was  the King    ; and  as    he       wore his     crown     over    the wig     ,
+# D+  NSg/VB+ . P  D+  NSg/J+ . VLPt D+  NPr/VB+ . VB/C R/C/P NPr/ISg+ VPt  ISg/D$+ NSg/VB/J+ NSg/J/P D+  NSg/VB+ .
 > ( look   at    the frontispiece if    you    want   to see    how   he       did  it       , ) he       did  not     look   at
 # . NSg/VB NSg/P D   NSg/VB       NSg/C ISgPl+ NSg/VB P  NSg/VB NSg/C NPr/ISg+ VXPt NPr/ISg+ . . NPr/ISg+ VXPt NSg/R/C NSg/VB NSg/P
 > all          comfortable , and  it       was  certainly not     becoming .
@@ -5083,15 +5083,15 @@
 > “ Stupid things ! ” Alice began in        a   loud  , indignant voice   , but     she  stopped
 # . NSg/J+ NPl+   . . NPr+  VPt   NPr/J/R/P D/P NSg/J . J         NSg/VB+ . NSg/C/P ISg+ VP/J
 > hastily , for   the White       Rabbit  cried out          , “ Silence in        the court      ! ” and  the King
-# R       . R/C/P D   NPr🅪Sg/VB/J NSg/VB+ VP/J  NSg/VB/J/R/P . . NSg/VB+ NPr/J/R/P D   N🅪Sg/VB/J+ . . VB/C D+  NPr/VB/J+
+# R       . R/C/P D   NPr🅪Sg/VB/J NSg/VB+ VP/J  NSg/VB/J/R/P . . NSg/VB+ NPr/J/R/P D   N🅪Sg/VB/J+ . . VB/C D+  NPr/VB+
 > put     on  his     spectacles and  looked anxiously round      , to make   out          who    was  talking .
 # NSg/VBP J/P ISg/D$+ NPl        VB/C VP/J   R         NSg/VB/J/P . P  NSg/VB NSg/VB/J/R/P NPr/I+ VLPt Nᴹ/Vg/J .
 >
 #
-> Alice could   see    , as    well       as    if    she  were looking over    their shoulders , that     all
-# NPr+  NSg/VXB NSg/VB . R/C/P NSg/VB/J/R R/C/P NSg/C ISg+ VLPt Nᴹ/Vg/J NSg/J/P D$+   NPl/V3+   . I/C/Ddem NSg/I/J/C/Dq
+> Alice could see    , as    well       as    if    she  were looking over    their shoulders , that     all
+# NPr+  VXB   NSg/VB . R/C/P NSg/VB/J/R R/C/P NSg/C ISg+ VLPt Nᴹ/Vg/J NSg/J/P D$+   NPl/V3+   . I/C/Ddem NSg/I/J/C/Dq
 > the jurors were writing down        “ stupid things ! ” on  their slates , and  she  could
-# D   NPl    VLPt Nᴹ/Vg/J N🅪Sg/VB/J/P . NSg/J  NPl+   . . J/P D$+   NPl/V3 . VB/C ISg+ NSg/VXB
+# D   NPl    VLPt Nᴹ/Vg/J N🅪Sg/VB/J/P . NSg/J  NPl+   . . J/P D$+   NPl/V3 . VB/C ISg+ VXB
 > even       make   out          that     one     of them     didn’t know how   to spell  “ stupid , ” and  that     he
 # NSg/VB/J/R NSg/VB NSg/VB/J/R/P I/C/Ddem NSg/I/J P  NSg/IPl+ VXPt   VB   NSg/C P  NSg/VB . NSg/J  . . VB/C I/C/Ddem NPr/ISg+
 > had to ask    his     neighbour      to tell   him  . “ A    nice   muddle  their slates’ll be       in
@@ -5100,14 +5100,14 @@
 # C/P    D   NSg$    NSg/J/P . . N🅪Sg/VP NPr+  .
 >
 #
-> One     of the jurors had a   pencil  that      squeaked . This   of course  , Alice could   not
-# NSg/I/J P  D   NPl    VP  D/P NSg/VB+ I/C/Ddem+ VP/J     . I/Ddem P  NSg/VB+ . NPr+  NSg/VXB NSg/R/C
-> stand  , and  she  went    round      the court      and  got behind  him  , and  very soon found  an
-# NSg/VB . VB/C ISg+ NSg/VPt NSg/VB/J/P D+  N🅪Sg/VB/J+ VB/C VP  NSg/J/P ISg+ . VB/C J/R  J/R  NSg/VP D/P
+> One     of the jurors had a   pencil  that      squeaked . This   of course  , Alice could not
+# NSg/I/J P  D   NPl    VP  D/P NSg/VB+ I/C/Ddem+ VP/J     . I/Ddem P  NSg/VB+ . NPr+  VXB   NSg/R/C
+> stand  , and  she  went round      the court      and  got behind  him  , and  very soon found  an
+# NSg/VB . VB/C ISg+ VPt  NSg/VB/J/P D+  N🅪Sg/VB/J+ VB/C VP  NSg/J/P ISg+ . VB/C J/R  J/R  NSg/VP D/P
 > opportunity of taking   it       away . She  did  it       so          quickly that     the poor     little     juror
 # N🅪Sg        P  NSg/Vg/J NPr/ISg+ VB/J . ISg+ VXPt NPr/ISg+ NSg/I/J/R/C R       I/C/Ddem D   NSg/VB/J NPr/I/J/Dq NSg
-> ( it       was  Bill    , the Lizard ) could   not     make   out          at    all          what   had become of it       ; so          ,
-# . NPr/ISg+ VLPt NPr/VB+ . D   NSg    . NSg/VXB NSg/R/C NSg/VB NSg/VB/J/R/P NSg/P NSg/I/J/C/Dq NSg/I+ VP  VBPp   P  NPr/ISg+ . NSg/I/J/R/C .
+> ( it       was  Bill    , the Lizard ) could not     make   out          at    all          what   had become of it       ; so          ,
+# . NPr/ISg+ VLPt NPr/VB+ . D   NSg    . VXB   NSg/R/C NSg/VB NSg/VB/J/R/P NSg/P NSg/I/J/C/Dq NSg/I+ VP  VBPp   P  NPr/ISg+ . NSg/I/J/R/C .
 > after hunting all          about for   it       , he       was  obliged to write  with one     finger  for   the
 # P     Nᴹ/Vg/J NSg/I/J/C/Dq J/P+  R/C/P NPr/ISg+ . NPr/ISg+ VLPt VP/J    P  NSg/VB P    NSg/I/J NSg/VB+ R/C/P D
 > rest   of the day     ; and  this    was  of very little     use      , as    it       left     no       mark    on  the
@@ -5116,8 +5116,8 @@
 # NSg/VB/J+ .
 >
 #
-> “ Herald  , read    the accusation ! ” said the King      .
-# . NSg/VB+ . NSg/VBP D   N🅪Sg       . . VP/J D+  NPr/VB/J+ .
+> “ Herald  , read    the accusation ! ” said the King    .
+# . NSg/VB+ . NSg/VBP D   N🅪Sg       . . VP/J D+  NPr/VB+ .
 >
 #
 > On  this    the White        Rabbit  blew      three blasts on  the trumpet , and  then      unrolled the
@@ -5126,14 +5126,14 @@
 # N🅪Sg+     NSg/VB . VB/C NSg/VBP R/C/P NPl/V3  . .
 >
 #
-> “ The Queen    of Hearts  , she  made some     tarts  , All          on  a   summer     day     : The Knave of
-# . D   NPr/VB/J P  NPl/V3+ . ISg+ VP   I/J/R/Dq NPl/V3 . NSg/I/J/C/Dq J/P D/P NPr🅪Sg/VB+ NPr🅪Sg+ . D   NSg   P
+> “ The Queen  of Hearts  , she  made some     tarts  , All          on  a   summer     day     : The Knave of
+# . D   NPr/VB P  NPl/V3+ . ISg+ VP   I/J/R/Dq NPl/V3 . NSg/I/J/C/Dq J/P D/P NPr🅪Sg/VB+ NPr🅪Sg+ . D   NSg   P
 > Hearts  , he       stole   those  tarts  , And  took them     quite away ! ”
 # NPl/V3+ . NPr/ISg+ NSg/VPt I/Ddem NPl/V3 . VB/C VPt  NSg/IPl+ R     VB/J . .
 >
 #
-> “ Consider your verdict , ” the King      said to the jury      .
-# . VB       D$+  NSg+    . . D+  NPr/VB/J+ VP/J P  D+  NSg/VB/J+ .
+> “ Consider your verdict , ” the King    said to the jury      .
+# . VB       D$+  NSg+    . . D+  NPr/VB+ VP/J P  D+  NSg/VB/J+ .
 >
 #
 > “ Not     yet      , not     yet      ! ” the Rabbit  hastily interrupted . “ There’s a   great deal      to
@@ -5142,8 +5142,8 @@
 # NSg/VBPp/P C/P    I/C/Ddem+ . .
 >
 #
-> “ Call   the first  witness , ” said the King      ; and  the White        Rabbit  blew      three blasts
-# . NSg/VB D+  NSg/J+ NSg/VB+ . . VP/J D+  NPr/VB/J+ . VB/C D+  NPr🅪Sg/VB/J+ NSg/VB+ NSg/VPt/J NSg   NPl/V3
+> “ Call   the first  witness , ” said the King    ; and  the White        Rabbit  blew      three blasts
+# . NSg/VB D+  NSg/J+ NSg/VB+ . . VP/J D+  NPr/VB+ . VB/C D+  NPr🅪Sg/VB/J+ NSg/VB+ NSg/VPt/J NSg   NPl/V3
 > on  the trumpet , and  called out          , “ First witness ! ”
 # J/P D   NSg/VB+ . VB/C VP/J   NSg/VB/J/R/P . . NSg/J NSg/VB+ . .
 >
@@ -5156,8 +5156,8 @@
 # . R/C/P Nᴹ/Vg/J  I/Ddem NPr/J/R/P . NSg/C/P ISg/#r+ VPt    R     VP/J     D$+ N🅪Sg/VB+ NSg/I/C ISg/#r+ VLPt NSg/VP R/C/P . .
 >
 #
-> “ You    ought     to have    finished , ” said the King      . “ When    did  you    begin  ? ”
-# . ISgPl+ NSg/I/VXB P  NSg/VXB VP/J     . . VP/J D+  NPr/VB/J+ . . NSg/I/C VXPt ISgPl+ NSg/VB . .
+> “ You    ought     to have    finished , ” said the King    . “ When    did  you    begin  ? ”
+# . ISgPl+ NSg/I/VXB P  NSg/VXB VP/J     . . VP/J D+  NPr/VB+ . . NSg/I/C VXPt ISgPl+ NSg/VB . .
 >
 #
 > The Hatter looked at    the March   Hare , who    had followed him  into the court      ,
@@ -5174,24 +5174,24 @@
 # . NSg/J     . . VP/J  D   NSg      .
 >
 #
-> “ Write  that      down        , ” the King      said to the jury      , and  the jury      eagerly wrote down
-# . NSg/VB I/C/Ddem+ N🅪Sg/VB/J/P . . D+  NPr/VB/J+ VP/J P  D+  NSg/VB/J+ . VB/C D+  NSg/VB/J+ R       VPt   N🅪Sg/VB/J/P
+> “ Write  that      down        , ” the King    said to the jury      , and  the jury      eagerly wrote down
+# . NSg/VB I/C/Ddem+ N🅪Sg/VB/J/P . . D+  NPr/VB+ VP/J P  D+  NSg/VB/J+ . VB/C D+  NSg/VB/J+ R       VPt   N🅪Sg/VB/J/P
 > all          three dates   on  their slates , and  then      added them     up         , and  reduced the answer
 # NSg/I/J/C/Dq NSg   NPl/V3+ J/P D$+   NPl/V3 . VB/C NSg/J/R/C VP/J  NSg/IPl+ NSg/VB/J/P . VB/C VP/J    D   NSg/VB+
 > to shillings and  pence .
 # P  NPl       VB/C NPl   .
 >
 #
-> “ Take   off        your hat     , ” the King      said to the Hatter .
-# . NSg/VB NSg/VB/J/P D$+  NSg/VB+ . . D+  NPr/VB/J+ VP/J P  D   NSg/VB .
+> “ Take   off        your hat     , ” the King    said to the Hatter .
+# . NSg/VB NSg/VB/J/P D$+  NSg/VB+ . . D+  NPr/VB+ VP/J P  D   NSg/VB .
 >
 #
 > “ It       isn’t   mine      , ” said the Hatter .
 # . NPr/ISg+ NSg/VX3 NSg/I/VB+ . . VP/J D   NSg/VB .
 >
 #
-> “ Stolen    ! ” the King      exclaimed , turning to the jury      , who    instantly made a
-# . NSg/VPp/J . . D+  NPr/VB/J+ VP/J      . Nᴹ/Vg/J P  D+  NSg/VB/J+ . NPr/I+ R         VP   D/P
+> “ Stolen    ! ” the King    exclaimed , turning to the jury      , who    instantly made a
+# . NSg/VPp/J . . D+  NPr/VB+ VP/J      . Nᴹ/Vg/J P  D+  NSg/VB/J+ . NPr/I+ R         VP   D/P
 > memorandum of the fact .
 # NSg        P  D   NSg+ .
 >
@@ -5202,22 +5202,22 @@
 # K   D/P NSg/VB . .
 >
 #
-> Here the Queen     put     on  her     spectacles , and  began staring at    the Hatter , who
-# J/R  D+  NPr/VB/J+ NSg/VBP J/P ISg/D$+ NPl        . VB/C VPt   Nᴹ/Vg/J NSg/P D   NSg/VB . NPr/I+
+> Here the Queen   put     on  her     spectacles , and  began staring at    the Hatter , who
+# R    D+  NPr/VB+ NSg/VBP J/P ISg/D$+ NPl        . VB/C VPt   Nᴹ/Vg/J NSg/P D   NSg/VB . NPr/I+
 > turned pale     and  fidgeted .
 # VP/J   NSg/VB/J VB/C VP/J     .
 >
 #
-> “ Give   your evidence , ” said the King      ; “ and  don’t be       nervous , or    I’ll have    you
-# . NSg/VB D$+  Nᴹ/VB+   . . VP/J D+  NPr/VB/J+ . . VB/C VXB   NSg/VLXB J       . NPr/C K    NSg/VXB ISgPl+
+> “ Give   your evidence , ” said the King    ; “ and  don’t be       nervous , or    I’ll have    you
+# . NSg/VB D$+  Nᴹ/VB+   . . VP/J D+  NPr/VB+ . . VB/C VXB   NSg/VLXB J       . NPr/C K    NSg/VXB ISgPl+
 > executed on  the spot      . ”
 # VP/J     J/P D   NSg/VB/J+ . .
 >
 #
 > This    did  not     seem to encourage the witness at    all          : he       kept shifting from one
 # I/Ddem+ VXPt NSg/R/C VB   P  VB        D+  NSg/VB+ NSg/P NSg/I/J/C/Dq . NPr/ISg+ VP   Nᴹ/Vg/J+ P    NSg/I/J+
-> foot    to the other    , looking uneasily at    the Queen     , and  in        his     confusion he       bit     a
-# NSg/VB+ P  D   NSg/VB/J . Nᴹ/Vg/J R        NSg/P D   NPr/VB/J+ . VB/C NPr/J/R/P ISg/D$+ N🅪Sg/VB+  NPr/ISg+ NSg/VPt D/P
+> foot    to the other    , looking uneasily at    the Queen   , and  in        his     confusion he       bit     a
+# NSg/VB+ P  D   NSg/VB/J . Nᴹ/Vg/J R        NSg/P D   NPr/VB+ . VB/C NPr/J/R/P ISg/D$+ N🅪Sg/VB+  NPr/ISg+ NSg/VPt D/P
 > large piece   out          of his     teacup instead of the bread    - and  - butter  .
 # NSg/J NSg/VB+ NSg/VB/J/R/P P  ISg/D$+ NSg/J  R       P  D   N🅪Sg/VB+ . VB/C . NSg/VB+ .
 >
@@ -5245,7 +5245,7 @@
 >
 #
 > “ You’ve no       right     to grow here , ” said the Dormouse .
-# . K      NSg/Dq/P NPr/VB/J+ P  VB   J/R  . . VP/J D   NSg      .
+# . K      NSg/Dq/P NPr/VB/J+ P  VB   R    . . VP/J D   NSg      .
 >
 #
 > “ Don’t talk    nonsense , ” said Alice more         boldly : “ you    know you’re growing too . ”
@@ -5260,8 +5260,8 @@
 # NSg/VB/J P  D   N🅪Sg/VB/J+ .
 >
 #
-> All           this    time       the Queen     had never left     off        staring at    the Hatter , and  , just as
-# NSg/I/J/C/Dq+ I/Ddem+ N🅪Sg/VB/J+ D+  NPr/VB/J+ VP  R     NPr/VP/J NSg/VB/J/P Nᴹ/Vg/J NSg/P D   NSg/VB . VB/C . J/R  R/C/P
+> All           this    time       the Queen   had never left     off        staring at    the Hatter , and  , just as
+# NSg/I/J/C/Dq+ I/Ddem+ N🅪Sg/VB/J+ D+  NPr/VB+ VP  R     NPr/VP/J NSg/VB/J/P Nᴹ/Vg/J NSg/P D   NSg/VB . VB/C . J/R  R/C/P
 > the Dormouse crossed the court      , she  said to one     of the officers of the court      ,
 # D   NSg      VP/J    D   N🅪Sg/VB/J+ . ISg+ VP/J P  NSg/I/J P  D   NPl/V3   P  D   N🅪Sg/VB/J+ .
 > “ Bring me       the list   of the singers in        the last     concert ! ” on  which the wretched
@@ -5270,8 +5270,8 @@
 # NSg/VB VP/J     NSg/I/J/R/C . I/C/Ddem NPr/ISg+ NSg/VPt/J I/C/Dq ISg/D$+ NPl/V3+ NSg/VB/J/P .
 >
 #
-> “ Give   your evidence , ” the King      repeated angrily , “ or    I’ll have    you    executed ,
-# . NSg/VB D$+  Nᴹ/VB+   . . D+  NPr/VB/J+ VP/J     R       . . NPr/C K    NSg/VXB ISgPl+ VP/J     .
+> “ Give   your evidence , ” the King    repeated angrily , “ or    I’ll have    you    executed ,
+# . NSg/VB D$+  Nᴹ/VB+   . . D+  NPr/VB+ VP/J     R       . . NPr/C K    NSg/VXB ISgPl+ VP/J     .
 > whether you’re nervous or    not     . ”
 # I/C     K      J       NPr/C NSg/R/C . .
 >
@@ -5284,22 +5284,22 @@
 # NSg/Vg  NSg/I/J/R/C NSg/VB/J . VB/C D   N🅪Sg/Vg/J P  D   N🅪Sg/VB+ . .
 >
 #
-> “ The twinkling of the what   ? ” said the King      .
-# . D   N🅪Sg/Vg/J P  D   NSg/I+ . . VP/J D+  NPr/VB/J+ .
+> “ The twinkling of the what   ? ” said the King    .
+# . D   N🅪Sg/Vg/J P  D   NSg/I+ . . VP/J D+  NPr/VB+ .
 >
 #
 > “ It       began with the tea      , ” the Hatter replied .
 # . NPr/ISg+ VPt   P    D+  N🅪Sg/VB+ . . D   NSg/VB VP/J    .
 >
 #
-> “ Of course  twinkling begins with a   T      ! ” said the King      sharply . “ Do  you    take   me
-# . P  NSg/VB+ N🅪Sg/Vg/J NPl/V3 P    D/P NPr/J+ . . VP/J D+  NPr/VB/J+ R       . . VXB ISgPl+ NSg/VB NPr/ISg+
+> “ Of course  twinkling begins with a   T      ! ” said the King    sharply . “ Do  you    take   me
+# . P  NSg/VB+ N🅪Sg/Vg/J NPl/V3 P    D/P NPr/J+ . . VP/J D+  NPr/VB+ R       . . VXB ISgPl+ NSg/VB NPr/ISg+
 > for   a   dunce ? Go       on  ! ”
 # R/C/P D/P NSg   . NSg/VB/J J/P . .
 >
 #
-> “ I’m a    poor     man     , ” the Hatter went    on  , “ and  most         things twinkled after that      — only
-# . K   D/P+ NSg/VB/J NPr/VB+ . . D   NSg/VB NSg/VPt J/P . . VB/C NSg/I/J/R/Dq NPl+   VP/J     P     I/C/Ddem+ . J/R/C
+> “ I’m a    poor     man     , ” the Hatter went on  , “ and  most         things twinkled after that      — only
+# . K   D/P+ NSg/VB/J NPr/VB+ . . D   NSg/VB VPt  J/P . . VB/C NSg/I/J/R/Dq NPl+   VP/J     P     I/C/Ddem+ . J/R/C
 > the March   Hare said — ”
 # D   NPr/VB+ NSg+ VP/J . .
 >
@@ -5316,12 +5316,12 @@
 # . ISg/#r+ VB   NPr/ISg+ . . VP/J D+  NPr/VB+ NSg+ .
 >
 #
-> “ He       denies it       , ” said the King      : “ leave  out          that     part      . ”
-# . NPr/ISg+ V3     NPr/ISg+ . . VP/J D   NPr/VB/J+ . . NSg/VB NSg/VB/J/R/P I/C/Ddem NSg/VB/J+ . .
+> “ He       denies it       , ” said the King    : “ leave  out          that     part      . ”
+# . NPr/ISg+ V3     NPr/ISg+ . . VP/J D   NPr/VB+ . . NSg/VB NSg/VB/J/R/P I/C/Ddem NSg/VB/J+ . .
 >
 #
-> “ Well       , at    any     rate    , the Dormouse said — ” the Hatter went    on  , looking anxiously
-# . NSg/VB/J/R . NSg/P I/R/Dq+ NSg/VB+ . D   NSg      VP/J . . D   NSg/VB NSg/VPt J/P . Nᴹ/Vg/J R
+> “ Well       , at    any     rate    , the Dormouse said — ” the Hatter went on  , looking anxiously
+# . NSg/VB/J/R . NSg/P I/R/Dq+ NSg/VB+ . D   NSg      VP/J . . D   NSg/VB VPt  J/P . Nᴹ/Vg/J R
 > round      to see    if    he       would deny it       too : but     the Dormouse denied nothing  , being
 # NSg/VB/J/P P  NSg/VB NSg/C NPr/ISg+ VXB   VB   NPr/ISg+ R   . NSg/C/P D   NSg      VP/J   NSg/I/J+ . N🅪Sg/VLg/J/C
 > fast       asleep .
@@ -5340,22 +5340,22 @@
 # . I/C/Ddem ISg/#r+ VXB   NSg/VB   . . VP/J D   NSg/VB .
 >
 #
-> “ You    must    remember , ” remarked the King      , “ or    I’ll have    you    executed . ”
-# . ISgPl+ NSg/VXB NSg/VB   . . VP/J     D+  NPr/VB/J+ . . NPr/C K    NSg/VXB ISgPl+ VP/J     . .
+> “ You    must    remember , ” remarked the King    , “ or    I’ll have    you    executed . ”
+# . ISgPl+ NSg/VXB NSg/VB   . . VP/J     D+  NPr/VB+ . . NPr/C K    NSg/VXB ISgPl+ VP/J     . .
 >
 #
-> The miserable Hatter dropped his     teacup and  bread    - and  - butter  , and  went    down        on
-# D   J         NSg/VB VP/J    ISg/D$+ NSg/J  VB/C N🅪Sg/VB+ . VB/C . NSg/VB+ . VB/C NSg/VPt N🅪Sg/VB/J/P J/P
+> The miserable Hatter dropped his     teacup and  bread    - and  - butter  , and  went down        on
+# D   J         NSg/VB VP/J    ISg/D$+ NSg/J  VB/C N🅪Sg/VB+ . VB/C . NSg/VB+ . VB/C VPt  N🅪Sg/VB/J/P J/P
 > one     knee    . “ I’m a    poor     man     , your Majesty , ” he       began .
 # NSg/I/J NSg/VB+ . . K   D/P+ NSg/VB/J NPr/VB+ . D$+  N🅪Sg/I+ . . NPr/ISg+ VPt   .
 >
 #
-> “ You’re a   very poor     speaker , ” said the King      .
-# . K      D/P J/R  NSg/VB/J NSg+    . . VP/J D   NPr/VB/J+ .
+> “ You’re a   very poor     speaker , ” said the King    .
+# . K      D/P J/R  NSg/VB/J NSg+    . . VP/J D   NPr/VB+ .
 >
 #
 > Here one     of the guinea - pigs    cheered , and  was  immediately suppressed by the
-# J/R  NSg/I/J P  D+  NPr+   . NPl/V3+ VP/J    . VB/C VLPt R           VP/J       P  D
+# R    NSg/I/J P  D+  NPr+   . NPl/V3+ VP/J    . VB/C VLPt R           VP/J       P  D
 > officers of the court      . ( As    that      is  rather     a   hard     word   , I       will    just explain to
 # NPl/V3   P  D+  N🅪Sg/VB/J+ . . R/C/P I/C/Ddem+ VL3 NPr/VB/J/R D/P N🅪Sg/J/R NSg/VB . ISg/#r+ NPr/VXB J/R  VB      P
 > you    how   it       was  done      . They had a    large  canvas  bag     , which tied up         at    the mouth
@@ -5376,20 +5376,20 @@
 # NSg/I+ NPr/ISg+ VP    NSg/VB/C/P NSg/J/R/C . .
 >
 #
-> “ If    that’s all          you    know about it       , you    may     stand  down        , ” continued the King      .
-# . NSg/C K      NSg/I/J/C/Dq ISgPl+ VB   J/P   NPr/ISg+ . ISgPl+ NPr/VXB NSg/VB N🅪Sg/VB/J/P . . VP/J      D   NPr/VB/J+ .
+> “ If    that’s all          you    know about it       , you    may     stand  down        , ” continued the King    .
+# . NSg/C K      NSg/I/J/C/Dq ISgPl+ VB   J/P   NPr/ISg+ . ISgPl+ NPr/VXB NSg/VB N🅪Sg/VB/J/P . . VP/J      D   NPr/VB+ .
 >
 #
 > “ I       can’t go       no       lower     , ” said the Hatter : “ I’m on  the floor   , as    it       is  . ”
 # . ISg/#r+ VXB   NSg/VB/J NSg/Dq/P NSg/VB/JC . . VP/J D   NSg/VB . . K   J/P D   NSg/VB+ . R/C/P NPr/ISg+ VL3 . .
 >
 #
-> “ Then      you    may     sit    down        , ” the King      replied .
-# . NSg/J/R/C ISgPl+ NPr/VXB NSg/VB N🅪Sg/VB/J/P . . D+  NPr/VB/J+ VP/J    .
+> “ Then      you    may     sit    down        , ” the King    replied .
+# . NSg/J/R/C ISgPl+ NPr/VXB NSg/VB N🅪Sg/VB/J/P . . D+  NPr/VB+ VP/J    .
 >
 #
 > Here the other    guinea - pig     cheered , and  was  suppressed .
-# J/R  D   NSg/VB/J NPr+   . NSg/VB+ VP/J    . VB/C VLPt VP/J       .
+# R    D   NSg/VB/J NPr+   . NSg/VB+ VP/J    . VB/C VLPt VP/J       .
 >
 #
 > “ Come       , that      finished the guinea - pigs    ! ” thought Alice . “ Now       we   shall get    on
@@ -5398,26 +5398,26 @@
 # NSg/VXB/JC . .
 >
 #
-> “ I’d rather     finish my  tea      , ” said the Hatter , with an  anxious look   at    the Queen     ,
-# . K   NPr/VB/J/R NSg/VB D$+ N🅪Sg/VB+ . . VP/J D   NSg/VB . P    D/P J       NSg/VB NSg/P D   NPr/VB/J+ .
+> “ I’d rather     finish my  tea      , ” said the Hatter , with an  anxious look   at    the Queen   ,
+# . K   NPr/VB/J/R NSg/VB D$+ N🅪Sg/VB+ . . VP/J D   NSg/VB . P    D/P J       NSg/VB NSg/P D   NPr/VB+ .
 > who    was  reading     the list   of singers .
 # NPr/I+ VLPt NPr🅪Sg/Vg/J D   NSg/VB P  +       .
 >
 #
-> “ You    may     go       , ” said the King      , and  the Hatter hurriedly left     the court      , without
-# . ISgPl+ NPr/VXB NSg/VB/J . . VP/J D+  NPr/VB/J+ . VB/C D   NSg/VB R         NPr/VP/J D   N🅪Sg/VB/J+ . C/P
+> “ You    may     go       , ” said the King    , and  the Hatter hurriedly left     the court      , without
+# . ISgPl+ NPr/VXB NSg/VB/J . . VP/J D+  NPr/VB+ . VB/C D   NSg/VB R         NPr/VP/J D   N🅪Sg/VB/J+ . C/P
 > even       waiting to put     his     shoes   on  .
 # NSg/VB/J/R Nᴹ/Vg/J P  NSg/VBP ISg/D$+ NPl/V3+ J/P .
 >
 #
-> “ — and  just take   his     head      off        outside   , ” the Queen     added to one     of the officers :
-# . . VB/C J/R  NSg/VB ISg/D$+ NPr/VB/J+ NSg/VB/J/P Nᴹ/VB/J/P . . D+  NPr/VB/J+ VP/J  P  NSg/I/J P  D+  NPl/V3+  .
-> but     the Hatter was  out          of sight    before the officer could   get    to the door    .
-# NSg/C/P D   NSg/VB VLPt NSg/VB/J/R/P P  N🅪Sg/VB+ C/P    D   NSg/VB+ NSg/VXB NSg/VB P  D   NSg/VB+ .
+> “ — and  just take   his     head      off        outside   , ” the Queen   added to one     of the officers :
+# . . VB/C J/R  NSg/VB ISg/D$+ NPr/VB/J+ NSg/VB/J/P Nᴹ/VB/J/P . . D+  NPr/VB+ VP/J  P  NSg/I/J P  D+  NPl/V3+  .
+> but     the Hatter was  out          of sight    before the officer could get    to the door    .
+# NSg/C/P D   NSg/VB VLPt NSg/VB/J/R/P P  N🅪Sg/VB+ C/P    D   NSg/VB+ VXB   NSg/VB P  D   NSg/VB+ .
 >
 #
-> “ Call   the next     witness ! ” said the King      .
-# . NSg/VB D+  NSg/J/P+ NSg/VB+ . . VP/J D+  NPr/VB/J+ .
+> “ Call   the next     witness ! ” said the King    .
+# . NSg/VB D+  NSg/J/P+ NSg/VB+ . . VP/J D+  NPr/VB+ .
 >
 #
 > The next     witness was  the Duchess’s cook   . She  carried the pepper   - box    in        her     hand    ,
@@ -5428,22 +5428,22 @@
 # NPl/VB+ NSg/VB/J/P D+  NSg/VB+ VPt   Nᴹ/Vg/J  NSg/I/J/C/Dq NSg/P NSg/C .
 >
 #
-> “ Give   your evidence , ” said the King      .
-# . NSg/VB D$+  Nᴹ/VB+   . . VP/J D+  NPr/VB/J+ .
+> “ Give   your evidence , ” said the King    .
+# . NSg/VB D$+  Nᴹ/VB+   . . VP/J D+  NPr/VB+ .
 >
 #
 > “ Shan’t , ” said the cook    .
 # . VXB    . . VP/J D   NPr/VB+ .
 >
 #
-> The King      looked anxiously at    the White        Rabbit  , who    said in        a    low         voice   , “ Your
-# D+  NPr/VB/J+ VP/J   R         NSg/P D+  NPr🅪Sg/VB/J+ NSg/VB+ . NPr/I+ VP/J NPr/J/R/P D/P+ NSg/VB/J/R+ NSg/VB+ . . D$+
+> The King    looked anxiously at    the White        Rabbit  , who    said in        a    low         voice   , “ Your
+# D+  NPr/VB+ VP/J   R         NSg/P D+  NPr🅪Sg/VB/J+ NSg/VB+ . NPr/I+ VP/J NPr/J/R/P D/P+ NSg/VB/J/R+ NSg/VB+ . . D$+
 > Majesty must    cross       - examine this    witness . ”
 # N🅪Sg/I+ NSg/VXB NPr/VB/J/P+ . NSg/VB  I/Ddem+ NSg/VB+ . .
 >
 #
-> “ Well       , if    I       must    , I       must    , ” the King      said , with a   melancholy air      , and  , after
-# . NSg/VB/J/R . NSg/C ISg/#r+ NSg/VXB . ISg/#r+ NSg/VXB . . D+  NPr/VB/J+ VP/J . P    D/P NSg/J      N🅪Sg/VB+ . VB/C . P
+> “ Well       , if    I       must    , I       must    , ” the King    said , with a   melancholy air      , and  , after
+# . NSg/VB/J/R . NSg/C ISg/#r+ NSg/VXB . ISg/#r+ NSg/VXB . . D+  NPr/VB+ VP/J . P    D/P NSg/J      N🅪Sg/VB+ . VB/C . P
 > folding his     arms    and  frowning at    the cook    till       his     eyes    were nearly out          of
 # Nᴹ/Vg/J ISg/D$+ NPl/V3+ VB/C Nᴹ/Vg/J  NSg/P D   NPr/VB+ NSg/VB/C/P ISg/D$+ NPl/V3+ VLPt R      NSg/VB/J/R/P P
 > sight    , he       said in        a   deep  voice   , “ What   are tarts  made of ? ”
@@ -5458,8 +5458,8 @@
 # . Nᴹ/VB   . . VP/J D/P NSg/J  NSg/VB+ NSg/J/P ISg/D$+ .
 >
 #
-> “ Collar  that      Dormouse , ” the Queen     shrieked out          . “ Behead that      Dormouse ! Turn   that
-# . NSg/VB+ I/C/Ddem+ NSg      . . D   NPr/VB/J+ VP/J     NSg/VB/J/R/P . . VB     I/C/Ddem+ NSg      . NSg/VB I/C/Ddem+
+> “ Collar  that      Dormouse , ” the Queen   shrieked out          . “ Behead that      Dormouse ! Turn   that
+# . NSg/VB+ I/C/Ddem+ NSg      . . D   NPr/VB+ VP/J     NSg/VB/J/R/P . . VB     I/C/Ddem+ NSg      . NSg/VB I/C/Ddem+
 > Dormouse out          of court      ! Suppress him  ! Pinch  him  ! Off        with his     whiskers ! ”
 # NSg      NSg/VB/J/R/P P  N🅪Sg/VB/J+ . VB       ISg+ . NSg/VB ISg+ . NSg/VB/J/P P    ISg/D$+ NPl      . .
 >
@@ -5470,10 +5470,10 @@
 # NSg/VB/J/R/P . VB/C . P  D   N🅪Sg/VB/J+ IPl+ VP  VP/J    N🅪Sg/VB/J/P P     . D   NPr/VB+ VP  VP/J        .
 >
 #
-> “ Never mind    ! ” said the King      , with an  air     of great  relief . “ Call   the next
-# . R     NSg/VB+ . . VP/J D+  NPr/VB/J+ . P    D/P N🅪Sg/VB P  NSg/J+ NSg/J+ . . NSg/VB D+  NSg/J/P+
-> witness . ” And  he       added in        an  undertone to the Queen     , “ Really , my  dear     , you    must
-# NSg/VB+ . . VB/C NPr/ISg+ VP/J  NPr/J/R/P D/P NSg/VB    P  D   NPr/VB/J+ . . R      . D$+ NSg/VB/J . ISgPl+ NSg/VXB
+> “ Never mind    ! ” said the King    , with an  air     of great  relief . “ Call   the next
+# . R     NSg/VB+ . . VP/J D+  NPr/VB+ . P    D/P N🅪Sg/VB P  NSg/J+ NSg/J+ . . NSg/VB D+  NSg/J/P+
+> witness . ” And  he       added in        an  undertone to the Queen   , “ Really , my  dear     , you    must
+# NSg/VB+ . . VB/C NPr/ISg+ VP/J  NPr/J/R/P D/P NSg/VB    P  D   NPr/VB+ . . R      . D$+ NSg/VB/J . ISgPl+ NSg/VXB
 > cross       - examine the next    witness . It       quite makes  my  forehead ache    ! ”
 # NPr/VB/J/P+ . NSg/VB  D   NSg/J/P NSg/VB+ . NPr/ISg+ R     NPl/V3 D$+ NSg+     NSg/VB+ . .
 >
@@ -5493,7 +5493,7 @@
 >
 #
 > “ Here ! ” cried Alice , quite forgetting in        the flurry of the moment how   large she
-# . J/R  . . VP/J  NPr+  . R     NSg/Vg     NPr/J/R/P D   NSg/VB P  D   NSg+   NSg/C NSg/J ISg+
+# . R    . . VP/J  NPr+  . R     NSg/Vg     NPr/J/R/P D   NSg/VB P  D   NSg+   NSg/C NSg/J ISg+
 > had grown in        the last     few      minutes , and  she  jumped up         in        such  a   hurry   that      she
 # VP  VB/J  NPr/J/R/P D   NSg/VB/J NSg/I/Dq NPl/V3+ . VB/C ISg+ VP/J   NSg/VB/J/P NPr/J/R/P NSg/I D/P NSg/VB+ I/C/Ddem+ ISg+
 > tipped over    the jury      - box    with the edge   of her     skirt  , upsetting all          the jurymen
@@ -5508,16 +5508,16 @@
 #
 > “ Oh     , I       beg    your pardon ! ” she  exclaimed in        a   tone      of great  dismay  , and  began
 # . NPr/VB . ISg/#r+ NSg/VB D$+  NSg/VB . . ISg+ VP/J      NPr/J/R/P D/P N🅪Sg/I/VB P  NSg/J+ NSg/VB+ . VB/C VPt
-> picking them     up         again as    quickly as    she  could   , for   the accident of the goldfish
-# Nᴹ/Vg/J NSg/IPl+ NSg/VB/J/P P     R/C/P R       R/C/P ISg+ NSg/VXB . R/C/P D   NSg/J    P  D   NSgPl
+> picking them     up         again as    quickly as    she  could , for   the accident of the goldfish
+# Nᴹ/Vg/J NSg/IPl+ NSg/VB/J/P P     R/C/P R       R/C/P ISg+ VXB   . R/C/P D   NSg/J    P  D   NSgPl
 > kept running   in        her     head      , and  she  had a   vague    sort   of idea that      they must    be
 # VP   Nᴹ/Vg/J/P NPr/J/R/P ISg/D$+ NPr/VB/J+ . VB/C ISg+ VP  D/P NSg/VB/J NSg/VB P  NSg+ I/C/Ddem+ IPl+ NSg/VXB NSg/VLXB
 > collected at    once  and  put     back     into the jury      - box     , or    they would die    .
 # VP/J      NSg/P NSg/C VB/C NSg/VBP NSg/VB/J P    D   NSg/VB/J+ . NSg/VB+ . NPr/C IPl+ VXB   NSg/VB .
 >
 #
-> “ The trial     cannot  proceed , ” said the King      in        a   very grave     voice   , “ until all          the
-# . D+  NSg/VB/J+ NSg/VXB VB      . . VP/J D   NPr/VB/J+ NPr/J/R/P D/P J/R  NSg/VB/J+ NSg/VB+ . . C/P   NSg/I/J/C/Dq D
+> “ The trial     cannot  proceed , ” said the King    in        a   very grave     voice   , “ until all          the
+# . D+  NSg/VB/J+ NSg/VXB VB      . . VP/J D   NPr/VB+ NPr/J/R/P D/P J/R  NSg/VB/J+ NSg/VB+ . . C/P   NSg/I/J/C/Dq D
 > jurymen are back     in        their proper places  — all          , ” he       repeated with great emphasis ,
 # NPl     VLB NSg/VB/J NPr/J/R/P D$+   NSg/J  NPl/V3+ . NSg/I/J/C/Dq . . NPr/ISg+ VP/J     P    NSg/J NSg+     .
 > looking hard     at    Alice as    he       said so          .
@@ -5548,24 +5548,24 @@
 # Nᴹ/Vg/J NSg/VB/J/P P    D   NSg/VB P  D   N🅪Sg/VB/J+ .
 >
 #
-> “ What   do  you    know about this    business ? ” the King      said to Alice .
-# . NSg/I+ VXB ISgPl+ VB   J/P   I/Ddem+ N🅪Sg/J+  . . D+  NPr/VB/J+ VP/J P  NPr+  .
+> “ What   do  you    know about this    business ? ” the King    said to Alice .
+# . NSg/I+ VXB ISgPl+ VB   J/P   I/Ddem+ N🅪Sg/J+  . . D+  NPr/VB+ VP/J P  NPr+  .
 >
 #
 > “ Nothing  , ” said Alice .
 # . NSg/I/J+ . . VP/J NPr+  .
 >
 #
-> “ Nothing  whatever ? ” persisted the King      .
-# . NSg/I/J+ NSg/I/J+ . . VP/J      D+  NPr/VB/J+ .
+> “ Nothing  whatever ? ” persisted the King    .
+# . NSg/I/J+ NSg/I/J+ . . VP/J      D+  NPr/VB+ .
 >
 #
 > “ Nothing  whatever , ” said Alice .
 # . NSg/I/J+ NSg/I/J+ . . VP/J NPr+  .
 >
 #
-> “ That’s very important , ” the King      said , turning to the jury      . They were just
-# . K      J/R  J         . . D   NPr/VB/J+ VP/J . Nᴹ/Vg/J P  D   NSg/VB/J+ . IPl+ VLPt J/R
+> “ That’s very important , ” the King    said , turning to the jury      . They were just
+# . K      J/R  J         . . D   NPr/VB+ VP/J . Nᴹ/Vg/J P  D   NSg/VB/J+ . IPl+ VLPt J/R
 > beginning to write  this   down        on  their slates , when    the White       Rabbit  interrupted :
 # NSg/Vg/J  P  NSg/VB I/Ddem N🅪Sg/VB/J/P J/P D$+   NPl/V3 . NSg/I/C D   NPr🅪Sg/VB/J NSg/VB+ VP/J        .
 > “ Unimportant , your Majesty means  , of course  , ” he       said in        a   very respectful tone       ,
@@ -5574,8 +5574,8 @@
 # NSg/C/P Nᴹ/Vg/J  VB/C Nᴹ/Vg/J NPl/V3+ NSg/P ISg+ R/C/P NPr/ISg+ NSg/VPt .
 >
 #
-> “ Unimportant , of course  , I       meant , ” the King      hastily said , and  went    on  to himself
-# . J           . P  NSg/VB+ . ISg/#r+ VP    . . D+  NPr/VB/J+ R       VP/J . VB/C NSg/VPt J/P P  ISg+
+> “ Unimportant , of course  , I       meant , ” the King    hastily said , and  went on  to himself
+# . J           . P  NSg/VB+ . ISg/#r+ VP    . . D+  NPr/VB+ R       VP/J . VB/C VPt  J/P P  ISg+
 > in        an  undertone ,
 # NPr/J/R/P D/P NSg/VB    .
 >
@@ -5587,15 +5587,15 @@
 >
 #
 > Some     of the jury      wrote it       down        “ important , ” and  some     “ unimportant . ” Alice could
-# I/J/R/Dq P  D+  NSg/VB/J+ VPt   NPr/ISg+ N🅪Sg/VB/J/P . J         . . VB/C I/J/R/Dq . J           . . NPr+  NSg/VXB
+# I/J/R/Dq P  D+  NSg/VB/J+ VPt   NPr/ISg+ N🅪Sg/VB/J/P . J         . . VB/C I/J/R/Dq . J           . . NPr+  VXB
 > see    this    , as    she  was  near       enough to look   over    their slates ; “ but     it       doesn’t
 # NSg/VB I/Ddem+ . R/C/P ISg+ VLPt NSg/VB/J/P NSg/I  P  NSg/VB NSg/J/P D$+   NPl/V3 . . NSg/C/P NPr/ISg+ VX3
 > matter   a   bit      , ” she  thought to herself .
 # N🅪Sg/VB+ D/P NSg/VPt+ . . ISg+ N🅪Sg/VP P  ISg+    .
 >
 #
-> At    this    moment the King      , who    had been   for   some      time       busily writing in        his
-# NSg/P I/Ddem+ NSg+   D+  NPr/VB/J+ . NPr/I+ VP  VLPp/B R/C/P I/J/R/Dq+ N🅪Sg/VB/J+ R      Nᴹ/Vg/J NPr/J/R/P ISg/D$+
+> At    this    moment the King    , who    had been   for   some      time       busily writing in        his
+# NSg/P I/Ddem+ NSg+   D+  NPr/VB+ . NPr/I+ VP  VLPp/B R/C/P I/J/R/Dq+ N🅪Sg/VB/J+ R      Nᴹ/Vg/J NPr/J/R/P ISg/D$+
 > note    - book    , cackled out          “ Silence ! ” and  read    out          from his     book    , “ Rule    Forty - two .
 # NSg/VB+ . NSg/VB+ . VP/J    NSg/VB/J/R/P . NSg/VB+ . . VB/C NSg/VBP NSg/VB/J/R/P P    ISg/D$+ NSg/VB+ . . NSg/VB+ NSg/J . NSg .
 > All           persons more         than a    mile high       to leave  the court      . ”
@@ -5610,12 +5610,12 @@
 # . K   NSg/R/C D/P NSg+ NSg/VB/J/R . . VP/J NPr+  .
 >
 #
-> “ You    are , ” said the King      .
-# . ISgPl+ VLB . . VP/J D+  NPr/VB/J+ .
+> “ You    are , ” said the King    .
+# . ISgPl+ VLB . . VP/J D+  NPr/VB+ .
 >
 #
-> “ Nearly two  miles  high       , ” added the Queen     .
-# . R      NSg+ NPrPl+ NSg/VB/J/R . . VP/J  D+  NPr/VB/J+ .
+> “ Nearly two  miles  high       , ” added the Queen   .
+# . R      NSg+ NPrPl+ NSg/VB/J/R . . VP/J  D+  NPr/VB+ .
 >
 #
 > “ Well       , I       shan’t go       , at    any    rate    , ” said Alice : “ besides , that’s not     a   regular
@@ -5624,16 +5624,16 @@
 # NSg/VB+ . ISgPl+ VP/J     NPr/ISg+ J/R  NSg/J/R/C . .
 >
 #
-> “ It’s the oldest rule    in        the book    , ” said the King      .
-# . K    D   JS     NSg/VB+ NPr/J/R/P D   NSg/VB+ . . VP/J D   NPr/VB/J+ .
+> “ It’s the oldest rule    in        the book    , ” said the King    .
+# . K    D   JS     NSg/VB+ NPr/J/R/P D   NSg/VB+ . . VP/J D   NPr/VB+ .
 >
 #
 > “ Then      it       ought     to be       Number      One     , ” said Alice .
 # . NSg/J/R/C NPr/ISg+ NSg/I/VXB P  NSg/VLXB N🅪Sg/VB/JC+ NSg/I/J . . VP/J NPr+  .
 >
 #
-> The King      turned pale     , and  shut      his     note    - book    hastily . “ Consider your verdict , ”
-# D+  NPr/VB/J+ VP/J   NSg/VB/J . VB/C NSg/VBP/J ISg/D$+ NSg/VB+ . NSg/VB+ R       . . VB       D$+  NSg+    . .
+> The King    turned pale     , and  shut      his     note    - book    hastily . “ Consider your verdict , ”
+# D+  NPr/VB+ VP/J   NSg/VB/J . VB/C NSg/VBP/J ISg/D$+ NSg/VB+ . NSg/VB+ R       . . VB       D$+  NSg+    . .
 > he       said to the jury      , in        a   low        , trembling voice   .
 # NPr/ISg+ VP/J P  D+  NSg/VB/J+ . NPr/J/R/P D/P NSg/VB/J/R . Nᴹ/Vg/J   NSg/VB+ .
 >
@@ -5644,8 +5644,8 @@
 # Nᴹ/Vg/J NSg/VB/J/P NPr/J/R/P D/P NSg/J NSg/VB+ . . I/Ddem N🅪Sg/VB/J+ V3  J/R  VLPp/B VP/J   NSg/VB/J/P . .
 >
 #
-> “ What’s in        it       ? ” said the Queen     .
-# . K      NPr/J/R/P NPr/ISg+ . . VP/J D+  NPr/VB/J+ .
+> “ What’s in        it       ? ” said the Queen   .
+# . K      NPr/J/R/P NPr/ISg+ . . VP/J D+  NPr/VB+ .
 >
 #
 > “ I       haven’t opened it       yet      , ” said the White       Rabbit  , “ but     it       seems to be       a   letter  ,
@@ -5654,8 +5654,8 @@
 # VPp/J   P  D   NSg+     P  . P  NSg/I+   . .
 >
 #
-> “ It       must    have    been   that      , ” said the King      , “ unless it       was  written to nobody , which
-# . NPr/ISg+ NSg/VXB NSg/VXB VLPp/B I/C/Ddem+ . . VP/J D+  NPr/VB/J+ . . C      NPr/ISg+ VLPt VPp/J   P  NSg/I+ . I/C+
+> “ It       must    have    been   that      , ” said the King    , “ unless it       was  written to nobody , which
+# . NPr/ISg+ NSg/VXB NSg/VXB VLPp/B I/C/Ddem+ . . VP/J D+  NPr/VB+ . . C      NPr/ISg+ VLPt VPp/J   P  NSg/I+ . I/C+
 > isn’t   usual , you    know . ”
 # NSg/VX3 NSg/J . ISgPl+ VB   . .
 >
@@ -5682,8 +5682,8 @@
 # NPr/ISg+ . . . D+  NSg/VB/J+ NSg/I/J/C/Dq VP/J   VP/J    . .
 >
 #
-> “ He       must    have    imitated somebody else’s hand    , ” said the King      . ( The jury      all
-# . NPr/ISg+ NSg/VXB NSg/VXB VP/J     NSg/I+   NSg$   NSg/VB+ . . VP/J D   NPr/VB/J+ . . D+  NSg/VB/J+ NSg/I/J/C/Dq
+> “ He       must    have    imitated somebody else’s hand    , ” said the King    . ( The jury      all
+# . NPr/ISg+ NSg/VXB NSg/VXB VP/J     NSg/I+   NSg$   NSg/VB+ . . VP/J D   NPr/VB+ . . D+  NSg/VB/J+ NSg/I/J/C/Dq
 > brightened up         again . )
 # VP/J       NSg/VB/J/P P     . .
 >
@@ -5694,8 +5694,8 @@
 # ISg/#r+ VXPt . K       NSg/Dq/P NSg/VB+ VP/J   NSg/P D   NSg/VB+ . .
 >
 #
-> “ If    you    didn’t sign    it       , ” said the King      , “ that      only  makes  the matter   worse     . You
-# . NSg/C ISgPl+ VXPt   NSg/VB+ NPr/ISg+ . . VP/J D   NPr/VB/J+ . . I/C/Ddem+ J/R/C NPl/V3 D   N🅪Sg/VB+ NSg/VB/JC . ISgPl+
+> “ If    you    didn’t sign    it       , ” said the King    , “ that      only  makes  the matter   worse     . You
+# . NSg/C ISgPl+ VXPt   NSg/VB+ NPr/ISg+ . . VP/J D   NPr/VB+ . . I/C/Ddem+ J/R/C NPl/V3 D   N🅪Sg/VB+ NSg/VB/JC . ISgPl+
 > must    have    meant some      mischief , or    else    you’d have    signed your name    like         an
 # NSg/VXB NSg/VXB VP    I/J/R/Dq+ NSg/VB+  . NPr/C NSg/J/C K     NSg/VXB VP/J   D$+  NSg/VB+ NSg/VB/J/C/P D/P
 > honest man     . ”
@@ -5704,12 +5704,12 @@
 #
 > There was  a   general  clapping of hands   at    this    : it       was  the first really clever
 # R+    VLPt D/P NSg/VB/J Nᴹ/Vg    P  NPl/V3+ NSg/P I/Ddem+ . NPr/ISg+ VLPt D   NSg/J R      J
-> thing the King      had said that     day     .
-# NSg+  D+  NPr/VB/J+ VP  VP/J I/C/Ddem NPr🅪Sg+ .
+> thing the King    had said that     day     .
+# NSg+  D+  NPr/VB+ VP  VP/J I/C/Ddem NPr🅪Sg+ .
 >
 #
-> “ That      proves his     guilt   , ” said the Queen     .
-# . I/C/Ddem+ NPl/V3 ISg/D$+ NSg/VB+ . . VP/J D+  NPr/VB/J+ .
+> “ That      proves his     guilt   , ” said the Queen   .
+# . I/C/Ddem+ NPl/V3 ISg/D$+ NSg/VB+ . . VP/J D+  NPr/VB+ .
 >
 #
 > “ It       proves nothing of the sort    ! ” said Alice . “ Why    , you    don’t even       know what
@@ -5718,8 +5718,8 @@
 # K       J/P   . .
 >
 #
-> “ Read    them     , ” said the King      .
-# . NSg/VBP NSg/IPl+ . . VP/J D+  NPr/VB/J+ .
+> “ Read    them     , ” said the King    .
+# . NSg/VBP NSg/IPl+ . . VP/J D+  NPr/VB+ .
 >
 #
 > The White        Rabbit  put     on  his     spectacles . “ Where   shall I       begin  , please your
@@ -5728,8 +5728,8 @@
 # N🅪Sg/I+ . . NPr/ISg+ VP/J  .
 >
 #
-> “ Begin  at    the beginning , ” the King      said gravely , “ and  go       on  till       you    come       to the
-# . NSg/VB NSg/P D+  NSg/Vg/J+ . . D+  NPr/VB/J+ VP/J R       . . VB/C NSg/VB/J J/P NSg/VB/C/P ISgPl+ NSg/VBPp/P P  D
+> “ Begin  at    the beginning , ” the King    said gravely , “ and  go       on  till       you    come       to the
+# . NSg/VB NSg/P D+  NSg/Vg/J+ . . D+  NPr/VB+ VP/J R       . . VB/C NSg/VB/J J/P NSg/VB/C/P ISgPl+ NSg/VBPp/P P  D
 > end     : then      stop   . ”
 # NSg/VB+ . NSg/J/R/C NSg/VB . .
 >
@@ -5740,8 +5740,8 @@
 #
 > “ They told me       you    had been   to her     , And  mentioned me       to him  : She  gave me       a    good
 # . IPl+ VP   NPr/ISg+ ISgPl+ VP  VLPp/B P  ISg/D$+ . VB/C VP/J      NPr/ISg+ P  ISg+ . ISg+ VPt  NPr/ISg+ D/P+ NPr/VB/J+
-> character , But     said I       could   not     swim   .
-# N🅪Sg/VB+  . NSg/C/P VP/J ISg/#r+ NSg/VXB NSg/R/C NSg/VB .
+> character , But     said I       could not     swim   .
+# N🅪Sg/VB+  . NSg/C/P VP/J ISg/#r+ VXB   NSg/R/C NSg/VB .
 >
 #
 > He       sent   them     word    I       had not     gone    ( We   know it       to be       true     ) : If    she  should push
@@ -5774,8 +5774,8 @@
 # P    NSg/I/J/C/Dq D   NSg/VB+ . NSg/P   ISg+     VB/C NPr/ISg+ . .
 >
 #
-> “ That’s the most         important piece  of evidence we’ve heard yet      , ” said the King      ,
-# . K      D   NSg/I/J/R/Dq J         NSg/VB P  Nᴹ/VB+   K     VP/J  NSg/VB/C . . VP/J D   NPr/VB/J+ .
+> “ That’s the most         important piece  of evidence we’ve heard yet      , ” said the King    ,
+# . K      D   NSg/I/J/R/Dq J         NSg/VB P  Nᴹ/VB+   K     VP/J  NSg/VB/C . . VP/J D   NPr/VB+ .
 > rubbing his     hands   ; “ so          now       let     the jury      — ”
 # NSg/Vg  ISg/D$+ NPl/V3+ . . NSg/I/J/R/C NSg/J/R/C NSg/VBP D   NSg/VB/J+ . .
 >
@@ -5794,14 +5794,14 @@
 # N🅪Sg/Vg/J+ NPr/J/R/P NPr/ISg+ . . NSg/C/P I    P  NSg/IPl+ VP/J      P  VB      D   N🅪Sg/VB/J+ .
 >
 #
-> “ If    there’s no       meaning    in        it       , ” said the King      , “ that      saves  a   world  of trouble  ,
-# . NSg/C K       NSg/Dq/P N🅪Sg/Vg/J+ NPr/J/R/P NPr/ISg+ . . VP/J D   NPr/VB/J+ . . I/C/Ddem+ NPl/V3 D/P NSg/VB P  N🅪Sg/VB+ .
-> you    know , as    we   needn’t try      to find   any    . And  yet      I       don’t know , ” he       went    on  ,
-# ISgPl+ VB   . R/C/P IPl+ VXB     NSg/VB/J P  NSg/VB I/R/Dq . VB/C NSg/VB/C ISg/#r+ VXB   VB   . . NPr/ISg+ NSg/VPt J/P .
+> “ If    there’s no       meaning    in        it       , ” said the King    , “ that      saves  a   world  of trouble  ,
+# . NSg/C K       NSg/Dq/P N🅪Sg/Vg/J+ NPr/J/R/P NPr/ISg+ . . VP/J D   NPr/VB+ . . I/C/Ddem+ NPl/V3 D/P NSg/VB P  N🅪Sg/VB+ .
+> you    know , as    we   needn’t try      to find   any    . And  yet      I       don’t know , ” he       went on  ,
+# ISgPl+ VB   . R/C/P IPl+ VXB     NSg/VB/J P  NSg/VB I/R/Dq . VB/C NSg/VB/C ISg/#r+ VXB   VB   . . NPr/ISg+ VPt  J/P .
 > spreading out          the verses on  his     knee    , and  looking at    them     with one     eye     ; “ I       seem
 # Nᴹ/Vg/J   NSg/VB/J/R/P D   NPl/V3 J/P ISg/D$+ NSg/VB+ . VB/C Nᴹ/Vg/J NSg/P NSg/IPl+ P    NSg/I/J NSg/VB+ . . ISg/#r+ VB
-> to see    some     meaning    in        them     , after all          . “ — said I       could   not     swim   — ” you    can’t
-# P  NSg/VB I/J/R/Dq N🅪Sg/Vg/J+ NPr/J/R/P NSg/IPl+ . P     NSg/I/J/C/Dq . . . VP/J ISg/#r+ NSg/VXB NSg/R/C NSg/VB . . ISgPl+ VXB
+> to see    some     meaning    in        them     , after all          . “ — said I       could not     swim   — ” you    can’t
+# P  NSg/VB I/J/R/Dq N🅪Sg/Vg/J+ NPr/J/R/P NSg/IPl+ . P     NSg/I/J/C/Dq . . . VP/J ISg/#r+ VXB   NSg/R/C NSg/VB . . ISgPl+ VXB
 > swim   , can     you    ? ” he       added , turning to the Knave .
 # NSg/VB . NPr/VXB ISgPl+ . . NPr/ISg+ VP/J  . Nᴹ/Vg/J P  D   NSg   .
 >
@@ -5812,8 +5812,8 @@
 # R         VXPt NSg/R/C . N🅪Sg/VLg/J/C VP   R        P  Nᴹ/J+     . .
 >
 #
-> “ All          right    , so          far      , ” said the King      , and  he       went    on  muttering over    the verses to
-# . NSg/I/J/C/Dq NPr/VB/J . NSg/I/J/R/C NSg/VB/J . . VP/J D+  NPr/VB/J+ . VB/C NPr/ISg+ NSg/VPt J/P Nᴹ/Vg/J   NSg/J/P D   NPl/V3 P
+> “ All          right    , so          far      , ” said the King    , and  he       went on  muttering over    the verses to
+# . NSg/I/J/C/Dq NPr/VB/J . NSg/I/J/R/C NSg/VB/J . . VP/J D+  NPr/VB+ . VB/C NPr/ISg+ VPt  J/P Nᴹ/Vg/J   NSg/J/P D   NPl/V3 P
 > himself : “ ‘ We   know it       to be       true     — ’ that’s the jury      , of course  — ‘ I       gave her     one     ,
 # ISg+    . . . IPl+ VB   NPr/ISg+ P  NSg/VLXB NSg/VB/J . . K      D   NSg/VB/J+ . P  NSg/VB+ . . ISg/#r+ VPt  ISg/D$+ NSg/I/J .
 > they gave him  two — ’ why    , that      must    be       what   he       did  with the tarts  , you    know — ”
@@ -5824,16 +5824,16 @@
 # . NSg/C/P . NPr/ISg+ NPl/V3 J/P . IPl+ NSg/I/J/C/Dq VP/J+    P    ISg+ P  ISgPl+ . . . VP/J NPr+  .
 >
 #
-> “ Why    , there they are ! ” said the King      triumphantly , pointing to the tarts  on  the
-# . NSg/VB . R+    IPl+ VLB . . VP/J D+  NPr/VB/J+ R            . Nᴹ/Vg/J  P  D   NPl/V3 J/P D
+> “ Why    , there they are ! ” said the King    triumphantly , pointing to the tarts  on  the
+# . NSg/VB . R+    IPl+ VLB . . VP/J D+  NPr/VB+ R            . Nᴹ/Vg/J  P  D   NPl/V3 J/P D
 > table   . “ Nothing  can     be       clearer than that      . Then      again — ‘ before she  had this    fit        — ’
 # NSg/VB+ . . NSg/I/J+ NPr/VXB NSg/VLXB NSg/JC  C/P  I/C/Ddem+ . NSg/J/R/C P     . . C/P    ISg+ VP  I/Ddem+ NSg/VBP/J+ . .
-> you    never had fits   , my  dear     , I       think  ? ” he       said to the Queen     .
-# ISgPl+ R     VP  NPl/V3 . D$+ NSg/VB/J . ISg/#r+ NSg/VB . . NPr/ISg+ VP/J P  D+  NPr/VB/J+ .
+> you    never had fits   , my  dear     , I       think  ? ” he       said to the Queen   .
+# ISgPl+ R     VP  NPl/V3 . D$+ NSg/VB/J . ISg/#r+ NSg/VB . . NPr/ISg+ VP/J P  D+  NPr/VB+ .
 >
 #
-> “ Never ! ” said the Queen     furiously , throwing an  inkstand at    the Lizard as    she
-# . R     . . VP/J D+  NPr/VB/J+ R         . Nᴹ/Vg/J  D/P NSg      NSg/P D   NSg    R/C/P ISg+
+> “ Never ! ” said the Queen   furiously , throwing an  inkstand at    the Lizard as    she
+# . R     . . VP/J D+  NPr/VB+ R         . Nᴹ/Vg/J  D/P NSg      NSg/P D   NSg    R/C/P ISg+
 > spoke   . ( The unfortunate little      Bill    had left     off        writing on  his     slate     with one
 # NSg/VPt . . D+  NSg/J+      NPr/I/J/Dq+ NPr/VB+ VP  NPr/VP/J NSg/VB/J/P Nᴹ/Vg/J J/P ISg/D$+ NSg/VB/J+ P    NSg/I/J+
 > finger  , as    he       found  it       made no        mark    ; but     he       now       hastily began again , using   the
@@ -5842,22 +5842,22 @@
 # N🅪Sg/VB+ . I/C/Ddem+ VLPt Nᴹ/Vg/J   N🅪Sg/VB/J/P ISg/D$+ NSg/VB+ . R/C/P NPr/VB/J R/C/P NPr/ISg+ VP/J   . .
 >
 #
-> “ Then      the words   don’t fit       you    , ” said the King      , looking round      the court      with a
-# . NSg/J/R/C D+  NPl/V3+ VXB   NSg/VBP/J ISgPl+ . . VP/J D   NPr/VB/J+ . Nᴹ/Vg/J NSg/VB/J/P D   N🅪Sg/VB/J+ P    D/P
+> “ Then      the words   don’t fit       you    , ” said the King    , looking round      the court      with a
+# . NSg/J/R/C D+  NPl/V3+ VXB   NSg/VBP/J ISgPl+ . . VP/J D   NPr/VB+ . Nᴹ/Vg/J NSg/VB/J/P D   N🅪Sg/VB/J+ P    D/P
 > smile   . There was  a    dead      silence .
 # NSg/VB+ . R+    VLPt D/P+ NSg/VB/J+ NSg/VB+ .
 >
 #
-> “ It’s a    pun     ! ” the King      added in        an   offended tone       , and  everybody laughed , “ Let
-# . K    D/P+ NSg/VB+ . . D+  NPr/VB/J+ VP/J  NPr/J/R/P D/P+ VP/J     N🅪Sg/I/VB+ . VB/C NSg/I+    VP/J    . . NSg/VBP
-> the jury      consider their verdict , ” the King      said , for   about the twentieth time
-# D+  NSg/VB/J+ VB       D$+   NSg+    . . D+  NPr/VB/J+ VP/J . R/C/P J/P   D+  NSg/J+    N🅪Sg/VB/J+
+> “ It’s a    pun     ! ” the King    added in        an   offended tone       , and  everybody laughed , “ Let
+# . K    D/P+ NSg/VB+ . . D+  NPr/VB+ VP/J  NPr/J/R/P D/P+ VP/J     N🅪Sg/I/VB+ . VB/C NSg/I+    VP/J    . . NSg/VBP
+> the jury      consider their verdict , ” the King    said , for   about the twentieth time
+# D+  NSg/VB/J+ VB       D$+   NSg+    . . D+  NPr/VB+ VP/J . R/C/P J/P   D+  NSg/J+    N🅪Sg/VB/J+
 > that      day     .
 # I/C/Ddem+ NPr🅪Sg+ .
 >
 #
-> “ No       , no       ! ” said the Queen     . “ Sentence first — verdict afterwards . ”
-# . NSg/Dq/P . NSg/Dq/P . . VP/J D+  NPr/VB/J+ . . NSg/VB+  NSg/J . NSg+    R/Comm     . .
+> “ No       , no       ! ” said the Queen   . “ Sentence first — verdict afterwards . ”
+# . NSg/Dq/P . NSg/Dq/P . . VP/J D+  NPr/VB+ . . NSg/VB+  NSg/J . NSg+    R/Comm     . .
 >
 #
 > “ Stuff and  nonsense ! ” said Alice loudly . “ The idea of having  the sentence
@@ -5866,16 +5866,16 @@
 # NSg/J . .
 >
 #
-> “ Hold     your tongue   ! ” said the Queen     , turning purple    .
-# . NSg/VB/J D$+  N🅪Sg/VB+ . . VP/J D+  NPr/VB/J+ . Nᴹ/Vg/J N🅪Sg/VB/J .
+> “ Hold     your tongue   ! ” said the Queen   , turning purple    .
+# . NSg/VB/J D$+  N🅪Sg/VB+ . . VP/J D+  NPr/VB+ . Nᴹ/Vg/J N🅪Sg/VB/J .
 >
 #
 > “ I       won’t ! ” said Alice .
 # . ISg/#r+ VXB   . . VP/J NPr+  .
 >
 #
-> “ Off        with her     head      ! ” the Queen     shouted at    the top      of her     voice   . Nobody moved .
-# . NSg/VB/J/P P    ISg/D$+ NPr/VB/J+ . . D+  NPr/VB/J+ VP/J    NSg/P D   NSg/VB/J P  ISg/D$+ NSg/VB+ . NSg/I+ VP/J  .
+> “ Off        with her     head      ! ” the Queen   shouted at    the top      of her     voice   . Nobody moved .
+# . NSg/VB/J/P P    ISg/D$+ NPr/VB/J+ . . D+  NPr/VB+ VP/J    NSg/P D   NSg/VB/J P  ISg/D$+ NSg/VB+ . NSg/I+ VP/J  .
 >
 #
 > “ Who    cares  for   you    ? ” said Alice , ( she  had grown to her     full      size     by this    time       . )
@@ -5902,8 +5902,8 @@
 #
 > “ Oh     , I’ve had such  a   curious dream     ! ” said Alice , and  she  told her     sister  , as
 # . NPr/VB . K    VP  NSg/I D/P J       NSg/VB/J+ . . VP/J NPr+  . VB/C ISg+ VP   ISg/D$+ NSg/VB+ . R/C/P
-> well       as    she  could   remember them     , all          these  strange  Adventures of hers that     you
-# NSg/VB/J/R R/C/P ISg+ NSg/VXB NSg/VB   NSg/IPl+ . NSg/I/J/C/Dq I/Ddem NSg/VB/J NPl/V3     P  ISg+ I/C/Ddem ISgPl+
+> well       as    she  could remember them     , all          these  strange  Adventures of hers that     you
+# NSg/VB/J/R R/C/P ISg+ VXB   NSg/VB   NSg/IPl+ . NSg/I/J/C/Dq I/Ddem NSg/VB/J NPl/V3     P  ISg+ I/C/Ddem ISgPl+
 > have    just been   reading     about ; and  when    she  had finished , her     sister  kissed her     ,
 # NSg/VXB J/R  VLPp/B NPr🅪Sg/Vg/J J/P   . VB/C NSg/I/C ISg+ VP  VP/J     . ISg/D$+ NSg/VB+ VP/J   ISg/D$+ .
 > and  said , “ It       was  a   curious dream    , dear     , certainly : but     now       run      in        to your tea      ;
@@ -5928,8 +5928,8 @@
 # NSg/J . ISg+ VP/J/NoAm/Au P  NPr/I/J/Dq+ NPr+  ISg+    . VB/C NSg/C P     D+  NSg/J+ NPl/V3+ VLPt
 > clasped upon her     knee    , and  the bright   eager    eyes    were looking up         into hers — she
 # VP/J    P    ISg/D$+ NSg/VB+ . VB/C D   NPr/VB/J NSg/VB/J NPl/V3+ VLPt Nᴹ/Vg/J NSg/VB/J/P P    ISg+ . ISg+
-> could   hear the very tones  of her     voice   , and  see    that     queer    little     toss   of her
-# NSg/VXB VB   D   J/R  NPl/V3 P  ISg/D$+ NSg/VB+ . VB/C NSg/VB I/C/Ddem NSg/VB/J NPr/I/J/Dq NSg/VB P  ISg/D$+
+> could hear the very tones  of her     voice   , and  see    that     queer    little     toss   of her
+# VXB   VB   D   J/R  NPl/V3 P  ISg/D$+ NSg/VB+ . VB/C NSg/VB I/C/Ddem NSg/VB/J NPr/I/J/Dq NSg/VB P  ISg/D$+
 > head      to keep   back     the wandering hair     that      would always get    into her     eyes    — and
 # NPr/VB/J+ P  NSg/VB NSg/VB/J D   Nᴹ/Vg/J   N🅪Sg/VB+ I/C/Ddem+ VXB   R      NSg/VB P    ISg/D$+ NPl/V3+ . VB/C
 > still      as    she  listened , or    seemed to listen , the whole place    around her     became
@@ -5940,12 +5940,12 @@
 #
 > The long      grass      rustled at    her     feet as    the White       Rabbit  hurried by — the frightened
 # D+  NPr/VB/J+ NPr🅪Sg/VB+ VP/J    NSg/P ISg/D$+ NPl+ R/C/P D   NPr🅪Sg/VB/J NSg/VB+ VP/J    P  . D   VP/J
-> Mouse   splashed his     way    through the neighbouring pool    — she  could   hear the rattle
-# NSg/VB+ VP/J     ISg/D$+ NSg/J+ J/P     D   Nᴹ/Vg/J/Comm NSg/VB+ . ISg+ NSg/VXB VB   D   NSg/VB
+> Mouse   splashed his     way    through the neighbouring pool    — she  could hear the rattle
+# NSg/VB+ VP/J     ISg/D$+ NSg/J+ J/P     D   Nᴹ/Vg/J/Comm NSg/VB+ . ISg+ VXB   VB   D   NSg/VB
 > of the teacups as    the March   Hare and  his     friends   shared their never - ending  meal    ,
 # P  D   NPl     R/C/P D   NPr/VB+ NSg+ VB/C ISg/D$+ NPrPl/V3+ VP/J   D$+   R     . Nᴹ/Vg/J NSg/VB+ .
-> and  the shrill   voice  of the Queen     ordering off        her     unfortunate guests  to
-# VB/C D   NSg/VB/J NSg/VB P  D   NPr/VB/J+ Nᴹ/Vg/J+ NSg/VB/J/P ISg/D$+ NSg/J       NPl/V3+ P
+> and  the shrill   voice  of the Queen   ordering off        her     unfortunate guests  to
+# VB/C D   NSg/VB/J NSg/VB P  D   NPr/VB+ Nᴹ/Vg/J+ NSg/VB/J/P ISg/D$+ NSg/J       NPl/V3+ P
 > execution — once  more         the pig     - baby      was  sneezing on  the Duchess’s knee    , while
 # N🅪Sg      . NSg/C NPr/I/J/R/Dq D   NSg/VB+ . NSg/VB/J+ VLPt Nᴹ/Vg/J  J/P D   NSg$      NSg/VB+ . NSg/VB/C/P
 > plates and  dishes  crashed around it       — once  more         the shriek of the Gryphon , the

--- a/harper-core/tests/text/tagged/Computer science.md
+++ b/harper-core/tests/text/tagged/Computer science.md
@@ -294,8 +294,8 @@
 # NSg/P   D   J       NSg+     . J+      NPl/V3+     . NSg+     N🅪Sg/VB+ Nᴹ/VB+   R/C
 > often intersects other    disciplines , such  as    cognitive science , linguistics ,
 # R     V3+        NSg/VB/J NPl/V3+     . NSg/I R/C/P NSg/J     N🅪Sg/VB . Nᴹ+         .
-> mathematics , physics , biology , Earth    science  , statistics , philosophy , and  logic    .
-# Nᴹ+         . NPl/V3+ . N🅪Sg+   . NPrᴹ/VB+ N🅪Sg/VB+ . NPl/V3+    . N🅪Sg/VB+   . VB/C Nᴹ/VB/J+ .
+> mathematics , physics , biology , Earth      science  , statistics , philosophy , and  logic    .
+# Nᴹ+         . NPl/V3+ . N🅪Sg+   . NPr🅪Sg/VB+ N🅪Sg/VB+ . NPl/V3+    . N🅪Sg/VB+   . VB/C Nᴹ/VB/J+ .
 >
 #
 > Computer science  is  considered by some     to have    a   much         closer relationship with

--- a/harper-core/tests/text/tagged/Computer science.md
+++ b/harper-core/tests/text/tagged/Computer science.md
@@ -142,8 +142,8 @@
 # NPr    VP/J      NPr/J/R/P NPr+  D   J                 ?            . D/P NSg/VB+   I/C/Ddem+
 > demonstrated the feasibility of an  electromechanical analytical engine  , on  which
 # VP/J         D   Nᴹ          P  D/P J                 J          NSg/VB+ . J/P I/C+
-> commands could   be       typed and  the results printed automatically . In        1937 , one
-# NPl/V3+  NSg/VXB NSg/VLXB VP/J  VB/C D   NPl/V3+ VP/J    R             . NPr/J/R/P #    . NSg/I/J
+> commands could be       typed and  the results printed automatically . In        1937 , one
+# NPl/V3+  VXB   NSg/VLXB VP/J  VB/C D   NPl/V3+ VP/J    R             . NPr/J/R/P #    . NSg/I/J
 > hundred years after Babbage's impossible dream     , Howard Aiken convinced IBM  ,
 # NSg     NPl+  P     NPr$      NSg/J      NSg/VB/J+ . NPr+   NPr   VP/J      NPr+ .
 > which was  making  all          kinds of punched card     equipment and  was  also in        the
@@ -164,8 +164,8 @@
 # NPl/V3   NSg/I R/C/P D   ?         . NPr🅪Sg/VB+ NSg+     VB/C ?     . D   NSg/VB/J+ NSg+     NSg/VPt/P
 > to refer  to the machines rather     than their human    predecessors . As    it       became
 # P  NSg/VB P  D   NPl/V3+  NPr/VB/J/R C/P  D$+   NSg/VB/J NPl+         . R/C/P NPr/ISg+ VPt
-> clear    that     computers could   be       used for   more         than just mathematical calculations ,
-# NSg/VB/J I/C/Ddem NPl+      NSg/VXB NSg/VLXB VP/J R/C/P NPr/I/J/R/Dq C/P  J/R  J+           +            .
+> clear    that     computers could be       used for   more         than just mathematical calculations ,
+# NSg/VB/J I/C/Ddem NPl+      VXB   NSg/VLXB VP/J R/C/P NPr/I/J/R/Dq C/P  J/R  J+           +            .
 > the field  of computer science  broadened to study  computation in        general  . In
 # D   NSg/VB P  NSg+     N🅪Sg/VB+ VP/J      P  NSg/VB NSg         NPr/J/R/P NSg/VB/J . NPr/J/R/P
 > 1945 , IBM  founded the Watson Scientific Computing Laboratory at    Columbia
@@ -216,8 +216,8 @@
 # NSg/VB/C/P Nᴹ/Vg/J D   NPl+            NSg/J   P  D/P NSg/J    NSg/VB+    . ISg/D$+ NPl/V3+ .
 > and  those  of others  such  as    numerical analyst George Forsythe , were rewarded :
 # VB/C I/Ddem P  NPl/V3+ NSg/I R/C/P J+        NSg+    NPr+   ?        . VLPt VP/J     .
-> universities went    on  to create such  departments , starting with Purdue in        1962 .
-# NPl+         NSg/VPt J/P P  VB/J   NSg/I NPl+        . Nᴹ/Vg/J  P    NPr    NPr/J/R/P #    .
+> universities went on  to create such  departments , starting with Purdue in        1962 .
+# NPl+         VPt  J/P P  VB/J   NSg/I NPl+        . Nᴹ/Vg/J  P    NPr    NPr/J/R/P #    .
 > Despite  its     name    , a   significant amount of computer science  does    not     involve the
 # NSg/VB/P ISg/D$+ NSg/VB+ . D/P NSg/J       NSg/VB P  NSg+     N🅪Sg/VB+ NPl/VX3 NSg/R/C VB      D
 > study  of computers themselves . Because of this    , several alternative names   have
@@ -806,8 +806,8 @@
 # N🅪Sg        . I/Ddem+ VL3 VPp/J R/C/P D/P VP/J+       NSg+   . NPl       NSg/J/P I/C/Ddem+
 > distributed system have    their own       private   memory , and  information can     be
 # VP/J        NSg+   NSg/VXB D$+   NSg/VB/J+ NSg/VB/J+ N🅪Sg+  . VB/C Nᴹ+         NPr/VXB NSg/VLXB
-> exchanged to achieve common    goals   .
-# VP/J      P  VB      NSg/VB/J+ NPl/V3+ .
+> exchanged to achieve common goals   .
+# VP/J      P  VB      VB/J+  NPl/V3+ .
 >
 #
 >              Computer networks
@@ -982,8 +982,8 @@
 #
 > Programming languages can     be       used to accomplish different tasks   in        different
 # Nᴹ/Vg/J+    NPl+      NPr/VXB NSg/VLXB VP/J P  VB         NSg/J     NPl/V3+ NPr/J/R/P NSg/J+
-> ways . Common    programming paradigms include :
-# NPl+ . NSg/VB/J+ Nᴹ/Vg/J+    NPl+      NSg/VB  .
+> ways . Common programming paradigms include :
+# NPl+ . VB/J+  Nᴹ/Vg/J+    NPl+      NSg/VB  .
 >
 #
 >

--- a/harper-core/tests/text/tagged/Difficult sentences.md
+++ b/harper-core/tests/text/tagged/Difficult sentences.md
@@ -3,7 +3,7 @@
 >
 #
 > A   collection of difficult sentences to test   Harper's ability to correctly tag     unusual / uncommon but     correct  sentences .
-# D/P N🅪Sg       P  VB/J      NPl/V3+   P  NSg/VB NPr$     N🅪Sg+   P  R         NSg/VB+ NSg/J   . NSg/VB/J NSg/C/P NSg/VB/J NPl/V3+   .
+# D/P N🅪Sg       P  VB/J      NPl/V3+   P  NSg/VB NPr$     N🅪Sg+   P  R         NSg/VB+ NSg/J   . VB/J     NSg/C/P NSg/VB/J NPl/V3+   .
 >
 #
 > Note    that     some      word    may     not     be       tagged correctly right    now       .
@@ -120,8 +120,8 @@
 # ISg/#r+ VP/J    D+  NPl/V3+ P  Nᴹ/Vg/J J/R/C NSg/I/C IPl+ VPt     Nᴹ/Vg/J .
 > By Pythagoras ' theorem , we   can     calculate the length  of the hypotenuse .
 # P  NPr        . NSg/VB  . IPl+ NPr/VXB VB        D   N🅪Sg/VB P  D   NSg        .
-> We   went    by bus     .
-# IPl+ NSg/VPt P  NSg/VB+ .
+> We   went by bus     .
+# IPl+ VPt  P  NSg/VB+ .
 > I       discovered it       by chance    .
 # ISg/#r+ VP/J       NPr/ISg+ P  NPr/VB/J+ .
 > By ' maybe   ' she  means  ' no       ' .
@@ -144,8 +144,8 @@
 # IPl+ NSgPl/VP P  NSg+ NPl/V3+ P  NSg   .
 > His     date    of birth     was  wrong      by ten  years .
 # ISg/D$+ N🅪Sg/VB P  NSg/VB/J+ VLPt NSg/VB/J/R P  NSg+ NPl+  .
-> We   went    through the book    page    by page    .
-# IPl+ NSg/VPt J/P     D+  NSg/VB+ NPr/VB+ P  NPr/VB+ .
+> We   went through the book    page    by page    .
+# IPl+ VPt  J/P     D+  NSg/VB+ NPr/VB+ P  NPr/VB+ .
 > We   crawled forward  by inches  .
 # IPl+ VP/J    NSg/VB/J P  NPl/V3+ .
 > sold   by the yard    ; cheaper if    bought by the gross
@@ -267,7 +267,7 @@
 > Police combed his     flat     for   clues   .
 # Nᴹ/VB+ VP/J   ISg/D$+ NSg/VB/J R/C/P NPl/V3+ .
 > I've lived here for   three years .
-# K    VP/J  J/R  R/C/P NSg   NPl+  .
+# K    VP/J  R    R/C/P NSg   NPl+  .
 > They fought for   days over    a    silly  pencil  .
 # IPl+ VP     R/C/P NPl+ NSg/J/P D/P+ NSg/J+ NSg/VB+ .
 > The store   is  closed for   the day     .
@@ -314,8 +314,8 @@
 # NPr/J/R/P NSg/VB/J P  NSg/VB/J+ NPl/V3 . NPr/VB+ VLPt NSg   R/C/P NSg  J/P D+  NPr🅪Sg+
 > At    close    of play    , England were 305 for   3 .
 # NSg/P NSg/VB/J P  N🅪Sg/VB . NPr+    VLPt #   R/C/P # .
-> He       took the swing   shift   for   he       could   get    more         overtime .
-# NPr/ISg+ VPt  D+  NSg/VB+ NSg/VB+ R/C/P NPr/ISg+ NSg/VXB NSg/VB NPr/I/J/R/Dq NSg/VB   .
+> He       took the swing   shift   for   he       could get    more         overtime .
+# NPr/ISg+ VPt  D+  NSg/VB+ NSg/VB+ R/C/P NPr/ISg+ VXB   NSg/VB NPr/I/J/R/Dq NSg/VB   .
 > to account for   one's whereabouts .
 # P  NSg/VB  R/C/P NSg$+ NSg+        .
 >
@@ -349,11 +349,11 @@
 > You    can     study  anything  from math to literature .
 # ISgPl+ NPr/VXB NSg/VB NSg/I/VB+ P    +    P  Nᴹ         .
 > It's hard     to tell   from here .
-# +    N🅪Sg/J/R P  NPr/VB P    J/R  .
+# +    N🅪Sg/J/R P  NPr/VB P    R    .
 > Try      to see    it       from his     point  of view    .
 # NSg/VB/J P  NSg/VB NPr/ISg+ P    ISg/D$+ NSg/VB P  NSg/VB+ .
-> The bomb      went     off        just 100 yards   from where   they were standing .
-# D+  NSg/VB/J+ NSg/VPt+ NSg/VB/J/P J/R  #   NPl/V3+ P    NSg/R/C IPl+ VLPt Nᴹ/Vg/J  .
+> The bomb      went off        just 100 yards   from where   they were standing .
+# D+  NSg/VB/J+ VPt+ NSg/VB/J/P J/R  #   NPl/V3+ P    NSg/R/C IPl+ VLPt Nᴹ/Vg/J  .
 > From the top      of the lighthouse you    can     just see    the mainland .
 # P    D   NSg/VB/J P  D+  NSg+       ISgPl+ NPr/VXB J/R  NSg/VB D+  NSg+     .
 > I’ve been   doing   this    from pickney .
@@ -594,8 +594,8 @@
 # NSg/I/J/C/Dq+ D+  NPl/V3+ VLB J/P . NSg/I/J/R/C IPl+ NSg/VXB NSg/VLXB NSg/VB/J+ .
 > We   had to ration our food because there was  a    war      on  .
 # IPl+ VP  P  NSg/VB D$+ NSg+ C/P     R+    VLPt D/P+ N🅪Sg/VB+ J/P .
-> Some     of the cast     went    down        with flu  , but     the show's still      on  .
-# I/J/R/Dq P  D   NSg/VB/J NSg/VPt N🅪Sg/VB/J/P P    NSg+ . NSg/C/P D   NSg$   NSg/VB/J/R J/P .
+> Some     of the cast     went down        with flu  , but     the show's still      on  .
+# I/J/R/Dq P  D   NSg/VB/J VPt  N🅪Sg/VB/J/P P    NSg+ . NSg/C/P D   NSg$   NSg/VB/J/R J/P .
 > That      TV   programme     that      you    wanted to watch  is  on  now       .
 # I/C/Ddem+ NSg+ NSg/VB/Au/Br+ I/C/Ddem+ ISgPl+ VP/J   P  NSg/VB VL3 J/P NSg/J/R/C .
 > This    is  her     last      song  . You're on  next    !
@@ -800,8 +800,8 @@
 # ISg/#r+ N🅪Sg/VXB I/J/R/Dq NPr/I/J/R/Dq NPl/V3+ P  NSg/VBP VB/C NPrPl/V3+ P  NSg/VB/J Nᴹ/Vg/J  P    .
 > If    he       hasn't read    it       yet      , he       ought     to .
 # NSg/C NPr/ISg+ V3     NSg/VBP NPr/ISg+ NSg/VB/C . NPr/ISg+ NSg/I/VXB P  .
-> I       went    to the shops   to buy    some      bread    .
-# ISg/#r+ NSg/VPt P  D+  NPl/V3+ P  NSg/VB I/J/R/Dq+ N🅪Sg/VB+ .
+> I       went to the shops   to buy    some      bread    .
+# ISg/#r+ VPt  P  D+  NPl/V3+ P  NSg/VB I/J/R/Dq+ N🅪Sg/VB+ .
 >
 #
 >              Preposition
@@ -870,8 +870,8 @@
 #
 > He       picked a   fight  with the class      bully     .
 # NPr/ISg+ VP/J   D/P NSg/VB P    D+  N🅪Sg/VB/J+ NSg/VB/J+ .
-> He       went    with his     friends   .
-# NPr/ISg+ NSg/VPt P    ISg/D$+ NPrPl/V3+ .
+> He       went with his     friends   .
+# NPr/ISg+ VPt  P    ISg/D$+ NPrPl/V3+ .
 > She  owns   a    motorcycle with a   sidecar .
 # ISg+ NPl/V3 D/P+ NSg/VB+    P    D/P NSg     .
 > Jim  was  listening to Bach with his     eyes    closed .

--- a/harper-core/tests/text/tagged/Difficult sentences.md
+++ b/harper-core/tests/text/tagged/Difficult sentences.md
@@ -888,8 +888,8 @@
 # IPl+ VLB P    ISgPl+ NSg/I/J/C/Dq D+  NSg/J+ .
 > There are a   number     of problems with your plan   .
 # R+    VLB D/P N🅪Sg/VB/JC P  NPl+     P    D$+  NSg/VB .
-> What   on  Earth    is  wrong      with my  keyboard ?
-# NSg/I+ J/P NPrᴹ/VB+ VL3 NSg/VB/J/R P    D$+ NSg/VB+  .
+> What   on  Earth      is  wrong      with my  keyboard ?
+# NSg/I+ J/P NPr🅪Sg/VB+ VL3 NSg/VB/J/R P    D$+ NSg/VB+  .
 > He       was  pleased with the outcome .
 # NPr/ISg+ VLPt VP/J    P    D+  NSg+    .
 > I’m upset    with my  father  .

--- a/harper-core/tests/text/tagged/Part-of-speech tagging.md
+++ b/harper-core/tests/text/tagged/Part-of-speech tagging.md
@@ -59,9 +59,9 @@
 >
 #
 > Correct  grammatical tagging will    reflect that      " dogs    " is  here used as    a   verb    , not
-# NSg/VB/J J           NSg/Vg  NPr/VXB VB      I/C/Ddem+ . NPl/V3+ . VL3 J/R  VP/J R/C/P D/P NSg/VB+ . NSg/R/C
-> as    the more         common   plural noun    . Grammatical context  is  one     way   to determine
-# R/C/P D   NPr/I/J/R/Dq NSg/VB/J NSg/J  NSg/VB+ . J+          N🅪Sg/VB+ VL3 NSg/I/J NSg/J P  VB
+# NSg/VB/J J           NSg/Vg  NPr/VXB VB      I/C/Ddem+ . NPl/V3+ . VL3 R    VP/J R/C/P D/P NSg/VB+ . NSg/R/C
+> as    the more         common plural noun    . Grammatical context  is  one     way   to determine
+# R/C/P D   NPr/I/J/R/Dq VB/J   NSg/J  NSg/VB+ . J+          N🅪Sg/VB+ VL3 NSg/I/J NSg/J P  VB
 > this    ; semantic analysis can     also be       used to infer that      " sailor " and  " hatch  "
 # I/Ddem+ . NSg/J+   N🅪Sg+    NPr/VXB R/C  NSg/VLXB VP/J P  VB    I/C/Ddem+ . NSg+   . VB/C . NSg/VB .
 > implicate " dogs    " as    1 ) in        the nautical context  and  2 ) an  action     applied to the
@@ -92,8 +92,8 @@
 # VB/C NSg/VB/J+ NPl+   . NPr/J/R/P I/J/R/Dq NSg/Vg  NPl+    . NSg/J     NPl         P  D   I/J
 > root    word    will    get    different parts  of speech   , resulting in        a   large number     of
 # NPr/VB+ NSg/VB+ NPr/VXB NSg/VB NSg/J     NPl/V3 P  N🅪Sg/VB+ . Nᴹ/Vg/J   NPr/J/R/P D/P NSg/J N🅪Sg/VB/JC P
-> tags    . For   example , NN for   singular common   nouns  , NNS for   plural common   nouns  , NP
-# NPl/V3+ . R/C/P NSg/VB+ . ?  R/C/P NSg/J    NSg/VB/J NPl/V3 . ?   R/C/P NSg/J  NSg/VB/J NPl/V3 . NPr
+> tags    . For   example , NN for   singular common nouns  , NNS for   plural common nouns  , NP
+# NPl/V3+ . R/C/P NSg/VB+ . ?  R/C/P NSg/J    VB/J   NPl/V3 . ?   R/C/P NSg/J  VB/J   NPl/V3 . NPr
 > for   singular proper nouns  ( see    the POS  tags    used in        the Brown       Corpus ) . Other
 # R/C/P NSg/J    NSg/J  NPl/V3 . NSg/VB D   NSg+ NPl/V3+ VP/J NPr/J/R/P D   NPr🅪Sg/VB/J NSg+   . . NSg/VB/J
 > tagging systems use     a   smaller number     of tags    and  ignore fine     differences or
@@ -114,8 +114,8 @@
 # ?               NSg        NPr/J/R/P D   NPr🅪Sg/VB P  ?               NPr/VB/J NPl+      VL3
 > commonly expressed using   very short      mnemonics , such  as    Ncmsan for   Category = Noun    ,
 # R        VP/J      Nᴹ/Vg/J J/R  NPr/VB/J/P NPl       . NSg/I R/C/P ?      R/C/P NSg+     . NSg/VB+ .
-> Type    = common   , Gender     = masculine , Number      = singular , Case       = accusative , Animate
-# NSg/VB+ . NSg/VB/J . N🅪Sg/VB/J+ . NSg/J     . N🅪Sg/VB/JC+ . NSg/J    . NPr🅪Sg/VB+ . NSg/J      . VB/J
+> Type    = common , Gender     = masculine , Number      = singular , Case       = accusative , Animate
+# NSg/VB+ . VB/J   . N🅪Sg/VB/J+ . NSg/J     . N🅪Sg/VB/JC+ . NSg/J    . NPr🅪Sg/VB+ . NSg/J      . VB/J
 > = no       .
 # . NSg/Dq/P .
 >
@@ -184,8 +184,8 @@
 # D+  NPr🅪Sg/VB/J+ NSg+   VLPt R             . VP/J   . P    NSg/VB/J+ . P  . N🅪Sg/VB+ NPl/V3  NSg/J/P
 > many        years . A    first  approximation was  done      with a    program by Greene and  Rubin ,
 # NSg/I/J/Dq+ NPl+  . D/P+ NSg/J+ N🅪Sg+         VLPt NSg/VPp/J P    D/P+ NPr/VB+ P  NPr    VB/C NPr   .
-> which consisted of a   huge handmade list   of what   categories could   co     - occur at
-# I/C+  VP/J      P  D/P J    NSg/J    NSg/VB P  NSg/I+ NPl+       NSg/VXB NPr/I+ . VB    NSg/P
+> which consisted of a   huge handmade list   of what   categories could co     - occur at
+# I/C+  VP/J      P  D/P J    NSg/J    NSg/VB P  NSg/I+ NPl+       VXB   NPr/I+ . VB    NSg/P
 > all          . For   example , article then      noun    can     occur , but     article then      verb    ( arguably )
 # NSg/I/J/C/Dq . R/C/P NSg/VB+ . NSg/VB+ NSg/J/R/C NSg/VB+ NPr/VXB VB    . NSg/C/P NSg/VB+ NSg/J/R/C NSg/VB+ . R        .
 > cannot  . The program got about 70 % correct  . Its     results were repeatedly reviewed
@@ -278,12 +278,12 @@
 #
 > Eugene Charniak points  out          in        Statistical techniques for   natural language
 # NPr+   ?        NPl/V3+ NSg/VB/J/R/P NPr/J/R/P J           NPl        R/C/P NSg/J+  N🅪Sg+
-> parsing ( 1997 ) that      merely assigning the most         common   tag     to each known word    and
-# Nᴹ/Vg/J . #    . I/C/Ddem+ R      Nᴹ/Vg/J   D   NSg/I/J/R/Dq NSg/VB/J NSg/VB+ P  Dq   VPp/J NSg/VB+ VB/C
+> parsing ( 1997 ) that      merely assigning the most         common tag     to each known word    and
+# Nᴹ/Vg/J . #    . I/C/Ddem+ R      Nᴹ/Vg/J   D   NSg/I/J/R/Dq VB/J   NSg/VB+ P  Dq   VPp/J NSg/VB+ VB/C
 > the tag     " proper noun    " to all          unknowns will    approach 90 % accuracy because many
 # D   NSg/VB+ . NSg/J  NSg/VB+ . P  NSg/I/J/C/Dq NPl/V3+  NPr/VXB N🅪Sg/VB+ #  . N🅪Sg+    C/P     NSg/I/J/Dq
 > words   are unambiguous , and  many       others  only  rarely represent their less    - common
-# NPl/V3+ VLB J           . VB/C NSg/I/J/Dq NPl/V3+ J/R/C R      VB        D$+   J/R/C/P . NSg/VB/J
+# NPl/V3+ VLB J           . VB/C NSg/I/J/Dq NPl/V3+ J/R/C R      VB        D$+   J/R/C/P . VB/J
 > parts  of speech   .
 # NPl/V3 P  N🅪Sg/VB+ .
 >
@@ -346,8 +346,8 @@
 # ?        VB/C NPr$     NPl+    VXPt NSg/VB/J R/C/P I/J/R/Dq P  D   VPp/J NPl/V3+ NSg/R/C
 > semantics is  required , but     those  proved negligibly rare     . This   convinced many       in
 # NPl+      VL3 VP/J     . NSg/C/P I/Ddem VP/J   R          NSg/VB/J . I/Ddem VP/J      NSg/I/J/Dq NPr/J/R/P
-> the field   that      part      - of - speech   tagging could   usefully be       separated from the other
-# D+  NSg/VB+ I/C/Ddem+ NSg/VB/J+ . P  . N🅪Sg/VB+ NSg/Vg  NSg/VXB R        NSg/VLXB VP/J      P    D   NSg/VB/J
+> the field   that      part      - of - speech   tagging could usefully be       separated from the other
+# D+  NSg/VB+ I/C/Ddem+ NSg/VB/J+ . P  . N🅪Sg/VB+ NSg/Vg  VXB   R        NSg/VLXB VP/J      P    D   NSg/VB/J
 > levels of processing ; this    , in        turn   , simplified the theory and  practice of
 # NPl/V3 P  Nᴹ/Vg/J+   . I/Ddem+ . NPr/J/R/P NSg/VB . VP/J       D   N🅪Sg   VB/C NSg/VB   P
 > computerized language analysis and  encouraged researchers to find   ways to
@@ -429,7 +429,7 @@
 > this   particular dataset ) . Thus , it       should not     be       assumed that     the results
 # I/Ddem NSg/J      NSg     . . NSg  . NPr/ISg+ VXB    NSg/R/C NSg/VLXB VP/J    I/C/Ddem D+  NPl/V3+
 > reported here are the best       that      can     be       achieved with a    given        approach ; nor   even
-# VP/J     J/R  VLB D   NPr/VXB/JS I/C/Ddem+ NPr/VXB NSg/VLXB VP/J     P    D/P+ NSg/VPp/J/P+ N🅪Sg/VB+ . NSg/C NSg/VB/J/R
+# VP/J     R    VLB D   NPr/VXB/JS I/C/Ddem+ NPr/VXB NSg/VLXB VP/J     P    D/P+ NSg/VPp/J/P+ N🅪Sg/VB+ . NSg/C NSg/VB/J/R
 > the best        that      have    been   achieved with a    given        approach .
 # D+  NPr/VXB/JS+ I/C/Ddem+ NSg/VXB VLPp/B VP/J     P    D/P+ NSg/VPp/J/P+ N🅪Sg/VB+ .
 >

--- a/harper-core/tests/text/tagged/The Constitution of the United States.md
+++ b/harper-core/tests/text/tagged/The Constitution of the United States.md
@@ -1389,7 +1389,7 @@
 > Purposes , as    Part     of this   Constitution , when    ratified by the Legislatures of
 # NPl/V3+  . R/C/P NSg/VB/J P  I/Ddem NPr+         . NSg/I/C VP/J     P  D   NPl          P
 > three fourths of the several States    , or    by Conventions in        three fourths
-# NSg   NSg     P  D   J/Dq    NPrPl/V3+ . NPr/C P  NPl+        NPr/J/R/P NSg   NSg
+# NSg   NPl     P  D   J/Dq    NPrPl/V3+ . NPr/C P  NPl+        NPr/J/R/P NSg   NPl
 > thereof , as    the one      or    the other    Mode of Ratification may     be       proposed by the
 # R       . R/C/P D   NSg/I/J+ NPr/C D   NSg/VB/J NSg  P  NSg+         NPr/VXB NSg/VLXB VP/J     P  D
 > Congress ; Provided that     no       Amendment which may     be       made prior to the Year One

--- a/harper-core/tests/text/tagged/The Constitution of the United States.md
+++ b/harper-core/tests/text/tagged/The Constitution of the United States.md
@@ -6,8 +6,8 @@
 #
 > We   the People of the United States    , in        Order    to form    a   more         perfect   Union     ,
 # IPl+ D   NPl/VB P  D+  VP/J   NPrPl/V3+ . NPr/J/R/P N🅪Sg/VB+ P  N🅪Sg/VB D/P NPr/I/J/R/Dq NSg/VB/J+ NPr/VB/J+ .
-> establish Justice , insure domestic Tranquility , provide for   the common   defence    ,
-# VB        NPr🅪Sg+ . VB     NSg/J    NSg         . VB      R/C/P D   NSg/VB/J N🅪Sg/Comm+ .
+> establish Justice , insure domestic Tranquility , provide for   the common defence    ,
+# VB        NPr🅪Sg+ . VB     NSg/J    NSg         . VB      R/C/P D   VB/J   N🅪Sg/Comm+ .
 > promote the general  Welfare , and  secure the Blessings of Liberty to ourselves
 # NSg/VB  D   NSg/VB/J Nᴹ/VB+  . VB/C VB/J   D   NPl/V3    P  NSg+    P  IPl+
 > and  our Posterity , do  ordain and  establish this   Constitution for   the United
@@ -390,8 +390,8 @@
 #
 > The Congress shall have    Power      To lay        and  collect  Taxes   , Duties ,
 # D+  NPr+     VXB   NSg/VXB N🅪Sg/VB/J+ P  NSg/VBPt/J VB/C NSg/VB/J NPl/V3+ . NPl+   .
-> Imposts and  Excises , to pay      the Debts and  provide for   the common   Defence    and
-# NPl     VB/C NPl/V3  . P  NSg/VB/J D   NPl+  VB/C VB      R/C/P D   NSg/VB/J N🅪Sg/Comm+ VB/C
+> Imposts and  Excises , to pay      the Debts and  provide for   the common Defence    and
+# NPl     VB/C NPl/V3  . P  NSg/VB/J D   NPl+  VB/C VB      R/C/P D   VB/J   N🅪Sg/Comm+ VB/C
 > general  Welfare of the United States    ; but     all          Duties , Imposts and  Excises shall
 # NSg/VB/J Nᴹ/VB   P  D   VP/J   NPrPl/V3+ . NSg/C/P NSg/I/J/C/Dq NPl+   . NPl     VB/C NPl/V3  VXB
 > be       uniform  throughout the United States    ;
@@ -646,8 +646,8 @@
 # Nᴹ/Vg/J I/R/Dq NSg/VB P  N🅪Sg/VBP/J+ NPr/C N🅪Sg/VB/J NSg/J/P NSg/IPl+ . VXB   . C/P     D   N🅪Sg/VP P
 > the Congress , accept   of any    present  , Emolument , Office  , or    Title   , of any    kind
 # D   NPr+     . NSg/VB/J P  I/R/Dq NSg/VB/J . NSg       . NSg/VB+ . NPr/C NSg/VB+ . P  I/R/Dq NSg/J+
-> whatever , from any    King      , Prince    , or    foreign State    .
-# NSg/I/J+ . P    I/R/Dq NPr/VB/J+ . NPr/VB/J+ . NPr/C NSg/J   N🅪Sg/VB+ .
+> whatever , from any    King    , Prince    , or    foreign State    .
+# NSg/I/J+ . P    I/R/Dq NPr/VB+ . NPr/VB/J+ . NPr/C NSg/J   N🅪Sg/VB+ .
 >
 #
 > The right    of citizens of the United States    to vote   in        any    primary  or    other
@@ -1226,14 +1226,14 @@
 # NSg/VB+ R/C/P ISg/D$+ N🅪Sg/VB/Am+ .
 >
 #
-> In        suits  at    common    law      , where   the value    in        controversy shall exceed twenty
-# NPr/J/R/P NPl/V3 NSg/P NSg/VB/J+ N🅪Sg/VB+ . NSg/R/C D   N🅪Sg/VB+ NPr/J/R/P N🅪Sg+       VXB   VB     NSg+
+> In        suits  at    common law      , where   the value    in        controversy shall exceed twenty
+# NPr/J/R/P NPl/V3 NSg/P VB/J+  N🅪Sg/VB+ . NSg/R/C D   N🅪Sg/VB+ NPr/J/R/P N🅪Sg+       VXB   VB     NSg+
 > dollars , the right    of trial     by jury      shall be       preserved , and  no        fact tried by a
 # NPl+    . D   NPr/VB/J P  NSg/VB/J+ P  NSg/VB/J+ VXB   NSg/VLXB VP/J      . VB/C NSg/Dq/P+ NSg+ VP/J  P  D/P+
 > jury      , shall be       otherwise reexamined in        any    court     of the United States    , than
 # NSg/VB/J+ . VXB   NSg/VLXB J/R/C     VP/J       NPr/J/R/P I/R/Dq N🅪Sg/VB/J P  D   VP/J   NPrPl/V3+ . C/P
-> according to the rules  of the common   law      .
-# Nᴹ/Vg/J   P  D   NPl/V3 P  D   NSg/VB/J N🅪Sg/VB+ .
+> according to the rules  of the common law      .
+# Nᴹ/Vg/J   P  D   NPl/V3 P  D   VB/J   N🅪Sg/VB+ .
 >
 #
 > Excessive bail    shall not     be       required , nor   excessive fines  imposed , nor   cruel

--- a/harper-core/tests/text/tagged/The Great Gatsby.md
+++ b/harper-core/tests/text/tagged/The Great Gatsby.md
@@ -1039,7 +1039,7 @@
 >
 #
 > “ You    see    I       think  everything’s terrible anyhow , ” she  went on  in        a   convinced way    .
-# . ISgPl+ NSg/VB ISg/#r+ NSg/VB NSg$         J        J      . . ISg+ VPt  J/P NPr/J/R/P D/P VP/J      NSg/J+ .
+# . ISgPl+ NSg/VB ISg/#r+ NSg/VB NSg$         J        R      . . ISg+ VPt  J/P NPr/J/R/P D/P VP/J      NSg/J+ .
 > “ Everybody thinks so          — the most         advanced people  . And  I       know . I’ve been   everywhere
 # . NSg/I+    NPl/V3 NSg/I/J/R/C . D   NSg/I/J/R/Dq VP/J+    NPl/VB+ . VB/C ISg/#r+ VB   . K    VLPp/B Nᴹ/R
 > and  seen    everything and  done      everything . ” Her     eyes    flashed around her     in        a
@@ -3011,7 +3011,7 @@
 >
 #
 > “ Anyhow , he       gives  large  parties , ” said Jordan , changing the subject   with an
-# . J      . NPr/ISg+ NPl/V3 NSg/J+ NPl/V3+ . . VP/J NPr+   . Nᴹ/Vg/J  D   NSg/VB/J+ P    D/P
+# . R      . NPr/ISg+ NPl/V3 NSg/J+ NPl/V3+ . . VP/J NPr+   . Nᴹ/Vg/J  D   NSg/VB/J+ P    D/P
 > urban distaste for   the concrete   . “ And  I       like         large  parties . They’re so          intimate .
 # NPr/J NSg/VB   R/C/P D+  N🅪Sg/VB/J+ . . VB/C ISg/#r+ NSg/VB/J/C/P NSg/J+ NPl/V3+ . K       NSg/I/J/R/C NSg/VB/J .
 > At    small     parties there isn’t   any     privacy . ”
@@ -3877,7 +3877,7 @@
 > “ Look   here , old    sport   , ” he       broke     out          surprisingly , “ what’s your opinion of me       ,
 # . NSg/VB R    . NSg/J+ NSg/VB+ . . NPr/ISg+ NSg/VPt/J NSg/VB/J/R/P R            . . K      D$+  N🅪Sg    P  NPr/ISg+ .
 > anyhow ? ”
-# J      . .
+# R      . .
 >
 #
 > A    little      overwhelmed , I       began the generalized evasions which that     question
@@ -4471,7 +4471,7 @@
 >
 #
 > “ Who    is  he       , anyhow , an   actor ? ”
-# . NPr/I+ VL3 NPr/ISg+ . J      . D/P+ NSg+  . .
+# . NPr/I+ VL3 NPr/ISg+ . R      . D/P+ NSg+  . .
 >
 #
 > “ No       . ”
@@ -4551,7 +4551,7 @@
 >
 #
 > “ How’ve you    been   , anyhow ? ” demanded Tom    of me       . “ How’d you    happen to come       up         this
-# . ?      ISgPl+ VLPp/B . J      . . VP/J     NPr/VB P  NPr/ISg+ . . K     ISgPl+ VB     P  NSg/VBPp/P NSg/VB/J/P I/Ddem
+# . ?      ISgPl+ VLPp/B . R      . . VP/J     NPr/VB P  NPr/ISg+ . . K     ISgPl+ VB     P  NSg/VBPp/P NSg/VB/J/P I/Ddem
 > far      to eat ? ”
 # NSg/VB/J P  VB  . .
 >
@@ -6267,7 +6267,7 @@
 > He       was  profoundly affected by the fact that      Tom     was  there . But     he       would be
 # NPr/ISg+ VLPt R          NSg/VP/J P  D+  NSg+ I/C/Ddem+ NPr/VB+ VLPt R     . NSg/C/P NPr/ISg+ VXB   NSg/VLXB
 > uneasy   anyhow until he       had given       them     something , realizing         in        a    vague     way    that
-# NSg/VB/J J      C/P   NPr/ISg+ VP  NSg/VPp/J/P NSg/IPl+ NSg/I/J+  . Nᴹ/Vg/J/Comm/NoAm NPr/J/R/P D/P+ NSg/VB/J+ NSg/J+ I/C/Ddem+
+# NSg/VB/J R      C/P   NPr/ISg+ VP  NSg/VPp/J/P NSg/IPl+ NSg/I/J+  . Nᴹ/Vg/J/Comm/NoAm NPr/J/R/P D/P+ NSg/VB/J+ NSg/J+ I/C/Ddem+
 > that      was  all          they came      for   . Mr   . Sloane wanted nothing  . A    lemonade ? No       , thanks  . A
 # I/C/Ddem+ VLPt NSg/I/J/C/Dq IPl+ NSg/VPt/P R/C/P . NSg+ . NPr    VP/J   NSg/I/J+ . D/P+ N🅪Sg+    . NSg/Dq/P . NPl/V3+ . D/P+
 > little      champagne  ? Nothing  at    all          , thanks  . . . . I’m sorry    — — —
@@ -6571,7 +6571,7 @@
 >
 #
 > “ Well       , I       liked him  anyhow . ”
-# . NSg/VB/J/R . ISg/#r+ VP/J  ISg+ J      . .
+# . NSg/VB/J/R . ISg/#r+ VP/J  ISg+ R      . .
 >
 #
 > “ I’d a   little     rather     not     be       the polo  player , ” said Tom     pleasantly , “ I’d rather
@@ -6721,7 +6721,7 @@
 >
 #
 > “ Who    is  this   Gatsby anyhow ? ” demanded Tom     suddenly . “ Some     big   bootlegger ? ”
-# . NPr/I+ VL3 I/Ddem NPr    J      . . VP/J     NPr/VB+ R        . . I/J/R/Dq NSg/J NSg        . .
+# . NPr/I+ VL3 I/Ddem NPr    R      . . VP/J     NPr/VB+ R        . . I/J/R/Dq NSg/J NSg        . .
 >
 #
 > “ Where’d you    hear that      ? ” I       inquired .
@@ -7491,7 +7491,7 @@
 >
 #
 > “ Come       on  ! ” His     temper     cracked a   little     . “ What’s the matter   , anyhow ? If    we’re
-# . NSg/VBPp/P J/P . . ISg/D$+ NSg/VB/JC+ VP/J    D/P NPr/I/J/Dq . . K      D+  N🅪Sg/VB+ . J      . NSg/C K
+# . NSg/VBPp/P J/P . . ISg/D$+ NSg/VB/JC+ VP/J    D/P NPr/I/J/Dq . . K      D+  N🅪Sg/VB+ . R      . NSg/C K
 > going   to town , let’s start  . ”
 # Nᴹ/Vg/J P  NSg  . NSg$  NSg/VB . .
 >
@@ -8277,7 +8277,7 @@
 >
 #
 > “ What   kind  of a    row     are you    trying  to cause     in        my  house   anyhow ? ”
-# . NSg/I+ NSg/J P  D/P+ NSg/VB+ VLB ISgPl+ Nᴹ/Vg/J P  N🅪Sg/VB/C NPr/J/R/P D$+ NPr/VB+ J      . .
+# . NSg/I+ NSg/J P  D/P+ NSg/VB+ VLB ISgPl+ Nᴹ/Vg/J P  N🅪Sg/VB/C NPr/J/R/P D$+ NPr/VB+ R      . .
 >
 #
 > They were out          in        the open     at    last     and  Gatsby was  content    .
@@ -8597,7 +8597,7 @@
 >
 #
 > “ Who    are you    , anyhow ? ” broke     out          Tom     . “ You’re one     of that     bunch   that      hangs
-# . NPr/I+ VLB ISgPl+ . J      . . NSg/VPt/J NSg/VB/J/R/P NPr/VB+ . . K      NSg/I/J P  I/C/Ddem NSg/VB+ I/C/Ddem+ NPl/V3
+# . NPr/I+ VLB ISgPl+ . R      . . NSg/VPt/J NSg/VB/J/R/P NPr/VB+ . . K      NSg/I/J P  I/C/Ddem NSg/VB+ I/C/Ddem+ NPl/V3
 > around with Meyer Wolfshiem — that      much         I       happen to know . I’ve made a   little
 # J/P    P    NPr   ?         . I/C/Ddem+ NSg/I/J/R/Dq ISg/#r+ VB     P  VB   . K    VP   D/P NPr/I/J/Dq
 > investigation into your affairs — and  I’ll carry  it       further to - morrow . ”
@@ -9355,7 +9355,7 @@
 >
 #
 > “ Don’t tell   me       , old   sport   . ” He       winced . “ Anyhow — Daisy stepped on  it       . I       tried to
-# . VXB   NPr/VB NPr/ISg+ . NSg/J NSg/VB+ . . NPr/ISg+ VP/J   . . J      . NPr+  J       J/P NPr/ISg+ . ISg/#r+ VP/J  P
+# . VXB   NPr/VB NPr/ISg+ . NSg/J NSg/VB+ . . NPr/ISg+ VP/J   . . R      . NPr+  J       J/P NPr/ISg+ . ISg/#r+ VP/J  P
 > make   her     stop   , but     she  couldn’t , so          I       pulled on  the emergency brake  . Then      she
 # NSg/VB ISg/D$+ NSg/VB . NSg/C/P ISg+ VXB      . NSg/I/J/R/C ISg/#r+ VP/J   J/P D   N🅪Sg+     NSg/VB . NSg/J/R/C ISg+
 > fell      over    into my  lap       and  I       drove   on  .
@@ -9385,7 +9385,7 @@
 >
 #
 > “ All           night    , if    necessary . Anyhow , till       they all          go       to bed       . ”
-# . NSg/I/J/C/Dq+ N🅪Sg/VB+ . NSg/C NSg/J     . J      . NSg/VB/C/P IPl+ NSg/I/J/C/Dq NSg/VB/J P  NSg/VBP/J . .
+# . NSg/I/J/C/Dq+ N🅪Sg/VB+ . NSg/C NSg/J     . R      . NSg/VB/C/P IPl+ NSg/I/J/C/Dq NSg/VB/J P  NSg/VBP/J . .
 >
 #
 > A   new   point  of view    occurred to me       . Suppose Tom     found  out          that     Daisy had been

--- a/harper-core/tests/text/tagged/The Great Gatsby.md
+++ b/harper-core/tests/text/tagged/The Great Gatsby.md
@@ -1262,8 +1262,8 @@
 # NPr🅪Sg/VB+ NSg/VB NPr/J/R/P D   NSg/VB+ . D+  N🅪Sg/VB+ VP  VPp/J NSg/VB/J/P . Nᴹ/Vg/J D/P NSg/J . NPr/VB/J N🅪Sg/VB+ .
 > with wings   beating in        the trees   and  a   persistent organ  sound      as    the full     bellows
 # P    NPl/V3+ Nᴹ/Vg/J NPr/J/R/P D+  NPl/V3+ VB/C D/P J          NSg/VB N🅪Sg/VB/J+ R/C/P D   NSg/VB/J NPl/V3
-> of the earth    blew      the frogs  full     of life     . The silhouette of a    moving  cat       wavered
-# P  D   NPrᴹ/VB+ NSg/VPt/J D   NPl/V3 NSg/VB/J P  N🅪Sg/VB+ . D   NSg/VB     P  D/P+ Nᴹ/Vg/J NSg/VB/J+ VP/J
+> of the earth      blew      the frogs  full     of life     . The silhouette of a    moving  cat       wavered
+# P  D   NPr🅪Sg/VB+ NSg/VPt/J D   NPl/V3 NSg/VB/J P  N🅪Sg/VB+ . D   NSg/VB     P  D/P+ Nᴹ/Vg/J NSg/VB/J+ VP/J
 > across the moonlight , and  turning my  head      to watch  it       , I       saw     that     I       was  not
 # NSg/P  D+  N🅪Sg/VB+  . VB/C Nᴹ/Vg/J D$+ NPr/VB/J+ P  NSg/VB NPr/ISg+ . ISg/#r+ NSg/VPt I/C/Ddem ISg/#r+ VLPt NSg/R/C
 > alone — fifty feet away a    figure  had emerged from the shadow   of my  neighbor’s
@@ -2390,8 +2390,8 @@
 # NSg/P   NPl+  NPr/I+ R     VPt  Dq   NSg$    NPl/V3+ .
 >
 #
-> The lights  grow brighter as    the earth    lurches away from the sun     , and  now       the
-# D+  NPl/V3+ VB   NSg/JC   R/C/P D+  NPrᴹ/VB+ NPl/V3  VB/J P    D   NPr/VB+ . VB/C NSg/J/R/C D
+> The lights  grow brighter as    the earth      lurches away from the sun     , and  now       the
+# D+  NPl/V3+ VB   NSg/JC   R/C/P D+  NPr🅪Sg/VB+ NPl/V3  VB/J P    D   NPr/VB+ . VB/C NSg/J/R/C D
 > orchestra is  playing yellow   cocktail  music      , and  the opera of voices  pitches a
 # NSg+      VL3 Nᴹ/Vg/J NSg/VB/J NSg/VB/J+ N🅪Sg/VB/J+ . VB/C D   NSg   P  NPl/V3+ NPl/V3+ D/P
 > key      higher . Laughter is  easier minute   by minute    , spilled with prodigality ,
@@ -5681,7 +5681,7 @@
 > vivid with new   flowers   , through dressing - rooms   and  poolrooms , and  bathrooms with
 # NSg/J P    NSg/J NPrPl/V3+ . J/P     Nᴹ/Vg/J+ . NPl/V3+ VB/C NPl       . VB/C NPl/V3+   P
 > sunken baths   — intruding into one     chamber where   a   dishevelled man     in        pajamas was
-# VPp/J  NSg/VB+ . Nᴹ/Vg/J   P    NSg/I/J NSg/VB+ NSg/R/C D/P VP/J/Comm   NPr/VB+ NPr/J/R/P NPl     VLPt
+# VPp/J  NPl/V3+ . Nᴹ/Vg/J   P    NSg/I/J NSg/VB+ NSg/R/C D/P VP/J/Comm   NPr/VB+ NPr/J/R/P NPl     VLPt
 > doing   liver   exercises on  the floor   . It       was  Mr   . Klipspringer , the ‘ ‘ boarder . ” I
 # Nᴹ/Vg/J N🅪Sg/J+ NPl/V3+   J/P D   NSg/VB+ . NPr/ISg+ VLPt NSg+ . ?            . D   . . NSg+    . . ISg/#r+
 > had seen    him  wandering hungrily about the beach   that      morning    . Finally we   came      to
@@ -7595,7 +7595,7 @@
 > Tom     came      out          of the house   wrapping a    quart     bottle  in        a    towel   , followed by Daisy
 # NPr/VB+ NSg/VPt/P NSg/VB/J/R/P P  D+  NPr/VB+ N🅪Sg/Vg+ D/P+ NSg/VB/J+ NSg/VB+ NPr/J/R/P D/P+ NSg/VB+ . VP/J     P  NPr
 > and  Jordan wearing small    tight hats   of metallic cloth and  carrying light      capes
-# VB/C NPr+   Nᴹ/Vg/J NPr/VB/J VB/J  NPl/V3 P  NSg/J+   NSg+  VB/C Nᴹ/Vg/J  N🅪Sg/VB/J+ NPl/V3+
+# VB/C NPr+   Nᴹ/Vg/J NPr/VB/J VB/J  NPl/V3 P  NSg/J+   N🅪Sg+ VB/C Nᴹ/Vg/J  N🅪Sg/VB/J+ NPl/V3+
 > over    their arms    .
 # NSg/J/P D$+   NPl/V3+ .
 >
@@ -7999,7 +7999,7 @@
 > of sweat    raced cool     across my  back     . The notion originated with Daisy’s
 # P  N🅪Sg/VB+ VP/J  NSg/VB/J NSg/P  D$+ NSg/VB/J . D+  NSg+   VP/J       P    NPr$
 > suggestion that      we   hire   five bathrooms and  take   cold  baths   , and  then      assumed
-# N🅪Sg+      I/C/Ddem+ IPl+ NSg/VB NSg  NPl/V3+   VB/C NSg/VB NSg/J NSg/VB+ . VB/C NSg/J/R/C VP/J
+# N🅪Sg+      I/C/Ddem+ IPl+ NSg/VB NSg  NPl/V3+   VB/C NSg/VB NSg/J NPl/V3+ . VB/C NSg/J/R/C VP/J
 > more         tangible form     as    “ a   place    to have    a   mint     julep . ” Each of us       said over    and
 # NPr/I/J/R/Dq NSg/J    N🅪Sg/VB+ R/C/P . D/P N🅪Sg/VB+ P  NSg/VXB D/P NSg/VB/J NSg   . . Dq   P  NPr/IPl+ VP/J NSg/J/P VB/C
 > over    that     it       was  a   “ crazy idea ” — we   all           talked at    once  to a   baffled clerk   and
@@ -11598,8 +11598,8 @@
 # ISg/D$+ N🅪Sg/VB . NSg/I/J+ N🅪Sg/VB+ ISg/#r+ VXPt VB   D/P+ N🅪Sg/VB/J+ NSg+ R     . VB/C NSg/VPt ISg/D$+ NPl/V3+ NSg/VB NSg/P
 > his     front     steps   . But     I       didn’t investigate . Probably it       was  some     final    guest  who
 # ISg/D$+ NSg/VB/J+ NPl/V3+ . NSg/C/P ISg/#r+ VXPt   VB          . R        NPr/ISg+ VLPt I/J/R/Dq NSg/VB/J NSg/VB NPr/I+
-> had been   away at    the ends   of the earth    and  didn’t know that     the party     was  over    .
-# VP  VLPp/B VB/J NSg/P D   NPl/V3 P  D+  NPrᴹ/VB+ VB/C VXPt   VB   I/C/Ddem D   NSg/VB/J+ VLPt NSg/J/P .
+> had been   away at    the ends   of the earth      and  didn’t know that     the party     was  over    .
+# VP  VLPp/B VB/J NSg/P D   NPl/V3 P  D+  NPr🅪Sg/VB+ VB/C VXPt   VB   I/C/Ddem D   NSg/VB/J+ VLPt NSg/J/P .
 >
 #
 > On  the last      night    , with my  trunk   packed and  my  car  sold   to the grocer , I       went

--- a/harper-core/tests/text/tagged/The Great Gatsby.md
+++ b/harper-core/tests/text/tagged/The Great Gatsby.md
@@ -101,7 +101,7 @@
 > tradition that      we’re descended from the Dukes  of Buccleuch , but     the actual
 # N🅪Sg/VB+  I/C/Ddem+ K     VP/J      P    D   NPl/V3 P  ?         . NSg/C/P D   NSg/J
 > founder of my  line    was  my  grandfather’s brother   , who    came      here in        fifty - one     ,
-# NSg/VB  P  D$+ NSg/VB+ VLPt D$+ NSg$          NSg/VB/J+ . NPr/I+ NSg/VPt/P J/R  NPr/J/R/P NSg   . NSg/I/J .
+# NSg/VB  P  D$+ NSg/VB+ VLPt D$+ NSg$          NSg/VB/J+ . NPr/I+ NSg/VPt/P R    NPr/J/R/P NSg   . NSg/I/J .
 > sent   a   substitute to the Civil War      , and  started the wholesale hardware business
 # NSg/VP D/P NSg/VB+    P  D   J     N🅪Sg/VB+ . VB/C VP/J    D   NSg/VB/J  Nᴹ+      N🅪Sg/J+
 > that      my  father  carries on  to - day     .
@@ -124,8 +124,8 @@
 # VP/J   NSg/VB/J/C/P D   VP/J   NSg/VB P  D   NPr+     . NSg/I/J/R/C ISg/#r+ NSg/VP/J P  NSg/VB/J NPr/J+ VB/C NSg/VB
 > the bond      business . Everybody I       knew was  in        the bond      business , so          I       supposed it
 # D   NPr/VB/J+ N🅪Sg/J+  . NSg/I+    ISg/#r+ VPt  VLPt NPr/J/R/P D+  NPr/VB/J+ N🅪Sg/J+  . NSg/I/J/R/C ISg/#r+ VP/J     NPr/ISg+
-> could   support  one     more         single    man     . All          my  aunts and  uncles talked it       over    as    if
-# NSg/VXB N🅪Sg/VB+ NSg/I/J NPr/I/J/R/Dq NSg/VB/J+ NPr/VB+ . NSg/I/J/C/Dq D$+ NPl   VB/C NPl/V3 VP/J   NPr/ISg+ NSg/J/P R/C/P NSg/C
+> could support  one     more         single    man     . All          my  aunts and  uncles talked it       over    as    if
+# VXB   N🅪Sg/VB+ NSg/I/J NPr/I/J/R/Dq NSg/VB/J+ NPr/VB+ . NSg/I/J/C/Dq D$+ NPl   VB/C NPl/V3 VP/J   NPr/ISg+ NSg/J/P R/C/P NSg/C
 > they were choosing a   prep   school   for   me       , and  finally said , “ Why    — ye       - es    , ” with
 # IPl+ VLPt Nᴹ/Vg/J  D/P Nᴹ/VB+ N🅪Sg/VB+ R/C/P NPr/ISg+ . VB/C R       VP/J . . NSg/VB . NSg/I/D+ . NPrPl . . P
 > very grave     , hesitant faces   . Father  agreed to finance me       for   a    year , and  after
@@ -144,8 +144,8 @@
 # VP/J    NSg/VB/J/C/P D/P NSg/J NSg+ . NPr/ISg+ NSg/VP D+  NPr/VB+ . D/P ?             Nᴹ/J+
 > bungalow at    eighty a   month  , but     at    the last     minute    the firm      ordered him  to
 # NSg      NSg/P NSg    D/P NSg/J+ . NSg/C/P NSg/P D   NSg/VB/J NSg/VB/J+ D   NSg/VB/J+ VP/J    ISg+ P
-> Washington , and  I       went    out          to the country alone . I       had a    dog       — at    least    I       had him
-# NPr+       . VB/C ISg/#r+ NSg/VPt NSg/VB/J/R/P P  D   NSg/J+  J     . ISg/#r+ VP  D/P+ NSg/VB/J+ . NSg/P NSg/J/Dq ISg/#r+ VP  ISg+
+> Washington , and  I       went out          to the country alone . I       had a    dog       — at    least    I       had him
+# NPr+       . VB/C ISg/#r+ VPt  NSg/VB/J/R/P P  D   NSg/J+  J     . ISg/#r+ VP  D/P+ NSg/VB/J+ . NSg/P NSg/J/Dq ISg/#r+ VP  ISg+
 > for   a    few       days until he       ran away — and  an  old   Dodge    and  a    Finnish woman   , who    made
 # R/C/P D/P+ NSg/I/Dq+ NPl+ C/P   NPr/ISg+ VPt VB/J . VB/C D/P NSg/J NPr/VB/J VB/C D/P+ NSg/J+  NSg/VB+ . NPr/I+ VP
 > my  bed        and  cooked breakfast and  muttered Finnish wisdom to herself over    the
@@ -287,7 +287,7 @@
 > Why    they came      East   I       don’t know . They had spent a   year in        France for   no
 # NSg/VB IPl+ NSg/VPt/P NPr/J+ ISg/#r+ VXB   VB   . IPl+ VP  VP/J  D/P NSg+ NPr/J/R/P NPr+   R/C/P NSg/Dq/P+
 > particular reason   , and  then      drifted here and  there unrestfully wherever people
-# NSg/J+     N🅪Sg/VB+ . VB/C NSg/J/R/C VP/J    J/R  VB/C R+    R           C        NPl/VB+
+# NSg/J+     N🅪Sg/VB+ . VB/C NSg/J/R/C VP/J    R    VB/C R+    R           C        NPl/VB+
 > played polo  and  were rich     together . This    was  a   permanent move   , said Daisy over
 # VP/J   NPrᴹ+ VB/C VLPt NPr/VB/J J        . I/Ddem+ VLPt D/P NSg/J     NSg/VB . VP/J NPr+  NSg/J/P
 > the telephone , but     I       didn’t believe it       — I       had no       sight    into Daisy’s heart    , but     I
@@ -328,10 +328,10 @@
 # J+       NPl/V3+ VP  VP/J        Nᴹ+       NSg/J/P ISg/D$+ NSg/VB+ VB/C VPt  ISg+ D
 > appearance of always leaning aggressively forward  . Not     even       the effeminate swank
 # NSg        P  R      Nᴹ/Vg/J R            NSg/VB/J . NSg/R/C NSg/VB/J/R D   NSg/VB/J   NSg/VB/J
-> of his     riding   clothes could   hide   the enormous power     of that     body    — he       seemed to
-# P  ISg/D$+ Nᴹ/Vg/J+ NPl/V3+ NSg/VXB NSg/VB D   J        N🅪Sg/VB/J P  I/C/Ddem NSg/VB+ . NPr/ISg+ VP/J   P
-> fill   those  glistening boots   until he       strained the top       lacing  , and  you    could   see
-# NSg/VB I/Ddem Nᴹ/Vg/J    NPl/V3+ C/P   NPr/ISg+ VP/J     D   NSg/VB/J+ Nᴹ/Vg/J . VB/C ISgPl+ NSg/VXB NSg/VB
+> of his     riding   clothes could hide   the enormous power     of that     body    — he       seemed to
+# P  ISg/D$+ Nᴹ/Vg/J+ NPl/V3+ VXB   NSg/VB D   J        N🅪Sg/VB/J P  I/C/Ddem NSg/VB+ . NPr/ISg+ VP/J   P
+> fill   those  glistening boots   until he       strained the top       lacing  , and  you    could see
+# NSg/VB I/Ddem Nᴹ/Vg/J    NPl/V3+ C/P   NPr/ISg+ VP/J     D   NSg/VB/J+ Nᴹ/Vg/J . VB/C ISgPl+ VXB   NSg/VB
 > a   great pack   of muscle   shifting when    his     shoulder moved under   his     thin     coat    . It
 # D/P NSg/J NSg/VB P  N🅪Sg/VB+ Nᴹ/Vg/J+ NSg/I/C ISg/D$+ NSg/VB+  VP/J  NSg/J/P ISg/D$+ NSg/VB/J NSg/VB+ . NPr/ISg+
 > was  a   body   capable of enormous leverage — a    cruel     body    .
@@ -363,7 +363,7 @@
 >
 #
 > “ I’ve got a   nice  place    here , ” he       said , his     eyes    flashing about restlessly .
-# . K    VP  D/P NPr/J N🅪Sg/VB+ J/R  . . NPr/ISg+ VP/J . ISg/D$+ NPl/V3+ Nᴹ/Vg/J  J/P   R          .
+# . K    VP  D/P NPr/J N🅪Sg/VB+ R    . . NPr/ISg+ VP/J . ISg/D$+ NPl/V3+ Nᴹ/Vg/J  J/P   R          .
 >
 #
 > Turning me       around by one      arm       , he       moved a    broad  flat      hand    along the front     vista   ,
@@ -632,8 +632,8 @@
 # . NPr    . . VP/J     NPr+  . . NSg/I+ NPr    . .
 >
 #
-> Before I       could   reply   that      he       was  my  neighbor     dinner   was  announced ; wedging his
-# C/P    ISg/#r+ NSg/VXB NSg/VB+ I/C/Ddem+ NPr/ISg+ VLPt D$+ NSg/VB/J/Am+ N🅪Sg/VB+ VLPt VP/J      . Nᴹ/Vg/J ISg/D$+
+> Before I       could reply   that      he       was  my  neighbor     dinner   was  announced ; wedging his
+# C/P    ISg/#r+ VXB   NSg/VB+ I/C/Ddem+ NPr/ISg+ VLPt D$+ NSg/VB/J/Am+ N🅪Sg/VB+ VLPt VP/J      . Nᴹ/Vg/J ISg/D$+
 > tense    arm       imperatively under   mine      , Tom     Buchanan compelled me       from the room     as
 # NSg/VB/J NSg/VB/J+ R            NSg/J/P NSg/I/VB+ . NPr/VB+ NPr+     VP/J      NPr/ISg+ P    D   N🅪Sg/VB+ R/C/P
 > though he       were moving  a   checker to another square   .
@@ -670,8 +670,8 @@
 # VXB NPl/VB+ NSg/VB+ . .
 >
 #
-> Before I       could   answer her     eyes    fastened with an  awed expression on  her     little
-# C/P    ISg/#r+ NSg/VXB NSg/VB ISg/D$+ NPl/V3+ VP/J     P    D/P VP/J N🅪Sg+      J/P ISg/D$+ NPr/I/J/Dq
+> Before I       could answer her     eyes    fastened with an  awed expression on  her     little
+# C/P    ISg/#r+ VXB   NSg/VB ISg/D$+ NPl/V3+ VP/J     P    D/P VP/J N🅪Sg+      J/P ISg/D$+ NPr/I/J/Dq
 > finger  .
 # NSg/VB+ .
 >
@@ -705,7 +705,7 @@
 > inconsequence that      was  never quite chatter , that      was  as    cool     as    their white
 # Nᴹ            I/C/Ddem+ VLPt R     R     NSg/VB+ . I/C/Ddem+ VLPt R/C/P NSg/VB/J R/C/P D$+   NPr🅪Sg/VB/J
 > dresses and  their impersonal eyes    in        the absence of all          desire   . They were here ,
-# NPl/V3+ VB/C D$+   NSg/J      NPl/V3+ NPr/J/R/P D   N🅪Sg    P  NSg/I/J/C/Dq N🅪Sg/VB+ . IPl+ VLPt J/R  .
+# NPl/V3+ VB/C D$+   NSg/J      NPl/V3+ NPr/J/R/P D   N🅪Sg    P  NSg/I/J/C/Dq N🅪Sg/VB+ . IPl+ VLPt R    .
 > and  they accepted Tom     and  me       , making  only  a   polite pleasant effort   to entertain
 # VB/C IPl+ VP/J     NPr/VB+ VB/C NPr/ISg+ . Nᴹ/Vg/J J/R/C D/P VB/J   NSg/J    N🅪Sg/VB+ P  NSg/VB
 > or    to be       entertained . They knew that     presently dinner   would be       over    and  a   little
@@ -818,12 +818,12 @@
 # NSg/VB/J NPr/ISg+ P    N🅪Sg/Vg/J+ NSg/VB/C/P N🅪Sg/VB+ . C/P   R       NPr/ISg+ VPt   P  NSg/VB ISg/D$+ NSg/VB+ . . . .
 >
 #
-> “ Things went    from bad      to worse     , ” suggested Miss   Baker .
-# . NPl+   NSg/VPt P    NSg/VB/J P  NSg/VB/JC . . VP/J      NSg/VB NPr+  .
+> “ Things went from bad      to worse     , ” suggested Miss   Baker .
+# . NPl+   VPt  P    NSg/VB/J P  NSg/VB/JC . . VP/J      NSg/VB NPr+  .
 >
 #
-> “ Yes    . Things went    from bad      to worse     , until finally he       had to give   up         his
-# . NPl/VB . NPl+   NSg/VPt P    NSg/VB/J P  NSg/VB/JC . C/P   R       NPr/ISg+ VP  P  NSg/VB NSg/VB/J/P ISg/D$+
+> “ Yes    . Things went from bad      to worse     , until finally he       had to give   up         his
+# . NPl/VB . NPl+   VPt  P    NSg/VB/J P  NSg/VB/JC . C/P   R       NPr/ISg+ VP  P  NSg/VB NSg/VB/J/P ISg/D$+
 > position . ”
 # NSg/VB+  . .
 >
@@ -840,8 +840,8 @@
 #
 > The butler came      back     and  murmured something close    to Tom’s ear       , whereupon Tom
 # D   NPr/VB NSg/VPt/P NSg/VB/J VB/C VP/J     NSg/I/J+  NSg/VB/J P  NPr$  NSg/VB/J+ . C         NPr/VB+
-> frowned , pushed back     his     chair   , and  without a   word    went    inside  . As    if    his
-# VP/J    . VP/J   NSg/VB/J ISg/D$+ NSg/VB+ . VB/C C/P     D/P NSg/VB+ NSg/VPt NSg/J/P . R/C/P NSg/C ISg/D$+
+> frowned , pushed back     his     chair   , and  without a   word    went inside  . As    if    his
+# VP/J    . VP/J   NSg/VB/J ISg/D$+ NSg/VB+ . VB/C C/P     D/P NSg/VB+ VPt  NSg/J/P . R/C/P NSg/C ISg/D$+
 > absence quickened something within  her     , Daisy leaned forward  again , her     voice
 # N🅪Sg+   VP/J      NSg/I/J+  NSg/J/P ISg/D$+ . NPr+  VP/J   NSg/VB/J P     . ISg/D$+ NSg/VB+
 > glowing and  singing .
@@ -862,8 +862,8 @@
 # NSg/C/P D/P NSg/Vg/J Nᴹ+    VP/J   P    ISg/D$+ . R/C/P NSg/C ISg/D$+ N🅪Sg/VB+ VLPt Nᴹ/Vg/J P  NSg/VBPp/P NSg/VB/J/R/P P
 > you    concealed in        one     of those  breathless , thrilling words   . Then      suddenly she
 # ISgPl+ VP/J      NPr/J/R/P NSg/I/J P  I/Ddem J          . Nᴹ/Vg/J   NPl/V3+ . NSg/J/R/C R        ISg+
-> threw her     napkin on  the table   and  excused herself and  went    into the house   .
-# VPt   ISg/D$+ NSg+   J/P D+  NSg/VB+ VB/C VP/J    ISg+    VB/C NSg/VPt P    D+  NPr/VB+ .
+> threw her     napkin on  the table   and  excused herself and  went into the house   .
+# VPt   ISg/D$+ NSg+   J/P D+  NSg/VB+ VB/C VP/J    ISg+    VB/C VPt  P    D+  NPr/VB+ .
 >
 #
 > Miss   Baker and  I       exchanged a    short       glance  consciously devoid of meaning    . I       was
@@ -1031,15 +1031,15 @@
 > abandoned feeling   , and  asked the nurse   right    away if    it       was  a   boy    or    a   girl    . She
 # VP/J      N🅪Sg/Vg/J . VB/C VP/J  D   NSg/VB+ NPr/VB/J VB/J NSg/C NPr/ISg+ VLPt D/P NSg/VB NPr/C D/P NSg/VB+ . ISg+
 > told me       it       was  a   girl   , and  so          I       turned my  head      away and  wept . ‘ All          right    , ’ I
-# VP   NPr/ISg+ NPr/ISg+ VLPt D/P NSg/VB . VB/C NSg/I/J/R/C ISg/#r+ VP/J   D$+ NPr/VB/J+ VB/J VB/C VB   . . NSg/I/J/C/Dq NPr/VB/J . . ISg/#r+
+# VP   NPr/ISg+ NPr/ISg+ VLPt D/P NSg/VB . VB/C NSg/I/J/R/C ISg/#r+ VP/J   D$+ NPr/VB/J+ VB/J VB/C VP   . . NSg/I/J/C/Dq NPr/VB/J . . ISg/#r+
 > said , ‘ I’m glad     it’s a   girl    . And  I       hope      she’ll be       a   fool      — that’s the best       thing a
 # VP/J . . K   NSg/VB/J K    D/P NSg/VB+ . VB/C ISg/#r+ NPr🅪Sg/VB K      NSg/VLXB D/P NSg/VB/J+ . K      D   NPr/VXB/JS NSg+  D/P
 > girl    can     be       in        this   world   , a   beautiful little     fool      . ’
 # NSg/VB+ NPr/VXB NSg/VLXB NPr/J/R/P I/Ddem NSg/VB+ . D/P NSg/J     NPr/I/J/Dq NSg/VB/J+ . .
 >
 #
-> “ You    see    I       think  everything’s terrible anyhow , ” she  went    on  in        a   convinced way    .
-# . ISgPl+ NSg/VB ISg/#r+ NSg/VB NSg$         J        J      . . ISg+ NSg/VPt J/P NPr/J/R/P D/P VP/J      NSg/J+ .
+> “ You    see    I       think  everything’s terrible anyhow , ” she  went on  in        a   convinced way    .
+# . ISgPl+ NSg/VB ISg/#r+ NSg/VB NSg$         J        J      . . ISg+ VPt  J/P NPr/J/R/P D/P VP/J      NSg/J+ .
 > “ Everybody thinks so          — the most         advanced people  . And  I       know . I’ve been   everywhere
 # . NSg/I+    NPl/V3 NSg/I/J/R/C . D   NSg/I/J/R/Dq VP/J+    NPl/VB+ . VB/C ISg/#r+ VB   . K    VLPp/B Nᴹ/R
 > and  seen    everything and  done      everything . ” Her     eyes    flashed around her     in        a
@@ -1163,7 +1163,7 @@
 > look   after her     , aren’t you    , Nick    ? She’s going   to spend  lots   of week   - ends    out
 # NSg/VB P     ISg/D$+ . VB     ISgPl+ . NPr/VB+ . K     Nᴹ/Vg/J P  NSg/VB NPl/V3 P  NSg/J+ . NPl/V3+ NSg/VB/J/R/P
 > here this   summer     . I       think  the home      influence will    be       very good     for   her     . ”
-# J/R  I/Ddem NPr🅪Sg/VB+ . ISg/#r+ NSg/VB D+  NSg/VB/J+ N🅪Sg/VB+  NPr/VXB NSg/VLXB J/R  NPr/VB/J R/C/P ISg/D$+ . .
+# R    I/Ddem NPr🅪Sg/VB+ . ISg/#r+ NSg/VB D+  NSg/VB/J+ N🅪Sg/VB+  NPr/VXB NSg/VLXB J/R  NPr/VB/J R/C/P ISg/D$+ . .
 >
 #
 > Daisy and  Tom     looked at    each other    for   a   moment in        silence .
@@ -1284,8 +1284,8 @@
 # VXB R/C/P D/P+ NSg+         . NSg/C/P ISg/#r+ VXPt   NSg/VB P  ISg+ . R/C/P NPr/ISg+ VPt  D/P NSg/J
 > intimation that     he       was  content    to be       alone — he       stretched out          his     arms    toward the
 # NSg        I/C/Ddem NPr/ISg+ VLPt N🅪Sg/VB/J+ P  NSg/VLXB J     . NPr/ISg+ VP/J      NSg/VB/J/R/P ISg/D$+ NPl/V3+ J/P    D
-> dark     water    in        a   curious way    , and  , far      as    I       was  from him  , I       could   have    sworn he
-# NSg/VB/J N🅪Sg/VB+ NPr/J/R/P D/P J       NSg/J+ . VB/C . NSg/VB/J R/C/P ISg/#r+ VLPt P    ISg+ . ISg/#r+ NSg/VXB NSg/VXB VB/J  NPr/ISg+
+> dark     water    in        a   curious way    , and  , far      as    I       was  from him  , I       could have    sworn he
+# NSg/VB/J N🅪Sg/VB+ NPr/J/R/P D/P J       NSg/J+ . VB/C . NSg/VB/J R/C/P ISg/#r+ VLPt P    ISg+ . ISg/#r+ VXB   NSg/VXB VB/J  NPr/ISg+
 > was  trembling . Involuntarily I       glanced seaward — and  distinguished nothing  except
 # VLPt Nᴹ/Vg/J   . R             ISg/#r+ VP/J    NSg/J   . VB/C VP/J          NSg/I/J+ VB/C/P
 > a   single   green       light      , minute    and  far      away , that      might    have    been   the end    of a
@@ -1361,7 +1361,7 @@
 > leaving her     at    a   table   , sauntered about , chatting with whomsoever he       knew .
 # Nᴹ/Vg/J ISg/D$+ NSg/P D/P NSg/VB+ . VP/J      J/P   . NSg/Vg   P    I          NPr/ISg+ VPt  .
 > Though I       was  curious to see    her     , I       had no        desire   to meet     her     — but     I       did  . I       went
-# C      ISg/#r+ VLPt J       P  NSg/VB ISg/D$+ . ISg/#r+ VP  NSg/Dq/P+ N🅪Sg/VB+ P  NSg/VB/J ISg/D$+ . NSg/C/P ISg/#r+ VXPt . ISg/#r+ NSg/VPt
+# C      ISg/#r+ VLPt J       P  NSg/VB ISg/D$+ . ISg/#r+ VP  NSg/Dq/P+ N🅪Sg/VB+ P  NSg/VB/J ISg/D$+ . NSg/C/P ISg/#r+ VXPt . ISg/#r+ VPt
 > up         to New   York with Tom     on  the train   one      afternoon , and  when    we   stopped by the
 # NSg/VB/J/P P  NSg/J NPr+ P    NPr/VB+ J/P D+  NSg/VB+ NSg/I/J+ N🅪Sg+     . VB/C NSg/I/C IPl+ VP/J    P  D
 > ashheaps he       jumped to his     feet and  , taking   hold     of my  elbow   , literally forced me
@@ -1472,8 +1472,8 @@
 # . NSg/VB I/J/R/Dq+ NPl/V3+ . NSg/VB VXB   ISgPl+ . NSg/I/J/R/C NSg/I+   NPr/VXB NSg/VB N🅪Sg/VB/J/P . .
 >
 #
-> “ Oh     , sure , ” agreed Wilson hurriedly , and  went    toward the little     office  , mingling
-# . NPr/VB . J    . . VP/J   NPr+   R         . VB/C NSg/VPt J/P    D   NPr/I/J/Dq NSg/VB+ . Nᴹ/Vg/J+
+> “ Oh     , sure , ” agreed Wilson hurriedly , and  went toward the little     office  , mingling
+# . NPr/VB . J    . . VP/J   NPr+   R         . VB/C VPt  J/P    D   NPr/I/J/Dq NSg/VB+ . Nᴹ/Vg/J+
 > immediately with the cement   color        of the walls     . A   white       ashen dust   veiled his
 # R           P    D   N🅪Sg/VB+ N🅪Sg/VB/J/Am P  D   NPrPl/V3+ . D/P NPr🅪Sg/VB/J J     Nᴹ/VB+ VP/J   ISg/D$+
 > dark     suit    and  his     pale     hair     as    it       veiled everything in        the vicinity — except his
@@ -1530,8 +1530,8 @@
 # VX3     VB   NPr$ J     . .
 >
 #
-> So          Tom     Buchanan and  his     girl    and  I       went    up         together to New    York — or    not     quite
-# NSg/I/J/R/C NPr/VB+ NPr+     VB/C ISg/D$+ NSg/VB+ VB/C ISg/#r+ NSg/VPt NSg/VB/J/P J        P  NSg/J+ NPr+ . NPr/C NSg/R/C R
+> So          Tom     Buchanan and  his     girl    and  I       went up         together to New    York — or    not     quite
+# NSg/I/J/R/C NPr/VB+ NPr+     VB/C ISg/D$+ NSg/VB+ VB/C ISg/#r+ VPt  NSg/VB/J/P J        P  NSg/J+ NPr+ . NPr/C NSg/R/C R
 > together , for   Mrs  . Wilson sat    discreetly in        another car  . Tom     deferred that      much
 # J        . R/C/P NPl+ . NPr+   NSg/VP R          NPr/J/R/P I/D     NSg+ . NPr/VB+ NSg/VP/J I/C/Ddem+ NSg/I/J/R/Dq
 > to the sensibilities of those  East   Eggers who    might    be       on  the train   .
@@ -1643,7 +1643,7 @@
 >
 #
 > “ Hold     on  , ” I       said , “ I       have    to leave  you    here . ”
-# . NSg/VB/J J/P . . ISg/#r+ VP/J . . ISg/#r+ NSg/VXB P  NSg/VB ISgPl+ J/R  . .
+# . NSg/VB/J J/P . . ISg/#r+ VP/J . . ISg/#r+ NSg/VXB P  NSg/VB ISgPl+ R    . .
 >
 #
 > “ No       , you    don’t , ” interposed Tom     quickly . “ Myrtle’ll be       hurt      if    you    don’t come       up
@@ -1662,14 +1662,14 @@
 # . NSg/VB/J/R . K   NSg/VB/J/C/P P  . NSg/C/P . .
 >
 #
-> We   went    on  , cutting  back     again over    the Park    toward the West      Hundreds . At    158th
-# IPl+ NSg/VPt J/P . NSg/Vg/J NSg/VB/J P     NSg/J/P D   NPr/VB+ J/P    D+  NPr/VB/J+ NPl+     . NSg/P #
+> We   went on  , cutting  back     again over    the Park    toward the West      Hundreds . At    158th
+# IPl+ VPt  J/P . NSg/Vg/J NSg/VB/J P     NSg/J/P D   NPr/VB+ J/P    D+  NPr/VB/J+ NPl+     . NSg/P #
 > Street    the cab     stopped at    one     slice     in        a   long     white       cake    of apartment - houses  .
 # NSg/VB/J+ D   NSg/VB+ VP/J    NSg/P NSg/I/J NSg/VB/J+ NPr/J/R/P D/P NPr/VB/J NPr🅪Sg/VB/J N🅪Sg/VB P  NSg+      . NPl/V3+ .
 > Throwing a   regal homecoming glance  around the neighborhood , Mrs  . Wilson gathered
 # Nᴹ/Vg/J  D/P NSg/J NSg        NSg/VB+ J/P    D   NSg/Am+      . NPl+ . NPr+   VP/J
-> up         her     dog       and  her     other     purchases , and  went    haughtily in        .
-# NSg/VB/J/P ISg/D$+ NSg/VB/J+ VB/C ISg/D$+ NSg/VB/J+ NPl/V3+   . VB/C NSg/VPt R         NPr/J/R/P .
+> up         her     dog       and  her     other     purchases , and  went haughtily in        .
+# NSg/VB/J/P ISg/D$+ NSg/VB/J+ VB/C ISg/D$+ NSg/VB/J+ NPl/V3+   . VB/C VPt  R         NPr/J/R/P .
 >
 #
 > “ I’m going   to have    the McKees come       up         , ” she  announced as    we   rose      in        the
@@ -1696,8 +1696,8 @@
 # J/Dq    NSg/J NPl/V3 P  NSg+ NSg/VB NSg/VBPt/J J/P D   NSg/VB+ J        P    D/P NSg/VB P
 > “ Simon Called Peter      , ” and  some     of the small    scandal  magazines of Broadway . Mrs  .
 # . NPr+  VP/J   NPr/VB/JC+ . . VB/C I/J/R/Dq P  D   NPr/VB/J N🅪Sg/VB+ NPl       P  NPr/J+   . NPl+ .
-> Wilson was  first concerned with the dog       . A   reluctant elevator - boy     went    for   a   box
-# NPr+   VLPt NSg/J VP/J      P    D+  NSg/VB/J+ . D/P J         NSg/VB+  . NSg/VB+ NSg/VPt R/C/P D/P NSg/VB
+> Wilson was  first concerned with the dog       . A   reluctant elevator - boy     went for   a   box
+# NPr+   VLPt NSg/J VP/J      P    D+  NSg/VB/J+ . D/P J         NSg/VB+  . NSg/VB+ VPt  R/C/P D/P NSg/VB
 > full     of straw     and  some      milk     , to which he       added on  his     own      initiative a   tin       of
 # NSg/VB/J P  N🅪Sg/VB/J VB/C I/J/R/Dq+ N🅪Sg/VB+ . P  I/C+  NPr/ISg+ VP/J  J/P ISg/D$+ NSg/VB/J NSg/J+     D/P N🅪Sg/VB/J P
 > large , hard      dog       - biscuits — one     of which decomposed apathetically in        the saucer of
@@ -1716,8 +1716,8 @@
 # NSg/J R       D+  NSg+      VLPt NSg/VB/J P  J+       NPr/VB+ . NSg/Vg/J J/P NPr$  NSg/VB/J+ NPl+ .
 > Wilson called up         several people  on  the telephone ; then      there were no        cigarettes ,
 # NPr+   VP/J   NSg/VB/J/P J/Dq    NPl/VB+ J/P D+  NSg/VB+   . NSg/J/R/C R+    VLPt NSg/Dq/P+ NPl/V3+    .
-> and  I       went    out          to buy    some     at    the drugstore on  the corner  . When    I       came      back     they
-# VB/C ISg/#r+ NSg/VPt NSg/VB/J/R/P P  NSg/VB I/J/R/Dq NSg/P D   NSg       J/P D   NSg/VB+ . NSg/I/C ISg/#r+ NSg/VPt/P NSg/VB/J IPl+
+> and  I       went out          to buy    some     at    the drugstore on  the corner  . When    I       came      back     they
+# VB/C ISg/#r+ VPt  NSg/VB/J/R/P P  NSg/VB I/J/R/Dq NSg/P D   NSg       J/P D   NSg/VB+ . NSg/I/C ISg/#r+ NSg/VPt/P NSg/VB/J IPl+
 > had both   disappeared , so          I       sat    down        discreetly in        the living     - room     and  read    a
 # VP  I/C/Dq VP/J        . NSg/I/J/R/C ISg/#r+ NSg/VP N🅪Sg/VB/J/P R          NPr/J/R/P D   N🅪Sg/Vg/J+ . N🅪Sg/VB+ VB/C NSg/VBP D/P
 > chapter of “ Simon Called Peter      ” — either it       was  terrible stuff  or    the whiskey
@@ -1749,7 +1749,7 @@
 > with such   a    proprietary haste   , and  looked around so          possessively at    the
 # P    NSg/I+ D/P+ NSg/J+      NSg/VB+ . VB/C VP/J   J/P    NSg/I/J/R/C R            NSg/P D+
 > furniture that      I       wondered if    she  lived here . But     when    I       asked her     she  laughed
-# Nᴹ+       I/C/Ddem+ ISg/#r+ VP/J     NSg/C ISg+ VP/J  J/R  . NSg/C/P NSg/I/C ISg/#r+ VP/J  ISg/D$+ ISg+ VP/J
+# Nᴹ+       I/C/Ddem+ ISg/#r+ VP/J     NSg/C ISg+ VP/J  R    . NSg/C/P NSg/I/C ISg/#r+ VP/J  ISg/D$+ ISg+ VP/J
 > immoderately , repeated my  question aloud , and  told me       she  lived with a   girl
 # R            . VP/J     D$+ NSg/VB+  J     . VB/C VP   NPr/ISg+ ISg+ VP/J  P    D/P NSg/VB+
 > friend    at    a   hotel .
@@ -1795,7 +1795,7 @@
 > “ My  dear     , ” she  told her     sister  in        a   high       , mincing shout  , “ most         of these  fellas
 # . D$+ NSg/VB/J . . ISg+ VP   ISg/D$+ NSg/VB+ NPr/J/R/P D/P NSg/VB/J/R . Nᴹ/Vg/J NSg/VB . . NSg/I/J/R/Dq P  I/Ddem NPl+
 > will    cheat  you    every time       . All          they think  of is  money   . I       had a    woman   up         here
-# NPr/VXB NSg/VB ISgPl+ Dq    N🅪Sg/VB/J+ . NSg/I/J/C/Dq IPl+ NSg/VB P  VL3 N🅪Sg/J+ . ISg/#r+ VP  D/P+ NSg/VB+ NSg/VB/J/P J/R
+# NPr/VXB NSg/VB ISgPl+ Dq    N🅪Sg/VB/J+ . NSg/I/J/C/Dq IPl+ NSg/VB P  VL3 N🅪Sg/J+ . ISg/#r+ VP  D/P+ NSg/VB+ NSg/VB/J/P R
 > last      week   to look   at    my  feet , and  when    she  gave me       the bill    you’d of thought she
 # NSg/VB/J+ NSg/J+ P  NSg/VB NSg/P D$+ NPl+ . VB/C NSg/I/C ISg+ VPt  NPr/ISg+ D+  NPr/VB+ K     P  N🅪Sg/VP ISg+
 > had my  appendicitus out          . ”
@@ -1826,8 +1826,8 @@
 #
 > “ But     it       looks  wonderful on  you    , if    you    know what   I       mean     , ” pursued Mrs  . McKee .
 # . NSg/C/P NPr/ISg+ NPl/V3 J         J/P ISgPl+ . NSg/C ISgPl+ VB   NSg/I+ ISg/#r+ NSg/VB/J . . VP/J    NPl+ . NPr   .
-> “ If    Chester could   only  get    you    in        that      pose   I       think  he       could   make   something of
-# . NSg/C NPr+    NSg/VXB J/R/C NSg/VB ISgPl+ NPr/J/R/P I/C/Ddem+ NSg/VB ISg/#r+ NSg/VB NPr/ISg+ NSg/VXB NSg/VB NSg/I/J   P
+> “ If    Chester could only  get    you    in        that      pose   I       think  he       could make   something of
+# . NSg/C NPr+    VXB   J/R/C NSg/VB ISgPl+ NPr/J/R/P I/C/Ddem+ NSg/VB ISg/#r+ NSg/VB NPr/ISg+ VXB   NSg/VB NSg/I/J   P
 > it       . ”
 # NPr/ISg+ . .
 >
@@ -1948,14 +1948,14 @@
 # Nᴹ/Vg/J  R        NSg/P NPr+      .
 >
 #
-> “ Chester , I       think  you    could   do  something with her     , ” she  broke     out          , but     Mr   . McKee
-# . NPr+    . ISg/#r+ NSg/VB ISgPl+ NSg/VXB VXB NSg/I/J+  P    ISg/D$+ . . ISg+ NSg/VPt/J NSg/VB/J/R/P . NSg/C/P NSg+ . NPr
+> “ Chester , I       think  you    could do  something with her     , ” she  broke     out          , but     Mr   . McKee
+# . NPr+    . ISg/#r+ NSg/VB ISgPl+ VXB   VXB NSg/I/J+  P    ISg/D$+ . . ISg+ NSg/VPt/J NSg/VB/J/R/P . NSg/C/P NSg+ . NPr
 > only  nodded in        a   bored way    , and  turned his     attention to Tom     .
 # J/R/C VP     NPr/J/R/P D/P VP/J  NSg/J+ . VB/C VP/J   ISg/D$+ NSg+      P  NPr/VB+ .
 >
 #
-> “ I’d like         to do  more         work     on  Long     Island  , if    I       could   get    the entry . All          I       ask    is
-# . K   NSg/VB/J/C/P P  VXB NPr/I/J/R/Dq N🅪Sg/VB+ J/P NPr/VB/J NSg/VB+ . NSg/C ISg/#r+ NSg/VXB NSg/VB D   NSg+  . NSg/I/J/C/Dq ISg/#r+ NSg/VB VL3
+> “ I’d like         to do  more         work     on  Long     Island  , if    I       could get    the entry . All          I       ask    is
+# . K   NSg/VB/J/C/P P  VXB NPr/I/J/R/Dq N🅪Sg/VB+ J/P NPr/VB/J NSg/VB+ . NSg/C ISg/#r+ VXB   NSg/VB D   NSg+  . NSg/I/J/C/Dq ISg/#r+ NSg/VB VL3
 > that     they should give   me       a    start   . ”
 # I/C/Ddem IPl+ VXB    NSg/VB NPr/ISg+ D/P+ NSg/VB+ . .
 >
@@ -2044,16 +2044,16 @@
 # . R      . .
 >
 #
-> “ Just last      year . I       went    over    there with another girl    . ”
-# . J/R  NSg/VB/J+ NSg+ . ISg/#r+ NSg/VPt NSg/J/P R     P    I/D+    NSg/VB+ . .
+> “ Just last      year . I       went over    there with another girl    . ”
+# . J/R  NSg/VB/J+ NSg+ . ISg/#r+ VPt  NSg/J/P R     P    I/D+    NSg/VB+ . .
 >
 #
 > “ Stay     long     ? ”
 # . NSg/VB/J NPr/VB/J . .
 >
 #
-> “ No       , we   just went    to Monte Carlo and  back     . We   went    by way   of Marseilles . We   had
-# . NSg/Dq/P . IPl+ J/R  NSg/VPt P  NPr   NPr+  VB/C NSg/VB/J . IPl+ NSg/VPt P  NSg/J P  NPr        . IPl+ VP
+> “ No       , we   just went to Monte Carlo and  back     . We   went by way   of Marseilles . We   had
+# . NSg/Dq/P . IPl+ J/R  VPt  P  NPr   NPr+  VB/C NSg/VB/J . IPl+ VPt  P  NSg/J P  NPr        . IPl+ VP
 > over    twelve hundred dollars when    we   started , but     we   got gyped out          of it       all          in
 # NSg/J/P NSg+   NSg+    NPl+    NSg/I/C IPl+ VP/J    . NSg/C/P IPl+ VP  ?     NSg/VB/J/R/P P  NPr/ISg+ NSg/I/J/C/Dq NPr/J/R/P
 > two days in        the private  rooms   . We   had an   awful time       getting back     , I       can     tell
@@ -2257,7 +2257,7 @@
 > way    he       turned around and  stared at    the scene  — his     wife     and  Catherine scolding and
 # NSg/J+ NPr/ISg+ VP/J   J/P    VB/C VP/J   NSg/P D   NSg/VB . ISg/D$+ NSg/VB/J VB/C NPr+      Nᴹ/Vg/J  VB/C
 > consoling as    they stumbled here and  there among the crowded furniture with
-# Nᴹ/Vg/J   R/C/P IPl+ VP/J     J/R  VB/C R     P     D   VP/J    Nᴹ+       P
+# Nᴹ/Vg/J   R/C/P IPl+ VP/J     R    VB/C R     P     D   VP/J    Nᴹ+       P
 > articles of aid      , and  the despairing figure  on  the couch   , bleeding fluently , and
 # NPl/V3   P  N🅪Sg/VB+ . VB/C D   Nᴹ/Vg/J    NSg/VB+ J/P D   NSg/VB+ . Nᴹ/Vg/J  R        . VB/C
 > trying  to spread   a   copy   of Town Tattle over    the tapestry scenes of Versailles .
@@ -2316,8 +2316,8 @@
 #
 > There was  music      from my  neighbor’s house   through the summer     nights  . In        his     blue
 # R+    VLPt N🅪Sg/VB/J+ P    D$+ NSg$/Am    NPr/VB+ J/P     D   NPr🅪Sg/VB+ NPl/V3+ . NPr/J/R/P ISg/D$+ N🅪Sg/VB/J
-> gardens men and  girls   came      and  went    like         moths   among the whisperings and  the
-# NPl/V3+ NPl VB/C NPl/V3+ NSg/VPt/P VB/C NSg/VPt NSg/VB/J/C/P NPl/VB+ P     D   NPl/V3      VB/C D
+> gardens men and  girls   came      and  went like         moths   among the whisperings and  the
+# NPl/V3+ NPl VB/C NPl/V3+ NSg/VPt/P VB/C VPt  NSg/VB/J/C/P NPl/VB+ P     D   NPl/V3      VB/C D
 > champagne and  the stars   . At    high       tide   in        the afternoon I       watched his     guests
 # N🅪Sg/VB/J VB/C D   NPl/V3+ . NSg/P NSg/VB/J/R NSg/VB NPr/J/R/P D+  N🅪Sg+     ISg/#r+ VP/J    ISg/D$+ NPl/V3+
 > diving   from the tower  of his     raft    , or    taking   the sun     on  the hot      sand     of his
@@ -2342,8 +2342,8 @@
 # Dq+   NSg+   NSg  NPl/V3 P  NPl/V3  VB/C NPl/V3+ VP/J    P    D/P NSg       NPr/J/R/P NSg/J
 > York — every Monday these  same oranges and  lemons  left     his     back     door    in        a   pyramid
 # NPr+ . Dq    NSg+   I/Ddem I/J  NPl/V3  VB/C NPl/V3+ NPr/VP/J ISg/D$+ NSg/VB/J NSg/VB+ NPr/J/R/P D/P NSg/VB
-> of pulpless halves . There was  a   machine in        the kitchen which could   extract the
-# P  ?        V3+    . R+    VLPt D/P NSg/VB+ NPr/J/R/P D+  NSg/VB+ I/C+  NSg/VXB NSg/VB  D
+> of pulpless halves . There was  a   machine in        the kitchen which could extract the
+# P  ?        V3+    . R+    VLPt D/P NSg/VB+ NPr/J/R/P D+  NSg/VB+ I/C+  VXB   NSg/VB  D
 > juice     of two hundred oranges in        half      an  hour if    a   little     button  was  pressed two
 # N🅪Sg/VB/J P  NSg NSg     NPl/V3  NPr/J/R/P N🅪Sg/J/P+ D/P NSg+ NSg/C D/P NPr/I/J/Dq NSg/VB+ VLPt VP/J    NSg
 > hundred times   by a   butler’s thumb   .
@@ -2401,7 +2401,7 @@
 > arrivals , dissolve and  form     in        the same breath     ; already there are wanderers ,
 # NPl      . NSg/VB   VB/C N🅪Sg/VB+ NPr/J/R/P D   I/J  N🅪Sg/VB/J+ . R       R+    VLB NPl       .
 > confident girls   who    weave  here and  there among the stouter and  more         stable   ,
-# NSg/J     NPl/V3+ NPr/I+ NSg/VB J/R  VB/C R     P     D   NSg/JC  VB/C NPr/I/J/R/Dq NSg/VB/J .
+# NSg/J     NPl/V3+ NPr/I+ NSg/VB R    VB/C R     P     D   NSg/JC  VB/C NPr/I/J/R/Dq NSg/VB/J .
 > become for   a   sharp    , joyous moment the centre      of a   group   , and  then      , excited with
 # VBPp   R/C/P D/P NPr/VB/J . J      NSg+   D   NSg/VB/Comm P  D/P NSg/VB+ . VB/C NSg/J/R/C . VP/J    P
 > triumph  , glide  on  through the sea  - change  of faces  and  voices and  color         under   the
@@ -2424,18 +2424,18 @@
 # VPp   .
 >
 #
-> I       believe that     on  the first  night    I       went    to Gatsby’s house   I       was  one     of the few
-# ISg/#r+ VB      I/C/Ddem J/P D+  NSg/J+ N🅪Sg/VB+ ISg/#r+ NSg/VPt P  NPr$     NPr/VB+ ISg/#r+ VLPt NSg/I/J P  D   NSg/I/Dq
-> guests  who    had actually been   invited  . People  were not     invited  — they went    there .
-# NPl/V3+ NPr/I+ VP  R        VLPp/B NSg/VP/J . NPl/VB+ VLPt NSg/R/C NSg/VP/J . IPl+ NSg/VPt R     .
+> I       believe that     on  the first  night    I       went to Gatsby’s house   I       was  one     of the few
+# ISg/#r+ VB      I/C/Ddem J/P D+  NSg/J+ N🅪Sg/VB+ ISg/#r+ VPt  P  NPr$     NPr/VB+ ISg/#r+ VLPt NSg/I/J P  D   NSg/I/Dq
+> guests  who    had actually been   invited  . People  were not     invited  — they went there .
+# NPl/V3+ NPr/I+ VP  R        VLPp/B NSg/VP/J . NPl/VB+ VLPt NSg/R/C NSg/VP/J . IPl+ VPt  R     .
 > They got into automobiles which bore     them     out          to Long     Island  , and  somehow they
 # IPl+ VP  P    NPl/V3      I/C+  NSg/VBPt NSg/IPl+ NSg/VB/J/R/P P  NPr/VB/J NSg/VB+ . VB/C R       IPl+
 > ended up         at    Gatsby’s door    . Once  there they were introduced by somebody who    knew
 # VP/J  NSg/VB/J/P NSg/P NPr$     NSg/VB+ . NSg/C R+    IPl+ VLPt VP/J       P  NSg/I+   NPr/I+ VPt
 > Gatsby , and  after that     they conducted themselves according to the rules  of
 # NPr    . VB/C P     I/C/Ddem IPl+ VP/J      IPl+       Nᴹ/Vg/J   P  D   NPl/V3 P
-> behavior associated with an  amusement park    . Sometimes they came      and  went    without
-# N🅪Sg/Am+ VP/J       P    D/P NSg+      NPr/VB+ . R         IPl+ NSg/VPt/P VB/C NSg/VPt C/P
+> behavior associated with an  amusement park    . Sometimes they came      and  went without
+# N🅪Sg/Am+ VP/J       P    D/P NSg+      NPr/VB+ . R         IPl+ NSg/VPt/P VB/C VPt  C/P
 > having  met Gatsby at    all          , came      for   the party     with a   simplicity of heart    that      was
 # Nᴹ/Vg/J VP  NPr    NSg/P NSg/I/J/C/Dq . NSg/VPt/P R/C/P D   NSg/VB/J+ P    D/P N🅪Sg       P  N🅪Sg/VB+ I/C/Ddem+ VLPt
 > its     own      ticket of admission .
@@ -2456,12 +2456,12 @@
 # VP/J      NPr/ISg+ . VP/J   NPr+ NPr    . NPr/J/R/P D/P J        NSg/VB+ .
 >
 #
-> Dressed up         in        white       flannels I       went    over    to his     lawn   a   little     after seven , and
-# VP/J    NSg/VB/J/P NPr/J/R/P NPr🅪Sg/VB/J NPl/V3   ISg/#r+ NSg/VPt NSg/J/P P  ISg/D$+ NSg/VB D/P NPr/I/J/Dq P     NSg   . VB/C
+> Dressed up         in        white       flannels I       went over    to his     lawn   a   little     after seven , and
+# VP/J    NSg/VB/J/P NPr/J/R/P NPr🅪Sg/VB/J NPl/V3   ISg/#r+ VPt  NSg/J/P P  ISg/D$+ NSg/VB D/P NPr/I/J/Dq P     NSg   . VB/C
 > wandered around rather     ill      at    ease   among swirls and  eddies of people  I       didn’t
 # VP/J     J/P    NPr/VB/J/R NSg/VB/J NSg/P Nᴹ/VB+ P     NPl/V3 VB/C NPl/V3 P  NPl/VB+ ISg/#r+ VXPt
 > know — though here and  there was  a   face    I       had noticed on  the commuting train   . I
-# VB   . C      J/R  VB/C R+    VLPt D/P NSg/VB+ ISg/#r+ VP  VP/J    J/P D   Nᴹ/Vg/J   NSg/VB+ . ISg/#r+
+# VB   . C      R    VB/C R+    VLPt D/P NSg/VB+ ISg/#r+ VP  VP/J    J/P D   Nᴹ/Vg/J   NSg/VB+ . ISg/#r+
 > was  immediately struck by the number      of young    Englishmen dotted about ; all          well
 # VLPt R           VB     P  D   N🅪Sg/VB/JC+ P  NPr/VB/J NPl        VP/J   J/P   . NSg/I/J/C/Dq NSg/VB/J/R
 > dressed , all          looking a   little     hungry , and  all          talking  in        low        , earnest   voices  to
@@ -2484,8 +2484,8 @@
 # VP/J   NSg/I/J/R/C R          I/R/Dq Nᴹ        P  ISg/D$+ NPl+      . I/C/Ddem ISg/#r+ NSg/VB NSg/VB/J/P NPr/J/R/P D
 > direction of the cocktail  table   — the only  place    in        the garden    where   a   single   man
 # N🅪Sg      P  D   NSg/VB/J+ NSg/VB+ . D   J/R/C N🅪Sg/VB+ NPr/J/R/P D   NSg/VB/J+ NSg/R/C D/P NSg/VB/J NPr/VB+
-> could   linger without looking purposeless and  alone .
-# NSg/VXB VB     C/P     Nᴹ/Vg/J J           VB/C J     .
+> could linger without looking purposeless and  alone .
+# VXB   VB     C/P     Nᴹ/Vg/J J           VB/C J     .
 >
 #
 > I       was  on  my  way    to get    roaring drunk     from sheer    embarrassment when    Jordan Baker
@@ -2509,7 +2509,7 @@
 >
 #
 > “ I       thought you    might    be       here , ” she  responded absently as    I       came      up         . “ I
-# . ISg/#r+ N🅪Sg/VP ISgPl+ Nᴹ/VXB/J NSg/VLXB J/R  . . ISg+ VP/J      R        R/C/P ISg/#r+ NSg/VPt/P NSg/VB/J/P . . ISg/#r+
+# . ISg/#r+ N🅪Sg/VP ISgPl+ Nᴹ/VXB/J NSg/VLXB R    . . ISg+ VP/J      R        R/C/P ISg/#r+ NSg/VPt/P NSg/VB/J/P . . ISg/#r+
 > remembered you    lived next     door    to — — ”
 # VP/J       ISgPl+ VP/J  NSg/J/P+ NSg/VB+ P  . . .
 >
@@ -2533,7 +2533,7 @@
 > “ You    don’t know who    we   are , ” said one     of the girls   in        yellow   , “ but     we   met you
 # . ISgPl+ VXB   VB   NPr/I+ IPl+ VLB . . VP/J NSg/I/J P  D   NPl/V3+ NPr/J/R/P NSg/VB/J . . NSg/C/P IPl+ VP  ISgPl+
 > here about a   month  ago . ”
-# J/R  J/P   D/P NSg/J+ J/P . .
+# R    J/P   D/P NSg/J+ J/P . .
 >
 #
 > “ You’ve dyed your hair     since then      , ” remarked Jordan , and  I       started , but     the
@@ -2569,7 +2569,7 @@
 > “ I       like         to come       , ” Lucille said . “ I       never care    what   I       do  , so          I       always have    a    good
 # . ISg/#r+ NSg/VB/J/C/P P  NSg/VBPp/P . . NPr+    VP/J . . ISg/#r+ R     N🅪Sg/VB NSg/I+ ISg/#r+ VXB . NSg/I/J/R/C ISg/#r+ R      NSg/VXB D/P+ NPr/VB/J+
 > time       . When    I       was  here last     I       tore     my  gown    on  a    chair   , and  he       asked me       my  name
-# N🅪Sg/VB/J+ . NSg/I/C ISg/#r+ VLPt J/R  NSg/VB/J ISg/#r+ NSg/VB/J D$+ NSg/VB+ J/P D/P+ NSg/VB+ . VB/C NPr/ISg+ VP/J  NPr/ISg+ D$+ NSg/VB
+# N🅪Sg/VB/J+ . NSg/I/C ISg/#r+ VLPt R    NSg/VB/J ISg/#r+ NSg/VB/J D$+ NSg/VB+ J/P D/P+ NSg/VB+ . VB/C NPr/ISg+ VP/J  NPr/ISg+ D$+ NSg/VB
 > and  address — inside  of a    week   I       got a    package from Croirier’s with a   new   evening
 # VB/C NSg/VB+ . NSg/J/P P  D/P+ NSg/J+ ISg/#r+ VP  D/P+ NSg/VB+ P    ?          P    D/P NSg/J N🅪Sg/Vg/J+
 > gown    in        it       . ”
@@ -2737,7 +2737,7 @@
 > “ Absolutely real  — have    pages   and  everything . I       thought they’d be       a   nice  durable
 # . R          NSg/J . NSg/VXB NPl/V3+ VB/C NSg/I/VB+  . ISg/#r+ N🅪Sg/VP K      NSg/VLXB D/P NPr/J NSg/J
 > cardboard . Matter  of fact , they’re absolutely real  . Pages   and  — Here ! Lemme show
-# Nᴹ/J+     . N🅪Sg/VB P  NSg+ . K       R          NSg/J . NPl/V3+ VB/C . J/R  . W?    NSg/VB
+# Nᴹ/J+     . N🅪Sg/VB P  NSg+ . K       R          NSg/J . NPl/V3+ VB/C . R    . W?    NSg/VB
 > you    . ”
 # ISgPl+ . .
 >
@@ -2787,7 +2787,7 @@
 >
 #
 > “ A    little      bit      , I       think  . I       can’t tell   yet      . I’ve only  been   here an  hour . Did  I
-# . D/P+ NPr/I/J/Dq+ NSg/VPt+ . ISg/#r+ NSg/VB . ISg/#r+ VXB   NPr/VB NSg/VB/C . K    J/R/C VLPp/B J/R  D/P NSg+ . VXPt ISg/#r+
+# . D/P+ NPr/I/J/Dq+ NSg/VPt+ . ISg/#r+ NSg/VB . ISg/#r+ VXB   NPr/VB NSg/VB/C . K    J/R/C VLPp/B R    D/P NSg+ . VXPt ISg/#r+
 > tell   you    about the books   ? They’re real  . They’re — ”
 # NPr/VB ISgPl+ J/P   D+  NPl/V3+ . K       NSg/J . K       . .
 >
@@ -2796,8 +2796,8 @@
 # . ISgPl+ VP   NPr/IPl+ . .
 >
 #
-> We   shook     hands   with him  gravely and  went    back     outdoors .
-# IPl+ NSg/VPt/J NPl/V3+ P    ISg+ R       VB/C NSg/VPt NSg/VB/J NSg/R    .
+> We   shook     hands   with him  gravely and  went back     outdoors .
+# IPl+ NSg/VPt/J NPl/V3+ P    ISg+ R       VB/C VPt  NSg/VB/J NSg/R    .
 >
 #
 > There was  dancing now       on  the canvas  in        the garden    ; old    men  pushing young     girls
@@ -2992,8 +2992,8 @@
 # . NSg/VB NSg/R/C . .
 >
 #
-> “ I       don’t know , ” she  insisted , “ I       just don’t think  he       went    there . ”
-# . ISg/#r+ VXB   VB   . . ISg+ VP/J     . . ISg/#r+ J/R  VXB   NSg/VB NPr/ISg+ NSg/VPt R     . .
+> “ I       don’t know , ” she  insisted , “ I       just don’t think  he       went there . ”
+# . ISg/#r+ VXB   VB   . . ISg+ VP/J     . . ISg/#r+ J/R  VXB   NSg/VB NPr/ISg+ VPt  R     . .
 >
 #
 > Something in        her     tone       reminded me       of the other    girl’s “ I       think  he       killed a   man     , ”
@@ -3050,8 +3050,8 @@
 # NSg/VB+ P  I/D     P    Nᴹ/Vg/J   NPl/V3+ . ISg/D$+ VP/J+  N🅪Sg/VB+ VLPt VPp/J R
 > tight on  his     face    and  his     short      hair     looked as    though it       were trimmed every day     .
 # VB/J  J/P ISg/D$+ NSg/VB+ VB/C ISg/D$+ NPr/VB/J/P N🅪Sg/VB+ VP/J   R/C/P C      NPr/ISg+ VLPt VP/J    Dq    NPr🅪Sg+ .
-> I       could   see    nothing  sinister about him  . I       wondered if    the fact that      he       was  not
-# ISg/#r+ NSg/VXB NSg/VB NSg/I/J+ J        J/P   ISg+ . ISg/#r+ VP/J     NSg/C D+  NSg+ I/C/Ddem+ NPr/ISg+ VLPt NSg/R/C
+> I       could see    nothing  sinister about him  . I       wondered if    the fact that      he       was  not
+# ISg/#r+ VXB   NSg/VB NSg/I/J+ J        J/P   ISg+ . ISg/#r+ VP/J     NSg/C D+  NSg+ I/C/Ddem+ NPr/ISg+ VLPt NSg/R/C
 > drinking helped to set       him  off        from his     guests  , for   it       seemed to me       that     he       grew
 # Nᴹ/Vg/J  VP/J   P  NPr/VBP/J ISg+ NSg/VB/J/P P    ISg/D$+ NPl/V3+ . R/C/P NPr/ISg+ VP/J   P  NPr/ISg+ I/C/Ddem NPr/ISg+ VPt
 > more         correct  as    the fraternal hilarity increased . When    the “ Jazz   History of the
@@ -3106,8 +3106,8 @@
 # VP  VP/J   P    D/P NPr/VB/J . NSg/I/J/Dq . VP/J     N🅪Sg/VB+ I/C+  VP/J     D   NSg/VB+ . Nᴹ/Vg/J
 > Jordan’s undergraduate , who    was  now       engaged in        an  obstetrical conversation with
 # NPr$     NSg/J         . NPr/I+ VLPt NSg/J/R/C VP/J    NPr/J/R/P D/P J           N🅪Sg/VB+     P
-> two chorus  girls   , and  who    implored me       to join   him  , I       went    inside  .
-# NSg NSg/VB+ NPl/V3+ . VB/C NPr/I+ VP/J     NPr/ISg+ P  NSg/VB ISg+ . ISg/#r+ NSg/VPt NSg/J/P .
+> two chorus  girls   , and  who    implored me       to join   him  , I       went inside  .
+# NSg NSg/VB+ NPl/V3+ . VB/C NPr/I+ VP/J     NPr/ISg+ P  NSg/VB ISg+ . ISg/#r+ VPt  NSg/J/P .
 >
 #
 > The large  room     was  full     of people  . One     of the girls   in        yellow   was  playing the
@@ -3130,8 +3130,8 @@
 # J    N🅪Sg/VB/J/Am+ . VB/C VP/J    D   NSg/VB P  D$+   NSg/J+ NPr/J/R/P NSg/VB/J N🅪Sg/VB/J NPl      . D/P J
 > suggestion was  made that     she  sing     the notes   on  her     face    , whereupon she  threw up
 # N🅪Sg+      VLPt VP   I/C/Ddem ISg+ NSg/VB/J D   NPl/V3+ J/P ISg/D$+ NSg/VB+ . C         ISg+ VPt   NSg/VB/J/P
-> her     hands   , sank into a   chair   , and  went    off        into a   deep  vinous sleep    .
-# ISg/D$+ NPl/V3+ . VPt  P    D/P NSg/VB+ . VB/C NSg/VPt NSg/VB/J/P P    D/P NSg/J J      N🅪Sg/VB+ .
+> her     hands   , sank into a   chair   , and  went off        into a   deep  vinous sleep    .
+# ISg/D$+ NPl/V3+ . VPt  P    D/P NSg/VB+ . VB/C VPt  NSg/VB/J/P P    D/P NSg/J J      N🅪Sg/VB+ .
 >
 #
 > “ She  had a   fight  with a    man     who    says   he’s her     husband , ” explained a   girl    at    my
@@ -3223,7 +3223,7 @@
 > “ It       was  . . . simply amazing , ” she  repeated abstractedly . “ But     I       swore I
 # . NPr/ISg+ VLPt . . . R      Nᴹ/Vg/J . . ISg+ VP/J     R            . . NSg/C/P ISg/#r+ VB    ISg/#r+
 > wouldn’t tell   it       and  here I       am        tantalizing you    . ” She  yawned gracefully in        my
-# VXB      NPr/VB NPr/ISg+ VB/C J/R  ISg/#r+ NPr/VLB/J Nᴹ/Vg/J     ISgPl+ . . ISg+ VP/J   R          NPr/J/R/P D$+
+# VXB      NPr/VB NPr/ISg+ VB/C R    ISg/#r+ NPr/VLB/J Nᴹ/Vg/J     ISgPl+ . . ISg+ VP/J   R          NPr/J/R/P D$+
 > face    . “ Please come       and  see    me       . . . . Phone   book    . . . . Under   the name   of Mrs  .
 # NSg/VB+ . . VB     NSg/VBPp/P VB/C NSg/VB NPr/ISg+ . . . . NSg/VB+ NSg/VB+ . . . . NSg/J/P D   NSg/VB P  NPl+ .
 > Sigourney Howard . . . . My  aunt . . . . ” She  was  hurrying off        as    she  talked — her
@@ -3304,8 +3304,8 @@
 # NPr/J/R/P D/P NSg/J    . VP/J    NSg/J+ .
 >
 #
-> “ See    ! ” he       explained . “ It       went    in        the ditch   . ”
-# . NSg/VB . . NPr/ISg+ VP/J      . . NPr/ISg+ NSg/VPt NPr/J/R/P D+  NSg/VB+ . .
+> “ See    ! ” he       explained . “ It       went in        the ditch   . ”
+# . NSg/VB . . NPr/ISg+ VP/J      . . NPr/ISg+ VPt  NPr/J/R/P D+  NSg/VB+ . .
 >
 #
 > The fact was  infinitely astonishing to him  , and  I       recognized first the unusual
@@ -3480,16 +3480,16 @@
 # NPl      VB/C N🅪Sg/VB/J+ . ISg/#r+ NSg/VB/J/R VP  D/P NPr/VB/J/P NSg    P    D/P+ NSg/VB+ NPr/I+ VP/J  NPr/J/R/P NPr+
 > City and  worked in        the accounting department , but     her     brother   began throwing
 # NSg+ VB/C VP/J   NPr/J/R/P D+  Nᴹ/Vg/J+   NSg+       . NSg/C/P ISg/D$+ NSg/VB/J+ VPt   Nᴹ/Vg/J
-> mean     looks  in        my  direction , so          when    she  went    on  her     vacation in        July I       let     it
-# NSg/VB/J NPl/V3 NPr/J/R/P D$+ N🅪Sg+     . NSg/I/J/R/C NSg/I/C ISg+ NSg/VPt J/P ISg/D$+ NSg/VB+  NPr/J/R/P NPr+ ISg/#r+ NSg/VBP NPr/ISg+
+> mean     looks  in        my  direction , so          when    she  went on  her     vacation in        July I       let     it
+# NSg/VB/J NPl/V3 NPr/J/R/P D$+ N🅪Sg+     . NSg/I/J/R/C NSg/I/C ISg+ VPt  J/P ISg/D$+ NSg/VB+  NPr/J/R/P NPr+ ISg/#r+ NSg/VBP NPr/ISg+
 > blow     quietly away .
 # NSg/VB/J R       VB/J .
 >
 #
 > I       took dinner   usually at    the Yale Club    — for   some      reason   it       was  the gloomiest
 # ISg/#r+ VPt  N🅪Sg/VB+ R       NSg/P D+  NPr+ NSg/VB+ . R/C/P I/J/R/Dq+ N🅪Sg/VB+ NPr/ISg+ VLPt D   JS
-> event  of my  day     — and  then      I       went    up         - stairs to the library and  studied investments
-# NSg/VB P  D$+ NPr🅪Sg+ . VB/C NSg/J/R/C ISg/#r+ NSg/VPt NSg/VB/J/P . NPl+   P  D   NSg+    VB/C VP/J    NPl+
+> event  of my  day     — and  then      I       went up         - stairs to the library and  studied investments
+# NSg/VB P  D$+ NPr🅪Sg+ . VB/C NSg/J/R/C ISg/#r+ VPt  NSg/VB/J/P . NPl+   P  D   NSg+    VB/C VP/J    NPl+
 > and  securities for   a   conscientious hour . There were generally a   few      rioters
 # VB/C NPl+       R/C/P D/P J             NSg+ . R+    VLPt R         D/P NSg/I/Dq NPl
 > around , but     they never came      into the library , so          it       was  a   good     place    to work    .
@@ -3641,7 +3641,7 @@
 > knew that     first I       had to get    myself definitely out          of that      tangle back     home      . I'd
 # VPt  I/C/Ddem NSg/J ISg/#r+ VP  P  NSg/VB ISg+   R          NSg/VB/J/R/P P  I/C/Ddem+ NSg/VB NSg/VB/J NSg/VB/J+ . +
 > been   writing letters once  a    week   and  signing them     : “ Love      , Nick    , ” and  all          I       could
-# VLPp/B Nᴹ/Vg/J NPl/V3+ NSg/C D/P+ NSg/J+ VB/C Nᴹ/Vg/J NSg/IPl+ . . NPr🅪Sg/VB . NPr/VB+ . . VB/C NSg/I/J/C/Dq ISg/#r+ NSg/VXB
+# VLPp/B Nᴹ/Vg/J NPl/V3+ NSg/C D/P+ NSg/J+ VB/C Nᴹ/Vg/J NSg/IPl+ . . NPr🅪Sg/VB . NPr/VB+ . . VB/C NSg/I/J/C/Dq ISg/#r+ VXB
 > think  of was  how   , when    that      certain girl    played tennis  , a   faint    mustache of
 # NSg/VB P  VLPt NSg/C . NSg/I/C I/C/Ddem+ I/J+    NSg/VB+ VP/J   NSg/VB+ . D/P NSg/VB/J NSg      P
 > perspiration appeared on  her     upper  lip     . Nevertheless there was  a    vague
@@ -3716,8 +3716,8 @@
 # VB/JC   NSg/VB/J/R/P J/P D+  NSg/VB+ NSg/VPt/P D   ?        VB/C D   ?  ?  ?  ?          . VB/C D
 > Stonewall Jackson Abrams of Georgia , and  the Fishguards and  the Ripley Snells .
 # NSg/VB/J  NPr+    NPrPl  P  NPr+    . VB/C D   ?          VB/C D   NPr    ?      .
-> Snell was  there three days before he       went    to the penitentiary , so          drunk     out          on
-# NPr   VLPt R+    NSg   NPl+ C/P    NPr/ISg+ NSg/VPt P  D   NSg/J+       . NSg/I/J/R/C NSg/VPp/J NSg/VB/J/R/P J/P
+> Snell was  there three days before he       went to the penitentiary , so          drunk     out          on
+# NPr   VLPt R+    NSg   NPl+ C/P    NPr/ISg+ VPt  P  D   NSg/J+       . NSg/I/J/R/C NSg/VPp/J NSg/VB/J/R/P J/P
 > the gravel   drive   that     Mrs  . Ulysses Swett’s automobile ran over    his     right    hand    .
 # D   Nᴹ/VB/J+ N🅪Sg/VB I/C/Ddem NPl+ . NPr+    ?       NSg/VB/J   VPt NSg/J/P ISg/D$+ NPr/VB/J NSg/VB+ .
 > The Dancies came      , too , and  S. B. Whitebait , who    was  well       over    sixty , and  Maurice
@@ -3847,7 +3847,7 @@
 > I’d seen    it       . Everybody had seen    it       . It       was  a   rich     cream     color        , bright   with
 # K   NSg/VPp NPr/ISg+ . NSg/I+    VP  NSg/VPp NPr/ISg+ . NPr/ISg+ VLPt D/P NPr/VB/J N🅪Sg/VB/J N🅪Sg/VB/J/Am . NPr/VB/J P
 > nickel   , swollen here and  there in        its     monstrous length   with triumphant hat     - boxes
-# NSg/VB/J . VB/J    J/R  VB/C R     NPr/J/R/P ISg/D$+ J         N🅪Sg/VB+ P    J          NSg/VB+ . NPl/V3
+# NSg/VB/J . VB/J    R    VB/C R     NPr/J/R/P ISg/D$+ J         N🅪Sg/VB+ P    J          NSg/VB+ . NPl/V3
 > and  supper  - boxes  and  tool    - boxes   , and  terraced with a   labyrinth of wind     - shields
 # VB/C NSg/VB+ . NPl/V3 VB/C NSg/VB+ . NPl/V3+ . VB/C VP/J     P    D/P NSg/VB    P  N🅪Sg/VB+ . NPrPl/V3+
 > that     mirrored a   dozen suns     . Sitting  down        behind  many       layers of glass      in        a   sort
@@ -3875,7 +3875,7 @@
 >
 #
 > “ Look   here , old    sport   , ” he       broke     out          surprisingly , “ what’s your opinion of me       ,
-# . NSg/VB J/R  . NSg/J+ NSg/VB+ . . NPr/ISg+ NSg/VPt/J NSg/VB/J/R/P R            . . K      D$+  N🅪Sg    P  NPr/ISg+ .
+# . NSg/VB R    . NSg/J+ NSg/VB+ . . NPr/ISg+ NSg/VPt/J NSg/VB/J/R/P R            . . K      D$+  N🅪Sg    P  NPr/ISg+ .
 > anyhow ? ”
 # J      . .
 >
@@ -4051,7 +4051,7 @@
 > I       didn’t want   you    to think  I       was  just some     nobody . You    see    , I       usually find
 # ISg/#r+ VXPt   NSg/VB ISgPl+ P  NSg/VB ISg/#r+ VLPt J/R  I/J/R/Dq NSg/I+ . ISgPl+ NSg/VB . ISg/#r+ R       NSg/VB
 > myself among strangers because I       drift  here and  there trying  to forget the sad
-# ISg+   P     +         C/P     ISg/#r+ NSg/VB J/R  VB/C R+    Nᴹ/Vg/J P  VB     D+  NSg/VB/J+
+# ISg+   P     +         C/P     ISg/#r+ NSg/VB R    VB/C R+    Nᴹ/Vg/J P  VB     D+  NSg/VB/J+
 > thing that      happened to me       . ” He       hesitated . “ You’ll hear about it       this   afternoon . ”
 # NSg+  I/C/Ddem+ VP/J     P  NPr/ISg+ . . NPr/ISg+ VP/J      . . K      VB   J/P   NPr/ISg+ I/Ddem N🅪Sg+     . .
 >
@@ -4096,8 +4096,8 @@
 # D   J+    . NSg/VB/J NSg      . NPl+     . NSg/J/R/C D   NSg/VB P  NPl/V3+ VP/J   NSg/VB/J/R/P J/P I/C/Dq
 > sides  of us       , and  I       had a   glimpse of Mrs  . Wilson straining at    the garage  pump
 # NPl/V3 P  NPr/IPl+ . VB/C ISg/#r+ VP  D/P NSg/VB  P  NPl+ . NPr+   Nᴹ/Vg/J   NSg/P D+  NSg/VB+ NSg/VB+
-> with panting vitality as    we   went    by .
-# P    Nᴹ/Vg/J Nᴹ+      R/C/P IPl+ NSg/VPt P  .
+> with panting vitality as    we   went by .
+# P    Nᴹ/Vg/J Nᴹ+      R/C/P IPl+ VPt  P  .
 >
 #
 > With fenders spread   like         wings   we   scattered light      through half      Astoria — only
@@ -4166,8 +4166,8 @@
 # NSg/P NSg/I/J/C/Dq . . . . .
 >
 #
-> Even       Gatsby could   happen , without any    particular wonder   .
-# NSg/VB/J/R NPr    NSg/VXB VB     . C/P     I/R/Dq NSg/J      N🅪Sg/VB+ .
+> Even       Gatsby could happen , without any    particular wonder   .
+# NSg/VB/J/R NPr    VXB   VB     . C/P     I/R/Dq NSg/J      N🅪Sg/VB+ .
 >
 #
 > Roaring noon    . In        a    well        - fanned Forty - second   Street    cellar  I       met Gatsby for
@@ -4225,7 +4225,7 @@
 >
 #
 > “ This    is  a   nice  restaurant here , ” said Mr   . Wolfshiem , looking at    the
-# . I/Ddem+ VL3 D/P NPr/J NSg        J/R  . . VP/J NSg+ . ?         . Nᴹ/Vg/J NSg/P D
+# . I/Ddem+ VL3 D/P NPr/J NSg        R    . . VP/J NSg+ . ?         . Nᴹ/Vg/J NSg/P D
 > Presbyterian nymphs on  the ceiling . “ But     I       like         across the street    better     ! ”
 # NSg/J        NPl/VB J/P D   NSg/VB+ . . NSg/C/P ISg/#r+ NSg/VB/J/C/P NSg/P  D+  NSg/VB/J+ NSg/VXB/JC . .
 >
@@ -4265,7 +4265,7 @@
 >
 #
 > “ ‘ Let     the bastards come       in        here if    they want   you    , Rosy     , but     don’t you    , so          help
-# . . NSg/VBP D   NPl/V3   NSg/VBPp/P NPr/J/R/P J/R  NSg/C IPl+ NSg/VB ISgPl+ . NSg/VB/J . NSg/C/P VXB   ISgPl+ . NSg/I/J/R/C NSg/VB
+# . . NSg/VBP D   NPl/V3   NSg/VBPp/P NPr/J/R/P R    NSg/C IPl+ NSg/VB ISgPl+ . NSg/VB/J . NSg/C/P VXB   ISgPl+ . NSg/I/J/R/C NSg/VB
 > me       , move   outside   this   room     . ’
 # NPr/ISg+ . NSg/VB Nᴹ/VB/J/P I/Ddem N🅪Sg/VB+ . .
 >
@@ -4280,12 +4280,12 @@
 # . VXPt NPr/ISg+ NSg/VB/J . . ISg/#r+ VP/J  R          .
 >
 #
-> “ Sure he       went    . ” Mr   . Wolfshiem’s nose    flashed at    me       indignantly . “ He       turned
-# . J    NPr/ISg+ NSg/VPt . . NSg+ . ?           NSg/VB+ VP/J    NSg/P NPr/ISg+ R           . . NPr/ISg+ VP/J
+> “ Sure he       went . ” Mr   . Wolfshiem’s nose    flashed at    me       indignantly . “ He       turned
+# . J    NPr/ISg+ VPt  . . NSg+ . ?           NSg/VB+ VP/J    NSg/P NPr/ISg+ R           . . NPr/ISg+ VP/J
 > around in        the door    and  says   : ‘ Don’t let     that     waiter  take   away my  coffee     ! ’ Then
 # J/P    NPr/J/R/P D+  NSg/VB+ VB/C NPl/V3 . . VXB   NSg/VBP I/C/Ddem NSg/VB+ NSg/VB VB/J D$+ N🅪Sg/VB/J+ . . NSg/J/R/C
-> he       went    out          on  the sidewalk , and  they shot      him  three times   in        his     full      belly   and
-# NPr/ISg+ NSg/VPt NSg/VB/J/R/P J/P D+  NSg+     . VB/C IPl+ NSg/VP/J+ ISg+ NSg+  NPl/V3+ NPr/J/R/P ISg/D$+ NSg/VB/J+ NSg/VB+ VB/C
+> he       went out          on  the sidewalk , and  they shot      him  three times   in        his     full      belly   and
+# NPr/ISg+ VPt  NSg/VB/J/R/P J/P D+  NSg+     . VB/C IPl+ NSg/VP/J+ ISg+ NSg+  NPl/V3+ NPr/J/R/P ISg/D$+ NSg/VB/J+ NSg/VB+ VB/C
 > drove   away . ”
 # NSg/VPt VB/J . .
 >
@@ -4333,7 +4333,7 @@
 >
 #
 > “ Look   here , old    sport   , ” said Gatsby , leaning toward me       , “ I’m afraid I       made you    a
-# . NSg/VB J/R  . NSg/J+ NSg/VB+ . . VP/J NPr    . Nᴹ/Vg/J J/P    NPr/ISg+ . . K   J      ISg/#r+ VP   ISgPl+ D/P
+# . NSg/VB R    . NSg/J+ NSg/VB+ . . VP/J NPr    . Nᴹ/Vg/J J/P    NPr/ISg+ . . K   J      ISg/#r+ VP   ISgPl+ D/P
 > little     angry this   morning    in        the car  . ”
 # NPr/I/J/Dq VB/J  I/Ddem N🅪Sg/Vg/J+ NPr/J/R/P D   NSg+ . .
 >
@@ -4380,8 +4380,8 @@
 # . NPr/VB . .
 >
 #
-> “ He       went    to Oggsford College in        England . You    know Oggsford College ? ”
-# . NPr/ISg+ NSg/VPt P  ?        NSg+    NPr/J/R/P NPr+    . ISgPl+ VB   ?        NSg+    . .
+> “ He       went to Oggsford College in        England . You    know Oggsford College ? ”
+# . NPr/ISg+ VPt  P  ?        NSg+    NPr/J/R/P NPr+    . ISgPl+ VB   ?        NSg+    . .
 >
 #
 > “ I’ve heard of it       . ”
@@ -4451,7 +4451,7 @@
 > “ You’re very polite , but     I       belong to another generation , ” he       announced solemnly .
 # . K      J/R  VB/J   . NSg/C/P ISg/#r+ VB/P   P  I/D     NSg+       . . NPr/ISg+ VP/J      R        .
 > “ You    sit    here and  discuss your sports and  your young     ladies  and  your — ” He
-# . ISgPl+ NSg/VB J/R  VB/C NSg/VB  D$+  NPl/V3 VB/C D$+  NPr/VB/J+ NPl/V3+ VB/C D$+  . . NPr/ISg+
+# . ISgPl+ NSg/VB R    VB/C NSg/VB  D$+  NPl/V3 VB/C D$+  NPr/VB/J+ NPl/V3+ VB/C D$+  . . NPr/ISg+
 > supplied an  imaginary noun    with another wave   of his     hand    . “ As    for   me       , I       am        fifty
 # VP/J     D/P NSg/J     NSg/VB+ P    I/D     NSg/VB P  ISg/D$+ NSg/VB+ . . R/C/P R/C/P NPr/ISg+ . ISg/#r+ NPr/VLB/J NSg+
 > years old   , and  I       won’t impose myself on  you    any    longer . ”
@@ -4498,8 +4498,8 @@
 # VP/J  NPr/J/R/P #    . NSg/C/P NSg/C ISg/#r+ VP  N🅪Sg/VP P  NPr/ISg+ NSg/P NSg/I/J/C/Dq ISg/#r+ VXB   NSg/VXB N🅪Sg/VP P  NPr/ISg+ R/C/P D/P
 > thing that      merely happened , the end    of some     inevitable chain    . It       never occurred
 # NSg+  I/C/Ddem+ R      VP/J     . D   NSg/VB P  I/J/R/Dq NSg/J      N🅪Sg/VB+ . NPr/ISg+ R     VP
-> to me       that      one      man     could   start  to play    with the faith  of fifty million
-# P  NPr/ISg+ I/C/Ddem+ NSg/I/J+ NPr/VB+ NSg/VXB NSg/VB P  N🅪Sg/VB P    D   NPr🅪Sg P  NSg   NSg+
+> to me       that      one      man     could start  to play    with the faith  of fifty million
+# P  NPr/ISg+ I/C/Ddem+ NSg/I/J+ NPr/VB+ VXB   NSg/VB P  N🅪Sg/VB P    D   NPr🅪Sg P  NSg   NSg+
 > people  — with the single   - mindedness of a    burglar blowing a   safe     .
 # NPl/VB+ . P    D   NSg/VB/J . Nᴹ         P  D/P+ NSg/VB+ Nᴹ/Vg/J D/P NSg/VB/J .
 >
@@ -4613,7 +4613,7 @@
 >
 #
 > “ Hello  , Jordan , ” she  called unexpectedly . “ Please come       here . ”
-# . NSg/VB . NPr+   . . ISg+ VP/J   R            . . VB     NSg/VBPp/P J/R  . .
+# . NSg/VB . NPr+   . . ISg+ VP/J   R            . . VB     NSg/VBPp/P R    . .
 >
 #
 > I       was  flattered that     she  wanted to speak  to me       , because of all           the older girls   I
@@ -4636,10 +4636,10 @@
 #
 > That      was  nineteen - seventeen . By the next     year I       had a   few      beaux myself , and  I
 # I/C/Ddem+ VLPt NSg      . NSg       . P  D+  NSg/J/P+ NSg+ ISg/#r+ VP  D/P NSg/I/Dq ?     ISg+   . VB/C ISg/#r+
-> began to play    in        tournaments , so          I       didn’t see    Daisy very often . She  went    with a
-# VPt   P  N🅪Sg/VB NPr/J/R/P NPl         . NSg/I/J/R/C ISg/#r+ VXPt   NSg/VB NPr+  J/R  R     . ISg+ NSg/VPt P    D/P
-> slightly older crowd   — when    she  went    with anyone at    all          . Wild      rumors     were
-# R        JC+   NSg/VB+ . NSg/I/C ISg+ NSg/VPt P    NSg/I+ NSg/P NSg/I/J/C/Dq . NSg/VB/J+ NPl/V3/Am+ VLPt
+> began to play    in        tournaments , so          I       didn’t see    Daisy very often . She  went with a
+# VPt   P  N🅪Sg/VB NPr/J/R/P NPl         . NSg/I/J/R/C ISg/#r+ VXPt   NSg/VB NPr+  J/R  R     . ISg+ VPt  P    D/P
+> slightly older crowd   — when    she  went with anyone at    all          . Wild      rumors     were
+# R        JC+   NSg/VB+ . NSg/I/C ISg+ VPt  P    NSg/I+ NSg/P NSg/I/J/C/Dq . NSg/VB/J+ NPl/V3/Am+ VLPt
 > circulating about her     — how   her     mother    had found  her     packing her     bag     one      winter
 # Nᴹ/Vg/J     J/P   ISg/D$+ . NSg/C ISg/D$+ NSg/VB/J+ VP  NSg/VP ISg/D$+ Nᴹ/Vg/J ISg/D$+ NSg/VB+ NSg/I/J+ N🅪Sg/VB+
 > night    to go       to New    York and  say    good     - by to a    soldier   who    was  going   overseas . She
@@ -4695,7 +4695,7 @@
 >
 #
 > “ Here , deares ’ . ” She  groped around in        a   wastebasket she  had with her     on  the bed
-# . J/R  . ?      . . . ISg+ VP/J   J/P    NPr/J/R/P D/P NSg/VB      ISg+ VP  P    ISg/D$+ J/P D   NSg/VBP/J+
+# . R    . ?      . . . ISg+ VP/J   J/P    NPr/J/R/P D/P NSg/VB      ISg+ VP  P    ISg/D$+ J/P D   NSg/VBP/J+
 > and  pulled out          the string of pearls  . ‘ Take   ’ em       down        - stairs and  give   ’ em       back     to
 # VB/C VP/J   NSg/VB/J/R/P D   NSg/VB P  NPl/V3+ . . NSg/VB . NSg/I/J+ N🅪Sg/VB/J/P . NPl+   VB/C NSg/VB . NSg/I/J+ NSg/VB/J P
 > whoever they belong to . Tell   ’ em       all          Daisy’s change   ’ her     mine      . Say    : ‘ Daisy’s
@@ -4752,8 +4752,8 @@
 # D   NPr+  NPr+    NSg+  .
 >
 #
-> The next     April Daisy had her     little      girl    , and  they went    to France for   a    year . I
-# D+  NSg/J/P+ NPr+  NPr+  VP  ISg/D$+ NPr/I/J/Dq+ NSg/VB+ . VB/C IPl+ NSg/VPt P  NPr+   R/C/P D/P+ NSg+ . ISg/#r+
+> The next     April Daisy had her     little      girl    , and  they went to France for   a    year . I
+# D+  NSg/J/P+ NPr+  NPr+  VP  ISg/D$+ NPr/I/J/Dq+ NSg/VB+ . VB/C IPl+ VPt  P  NPr+   R/C/P D/P+ NSg+ . ISg/#r+
 > saw     them     one     spring  in        Cannes , and  later in        Deauville , and  then      they came      back
 # NSg/VPt NSg/IPl+ NSg/I/J N🅪Sg/VB NPr/J/R/P NPr+   . VB/C JC    NPr/J/R/P ?         . VB/C NSg/J/R/C IPl+ NSg/VPt/P NSg/VB/J
 > to Chicago to settle down        . Daisy was  popular in        Chicago , as    you    know . They moved
@@ -4767,7 +4767,7 @@
 > and  , moreover , you    can     time      any    little     irregularity of your own      so          that
 # VB/C . R        . ISgPl+ NPr/VXB N🅪Sg/VB/J I/R/Dq NPr/I/J/Dq NSg          P  D$+  NSg/VB/J NSg/I/J/R/C I/C/Ddem
 > everybody else    is  so          blind    that     they don’t see    or    care     . Perhaps Daisy never went
-# NSg/I+    NSg/J/C VL3 NSg/I/J/R/C NSg/VB/J I/C/Ddem IPl+ VXB   NSg/VB NPr/C N🅪Sg/VB+ . NSg/R   NPr+  R     NSg/VPt
+# NSg/I+    NSg/J/C VL3 NSg/I/J/R/C NSg/VB/J I/C/Ddem IPl+ VXB   NSg/VB NPr/C N🅪Sg/VB+ . NSg/R   NPr+  R     VPt
 > in        for   amour at    all          — and  yet      there’s something in        that     voice  of hers . . . .
 # NPr/J/R/P R/C/P NSg   NSg/P NSg/I/J/C/Dq . VB/C NSg/VB/C K       NSg/I/J+  NPr/J/R/P I/C/Ddem NSg/VB P  ISg+ . . . .
 >
@@ -4836,14 +4836,14 @@
 #
 > The modesty of the demand   shook     me       . He       had waited five years and  bought a
 # D   Nᴹ      P  D   N🅪Sg/VB+ NSg/VPt/J NPr/ISg+ . NPr/ISg+ VP  VP/J   NSg+ NPl+  VB/C NSg/VP D/P+
-> mansion where   he       dispensed starlight to casual moths   — so          that     he       could   “ come
-# NSg+    NSg/R/C NPr/ISg+ VP/J      NSg       P  NSg/J  NPl/VB+ . NSg/I/J/R/C I/C/Ddem NPr/ISg+ NSg/VXB . NSg/VBPp/P
+> mansion where   he       dispensed starlight to casual moths   — so          that     he       could “ come
+# NSg+    NSg/R/C NPr/ISg+ VP/J      NSg       P  NSg/J  NPl/VB+ . NSg/I/J/R/C I/C/Ddem NPr/ISg+ VXB   . NSg/VBPp/P
 > over    ” some     afternoon to a   stranger’s garden    .
 # NSg/J/P . I/J/R/Dq N🅪Sg+     P  D/P NSg$       NSg/VB/J+ .
 >
 #
-> “ Did  I       have    to know all          this   before he       could   ask    such   a    little      thing ? ”
-# . VXPt ISg/#r+ NSg/VXB P  VB   NSg/I/J/C/Dq I/Ddem C/P    NPr/ISg+ NSg/VXB NSg/VB NSg/I+ D/P+ NPr/I/J/Dq+ NSg+  . .
+> “ Did  I       have    to know all          this   before he       could ask    such   a    little      thing ? ”
+# . VXPt ISg/#r+ NSg/VXB P  VB   NSg/I/J/C/Dq I/Ddem C/P    NPr/ISg+ VXB   NSg/VB NSg/I+ D/P+ NPr/I/J/Dq+ NSg+  . .
 >
 #
 > “ He’s afraid , he’s waited so          long     . He       thought you    might    be       offended . You    see    ,
@@ -4872,8 +4872,8 @@
 #
 > “ I       think  he       half      expected her     to wander into one     of his     parties , some      night    , ”
 # . ISg/#r+ NSg/VB NPr/ISg+ N🅪Sg/J/P+ NSg/VP/J ISg/D$+ P  NSg/VB P    NSg/I/J P  ISg/D$+ NPl/V3+ . I/J/R/Dq+ N🅪Sg/VB+ . .
-> went    on  Jordan , “ but     she  never did  . Then      he       began asking  people  casually if    they
-# NSg/VPt J/P NPr+   . . NSg/C/P ISg+ R     VXPt . NSg/J/R/C NPr/ISg+ VPt   Nᴹ/Vg/J NPl/VB+ R        NSg/C IPl+
+> went on  Jordan , “ but     she  never did  . Then      he       began asking  people  casually if    they
+# VPt  J/P NPr+   . . NSg/C/P ISg+ R     VXPt . NSg/J/R/C NPr/ISg+ VPt   Nᴹ/Vg/J NPl/VB+ R        NSg/C IPl+
 > knew her     , and  I       was  the first one     he       found  . It       was  that     night   he       sent   for   me       at
 # VPt  ISg/D$+ . VB/C ISg/#r+ VLPt D   NSg/J NSg/I/J NPr/ISg+ NSg/VP . NPr/ISg+ VLPt I/C/Ddem N🅪Sg/VB NPr/ISg+ NSg/VP R/C/P NPr/ISg+ NSg/P
 > his     dance    , and  you    should have    heard the elaborate way    he       worked up         to it       . Of
@@ -5009,7 +5009,7 @@
 > “ I       talked with Miss   Baker , ” I       said after a    moment . “ I’m going   to call   up         Daisy
 # . ISg/#r+ VP/J   P    NSg/VB NPr+  . . ISg/#r+ VP/J P     D/P+ NSg+   . . K   Nᴹ/Vg/J P  NSg/VB NSg/VB/J/P NPr+
 > to - morrow and  invite her     over    here to tea     . ”
-# P  . NPr/VB VB/C NSg/VB ISg/D$+ NSg/J/P J/R  P  N🅪Sg/VB . .
+# P  . NPr/VB VB/C NSg/VB ISg/D$+ NSg/J/P R    P  N🅪Sg/VB . .
 >
 #
 > “ Oh     , that’s all          right    , ” he       said carelessly . “ I       don’t want   to put     you    to any
@@ -5059,7 +5059,7 @@
 > “ Oh     , it       isn’t   about that      . At    least    — ’ ’ He       fumbled with a   series of beginnings .
 # . NPr/VB . NPr/ISg+ NSg/VX3 J/P   I/C/Ddem+ . NSg/P NSg/J/Dq . . . NPr/ISg+ VP/J    P    D/P NSgPl  P  NPl/V3+    .
 > “ Why    , I       thought — why    , look   here , old    sport   , you    don’t make   much         money   , do  you    ? ”
-# . NSg/VB . ISg/#r+ N🅪Sg/VP . NSg/VB . NSg/VB J/R  . NSg/J+ NSg/VB+ . ISgPl+ VXB   NSg/VB NSg/I/J/R/Dq N🅪Sg/J+ . VXB ISgPl+ . .
+# . NSg/VB . ISg/#r+ N🅪Sg/VP . NSg/VB . NSg/VB R    . NSg/J+ NSg/VB+ . ISgPl+ VXB   NSg/VB NSg/I/J/R/Dq N🅪Sg/J+ . VXB ISgPl+ . .
 >
 #
 > “ Not     very much         . ”
@@ -5112,14 +5112,14 @@
 # ISg/#r+ VLPt Nᴹ/Vg/J VB/J P    D   . ?          . VP/J      NSg/P N🅪Sg/VB+ . NSg/C/P ISg/#r+ NSg/VP/J ISg+ NPr/ISg+
 > was  wrong      . He       waited a    moment longer , hoping  I’d begin  a    conversation , but     I       was
 # VLPt NSg/VB/J/R . NPr/ISg+ VP/J   D/P+ NSg+   NSg/JC . Nᴹ/Vg/J K   NSg/VB D/P+ N🅪Sg/VB+     . NSg/C/P ISg/#r+ VLPt
-> too absorbed to be       responsive , so          he       went    unwillingly home      .
-# R   VP/J     P  NSg/VLXB J          . NSg/I/J/R/C NPr/ISg+ NSg/VPt R           NSg/VB/J+ .
+> too absorbed to be       responsive , so          he       went unwillingly home      .
+# R   VP/J     P  NSg/VLXB J          . NSg/I/J/R/C NPr/ISg+ VPt  R           NSg/VB/J+ .
 >
 #
 > The evening    had made me       light      - headed and  happy    ; I       think  I       walked into a    deep
 # D+  N🅪Sg/Vg/J+ VP  VP   NPr/ISg+ N🅪Sg/VB/J+ . VP/J   VB/C NSg/VB/J . ISg/#r+ NSg/VB ISg/#r+ VP/J   P    D/P+ NSg/J+
-> sleep    as    I       entered my  front     door    . So          I       don’t know whether or    not     Gatsby went    to
-# N🅪Sg/VB+ R/C/P ISg/#r+ VP/J    D$+ NSg/VB/J+ NSg/VB+ . NSg/I/J/R/C ISg/#r+ VXB   VB   I/C     NPr/C NSg/R/C NPr    NSg/VPt P
+> sleep    as    I       entered my  front     door    . So          I       don’t know whether or    not     Gatsby went to
+# N🅪Sg/VB+ R/C/P ISg/#r+ VP/J    D$+ NSg/VB/J+ NSg/VB+ . NSg/I/J/R/C ISg/#r+ VXB   VB   I/C     NPr/C NSg/R/C NPr    VPt  P
 > Coney Island  , or    for   how   many       hours he       “ glanced into rooms   ” while      his     house
 # ?     NSg/VB+ . NPr/C R/C/P NSg/C NSg/I/J/Dq NPl+  NPr/ISg+ . VP/J    P    NPl/V3+ . NSg/VB/C/P ISg/D$+ NPr/VB+
 > blazed gaudily on  . I       called up         Daisy from the office  next     morning    , and  invited
@@ -5238,8 +5238,8 @@
 # NPr/ISg+ NSg/VP N🅪Sg/VB/J/P R         . R/C/P NSg/C ISg/#r+ VP  VP/J   ISg+ . VB/C R              R+    VLPt D
 > sound     of a    motor     turning into my  lane . We   both   jumped up         , and  , a   little     harrowed
 # N🅪Sg/VB/J P  D/P+ NSg/VB/J+ Nᴹ/Vg/J P    D$+ NPr+ . IPl+ I/C/Dq VP/J   NSg/VB/J/P . VB/C . D/P NPr/I/J/Dq VP/J
-> myself , I       went    out          into the yard    .
-# ISg+   . ISg/#r+ NSg/VPt NSg/VB/J/R/P P    D   NSg/VB+ .
+> myself , I       went out          into the yard    .
+# ISg+   . ISg/#r+ VPt  NSg/VB/J/R/P P    D   NSg/VB+ .
 >
 #
 > Under   the dripping bare     lilac  - trees   a   large open     car  was  coming  up         the drive    . It
@@ -5290,8 +5290,8 @@
 # . ISg/#r+ VXB   NSg/VB NSg/I/J/R/C . . ISg+ VP/J R          . . NSg/VB . .
 >
 #
-> We   went    in        . To my  overwhelming surprise the living     - room     was  deserted .
-# IPl+ NSg/VPt NPr/J/R/P . P  D$+ Nᴹ/Vg/J+     NSg/VB+  D+  N🅪Sg/Vg/J+ . N🅪Sg/VB+ VLPt VP/J     .
+> We   went in        . To my  overwhelming surprise the living     - room     was  deserted .
+# IPl+ VPt  NPr/J/R/P . P  D$+ Nᴹ/Vg/J+     NSg/VB+  D+  N🅪Sg/Vg/J+ . N🅪Sg/VB+ VLPt VP/J     .
 >
 #
 > “ Well       , that’s funny , ” I       exclaimed .
@@ -5304,8 +5304,8 @@
 #
 > She  turned her     head      as    there was  a    light      dignified knocking at    the front     door    . I
 # ISg+ VP/J   ISg/D$+ NPr/VB/J+ R/C/P R+    VLPt D/P+ N🅪Sg/VB/J+ VP/J      Nᴹ/Vg/J  NSg/P D   NSg/VB/J+ NSg/VB+ . ISg/#r+
-> went    out          and  opened it       . Gatsby , pale     as    death   , with his     hands   plunged like
-# NSg/VPt NSg/VB/J/R/P VB/C VP/J   NPr/ISg+ . NPr    . NSg/VB/J R/C/P NPr🅪Sg+ . P    ISg/D$+ NPl/V3+ VP/J    NSg/VB/J/C/P
+> went out          and  opened it       . Gatsby , pale     as    death   , with his     hands   plunged like
+# VPt  NSg/VB/J/R/P VB/C VP/J   NPr/ISg+ . NPr    . NSg/VB/J R/C/P NPr🅪Sg+ . P    ISg/D$+ NPl/V3+ VP/J    NSg/VB/J/C/P
 > weights in        his     coat    pockets , was  standing in        a   puddle of water    glaring
 # NPl/V3+ NPr/J/R/P ISg/D$+ NSg/VB+ NPl/V3+ . VLPt Nᴹ/Vg/J  NPr/J/R/P D/P NSg/VB P  N🅪Sg/VB+ Nᴹ/Vg/J
 > tragically into my  eyes    .
@@ -5334,8 +5334,8 @@
 # . ISg/#r+ R         NPr/VLB/J R       NSg/VB/J P  NSg/VB ISgPl+ P     . .
 >
 #
-> A    pause   ; it       endured horribly . I       had nothing  to do  in        the hall , so          I       went    into
-# D/P+ NSg/VB+ . NPr/ISg+ VP/J    R        . ISg/#r+ VP  NSg/I/J+ P  VXB NPr/J/R/P D+  NPr+ . NSg/I/J/R/C ISg/#r+ NSg/VPt P
+> A    pause   ; it       endured horribly . I       had nothing  to do  in        the hall , so          I       went into
+# D/P+ NSg/VB+ . NPr/ISg+ VP/J    R        . ISg/#r+ VP  NSg/I/J+ P  VXB NPr/J/R/P D+  NPr+ . NSg/I/J/R/C ISg/#r+ VPt  P
 > the room     .
 # D+  N🅪Sg/VB+ .
 >
@@ -5384,8 +5384,8 @@
 #
 > “ We   haven’t met for   many       years , ” said Daisy , her     voice   as    matter   - of - fact as    it
 # . IPl+ VXB     VP  R/C/P NSg/I/J/Dq NPl+  . . VP/J NPr+  . ISg/D$+ NSg/VB+ R/C/P N🅪Sg/VB+ . P  . NSg+ R/C/P NPr/ISg+
-> could   ever be       .
-# NSg/VXB J/R  NSg/VLXB .
+> could ever be       .
+# VXB   J/R  NSg/VLXB .
 >
 #
 > “ Five years next     November . ”
@@ -5466,8 +5466,8 @@
 #
 > He       raised his     hand    to stop   my  words   , looked at    me       with unforgettable reproach ,
 # NPr/ISg+ VP/J   ISg/D$+ NSg/VB+ P  NSg/VB D$+ NPl/V3+ . VP/J   NSg/P NPr/ISg+ P    J             NSg/VB   .
-> and  , opening the door    cautiously , went    back     into the other    room     .
-# VB/C . Nᴹ/Vg/J D   NSg/VB+ R          . NSg/VPt NSg/VB/J P    D   NSg/VB/J N🅪Sg/VB+ .
+> and  , opening the door    cautiously , went back     into the other    room     .
+# VB/C . Nᴹ/Vg/J D   NSg/VB+ R          . VPt  NSg/VB/J P    D   NSg/VB/J N🅪Sg/VB+ .
 >
 #
 > I       walked out          the back      way    — just as    Gatsby had when    he       had made his     nervous
@@ -5490,8 +5490,8 @@
 # J/P NSg/I/J/C/Dq D   Nᴹ/Vg/J/Am  NPl/V3+  NSg/C D   NPl+   VXB   NSg/VXB D$+   NPl/V3+ VP/J
 > with straw      . Perhaps their refusal took the heart    out          of his     plan    to Found  a
 # P    N🅪Sg/VB/J+ . NSg/R   D$+   NSg+    VPt  D+  N🅪Sg/VB+ NSg/VB/J/R/P P  ISg/D$+ NSg/VB+ P  NSg/VP D/P+
-> Family  — he       went    into an   immediate decline . His     children sold   his     house   with the
-# N🅪Sg/J+ . NPr/ISg+ NSg/VPt P    D/P+ J+        NSg/VB+ . ISg/D$+ NPl+     NSg/VP ISg/D$+ NPr/VB+ P    D
+> Family  — he       went into an   immediate decline . His     children sold   his     house   with the
+# N🅪Sg/J+ . NPr/ISg+ VPt  P    D/P+ J+        NSg/VB+ . ISg/D$+ NPl+     NSg/VP ISg/D$+ NPr/VB+ P    D
 > black     wreath still      on  the door    . Americans , while      willing  , even       eager    , to be
 # N🅪Sg/VB/J NSg/VB NSg/VB/J/R J/P D   NSg/VB+ . NPrPl+    . NSg/VB/C/P NSg/Vg/J . NSg/VB/J/R NSg/VB/J . P  NSg/VLXB
 > serfs , have    always been   obstinate about being        peasantry .
@@ -5506,8 +5506,8 @@
 # VXB      VB  D/P NSg      . D/P+ NSg+ VPt   Nᴹ/Vg/J D   NSg/J NPrPl/V3 P  ISg/D$+ NPr/VB+ .
 > appeared momentarily in        each , and  , leaning from the large central bay       , spat
 # VP/J     R           NPr/J/R/P Dq   . VB/C . Nᴹ/Vg/J P    D   NSg/J NPr/J   NSg/VB/J+ . NSg/VB
-> meditatively into the garden    . It       was  time      I       went    back     . While      the rain     continued
-# R            P    D   NSg/VB/J+ . NPr/ISg+ VLPt N🅪Sg/VB/J ISg/#r+ NSg/VPt NSg/VB/J . NSg/VB/C/P D+  N🅪Sg/VB+ VP/J
+> meditatively into the garden    . It       was  time      I       went back     . While      the rain     continued
+# R            P    D   NSg/VB/J+ . NPr/ISg+ VLPt N🅪Sg/VB/J ISg/#r+ VPt  NSg/VB/J . NSg/VB/C/P D+  N🅪Sg/VB+ VP/J
 > it       had seemed like         the murmur of their voices  , rising    and  swelling a   little     now
 # NPr/ISg+ VP  VP/J   NSg/VB/J/C/P D   NSg/VB P  D$+   NPl/V3+ . Nᴹ/Vg/J/P VB/C Nᴹ/Vg/J  D/P NPr/I/J/Dq NSg/J/R/C
 > and  then      with gusts  of emotion . But     in        the new    silence I       felt      that     silence had
@@ -5516,8 +5516,8 @@
 # VPp/J  NSg/J/P D+  NPr/VB+ R   .
 >
 #
-> I       went    in        — after making  every possible noise    in        the kitchen , short      of pushing
-# ISg/#r+ NSg/VPt NPr/J/R/P . P     Nᴹ/Vg/J Dq+   NSg/J    N🅪Sg/VB+ NPr/J/R/P D+  NSg/VB+ . NPr/VB/J/P P  Nᴹ/Vg/J
+> I       went in        — after making  every possible noise    in        the kitchen , short      of pushing
+# ISg/#r+ VPt  NPr/J/R/P . P     Nᴹ/Vg/J Dq+   NSg/J    N🅪Sg/VB+ NPr/J/R/P D+  NSg/VB+ . NPr/VB/J/P P  Nᴹ/Vg/J
 > over    the stove   — but     I       don’t believe they heard a   sound      . They were sitting  at
 # NSg/J/P D+  NSg/VB+ . NSg/C/P ISg/#r+ VXB   VB      IPl+ VP/J  D/P N🅪Sg/VB/J+ . IPl+ VLPt NSg/Vg/J NSg/P
 > either end    of the couch   , looking at    each other    as    if    some      question had been
@@ -5574,8 +5574,8 @@
 # . R          . NSg/J+ NSg/VB+ . .
 >
 #
-> Daisy went    up         - stairs to wash   her     face    — too late  I       thought with humiliation of my
-# NPr+  NSg/VPt NSg/VB/J/P . NPl+   P  NPr/VB ISg/D$+ NSg/VB+ . R   NSg/J ISg/#r+ N🅪Sg/VP P    NSg         P  D$+
+> Daisy went up         - stairs to wash   her     face    — too late  I       thought with humiliation of my
+# NPr+  VPt  NSg/VB/J/P . NPl+   P  NPr/VB ISg/D$+ NSg/VB+ . R   NSg/J ISg/#r+ N🅪Sg/VP P    NSg         P  D$+
 > towels  — while      Gatsby and  I       waited on  the lawn    .
 # NPl/V3+ . NSg/VB/C/P NPr    VB/C ISg/#r+ VP/J   J/P D   NSg/VB+ .
 >
@@ -5590,8 +5590,8 @@
 # ISg/#r+ VP/J   I/C/Ddem NPr/ISg+ VLPt J        .
 >
 #
-> “ Yes    . ” His     eyes    went    over    it       , every arched door   and  square    tower   . “ It       took me
-# . NPl/VB . . ISg/D$+ NPl/V3+ NSg/VPt NSg/J/P NPr/ISg+ . Dq    VP/J   NSg/VB VB/C NSg/VB/J+ NSg/VB+ . . NPr/ISg+ VPt  NPr/ISg+
+> “ Yes    . ” His     eyes    went over    it       , every arched door   and  square    tower   . “ It       took me
+# . NPl/VB . . ISg/D$+ NPl/V3+ VPt  NSg/J/P NPr/ISg+ . Dq    VP/J   NSg/VB VB/C NSg/VB/J+ NSg/VB+ . . NPr/ISg+ VPt  NPr/ISg+
 > just three years to earn   the money   that      bought it       . ”
 # J/R  NSg   NPl+  P  NSg/VB D+  N🅪Sg/J+ I/C/Ddem+ NSg/VP NPr/ISg+ . .
 >
@@ -5624,8 +5624,8 @@
 # VP/J     D   NSg/VB/J N🅪Sg/VB+ . .
 >
 #
-> Before I       could   answer  , Daisy came      out          of the house   and  two rows   of brass      buttons
-# C/P    ISg/#r+ NSg/VXB NSg/VB+ . NPr+  NSg/VPt/P NSg/VB/J/R/P P  D   NPr/VB+ VB/C NSg NPl/V3 P  N🅪Sg/VB/J+ NPl/V3+
+> Before I       could answer  , Daisy came      out          of the house   and  two rows   of brass      buttons
+# C/P    ISg/#r+ VXB   NSg/VB+ . NPr+  NSg/VPt/P NSg/VB/J/R/P P  D   NPr/VB+ VB/C NSg NPl/V3 P  N🅪Sg/VB/J+ NPl/V3+
 > on  her     dress   gleamed in        the sunlight .
 # J/P ISg/D$+ NSg/VB+ VP/J    NPr/J/R/P D   NSg/VB+  .
 >
@@ -5648,8 +5648,8 @@
 # Vg/J+       NPl+   . VP/J       NPl/VB+ . .
 >
 #
-> Instead of taking   the short      cut       along the Sound      we   went    down        to the road    and
-# R       P  NSg/Vg/J D   NPr/VB/J/P NSg/VBP/J P     D+  N🅪Sg/VB/J+ IPl+ NSg/VPt N🅪Sg/VB/J/P P  D+  N🅪Sg/J+ VB/C
+> Instead of taking   the short      cut       along the Sound      we   went down        to the road    and
+# R       P  NSg/Vg/J D   NPr/VB/J/P NSg/VBP/J P     D+  N🅪Sg/VB/J+ IPl+ VPt  N🅪Sg/VB/J/P P  D+  N🅪Sg/J+ VB/C
 > entered by the big   postern . With enchanting murmurs Daisy admired this   aspect   or
 # VP/J    P  D   NSg/J ?       . P    Nᴹ/Vg/J    NPl/V3  NPr+  VP/J    I/Ddem N🅪Sg/VB+ NPr/C
 > that     of the feudal silhouette against the sky      , admired the gardens , the
@@ -5670,14 +5670,14 @@
 # NPl+   . ISg/#r+ N🅪Sg/VP/J I/C/Ddem R+    VLPt NPl/V3+ VP/J      NSg/J/P Dq    NSg/VB VB/C NSg/VB+ .
 > under   orders  to be       breathlessly silent until we   had passed through . As    Gatsby
 # NSg/J/P NPl/V3+ P  NSg/VLXB R            NSg/J  C/P   IPl+ VP  VP/J   J/P     . R/C/P NPr
-> closed the door   of ‘ ‘ the Merton College Library ” I       could   have    sworn I       heard the
-# VP/J   D   NSg/VB P  . . D   NPr    NSg+    NSg+    . ISg/#r+ NSg/VXB NSg/VXB VB/J  ISg/#r+ VP/J  D
+> closed the door   of ‘ ‘ the Merton College Library ” I       could have    sworn I       heard the
+# VP/J   D   NSg/VB P  . . D   NPr    NSg+    NSg+    . ISg/#r+ VXB   NSg/VXB VB/J  ISg/#r+ VP/J  D
 > owl     - eyed man     break   into ghostly laughter .
 # NSg/VB+ . VP/J NPr/VB+ NSg/VB+ P    J/R     Nᴹ+      .
 >
 #
-> We   went    up         - stairs , through period    bedrooms swathed in        rose      and  lavender silk     and
-# IPl+ NSg/VPt NSg/VB/J/P . NPl+   . J/P     NSg/VB/J+ NPl+     J/Am    NPr/J/R/P NPr/VPt/J VB/C Nᴹ/VB/J  N🅪Sg/VB+ VB/C
+> We   went up         - stairs , through period    bedrooms swathed in        rose      and  lavender silk     and
+# IPl+ VPt  NSg/VB/J/P . NPl+   . J/P     NSg/VB/J+ NPl+     J/Am    NPr/J/R/P NPr/VPt/J VB/C Nᴹ/VB/J  N🅪Sg/VB+ VB/C
 > vivid with new   flowers   , through dressing - rooms   and  poolrooms , and  bathrooms with
 # NSg/J P    NSg/J NPrPl/V3+ . J/P     Nᴹ/Vg/J+ . NPl/V3+ VB/C NPl       . VB/C NPl/V3+   P
 > sunken baths   — intruding into one     chamber where   a   dishevelled man     in        pajamas was
@@ -5778,8 +5778,8 @@
 # N🅪Sg/VB P     . NSg/I/J/R/C IPl+ VP    NPr/J/R/P D/P NSg/VB+ Nᴹ/Vg/J NSg/P D   VP/J       NSg/VB  P  D   N🅪Sg/VB/J+ .
 >
 #
-> “ If    it       wasn’t for   the mist     we   could   see    your home      across the bay       , ” said Gatsby .
-# . NSg/C NPr/ISg+ VPt    R/C/P D   N🅪Sg/VB+ IPl+ NSg/VXB NSg/VB D$+  NSg/VB/J+ NSg/P  D   NSg/VB/J+ . . VP/J NPr    .
+> “ If    it       wasn’t for   the mist     we   could see    your home      across the bay       , ” said Gatsby .
+# . NSg/C NPr/ISg+ VPt    R/C/P D   N🅪Sg/VB+ IPl+ VXB   NSg/VB D$+  NSg/VB/J+ NSg/P  D   NSg/VB/J+ . . VP/J NPr    .
 > “ You    always have    a    green        light      that      burns    all          night    at    the end    of your dock    . ”
 # . ISgPl+ R      NSg/VXB D/P+ NPr🅪Sg/VB/J+ N🅪Sg/VB/J+ I/C/Ddem+ NPrPl/V3 NSg/I/J/C/Dq N🅪Sg/VB+ NSg/P D   NSg/VB P  D$+  NSg/VB+ . .
 >
@@ -5855,7 +5855,7 @@
 >
 #
 > “ Come       here quick    ! ” cried Daisy at    the window  .
-# . NSg/VBPp/P J/R  NSg/VB/J . . VP/J  NPr+  NSg/P D+  NSg/VB+ .
+# . NSg/VBPp/P R    NSg/VB/J . . VP/J  NPr+  NSg/P D+  NSg/VB+ .
 >
 #
 > The rain     was  still      falling , but     the darkness had parted in        the west      , and  there
@@ -5880,8 +5880,8 @@
 # . ISg/#r+ VB   NSg/I+ K     VXB . . VP/J NPr    . . K     NSg/VXB ?            N🅪Sg/VB D   NSg/VB/J+ . .
 >
 #
-> He       went    out          of the room     calling “ Ewing ! ” and  returned in        a    few       minutes
-# NPr/ISg+ NSg/VPt NSg/VB/J/R/P P  D+  N🅪Sg/VB+ Nᴹ/Vg/J . NPr   . . VB/C VP/J     NPr/J/R/P D/P+ NSg/I/Dq+ NPl/V3+
+> He       went out          of the room     calling “ Ewing ! ” and  returned in        a    few       minutes
+# NPr/ISg+ VPt  NSg/VB/J/R/P P  D+  N🅪Sg/VB+ Nᴹ/Vg/J . NPr   . . VB/C VP/J     NPr/J/R/P D/P+ NSg/I/Dq+ NPl/V3+
 > accompanied by an  embarrassed , slightly worn  young    man     , with shell      - rimmed
 # VP/J        P  D/P VP/J        . R        VPp/J NPr/VB/J NPr/VB+ . P    NPr🅪Sg/VB+ . VP/J
 > glasses and  scanty blond    hair     . He       was  now       decently clothed in        a   “ sport   shirt   , ”
@@ -5962,8 +5962,8 @@
 # NSg/VB . NPl+     . NPr/J/R/P D+  NSg+     . NPr/J/R/P NSg/P   N🅪Sg/VB/J+ . . . .
 >
 #
-> As    I       went    over    to say    good     - by I       saw     that     the expression of bewilderment had come
-# R/C/P ISg/#r+ NSg/VPt NSg/J/P P  NSg/VB NPr/VB/J . P  ISg/#r+ NSg/VPt I/C/Ddem D   N🅪Sg+      P  NSg          VP  NSg/VBPp/P
+> As    I       went over    to say    good     - by I       saw     that     the expression of bewilderment had come
+# R/C/P ISg/#r+ VPt  NSg/J/P P  NSg/VB NPr/VB/J . P  ISg/#r+ NSg/VPt I/C/Ddem D   N🅪Sg+      P  NSg          VP  NSg/VBPp/P
 > back     into Gatsby’s face    , as    though a   faint    doubt    had occurred to him  as    to the
 # NSg/VB/J P    NPr$     NSg/VB+ . R/C/P C      D/P NSg/VB/J N🅪Sg/VB+ VP  VP       P  ISg+ R/C/P P  D
 > quality of his     present  happiness . Almost five years ! There must    have    been
@@ -5996,8 +5996,8 @@
 # IPl+ VP  NSg/VPp/J NPr/ISg+ . NSg/C/P NPr+  VP/J    NSg/VB/J/P VB/C VP   NSg/VB/J/R/P ISg/D$+ NSg/VB+ . NPr    VXPt
 > know me       now       at    all          . I       looked once  more         at    them     and  they looked back     at    me       ,
 # VB   NPr/ISg+ NSg/J/R/C NSg/P NSg/I/J/C/Dq . ISg/#r+ VP/J   NSg/C NPr/I/J/R/Dq NSg/P NSg/IPl+ VB/C IPl+ VP/J   NSg/VB/J NSg/P NPr/ISg+ .
-> remotely , possessed by intense life     . Then      I       went    out          of the room     and  down        the
-# R        . VP/J      P  J+      N🅪Sg/VB+ . NSg/J/R/C ISg/#r+ NSg/VPt NSg/VB/J/R/P P  D+  N🅪Sg/VB+ VB/C N🅪Sg/VB/J/P D+
+> remotely , possessed by intense life     . Then      I       went out          of the room     and  down        the
+# R        . VP/J      P  J+      N🅪Sg/VB+ . NSg/J/R/C ISg/#r+ VPt  NSg/VB/J/R/P P  D+  N🅪Sg/VB+ VB/C N🅪Sg/VB/J/P D+
 > marble    steps   into the rain     , leaving them     there together .
 # NSg/VB/J+ NPl/V3+ P    D+  N🅪Sg/VB+ . Nᴹ/Vg/J NSg/IPl+ R+    J        .
 >
@@ -6146,8 +6146,8 @@
 # VP/J  P  NSg/VB/J ISg+ P    ISg/D$+ N🅪Sg/J+ . D+  I+   R   NSg/J  +             P  I/C+
 > Ella Kaye , the newspaper woman   , played Madame de   Maintenon to his     weakness and
 # NPr  NPr  . D   N🅪Sg/VB+  NSg/VB+ . VP/J   NSg+   NPr+ ?         P  ISg/D$+ N🅪Sg+    VB/C
-> sent   him  to sea in        a   yacht   , were common   property of the turgid journalism
-# NSg/VP ISg+ P  NSg NPr/J/R/P D/P NSg/VB+ . VLPt NSg/VB/J NSg/VB   P  D   J      Nᴹ+
+> sent   him  to sea in        a   yacht   , were common property of the turgid journalism
+# NSg/VP ISg+ P  NSg NPr/J/R/P D/P NSg/VB+ . VLPt VB/J   NSg/VB   P  D   J      Nᴹ+
 > of 1902 . He       had been   coasting along all          too hospitable shores  for   five years
 # P  #    . NPr/ISg+ VP  VLPp/B Nᴹ/Vg/J  P     NSg/I/J/C/Dq R   J          NPl/V3+ R/C/P NSg  NPl+
 > when    he       turned up         as    James  Gatz’s destiny in        Little     Girl    Bay       .
@@ -6180,8 +6180,8 @@
 # VPt  NSg/I+ NSg/VB/J NPl/V3 NPr+ NPr  NSg/VPp/J Nᴹ/VXB/J J/R  NSg/VLXB J/P   . VB/C NPr/ISg+ VP/J/C   R/C/P
 > such  contingencies by reposing more         and  more         trust     in        Gatsby . The arrangement
 # NSg/I NPl+          P  Nᴹ/Vg/J  NPr/I/J/R/Dq VB/C NPr/I/J/R/Dq N🅪Sg/VB/J NPr/J/R/P NPr    . D+  NSg+
-> lasted five years , during which the boat    went    three times   around the Continent .
-# VP/J   NSg+ NPl+  . VB/P   I/C+  D+  NSg/VB+ NSg/VPt NSg   NPl/V3+ J/P    D+  NPr/J+    .
+> lasted five years , during which the boat    went three times   around the Continent .
+# VP/J   NSg+ NPl+  . VB/P   I/C+  D+  NSg/VB+ VPt  NSg   NPl/V3+ J/P    D+  NPr/J+    .
 > It       might    have    lasted indefinitely except for   the fact that      Ella Kaye came      on
 # NPr/ISg+ Nᴹ/VXB/J NSg/VXB VP/J   R            VB/C/P R/C/P D+  NSg+ I/C/Ddem+ NPr  NPr  NSg/VPt/P J/P
 > board    one     night    in        Boston and  a   week   later Dan  Cody inhospitably died .
@@ -6206,8 +6206,8 @@
 # VB/C NPr/ISg+ VLPt P    NPr  I/C/Ddem NPr/ISg+ VP/J      N🅪Sg/J+ . D/P NSg/J  P  NSg    . NSg  NSg
 > dollars . He       didn’t get    it       . He       never understood the legal  device   that      was  used
 # NPl+    . NPr/ISg+ VXPt   NSg/VB NPr/ISg+ . NPr/ISg+ R     VP/J       D+  NSg/J+ NSg/J/P+ I/C/Ddem+ VLPt VP/J
-> against him  , but     what   remained of the millions went    intact to Ella Kaye . He       was
-# C/P     ISg+ . NSg/C/P NSg/I+ VP/J     P  D+  NPl+     NSg/VPt J      P  NPr  NPr  . NPr/ISg+ VLPt
+> against him  , but     what   remained of the millions went intact to Ella Kaye . He       was
+# C/P     ISg+ . NSg/C/P NSg/I+ VP/J     P  D+  NPl+     VPt  J      P  NPr  NPr  . NPr/ISg+ VLPt
 > left     with his     singularly appropriate education ; the vague    contour of Jay  Gatsby
 # NPr/VP/J P    ISg/D$+ R          VB/J+       NSg+      . D   NSg/VB/J NSg/VB  P  NPr+ NPr
 > had filled out          to the substantiality of a   man     .
@@ -6215,7 +6215,7 @@
 >
 #
 > He       told me       all          this   very much         later , but     I’ve put     it       down        here with the idea of
-# NPr/ISg+ VP   NPr/ISg+ NSg/I/J/C/Dq I/Ddem J/R  NSg/I/J/R/Dq JC    . NSg/C/P K    NSg/VBP NPr/ISg+ N🅪Sg/VB/J/P J/R  P    D   NSg  P
+# NPr/ISg+ VP   NPr/ISg+ NSg/I/J/C/Dq I/Ddem J/R  NSg/I/J/R/Dq JC    . NSg/C/P K    NSg/VBP NPr/ISg+ N🅪Sg/VB/J/P R    P    D   NSg  P
 > exploding those  first wild     rumors     about his     antecedents , which weren’t even
 # Nᴹ/Vg/J   I/Ddem NSg/J NSg/VB/J NPl/V3/Am+ J/P   ISg/D$+ NPl         . I/C+  VPt     NSg/VB/J/R
 > faintly true     . Moreover he       told it       to me       at    a   time      of confusion , when    I       had
@@ -6234,8 +6234,8 @@
 # VXPt   NSg/VB ISg+ NPr/C VB   ISg/D$+ NSg/VB+ J/P D   NSg/VB+ . R      ISg/#r+ VLPt NPr/J/R/P NSg/J NPr+ . NSg/Vg/J
 > around with Jordan and  trying  to ingratiate myself with her     senile aunt — but
 # J/P    P    NPr+   VB/C Nᴹ/Vg/J P  VB         ISg+   P    ISg/D$+ NSg/J  NSg+ . NSg/C/P
-> finally I       went    over    to his     house   one      Sunday  afternoon . I       hadn’t been   there two
-# R       ISg/#r+ NSg/VPt NSg/J/P P  ISg/D$+ NPr/VB+ NSg/I/J+ NSg/VB+ N🅪Sg+     . ISg/#r+ VPt    VLPp/B R+    NSg
+> finally I       went over    to his     house   one      Sunday  afternoon . I       hadn’t been   there two
+# R       ISg/#r+ VPt  NSg/J/P P  ISg/D$+ NPr/VB+ NSg/I/J+ NSg/VB+ N🅪Sg+     . ISg/#r+ VPt    VLPp/B R+    NSg
 > minutes when    somebody brought Tom     Buchanan in        for   a   drink   . I       was  startled ,
 # NPl/V3+ NSg/I/C NSg/I+   VP      NPr/VB+ NPr+     NPr/J/R/P R/C/P D/P NSg/VB+ . ISg/#r+ VLPt VP/J     .
 > naturally , but     the really surprising thing was  that     it       hadn’t happened before .
@@ -6279,7 +6279,7 @@
 >
 #
 > “ Very good      roads around here . ”
-# . J/R  NPr/VB/J+ NPl+  J/P    J/R  . .
+# . J/R  NPr/VB/J+ NPl+  J/P    R    . .
 >
 #
 > “ I       suppose the automobiles — — — ”
@@ -6311,7 +6311,7 @@
 >
 #
 > “ That’s right    . You    were with Nick    here . ”
-# . K      NPr/VB/J . ISgPl+ VLPt P    NPr/VB+ J/R  . .
+# . K      NPr/VB/J . ISgPl+ VLPt P    NPr/VB+ R    . .
 >
 #
 > “ I       know your wife      , ” continued Gatsby , almost aggressively .
@@ -6327,7 +6327,7 @@
 >
 #
 > “ You    live near       here , Nick    ? ”
-# . ISgPl+ VB/J NSg/VB/J/P J/R  . NPr/VB+ . .
+# . ISgPl+ VB/J NSg/VB/J/P R    . NPr/VB+ . .
 >
 #
 > “ Next     door    . ”
@@ -6519,7 +6519,7 @@
 > “ We   don’t go       around very much         , ” he       said ; “ in        fact , I       was  just thinking I       don’t
 # . IPl+ VXB   NSg/VB/J J/P    J/R  NSg/I/J/R/Dq . . NPr/ISg+ VP/J . . NPr/J/R/P NSg+ . ISg/#r+ VLPt J/R  Nᴹ/Vg/J  ISg/#r+ VXB
 > know a   soul     here . ”
-# VB   D/P N🅪Sg/VB+ J/R  . .
+# VB   D/P N🅪Sg/VB+ R    . .
 >
 #
 > “ Perhaps you    know that      lady    , ” Gatsby indicated a   gorgeous , scarcely human    orchid
@@ -6595,7 +6595,7 @@
 > Tom     appeared from his     oblivion as    we   were sitting  down        to supper together . “ Do
 # NPr/VB+ VP/J     P    ISg/D$+ NSg/VB+  R/C/P IPl+ VLPt NSg/Vg/J N🅪Sg/VB/J/P P  NSg/VB J        . . VXB
 > you    mind    if    I       eat with some      people  over    here ? ” he       said . “ A   fellow’s getting off
-# ISgPl+ NSg/VB+ NSg/C ISg/#r+ VB  P    I/J/R/Dq+ NPl/VB+ NSg/J/P J/R  . . NPr/ISg+ VP/J . . D/P NSg$     NSg/Vg+ NSg/VB/J/P
+# ISgPl+ NSg/VB+ NSg/C ISg/#r+ VB  P    I/J/R/Dq+ NPl/VB+ NSg/J/P R    . . NPr/ISg+ VP/J . . D/P NSg$     NSg/Vg+ NSg/VB/J/P
 > some     funny stuff  . ”
 # I/J/R/Dq NSg/J Nᴹ/VB+ . .
 >
@@ -6604,8 +6604,8 @@
 # . NSg/VB/J R     . . VP/J     NPr+  R        . . VB/C NSg/C ISgPl+ NSg/VB P  NSg/VB N🅪Sg/VB/J/P I/R/Dq NPl/V3+
 > here’s my  little     gold     pencil  . ” . . . She  looked around after a    moment and  told
 # K      D$+ NPr/I/J/Dq Nᴹ/VB/J+ NSg/VB+ . . . . . ISg+ VP/J   J/P    P     D/P+ NSg+   VB/C VP
-> me       the girl    was  “ common   but     pretty     , ” and  I       knew that     except for   the half      - hour
-# NPr/ISg+ D+  NSg/VB+ VLPt . NSg/VB/J NSg/C/P NSg/VB/J/R . . VB/C ISg/#r+ VPt  I/C/Ddem VB/C/P R/C/P D+  N🅪Sg/J/P+ . NSg+
+> me       the girl    was  “ common but     pretty     , ” and  I       knew that     except for   the half      - hour
+# NPr/ISg+ D+  NSg/VB+ VLPt . VB/J   NSg/C/P NSg/VB/J/R . . VB/C ISg/#r+ VPt  I/C/Ddem VB/C/P R/C/P D+  N🅪Sg/J/P+ . NSg+
 > she’d been   alone with Gatsby she  wasn’t having  a   good     time       .
 # K     VLPp/B J     P    NPr    ISg+ VPt    Nᴹ/Vg/J D/P NPr/VB/J N🅪Sg/VB/J+ .
 >
@@ -6649,7 +6649,7 @@
 >
 #
 > “ We   heard you    yelling , so          I       said to Doc Civet here : ‘ There’s somebody that      needs
-# . IPl+ VP/J  ISgPl+ Nᴹ/Vg/J . NSg/I/J/R/C ISg/#r+ VP/J P  NSg NSg+  J/R  . . K       NSg/I+   I/C/Ddem+ NPl/V3
+# . IPl+ VP/J  ISgPl+ Nᴹ/Vg/J . NSg/I/J/R/C ISg/#r+ VP/J P  NSg NSg+  R    . . K       NSg/I+   I/C/Ddem+ NPl/V3
 > your help   , Doc  . ’ ”
 # D$+  NSg/VB . NSg+ . . .
 >
@@ -6711,7 +6711,7 @@
 > I       sat    on  the front     steps   with them     while      they waited for   their car  . It       was  dark
 # ISg/#r+ NSg/VP J/P D+  NSg/VB/J+ NPl/V3+ P    NSg/IPl+ NSg/VB/C/P IPl+ VP/J   R/C/P D$+   NSg+ . NPr/ISg+ VLPt NSg/VB/J
 > here in        front     ; only  the bright   door    sent   ten square   feet of light      volleying out
-# J/R  NPr/J/R/P NSg/VB/J+ . J/R/C D   NPr/VB/J NSg/VB+ NSg/VP NSg NSg/VB/J NPl  P  N🅪Sg/VB/J+ Nᴹ/Vg/J   NSg/VB/J/R/P
+# R    NPr/J/R/P NSg/VB/J+ . J/R/C D   NPr/VB/J NSg/VB+ NSg/VP NSg NSg/VB/J NPl  P  N🅪Sg/VB/J+ Nᴹ/Vg/J   NSg/VB/J/R/P
 > into the soft  black     morning    . Sometimes a    shadow    moved against a   dressing - room
 # P    D   NSg/J N🅪Sg/VB/J N🅪Sg/Vg/J+ . R         D/P+ NSg/VB/J+ VP/J  C/P     D/P Nᴹ/Vg/J+ . N🅪Sg/VB
 > blind    above   , gave way    to another shadow    , an  indefinite procession of shadows ,
@@ -6879,7 +6879,7 @@
 > He       wanted nothing  less    of Daisy than that     she  should go       to Tom     and  say    : “ I       never
 # NPr/ISg+ VP/J   NSg/I/J+ J/R/C/P P  NPr+  C/P  I/C/Ddem ISg+ VXB    NSg/VB/J P  NPr/VB+ VB/C NSg/VB . . ISg/#r+ R
 > loved you    . ” After she  had obliterated four years with that     sentence they could
-# VP/J  ISgPl+ . . P     ISg+ VP  VP/J        NSg  NPl   P    I/C/Ddem NSg/VB+  IPl+ NSg/VXB
+# VP/J  ISgPl+ . . P     ISg+ VP  VP/J        NSg  NPl   P    I/C/Ddem NSg/VB+  IPl+ VXB
 > decide upon the more         practical measures to be       taken . One     of them     was  that      , after
 # VB     P    D   NPr/I/J/R/Dq NSg/J     NPl/V3   P  NSg/VLXB VPp/J . NSg/I/J P  NSg/IPl+ VLPt I/C/Ddem+ . P
 > she  was  free     , they were to go       back     to Louisville and  be       married  from her
@@ -6909,7 +6909,7 @@
 >
 #
 > He       looked around him  wildly , as    if    the past       were lurking here in        the shadow   of
-# NPr/ISg+ VP/J   J/P    ISg+ R      . R/C/P NSg/C D   NSg/VB/J/P VLPt Nᴹ/Vg/J J/R  NPr/J/R/P D   NSg/VB/J P
+# NPr/ISg+ VP/J   J/P    ISg+ R      . R/C/P NSg/C D   NSg/VB/J/P VLPt Nᴹ/Vg/J R    NPr/J/R/P D   NSg/VB/J P
 > his     house   , just out          of reach  of his     hand    .
 # ISg/D$+ NPr/VB+ . J/R  NSg/VB/J/R/P P  NSg/VB P  ISg/D$+ NSg/VB+ .
 >
@@ -6924,10 +6924,10 @@
 # NPr/ISg+ VP/J   D/P+ NPr/VB+ J/P   D   NSg/VB/J/P . VB/C ISg/#r+ VP/J     I/C/Ddem NPr/ISg+ VP/J   P  N🅪Sg/VB/J
 > something , some     idea of himself perhaps , that      had gone    into loving   Daisy . His
 # NSg/I/J+  . I/J/R/Dq NSg  P  ISg+    NSg/R   . I/C/Ddem+ VP  VPp/J/P P    Nᴹ/Vg/J+ NPr+  . ISg/D$+
-> life     had been   confused and  disordered since then      , but     if    he       could   once  return to
-# N🅪Sg/VB+ VP  VLPp/B VP/J     VB/C VP/J       C/P   NSg/J/R/C . NSg/C/P NSg/C NPr/ISg+ NSg/VXB NSg/C NSg/VB P
-> a   certain starting place    and  go       over    it       all          slowly , he       could   find   out          what   that
-# D/P I/J     Nᴹ/Vg/J+ N🅪Sg/VB+ VB/C NSg/VB/J NSg/J/P NPr/ISg+ NSg/I/J/C/Dq R      . NPr/ISg+ NSg/VXB NSg/VB NSg/VB/J/R/P NSg/I+ I/C/Ddem
+> life     had been   confused and  disordered since then      , but     if    he       could once  return to
+# N🅪Sg/VB+ VP  VLPp/B VP/J     VB/C VP/J       C/P   NSg/J/R/C . NSg/C/P NSg/C NPr/ISg+ VXB   NSg/C NSg/VB P
+> a   certain starting place    and  go       over    it       all          slowly , he       could find   out          what   that
+# D/P I/J     Nᴹ/Vg/J+ N🅪Sg/VB+ VB/C NSg/VB/J NSg/J/P NPr/ISg+ NSg/I/J/C/Dq R      . NPr/ISg+ VXB   NSg/VB NSg/VB/J/R/P NSg/I+ I/C/Ddem
 > thing was  . . . .
 # NSg+  VLPt . . . .
 >
@@ -6937,7 +6937,7 @@
 > when    the leaves  were falling , and  they came      to a    place    where   there were no       trees
 # NSg/I/C D+  NPl/V3+ VLPt Nᴹ/Vg/J . VB/C IPl+ NSg/VPt/P P  D/P+ N🅪Sg/VB+ NSg/R/C R+    VLPt NSg/Dq/P NPl/V3
 > and  the sidewalk was  white       with moonlight . They stopped here and  turned toward
-# VB/C D+  NSg+     VLPt NPr🅪Sg/VB/J P    N🅪Sg/VB+  . IPl+ VP/J    J/R  VB/C VP/J   J/P
+# VB/C D+  NSg+     VLPt NPr🅪Sg/VB/J P    N🅪Sg/VB+  . IPl+ VP/J    R    VB/C VP/J   J/P
 > each other    . Now       it       was  a   cool     night   with that      mysterious excitement in        it       which
 # Dq   NSg/VB/J . NSg/J/R/C NPr/ISg+ VLPt D/P NSg/VB/J N🅪Sg/VB P    I/C/Ddem+ J+         NSg+       NPr/J/R/P NPr/ISg+ I/C+
 > comes  at    the two changes of the year . The quiet     lights  in        the houses  were
@@ -6946,10 +6946,10 @@
 # NSg/Vg/J NSg/VB/J/R/P P    D+  Nᴹ+      VB/C R+    VLPt D/P NSg/VB VB/C NSg/VB P     D+  NPl/V3+ .
 > Out          of the corner of his     eye     Gatsby saw     that     the blocks of the sidewalks really
 # NSg/VB/J/R/P P  D   NSg/VB P  ISg/D$+ NSg/VB+ NPr    NSg/VPt I/C/Ddem D   NPl/V3 P  D   NPl+      R
-> formed a   ladder  and  mounted to a   secret   place    above   the trees   — he       could   climb  to
-# VP/J   D/P NSg/VB+ VB/C VP/J    P  D/P NSg/VB/J N🅪Sg/VB+ NSg/J/P D   NPl/V3+ . NPr/ISg+ NSg/VXB NSg/VB P
-> it       , if    he       climbed alone , and  once  there he       could   suck   on  the pap      of life     , gulp
-# NPr/ISg+ . NSg/C NPr/ISg+ VP/J    J     . VB/C NSg/C R+    NPr/ISg+ NSg/VXB NSg/VB J/P D   NSg/VB/J P  N🅪Sg/VB+ . NSg/VB
+> formed a   ladder  and  mounted to a   secret   place    above   the trees   — he       could climb  to
+# VP/J   D/P NSg/VB+ VB/C VP/J    P  D/P NSg/VB/J N🅪Sg/VB+ NSg/J/P D   NPl/V3+ . NPr/ISg+ VXB   NSg/VB P
+> it       , if    he       climbed alone , and  once  there he       could suck   on  the pap      of life     , gulp
+# NPr/ISg+ . NSg/C NPr/ISg+ VP/J    J     . VB/C NSg/C R+    NPr/ISg+ VXB   NSg/VB J/P D   NSg/VB/J P  N🅪Sg/VB+ . NSg/VB
 > down        the incomparable milk    of wonder   .
 # N🅪Sg/VB/J/P D   NSg/J        N🅪Sg/VB P  N🅪Sg/VB+ .
 >
@@ -6994,8 +6994,8 @@
 # NSg/VB/J+ R/C/P ?          VLPt NSg/J/P . J/R/C R         VXPt ISg/#r+ VBPp   VB/J  I/C/Ddem D
 > automobiles which turned expectantly into his     drive   stayed for   just a   minute    and
 # NPl/V3      I/C+  VP/J   R           P    ISg/D$+ N🅪Sg/VB VP/J   R/C/P J/R  D/P NSg/VB/J+ VB/C
-> then      drove   sulkily away . Wondering if    he       were sick     I       went    over    to find   out          — an
-# NSg/J/R/C NSg/VPt R       VB/J . Nᴹ/Vg/J   NSg/C NPr/ISg+ VLPt NSg/VB/J ISg/#r+ NSg/VPt NSg/J/P P  NSg/VB NSg/VB/J/R/P . D/P
+> then      drove   sulkily away . Wondering if    he       were sick     I       went over    to find   out          — an
+# NSg/J/R/C NSg/VPt R       VB/J . Nᴹ/Vg/J   NSg/C NPr/ISg+ VLPt NSg/VB/J ISg/#r+ VPt  NSg/J/P P  NSg/VB NSg/VB/J/R/P . D/P
 > unfamiliar butler with a   villainous face    squinted at    me       suspiciously from the
 # NSg/J      NPr/VB P    D/P J          NSg/VB+ VP/J     NSg/P NPr/ISg+ R            P    D
 > door    .
@@ -7034,8 +7034,8 @@
 #
 > My  Finn informed me       that     Gatsby had dismissed every servant in        his     house  a   week
 # D$+ NPr+ VP/J     NPr/ISg+ I/C/Ddem NPr    VP  VP/J      Dq    NSg/VB+ NPr/J/R/P ISg/D$+ NPr/VB D/P NSg/J+
-> ago and  replaced them     with half      a   dozen others  , who    never went    into West      Egg
-# J/P VB/C VP/J     NSg/IPl+ P    N🅪Sg/J/P+ D/P NSg   NPl/V3+ . NPr/I+ R     NSg/VPt P    NPr/VB/J+ N🅪Sg/VB+
+> ago and  replaced them     with half      a   dozen others  , who    never went into West      Egg
+# J/P VB/C VP/J     NSg/IPl+ P    N🅪Sg/J/P+ D/P NSg   NPl/V3+ . NPr/I+ R     VPt  P    NPr/VB/J+ N🅪Sg/VB+
 > Village to be       bribed by the tradesmen , but     ordered moderate supplies over    the
 # NSg+    P  NSg/VLXB VP/J   P  D   NPl       . NSg/C/P VP/J    NSg/VB/J NPl/V3+  NSg/J/P D
 > telephone . The grocery boy     reported that     the kitchen looked like         a    pigsty , and
@@ -7164,8 +7164,8 @@
 #
 > “ Madame expects you    in        the salon ! ” he       cried , needlessly indicating the
 # . NSg+   V3      ISgPl+ NPr/J/R/P D+  NSg+  . . NPr/ISg+ VP/J  . R          Nᴹ/Vg/J    D
-> direction . In        this    heat   every extra  gesture was  an  affront to the common   store
-# N🅪Sg+     . NPr/J/R/P I/Ddem+ Nᴹ/VB+ Dq+   NSg/J+ NSg/VB+ VLPt D/P NSg/VB  P  D   NSg/VB/J NSg/VB
+> direction . In        this    heat   every extra  gesture was  an  affront to the common store
+# N🅪Sg+     . NPr/J/R/P I/Ddem+ Nᴹ/VB+ Dq+   NSg/J+ NSg/VB+ VLPt D/P NSg/VB  P  D   VB/J   NSg/VB
 > of life     .
 # P  N🅪Sg/VB+ .
 >
@@ -7242,8 +7242,8 @@
 # . NSg/VB NPr/IPl+ D/P+ NSg/J+ NSg/VB+ . . VP/J  NPr+  .
 >
 #
-> As    he       left     the room     again she  got up         and  went    over    to Gatsby and  pulled his     face
-# R/C/P NPr/ISg+ NPr/VP/J D+  N🅪Sg/VB+ P     ISg+ VP  NSg/VB/J/P VB/C NSg/VPt NSg/J/P P  NPr    VB/C VP/J   ISg/D$+ NSg/VB+
+> As    he       left     the room     again she  got up         and  went over    to Gatsby and  pulled his     face
+# R/C/P NPr/ISg+ NPr/VP/J D+  N🅪Sg/VB+ P     ISg+ VP  NSg/VB/J/P VB/C VPt  NSg/J/P P  NPr    VB/C VP/J   ISg/D$+ NSg/VB+
 > down        , kissing him  on  the mouth   .
 # N🅪Sg/VB/J/P . Nᴹ/Vg/J ISg+ J/P D   NSg/VB+ .
 >
@@ -7382,8 +7382,8 @@
 # N🅪Sg/VB+ . .
 >
 #
-> I       went    with them     out          to the veranda      . On  the green        Sound      , stagnant in        the heat   ,
-# ISg/#r+ NSg/VPt P    NSg/IPl+ NSg/VB/J/R/P P  D+  NSg/NoAm/Br+ . J/P D+  NPr🅪Sg/VB/J+ N🅪Sg/VB/J+ . J        NPr/J/R/P D   Nᴹ/VB+ .
+> I       went with them     out          to the veranda      . On  the green        Sound      , stagnant in        the heat   ,
+# ISg/#r+ VPt  P    NSg/IPl+ NSg/VB/J/R/P P  D+  NSg/NoAm/Br+ . J/P D+  NPr🅪Sg/VB/J+ N🅪Sg/VB/J+ . J        NPr/J/R/P D   Nᴹ/VB+ .
 > one     small    sail    crawled slowly toward the fresher sea  . Gatsby’s eyes    followed it
 # NSg/I/J NPr/VB/J NSg/VB+ VP/J    R      J/P    D   NSg/JC  NSg+ . NPr$     NPl/V3+ VP/J     NPr/ISg+
 > momentarily ; he       raised his     hand    and  pointed across the bay       .
@@ -7474,8 +7474,8 @@
 # VP  J/R  VP/J       ISg/D$+ R/C/P I/J/R/Dq NSg/I/J+ NPr/ISg+ VPt  D/P NPr/VB/J N🅪Sg/VB/J+ J/P .
 >
 #
-> “ You    resemble the advertisement of the man     , ” she  went    on  innocently . ‘ You    know
-# . ISgPl+ VB       D   NSg           P  D   NPr/VB+ . . ISg+ NSg/VPt J/P R          . . ISgPl+ VB
+> “ You    resemble the advertisement of the man     , ” she  went on  innocently . ‘ You    know
+# . ISgPl+ VB       D   NSg           P  D   NPr/VB+ . . ISg+ VPt  J/P R          . . ISgPl+ VB
 > the advertisement of the man     — ”
 # D   NSg           P  D   NPr/VB+ . .
 >
@@ -7526,8 +7526,8 @@
 # . NSg/VXB NPr/ISg+ D$+  NSg/VB/J+ NSg/J+ . . ISg+ VP/J . . NSg/VBPp/P J/P . NPr+   . .
 >
 #
-> They went    up         - stairs to get    ready    while      we   three men  stood there shuffling the
-# IPl+ NSg/VPt NSg/VB/J/P . NPl+   P  NSg/VB NSg/VB/J NSg/VB/C/P IPl+ NSg+  NPl+ VP    R+    Nᴹ/Vg/J   D
+> They went up         - stairs to get    ready    while      we   three men  stood there shuffling the
+# IPl+ VPt  NSg/VB/J/P . NPl+   P  NSg/VB NSg/VB/J NSg/VB/C/P IPl+ NSg+  NPl+ VP    R+    Nᴹ/Vg/J   D
 > hot      pebbles with our feet . A   silver   curve    of the moon    hovered already in        the
 # NSg/VB/J NPl/V3+ P    D$+ NPl+ . D/P Nᴹ/VB/J+ NSg/VB/J P  D+  NPr/VB+ VP/J    R       NPr/J/R/P D+
 > western sky      . Gatsby started to speak  , changed his     mind    , but     not     before Tom
@@ -7537,7 +7537,7 @@
 >
 #
 > “ Have    you    got your stables here ? ” asked Gatsby with an  effort   .
-# . NSg/VXB ISgPl+ VP  D$+  NPl/V3+ J/R  . . VP/J  NPr    P    D/P N🅪Sg/VB+ .
+# . NSg/VXB ISgPl+ VP  D$+  NPl/V3+ R    . . VP/J  NPr    P    D/P N🅪Sg/VB+ .
 >
 #
 > “ About a   quarter  of a    mile down        the road    . ”
@@ -7562,8 +7562,8 @@
 # . VXB   IPl+ NSg/VB NSg/I/VB+ P  NSg/VB . . VP/J   NPr+  P    D/P+ NSg/J+ NSg/VB+ .
 >
 #
-> “ I’ll get    some     whiskey , ” answered Tom     . He       went    inside  .
-# . K    NSg/VB I/J/R/Dq N🅪Sg    . . VP/J     NPr/VB+ . NPr/ISg+ NSg/VPt NSg/J/P .
+> “ I’ll get    some     whiskey , ” answered Tom     . He       went inside  .
+# . K    NSg/VB I/J/R/Dq N🅪Sg    . . VP/J     NPr/VB+ . NPr/ISg+ VPt  NSg/J/P .
 >
 #
 > Gatsby turned to me       rigidly :
@@ -7692,8 +7692,8 @@
 # P  D   J           NSg+  .
 >
 #
-> “ I’ve made a   small    investigation of this   fellow , ” he       continued . “ I       could   have
-# . K    VP   D/P NPr/VB/J N🅪Sg          P  I/Ddem NSg    . . NPr/ISg+ VP/J      . . ISg/#r+ NSg/VXB NSg/VXB
+> “ I’ve made a   small    investigation of this   fellow , ” he       continued . “ I       could have
+# . K    VP   D/P NPr/VB/J N🅪Sg          P  I/Ddem NSg    . . NPr/ISg+ VP/J      . . ISg/#r+ VXB   NSg/VXB
 > gone    deeper if    I’d known — — — ”
 # VPp/J/P JC     NSg/C K   VPp/J . . . .
 >
@@ -7755,7 +7755,7 @@
 >
 #
 > “ But     there’s a    garage  right    here , ” objected Jordan . “ I       don’t want   to get    stalled
-# . NSg/C/P K       D/P+ NSg/VB+ NPr/VB/J J/R  . . VP/J     NPr+   . . ISg/#r+ VXB   NSg/VB P  NSg/VB VP/J
+# . NSg/C/P K       D/P+ NSg/VB+ NPr/VB/J R    . . VP/J     NPr+   . . ISg/#r+ VXB   NSg/VB P  NSg/VB VP/J
 > in        this   baking   heat   . ”
 # NPr/J/R/P I/Ddem Nᴹ/Vg/J+ Nᴹ/VB+ . .
 >
@@ -7816,8 +7816,8 @@
 # . NSg/VB/J/C/P P  NSg/VB NPr/ISg+ . .
 >
 #
-> “ Big    chance    , ” Wilson smiled faintly . “ No       , but     I       could   make   some      money   on  the
-# . NSg/J+ NPr/VB/J+ . . NPr+   VP/J   R       . . NSg/Dq/P . NSg/C/P ISg/#r+ NSg/VXB NSg/VB I/J/R/Dq+ N🅪Sg/J+ J/P D
+> “ Big    chance    , ” Wilson smiled faintly . “ No       , but     I       could make   some      money   on  the
+# . NSg/J+ NPr/VB/J+ . . NPr+   VP/J   R       . . NSg/Dq/P . NSg/C/P ISg/#r+ VXB   NSg/VB I/J/R/Dq+ N🅪Sg/J+ J/P D
 > other    . ”
 # NSg/VB/J . .
 >
@@ -7827,7 +7827,7 @@
 >
 #
 > “ I’ve been   here too long     . I       want   to get    away . My  wife      and  I       want   to go       West      . ”
-# . K    VLPp/B J/R  R   NPr/VB/J . ISg/#r+ NSg/VB P  NSg/VB VB/J . D$+ NSg/VB/J+ VB/C ISg/#r+ NSg/VB P  NSg/VB/J NPr/VB/J+ . .
+# . K    VLPp/B R    R   NPr/VB/J . ISg/#r+ NSg/VB P  NSg/VB VB/J . D$+ NSg/VB/J+ VB/C ISg/#r+ NSg/VB P  NSg/VB/J NPr/VB/J+ . .
 >
 #
 > “ Your wife      does    , ” exclaimed Tom     , startled .
@@ -7946,8 +7946,8 @@
 #
 > The word    “ sensuous ” had the effect of further disquieting Tom     , but     before he
 # D+  NSg/VB+ . J        . VP  D   NSg/VB P  VB/JC   Nᴹ/Vg/J     NPr/VB+ . NSg/C/P C/P    NPr/ISg+
-> could   invent a   protest  the coupé came      to a   stop    , and  Daisy signalled us       to draw
-# NSg/VXB VB     D/P N🅪Sg/VB+ D   ?     NSg/VPt/P P  D/P NSg/VB+ . VB/C NPr+  VP/Comm   NPr/IPl+ P  NSg/VB
+> could invent a   protest  the coupé came      to a   stop    , and  Daisy signalled us       to draw
+# VXB   VB     D/P N🅪Sg/VB+ D   ?     NSg/VPt/P P  D/P NSg/VB+ . VB/C NPr+  VP/Comm   NPr/IPl+ P  NSg/VB
 > up         alongside .
 # NSg/VB/J/P P         .
 >
@@ -7969,7 +7969,7 @@
 >
 #
 > “ We   can’t argue about it       here , ” Tom     said impatiently , as    a   truck   gave out          a
-# . IPl+ VXB   VB    J/P   NPr/ISg+ J/R  . . NPr/VB+ VP/J R           . R/C/P D/P NSg/VB+ VPt  NSg/VB/J/R/P D/P
+# . IPl+ VXB   VB    J/P   NPr/ISg+ R    . . NPr/VB+ VP/J R           . R/C/P D/P NSg/VB+ VPt  NSg/VB/J/R/P D/P
 > cursing whistle behind  us       . “ You    follow me       to the south     side     of Central Park    , in
 # Nᴹ/Vg/J NSg/VB  NSg/J/P NPr/IPl+ . . ISgPl+ NSg/VB NPr/ISg+ P  D   NPr/VB/J+ NSg/VB/J P  NPr/J+  NPr/VB+ . NPr/J/R/P
 > front    of the Plaza . ”
@@ -8012,8 +8012,8 @@
 # D+  N🅪Sg/VB+ VLPt NSg/J VB/C Nᴹ/Vg/J  . VB/C . C      NPr/ISg+ VLPt R       NSg  R       .
 > opening the windows   admitted only  a   gust   of hot      shrubbery from the Park    . Daisy
 # Nᴹ/Vg/J D   NPrPl/V3+ VP/J     J/R/C D/P NSg/VB P  NSg/VB/J NSg       P    D   NPr/VB+ . NPr+
-> went    to the mirror  and  stood with her     back     to us       , fixing  her     hair     .
-# NSg/VPt P  D+  NSg/VB+ VB/C VP    P    ISg/D$+ NSg/VB/J P  NPr/IPl+ . Nᴹ/Vg/J ISg/D$+ N🅪Sg/VB+ .
+> went to the mirror  and  stood with her     back     to us       , fixing  her     hair     .
+# VPt  P  D+  NSg/VB+ VB/C VP    P    ISg/D$+ NSg/VB/J P  NPr/IPl+ . Nᴹ/Vg/J ISg/D$+ N🅪Sg/VB+ .
 >
 #
 > “ It’s a    swell     suite , ” whispered Jordan respectfully , and  every one      laughed .
@@ -8079,9 +8079,9 @@
 >
 #
 > “ Now       see    here , Tom     , ” said Daisy , turning around from the mirror  , “ if    you’re
-# . NSg/J/R/C NSg/VB J/R  . NPr/VB+ . . VP/J NPr+  . Nᴹ/Vg/J J/P    P    D+  NSg/VB+ . . NSg/C K
+# . NSg/J/R/C NSg/VB R    . NPr/VB+ . . VP/J NPr+  . Nᴹ/Vg/J J/P    P    D+  NSg/VB+ . . NSg/C K
 > going   to make   personal remarks I       won’t stay     here a   minute    . Call   up         and  order
-# Nᴹ/Vg/J P  NSg/VB NSg/J+   NPl/V3+ ISg/#r+ VXB   NSg/VB/J J/R  D/P NSg/VB/J+ . NSg/VB NSg/VB/J/P VB/C N🅪Sg/VB
+# Nᴹ/Vg/J P  NSg/VB NSg/J+   NPl/V3+ ISg/#r+ VXB   NSg/VB/J R    D/P NSg/VB/J+ . NSg/VB NSg/VB/J/P VB/C N🅪Sg/VB
 > some      ice        for   the mint     julep . ”
 # I/J/R/Dq+ NPr🅪Sg/VB+ R/C/P D   NSg/VB/J NSg   . .
 >
@@ -8202,20 +8202,20 @@
 # . NSg/R/C R       . .
 >
 #
-> “ Oh     , yes    , I       understand you    went    to Oxford . ”
-# . NPr/VB . NPl/VB . ISg/#r+ VB         ISgPl+ NSg/VPt P  NPr+   . .
+> “ Oh     , yes    , I       understand you    went to Oxford . ”
+# . NPr/VB . NPl/VB . ISg/#r+ VB         ISgPl+ VPt  P  NPr+   . .
 >
 #
-> “ Yes    — I       went    there . ”
-# . NPl/VB . ISg/#r+ NSg/VPt R     . .
+> “ Yes    — I       went there . ”
+# . NPl/VB . ISg/#r+ VPt  R     . .
 >
 #
 > A    pause   . Then      Tom’s voice   , incredulous and  insulting :
 # D/P+ NSg/VB+ . NSg/J/R/C NPr$  NSg/VB+ . J           VB/C Nᴹ/Vg/J   .
 >
 #
-> “ You    must    have    gone    there about the time       Biloxi went    to New    Haven   . ”
-# . ISgPl+ NSg/VXB NSg/VXB VPp/J/P R     J/P   D+  N🅪Sg/VB/J+ ?      NSg/VPt P  NSg/J+ NSg/VB+ . .
+> “ You    must    have    gone    there about the time       Biloxi went to New    Haven   . ”
+# . ISgPl+ NSg/VXB NSg/VXB VPp/J/P R     J/P   D+  N🅪Sg/VB/J+ ?      VPt  P  NSg/J+ NSg/VB+ . .
 >
 #
 > Another pause   . A    waiter  knocked and  came      in        with crushed mint     and  ice        but     the
@@ -8226,8 +8226,8 @@
 # J+         N🅪Sg/VB/J+ VLPt P  NSg/VLXB VP/J    NSg/VB/J/P NSg/P NSg/VB/J .
 >
 #
-> “ I       told you    I       went    there , ” said Gatsby .
-# . ISg/#r+ VP   ISgPl+ ISg/#r+ NSg/VPt R     . . VP/J NPr    .
+> “ I       told you    I       went there , ” said Gatsby .
+# . ISg/#r+ VP   ISgPl+ ISg/#r+ VPt  R     . . VP/J NPr    .
 >
 #
 > “ I       heard you    , but     I’d like         to know when    . ”
@@ -8248,8 +8248,8 @@
 #
 > “ It       was  an  opportunity they gave to some     of the officers after the armistice , ”
 # . NPr/ISg+ VLPt D/P N🅪Sg        IPl+ VPt  P  I/J/R/Dq P  D+  NPl/V3+  P     D   NPr🅪Sg    . .
-> he       continued . “ We   could   go       to any    of the universities in        England or    France . ”
-# NPr/ISg+ VP/J      . . IPl+ NSg/VXB NSg/VB/J P  I/R/Dq P  D   NPl+         NPr/J/R/P NPr     NPr/C NPr+   . .
+> he       continued . “ We   could go       to any    of the universities in        England or    France . ”
+# NPr/ISg+ VP/J      . . IPl+ VXB   NSg/VB/J P  I/R/Dq P  D   NPl+         NPr/J/R/P NPr     NPr/C NPr+   . .
 >
 #
 > I       wanted to get    up         and  slap      him  on  the back     . I       had one     of those  renewals of
@@ -8258,8 +8258,8 @@
 # NSg/VB/J NPr🅪Sg+ NPr/J/R/P ISg+ I/C/Ddem+ K   VP/J        C/P    .
 >
 #
-> Daisy rose      , smiling faintly , and  went    to the table   .
-# NPr+  NPr/VPt/J . Nᴹ/Vg/J R       . VB/C NSg/VPt P  D+  NSg/VB+ .
+> Daisy rose      , smiling faintly , and  went to the table   .
+# NPr+  NPr/VPt/J . Nᴹ/Vg/J R       . VB/C VPt  P  D+  NSg/VB+ .
 >
 #
 > “ Open     the whiskey , Tom     , ” she  ordered , ‘ ‘ and  I'll make   you    a   mint     julep . Then      you
@@ -8309,7 +8309,7 @@
 >
 #
 > “ We’re all          white       here , ” murmured Jordan .
-# . K     NSg/I/J/C/Dq NPr🅪Sg/VB/J J/R  . . VP/J     NPr+   .
+# . K     NSg/I/J/C/Dq NPr🅪Sg/VB/J R    . . VP/J     NPr+   .
 >
 #
 > “ I       know I’m not     very popular . I       don’t give   big   parties . I       suppose you’ve got to
@@ -8458,8 +8458,8 @@
 # NSg/J   . .
 >
 #
-> She  looked at    him  blindly . “ Why    — how   could   I       love      him  — possibly ? ”
-# ISg+ VP/J   NSg/P ISg+ R       . . NSg/VB . NSg/C NSg/VXB ISg/#r+ NPr🅪Sg/VB ISg+ . R        . .
+> She  looked at    him  blindly . “ Why    — how   could I       love      him  — possibly ? ”
+# ISg+ VP/J   NSg/P ISg+ R       . . NSg/VB . NSg/C VXB   ISg/#r+ NPr🅪Sg/VB ISg+ . R        . .
 >
 #
 > “ You    never loved him  . ”
@@ -8568,8 +8568,8 @@
 # NSg/VB N🅪Sg/VB P  ISg/D$+ I/R/Dq NPr/I/J/R/Dq . .
 >
 #
-> “ I’m not     ? ” Tom     opened his     eyes    wide  and  laughed . He       could   afford to control
-# . K   NSg/R/C . . NPr/VB+ VP/J   ISg/D$+ NPl/V3+ NSg/J VB/C VP/J    . NPr/ISg+ NSg/VXB VB     P  N🅪Sg/VB
+> “ I’m not     ? ” Tom     opened his     eyes    wide  and  laughed . He       could afford to control
+# . K   NSg/R/C . . NPr/VB+ VP/J   ISg/D$+ NPl/V3+ NSg/J VB/C VP/J    . NPr/ISg+ VXB   VB     P  N🅪Sg/VB
 > himself now       . “ Why’s that      ? ”
 # ISg+    NSg/J/R/C . . NSg$  I/C/Ddem+ . .
 >
@@ -8588,8 +8588,8 @@
 #
 > “ She’s not     leaving me       ! ” Tom’s words   suddenly leaned down        over    Gatsby . “ Certainly
 # . K     NSg/R/C Nᴹ/Vg/J NPr/ISg+ . . NPr$  NPl/V3+ R        VP/J   N🅪Sg/VB/J/P NSg/J/P NPr    . . R
-> not     for   a   common   swindler who’d have    to steal  the ring    he       put     on  her     finger  . ”
-# NSg/R/C R/C/P D/P NSg/VB/J NSg      K     NSg/VXB P  NSg/VB D   NSg/VB+ NPr/ISg+ NSg/VBP J/P ISg/D$+ NSg/VB+ . .
+> not     for   a   common swindler who’d have    to steal  the ring    he       put     on  her     finger  . ”
+# NSg/R/C R/C/P D/P VB/J   NSg      K     NSg/VXB P  NSg/VB D   NSg/VB+ NPr/ISg+ NSg/VBP J/P ISg/D$+ NSg/VB+ . .
 >
 #
 > “ I       won’t stand  this    ! ” cried Daisy . “ Oh     , please let’s get    out          . ”
@@ -8611,7 +8611,7 @@
 > “ I       found  out          what   your ‘ drug    - stores  ’ were . ” He       turned to us       and  spoke   rapidly .
 # . ISg/#r+ NSg/VP NSg/VB/J/R/P NSg/I+ D$+  . NSg/VB+ . NPl/V3+ . VLPt . . NPr/ISg+ VP/J   P  NPr/IPl+ VB/C NSg/VPt R       .
 > “ He       and  this   Wolfshiem bought up         a   lot    of side      - street    drug    - stores  here and  in
-# . NPr/ISg+ VB/C I/Ddem ?         NSg/VP NSg/VB/J/P D/P NPr/VB P  NSg/VB/J+ . NSg/VB/J+ NSg/VB+ . NPl/V3+ J/R  VB/C NPr/J/R/P
+# . NPr/ISg+ VB/C I/Ddem ?         NSg/VP NSg/VB/J/P D/P NPr/VB P  NSg/VB/J+ . NSg/VB/J+ NSg/VB+ . NPl/V3+ R    VB/C NPr/J/R/P
 > Chicago and  sold   grain    alcohol over    the counter   . That’s one     of his     little
 # NPr+    VB/C NSg/VP N🅪Sg/VB+ N🅪Sg+   NSg/J/P D   NSg/VB/J+ . K      NSg/I/J P  ISg/D$+ NPr/I/J/Dq
 > stunts . I       picked him  for   a   bootlegger the first time       I       saw     him  , and  I       wasn’t far
@@ -8637,7 +8637,7 @@
 >
 #
 > “ Don’t you    call   me       ‘ old   sport   ’ ! ” cried Tom     . Gatsby said nothing  . “ Walter could
-# . VXB   ISgPl+ NSg/VB NPr/ISg+ . NSg/J NSg/VB+ . . . VP/J  NPr/VB+ . NPr    VP/J NSg/I/J+ . . NPr+   NSg/VXB
+# . VXB   ISgPl+ NSg/VB NPr/ISg+ . NSg/J NSg/VB+ . . . VP/J  NPr/VB+ . NPr    VP/J NSg/I/J+ . . NPr+   VXB
 > have    you    up         on  the betting  laws    too , but     Wolfshiem scared him  into shutting his
 # NSg/VXB ISgPl+ NSg/VB/J/P J/P D   NSg/Vg/J NPl/V3+ R   . NSg/C/P ?         VP/J   ISg+ P    NSg/Vg   ISg/D$+
 > mouth   . ”
@@ -8664,8 +8664,8 @@
 # N🅪Sg+      . NPr/ISg+ VP/J   . VB/C I/Ddem+ VL3 VP/J NPr/J/R/P NSg/I/J/C/Dq Nᴹ+      R/C/P D   VP/J    NSg/VB
 > of his     garden    — as    if    he       had “ killed a   man     . ” For   a    moment the set       of his     face
 # P  ISg/D$+ NSg/VB/J+ . R/C/P NSg/C NPr/ISg+ VP  . VP/J   D/P NPr/VB+ . . R/C/P D/P+ NSg+   D   NPr/VBP/J P  ISg/D$+ NSg/VB+
-> could   be       described in        just that      fantastic way    .
-# NSg/VXB NSg/VLXB VP/J      NPr/J/R/P J/R  I/C/Ddem+ NSg/J+    NSg/J+ .
+> could be       described in        just that      fantastic way    .
+# VXB   NSg/VLXB VP/J      NPr/J/R/P J/R  I/C/Ddem+ NSg/J+    NSg/J+ .
 >
 #
 > It       passed , and  he       began to talk    excitedly to Daisy , denying everything ,
@@ -8840,8 +8840,8 @@
 #
 > A    moment later she  rushed out          into the dusk     , waving  her     hands  and
 # D/P+ NSg+   JC    ISg+ VP/J   NSg/VB/J/R/P P    D+  Nᴹ/VB/J+ . Nᴹ/Vg/J ISg/D$+ NPl/V3 VB/C
-> shouting — before he       could   move   from his     door   the business was  over    .
-# Nᴹ/Vg/J+ . C/P    NPr/ISg+ NSg/VXB NSg/VB P    ISg/D$+ NSg/VB D+  N🅪Sg/J+  VLPt NSg/J/P .
+> shouting — before he       could move   from his     door   the business was  over    .
+# Nᴹ/Vg/J+ . C/P    NPr/ISg+ VXB   NSg/VB P    ISg/D$+ NSg/VB D+  N🅪Sg/J+  VLPt NSg/J/P .
 >
 #
 > The “ death   car  ” as    the newspapers called it       , didn’t stop   ; it       came      out          of the
@@ -8907,7 +8907,7 @@
 >
 #
 > “ There’s some      bad      trouble  here , ” said Tom     excitedly .
-# . K       I/J/R/Dq+ NSg/VB/J N🅪Sg/VB+ J/R  . . VP/J NPr/VB+ R         .
+# . K       I/J/R/Dq+ NSg/VB/J N🅪Sg/VB+ R    . . VP/J NPr/VB+ R         .
 >
 #
 > He       reached up         on  tiptoes and  peered over    a   circle of heads   into the garage  ,
@@ -8922,8 +8922,8 @@
 #
 > The circle  closed up         again with a   running   murmur of expostulation ; it       was  a
 # D+  NSg/VB+ VP/J   NSg/VB/J/P P     P    D/P Nᴹ/Vg/J/P NSg/VB P  NSg+          . NPr/ISg+ VLPt D/P
-> minute    before I       could   see    anything  at    all          . Then      new   arrivals deranged the line    ,
-# NSg/VB/J+ C/P    ISg/#r+ NSg/VXB NSg/VB NSg/I/VB+ NSg/P NSg/I/J/C/Dq . NSg/J/R/C NSg/J NPl      VP/J     D   NSg/VB+ .
+> minute    before I       could see    anything  at    all          . Then      new   arrivals deranged the line    ,
+# NSg/VB/J+ C/P    ISg/#r+ VXB   NSg/VB NSg/I/VB+ NSg/P NSg/I/J/C/Dq . NSg/J/R/C NSg/J NPl      VP/J     D   NSg/VB+ .
 > and  Jordan and  I       were pushed suddenly inside  .
 # VB/C NPr+   VB/C ISg/#r+ VLPt VP/J   R        NSg/J/P .
 >
@@ -9023,7 +9023,7 @@
 >
 #
 > “ What’s the name   of this   place    here ? ” demanded the officer .
-# . K      D   NSg/VB P  I/Ddem N🅪Sg/VB+ J/R  . . VP/J     D+  NSg/VB+ .
+# . K      D   NSg/VB P  I/Ddem N🅪Sg/VB+ R    . . VP/J     D+  NSg/VB+ .
 >
 #
 > “ Hasn’t got any    name    . ”
@@ -9049,7 +9049,7 @@
 >
 #
 > “ Come       here and  let’s have    your name    . Look   out          now       . I       want   to get    his     name    . ”
-# . NSg/VBPp/P J/R  VB/C NSg$  NSg/VXB D$+  NSg/VB+ . NSg/VB NSg/VB/J/R/P NSg/J/R/C . ISg/#r+ NSg/VB P  NSg/VB ISg/D$+ NSg/VB+ . .
+# . NSg/VBPp/P R    VB/C NSg$  NSg/VXB D$+  NSg/VB+ . NSg/VB NSg/VB/J/R/P NSg/J/R/C . ISg/#r+ NSg/VB P  NSg/VB ISg/D$+ NSg/VB+ . .
 >
 #
 > Some     words  of this    conversation must    have    reached Wilson , swaying in        the office
@@ -9083,7 +9083,7 @@
 >
 #
 > “ Listen , ” said Tom     , shaking him  a   little     . “ I       just got here a    minute    ago , from
-# . NSg/VB . . VP/J NPr/VB+ . Nᴹ/Vg/J ISg+ D/P NPr/I/J/Dq . . ISg/#r+ J/R  VP  J/R  D/P+ NSg/VB/J+ J/P . P
+# . NSg/VB . . VP/J NPr/VB+ . Nᴹ/Vg/J ISg+ D/P NPr/I/J/Dq . . ISg/#r+ J/R  VP  R    D/P+ NSg/VB/J+ J/P . P
 > New    York . I       was  bringing you    that     coupé we’ve been   talking about . That      yellow
 # NSg/J+ NPr+ . ISg/#r+ VLPt Nᴹ/Vg/J  ISgPl+ I/C/Ddem ?     K     VLPp/B Nᴹ/Vg/J J/P   . I/C/Ddem+ NSg/VB/J+
 > car  I       was  driving this    afternoon wasn’t mine      — do  you    hear ? I       haven’t seen    it       all
@@ -9141,9 +9141,9 @@
 >
 #
 > “ If    somebody’ll come       here and  sit    with him  , ” he       snapped authoritatively . He
-# . NSg/C ?           NSg/VBPp/P J/R  VB/C NSg/VB P    ISg+ . . NPr/ISg+ VP      R               . NPr/ISg+
+# . NSg/C ?           NSg/VBPp/P R    VB/C NSg/VB P    ISg+ . . NPr/ISg+ VP      R               . NPr/ISg+
 > watched while      the two  men  standing closest glanced at    each other    and  went
-# VP/J    NSg/VB/C/P D+  NSg+ NPl+ Nᴹ/Vg/J  JS      VP/J    NSg/P Dq   NSg/VB/J VB/C NSg/VPt
+# VP/J    NSg/VB/C/P D+  NSg+ NPl+ Nᴹ/Vg/J  JS      VP/J    NSg/P Dq   NSg/VB/J VB/C VPt
 > unwillingly into the room     . Then      Tom     shut      the door    on  them     and  came      down        the
 # R           P    D+  N🅪Sg/VB+ . NSg/J/R/C NPr/VB+ NSg/VBP/J D+  NSg/VB+ J/P NSg/IPl+ VB/C NSg/VPt/P N🅪Sg/VB/J/P D+
 > single    step    , his     eyes    avoiding the table   . As    he       passed close    to me       he       whispered :
@@ -9252,8 +9252,8 @@
 # ISg/#r+ VPt    VPp/J/P NSg    NPl/V3+ NSg/I/C ISg/#r+ VP/J  D$+ NSg/VB+ VB/C NPr    J       P    NSg/P
 > two bushes  into the path    . I       must    have    felt      pretty     weird    by that      time       , because I
 # NSg NPl/V3+ P    D   NSg/VB+ . ISg/#r+ NSg/VXB NSg/VXB N🅪Sg/VP/J NSg/VB/J/R NSg/VB/J P  I/C/Ddem+ N🅪Sg/VB/J+ . C/P     ISg/#r+
-> could   think  of nothing  except the luminosity of his     pink      suit    under   the moon    .
-# NSg/VXB NSg/VB P  NSg/I/J+ VB/C/P D   Nᴹ         P  ISg/D$+ N🅪Sg/VB/J NSg/VB+ NSg/J/P D   NPr/VB+ .
+> could think  of nothing  except the luminosity of his     pink      suit    under   the moon    .
+# VXB   NSg/VB P  NSg/I/J+ VB/C/P D   Nᴹ         P  ISg/D$+ N🅪Sg/VB/J NSg/VB+ NSg/J/P D   NPr/VB+ .
 >
 #
 > “ What   are you    doing   ? ” I       inquired .
@@ -9261,7 +9261,7 @@
 >
 #
 > “ Just standing here , old    sport   . ”
-# . J/R  Nᴹ/Vg/J  J/R  . NSg/J+ NSg/VB+ . .
+# . J/R  Nᴹ/Vg/J  R    . NSg/J+ NSg/VB+ . .
 >
 #
 > Somehow , that      seemed a   despicable occupation . For   all           I       knew he       was  going   to rob
@@ -9302,8 +9302,8 @@
 # NPr/ISg+ NSg/VPt R/C/P NSg/C NPr$    N🅪Sg/VB/J+ VLPt D   J/R/C NSg+  I/C/Ddem+ VP/J     .
 >
 #
-> “ I       got to West      Egg      by a    side      road    , ” he       went    on  , “ and  left     the car  in        my  garage  .
-# . ISg/#r+ VP  P  NPr/VB/J+ N🅪Sg/VB+ P  D/P+ NSg/VB/J+ N🅪Sg/J+ . . NPr/ISg+ NSg/VPt J/P . . VB/C NPr/VP/J D+  NSg+ NPr/J/R/P D$+ NSg/VB+ .
+> “ I       got to West      Egg      by a    side      road    , ” he       went on  , “ and  left     the car  in        my  garage  .
+# . ISg/#r+ VP  P  NPr/VB/J+ N🅪Sg/VB+ P  D/P+ NSg/VB/J+ N🅪Sg/J+ . . NPr/ISg+ VPt  J/P . . VB/C NPr/VP/J D+  NSg+ NPr/J/R/P D$+ NSg/VB+ .
 > I       don’t think  anybody saw     us       , but     of course  I       can’t be       sure . ”
 # ISg/#r+ VXB   NSg/VB NSg/I+  NSg/VPt NPr/IPl+ . NSg/C/P P  NSg/VB+ ISg/#r+ VXB   NSg/VLXB J    . .
 >
@@ -9363,7 +9363,7 @@
 >
 #
 > “ She'll be       all          right     to - morrow , ” he       said presently . “ I’m just going   to wait   here
-# . K      NSg/VLXB NSg/I/J/C/Dq NPr/VB/J+ P  . NPr/VB . . NPr/ISg+ VP/J R         . . K   J/R  Nᴹ/Vg/J P  NSg/VB J/R
+# . K      NSg/VLXB NSg/I/J/C/Dq NPr/VB/J+ P  . NPr/VB . . NPr/ISg+ VP/J R         . . K   J/R  Nᴹ/Vg/J P  NSg/VB R
 > and  see    if    he       tries  to bother her     about that      unpleasantness this   afternoon .
 # VB/C NSg/VB NSg/C NPr/ISg+ NPl/V3 P  Nᴹ/VB  ISg/D$+ J/P   I/C/Ddem+ NSg            I/Ddem N🅪Sg+     .
 > She’s locked herself into her     room     , and  if    he       tries  any    brutality she’s going   to
@@ -9399,7 +9399,7 @@
 >
 #
 > “ You    wait   here , ” I       said . “ I’ll see    if    there’s any    sign   of a   commotion . ”
-# . ISgPl+ NSg/VB J/R  . . ISg/#r+ VP/J . . K    NSg/VB NSg/C K       I/R/Dq NSg/VB P  D/P N🅪Sg      . .
+# . ISgPl+ NSg/VB R    . . ISg/#r+ VP/J . . K    NSg/VB NSg/C K       I/R/Dq NSg/VB P  D/P N🅪Sg      . .
 >
 #
 > I       walked back     along the border of the lawn    , traversed the gravel   softly , and
@@ -9455,7 +9455,7 @@
 >
 #
 > “ I       want   to wait   here till       Daisy goes   to bed       . Good      night    , old    sport   . ”
-# . ISg/#r+ NSg/VB P  NSg/VB J/R  NSg/VB/C/P NPr+  NPl/V3 P  NSg/VBP/J . NPr/VB/J+ N🅪Sg/VB+ . NSg/J+ NSg/VB+ . .
+# . ISg/#r+ NSg/VB P  NSg/VB R    NSg/VB/C/P NPr+  NPl/V3 P  NSg/VBP/J . NPr/VB/J+ N🅪Sg/VB+ . NSg/J+ NSg/VB+ . .
 >
 #
 > He       put     his     hands   in        his     coat    pockets and  turned back     eagerly to his     scrutiny of
@@ -9548,8 +9548,8 @@
 # ISg+ VLPt D   NSg/J . NPr/J . NSg/VB+ NPr/ISg+ VP  J/R  VPp/J . NPr/J/R/P J       VP/J
 > capacities he       had come       in        contact  with such  people  , but     always with
 # NPl+       NPr/ISg+ VP  NSg/VBPp/P NPr/J/R/P N🅪Sg/VB+ P    NSg/I NPl/VB+ . NSg/C/P R      P
-> indiscernible barbed wire     between . He       found  her     excitingly desirable . He       went    to
-# J             VP/J   N🅪Sg/VB+ NSg/P   . NPr/ISg+ NSg/VP ISg/D$+ R          J         . NPr/ISg+ NSg/VPt P
+> indiscernible barbed wire     between . He       found  her     excitingly desirable . He       went to
+# J             VP/J   N🅪Sg/VB+ NSg/P   . NPr/ISg+ NSg/VP ISg/D$+ R          J         . NPr/ISg+ VPt  P
 > her     house   , at    first with other    officers from Camp      Taylor , then      alone . It       amazed
 # ISg/D$+ NPr/VB+ . NSg/P NSg/J P    NSg/VB/J NPl/V3   P    NSg/VB/J+ NPr+   . NSg/J/R/C J     . NPr/ISg+ VP/J
 > him  — he       had never been   in        such  a    beautiful house   before . But     what   gave it       an  air
@@ -9581,7 +9581,7 @@
 > man     without a   past       , and  at    any    moment the invisible cloak  of his     uniform  might
 # NPr/VB+ C/P     D/P NSg/VB/J/P . VB/C NSg/P I/R/Dq NSg+   D   J         NSg/VB P  ISg/D$+ NSg/VB/J Nᴹ/VXB/J
 > slip   from his     shoulders . So          he       made the most         of his     time       . He       took what   he       could
-# NSg/VB P    ISg/D$+ NPl/V3+   . NSg/I/J/R/C NPr/ISg+ VP   D   NSg/I/J/R/Dq P  ISg/D$+ N🅪Sg/VB/J+ . NPr/ISg+ VPt  NSg/I+ NPr/ISg+ NSg/VXB
+# NSg/VB P    ISg/D$+ NPl/V3+   . NSg/I/J/R/C NPr/ISg+ VP   D   NSg/I/J/R/Dq P  ISg/D$+ N🅪Sg/VB/J+ . NPr/ISg+ VPt  NSg/I+ NPr/ISg+ VXB
 > get    , ravenously and  unscrupulously — eventually he       took Daisy one     still      October
 # NSg/VB . R          VB/C R              . R          NPr/ISg+ VPt  NPr+  NSg/I/J NSg/VB/J/R NPr/VB+
 > night    , took her     because he       had no       real  right    to touch   her     hand    .
@@ -9606,12 +9606,12 @@
 #
 > But     he       didn’t despise himself and  it       didn’t turn   out          as    he       had imagined . He       had
 # NSg/C/P NPr/ISg+ VXPt   VB      ISg+    VB/C NPr/ISg+ VXPt   NSg/VB NSg/VB/J/R/P R/C/P NPr/ISg+ VP  VP/J     . NPr/ISg+ VP
-> intended , probably , to take   what   he       could   and  go       — but     now       he       found  that     he       had
-# NSg/VP/J . R        . P  NSg/VB NSg/I+ NPr/ISg+ NSg/VXB VB/C NSg/VB/J . NSg/C/P NSg/J/R/C NPr/ISg+ NSg/VP I/C/Ddem NPr/ISg+ VP
+> intended , probably , to take   what   he       could and  go       — but     now       he       found  that     he       had
+# NSg/VP/J . R        . P  NSg/VB NSg/I+ NPr/ISg+ VXB   VB/C NSg/VB/J . NSg/C/P NSg/J/R/C NPr/ISg+ NSg/VP I/C/Ddem NPr/ISg+ VP
 > committed himself to the following   of a    grail . He       knew that     Daisy was
 # VP/J      ISg+    P  D   N🅪Sg/Vg/J/P P  D/P+ NSg+  . NPr/ISg+ VPt  I/C/Ddem NPr+  VLPt
 > extraordinary , but     he       didn’t realize      just how   extraordinary a   “ nice  ” girl    could
-# NSg/J         . NSg/C/P NPr/ISg+ VXPt   VB/Comm/NoAm J/R  NSg/C NSg/J         D/P . NPr/J . NSg/VB+ NSg/VXB
+# NSg/J         . NSg/C/P NPr/ISg+ VXPt   VB/Comm/NoAm J/R  NSg/C NSg/J         D/P . NPr/J . NSg/VB+ VXB
 > be       . She  vanished into her     rich      house   , into her     rich     , full      life     , leaving
 # NSg/VLXB . ISg+ VP/J     P    ISg/D$+ NPr/VB/J+ NPr/VB+ . P    ISg/D$+ NPr/VB/J . NSg/VB/J+ N🅪Sg/VB+ . Nᴹ/Vg/J
 > Gatsby — nothing  . He       felt      married  to her     , that      was  all          .
@@ -9646,14 +9646,14 @@
 # NPl+   P    ISg/D$+ . . . NSg/VB/J/R . R+    ISg/#r+ VLPt . . NSg/J+ NSg/VB/J/P D$+ NPl/V3+   . NSg/Vg  JC
 > in        love      every minute    , and  all          of a   sudden I       didn’t care     . What   was  the use     of
 # NPr/J/R/P NPr🅪Sg/VB Dq+   NSg/VB/J+ . VB/C NSg/I/J/C/Dq P  D/P NSg/J  ISg/#r+ VXPt   N🅪Sg/VB+ . NSg/I+ VLPt D   N🅪Sg/VB P
-> doing   great  things if    I       could   have    a    better      time       telling her     what   I       was  going   to
-# Nᴹ/Vg/J NSg/J+ NPl+   NSg/C ISg/#r+ NSg/VXB NSg/VXB D/P+ NSg/VXB/JC+ N🅪Sg/VB/J+ Nᴹ/Vg/J ISg/D$+ NSg/I+ ISg/#r+ VLPt Nᴹ/Vg/J P
+> doing   great  things if    I       could have    a    better      time       telling her     what   I       was  going   to
+# Nᴹ/Vg/J NSg/J+ NPl+   NSg/C ISg/#r+ VXB   NSg/VXB D/P+ NSg/VXB/JC+ N🅪Sg/VB/J+ Nᴹ/Vg/J ISg/D$+ NSg/I+ ISg/#r+ VLPt Nᴹ/Vg/J P
 > do  ? ”
 # VXB . .
 >
 #
-> On  the last      afternoon before he       went    abroad  , he       sat    with Daisy in        his     arms    for   a
-# J/P D+  NSg/VB/J+ N🅪Sg+     C/P    NPr/ISg+ NSg/VPt NSg/J/P . NPr/ISg+ NSg/VP P    NPr+  NPr/J/R/P ISg/D$+ NPl/V3+ R/C/P D/P
+> On  the last      afternoon before he       went abroad  , he       sat    with Daisy in        his     arms    for   a
+# J/P D+  NSg/VB/J+ N🅪Sg+     C/P    NPr/ISg+ VPt  NSg/J/P . NPr/ISg+ NSg/VP P    NPr+  NPr/J/R/P ISg/D$+ NPl/V3+ R/C/P D/P
 > long     , silent time       . It       was  a   cold  fall    day    , with fire       in        the room    and  her     cheeks
 # NPr/VB/J . NSg/J+ N🅪Sg/VB/J+ . NPr/ISg+ VLPt D/P NSg/J N🅪Sg/VB NPr🅪Sg . P    N🅪Sg/VB/J+ NPr/J/R/P D   N🅪Sg/VB VB/C ISg/D$+ NPl/V3+
 > flushed . Now       and  then      she  moved and  he       changed his     arm      a   little     , and  once  he
@@ -9672,8 +9672,8 @@
 # VLPt J      .
 >
 #
-> He       did  extraordinarily well       in        the war      . He       was  a   captain before he       went    to the
-# NPr/ISg+ VXPt R               NSg/VB/J/R NPr/J/R/P D+  N🅪Sg/VB+ . NPr/ISg+ VLPt D/P NSg/VB  C/P    NPr/ISg+ NSg/VPt P  D+
+> He       did  extraordinarily well       in        the war      . He       was  a   captain before he       went to the
+# NPr/ISg+ VXPt R               NSg/VB/J/R NPr/J/R/P D+  N🅪Sg/VB+ . NPr/ISg+ VLPt D/P NSg/VB  C/P    NPr/ISg+ VPt  P  D+
 > front     , and  following   the Argonne battles he       got his     majority and  the command of
 # NSg/VB/J+ . VB/C N🅪Sg/Vg/J/P D   NPr     NPl/V3+ NPr/ISg+ VP  ISg/D$+ NSg+     VB/C D   NSg/VB  P
 > the divisional machine - guns    . After the armistice he       tried frantically to get
@@ -9703,7 +9703,7 @@
 > gray            tea      hour there were always rooms  that      throbbed incessantly with this   low        ,
 # NPr🅪Sg/VB/J/Am+ N🅪Sg/VB+ NSg+ R+    VLPt R      NPl/V3 I/C/Ddem+ VP       R           P    I/Ddem NSg/VB/J/R .
 > sweet    fever   , while      fresh    faces   drifted here and  there like         rose      petals blown by
-# NPr/VB/J NSg/VB+ . NSg/VB/C/P NSg/VB/J NPl/V3+ VP/J    J/R  VB/C R+    NSg/VB/J/C/P NPr/VPt/J NPl/V3 VPp/J P
+# NPr/VB/J NSg/VB+ . NSg/VB/C/P NSg/VB/J NPl/V3+ VP/J    R    VB/C R+    NSg/VB/J/C/P NPr/VPt/J NPl/V3 VPp/J P
 > the sad      horns  around the floor   .
 # D   NSg/VB/J NPl/V3 J/P    D   NSg/VB+ .
 >
@@ -9734,8 +9734,8 @@
 # NSg/VB+ VP/J    NPr    NSg/VB/C/P NPr/ISg+ VLPt NSg/VB/J/R NSg/P NPr+   .
 >
 #
-> It       was  dawn       now       on  Long      Island  and  we   went    about opening the rest   of the windows
-# NPr/ISg+ VLPt NPr🅪Sg/VB+ NSg/J/R/C J/P NPr/VB/J+ NSg/VB+ VB/C IPl+ NSg/VPt J/P   Nᴹ/Vg/J D   NSg/VB P  D+  NPrPl/V3+
+> It       was  dawn       now       on  Long      Island  and  we   went about opening the rest   of the windows
+# NPr/ISg+ VLPt NPr🅪Sg/VB+ NSg/J/R/C J/P NPr/VB/J+ NSg/VB+ VB/C IPl+ VPt  J/P   Nᴹ/Vg/J D   NSg/VB P  D+  NPrPl/V3+
 > down        - stairs , filling   the house   with gray           - turning , gold     - turning light      . The shadow
 # N🅪Sg/VB/J/P . NPl+   . N🅪Sg/Vg/J D+  NPr/VB+ P    NPr🅪Sg/VB/J/Am . Nᴹ/Vg/J . Nᴹ/VB/J+ . Nᴹ/Vg/J N🅪Sg/VB/J+ . D   NSg/VB/J
 > of a    tree    fell      abruptly across the dew      and  ghostly birds   began to sing     among the
@@ -9776,8 +9776,8 @@
 # . NPr/J/R/P I/R/Dq+ NPr🅪Sg/VB+ . . NPr/ISg+ VP/J . . NPr/ISg+ VLPt J/R  NSg/J    . .
 >
 #
-> What   could   you    make   of that      , except to suspect  some      intensity in        his     conception
-# NSg/I+ NSg/VXB ISgPl+ NSg/VB P  I/C/Ddem+ . VB/C/P P  NSg/VB/J I/J/R/Dq+ Nᴹ+       NPr/J/R/P ISg/D$+ N🅪Sg
+> What   could you    make   of that      , except to suspect  some      intensity in        his     conception
+# NSg/I+ VXB   ISgPl+ NSg/VB P  I/C/Ddem+ . VB/C/P P  NSg/VB/J I/J/R/Dq+ Nᴹ+       NPr/J/R/P ISg/D$+ N🅪Sg
 > of the affair that      couldn’t be       measured ?
 # P  D   NSg+   I/C/Ddem+ VXB      NSg/VLXB VP/J     .
 >
@@ -9802,8 +9802,8 @@
 #
 > He       left     feeling   that     if    he       had searched harder , he       might    have    found  her     — that     he
 # NPr/ISg+ NPr/VP/J N🅪Sg/Vg/J I/C/Ddem NSg/C NPr/ISg+ VP  VP/J     JC     . NPr/ISg+ Nᴹ/VXB/J NSg/VXB NSg/VP ISg/D$+ . I/C/Ddem NPr/ISg+
-> was  leaving her     behind  . The day     - coach   — he       was  penniless now       — was  hot      . He       went    out
-# VLPt Nᴹ/Vg/J ISg/D$+ NSg/J/P . D+  NPr🅪Sg+ . NSg/VB+ . NPr/ISg+ VLPt J         NSg/J/R/C . VLPt NSg/VB/J . NPr/ISg+ NSg/VPt NSg/VB/J/R/P
+> was  leaving her     behind  . The day     - coach   — he       was  penniless now       — was  hot      . He       went out
+# VLPt Nᴹ/Vg/J ISg/D$+ NSg/J/P . D+  NPr🅪Sg+ . NSg/VB+ . NPr/ISg+ VLPt J         NSg/J/R/C . VLPt NSg/VB/J . NPr/ISg+ VPt  NSg/VB/J/R/P
 > to the open     vestibule and  sat    down        on  a   folding  - chair   , and  the station slid away
 # P  D   NSg/VB/J NSg/VB    VB/C NSg/VP N🅪Sg/VB/J/P J/P D/P Nᴹ/Vg/J+ . NSg/VB+ . VB/C D   NSg/VB+ VP   VB/J
 > and  the backs  of unfamiliar buildings moved by . Then      out          into the spring   fields    ,
@@ -9828,8 +9828,8 @@
 # VP  VP/J I/C/Ddem NSg/VB/J P  NPr/ISg+ . D   JS       VB/C D   NPr/VXB/JS . NSg/J   .
 >
 #
-> It       was  nine o’clock when    we   finished breakfast and  went    out          on  the porch . The
-# NPr/ISg+ VLPt NSg  R       NSg/I/C IPl+ VP/J     N🅪Sg/VB+  VB/C NSg/VPt NSg/VB/J/R/P J/P D+  NSg+  . D+
+> It       was  nine o’clock when    we   finished breakfast and  went out          on  the porch . The
+# NPr/ISg+ VLPt NSg  R       NSg/I/C IPl+ VP/J     N🅪Sg/VB+  VB/C VPt  NSg/VB/J/R/P J/P D+  NSg+  . D+
 > night    had made a   sharp    difference in        the weather  and  there was  an  autumn     flavor
 # N🅪Sg/VB+ VP  VP   D/P NPr/VB/J N🅪Sg/VB    NPr/J/R/P D+  Nᴹ/VB/J+ VB/C R+    VLPt D/P NPr🅪Sg/VB+ N🅪Sg/VB/Am
 > in        the air      . The gardener , the last     one     of Gatsby’s former servants , came      to the
@@ -9862,8 +9862,8 @@
 # ISg/#r+ VXPt   NSg/VB P  NSg/VB/J P  D   NSg+ . ISg/#r+ VPt    NSg/VB/J D/P J      NSg/VB P  N🅪Sg/VB+ . NSg/C/P NPr/ISg+
 > was  more         than that      — I       didn’t want   to leave  Gatsby . I       missed that      train   , and  then
 # VLPt NPr/I/J/R/Dq C/P  I/C/Ddem+ . ISg/#r+ VXPt   NSg/VB P  NSg/VB NPr    . ISg/#r+ VP/J   I/C/Ddem+ NSg/VB+ . VB/C NSg/J/R/C
-> another , before I       could   get    myself away .
-# I/D     . C/P    ISg/#r+ NSg/VXB NSg/VB ISg+   VB/J .
+> another , before I       could get    myself away .
+# I/D     . C/P    ISg/#r+ VXB   NSg/VB ISg+   VB/J .
 >
 #
 > “ I’ll call   you    up         , ” I       said finally .
@@ -9972,8 +9972,8 @@
 # . ISgPl+ VPt     NSg/I/J/R/C NPr/J P  NPr/ISg+ NSg/VB/J N🅪Sg/VB+ . .
 >
 #
-> “ How   could   it       have    mattered then      ? ”
-# . NSg/C NSg/VXB NPr/ISg+ NSg/VXB VP/J     NSg/J/R/C . .
+> “ How   could it       have    mattered then      ? ”
+# . NSg/C VXB   NPr/ISg+ NSg/VXB VP/J     NSg/J/R/C . .
 >
 #
 > Silence for   a    moment . Then      :
@@ -10034,8 +10034,8 @@
 # NSg/I/J/C/Dq NPr🅪Sg+ P    NPr/I/J/Dq NPl/V3+ Nᴹ/Vg/J   R/C/P NSg/VB/J NPl/V3+ NPr/J/R/P D   Nᴹ/VB+ . VB/C I/J/R/Dq
 > garrulous man     telling over    and  over    what   had happened , until it       became less    and
 # J         NPr/VB+ Nᴹ/Vg/J NSg/J/P VB/C NSg/J/P NSg/I+ VP  VP/J     . C/P   NPr/ISg+ VPt    J/R/C/P VB/C
-> less    real  even       to him  and  he       could   tell   it       no       longer , and  Myrtle Wilson’s tragic
-# J/R/C/P NSg/J NSg/VB/J/R P  ISg+ VB/C NPr/ISg+ NSg/VXB NPr/VB NPr/ISg+ NSg/Dq/P NSg/JC . VB/C NPr    NPr$     NSg/J
+> less    real  even       to him  and  he       could tell   it       no       longer , and  Myrtle Wilson’s tragic
+# J/R/C/P NSg/J NSg/VB/J/R P  ISg+ VB/C NPr/ISg+ VXB   NPr/VB NPr/ISg+ NSg/Dq/P NSg/JC . VB/C NPr    NPr$     NSg/J
 > achievement was  forgotten . Now       I       want   to go       back     a   little     and  tell   what   happened
 # N🅪Sg+       VLPt NSg/VPp/J . NSg/J/R/C ISg/#r+ NSg/VB P  NSg/VB/J NSg/VB/J D/P NPr/I/J/Dq VB/C NPr/VB NSg/I+ VP/J
 > at    the garage  after we   left     there the night    before .
@@ -10068,8 +10068,8 @@
 # VB/C VP/J   D+  NSg/VB+ . ?         VB/C J/Dq+   NSg/VB/J+ NPl+ VLPt P    ISg+ . NSg/J . NSg
 > or    five men  , later two or    three men  . Still      later Michaelis had to ask    the last
 # NPr/C NSg+ NPl+ . JC    NSg NPr/C NSg+  NPl+ . NSg/VB/J/R JC    ?         VP  P  NSg/VB D+  NSg/VB/J+
-> stranger   to wait   there fifteen minutes longer , while      he       went    back     to his     own
-# NSg/VB/JC+ P  NSg/VB R+    NSg+    NPl/V3+ NSg/JC . NSg/VB/C/P NPr/ISg+ NSg/VPt NSg/VB/J P  ISg/D$+ NSg/VB/J+
+> stranger   to wait   there fifteen minutes longer , while      he       went back     to his     own
+# NSg/VB/JC+ P  NSg/VB R+    NSg+    NPl/V3+ NSg/JC . NSg/VB/C/P NPr/ISg+ VPt  NSg/VB/J P  ISg/D$+ NSg/VB/J+
 > place    and  made a   pot     of coffee     . After that      , he       stayed there alone with Wilson
 # N🅪Sg/VB+ VB/C VP   D/P N🅪Sg/VB P  N🅪Sg/VB/J+ . P     I/C/Ddem+ . NPr/ISg+ VP/J   R     J     P    NPr+
 > until dawn       .
@@ -10128,10 +10128,10 @@
 #
 > “ Have    you    got a    church     you    go       to sometimes , George ? Maybe   even       if    you    haven’t
 # . NSg/VXB ISgPl+ VP  D/P+ NPr🅪Sg/VB+ ISgPl+ NSg/VB/J P  R         . NPr+   . NSg/J/R NSg/VB/J/R NSg/C ISgPl+ VXB
-> been   there for   a   long     time       ? Maybe   I       could   call   up         the church     and  get    a   priest    to
-# VLPp/B R     R/C/P D/P NPr/VB/J N🅪Sg/VB/J+ . NSg/J/R ISg/#r+ NSg/VXB NSg/VB NSg/VB/J/P D+  NPr🅪Sg/VB+ VB/C NSg/VB D/P NSg/VB/J+ P
-> come       over    and  he       could   talk    to you    , see    ? ”
-# NSg/VBPp/P NSg/J/P VB/C NPr/ISg+ NSg/VXB N🅪Sg/VB P  ISgPl+ . NSg/VB . .
+> been   there for   a   long     time       ? Maybe   I       could call   up         the church     and  get    a   priest    to
+# VLPp/B R     R/C/P D/P NPr/VB/J N🅪Sg/VB/J+ . NSg/J/R ISg/#r+ VXB   NSg/VB NSg/VB/J/P D+  NPr🅪Sg/VB+ VB/C NSg/VB D/P NSg/VB/J+ P
+> come       over    and  he       could talk    to you    , see    ? ”
+# NSg/VBPp/P NSg/J/P VB/C NPr/ISg+ VXB   N🅪Sg/VB P  ISgPl+ . NSg/VB . .
 >
 #
 > “ Don’t belong to any    . ”
@@ -10260,8 +10260,8 @@
 # P    ISg/D$+ NSg/VB+ . NPr/VB/J/R C/P  Nᴹ/Vg/J P  NSg/VB I/R/Dq+ NSg/J+     NSg+ .
 >
 #
-> “ How   could   she  of been   like         that      ? ”
-# . NSg/C NSg/VXB ISg+ P  VLPp/B NSg/VB/J/C/P I/C/Ddem+ . .
+> “ How   could she  of been   like         that      ? ”
+# . NSg/C VXB   ISg+ P  VLPp/B NSg/VB/J/C/P I/C/Ddem+ . .
 >
 #
 > “ She’s a    deep  one      , ” said Wilson , as    if    that      answered the question . “ Ah       - h      - h      — — — ”
@@ -10272,8 +10272,8 @@
 # NPr/ISg+ VPt   P  NPr🅪Sg/VB P     . VB/C ?         VP    Nᴹ/Vg/J  D+  NSg/VB+ NPr/J/R/P ISg/D$+ NSg/VB+ .
 >
 #
-> “ Maybe   you    got some      friend    that      I       could   telephone for   , George ? ”
-# . NSg/J/R ISgPl+ VP  I/J/R/Dq+ NPr/VB/J+ I/C/Ddem+ ISg/#r+ NSg/VXB NSg/VB    R/C/P . NPr+   . .
+> “ Maybe   you    got some      friend    that      I       could telephone for   , George ? ”
+# . NSg/J/R ISgPl+ VP  I/J/R/Dq+ NPr/VB/J+ I/C/Ddem+ ISg/#r+ VXB   NSg/VB    R/C/P . NPr+   . .
 >
 #
 > This    was  a   forlorn  hope      — he       was  almost sure that     Wilson had no       friend    : there was
@@ -10291,7 +10291,7 @@
 > Wilson’s glazed eyes    turned out          to the ashheaps , where   small    gray           clouds  took on
 # NPr$     VP/J   NPl/V3+ VP/J   NSg/VB/J/R/P P  D   ?        . NSg/R/C NPr/VB/J NPr🅪Sg/VB/J/Am NPl/V3+ VPt  J/P
 > fantastic shapes  and  scurried here and  there in        the faint    dawn       wind     .
-# NSg/J     NPl/V3+ VB/C VP/J     J/R  VB/C R     NPr/J/R/P D   NSg/VB/J NPr🅪Sg/VB+ N🅪Sg/VB+ .
+# NSg/J     NPl/V3+ VB/C VP/J     R    VB/C R     NPr/J/R/P D   NSg/VB/J NPr🅪Sg/VB+ N🅪Sg/VB+ .
 >
 #
 > “ I       spoke   to her     , ” he       muttered , after a    long      silence . “ I       told her     she  might    fool
@@ -10332,8 +10332,8 @@
 # NSg/Vg   Nᴹ/VB/J/P . NPr/ISg+ VLPt NSg/I/J P  D   NPl      P  D+  N🅪Sg/VB+ C/P    NPr/I+ VP
 > promised to come       back     , so          he       cooked breakfast for   three , which he       and  the other
 # VP/J     P  NSg/VBPp/P NSg/VB/J . NSg/I/J/R/C NPr/ISg+ VP/J   N🅪Sg/VB+  R/C/P NSg   . I/C+  NPr/ISg+ VB/C D+  NSg/VB/J+
-> man     ate     together . Wilson was  quieter now       , and  Michaelis went    home      to sleep   ; when
-# NPr/VB+ NSg/VPt J        . NPr+   VLPt NSg/JC  NSg/J/R/C . VB/C ?         NSg/VPt NSg/VB/J+ P  N🅪Sg/VB . NSg/I/C
+> man     ate     together . Wilson was  quieter now       , and  Michaelis went home      to sleep   ; when
+# NPr/VB+ NSg/VPt J        . NPr+   VLPt NSg/JC  NSg/J/R/C . VB/C ?         VPt  NSg/VB/J+ P  N🅪Sg/VB . NSg/I/C
 > he       awoke four hours later and  hurried back     to the garage  , Wilson was  gone    .
 # NPr/ISg+ VPt   NSg+ NPl+  JC    VB/C VP/J    NSg/VB/J P  D   NSg/VB+ . NPr+   VLPt VPp/J/P .
 >
@@ -10388,8 +10388,8 @@
 # ISg/D$+ NPr/VB/J+ VB/C NPr/J/R/P D/P NSg+   VP/J        P     D   Nᴹ/Vg/J   NPl/V3+ .
 >
 #
-> No        telephone message arrived , but     the butler went    without his     sleep    and  waited
-# NSg/Dq/P+ NSg/VB+   NSg/VB+ VP/J    . NSg/C/P D   NPr/VB NSg/VPt C/P     ISg/D$+ N🅪Sg/VB+ VB/C VP/J
+> No        telephone message arrived , but     the butler went without his     sleep    and  waited
+# NSg/Dq/P+ NSg/VB+   NSg/VB+ VP/J    . NSg/C/P D   NPr/VB VPt  C/P     ISg/D$+ N🅪Sg/VB+ VB/C VP/J
 > for   it       until four o’clock — until long     after there was  any    one      to give   it       to if    it
 # R/C/P NPr/ISg+ C/P   NSg  R       . C/P   NPr/VB/J P     R+    VLPt I/R/Dq NSg/I/J+ P  NSg/VB NPr/ISg+ P  NSg/C NPr/ISg+
 > came      . I       have    an   idea that      Gatsby himself didn’t believe it       would come       , and
@@ -10414,8 +10414,8 @@
 #
 > The chauffeur — he       was  one     of Wolfshiem’s protégés — heard the shots   — afterward he
 # D   NSg/VB    . NPr/ISg+ VLPt NSg/I/J P  ?           ?        . VP/J  D   NPl/V3+ . R/Am      NPr/ISg+
-> could   only  say    that     he       hadn’t thought anything  much         about them     . I       drove   from the
-# NSg/VXB J/R/C NSg/VB I/C/Ddem NPr/ISg+ VPt    N🅪Sg/VP NSg/I/VB+ NSg/I/J/R/Dq J/P   NSg/IPl+ . ISg/#r+ NSg/VPt P    D+
+> could only  say    that     he       hadn’t thought anything  much         about them     . I       drove   from the
+# VXB   J/R/C NSg/VB I/C/Ddem NPr/ISg+ VPt    N🅪Sg/VP NSg/I/VB+ NSg/I/J/R/Dq J/P   NSg/IPl+ . ISg/#r+ NSg/VPt P    D+
 > station directly to Gatsby’s house   and  my  rushing anxiously up         the front     steps
 # NSg/VB+ R/C      P  NPr$     NPr/VB+ VB/C D$+ Nᴹ/Vg/J R         NSg/VB/J/P D   NSg/VB/J+ NPl/V3+
 > was  the first thing that     alarmed any    one      . But     they knew then      , I       firmly believe .
@@ -10460,8 +10460,8 @@
 # VB/C NSg/VB/J/R/P P  NPr$     NSg/VB/J+ NSg/VB+ . D/P+ NSg/VB+ VP/J      NSg/P  D   NSg/VB/J NSg/VB VB/C D/P+
 > policeman by it       kept out          the curious , but     little      boys    soon discovered that     they
 # NSg+      P  NPr/ISg+ VP   NSg/VB/J/R/P D   J       . NSg/C/P NPr/I/J/Dq+ NPl/V3+ J/R  VP/J       I/C/Ddem IPl+
-> could   enter  through my  yard    , and  there were always a   few      of them     clustered
-# NSg/VXB NSg/VB J/P     D$+ NSg/VB+ . VB/C R+    VLPt R      D/P NSg/I/Dq P  NSg/IPl+ VP/J
+> could enter  through my  yard    , and  there were always a   few      of them     clustered
+# VXB   NSg/VB J/P     D$+ NSg/VB+ . VB/C R+    VLPt R      D/P NSg/I/Dq P  NSg/IPl+ VP/J
 > open     - mouthed about the pool    . Some     one     with a    positive manner , perhaps a
 # NSg/VB/J . VP/J    J/P   D+  NSg/VB+ . I/J/R/Dq NSg/I/J P    D/P+ NSg/J+   NSg+   . NSg/R   D/P+
 > detective , used the expression “ madman ” as    he       bent     over    Wilson’s body    that
@@ -10490,8 +10490,8 @@
 # NSg/VB+ . I/C/Ddem ISg/D$+ NSg/VB+ VP  VLPp/B P    NSg/Dq/P NSg/VB+  NSg/I/J+ . ISg+ VP/J
 > herself of it       , and  cried into her     handkerchief , as    if    the very suggestion was
 # ISg+    P  NPr/ISg+ . VB/C VP/J  P    ISg/D$+ NSg+         . R/C/P NSg/C D+  J/R+ N🅪Sg+      VLPt
-> more         than she  could   endure . So          Wilson was  reduced to a    man     “ deranged by grief  ”
-# NPr/I/J/R/Dq C/P  ISg+ NSg/VXB VB     . NSg/I/J/R/C NPr+   VLPt VP/J    P  D/P+ NPr/VB+ . VP/J     P  Nᴹ/VB+ .
+> more         than she  could endure . So          Wilson was  reduced to a    man     “ deranged by grief  ”
+# NPr/I/J/R/Dq C/P  ISg+ VXB   VB     . NSg/I/J/R/C NPr+   VLPt VP/J    P  D/P+ NPr/VB+ . VP/J     P  Nᴹ/VB+ .
 > in        order    that     the case       might    remain in        its     simplest form     . And  it       rested there .
 # NPr/J/R/P N🅪Sg/VB+ I/C/Ddem D   NPr🅪Sg/VB+ Nᴹ/VXB/J NSg/VB NPr/J/R/P ISg/D$+ JS       N🅪Sg/VB+ . VB/C NPr/ISg+ VP/J   R     .
 >
@@ -10538,8 +10538,8 @@
 # . NSg/Dq/P . .
 >
 #
-> “ Any     idea where   they are ? How   I       could   reach  them     ? ”
-# . I/R/Dq+ NSg+ NSg/R/C IPl+ VLB . NSg/C ISg/#r+ NSg/VXB NSg/VB NSg/IPl+ . .
+> “ Any     idea where   they are ? How   I       could reach  them     ? ”
+# . I/R/Dq+ NSg+ NSg/R/C IPl+ VLB . NSg/C ISg/#r+ VXB   NSg/VB NSg/IPl+ . .
 >
 #
 > “ I       don’t know . Can’t say    . ”
@@ -10578,8 +10578,8 @@
 # . NSg/VB/J . K   J      NSg/Dq/P NSg$  R     . .
 >
 #
-> I       went    back     to the drawing    - room     and  thought for   an  instant  that     they were chance
-# ISg/#r+ NSg/VPt NSg/VB/J P  D+  N🅪Sg/Vg/J+ . N🅪Sg/VB+ VB/C N🅪Sg/VP R/C/P D/P NSg/VB/J I/C/Ddem IPl+ VLPt NPr/VB/J+
+> I       went back     to the drawing    - room     and  thought for   an  instant  that     they were chance
+# ISg/#r+ VPt  NSg/VB/J P  D+  N🅪Sg/Vg/J+ . N🅪Sg/VB+ VB/C N🅪Sg/VP R/C/P D/P NSg/VB/J I/C/Ddem IPl+ VLPt NPr/VB/J+
 > visitors , all          these   official people  who    suddenly filled it       . But     , though they
 # NPl+     . NSg/I/J/C/Dq I/Ddem+ NSg/J+   NPl/VB+ NPr/I+ R        VP/J   NPr/ISg+ . NSg/C/P . C      IPl+
 > drew    back     the sheet   and  looked at    Gatsby with shocked eyes    , his     protest
@@ -10589,7 +10589,7 @@
 >
 #
 > “ Look   here , old    sport   , you’ve got to get    somebody for   me       . You’ve got to try
-# . NSg/VB J/R  . NSg/J+ NSg/VB+ . K      VP  P  NSg/VB NSg/I+   R/C/P NPr/ISg+ . K      VP  P  NSg/VB/J
+# . NSg/VB R    . NSg/J+ NSg/VB+ . K      VP  P  NSg/VB NSg/I+   R/C/P NPr/ISg+ . K      VP  P  NSg/VB/J
 > hard     . I       can’t go       through this   alone . ”
 # N🅪Sg/J/R . ISg/#r+ VXB   NSg/VB/J J/P     I/Ddem J     . .
 >
@@ -10689,7 +10689,7 @@
 >
 #
 > “ Hello  ! ” I       interrupted breathlessly . “ Look   here — this   isn’t   Mr   . Gatsby . Mr   .
-# . NSg/VB . . ISg/#r+ VP/J        R            . . NSg/VB J/R  . I/Ddem NSg/VX3 NSg+ . NPr    . NSg+ .
+# . NSg/VB . . ISg/#r+ VP/J        R            . . NSg/VB R    . I/Ddem NSg/VX3 NSg+ . NPr    . NSg+ .
 > Gatsby’s dead     . ”
 # NPr$     NSg/VB/J . .
 >
@@ -10762,8 +10762,8 @@
 # ISg/#r+ VPt  ISg+ P    D   N🅪Sg/Vg/J+ . N🅪Sg/VB+ . NSg/R/C ISg/D$+ NPr/VB+ NSg/VBPt/J . VB/C NPr/VP/J ISg+ R     . I/J/R/Dq+
 > little      boys    had come       up         on  the steps   and  were looking into the hall ; when    I       told
 # NPr/I/J/Dq+ NPl/V3+ VP  NSg/VBPp/P NSg/VB/J/P J/P D+  NPl/V3+ VB/C VLPt Nᴹ/Vg/J P    D+  NPr+ . NSg/I/C ISg/#r+ VP
-> them     who    had arrived , they went    reluctantly away .
-# NSg/IPl+ NPr/I+ VP  VP/J    . IPl+ NSg/VPt R           VB/J .
+> them     who    had arrived , they went reluctantly away .
+# NSg/IPl+ NPr/I+ VP  VP/J    . IPl+ VPt  R           VB/J .
 >
 #
 > After a   little     while      Mr   . Gatz opened the door    and  came      out          , his     mouth   ajar , his
@@ -10813,7 +10813,7 @@
 > “ He       had a    big    future before him  , you    know . He       was  only  a   young    man    , but     he       had a
 # . NPr/ISg+ VP  D/P+ NSg/J+ NSg/J+ C/P    ISg+ . ISgPl+ VB   . NPr/ISg+ VLPt J/R/C D/P NPr/VB/J NPr/VB . NSg/C/P NPr/ISg+ VP  D/P
 > lot    of brain      power      here . ”
-# NPr/VB P  NPr🅪Sg/VB+ N🅪Sg/VB/J+ J/R  . .
+# NPr/VB P  NPr🅪Sg/VB+ N🅪Sg/VB/J+ R    . .
 >
 #
 > He       touched his     head      impressively , and  I       nodded .
@@ -10859,7 +10859,7 @@
 >
 #
 > “ The funeral’s to - morrow , ” I       said . “ Three o’clock , here at    the house   . I       wish
-# . D   NSg$      P  . NPr/VB . . ISg/#r+ VP/J . . NSg   R       . J/R  NSg/P D+  NPr/VB+ . ISg/#r+ NSg/VB
+# . D   NSg$      P  . NPr/VB . . ISg/#r+ VP/J . . NSg   R       . R    NSg/P D+  NPr/VB+ . ISg/#r+ NSg/VB
 > you’d tell   anybody who’d be       interested . ”
 # K     NPr/VB NSg/I+  K     NSg/VLXB VP/J       . .
 >
@@ -10889,15 +10889,15 @@
 > “ Well       , the fact is  — the truth   of the matter   is  that      I’m staying with some     people
 # . NSg/VB/J/R . D+  NSg+ VL3 . D   N🅪Sg/VB P  D+  N🅪Sg/VB+ VL3 I/C/Ddem+ K   Nᴹ/Vg/J P    I/J/R/Dq NPl/VB+
 > up         here in        Greenwich , and  they rather     expect me       to be       with them     tomorrow . In
-# NSg/VB/J/P J/R  NPr/J/R/P NPr+      . VB/C IPl+ NPr/VB/J/R VB     NPr/ISg+ P  NSg/VLXB P    NSg/IPl+ NSg+     . NPr/J/R/P
+# NSg/VB/J/P R    NPr/J/R/P NPr+      . VB/C IPl+ NPr/VB/J/R VB     NPr/ISg+ P  NSg/VLXB P    NSg/IPl+ NSg+     . NPr/J/R/P
 > fact , there’s a   sort   of picnic  or    something . Of course  I’ll do  my  very best       to
 # NSg+ . K       D/P NSg/VB P  NSg/VB+ NPr/C NSg/I/J+  . P  NSg/VB+ K    VXB D$+ J/R  NPr/VXB/JS P
 > get    away . ”
 # NSg/VB VB/J . .
 >
 #
-> I       ejaculated an  unrestrained “ Huh ! ” and  he       must    have    heard me       , for   he       went    on
-# ISg/#r+ VP/J       D/P VP/J         . W?  . . VB/C NPr/ISg+ NSg/VXB NSg/VXB VP/J  NPr/ISg+ . R/C/P NPr/ISg+ NSg/VPt J/P
+> I       ejaculated an  unrestrained “ Huh ! ” and  he       must    have    heard me       , for   he       went on
+# ISg/#r+ VP/J       D/P VP/J         . W?  . . VB/C NPr/ISg+ NSg/VXB NSg/VXB VP/J  NPr/ISg+ . R/C/P NPr/ISg+ VPt  J/P
 > nervously :
 # R         .
 >
@@ -10924,8 +10924,8 @@
 # NPr$     N🅪Sg/VB+ . VB/C ISg/#r+ VXB    NSg/VXB VPp/J NSg/VXB/JC C/P  P  NSg/VB ISg+ .
 >
 #
-> The morning   of the funeral I       went    up         to New    York to see    Meyer Wolfshiem ; I
-# D   N🅪Sg/Vg/J P  D+  NSg/J+  ISg/#r+ NSg/VPt NSg/VB/J/P P  NSg/J+ NPr+ P  NSg/VB NPr   ?         . ISg/#r+
+> The morning   of the funeral I       went up         to New    York to see    Meyer Wolfshiem ; I
+# D   N🅪Sg/Vg/J P  D+  NSg/J+  ISg/#r+ VPt  NSg/VB/J/P P  NSg/J+ NPr+ P  NSg/VB NPr   ?         . ISg/#r+
 > couldn’t seem to reach  him  any    other    way    . The door    that      I       pushed open     , on  the
 # VXB      VB   P  NSg/VB ISg+ I/R/Dq NSg/VB/J NSg/J+ . D+  NSg/VB+ I/C/Ddem+ ISg/#r+ VP/J   NSg/VB/J . J/P D
 > advice of an   elevator boy     , was  marked “ The Swastika Holding Company , ” and  at
@@ -10981,7 +10981,7 @@
 >
 #
 > “ You    young     men  think  you    can     force   your way    in        here any     time       , ” she  scolded .
-# . ISgPl+ NPr/VB/J+ NPl+ NSg/VB ISgPl+ NPr/VXB N🅪Sg/VB D$+  NSg/J+ NPr/J/R/P J/R  I/R/Dq+ N🅪Sg/VB/J+ . . ISg+ VP/J    .
+# . ISgPl+ NPr/VB/J+ NPl+ NSg/VB ISgPl+ NPr/VXB N🅪Sg/VB D$+  NSg/J+ NPr/J/R/P R    I/R/Dq+ N🅪Sg/VB/J+ . . ISg+ VP/J    .
 > “ We’re getting sick     in        tired of it       . When    I       say    he’s in        Chicago , he’s in
 # . K     NSg/Vg  NSg/VB/J NPr/J/R/P VP/J  P  NPr/ISg+ . NSg/I/C ISg/#r+ NSg/VB NPr$ NPr/J/R/P NPr+    . NPr$ NPr/J/R/P
 > Chicago . ”
@@ -11036,8 +11036,8 @@
 # . ISg/#r+ VP/J   ISg+ NSg/VB/J/P NSg/VB/J/R/P P  NSg/I/J+ . NPr/VB/J NSg/VB/J/R/P P  D   NSg/VB . ISg/#r+ NSg/VPt NPr/VB/J VB/J NPr/ISg+
 > was  a   fine     - appearing , gentlemanly young     man     , and  when    he       told me       he       was  an
 # VLPt D/P NSg/VB/J . Nᴹ/Vg/J   . J/R+        NPr/VB/J+ NPr/VB+ . VB/C NSg/I/C NPr/ISg+ VP   NPr/ISg+ NPr/ISg+ VLPt D/P
-> Oggsford I       knew I       could   use     him  good     . I       got him  to join   up         in        the American
-# ?        ISg/#r+ VPt  ISg/#r+ NSg/VXB N🅪Sg/VB ISg+ NPr/VB/J . ISg/#r+ VP  ISg+ P  NSg/VB NSg/VB/J/P NPr/J/R/P D+  NPr/J+
+> Oggsford I       knew I       could use     him  good     . I       got him  to join   up         in        the American
+# ?        ISg/#r+ VPt  ISg/#r+ VXB   N🅪Sg/VB ISg+ NPr/VB/J . ISg/#r+ VP  ISg+ P  NSg/VB NSg/VB/J/P NPr/J/R/P D+  NPr/J+
 > Legion    and  he       used to stand  high       there . Right    off        he       did  some     work    for   a   client
 # NSg/VB/J+ VB/C NPr/ISg+ VP/J P  NSg/VB NSg/VB/J/R R     . NPr/VB/J NSg/VB/J/P NPr/ISg+ VXPt I/J/R/Dq N🅪Sg/VB R/C/P D/P NSg
 > of mine      up         to Albany . We   were so          thick    like         that      in        everything ” — he       held up         two
@@ -11114,8 +11114,8 @@
 #
 > When    I       left     his     office the sky      had turned dark     and  I       got back     to West      Egg      in        a
 # NSg/I/C ISg/#r+ NPr/VP/J ISg/D$+ NSg/VB D+  N🅪Sg/VB+ VP  VP/J   NSg/VB/J VB/C ISg/#r+ VP  NSg/VB/J P  NPr/VB/J+ N🅪Sg/VB+ NPr/J/R/P D/P+
-> drizzle  . After changing my  clothes I       went    next    door    and  found  Mr   . Gatz walking
-# N🅪Sg/VB+ . P     Nᴹ/Vg/J  D$+ NPl/V3+ ISg/#r+ NSg/VPt NSg/J/P NSg/VB+ VB/C NSg/VP NSg+ . ?    Nᴹ/Vg/J
+> drizzle  . After changing my  clothes I       went next    door    and  found  Mr   . Gatz walking
+# N🅪Sg/VB+ . P     Nᴹ/Vg/J  D$+ NPl/V3+ ISg/#r+ VPt  NSg/J/P NSg/VB+ VB/C NSg/VP NSg+ . ?    Nᴹ/Vg/J
 > up         and  down        excitedly in        the hall . His     pride  in        his     son     and  in        his     son’s
 # NSg/VB/J/P VB/C N🅪Sg/VB/J/P R         NPr/J/R/P D   NPr+ . ISg/D$+ Nᴹ/VB+ NPr/J/R/P ISg/D$+ NPr/VB+ VB/C NPr/J/R/P ISg/D$+ NPr$
 > possessions was  continually increasing and  now       he       had something to show   me       .
@@ -11165,7 +11165,7 @@
 >
 #
 > “ Look   here , this    is  a   book   he       had when    he       was  a   boy    . It       just shows  you    . ”
-# . NSg/VB J/R  . I/Ddem+ VL3 D/P NSg/VB NPr/ISg+ VP  NSg/I/C NPr/ISg+ VLPt D/P NSg/VB . NPr/ISg+ J/R  NPl/V3 ISgPl+ . .
+# . NSg/VB R    . I/Ddem+ VL3 D/P NSg/VB NPr/ISg+ VP  NSg/I/C NPr/ISg+ VLPt D/P NSg/VB . NPr/ISg+ J/R  NPl/V3 ISgPl+ . .
 >
 #
 > He       opened it       at    the back     cover     and  turned it       around for   me       to see    . On  the last
@@ -11276,8 +11276,8 @@
 #
 > I       tried to think  about Gatsby then      for   a   moment , but     he       was  already too far
 # ISg/#r+ VP/J  P  NSg/VB J/P   NPr    NSg/J/R/C R/C/P D/P NSg+   . NSg/C/P NPr/ISg+ VLPt R       R   NSg/VB/J
-> away , and  I       could   only  remember , without resentment , that     Daisy hadn’t sent   a
-# VB/J . VB/C ISg/#r+ NSg/VXB J/R/C NSg/VB   . C/P     NSg+       . I/C/Ddem NPr+  VPt    NSg/VP D/P
+> away , and  I       could only  remember , without resentment , that     Daisy hadn’t sent   a
+# VB/J . VB/C ISg/#r+ VXB   J/R/C NSg/VB   . C/P     NSg+       . I/C/Ddem NPr+  VPt    NSg/VP D/P
 > message or    a   flower  . Dimly I       heard some      one      murmur “ Blessed are the dead     that
 # NSg/VB  NPr/C D/P NSg/VB+ . R     ISg/#r+ VP/J  I/J/R/Dq+ NSg/I/J+ NSg/VB . VP/J    VLB D   NSg/VB/J I/C/Ddem
 > the rain     falls   on  , ” and  then      the owl     - eyed man     said “ Amen   to that      , ” in        a   brave
@@ -11296,8 +11296,8 @@
 # . ISg/#r+ VXB      NSg/VB P  D   NPr/VB+ . . NPr/ISg+ VP/J     .
 >
 #
-> “ Neither could   anybody else    . ”
-# . I/C     NSg/VXB NSg/I+  NSg/J/C . .
+> “ Neither could anybody else    . ”
+# . I/C     VXB   NSg/I+  NSg/J/C . .
 >
 #
 > “ Go       on  ! ” He       started . “ Why    , my  God     ! they used to go       there by the hundreds . ”
@@ -11314,8 +11314,8 @@
 #
 > One     of my  most         vivid  memories is  of coming  back     West      from prep   school   and  later
 # NSg/I/J P  D$+ NSg/I/J/R/Dq NSg/J+ NPl+     VL3 P  Nᴹ/Vg/J NSg/VB/J NPr/VB/J+ P    Nᴹ/VB+ N🅪Sg/VB+ VB/C JC
-> from college at    Christmas time       . Those   who    went    farther than Chicago would gather
-# P    NSg     NSg/P NPr/VB/J+ N🅪Sg/VB/J+ . I/Ddem+ NPr/I+ NSg/VPt VB/JC   C/P  NPr+    VXB   NSg/VB
+> from college at    Christmas time       . Those   who    went farther than Chicago would gather
+# P    NSg     NSg/P NPr/VB/J+ N🅪Sg/VB/J+ . I/Ddem+ NPr/I+ VPt  VB/JC   C/P  NPr+    VXB   NSg/VB
 > in        the old    dim       Union     Street    station at    six o’clock of a    December evening    , with a
 # NPr/J/R/P D+  NSg/J+ NSg/VB/J+ NPr/VB/J+ NSg/VB/J+ NSg/VB+ NSg/P NSg R       P  D/P+ NPr+     N🅪Sg/Vg/J+ . P    D/P+
 > few       Chicago friends   , already caught up         into their own       holiday gayeties , to bid
@@ -11366,8 +11366,8 @@
 # NSg/J/R/C I/C/Ddem I/Ddem+ V3  VLPp/B D/P NSg/VB P  D+  NPr/VB/J+ . P     NSg/I/J/C/Dq . NPr/VB+ VB/C NPr    . NPr   VB/C
 > Jordan and  I       , were all          Westerners , and  perhaps we   possessed some     deficiency in
 # NPr+   VB/C ISg/#r+ . VLPt NSg/I/J/C/Dq +          . VB/C NSg/R   IPl+ VP/J      I/J/R/Dq NSg+       NPr/J/R/P
-> common   which made us       subtly unadaptable to Eastern life     .
-# NSg/VB/J I/C+  VP   NPr/IPl+ R      ?           P  J       N🅪Sg/VB+ .
+> common which made us       subtly unadaptable to Eastern life     .
+# VB/J   I/C+  VP   NPr/IPl+ R      ?           P  J       N🅪Sg/VB+ .
 >
 #
 > Even       when    the East   excited me       most         , even       when    I       was  most         keenly aware of its
@@ -11426,8 +11426,8 @@
 # NSg/VB+ . ISg/D$+ NSg/VB D   I/J  NPr🅪Sg/VB/J NSg/VB R/C/P D   ?          NSg/VB+ J/P ISg/D$+ NSg/VB+ . NSg/I/C ISg/#r+
 > had finished she  told me       without comment that      she  was  engaged to another man     . I
 # VP  VP/J     ISg+ VP   NPr/ISg+ C/P     NSg/VB+ I/C/Ddem+ ISg+ VLPt VP/J    P  I/D+    NPr/VB+ . ISg/#r+
-> doubted that      , though there were several she  could   have    married  at    a   nod    of her
-# VP/J    I/C/Ddem+ . C      R+    VLPt J/Dq    ISg+ NSg/VXB NSg/VXB NSg/VP/J NSg/P D/P NSg/VB P  ISg/D$+
+> doubted that      , though there were several she  could have    married  at    a   nod    of her
+# VP/J    I/C/Ddem+ . C      R+    VLPt J/Dq    ISg+ VXB   NSg/VXB NSg/VP/J NSg/P D/P NSg/VB P  ISg/D$+
 > head      , but     I       pretended to be       surprised . For   just a    minute    I       wondered if    I       wasn’t
 # NPr/VB/J+ . NSg/C/P ISg/#r+ VP/J      P  NSg/VLXB VP/J      . R/C/P J/R  D/P+ NSg/VB/J+ ISg/#r+ VP/J     NSg/C ISg/#r+ VPt
 > making  a   mistake , then      I       thought it       all          over    again quickly and  got up         to say
@@ -11485,7 +11485,7 @@
 > along Fifth    Avenue in        his     alert     , aggressive way    , his     hands   out          a   little     from his
 # P     NSg/VB/J NSg+   NPr/J/R/P ISg/D$+ NSg/VB/J+ . NSg/J+     NSg/J+ . ISg/D$+ NPl/V3+ NSg/VB/J/R/P D/P NPr/I/J/Dq P    ISg/D$+
 > body    as    if    to fight  off        interference , his     head      moving  sharply here and  there ,
-# NSg/VB+ R/C/P NSg/C P  NSg/VB NSg/VB/J/P NSg/VB+      . ISg/D$+ NPr/VB/J+ Nᴹ/Vg/J R       J/R  VB/C R     .
+# NSg/VB+ R/C/P NSg/C P  NSg/VB NSg/VB/J/P NSg/VB+      . ISg/D$+ NPr/VB/J+ Nᴹ/Vg/J R       R    VB/C R     .
 > adapting itself to his     restless eyes    . Just as    I       slowed up         to avoid overtaking
 # Nᴹ/Vg/J  ISg+   P  ISg/D$+ J        NPl/V3+ . J/R  R/C/P ISg/#r+ VP/J   NSg/VB/J/P P  VB    Nᴹ/Vg/J
 > him  he       stopped and  began frowning into the windows  of a    jewelry store   . Suddenly
@@ -11538,14 +11538,14 @@
 # VP/J    ISg/D$+ NSg+ . .
 >
 #
-> There was  nothing  I       could   say    , except the one      unutterable fact that      it       wasn’t
-# R+    VLPt NSg/I/J+ ISg/#r+ NSg/VXB NSg/VB . VB/C/P D+  NSg/I/J+ NSg/J       NSg+ I/C/Ddem+ NPr/ISg+ VPt
+> There was  nothing  I       could say    , except the one      unutterable fact that      it       wasn’t
+# R+    VLPt NSg/I/J+ ISg/#r+ VXB   NSg/VB . VB/C/P D+  NSg/I/J+ NSg/J       NSg+ I/C/Ddem+ NPr/ISg+ VPt
 > true     .
 # NSg/VB/J .
 >
 #
-> “ And  if    you    think  I       didn’t have    my  share  of suffering — look   here , when    I       went    to
-# . VB/C NSg/C ISgPl+ NSg/VB ISg/#r+ VXPt   NSg/VXB D$+ NSg/VB P  Nᴹ/Vg/J+  . NSg/VB J/R  . NSg/I/C ISg/#r+ NSg/VPt P
+> “ And  if    you    think  I       didn’t have    my  share  of suffering — look   here , when    I       went to
+# . VB/C NSg/C ISgPl+ NSg/VB ISg/#r+ VXPt   NSg/VXB D$+ NSg/VB P  Nᴹ/Vg/J+  . NSg/VB R    . NSg/I/C ISg/#r+ VPt  P
 > give   up         that     flat     and  saw     that     damn     box    of dog       biscuits sitting  there on  the
 # NSg/VB NSg/VB/J/P I/C/Ddem NSg/VB/J VB/C NSg/VPt I/C/Ddem NSg/VB/J NSg/VB P  NSg/VB/J+ NPl      NSg/Vg/J R     J/P D
 > sideboard , I       sat    down        and  cried like         a   baby      . By God     it       was  awful — ”
@@ -11566,8 +11566,8 @@
 #
 > I       shook     hands   with him  ; it       seemed silly not     to , for   I       felt      suddenly as    though I
 # ISg/#r+ NSg/VPt/J NPl/V3+ P    ISg+ . NPr/ISg+ VP/J   NSg/J NSg/R/C P  . R/C/P ISg/#r+ N🅪Sg/VP/J R        R/C/P C      ISg/#r+
-> were talking to a    child   . Then      he       went    into the jewelry store   to buy    a    pearl
-# VLPt Nᴹ/Vg/J P  D/P+ NSg/VB+ . NSg/J/R/C NPr/ISg+ NSg/VPt P    D+  Nᴹ/VB+  NSg/VB+ P  NSg/VB D/P+ NPr/VB+
+> were talking to a    child   . Then      he       went into the jewelry store   to buy    a    pearl
+# VLPt Nᴹ/Vg/J P  D/P+ NSg/VB+ . NSg/J/R/C NPr/ISg+ VPt  P    D+  Nᴹ/VB+  NSg/VB+ P  NSg/VB D/P+ NPr/VB+
 > necklace — or    perhaps only  a   pair   of cuff   buttons — rid of my  provincial
 # NSg/VB+  . NPr/C NSg/R   J/R/C D/P NSg/VB P  NSg/VB NPl/V3+ . VB  P  D$+ NSg/J
 > squeamishness forever .
@@ -11590,8 +11590,8 @@
 #
 > I       spent my  Saturday nights  in        New    York because those   gleaming , dazzling parties
 # ISg/#r+ VP/J  D$+ NSg/VB+  NPl/V3+ NPr/J/R/P NSg/J+ NPr+ C/P     I/Ddem+ Nᴹ/Vg/J+ . Nᴹ/Vg/J  NPl/V3
-> of his     were with me       so          vividly that     I       could   still      hear the music     and  the
-# P  ISg/D$+ VLPt P    NPr/ISg+ NSg/I/J/R/C R       I/C/Ddem ISg/#r+ NSg/VXB NSg/VB/J/R VB   D   N🅪Sg/VB/J VB/C D+
+> of his     were with me       so          vividly that     I       could still      hear the music     and  the
+# P  ISg/D$+ VLPt P    NPr/ISg+ NSg/I/J/R/C R       I/C/Ddem ISg/#r+ VXB   NSg/VB/J/R VB   D   N🅪Sg/VB/J VB/C D+
 > laughter , faint    and  incessant , from his     garden    , and  the cars going   up         and  down
 # Nᴹ+      . NSg/VB/J VB/C J         . P    ISg/D$+ NSg/VB/J+ . VB/C D+  NPl+ Nᴹ/Vg/J NSg/VB/J/P VB/C N🅪Sg/VB/J/P
 > his     drive   . One      night    I       did  hear a    material   car  there , and  saw     its     lights  stop   at
@@ -11603,7 +11603,7 @@
 >
 #
 > On  the last      night    , with my  trunk   packed and  my  car  sold   to the grocer , I       went
-# J/P D+  NSg/VB/J+ N🅪Sg/VB+ . P    D$+ NSg/VB+ VP/J   VB/C D$+ NSg+ NSg/VP P  D   NSg/VB . ISg/#r+ NSg/VPt
+# J/P D+  NSg/VB/J+ N🅪Sg/VB+ . P    D$+ NSg/VB+ VP/J   VB/C D$+ NSg+ NSg/VP P  D   NSg/VB . ISg/#r+ VPt
 > over    and  looked at    that     huge incoherent failure of a   house   once  more         . On  the
 # NSg/J/P VB/C VP/J   NSg/P I/C/Ddem J    J          N🅪Sg    P  D/P NPr/VB+ NSg/C NPr/I/J/R/Dq . J/P D+
 > white        steps   an  obscene word    , scrawled by some     boy     with a   piece  of brick      , stood
@@ -11621,7 +11621,7 @@
 > rose      higher the inessential houses  began to melt   away until gradually I       became
 # NPr/VPt/J NSg/JC D   NSg/J       NPl/V3+ VPt   P  NSg/VB VB/J C/P   R         ISg/#r+ VPt
 > aware of the old   island  here that     flowered once  for   Dutch     sailors ’ eyes    — a   fresh    ,
-# VB/J  P  D   NSg/J NSg/VB+ J/R  I/C/Ddem VP/J     NSg/C R/C/P NPrᴹ/VB/J NPl+    . NPl/V3+ . D/P NSg/VB/J .
+# VB/J  P  D   NSg/J NSg/VB+ R    I/C/Ddem VP/J     NSg/C R/C/P NPrᴹ/VB/J NPl+    . NPl/V3+ . D/P NSg/VB/J .
 > green       breast of the new   world   . Its     vanished trees   , the trees   that      had made way
 # NPr🅪Sg/VB/J NSg/VB P  D   NSg/J NSg/VB+ . ISg/D$+ VP/J     NPl/V3+ . D+  NPl/V3+ I/C/Ddem+ VP  VP   NSg/J
 > for   Gatsby’s house   , had once  pandered in        whispers to the last     and  greatest of
@@ -11642,8 +11642,8 @@
 # N🅪Sg/VB NSg/I/C NPr/ISg+ NSg/J VP/J   NSg/VB/J/R/P D   NPr🅪Sg/VB/J N🅪Sg/VB/J+ NSg/P D   NSg/VB P  NPr$    NSg/VB+ . NPr/ISg+
 > had come       a   long     way    to this    blue       lawn    , and  his     dream     must    have    seemed so          close
 # VP  NSg/VBPp/P D/P NPr/VB/J NSg/J+ P  I/Ddem+ N🅪Sg/VB/J+ NSg/VB+ . VB/C ISg/D$+ NSg/VB/J+ NSg/VXB NSg/VXB VP/J   NSg/I/J/R/C NSg/VB/J
-> that     he       could   hardly fail     to grasp  it       . He       did  not     know that     it       was  already
-# I/C/Ddem NPr/ISg+ NSg/VXB R      NSg/VB/J P  NSg/VB NPr/ISg+ . NPr/ISg+ VXPt NSg/R/C VB   I/C/Ddem NPr/ISg+ VLPt R
+> that     he       could hardly fail     to grasp  it       . He       did  not     know that     it       was  already
+# I/C/Ddem NPr/ISg+ VXB   R      NSg/VB/J P  NSg/VB NPr/ISg+ . NPr/ISg+ VXPt NSg/R/C VB   I/C/Ddem NPr/ISg+ VLPt R
 > behind  him  , somewhere back     in        that      vast   obscurity beyond the city , where   the
 # NSg/J/P ISg+ . R         NSg/VB/J NPr/J/R/P I/C/Ddem+ NSg/J+ Nᴹ+       NSg/P  D+  NSg+ . NSg/R/C D
 > dark     fields   of the republic rolled on  under   the night    .

--- a/harper-core/tests/text/tagged/this and that.md
+++ b/harper-core/tests/text/tagged/this and that.md
@@ -1,5 +1,5 @@
-> " This    " and  " that      " are common   and  fulfill multiple purposes in        everyday English      .
-# . I/Ddem+ . VB/C . I/C/Ddem+ . VLB NSg/VB/J VB/C VB/NoAm NSg/J/Dq NPl/V3   NPr/J/R/P NSg/J+   NPr🅪Sg/VB/J+ .
+> " This    " and  " that      " are common and  fulfill multiple purposes in        everyday English      .
+# . I/Ddem+ . VB/C . I/C/Ddem+ . VLB VB/J   VB/C VB/NoAm NSg/J/Dq NPl/V3   NPr/J/R/P NSg/J+   NPr🅪Sg/VB/J+ .
 > As    such  , disambiguating them     is  necessary .
 # R/C/P NSg/I . Nᴹ/Vg/J        NSg/IPl+ VL3 NSg/J     .
 >
@@ -50,10 +50,10 @@
 # I/Ddem+ NSg/VB+ NSg/VB/J/R .
 >
 #
-> That      could   be       a    solution .
-# I/C/Ddem+ NSg/VXB NSg/VLXB D/P+ N🅪Sg+    .
-> Find   all           candidates that      could   be       a    solution .
-# NSg/VB NSg/I/J/C/Dq+ NPl/V3+    I/C/Ddem+ NSg/VXB NSg/VLXB D/P+ N🅪Sg+    .
+> That      could be       a    solution .
+# I/C/Ddem+ VXB   NSg/VLXB D/P+ N🅪Sg+    .
+> Find   all           candidates that      could be       a    solution .
+# NSg/VB NSg/I/J/C/Dq+ NPl/V3+    I/C/Ddem+ VXB   NSg/VLXB D/P+ N🅪Sg+    .
 >
 #
 > This    is  all          that     I       have    .


### PR DESCRIPTION
# Issues 
N/A

# Description

I discovered that many nouns ending in -th did not have their plurals marked properly.

Other than that, mostly POS tweaks due to posslq
-common - not noun
-couchette - generate possessive
-coughs - plural & 3rd pers sg pres
-could - not noun
-here - not adj
-king - don't generate kingly
-queen - don't generate queenly
-setting - split into sg and pl entries
-went - not noun
-wept - past tense & participle
-anyhow - adverb→adjective

# How Has This Been Tested?

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
