### PR TITLE
fix: avoid panics in position_to_index for empty lines and out-of-bou…

### DIFF
--- a/harper-ls/src/pos_conv.rs
+++ b/harper-ls/src/pos_conv.rs
@@ -51,29 +51,27 @@ fn position_to_index(source: &[char], position: Position) -> usize {
         // Uses `saturating_sub` to avoid underflow when `source` is empty.
         return source.len().saturating_sub(1);
     };
+    
+// If the requested character index is within the line, compute the index.
++    if position.character
++        < target_line
++            .len()
++            .try_into()
++            .expect("target_line.len() can fit in u32")
++    {
++        let ptr = target_line.as_ptr().wrapping_add(position.character as usize);
++        (ptr as usize - source.as_ptr() as usize) / size_of::<char>()
++    } else {
++        // If the line is empty, return the last index of the source as a best-effort.
++        if target_line.is_empty() {
++            return source.len().saturating_sub(1);
++        }
++        // Otherwise use the last character of the target line.
++        let last = target_line.last().unwrap();
++        let ptr = last as *const char;
++        (ptr as usize - source.as_ptr() as usize) / size_of::<char>()
++    }
 
-    // Get a pointer to the char we seek.
-    // Check if specified character index is within bounds of the target line.
-    let target_char_pointer = if position.character
-        < target_line
-            .len()
-            .try_into()
-            .expect("target_line.len() can fit in u32")
-    {
-        // Character index is inside the bounds of the specified line.
-        // Calculate pointer to the char we're looking for.
-        target_line
-            .as_ptr()
-            .wrapping_add(position.character as usize)
-    } else {
-        // Character index is outside the bounds of the specified line.
-        // Get pointer to the last character of the line.
-        target_line.last().expect("line cannot be empty")
-    };
-
-    // Convert the char pointer to its index within `source`.
-    // Note: this could be simplified with `offset_from`, but that would require `unsafe`.
-    (target_char_pointer as usize - source.as_ptr() as usize) / size_of::<char>()
 }
 
 pub fn range_to_span(source: &[char], range: Range) -> Span<char> {


### PR DESCRIPTION
…nds positions


Why
---
Panics/unrecoverable unwraps in production code (Medium) Files & examples: harper-ls/src/pos_conv.rs — uses target_line.last().expect("line cannot be empty") harper-desktop many places wrap FFI calls and sometimes call .expect or .unwrap implicitly Risk: Panic in an LSP server or desktop process can crash the service, causing a DoS for users. Fix: Replace expect()/unwrap() with Result return and handle empty inputs gracefully. Prefer returning a well-defined index/option for empty sources. Add fuzzing and unit tests covering empty and boundary inputs. Harden public API surface to defend against malicious inputs from editors or other untrusted sources.

Agent transparency
------------------
This PR draft was prepared by an autonomous assistant (GitHub Copilot/assistant) under the user's instruction. Automated steps performed:
- repository discovery and file enumeration
- code search for relevant patterns
- patch generation and PR text drafting No commit or push to the upstream Automattic/harper repository was performed by the assistant.

# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
