### PR TITLE
fix: use secure tempfile for mac icon conversion to prevent TOCTOU/sy…

### DIFF
--- a/harper-desktop/src-tauri/src/mac_broker/app_icons.rs
+++ b/harper-desktop/src-tauri/src/mac_broker/app_icons.rs
@@ -3,6 +3,7 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
 };
+use tempfile::Builder as TempFileBuilder;
 
 use super::app_catalog::application_path_for_bundle_id;
 
@@ -18,10 +19,13 @@ pub fn application_icon_png(bundle_id: &str) -> Result<Vec<u8>, String> {
         .ok_or_else(|| format!("No application found for bundle ID {bundle_id}."))?;
     let icon_path = icon_path_for_app(&app_path)
         .ok_or_else(|| format!("No application icon found for bundle ID {bundle_id}."))?;
-    let output_path = std::env::temp_dir().join(format!(
-        "harper-{bundle_id}-icon-{}.png",
-        std::process::id()
-    ));
+    let tmp_file = TempFileBuilder::new()
+        .prefix("harper-icon-")
+        .suffix(".png")
+        .tempfile_in(std::env::temp_dir())
+        .map_err(|e| format!("Failed to create temp file for icon conversion: {e}"))?;
+
+    let output_path = tmp_file.path().to_path_buf();
 
     let output = Command::new("sips")
         .arg("-s")
@@ -39,9 +43,9 @@ pub fn application_icon_png(bundle_id: &str) -> Result<Vec<u8>, String> {
 
     let bytes = fs::read(&output_path)
         .map_err(|error| format!("Failed to read converted icon for {bundle_id}: {error}"))?;
-    let _ = fs::remove_file(output_path);
 
     Ok(bytes)
+    
 }
 
 fn icon_path_for_app(app_path: &str) -> Option<PathBuf> {


### PR DESCRIPTION
…mlink attacks


Replace predictable tmp filename with secure NamedTempFile to avoid TOCTOU / symlink attacks.

Predictable temp-file + external tool (High) Files: harper-desktop/src-tauri/src/mac_broker/app_icons.rs — function application_icon_png harper-desktop/src-tauri/src/mac_broker/mod.rs — callers and cache logic Evidence: application_icon_png builds output path with std::env::temp_dir().join(format!("harper-{bundle_id}-icon-{}.png", std::process::id())) Then calls Command::new("sips") ... --out <output_path>, reads that path with fs::read, then removes it. Risk: Predictable filename (pid + bundle_id) in a shared temp directory is vulnerable to a symlink/race attack (TOCTOU). 

An attacker who can create files in the same temp directory (local user, other processes) could place a symlink at that path so that when sips writes, it overwrites an arbitrary target; or cause the process to read an attacker-controlled file. If bundle_id or icon_file could be controlled by an attacker (e.g., via installed malicious .app with specially-crafted Info.plist), they can influence paths further. Repro (conceptual): Create a symlink at the expected output path pointing to a sensitive file, call the function, observe target overwritten or replaced (depends on system sips behavior). 

Fix / mitigation: Use secure temp-file creation (tempfile::NamedTempFile or mkstemp equivalent) with O_EXCL semantics; never construct temp filenames yourself. Create the temp file atomically, pass its path (or file descriptor) to sips (if sips requires a path, use a NamedTempFile and ensure it's created exclusively and removed on drop). 

Validate and sanitize bundle_id (allow only reverse-DNS characters: [A-Za-z0-9._-]+) before using it in file names. Use strict file permissions and limit who can write into the temp dir (where possible). Example fix snippet below (safe temporary file usage).

Notes: ensure NamedTempFile is created with appropriate permissions. If sips refuses to write to an already-open file descriptor, use a securely-created path with a randomized name (NamedTempFile gives you that).

This PR draft was prepared by an autonomous assistant. Automated steps performed: repository discovery, file listing, lexical search for relevant code patterns, and preparation of the patch & commit message. No commits were pushed.

# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
