### PR TITLE
fix: validate macOS bundle IDs and sanitize CFBundleIconFile to harde…

### DIFF
--- a/harper-desktop/src-tauri/src/mac_broker/app_icons.rs
+++ b/harper-desktop/src-tauri/src/mac_broker/app_icons.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use super::app_catalog::application_path_for_bundle_id;
+use super::app_catalog::sanitize_icon_file;
 
 /// Converts an installed app's icon resource to PNG bytes using the macOS `sips` tool.
 pub fn application_icon_png(bundle_id: &str) -> Result<Vec<u8>, String> {
@@ -77,9 +78,16 @@ fn app_icon_file(app_path: &str) -> Option<String> {
 
     let icon_file = String::from_utf8_lossy(&output.stdout).trim().to_string();
 
-    if icon_file.is_empty() {
-        None
-    } else {
-        Some(icon_file)
+    // Sanitize the icon filename. Reject absolute paths or traversal.
+    match sanitize_icon_file(&icon_file) {
+        Some(s) => Some(s),
+        None => {
+            eprintln!(
+                "Rejected CFBundleIconFile value for app at {}: {:?}",
+                app_path, icon_file
+            );
+            None
+        }
     }
+    
 }


### PR DESCRIPTION
…n system-tool calls


Sanitize CFBundleIconFile output read by PlistBuddy before using it to construct a resource path.

If sanitize fails, fail closed and return an error with a log.

Fix 2.

Panics/unrecoverable unwraps in production code (Medium)

Files & examples: harper-ls/src/pos_conv.rs — uses target_line.last().expect("line cannot be empty") harper-desktop many places wrap FFI calls and sometimes call .expect or .unwrap implicitly.

Risk: Panic in an LSP server or desktop process can crash the service, causing a DoS for users. 

Fix: Replace expect()/unwrap() with Result return and handle empty inputs gracefully. Prefer returning a well-defined index/option for empty sources. Add fuzzing and unit tests covering empty and boundary inputs. 

Harden public API surface to defend against malicious inputs from editors or other untrusted sources.

This PR draft was prepared by an autonomous assistant under user instruction.
- Automated steps performed: repository inspection, code search, patch generation, and PR text drafting.
- No code was pushed to the upstream Automattic/harper repository by the assistant.

# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
