### PR TITLE
fix: validate macOS bundle IDs and sanitize CFBundleIconFile to harde…

### DIFF
--- a/harper-desktop/src-tauri/src/mac_broker/mod.rs
+++ b/harper-desktop/src-tauri/src/mac_broker/mod.rs
@@ -422,6 +422,12 @@ impl OsBroker for MacBroker {
         if bundle_id.is_empty() {
             return Err("Bundle ID cannot be empty.".to_string());
         }
+
+        // Validate the bundle ID to avoid passing malformed inputs to `open -b`.
+        if !super::app_catalog::is_valid_bundle_id(bundle_id) {
+            return Err(format!("Invalid bundle ID: {}", bundle_id));
+        }
+        
         Command::new("open")
             .arg("-b")
             .arg(bundle_id)


### PR DESCRIPTION
…n system-tool calls


Validate bundle_id for launch_app_bundle before invoking open -b.

Log and return an error if invalid.

Fix 3.

Panics/unrecoverable unwraps in production code (Medium)

Files & examples: harper-ls/src/pos_conv.rs — uses target_line.last().expect("line cannot be empty") harper-desktop many places wrap FFI calls and sometimes call .expect or .unwrap implicitly.

Risk: Panic in an LSP server or desktop process can crash the service, causing a DoS for users. 

Fix: Replace expect()/unwrap() with Result return and handle empty inputs gracefully. Prefer returning a well-defined index/option for empty sources. Add fuzzing and unit tests covering empty and boundary inputs. 

Harden public API surface to defend against malicious inputs from editors or other untrusted sources.

This PR draft was prepared by an autonomous assistant under user instruction.
- Automated steps performed: repository inspection, code search, patch generation, and PR text drafting.
- No code was pushed to the upstream Automattic/harper repository by the assistant.

# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
