### PR TITLE
feat(mac_broker): add persistent per-app accessibility consent store

### DIFF
--- a/harper-desktop/src-tauri/src/mac_broker/accessibility_consent.rs
+++ b/harper-desktop/src-tauri/src/mac_broker/accessibility_consent.rs
@@ -1,0 +1,89 @@
+// harper-desktop/src-tauri/src/mac_broker/accessibility_consent.rs
+use std::collections::HashSet;
+use std::fs;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Simple persistent consent store for accessibility approvals.
+/// Stores a JSON object with an "allowed" array of bundle IDs in the user's config directory.
+#[derive(Serialize, Deserialize, Default)]
+struct ConsentStore {
+    allowed: HashSet<String>,
+}
+
+fn consent_file_path() -> Option<PathBuf> {
+    // Prefer XDG config directory if available, otherwise fallback to HOME.
+    if let Ok(cfg) = std::env::var("XDG_CONFIG_HOME") {
+        let mut p = PathBuf::from(cfg);
+        p.push("harper");
+        let _ = fs::create_dir_all(&p);
+        p.push("accessibility_consent.json");
+        return Some(p);
+    }
+
+    if let Ok(home) = std::env::var("HOME") {
+        let mut p = PathBuf::from(home);
+        p.push(".config");
+        p.push("harper");
+        let _ = fs::create_dir_all(&p);
+        p.push("accessibility_consent.json");
+        return Some(p);
+    }
+
+    None
+}
+
+fn load_store() -> ConsentStore {
+    let path = match consent_file_path() {
+        Some(p) => p,
+        None => return ConsentStore::default(),
+    };
+
+    let mut f = match fs::File::open(&path) {
+        Ok(mut fh) => {
+            let mut s = String::new();
+            if fh.read_to_string(&mut s).is_ok() {
+                if let Ok(store) = serde_json::from_str::<ConsentStore>(&s) {
+                    return store;
+                }
+            }
+            return ConsentStore::default();
+        }
+        Err(_) => return ConsentStore::default(),
+    };
+}
+
+fn save_store(store: &ConsentStore) -> Result<(), String> {
+    let path = consent_file_path().ok_or_else(|| "no config path".to_string())?;
+    let s = serde_json::to_string_pretty(store).map_err(|e| e.to_string())?;
+    let mut f = fs::File::create(&path).map_err(|e| e.to_string())?;
+    f.write_all(s.as_bytes()).map_err(|e| e.to_string())
+}
+
+/// Returns true if the user has explicitly consented to allow accessibility access
+/// for the given bundle_id.
+pub(crate) fn user_has_consented(bundle_id: &str) -> bool {
+    let b = bundle_id.trim();
+    if b.is_empty() {
+        return false;
+    }
+    let store = load_store();
+    store.allowed.contains(b)
+}
+
+/// Sets user consent for a bundle_id. `allow == true` grants consent; false removes it.
+pub(crate) fn set_user_consent(bundle_id: &str, allow: bool) -> Result<(), String> {
+    let b = bundle_id.trim();
+    if b.is_empty() {
+        return Err("bundle_id empty".to_string());
+    }
+    let mut store = load_store();
+    if allow {
+        store.allowed.insert(b.to_string());
+    } else {
+        store.allowed.remove(b);
+    }
+    save_store(&store)
+}


### PR DESCRIPTION
Summary: Adds a small local persistent consent store for per-app accessibility approvals. The store is saved to XDG_CONFIG_HOME/harper/accessibility_consent.json or ~/.config/harper/accessibility_consent.json. Provides two crate-private helpers: user_has_consented(bundle_id) and set_user_consent(bundle_id, allow).

PR 1.

Apply them in order: PR 1 -> PR 2 -> PR 3 (PR 2 depends on PR 1; PR 3 depends on PR 1).

Why: Accessibility APIs let the app read other applications.

Accessibility / privileged API use (Low → Medium) 

Files: harper-desktop src-tauri mac_broker accessibility_* modules Observations: The app requests accessibility permissions and manipulates AX attributes to read text from other apps. 

Risk: If manipulated or buggy, these features could interfere with other apps or leak user content. Ensure explicit user consent and clear UX; avoid doing anything sensitive without permission. 

Fix: Provide clear permission prompts, document why access is needed, and restrict operations to intended targets. Add robust error handling and logging of failures without leaking data.

UI/text. To reduce privacy risk and give users control, we require explicit per-app approvals persistently.

Files changed: harper-desktop/src-tauri/src/mac_broker/accessibility_consent.rs (new)

Testing: Recommend unit tests that set XDG_CONFIG_HOME to a tempdir and validate set/get behavior; manual check by calling set_user_consent and verifying file creation.

Agent transparency: Prepared by an autonomous assistant under user instruction. Actions: repository inspection and patch authored. No pushes were made.

# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
