### PR TITLE
feat(mac_broker): enforce per-app accessibility consent before AX access

### DIFF
--- a/harper-desktop/src-tauri/src/mac_broker/mod.rs
+++ b/harper-desktop/src-tauri/src/mac_broker/mod.rs
@@ -7,6 +7,8 @@ mod app_search_index;
 mod core_foundation_utilities;
 mod focused_window_pid;
 mod window_stability;
+// inside harper-desktop/src-tauri/src/mac_broker/mod.rs, near other `use` / `mod` lines:
+mod accessibility_consent;
 
 use accessibility::TreeWalker;
 use accessibility::ui_element::AXUIElement;
@@ -334,6 +336,19 @@ impl OsBroker for MacBroker {
         };
 
         if !integration_enabled {
+            self.window_movement = None;
+            self.reset_accessibility_activation();
+            return Vec::new();
+        }
+
+        // Additional user-level consent check: do not proceed to walk or probe
+        // accessibility trees for bundle identifiers the user has not explicitly approved.
+        // This is a privacy-first, fail-closed guard.
+        if !accessibility_consent::user_has_consented(&bundle_identifier) {
+            eprintln!(
+                "Accessibility access not granted by user for {}; skipping collection",
+                bundle_identifier
+            );
             self.window_movement = None;
             self.reset_accessibility_activation();
             return Vec::new();


### PR DESCRIPTION
Summary: Adds a privacy-first gate in the mac broker so it will not walk or probe another app's accessibility tree unless the user has explicitly consented to that bundle ID (via the consent store added in PR 1).

PR 2.

Apply them in order: PR 1 -> PR 2 -> PR 3 (PR 2 depends on PR 1; PR 3 depends on PR 1).

Why: Protects user privacy and stops accidental/unauthorized reading of other apps' UI content by failing closed when no consent exists.

Accessibility / privileged API use (Low → Medium)

Files: harper-desktop src-tauri mac_broker accessibility_* modules Observations: The app requests accessibility permissions and manipulates AX attributes to read text from other apps. 

Risk: If manipulated or buggy, these features could interfere with other apps or leak user content. Ensure explicit user consent and clear UX; avoid doing anything sensitive without permission. 

Fix: Provide clear permission prompts, document why access is needed, and restrict operations to intended targets. Add robust error handling and logging of failures without leaking data.

Files changed: harper-desktop/src-tauri/src/mac_broker/mod.rs (add mod declaration + consent check)

Testing: Apply PR 1, then verify that without consent the mac broker returns empty collections and logs a short, non-sensitive message. After granting consent, the previous behavior should resume.

Agent transparency: Prepared by an autonomous assistant under user instruction. Actions: authored patch text. No pushes were made.

# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
