### PR TITLE
feat(ui): add accessibility consent helper and Svelte settings component

### DIFF
--- a/harper-desktop/src/lib/settings/accessibilityConsent.js
+++ b/harper-desktop/src/lib/settings/accessibilityConsent.js
@@ -1,0 +1,34 @@
+// harper-desktop/src/lib/settings/accessibilityConsent.js
+import { invoke } from '@tauri-apps/api/tauri';
+
+/**
+ * Ensure user has consented to accessibility usage for the given bundleId.
+ * Returns true when consent is present (or granted through the prompt).
+ * Returns false otherwise.
+ */
+export async function ensureAccessibilityConsent(bundleId) {
+  if (!bundleId) return false;
+
+  try {
+    const already = await invoke('has_user_consented', { bundleId });
+    if (already) {
+      return true;
+    }
+
+    // Replace window.confirm with your modal dialog for a better UX.
+    const ok = window.confirm(
+      `Harper needs permission to read text from ${bundleId} to provide accessibility highlights for that app. Do you allow this?`
+    );
+
+    if (!ok) {
+      return false;
+    }
+
+    // Persist user's approval
+    await invoke('set_user_consent_cmd', { bundleId, allow: true });
+    return true;
+  } catch (e) {
+    console.error('Consent API error', e);
+    return false;
+  }
+}


### PR DESCRIPTION
Add the frontend helper and a small Svelte settings component that prompt the user and call the native Tauri commands to persist per-app consent.

Summary
This PR adds a small frontend helper and a Svelte settings component that let the user grant per-app accessibility consent. The helper calls two Tauri commands (has_user_consented, set_user_consent_cmd) and prompts the user with a clear message. The Svelte component is a small example to mount in Settings to request and show consent status.

Why
The app uses Accessibility APIs to read other apps. To reduce privacy risk we require explicit per-app consent before the mac broker accesses other apps; this PR provides the frontend UX to request and persist that consent.

Accessibility / privileged API use (Low → Medium)

Files: harper-desktop src-tauri mac_broker accessibility_* modules Observations: The app requests accessibility permissions and manipulates AX attributes to read text from other apps. 

Risk: If manipulated or buggy, these features could interfere with other apps or leak user content. Ensure explicit user consent and clear UX; avoid doing anything sensitive without permission. 

Fix: Provide clear permission prompts, document why access is needed, and restrict operations to intended targets. Add robust error handling and logging of failures without leaking data.

Files changed
harper-desktop/src/lib/settings/accessibilityConsent.js (new) harper-desktop/src/lib/settings/AccessibilityConsent.svelte (new)

Notes / Testing
Depends on PR 1 (native consent store) and Tauri commands being registered (has_user_consented, set_user_consent_cmd). Ensure those are available in src-tauri/src/main.rs before testing.

To test: run the desktop dev flow, open Settings, mount the component (see PR B) and grant consent. Verify that the consent JSON file is created (XDG_CONFIG_HOME/harper/accessibility_consent.json or ~/.config/harper/accessibility_consent.json) and that the mac broker resumes collection for that bundle id.

Agent transparency
Prepared by an autonomous assistant under the user's instruction. No changes were pushed upstream; these are local patch instructions.

# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
