### PR TITLE
feat: made us of→made use of

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -3520,6 +3520,13 @@
 						},
 						{
 							"Bool": {
+								"name": "MakeUseOf",
+								"state": true,
+								"label": "Make Use Of"
+							}
+						},
+						{
+							"Bool": {
 								"name": "MassNouns",
 								"state": true,
 								"label": "Mass Nouns"

--- a/harper-core/src/linting/weir_rules/MakeUseOf.weir
+++ b/harper-core/src/linting/weir_rules/MakeUseOf.weir
@@ -1,0 +1,29 @@
+# Corrects the eggcorn `made us of` -> `made use of`.
+expr main <([make, makes, made, making] us of), us>
+
+let message "Did you mean `use`? The idiom is `make use of`."
+let description "Corrects the eggcorn `us of` to `use of` in the idiom `make use of`."
+let kind "Typo"
+let becomes "use"
+let strategy "MatchCase"
+
+# True positives
+
+test "It was made us of to duplicate pages." "It was made use of to duplicate pages."
+test "Making us of them is simple." "Making use of them is simple."
+test "He makes us of every resource." "He makes use of every resource."
+test "They make us of the tool." "They make use of the tool."
+test "The feature was made us of widely." "The feature was made use of widely."
+test "We are making us of caching." "We are making use of caching."
+test "She made us of a loophole." "She made use of a loophole."
+test "Made us of properly, it works." "Made use of properly, it works."
+test "Please make us of it." "Please make use of it."
+test "It makes us of good data." "It makes use of good data."
+
+# False positives / true negatives
+
+allows "Please make use of it."
+allows "He gave us of his time."
+allows "It made us proud of our work."
+allows "Some of us of that era recall it."
+allows "The gods gave us of their wisdom."


### PR DESCRIPTION
Add the `MakeUseOf` Weir rule, correcting the eggcorn `us of` to `use of` in the idiom `make use of` (e.g. "making us of them" → "making use of them"). Enabled in the curated default config.

# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
