### PR TITLE
feat: as part as→as part of

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -3303,6 +3303,13 @@
 						},
 						{
 							"Bool": {
+								"name": "AsPartOf",
+								"state": true,
+								"label": "As Part Of"
+							}
+						},
+						{
+							"Bool": {
 								"name": "AspireTo",
 								"state": true,
 								"label": "Aspire To"

--- a/harper-core/src/linting/weir_rules/AsPartOf.weir
+++ b/harper-core/src/linting/weir_rules/AsPartOf.weir
@@ -1,0 +1,29 @@
+# Corrects `as part as` -> `as part of`.
+expr main <(as part as !well), (part as), as>
+
+let message "Did you mean `as part of`?"
+let description "Corrects the phrase `as part as` to the intended `as part of`."
+let kind "Grammar"
+let becomes "of"
+let strategy "MatchCase"
+
+# True positives
+
+test "It was used as part as a larger chain." "It was used as part of a larger chain."
+test "It ships as part as the bundle." "It ships as part of the bundle."
+test "Treated as part as the whole." "Treated as part of the whole."
+test "Included as part as our plan." "Included as part of our plan."
+test "Delivered as part as an update." "Delivered as part of an update."
+test "Counted as part as its total." "Counted as part of its total."
+test "As part as the release, we shipped it." "As part of the release, we shipped it."
+test "Shipped as part as one release." "Shipped as part of one release."
+test "It runs as part as a small team." "It runs as part of a small team."
+test "Done as part as this effort." "Done as part of this effort."
+
+# False positives / true negatives
+
+allows "It ships as part of the bundle."
+allows "Regarded as part, as well as the whole."
+allows "Counted as part as well as whole."
+allows "Known as part as well as parcel."
+allows "Seen as part as well as the sum."


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

# Description
Add the `AsPartOf` Weir rule, correcting `as part as` to the intended `as part of`, while leaving `as part ... as well as` constructions alone. Enabled in the curated default config.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [x] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
