### PR TITLE
feat: slight of hand→sleight of hand

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -3751,6 +3751,13 @@
 						},
 						{
 							"Bool": {
+								"name": "SleightOfHand",
+								"state": true,
+								"label": "Sleight Of Hand"
+							}
+						},
+						{
+							"Bool": {
 								"name": "SomebodyElses",
 								"state": true,
 								"label": "Somebody Elses"

--- a/harper-core/src/linting/weir_rules/SleightOfHand.weir
+++ b/harper-core/src/linting/weir_rules/SleightOfHand.weir
@@ -1,0 +1,29 @@
+# Corrects the eggcorn `slight of hand` -> `sleight of hand`.
+expr main <(slight of hand), slight>
+
+let message "The idiom is `sleight of hand`."
+let description "Corrects the eggcorn `slight of hand` to `sleight of hand`."
+let kind "Eggcorn"
+let becomes "sleight"
+let strategy "MatchCase"
+
+# True positives
+
+test "It was pure slight of hand." "It was pure sleight of hand."
+test "The magician used slight of hand." "The magician used sleight of hand."
+test "That was a slight of hand trick." "That was a sleight of hand trick."
+test "With some slight of hand, he swapped them." "With some sleight of hand, he swapped them."
+test "Slight of hand fooled the crowd." "Sleight of hand fooled the crowd."
+test "SLIGHT OF HAND is hard to master." "SLEIGHT OF HAND is hard to master."
+test "His slight of hand was flawless." "His sleight of hand was flawless."
+test "It relies on slight of hand." "It relies on sleight of hand."
+test "Pure slight of hand, nothing more." "Pure sleight of hand, nothing more."
+test "A bit of slight of hand did the trick." "A bit of sleight of hand did the trick."
+
+# False positives / true negatives
+
+allows "It was pure sleight of hand."
+allows "She felt a slight breeze on her face."
+allows "He took slight offense at the joke."
+allows "There was a slight delay in the release."
+allows "The change had only a slight effect."


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

# Description
Add the `SleightOfHand` Weir rule, correcting the eggcorn `slight of hand` to `sleight of hand`. Enabled in the curated default config.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [x] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
