### PR TITLE
feat: nip it in the butt→nip it in the bud

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -3590,6 +3590,13 @@
 						},
 						{
 							"Bool": {
+								"name": "NipInTheBud",
+								"state": true,
+								"label": "Nip In The Bud"
+							}
+						},
+						{
+							"Bool": {
 								"name": "NominalWants",
 								"state": true,
 								"label": "Nominal Wants"

--- a/harper-core/src/linting/weir_rules/NipInTheBud.weir
+++ b/harper-core/src/linting/weir_rules/NipInTheBud.weir
@@ -1,0 +1,30 @@
+# Corrects the eggcorn `nip it in the butt` -> `nip it in the bud`.
+expr nipverbs [nip, nips, nipped, nipping]
+expr main <(@nipverbs [it, this, that, them] in the butt), butt>
+
+let message "The idiom is `nip it in the bud`, from pruning plants."
+let description "Corrects the eggcorn `in the butt` to `in the bud` in the idiom `nip it in the bud`."
+let kind "Eggcorn"
+let becomes "bud"
+let strategy "MatchCase"
+
+# True positives
+
+test "Nip this problem in the butt early." "Nip this problem in the butt early."
+test "Let's nip it in the butt." "Let's nip it in the bud."
+test "We nipped that in the butt." "We nipped that in the bud."
+test "Nip this in the butt now." "Nip this in the bud now."
+test "They nip them in the butt fast." "They nip them in the bud fast."
+test "He nips it in the butt every time." "He nips it in the bud every time."
+test "Nipping it in the butt saved us." "Nipping it in the bud saved us."
+test "NIP IT IN THE BUTT." "NIP IT IN THE BUD."
+test "I nipped it in the butt yesterday." "I nipped it in the bud yesterday."
+test "We should nip that in the butt." "We should nip that in the bud."
+
+# False positives / true negatives
+
+allows "Let's nip it in the bud."
+allows "He kicked the ball and hit him in the butt."
+allows "The dog nipped him in the butt."
+allows "She fell and landed on her butt."
+allows "The comedian made a joke about the butt of the gun."


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

# Description
Add the `NipInTheBud` Weir rule, correcting `in the butt` to `in the bud` in the idiom `nip it in the bud`, anchored on `nip` and an object pronoun to avoid literal uses. Enabled in the curated default config.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [x] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
