### PR TITLE
feat: phase me→faze me

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -3653,6 +3653,13 @@
 						},
 						{
 							"Bool": {
+								"name": "PhaseFaze",
+								"state": true,
+								"label": "Phase Faze"
+							}
+						},
+						{
+							"Bool": {
 								"name": "PluralWrongWordOfPhrase",
 								"state": true,
 								"label": "Plural Wrong Word Of Phrase"

--- a/harper-core/src/linting/weir_rules/PhaseFaze.weir
+++ b/harper-core/src/linting/weir_rules/PhaseFaze.weir
@@ -1,0 +1,29 @@
+# Corrects `phase me` -> `faze me` (to disturb).
+expr main <(phase [me, him, her, us, you, one, anyone, anybody]), phase>
+
+let message "Use `faze` (to disturb) rather than `phase` here."
+let description "Corrects the confusion of `phase` with `faze` when it means to disturb someone."
+let kind "Grammar"
+let becomes "faze"
+let strategy "MatchCase"
+
+# True positives
+
+test "That didn't phase me at all." "That didn't faze me at all."
+test "Nothing could phase him." "Nothing could faze him."
+test "The setback did not phase her." "The setback did not faze her."
+test "It won't phase us one bit." "It won't faze us one bit."
+test "Loud noises never phase you." "Loud noises never faze you."
+test "The criticism didn't phase me." "The criticism didn't faze me."
+test "Deadlines don't phase anyone here." "Deadlines don't faze anyone here."
+test "Failure doesn't phase him anymore." "Failure doesn't faze him anymore."
+test "IT WILL NOT PHASE ME." "IT WILL NOT FAZE ME."
+test "Pressure rarely phase you." "Pressure rarely faze you."
+
+# False positives / true negatives
+
+allows "That didn't faze me at all."
+allows "They will phase out the old API."
+allows "We plan to phase in the new rules."
+allows "Engineers will phase them out next year."
+allows "The moon enters a new phase tonight."


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

# Description
Add the `PhaseFaze` Weir rule, correcting `phase` to `faze` (to disturb) before an object pronoun. Enabled in the curated default config.

# Demo
<!-- Add a screenshot or a video demonstration when possible and necessary. -->

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [x] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
