### PR TITLE
chore: dictionary curation

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -11942,7 +11942,7 @@ afterthought/NSg
 afterward/~R<
 afterwards/R!@_₹
 afterword/NgS
-again/~P
+again/~R
 against/~PC
 agape/JNg
 agar/~Ng
@@ -30650,6 +30650,7 @@ interest/~NwSgVdE
 interested/~JVtTU
 interesting/~JYV6
 interface/~NgSVGd
+interfacility/J
 interfaith/~J
 interfere/~VGdS
 interference/~NgSV
@@ -33880,7 +33881,7 @@ meaninglessness/Nmg
 meanness/Nmg
 meant/~VtTU
 meantime/~Ng
-meanwhile/~Ng
+meanwhile/~RN
 meany/NSg
 meas/Vh
 measles/~Nmg
@@ -51471,7 +51472,7 @@ untidy/J^>pV
 until/~PC
 untimely/~J^
 untiring/JY
-untaoasted/J
+untoasted/J
 untouchable/JNgS
 untoward/J
 untracked/J
@@ -54369,6 +54370,7 @@ SpaceX/Og
 Speccy/OgS          # nickname of the Sinclair ZX Spectrum 8-bit computer
 Spotify/Og
 Stellantis/Og       # car company
+SteamOS/Og
 Substack/Og
 Subversion/Og       # version control
 Svelte/Og           # js framework
@@ -54489,6 +54491,7 @@ a12s/9
 a8c/Sg
 aftertouch/Nmg      # MIDI feature
 ambitransitive/J    # verb which is both transitive and intransitive
+analyte/NgS
 anti-alias/VbSdG
 antimalware/Nmg
 arXiv/Og            # research archive
@@ -54506,6 +54509,7 @@ backend/NSg         # dictionaries prefer: back end
 backoff/NsG
 backtest/NgSVdG
 baz/~               # cf. foo, bar
+bazzite/NwgS
 bitfield/NgS        # in this section since it's not in Cambridge, Collins, Longman, OED, Oxford, or Websters
 blogpost/NgS        # !! blog post is many times more popular; both appear in some dictionaries
 catenative/J        # linguistics

--- a/harper-core/tests/text/linters/Spell.US.snap.yml
+++ b/harper-core/tests/text/linters/Spell.US.snap.yml
@@ -153,7 +153,7 @@ Message: |
 Suggest:
   - Replace with: “Analyze”
   - Replace with: “Analyst”
-  - Replace with: “Analysis”
+  - Replace with: “Analyte”
 
 
 

--- a/harper-core/tests/text/linters/Spell.snap.yml
+++ b/harper-core/tests/text/linters/Spell.snap.yml
@@ -57,7 +57,7 @@ Message: |
 Suggest:
   - Replace with: “analyze”
   - Replace with: “analyst”
-  - Replace with: “analysis”
+  - Replace with: “analyte”
 
 
 

--- a/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
+++ b/harper-core/tests/text/tagged/Alice's Adventures in Wonderland.md
@@ -59,7 +59,7 @@
 > In        another moment down        went Alice after it       , never once  considering how   in        the
 # NPr/J/R/P I/D+    NSg+   N🅪Sg/VB/J/P VPt  NPr+  P     NPr/ISg+ . R     NSg/C Nᴹ/Vg/J     NSg/C NPr/J/R/P D+
 > world   she  was  to get    out          again .
-# NSg/VB+ ISg+ VLPt P  NSg/VB NSg/VB/J/R/P P     .
+# NSg/VB+ ISg+ VLPt P  NSg/VB NSg/VB/J/R/P R     .
 >
 #
 > The rabbit  - hole    went straight   on  like         a   tunnel for   some      way    , and  then      dipped
@@ -123,7 +123,7 @@
 >
 #
 > Presently she  began again . “ I       wonder  if    I       shall fall     right    through the earth      !
-# R         ISg+ VPt   P     . . ISg/#r+ N🅪Sg/VB NSg/C ISg/#r+ VXB   N🅪Sg/VB+ NPr/VB/J J/P     D+  NPr🅪Sg/VB+ .
+# R         ISg+ VPt   R     . . ISg/#r+ N🅪Sg/VB NSg/C ISg/#r+ VXB   N🅪Sg/VB+ NPr/VB/J J/P     D+  NPr🅪Sg/VB+ .
 > How   funny it’ll seem to come       out          among the people  that      walk   with their heads
 # NSg/C NSg/J K     VB   P  NSg/VBPp/P NSg/VB/J/R/P P     D   NPl/VB+ I/C/Ddem+ NSg/VB P    D$+   NPl/V3+
 > downward ! The Antipathies , I       think  — ” ( she  was  rather     glad     there was  no       one
@@ -145,7 +145,7 @@
 > Down        , down        , down        . There was  nothing  else    to do  , so          Alice soon began talking
 # N🅪Sg/VB/J/P . N🅪Sg/VB/J/P . N🅪Sg/VB/J/P . R+    VLPt NSg/I/J+ NSg/J/C P  VXB . NSg/I/J/R/C NPr+  J/R  VPt   Nᴹ/Vg/J
 > again . “ Dinah’ll miss   me       very much         to - night    , I       should think  ! ” ( Dinah was  the
-# P     . . ?        NSg/VB NPr/ISg+ J/R  NSg/I/J/R/Dq P  . N🅪Sg/VB+ . ISg/#r+ VXB    NSg/VB . . . NPr   VLPt D
+# R     . . ?        NSg/VB NPr/ISg+ J/R  NSg/I/J/R/Dq P  . N🅪Sg/VB+ . ISg/#r+ VXB    NSg/VB . . . NPr   VLPt D
 > cat       . ) “ I       hope      they’ll remember her     saucer of milk     at    tea      - time       . Dinah my  dear     ! I
 # NSg/VB/J+ . . . ISg/#r+ NPr🅪Sg/VB K       NSg/VB   ISg/D$+ NSg/VB P  N🅪Sg/VB+ NSg/P N🅪Sg/VB+ . N🅪Sg/VB/J+ . NPr   D$+ NSg/VB/J . ISg/#r+
 > wish   you    were down        here with me       ! There are no       mice   in        the air      , I’m afraid , but
@@ -193,7 +193,7 @@
 > had been   all          the way   down        one      side      and  up         the other    , trying  every door    , she
 # VP  VLPp/B NSg/I/J/C/Dq D   NSg/J N🅪Sg/VB/J/P NSg/I/J+ NSg/VB/J+ VB/C NSg/VB/J/P D   NSg/VB/J . Nᴹ/Vg/J Dq+   NSg/VB+ . ISg+
 > walked sadly down        the middle   , wondering how   she  was  ever to get    out          again .
-# VP/J   R     N🅪Sg/VB/J/P D   NSg/VB/J . Nᴹ/Vg/J   NSg/C ISg+ VLPt J/R  P  NSg/VB NSg/VB/J/R/P P     .
+# VP/J   R     N🅪Sg/VB/J/P D   NSg/VB/J . Nᴹ/Vg/J   NSg/C ISg+ VLPt J/R  P  NSg/VB NSg/VB/J/R/P R     .
 >
 #
 > Suddenly she  came      upon a   little     three - legged   table   , all          made of solid glass      ;
@@ -425,7 +425,7 @@
 > through into the garden    with one      eye     ; but     to get    through was  more         hopeless than
 # J/P     P    D   NSg/VB/J+ P    NSg/I/J+ NSg/VB+ . NSg/C/P P  NSg/VB J/P     VLPt NPr/I/J/R/Dq J        C/P
 > ever : she  sat    down        and  began to cry    again .
-# J/R  . ISg+ NSg/VP N🅪Sg/VB/J/P VB/C VPt   P  NSg/VB P     .
+# J/R  . ISg+ NSg/VP N🅪Sg/VB/J/P VB/C VPt   P  NSg/VB R     .
 >
 #
 > “ You    ought     to be       ashamed of yourself , ” said Alice , “ a   great girl    like         you    , ” ( she
@@ -519,7 +519,7 @@
 > “ I’m sure those   are not     the right    words   , ” said poor     Alice , and  her     eyes    filled
 # . K   J    I/Ddem+ VLB NSg/R/C D   NPr/VB/J NPl/V3+ . . VP/J NSg/VB/J NPr+  . VB/C ISg/D$+ NPl/V3+ VP/J
 > with tears   again as    she  went on  , “ I       must    be       Mabel after all          , and  I       shall have    to
-# P    NPl/V3+ P     R/C/P ISg+ VPt  J/P . . ISg/#r+ NSg/VXB NSg/VLXB NPr   P     NSg/I/J/C/Dq . VB/C ISg/#r+ VXB   NSg/VXB P
+# P    NPl/V3+ R     R/C/P ISg+ VPt  J/P . . ISg/#r+ NSg/VXB NSg/VLXB NPr   P     NSg/I/J/C/Dq . VB/C ISg/#r+ VXB   NSg/VXB P
 > go       and  live in        that     poky  little     house   , and  have    next    to no       toys    to play    with ,
 # NSg/VB/J VB/C VB/J NPr/J/R/P I/C/Ddem NSg/J NPr/I/J/Dq NPr/VB+ . VB/C NSg/VXB NSg/J/P P  NSg/Dq/P NPl/V3+ P  N🅪Sg/VB P    .
 > and  oh     ! ever so          many       lessons to learn  ! No       , I’ve made up         my  mind    about it       ; if    I’m
@@ -527,7 +527,7 @@
 > Mabel , I’ll stay     down        here ! It’ll be       no       use     their putting their heads   down        and
 # NPr   . K    NSg/VB/J N🅪Sg/VB/J/P R    . K     NSg/VLXB NSg/Dq/P N🅪Sg/VB D$+   Nᴹ/Vg/J D$+   NPl/V3+ N🅪Sg/VB/J/P VB/C
 > saying    ‘ Come       up         again , dear     ! ’ I       shall only  look   up         and  say    ‘ Who    am        I       then      ? Tell
-# N🅪Sg/Vg/J . NSg/VBPp/P NSg/VB/J/P P     . NSg/VB/J . . ISg/#r+ VXB   J/R/C NSg/VB NSg/VB/J/P VB/C NSg/VB . NPr/I+ NPr/VLB/J ISg/#r+ NSg/J/R/C . NPr/VB
+# N🅪Sg/Vg/J . NSg/VBPp/P NSg/VB/J/P R     . NSg/VB/J . . ISg/#r+ VXB   J/R/C NSg/VB NSg/VB/J/P VB/C NSg/VB . NPr/I+ NPr/VLB/J ISg/#r+ NSg/J/R/C . NPr/VB
 > me       that     first , and  then      , if    I       like         being        that      person  , I’ll come       up         : if    not     , I’ll
 # NPr/ISg+ I/C/Ddem NSg/J . VB/C NSg/J/R/C . NSg/C ISg/#r+ NSg/VB/J/C/P N🅪Sg/VLg/J/C I/C/Ddem+ NSg/VB+ . K    NSg/VBPp/P NSg/VB/J/P . NSg/C NSg/R/C . K
 > stay     down        here till       I’m somebody else    ’ — but     , oh     dear     ! ” cried Alice , with a   sudden
@@ -543,7 +543,7 @@
 > had put     on  one     of the Rabbit’s little     white       kid     gloves  while      she  was  talking .
 # VP  NSg/VBP J/P NSg/I/J P  D   NSg$     NPr/I/J/Dq NPr🅪Sg/VB/J NSg/VB+ NPl/V3+ NSg/VB/C/P ISg+ VLPt Nᴹ/Vg/J .
 > “ How   can     I       have    done      that      ? ” she  thought . “ I       must    be       growing small    again . ” She
-# . NSg/C NPr/VXB ISg/#r+ NSg/VXB NSg/VPp/J I/C/Ddem+ . . ISg+ N🅪Sg/VP . . ISg/#r+ NSg/VXB NSg/VLXB Nᴹ/Vg/J NPr/VB/J P     . . ISg+
+# . NSg/C NPr/VXB ISg/#r+ NSg/VXB NSg/VPp/J I/C/Ddem+ . . ISg+ N🅪Sg/VP . . ISg/#r+ NSg/VXB NSg/VLXB Nᴹ/Vg/J NPr/VB/J R     . . ISg+
 > got up         and  went to the table   to measure herself by it       , and  found  that      , as    nearly
 # VP  NSg/VB/J/P VB/C VPt  P  D+  NSg/VB+ P  NSg/VB  ISg+    P  NPr/ISg+ . VB/C NSg/VP I/C/Ddem+ . R/C/P R
 > as    she  could guess  , she  was  now       about two  feet high       , and  was  going   on  shrinking
@@ -561,7 +561,7 @@
 > garden    ! ” and  she  ran with all           speed    back     to the little      door    : but     , alas  ! the
 # NSg/VB/J+ . . VB/C ISg+ VPt P    NSg/I/J/C/Dq+ N🅪Sg/VB+ NSg/VB/J P  D+  NPr/I/J/Dq+ NSg/VB+ . NSg/C/P . NPrPl . D+
 > little      door    was  shut      again , and  the little      golden    key       was  lying   on  the glass
-# NPr/I/J/Dq+ NSg/VB+ VLPt NSg/VBP/J P     . VB/C D+  NPr/I/J/Dq+ NPr/VB/J+ NPr/VB/J+ VLPt Nᴹ/Vg/J J/P D+  NPr🅪Sg/VB+
+# NPr/I/J/Dq+ NSg/VB+ VLPt NSg/VBP/J R     . VB/C D+  NPr/I/J/Dq+ NPr/VB/J+ NPr/VB/J+ VLPt Nᴹ/Vg/J J/P D+  NPr🅪Sg/VB+
 > table   as    before , “ and  things are worse     than ever , ” thought the poor      child   , “ for
 # NSg/VB+ R/C/P C/P    . . VB/C NPl+   VLB NSg/VB/JC C/P  J/R  . . N🅪Sg/VP D+  NSg/VB/J+ NSg/VB+ . . R/C/P
 > I       never was  so          small    as    this   before , never ! And  I       declare it’s too bad      , that     it
@@ -637,7 +637,7 @@
 > history , Alice had no       very clear     notion how   long     ago anything  had happened . ) So
 # N🅪Sg+   . NPr+  VP  NSg/Dq/P J/R  NSg/VB/J+ NSg+   NSg/C NPr/VB/J J/P NSg/I/VB+ VP  VP/J     . . NSg/I/J/R/C
 > she  began again : “ Où est  ma     chatte ? ” which was  the first sentence in        her     French
-# ISg+ VPt   P     . . ?  NPr+ NPr/J+ ?      . . I/C+  VLPt D   NSg/J NSg/VB   NPr/J/R/P ISg/D$+ NPr🅪Sg/VB/J
+# ISg+ VPt   R     . . ?  NPr+ NPr/J+ ?      . . I/C+  VLPt D   NSg/J NSg/VB   NPr/J/R/P ISg/D$+ NPr🅪Sg/VB/J
 > lesson  - book    . The Mouse   gave a    sudden leap      out          of the water    , and  seemed to quiver
 # NSg/VB+ . NSg/VB+ . D+  NSg/VB+ VPt  D/P+ NSg/J+ NSg/VB/J+ NSg/VB/J/R/P P  D+  N🅪Sg/VB+ . VB/C VP/J   P  NSg/VB/J
 > all          over     with fright   . “ Oh     , I       beg    your pardon ! ” cried Alice hastily , afraid that
@@ -665,7 +665,7 @@
 > soft  thing to nurse  — and  she’s such  a   capital one      for   catching mice    — oh     , I       beg
 # NSg/J NSg+  P  NSg/VB . VB/C K     NSg/I D/P N🅪Sg/J+ NSg/I/J+ R/C/P Nᴹ/Vg/J  NPl/VB+ . NPr/VB . ISg/#r+ NSg/VB
 > your pardon ! ” cried Alice again , for   this    time       the Mouse   was  bristling all          over    ,
-# D$+  NSg/VB . . VP/J  NPr+  P     . R/C/P I/Ddem+ N🅪Sg/VB/J+ D+  NSg/VB+ VLPt Nᴹ/Vg/J   NSg/I/J/C/Dq NSg/J/P .
+# D$+  NSg/VB . . VP/J  NPr+  R     . R/C/P I/Ddem+ N🅪Sg/VB/J+ D+  NSg/VB+ VLPt Nᴹ/Vg/J   NSg/I/J/C/Dq NSg/J/P .
 > and  she  felt      certain it       must    be       really offended . “ We   won’t talk    about her     any
 # VB/C ISg+ N🅪Sg/VP/J I/J     NPr/ISg+ NSg/VXB NSg/VLXB R      VP/J     . . IPl+ VXB   N🅪Sg/VB J/P   ISg/D$+ I/R/Dq
 > more         if    you’d rather     not     . ”
@@ -677,7 +677,7 @@
 > if    I       would talk    on  such  a    subject   ! Our family  always hated cats    : nasty , low        ,
 # NSg/C ISg/#r+ VXB   N🅪Sg/VB J/P NSg/I D/P+ NSg/VB/J+ . D$+ N🅪Sg/J+ R      VP/J  NPl/V3+ . NSg/J . NSg/VB/J/R .
 > vulgar things ! Don’t let     me       hear the name    again ! ”
-# NSg/J  NPl+   . VXB   NSg/VBP NPr/ISg+ VB   D   NSg/VB+ P     . .
+# NSg/J  NPl+   . VXB   NSg/VBP NPr/ISg+ VB   D   NSg/VB+ R     . .
 >
 #
 > “ I       won’t indeed ! ” said Alice , in        a   great hurry   to change  the subject  of
@@ -697,7 +697,7 @@
 > worth    a   hundred pounds  ! He       says   it       kills  all           the rats    and  — oh     dear     ! ” cried Alice
 # NSg/VB/J D/P NSg     NPl/V3+ . NPr/ISg+ NPl/V3 NPr/ISg+ NPl/V3 NSg/I/J/C/Dq+ D+  NPl/V3+ VB/C . NPr/VB NSg/VB/J . . VP/J  NPr+
 > in        a   sorrowful tone       , “ I’m afraid I’ve offended it       again ! ” For   the Mouse   was
-# NPr/J/R/P D/P J         N🅪Sg/I/VB+ . . K   J      K    VP/J     NPr/ISg+ P     . . R/C/P D+  NSg/VB+ VLPt
+# NPr/J/R/P D/P J         N🅪Sg/I/VB+ . . K   J      K    VP/J     NPr/ISg+ R     . . R/C/P D+  NSg/VB+ VLPt
 > swimming away from her     as    hard     as    it       could go       , and  making  quite a   commotion in
 # NSg/Vg   VB/J P    ISg/D$+ R/C/P N🅪Sg/J/R R/C/P NPr/ISg+ VXB   NSg/VB/J . VB/C Nᴹ/Vg/J R     D/P N🅪Sg      NPr/J/R/P
 > the pool    as    it       went .
@@ -705,7 +705,7 @@
 >
 #
 > So          she  called softly after it       , “ Mouse   dear     ! Do  come       back     again , and  we   won’t
-# NSg/I/J/R/C ISg+ VP/J   R      P     NPr/ISg+ . . NSg/VB+ NSg/VB/J . VXB NSg/VBPp/P NSg/VB/J P     . VB/C IPl+ VXB
+# NSg/I/J/R/C ISg+ VP/J   R      P     NPr/ISg+ . . NSg/VB+ NSg/VB/J . VXB NSg/VBPp/P NSg/VB/J R     . VB/C IPl+ VXB
 > talk    about cats    or    dogs    either , if    you    don’t like         them     ! ” When    the Mouse   heard
 # N🅪Sg/VB J/P   NPl/V3+ NPr/C NPl/V3+ I/C    . NSg/C ISgPl+ VXB   NSg/VB/J/C/P NSg/IPl+ . . NSg/I/C D+  NSg/VB+ VP/J
 > this    , it       turned round      and  swam slowly back     to her     : its     face    was  quite pale     ( with
@@ -741,7 +741,7 @@
 >
 #
 > The first question of course  was  , how   to get    dry      again : they had a   consultation
-# D   NSg/J NSg/VB   P  NSg/VB+ VLPt . NSg/C P  NSg/VB NSg/VB/J P     . IPl+ VP  D/P NSg+
+# D   NSg/J NSg/VB   P  NSg/VB+ VLPt . NSg/C P  NSg/VB NSg/VB/J R     . IPl+ VP  D/P NSg+
 > about this    , and  after a    few       minutes it       seemed quite natural to Alice to find
 # J/P   I/Ddem+ . VB/C P     D/P+ NSg/I/Dq+ NPl/V3+ NPr/ISg+ VP/J   R     NSg/J   P  NPr+  P  NSg/VB
 > herself talking familiarly with them     , as    if    she  had known them     all          her     life     .
@@ -881,7 +881,7 @@
 > when    the race     was  over    . However , when    they had been   running   half      an   hour or    so          ,
 # NSg/I/C D+  N🅪Sg/VB+ VLPt NSg/J/P . C       . NSg/I/C IPl+ VP  VLPp/B Nᴹ/Vg/J/P N🅪Sg/J/P+ D/P+ NSg+ NPr/C NSg/I/J/R/C .
 > and  were quite dry      again , the Dodo suddenly called out          “ The race     is  over    ! ” and
-# VB/C VLPt R     NSg/VB/J P     . D   NSg  R        VP/J   NSg/VB/J/R/P . D   N🅪Sg/VB+ VL3 NSg/J/P . . VB/C
+# VB/C VLPt R     NSg/VB/J R     . D   NSg  R        VP/J   NSg/VB/J/R/P . D   N🅪Sg/VB+ VL3 NSg/J/P . . VB/C
 > they all          crowded round      it       , panting , and  asking  , “ But     who    has won      ? ”
 # IPl+ NSg/I/J/C/Dq VP/J    NSg/VB/J/P NPr/ISg+ . Nᴹ/Vg/J . VB/C Nᴹ/Vg/J . . NSg/C/P NPr/I+ V3  NSgPl/VP . .
 >
@@ -959,7 +959,7 @@
 > choked and  had to be       patted on  the back     . However , it       was  over    at    last     , and  they
 # VP/J   VB/C VP  P  NSg/VLXB VP     J/P D   NSg/VB/J . C       . NPr/ISg+ VLPt NSg/J/P NSg/P NSg/VB/J . VB/C IPl+
 > sat    down        again in        a    ring    , and  begged the Mouse   to tell   them     something more         .
-# NSg/VP N🅪Sg/VB/J/P P     NPr/J/R/P D/P+ NSg/VB+ . VB/C VP     D+  NSg/VB+ P  NPr/VB NSg/IPl+ NSg/I/J+  NPr/I/J/R/Dq .
+# NSg/VP N🅪Sg/VB/J/P R     NPr/J/R/P D/P+ NSg/VB+ . VB/C VP     D+  NSg/VB+ P  NPr/VB NSg/IPl+ NSg/I/J+  NPr/I/J/R/Dq .
 >
 #
 > “ You    promised to tell   me       your history , you    know , ” said Alice , “ and  why    it       is  you
@@ -967,7 +967,7 @@
 > hate    — C         and  D         , ” she  added in        a    whisper , half      afraid that     it       would be       offended
 # N🅪Sg/VB . NPr/VB/#r VB/C NPr/J/#r+ . . ISg+ VP/J  NPr/J/R/P D/P+ NSg/VB+ . N🅪Sg/J/P+ J      I/C/Ddem NPr/ISg+ VXB   NSg/VLXB VP/J
 > again .
-# P     .
+# R     .
 >
 #
 > “ Mine      is  a   long     and  a    sad       tale    ! ” said the Mouse   , turning to Alice , and  sighing .
@@ -1105,9 +1105,9 @@
 > world   ! Oh     , my  dear     Dinah ! I       wonder  if    I       shall ever see    you    any    more         ! ” And  here
 # NSg/VB+ . NPr/VB . D$+ NSg/VB/J NPr   . ISg/#r+ N🅪Sg/VB NSg/C ISg/#r+ VXB   J/R  NSg/VB ISgPl+ I/R/Dq NPr/I/J/R/Dq . . VB/C R
 > poor      Alice began to cry    again , for   she  felt      very lonely and  low        - spirited . In        a
-# NSg/VB/J+ NPr+  VPt   P  NSg/VB P     . R/C/P ISg+ N🅪Sg/VP/J J/R  J/R    VB/C NSg/VB/J/R . VP/J     . NPr/J/R/P D/P
+# NSg/VB/J+ NPr+  VPt   P  NSg/VB R     . R/C/P ISg+ N🅪Sg/VP/J J/R  J/R    VB/C NSg/VB/J/R . VP/J     . NPr/J/R/P D/P
 > little     while      , however , she  again heard a   little     pattering of footsteps in        the
-# NPr/I/J/Dq NSg/VB/C/P . C       . ISg+ P     VP/J  D/P NPr/I/J/Dq Nᴹ/Vg/J   P  NPl+      NPr/J/R/P D
+# NPr/I/J/Dq NSg/VB/C/P . C       . ISg+ R     VP/J  D/P NPr/I/J/Dq Nᴹ/Vg/J   P  NPl+      NPr/J/R/P D
 > distance , and  she  looked up         eagerly , half      hoping  that     the Mouse   had changed his
 # N🅪Sg/VB+ . VB/C ISg+ VP/J   NSg/VB/J/P R       . N🅪Sg/J/P+ Nᴹ/Vg/J I/C/Ddem D   NSg/VB+ VP  VP/J    ISg/D$+
 > mind    , and  was  coming  back     to finish his     story   .
@@ -1119,7 +1119,7 @@
 >
 #
 > It       was  the White       Rabbit , trotting slowly back     again , and  looking anxiously about
-# NPr/ISg+ VLPt D   NPr🅪Sg/VB/J NSg/VB . NSg/Vg/J R      NSg/VB/J P     . VB/C Nᴹ/Vg/J R         J/P
+# NPr/ISg+ VLPt D   NPr🅪Sg/VB/J NSg/VB . NSg/Vg/J R      NSg/VB/J R     . VB/C Nᴹ/Vg/J R         J/P
 > as    it       went , as    if    it       had lost something ; and  she  heard it       muttering to itself
 # R/C/P NPr/ISg+ VPt  . R/C/P NSg/C NPr/ISg+ VP  VP/J NSg/I/J+  . VB/C ISg+ VP/J  NPr/ISg+ Nᴹ/Vg/J   P  ISg+
 > “ The Duchess ! The Duchess ! Oh     my  dear      paws    ! Oh     my  fur          and  whiskers ! She’ll get
@@ -1197,7 +1197,7 @@
 > anything  ; so          I’ll just see    what   this   bottle  does    . I       do  hope      it’ll make   me       grow
 # NSg/I/VB+ . NSg/I/J/R/C K    J/R  NSg/VB NSg/I+ I/Ddem NSg/VB+ NPl/VX3 . ISg/#r+ VXB NPr🅪Sg/VB K     NSg/VB NPr/ISg+ VB
 > large again , for   really I’m quite tired of being        such  a   tiny  little     thing ! ”
-# NSg/J P     . R/C/P R      K   R     VP/J  P  N🅪Sg/VLg/J/C NSg/I D/P NSg/J NPr/I/J/Dq NSg+  . .
+# NSg/J R     . R/C/P R      K   R     VP/J  P  N🅪Sg/VLg/J/C NSg/I D/P NSg/J NPr/I/J/Dq NSg+  . .
 >
 #
 > It       did  so          indeed , and  much         sooner than she  had expected : before she  had drunk
@@ -1233,7 +1233,7 @@
 > grew no       larger : still      it       was  very uncomfortable , and  , as    there seemed to be       no
 # VPt  NSg/Dq/P JC     . NSg/VB/J/R NPr/ISg+ VLPt J/R  J             . VB/C . R/C/P R+    VP/J   P  NSg/VLXB NSg/Dq/P
 > sort   of chance   of her     ever getting out          of the room     again , no       wonder  she  felt
-# NSg/VB P  NPr/VB/J P  ISg/D$+ J/R  NSg/Vg  NSg/VB/J/R/P P  D+  N🅪Sg/VB+ P     . NSg/Dq/P N🅪Sg/VB ISg+ N🅪Sg/VP/J
+# NSg/VB P  NPr/VB/J P  ISg/D$+ J/R  NSg/Vg  NSg/VB/J/R/P P  D+  N🅪Sg/VB+ R     . NSg/Dq/P N🅪Sg/VB ISg+ N🅪Sg/VP/J
 > unhappy  .
 # NSg/VB/J .
 >
@@ -1355,7 +1355,7 @@
 > then      ; such  as    , “ Sure , I       don’t like         it       , yer honour        , at    all          , at    all          ! ” “ Do  as    I
 # NSg/J/R/C . NSg/I R/C/P . . J    . ISg/#r+ VXB   NSg/VB/J/C/P NPr/ISg+ . +   N🅪Sg/VB/Comm+ . NSg/P NSg/I/J/C/Dq . NSg/P NSg/I/J/C/Dq . . . VXB R/C/P ISg/#r+
 > tell   you    , you    coward   ! ” and  at    last     she  spread   out          her     hand    again , and  made
-# NPr/VB ISgPl+ . ISgPl+ NPr/VB/J . . VB/C NSg/P NSg/VB/J ISg+ N🅪Sg/VBP NSg/VB/J/R/P ISg/D$+ NSg/VB+ P     . VB/C VP
+# NPr/VB ISgPl+ . ISgPl+ NPr/VB/J . . VB/C NSg/P NSg/VB/J ISg+ N🅪Sg/VBP NSg/VB/J/R/P ISg/D$+ NSg/VB+ R     . VB/C VP
 > another snatch in        the air      . This    time       there were two  little      shrieks , and  more
 # I/D     NSg/VB NPr/J/R/P D   N🅪Sg/VB+ . I/Ddem+ N🅪Sg/VB/J+ R+    VLPt NSg+ NPr/I/J/Dq+ NPl/V3+ . VB/C NPr/I/J/R/Dq
 > sounds of broken glass      . “ What   a   number     of cucumber - frames  there must    be       ! ”
@@ -1445,7 +1445,7 @@
 > they will    do  next    ! If    they had any     sense    , they’d take   the roof    off        . ” After a
 # IPl+ NPr/VXB VXB NSg/J/P . NSg/C IPl+ VP  I/R/Dq+ N🅪Sg/VB+ . K      NSg/VB D   NSg/VB+ NSg/VB/J/P . . P     D/P+
 > minute    or    two , they began moving  about again , and  Alice heard the Rabbit  say    , “ A
-# NSg/VB/J+ NPr/C NSg . IPl+ VPt   Nᴹ/Vg/J J/P   P     . VB/C NPr+  VP/J  D+  NSg/VB+ NSg/VB . . D/P
+# NSg/VB/J+ NPr/C NSg . IPl+ VPt   Nᴹ/Vg/J J/P   R     . VB/C NPr+  VP/J  D+  NSg/VB+ NSg/VB . . D/P
 > barrowful will    do  , to begin  with . ”
 # ?         NPr/VXB VXB . P  NSg/VB P    . .
 >
@@ -1457,7 +1457,7 @@
 > of them     hit       her     in        the face    . “ I’ll put     a   stop    to this    , ” she  said to herself , and
 # P  NSg/IPl+ NSg/VBP/J ISg/D$+ NPr/J/R/P D+  NSg/VB+ . . K    NSg/VBP D/P NSg/VB+ P  I/Ddem+ . . ISg+ VP/J P  ISg+    . VB/C
 > shouted out          , “ You’d better     not     do  that      again ! ” which produced another dead
-# VP/J    NSg/VB/J/R/P . . K     NSg/VXB/JC NSg/R/C VXB I/C/Ddem+ P     . . I/C+  VP/J     I/D+    NSg/VB/J+
+# VP/J    NSg/VB/J/R/P . . K     NSg/VXB/JC NSg/R/C VXB I/C/Ddem+ R     . . I/C+  VP/J     I/D+    NSg/VB/J+
 > silence .
 # NSg/VB+ .
 >
@@ -1491,7 +1491,7 @@
 > “ The first  thing I’ve got to do  , ” said Alice to herself , as    she  wandered about
 # . D+  NSg/J+ NSg+  K    VP  P  VXB . . VP/J NPr+  P  ISg+    . R/C/P ISg+ VP/J     J/P
 > in        the wood         , “ is  to grow to my  right    size     again ; and  the second   thing is  to find
-# NPr/J/R/P D   NPr🅪Sg/VB/J+ . . VL3 P  VB   P  D$+ NPr/VB/J N🅪Sg/VB+ P     . VB/C D   NSg/VB/J NSg+  VL3 P  NSg/VB
+# NPr/J/R/P D   NPr🅪Sg/VB/J+ . . VL3 P  VB   P  D$+ NPr/VB/J N🅪Sg/VB+ R     . VB/C D   NSg/VB/J NSg+  VL3 P  NSg/VB
 > my  way    into that     lovely garden    . I       think  that      will    be       the best        plan    . ”
 # D$+ NSg/J+ P    I/C/Ddem NSg/J  NSg/VB/J+ . ISg/#r+ NSg/VB I/C/Ddem+ NPr/VXB NSg/VLXB D+  NPr/VXB/JS+ NSg/VB+ . .
 >
@@ -1535,7 +1535,7 @@
 > expecting every moment to be       trampled under   its     feet , ran round      the thistle
 # Nᴹ/Vg/J   Dq    NSg+   P  NSg/VLXB VP/J     NSg/J/P ISg/D$+ NPl+ . VPt NSg/VB/J/P D   NSg
 > again ; then      the puppy   began a   series of short      charges at    the stick     , running   a
-# P     . NSg/J/R/C D   NSg/VB+ VPt   D/P NSgPl  P  NPr/VB/J/P NPl/V3+ NSg/P D   NSg/VB/J+ . Nᴹ/Vg/J/P D/P
+# R     . NSg/J/R/C D   NSg/VB+ VPt   D/P NSgPl  P  NPr/VB/J/P NPl/V3+ NSg/P D   NSg/VB/J+ . Nᴹ/Vg/J/P D/P
 > very little     way    forwards each time       and  a   long     way    back     , and  barking  hoarsely all
 # J/R  NPr/I/J/Dq NSg/J+ NPl/V3   Dq   N🅪Sg/VB/J+ VB/C D/P NPr/VB/J NSg/J+ NSg/VB/J . VB/C Nᴹ/Vg/J+ R        NSg/I/J/C/Dq
 > the while      , till       at    last     it       sat    down        a   good     way    off        , panting , with its     tongue
@@ -1559,7 +1559,7 @@
 > have    liked teaching   it       tricks  very much         , if    — if    I’d only  been   the right    size     to
 # NSg/VXB VP/J  N🅪Sg/Vg/J+ NPr/ISg+ NPl/V3+ J/R  NSg/I/J/R/Dq . NSg/C . NSg/C K   J/R/C VLPp/B D   NPr/VB/J N🅪Sg/VB+ P
 > do  it       ! Oh     dear     ! I’d nearly forgotten that     I’ve got to grow up         again ! Let     me
-# VXB NPr/ISg+ . NPr/VB NSg/VB/J . K   R      NSg/VPp/J I/C/Ddem K    VP  P  VB   NSg/VB/J/P P     . NSg/VBP NPr/ISg+
+# VXB NPr/ISg+ . NPr/VB NSg/VB/J . K   R      NSg/VPp/J I/C/Ddem K    VP  P  VB   NSg/VB/J/P R     . NSg/VBP NPr/ISg+
 > see    — how   is  it       to be       managed ? I       suppose I       ought     to eat or    drink   something or
 # NSg/VB . NSg/C VL3 NPr/ISg+ P  NSg/VLXB VP/J    . ISg/#r+ VB      ISg/#r+ NSg/I/VXB P  VB  NPr/C NSg/VB+ NSg/I/J+  NPr/C
 > other    ; but     the great  question is  , what   ? ”
@@ -1665,7 +1665,7 @@
 >
 #
 > Which brought them     back     again to the beginning of the conversation . Alice felt      a
-# I/C+  VP      NSg/IPl+ NSg/VB/J P     P  D   NSg/Vg/J  P  D+  N🅪Sg/VB+     . NPr+  N🅪Sg/VP/J D/P+
+# I/C+  VP      NSg/IPl+ NSg/VB/J R     P  D   NSg/Vg/J  P  D+  N🅪Sg/VB+     . NPr+  N🅪Sg/VP/J D/P+
 > little      irritated at    the Caterpillar’s making  such  very short      remarks , and  she
 # NPr/I/J/Dq+ VP/J+     NSg/P D   NSg$          Nᴹ/Vg/J NSg/I J/R  NPr/VB/J/P NPl/V3+ . VB/C ISg+
 > drew    herself up         and  said , very gravely , “ I       think  , you    ought     to tell   me       who    you
@@ -1693,7 +1693,7 @@
 >
 #
 > This   sounded promising , certainly : Alice turned and  came      back     again .
-# I/Ddem VP/J    Nᴹ/Vg/J   . R         . NPr+  VP/J   VB/C NSg/VPt/P NSg/VB/J P     .
+# I/Ddem VP/J    Nᴹ/Vg/J   . R         . NPr+  VP/J   VB/C NSg/VPt/P NSg/VB/J R     .
 >
 #
 > “ Keep   your temper     , ” said the Caterpillar .
@@ -1715,7 +1715,7 @@
 > away without speaking , but     at    last     it       unfolded its     arms    , took the hookah out          of
 # VB/J C/P     Nᴹ/Vg/J  . NSg/C/P NSg/P NSg/VB/J NPr/ISg+ VP/J     ISg/D$+ NPl/V3+ . VPt  D   NSg    NSg/VB/J/R/P P
 > its     mouth   again , and  said , “ So          you    think  you’re changed , do  you    ? ”
-# ISg/D$+ NSg/VB+ P     . VB/C VP/J . . NSg/I/J/R/C ISgPl+ NSg/VB K      VP/J    . VXB ISgPl+ . .
+# ISg/D$+ NSg/VB+ R     . VB/C VP/J . . NSg/I/J/R/C ISgPl+ NSg/VB K      VP/J    . VXB ISgPl+ . .
 >
 #
 > “ I’m afraid I       am        , sir     , ” said Alice ; “ I       can’t remember things as    I       used — and  I
@@ -1753,9 +1753,9 @@
 > “ In        my  youth , ” Father  William replied to his     son     , “ I       feared it       might    injure
 # . NPr/J/R/P D$+ NSg+  . . NPr/VB+ NPr+    VP/J    P  ISg/D$+ NPr/VB+ . . ISg/#r+ VP/J   NPr/ISg+ Nᴹ/VXB/J VB
 > the brain      ; But     , now       that      I’m perfectly sure I       have    none , Why    , I       do  it       again
-# D+  NPr🅪Sg/VB+ . NSg/C/P . NSg/J/R/C I/C/Ddem+ K   R         J    ISg/#r+ NSg/VXB I+   . NSg/VB . ISg/#r+ VXB NPr/ISg+ P
+# D+  NPr🅪Sg/VB+ . NSg/C/P . NSg/J/R/C I/C/Ddem+ K   R         J    ISg/#r+ NSg/VXB I+   . NSg/VB . ISg/#r+ VXB NPr/ISg+ R
 > and  again . ”
-# VB/C P     . .
+# VB/C R     . .
 >
 #
 > “ You    are old   , ” said the youth , “ as    I       mentioned before , And  have    grown most
@@ -1871,11 +1871,11 @@
 > “ You’ll get    used to it       in        time       , ” said the Caterpillar ; and  it       put     the hookah
 # . K      NSg/VB VP/J P  NPr/ISg+ NPr/J/R/P N🅪Sg/VB/J+ . . VP/J D   NSg/VB      . VB/C NPr/ISg+ NSg/VBP D   NSg
 > into its     mouth   and  began smoking  again .
-# P    ISg/D$+ NSg/VB+ VB/C VPt   Nᴹ/Vg/J+ P     .
+# P    ISg/D$+ NSg/VB+ VB/C VPt   Nᴹ/Vg/J+ R     .
 >
 #
 > This    time       Alice waited patiently until it       chose   to speak  again . In        a    minute    or
-# I/Ddem+ N🅪Sg/VB/J+ NPr+  VP/J   R         C/P   NPr/ISg+ NSg/VPt P  NSg/VB P     . NPr/J/R/P D/P+ NSg/VB/J+ NPr/C
+# I/Ddem+ N🅪Sg/VB/J+ NPr+  VP/J   R         C/P   NPr/ISg+ NSg/VPt P  NSg/VB R     . NPr/J/R/P D/P+ NSg/VB/J+ NPr/C
 > two the Caterpillar took the hookah out          of its     mouth   and  yawned once  or    twice ,
 # NSg D   NSg/VB      VPt  D   NSg    NSg/VB/J/R/P P  ISg/D$+ NSg/VB+ VB/C VP/J   NSg/C NPr/C R     .
 > and  shook     itself . Then      it       got down        off        the mushroom  , and  crawled away in        the
@@ -1973,7 +1973,7 @@
 >
 #
 > “ Serpent , I       say    again ! ” repeated the Pigeon  , but     in        a   more         subdued tone      , and
-# . NSg/VB+ . ISg/#r+ NSg/VB P     . . VP/J     D+  NSg/VB+ . NSg/C/P NPr/J/R/P D/P NPr/I/J/R/Dq VP/J+   N🅪Sg/I/VB . VB/C
+# . NSg/VB+ . ISg/#r+ NSg/VB R     . . VP/J     D+  NSg/VB+ . NSg/C/P NPr/J/R/P D/P NPr/I/J/R/Dq VP/J+   N🅪Sg/I/VB . VB/C
 > added with a   kind   of sob    , “ I’ve tried every way    , and  nothing  seems to suit
 # VP/J  P    D/P NSg/J+ P  NSg/VB . . K    VP/J  Dq    NSg/J+ . VB/C NSg/I/J+ V3    P  NSg/VB
 > them     ! ”
@@ -2077,7 +2077,7 @@
 >
 #
 > “ Well       , be       off        , then      ! ” said the Pigeon  in        a    sulky  tone       , as    it       settled down        again
-# . NSg/VB/J/R . NSg/VLXB NSg/VB/J/P . NSg/J/R/C . . VP/J D   NSg/VB+ NPr/J/R/P D/P+ NSg/J+ N🅪Sg/I/VB+ . R/C/P NPr/ISg+ VP/J    N🅪Sg/VB/J/P P
+# . NSg/VB/J/R . NSg/VLXB NSg/VB/J/P . NSg/J/R/C . . VP/J D   NSg/VB+ NPr/J/R/P D/P+ NSg/J+ N🅪Sg/I/VB+ . R/C/P NPr/ISg+ VP/J    N🅪Sg/VB/J/P R
 > into its     nest    . Alice crouched down        among the trees   as    well       as    she  could , for   her
 # P    ISg/D$+ NSg/VB+ . NPr+  VP/J     N🅪Sg/VB/J/P P     D+  NPl/V3+ R/C/P NSg/VB/J/R R/C/P ISg+ VXB   . R/C/P ISg/D$+
 > neck    kept getting entangled among the branches , and  every now       and  then      she  had
@@ -2111,7 +2111,7 @@
 > this   size     : why    , I       should frighten them     out          of their wits   ! ” So          she  began nibbling
 # I/Ddem N🅪Sg/VB+ . NSg/VB . ISg/#r+ VXB    VB       NSg/IPl+ NSg/VB/J/R/P P  D$+   NPl/V3 . . NSg/I/J/R/C ISg+ VPt   Nᴹ/Vg/J
 > at    the righthand bit      again , and  did  not     venture to go       near       the house   till       she
-# NSg/P D   ?         NSg/VPt+ P     . VB/C VXPt NSg/R/C NSg/VB+ P  NSg/VB/J NSg/VB/J/P D   NPr/VB+ NSg/VB/C/P ISg+
+# NSg/P D   ?         NSg/VPt+ R     . VB/C VXPt NSg/R/C NSg/VB+ P  NSg/VB/J NSg/VB/J/P D   NPr/VB+ NSg/VB/C/P ISg+
 > had brought herself down        to nine inches  high       .
 # VP  VP      ISg+    N🅪Sg/VB/J/P P  NSg  NPl/V3+ NSg/VB/J/R .
 >
@@ -2221,7 +2221,7 @@
 >
 #
 > “ How   am        I       to get    in        ? ” asked Alice again , in        a    louder tone       .
-# . NSg/C NPr/VLB/J ISg/#r+ P  NSg/VB NPr/J/R/P . . VP/J  NPr+  P     . NPr/J/R/P D/P+ JC+    N🅪Sg/I/VB+ .
+# . NSg/C NPr/VLB/J ISg/#r+ P  NSg/VB NPr/J/R/P . . VP/J  NPr+  R     . NPr/J/R/P D/P+ JC+    N🅪Sg/I/VB+ .
 >
 #
 > “ Are you    to get    in        at    all          ? ” said the Footman . “ That’s the first question , you
@@ -2303,7 +2303,7 @@
 > she  saw     in        another moment that      it       was  addressed to the baby      , and  not     to her     , so
 # ISg+ NSg/VPt NPr/J/R/P I/D+    NSg+   I/C/Ddem+ NPr/ISg+ VLPt VP/J      P  D+  NSg/VB/J+ . VB/C NSg/R/C P  ISg/D$+ . NSg/I/J/R/C
 > she  took courage , and  went on  again : —
-# ISg+ VPt  NSg/VB+ . VB/C VPt  J/P P     . .
+# ISg+ VPt  NSg/VB+ . VB/C VPt  J/P R     . .
 >
 #
 > “ I       didn’t know that     Cheshire cats    always grinned ; in        fact , I       didn’t know that
@@ -2377,13 +2377,13 @@
 > hint    ; but     the cook    was  busily stirring the soup     , and  seemed not     to be       listening ,
 # NSg/VB+ . NSg/C/P D+  NPr/VB+ VLPt R      NSg/Vg/J D+  N🅪Sg/VB+ . VB/C VP/J   NSg/R/C P  NSg/VLXB Nᴹ/Vg/J   .
 > so          she  went on  again : “ Twenty - four hours , I       think  ; or    is  it       twelve ? I       — ”
-# NSg/I/J/R/C ISg+ VPt  J/P P     . . NSg    . NSg  NPl+  . ISg/#r+ NSg/VB . NPr/C VL3 NPr/ISg+ NSg    . ISg/#r+ . .
+# NSg/I/J/R/C ISg+ VPt  J/P R     . . NSg    . NSg  NPl+  . ISg/#r+ NSg/VB . NPr/C VL3 NPr/ISg+ NSg    . ISg/#r+ . .
 >
 #
 > “ Oh     , don’t bother me       , ” said the Duchess ; “ I       never could abide figures ! ” And  with
 # . NPr/VB . VXB   Nᴹ/VB  NPr/ISg+ . . VP/J D   NSg/VB  . . ISg/#r+ R     VXB   VB    NPl/V3+ . . VB/C P
 > that     she  began nursing her     child   again , singing a   sort    of lullaby to it       as    she
-# I/C/Ddem ISg+ VPt   Nᴹ/Vg/J ISg/D$+ NSg/VB+ P     . Nᴹ/Vg/J D/P NSg/VB+ P  NSg/VB  P  NPr/ISg+ R/C/P ISg+
+# I/C/Ddem ISg+ VPt   Nᴹ/Vg/J ISg/D$+ NSg/VB+ R     . Nᴹ/Vg/J D/P NSg/VB+ P  NSg/VB  P  NPr/ISg+ R/C/P ISg+
 > did  so          , and  giving  it       a   violent  shake   at    the end    of every line    :
 # VXPt NSg/I/J/R/C . VB/C Nᴹ/Vg/J NPr/ISg+ D/P NSg/VB/J NSg/VB+ NSg/P D   NSg/VB P  Dq    NSg/VB+ .
 >
@@ -2443,7 +2443,7 @@
 > steam      - engine  when    she  caught it       , and  kept doubling itself up         and  straightening
 # N🅪Sg/VB/J+ . NSg/VB+ NSg/I/C ISg+ VP/J   NPr/ISg+ . VB/C VP   Nᴹ/Vg/J  ISg+   NSg/VB/J/P VB/C Nᴹ/Vg/J
 > itself out          again , so          that      altogether , for   the first minute    or    two , it       was  as
-# ISg+   NSg/VB/J/R/P P     . NSg/I/J/R/C I/C/Ddem+ NSg        . R/C/P D   NSg/J NSg/VB/J+ NPr/C NSg . NPr/ISg+ VLPt R/C/P
+# ISg+   NSg/VB/J/R/P R     . NSg/I/J/R/C I/C/Ddem+ NSg        . R/C/P D   NSg/J NSg/VB/J+ NPr/C NSg . NPr/ISg+ VLPt R/C/P
 > much         as    she  could do  to hold     it       .
 # NSg/I/J/R/Dq R/C/P ISg+ VXB   VXB P  NSg/VB/J NPr/ISg+ .
 >
@@ -2467,7 +2467,7 @@
 >
 #
 > The baby      grunted again , and  Alice looked very anxiously into its     face    to see
-# D+  NSg/VB/J+ VP/J    P     . VB/C NPr+  VP/J   J/R  R         P    ISg/D$+ NSg/VB+ P  NSg/VB
+# D+  NSg/VB/J+ VP/J    R     . VB/C NPr+  VP/J   J/R  R         P    ISg/D$+ NSg/VB+ P  NSg/VB
 > what   was  the matter   with it       . There could be       no        doubt    that      it       had a   very turn   - up
 # NSg/I+ VLPt D   N🅪Sg/VB+ P    NPr/ISg+ . R+    VXB   NSg/VLXB NSg/Dq/P+ N🅪Sg/VB+ I/C/Ddem+ NPr/ISg+ VP  D/P J/R  NSg/VB . NSg/VB/J/P
 > nose    , much         more         like         a   snout  than a   real  nose    ; also its     eyes    were getting
@@ -2477,7 +2477,7 @@
 > at    all          . “ But     perhaps it       was  only  sobbing  , ” she  thought , and  looked into its     eyes
 # NSg/P NSg/I/J/C/Dq . . NSg/C/P NSg/R   NPr/ISg+ VLPt J/R/C NSg/Vg/J . . ISg+ N🅪Sg/VP . VB/C VP/J   P    ISg/D$+ NPl/V3+
 > again , to see    if    there were any    tears   .
-# P     . P  NSg/VB NSg/C R+    VLPt I/R/Dq NPl/V3+ .
+# R     . P  NSg/VB NSg/C R+    VLPt I/R/Dq NPl/V3+ .
 >
 #
 > No       , there were no        tears   . “ If    you’re going   to turn   into a   pig     , my  dear     , ” said
@@ -2485,7 +2485,7 @@
 > Alice , seriously , “ I’ll have    nothing  more         to do  with you    . Mind    now       ! ” The poor
 # NPr+  . R         . . K    NSg/VXB NSg/I/J+ NPr/I/J/R/Dq P  VXB P    ISgPl+ . NSg/VB+ NSg/J/R/C . . D+  NSg/VB/J+
 > little      thing sobbed again ( or    grunted , it       was  impossible to say    which ) , and  they
-# NPr/I/J/Dq+ NSg+  VP     P     . NPr/C VP/J    . NPr/ISg+ VLPt NSg/J      P  NSg/VB I/C+  . . VB/C IPl+
+# NPr/I/J/Dq+ NSg+  VP     R     . NPr/C VP/J    . NPr/ISg+ VLPt NSg/J      P  NSg/VB I/C+  . . VB/C IPl+
 > went on  for   some     while      in        silence .
 # VPt  J/P R/C/P I/J/R/Dq NSg/VB/C/P NPr/J/R/P NSg/VB+ .
 >
@@ -2493,7 +2493,7 @@
 > Alice was  just beginning to think  to herself , “ Now       , what   am        I       to do  with this
 # NPr+  VLPt J/R  NSg/Vg/J  P  NSg/VB P  ISg+    . . NSg/J/R/C . NSg/I+ NPr/VLB/J ISg/#r+ P  VXB P    I/Ddem+
 > creature when    I       get    it       home      ? ” when    it       grunted again , so          violently , that     she
-# NSg+     NSg/I/C ISg/#r+ NSg/VB NPr/ISg+ NSg/VB/J+ . . NSg/I/C NPr/ISg+ VP/J    P     . NSg/I/J/R/C R         . I/C/Ddem ISg+
+# NSg+     NSg/I/C ISg/#r+ NSg/VB NPr/ISg+ NSg/VB/J+ . . NSg/I/C NPr/ISg+ VP/J    R     . NSg/I/J/R/C R         . I/C/Ddem ISg+
 > looked down        into its     face    in        some     alarm    . This    time       there could be       no       mistake
 # VP/J   N🅪Sg/VB/J/P P    ISg/D$+ NSg/VB+ NPr/J/R/P I/J/R/Dq N🅪Sg/VB+ . I/Ddem+ N🅪Sg/VB/J+ R+    VXB   NSg/VLXB NSg/Dq/P NSg/VB
 > about it       : it       was  neither more         nor   less    than a    pig     , and  she  felt      that     it       would be
@@ -2633,7 +2633,7 @@
 > happening . While      she  was  looking at    the place    where   it       had been   , it       suddenly
 # N🅪Sg/Vg/J . NSg/VB/C/P ISg+ VLPt Nᴹ/Vg/J NSg/P D+  N🅪Sg/VB+ NSg/R/C NPr/ISg+ VP  VLPp/B . NPr/ISg+ R
 > appeared again .
-# VP/J     P     .
+# VP/J     R     .
 >
 #
 > “ By - the - bye     , what   became of the baby      ? ” said the Cat       . “ I’d nearly forgotten to
@@ -2649,11 +2649,11 @@
 >
 #
 > “ I       thought it       would , ” said the Cat       , and  vanished again .
-# . ISg/#r+ N🅪Sg/VP NPr/ISg+ VXB   . . VP/J D+  NSg/VB/J+ . VB/C VP/J     P     .
+# . ISg/#r+ N🅪Sg/VP NPr/ISg+ VXB   . . VP/J D+  NSg/VB/J+ . VB/C VP/J     R     .
 >
 #
 > Alice waited a   little     , half      expecting to see    it       again , but     it       did  not     appear ,
-# NPr+  VP/J   D/P NPr/I/J/Dq . N🅪Sg/J/P+ Nᴹ/Vg/J   P  NSg/VB NPr/ISg+ P     . NSg/C/P NPr/ISg+ VXPt NSg/R/C VB     .
+# NPr+  VP/J   D/P NPr/I/J/Dq . N🅪Sg/J/P+ Nᴹ/Vg/J   P  NSg/VB NPr/ISg+ R     . NSg/C/P NPr/ISg+ VXPt NSg/R/C VB     .
 > and  after a    minute    or    two she  walked on  in        the direction in        which the March   Hare
 # VB/C P     D/P+ NSg/VB/J+ NPr/C NSg ISg+ VP/J   J/P NPr/J/R/P D+  N🅪Sg+     NPr/J/R/P I/C+  D+  NPr/VB+ NSg+
 > was  said to live . “ I’ve seen    hatters before , ” she  said to herself ; “ the March
@@ -2663,7 +2663,7 @@
 > raving  mad      — at    least    not     so          mad      as    it       was  in        March   . ” As    she  said this    , she  looked
 # Nᴹ/Vg/J NSg/VB/J . NSg/P NSg/J/Dq NSg/R/C NSg/I/J/R/C NSg/VB/J R/C/P NPr/ISg+ VLPt NPr/J/R/P NPr/VB+ . . R/C/P ISg+ VP/J I/Ddem+ . ISg+ VP/J
 > up         , and  there was  the Cat       again , sitting  on  a   branch of a    tree    .
-# NSg/VB/J/P . VB/C R+    VLPt D+  NSg/VB/J+ P     . NSg/Vg/J J/P D/P NPr/VB P  D/P+ NSg/VB+ .
+# NSg/VB/J/P . VB/C R+    VLPt D+  NSg/VB/J+ R     . NSg/Vg/J J/P D/P NPr/VB P  D/P+ NSg/VB+ .
 >
 #
 > “ Did  you    say    pig     , or    fig    ? ” said the Cat       .
@@ -2867,7 +2867,7 @@
 > The March   Hare took the watch  and  looked at    it       gloomily : then      he       dipped it       into
 # D+  NPr/VB+ NSg+ VPt  D   NSg/VB VB/C VP/J   NSg/P NPr/ISg+ R        . NSg/J/R/C NPr/ISg+ VP/J   NPr/ISg+ P
 > his     cup    of tea      , and  looked at    it       again : but     he       could think  of nothing  better     to
-# ISg/D$+ NSg/VB P  N🅪Sg/VB+ . VB/C VP/J   NSg/P NPr/ISg+ P     . NSg/C/P NPr/ISg+ VXB   NSg/VB P  NSg/I/J+ NSg/VXB/JC P
+# ISg/D$+ NSg/VB P  N🅪Sg/VB+ . VB/C VP/J   NSg/P NPr/ISg+ R     . NSg/C/P NPr/ISg+ VXB   NSg/VB P  NSg/I/J+ NSg/VXB/JC P
 > say    than his     first remark  , “ It       was  the best       butter  , you    know . ”
 # NSg/VB C/P  ISg/D$+ NSg/J NSg/VB+ . . NPr/ISg+ VLPt D   NPr/VXB/JS NSg/VB+ . ISgPl+ VB   . .
 >
@@ -2905,7 +2905,7 @@
 >
 #
 > “ The Dormouse is  asleep again , ” said the Hatter , and  he       poured a   little     hot      tea
-# . D   NSg      VL3 J      P     . . VP/J D   NSg/VB . VB/C NPr/ISg+ VP/J   D/P NPr/I/J/Dq NSg/VB/J N🅪Sg/VB+
+# . D   NSg      VL3 J      R     . . VP/J D   NSg/VB . VB/C NPr/ISg+ VP/J   D/P NPr/I/J/Dq NSg/VB/J N🅪Sg/VB+
 > upon its     nose    .
 # P    ISg/D$+ NSg/VB+ .
 >
@@ -2917,7 +2917,7 @@
 >
 #
 > “ Have    you    guessed the riddle  yet      ? ” the Hatter said , turning to Alice again .
-# . NSg/VXB ISgPl+ VP/J    D+  NPr/VB+ NSg/VB/C . . D   NSg/VB VP/J . Nᴹ/Vg/J P  NPr+  P     .
+# . NSg/VXB ISgPl+ VP/J    D+  NPr/VB+ NSg/VB/C . . D   NSg/VB VP/J . Nᴹ/Vg/J P  NPr+  R     .
 >
 #
 > “ No       , I       give   it       up         , ” Alice replied : “ what’s the answer  ? ”
@@ -3067,7 +3067,7 @@
 >
 #
 > “ But     what   happens when    you    come       to the beginning again ? ” Alice ventured to ask    .
-# . NSg/C/P NSg/I+ V3      NSg/I/C ISgPl+ NSg/VBPp/P P  D+  NSg/Vg/J+ P     . . NPr+  VP/J     P  NSg/VB .
+# . NSg/C/P NSg/I+ V3      NSg/I/C ISgPl+ NSg/VBPp/P P  D+  NSg/Vg/J+ R     . . NPr+  VP/J     P  NSg/VB .
 >
 #
 > “ Suppose we   change  the subject   , ” the March   Hare interrupted , yawning . “ I’m
@@ -3101,7 +3101,7 @@
 >
 #
 > “ And  be       quick    about it       , ” added the Hatter , “ or    you’ll be       asleep again before
-# . VB/C NSg/VLXB NSg/VB/J J/P   NPr/ISg+ . . VP/J  D   NSg/VB . . NPr/C K      NSg/VLXB J      P     C/P
+# . VB/C NSg/VLXB NSg/VB/J J/P   NPr/ISg+ . . VP/J  D   NSg/VB . . NPr/C K      NSg/VLXB J      R     C/P
 > it’s done      . ”
 # K    NSg/VPp/J . .
 >
@@ -3175,7 +3175,7 @@
 >
 #
 > The Dormouse again took a   minute    or    two to think  about it       , and  then      said , “ It
-# D   NSg      P     VPt  D/P NSg/VB/J+ NPr/C NSg P  NSg/VB J/P   NPr/ISg+ . VB/C NSg/J/R/C VP/J . . NPr/ISg+
+# D   NSg      R     VPt  D/P NSg/VB/J+ NPr/C NSg P  NSg/VB J/P   NPr/ISg+ . VB/C NSg/J/R/C VP/J . . NPr/ISg+
 > was  a   treacle - well       . ”
 # VLPt D/P Nᴹ/VB   . NSg/VB/J/R . .
 >
@@ -3189,7 +3189,7 @@
 >
 #
 > “ No       , please go       on  ! ” Alice said very humbly ; “ I       won’t interrupt again . I       dare    say
-# . NSg/Dq/P . VB     NSg/VB/J J/P . . NPr+  VP/J J/R  R      . . ISg/#r+ VXB   NSg/VB    P     . ISg/#r+ NPr/VXB NSg/VB
+# . NSg/Dq/P . VB     NSg/VB/J J/P . . NPr+  VP/J J/R  R      . . ISg/#r+ VXB   NSg/VB    R     . ISg/#r+ NPr/VXB NSg/VB
 > there may     be       one     . ”
 # R+    NPr/VXB NSg/VLXB NSg/I/J . .
 >
@@ -3225,7 +3225,7 @@
 >
 #
 > Alice did  not     wish   to offend the Dormouse again , so          she  began very cautiously :
-# NPr+  VXPt NSg/R/C NSg/VB P  VB     D   NSg      P     . NSg/I/J/R/C ISg+ VPt   J/R  R          .
+# NPr+  VXPt NSg/R/C NSg/VB P  VB     D   NSg      R     . NSg/I/J/R/C ISg+ VPt   J/R  R          .
 > “ But     I       don’t understand . Where   did  they draw   the treacle from ? ”
 # . NSg/C/P ISg/#r+ VXB   VB         . NSg/R/C VXPt IPl+ NSg/VB D   Nᴹ/VB   P    . .
 >
@@ -3275,7 +3275,7 @@
 > The Dormouse had closed its     eyes    by this   time       , and  was  going   off        into a   doze   ;
 # D   NSg      VP  VP/J   ISg/D$+ NPl/V3+ P  I/Ddem N🅪Sg/VB/J+ . VB/C VLPt Nᴹ/Vg/J NSg/VB/J/P P    D/P NSg/VB .
 > but     , on  being        pinched by the Hatter , it       woke     up         again with a   little     shriek , and
-# NSg/C/P . J/P N🅪Sg/VLg/J/C VP/J    P  D   NSg/VB . NPr/ISg+ NSg/VB/J NSg/VB/J/P P     P    D/P NPr/I/J/Dq NSg/VB . VB/C
+# NSg/C/P . J/P N🅪Sg/VLg/J/C VP/J    P  D   NSg/VB . NPr/ISg+ NSg/VB/J NSg/VB/J/P R     P    D/P NPr/I/J/Dq NSg/VB . VB/C
 > went on  : “ — that      begins with an  M           , such  as    mouse   - traps  , and  the moon    , and  memory ,
 # VPt  J/P . . . I/C/Ddem+ NPl/V3 P    D/P NPr/VB/J/#r . NSg/I R/C/P NSg/VB+ . NPl/V3 . VB/C D   NPr/VB+ . VB/C N🅪Sg+  .
 > and  muchness — you    know you    say    things are “ much         of a   muchness ” — did  you    ever see
@@ -3305,7 +3305,7 @@
 >
 #
 > “ At    any     rate    I’ll never go       there again ! ” said Alice as    she  picked her     way
-# . NSg/P I/R/Dq+ NSg/VB+ K    R     NSg/VB/J R+    P     . . VP/J NPr+  R/C/P ISg+ VP/J   ISg/D$+ NSg/J+
+# . NSg/P I/R/Dq+ NSg/VB+ K    R     NSg/VB/J R+    R     . . VP/J NPr+  R/C/P ISg+ VP/J   ISg/D$+ NSg/J+
 > through the wood         . “ It’s the stupidest tea      - party     I       ever was  at    in        all          my  life     ! ”
 # J/P     D+  NPr🅪Sg/VB/J+ . . K    D   JS        N🅪Sg/VB+ . NSg/VB/J+ ISg/#r+ J/R  VLPt NSg/P NPr/J/R/P NSg/I/J/C/Dq D$+ N🅪Sg/VB+ . .
 >
@@ -3535,7 +3535,7 @@
 >
 #
 > “ I       see    ! ” said the Queen   , who    had meanwhile been   examining the roses   . “ Off        with
-# . ISg/#r+ NSg/VB . . VP/J D+  NPr/VB+ . NPr/I+ VP  NSg       VLPp/B Nᴹ/Vg/J   D+  NPl/V3+ . . NSg/VB/J/P P
+# . ISg/#r+ NSg/VB . . VP/J D+  NPr/VB+ . NPr/I+ VP  NSg/R     VLPp/B Nᴹ/Vg/J   D+  NPl/V3+ . . NSg/VB/J/P P
 > their heads   ! ” and  the procession moved on  , three of the soldiers remaining
 # D$+   NPl/V3+ . . VB/C D+  NSg/VB+    VP/J  J/P . NSg   P  D+  NPl/V3+  Nᴹ/Vg/J
 > behind  to execute the unfortunate gardeners , who    ran to Alice for   protection .
@@ -3649,7 +3649,7 @@
 > that      she  could not     help   bursting out          laughing : and  when    she  had got its     head
 # I/C/Ddem+ ISg+ VXB   NSg/R/C NSg/VB Nᴹ/Vg/J  NSg/VB/J/R/P Nᴹ/Vg/J  . VB/C NSg/I/C ISg+ VP  VP  ISg/D$+ NPr/VB/J+
 > down        , and  was  going   to begin  again , it       was  very provoking to find   that     the
-# N🅪Sg/VB/J/P . VB/C VLPt Nᴹ/Vg/J P  NSg/VB P     . NPr/ISg+ VLPt J/R  Nᴹ/Vg/J   P  NSg/VB I/C/Ddem D
+# N🅪Sg/VB/J/P . VB/C VLPt Nᴹ/Vg/J P  NSg/VB R     . NPr/ISg+ VLPt J/R  Nᴹ/Vg/J   P  NSg/VB I/C/Ddem D
 > hedgehog had unrolled itself , and  was  in        the act     of crawling away : besides all
 # NSg/VB+  VP  VP/J     ISg+   . VB/C VLPt NPr/J/R/P D   NPr/VB+ P  Nᴹ/Vg/J  VB/J . R/P     NSg/I/J/C/Dq
 > this    , there was  generally a   ridge   or    furrow in        the way    wherever she  wanted to
@@ -3829,7 +3829,7 @@
 > Alice , “ as    all          the arches are gone    from this   side     of the ground     . ” So          she  tucked
 # NPr+  . . R/C/P NSg/I/J/C/Dq D   NPl/V3 VLB VPp/J/P P    I/Ddem NSg/VB/J P  D   N🅪Sg/VB/J+ . . NSg/I/J/R/C ISg+ VP/J
 > it       away under   her     arm       , that     it       might    not     escape  again , and  went back     for   a
-# NPr/ISg+ VB/J NSg/J/P ISg/D$+ NSg/VB/J+ . I/C/Ddem NPr/ISg+ Nᴹ/VXB/J NSg/R/C N🅪Sg/VB P     . VB/C VPt  NSg/VB/J R/C/P D/P
+# NPr/ISg+ VB/J NSg/J/P ISg/D$+ NSg/VB/J+ . I/C/Ddem NPr/ISg+ Nᴹ/VXB/J NSg/R/C N🅪Sg/VB R     . VB/C VPt  NSg/VB/J R/C/P D/P
 > little     more         conversation with her     friend    .
 # NPr/I/J/Dq NPr/I/J/R/Dq N🅪Sg/VB      P    ISg/D$+ NPr/VB/J+ .
 >
@@ -3901,7 +3901,7 @@
 >
 #
 > “ You    can’t think  how   glad     I       am        to see    you    again , you    dear     old   thing ! ” said the
-# . ISgPl+ VXB   NSg/VB NSg/C NSg/VB/J ISg/#r+ NPr/VLB/J P  NSg/VB ISgPl+ P     . ISgPl+ NSg/VB/J NSg/J NSg+  . . VP/J D
+# . ISgPl+ VXB   NSg/VB NSg/C NSg/VB/J ISg/#r+ NPr/VLB/J P  NSg/VB ISgPl+ R     . ISgPl+ NSg/VB/J NSg/J NSg+  . . VP/J D
 > Duchess , as    she  tucked her     arm       affectionately into Alice’s , and  they walked off
 # NSg/VB  . R/C/P ISg+ VP/J   ISg/D$+ NSg/VB/J+ R              P    NPr$    . VB/C IPl+ VP/J   NSg/VB/J/P
 > together .
@@ -4081,7 +4081,7 @@
 >
 #
 > “ Thinking again ? ” the Duchess asked , with another dig    of her     sharp    little     chin    .
-# . Nᴹ/Vg/J  P     . . D   NSg/VB  VP/J  . P    I/D     NSg/VB P  ISg/D$+ NPr/VB/J NPr/I/J/Dq NPr/VB+ .
+# . Nᴹ/Vg/J  R     . . D   NSg/VB  VP/J  . P    I/D     NSg/VB P  ISg/D$+ NPr/VB/J NPr/I/J/Dq NPr/VB+ .
 >
 #
 > “ I’ve a   right     to think  , ” said Alice sharply , for   she  was  beginning to feel     a
@@ -4319,7 +4319,7 @@
 >
 #
 > “ Hold     your tongue   ! ” added the Gryphon , before Alice could speak  again . The Mock
-# . NSg/VB/J D$+  N🅪Sg/VB+ . . VP/J  D   ?       . C/P    NPr+  VXB   NSg/VB P     . D+  NSg/VB/J+
+# . NSg/VB/J D$+  N🅪Sg/VB+ . . VP/J  D   ?       . C/P    NPr+  VXB   NSg/VB R     . D+  NSg/VB/J+
 > Turtle  went on  .
 # NSg/VB+ VPt  J/P .
 >
@@ -4499,7 +4499,7 @@
 > work    shaking him  and  punching him  in        the back     . At    last     the Mock      Turtle  recovered
 # N🅪Sg/VB Nᴹ/Vg/J ISg+ VB/C Nᴹ/Vg/J  ISg+ NPr/J/R/P D   NSg/VB/J . NSg/P NSg/VB/J D+  NSg/VB/J+ NSg/VB+ VP/J
 > his     voice   , and  , with tears   running   down        his     cheeks  , he       went on  again : —
-# ISg/D$+ NSg/VB+ . VB/C . P    NPl/V3+ Nᴹ/Vg/J/P N🅪Sg/VB/J/P ISg/D$+ NPl/V3+ . NPr/ISg+ VPt  J/P P     . .
+# ISg/D$+ NSg/VB+ . VB/C . P    NPl/V3+ Nᴹ/Vg/J/P N🅪Sg/VB/J/P ISg/D$+ NPl/V3+ . NPr/ISg+ VPt  J/P R     . .
 >
 #
 > “ You    may     not     have    lived much         under   the sea  — ” ( “ I       haven’t , ” said Alice ) — “ and
@@ -4567,15 +4567,15 @@
 >
 #
 > “ Change   lobsters again ! ” yelled the Gryphon at    the top      of its     voice   .
-# . N🅪Sg/VB+ NPl/V3   P     . . VP/J   D   ?       NSg/P D   NSg/VB/J P  ISg/D$+ NSg/VB+ .
+# . N🅪Sg/VB+ NPl/V3   R     . . VP/J   D   ?       NSg/P D   NSg/VB/J P  ISg/D$+ NSg/VB+ .
 >
 #
 > “ Back     to land      again , and  that’s all          the first figure  , ” said the Mock     Turtle  ,
-# . NSg/VB/J P  NPr🅪Sg/VB P     . VB/C K      NSg/I/J/C/Dq D   NSg/J NSg/VB+ . . VP/J D   NSg/VB/J NSg/VB+ .
+# . NSg/VB/J P  NPr🅪Sg/VB R     . VB/C K      NSg/I/J/C/Dq D   NSg/J NSg/VB+ . . VP/J D   NSg/VB/J NSg/VB+ .
 > suddenly dropping his     voice   ; and  the two creatures , who    had been   jumping about
 # R        NSg/Vg   ISg/D$+ NSg/VB+ . VB/C D   NSg NPl+      . NPr/I+ VP  VLPp/B Nᴹ/Vg/J J/P
 > like         mad      things all          this   time       , sat    down        again very sadly and  quietly , and  looked
-# NSg/VB/J/C/P NSg/VB/J NPl+   NSg/I/J/C/Dq I/Ddem N🅪Sg/VB/J+ . NSg/VP N🅪Sg/VB/J/P P     J/R  R     VB/C R       . VB/C VP/J
+# NSg/VB/J/C/P NSg/VB/J NPl+   NSg/I/J/C/Dq I/Ddem N🅪Sg/VB/J+ . NSg/VP N🅪Sg/VB/J/P R     J/R  R     VB/C R       . VB/C VP/J
 > at    Alice .
 # NSg/P NPr+  .
 >
@@ -4695,7 +4695,7 @@
 > dance    . So          they got thrown out          to sea . So          they had to fall    a    long      way    . So          they
 # N🅪Sg/VB+ . NSg/I/J/R/C IPl+ VP  VPp/J  NSg/VB/J/R/P P  NSg . NSg/I/J/R/C IPl+ VP  P  N🅪Sg/VB D/P+ NPr/VB/J+ NSg/J+ . NSg/I/J/R/C IPl+
 > got their tails   fast       in        their mouths  . So          they couldn’t get    them     out          again .
-# VP  D$+   NPl/V3+ NSg/VB/J/R NPr/J/R/P D$+   NPl/V3+ . NSg/I/J/R/C IPl+ VXB      NSg/VB NSg/IPl+ NSg/VB/J/R/P P     .
+# VP  D$+   NPl/V3+ NSg/VB/J/R NPr/J/R/P D$+   NPl/V3+ . NSg/I/J/R/C IPl+ VXB      NSg/VB NSg/IPl+ NSg/VB/J/R/P R     .
 > That’s all          . ”
 # K      NSg/I/J/C/Dq . .
 >
@@ -4877,7 +4877,7 @@
 > Alice said nothing  ; she  had sat    down        with her     face    in        her     hands   , wondering if
 # NPr+  VP/J NSg/I/J+ . ISg+ VP  NSg/VP N🅪Sg/VB/J/P P    ISg/D$+ NSg/VB+ NPr/J/R/P ISg/D$+ NPl/V3+ . Nᴹ/Vg/J   NSg/C
 > anything  would ever happen in        a    natural way    again .
-# NSg/I/VB+ VXB   J/R  VB     NPr/J/R/P D/P+ NSg/J+  NSg/J+ P     .
+# NSg/I/VB+ VXB   J/R  VB     NPr/J/R/P D/P+ NSg/J+  NSg/J+ R     .
 >
 #
 > “ I       should like         to have    it       explained , ” said the Mock      Turtle  .
@@ -4985,7 +4985,7 @@
 >
 #
 > “ Chorus  again ! ” cried the Gryphon , and  the Mock     Turtle  had just begun to repeat
-# . NSg/VB+ P     . . VP/J  D   ?       . VB/C D   NSg/VB/J NSg/VB+ VP  J/R  VPp   P  NSg/VB
+# . NSg/VB+ R     . . VP/J  D   ?       . VB/C D   NSg/VB/J NSg/VB+ VP  J/R  VPp   P  NSg/VB
 > it       , when    a   cry    of “ The trial’s beginning ! ” was  heard in        the distance .
 # NPr/ISg+ . NSg/I/C D/P NSg/VB P  . D   NSg$    NSg/Vg/J+ . . VLPt VP/J  NPr/J/R/P D+  N🅪Sg/VB+ .
 >
@@ -5227,7 +5227,7 @@
 > good      deal      until she  made out          what   it       was  : she  was  beginning to grow larger
 # NPr/VB/J+ NSg/VB/J+ C/P   ISg+ VP   NSg/VB/J/R/P NSg/I+ NPr/ISg+ VLPt . ISg+ VLPt NSg/Vg/J  P  VB   JC
 > again , and  she  thought at    first she  would get    up         and  leave  the court      ; but     on
-# P     . VB/C ISg+ N🅪Sg/VP NSg/P NSg/J ISg+ VXB   NSg/VB NSg/VB/J/P VB/C NSg/VB D+  N🅪Sg/VB/J+ . NSg/C/P J/P
+# R     . VB/C ISg+ N🅪Sg/VP NSg/P NSg/J ISg+ VXB   NSg/VB NSg/VB/J/P VB/C NSg/VB D+  N🅪Sg/VB/J+ . NSg/C/P J/P
 > second    thoughts she  decided  to remain where   she  was  as    long     as    there was  room
 # NSg/VB/J+ NPl/V3+  ISg+ NSg/VP/J P  NSg/VB NSg/R/C ISg+ VLPt R/C/P NPr/VB/J R/C/P R+    VLPt N🅪Sg/VB+
 > for   her     .
@@ -5467,7 +5467,7 @@
 > For   some      minutes the whole  court      was  in        confusion , getting the Dormouse turned
 # R/C/P I/J/R/Dq+ NPl/V3+ D+  NSg/J+ N🅪Sg/VB/J+ VLPt NPr/J/R/P N🅪Sg/VB+  . NSg/Vg  D   NSg      VP/J
 > out          , and  , by the time       they had settled down        again , the cook    had disappeared .
-# NSg/VB/J/R/P . VB/C . P  D   N🅪Sg/VB/J+ IPl+ VP  VP/J    N🅪Sg/VB/J/P P     . D   NPr/VB+ VP  VP/J        .
+# NSg/VB/J/R/P . VB/C . P  D   N🅪Sg/VB/J+ IPl+ VP  VP/J    N🅪Sg/VB/J/P R     . D   NPr/VB+ VP  VP/J        .
 >
 #
 > “ Never mind    ! ” said the King    , with an  air     of great  relief . “ Call   the next
@@ -5509,7 +5509,7 @@
 > “ Oh     , I       beg    your pardon ! ” she  exclaimed in        a   tone      of great  dismay  , and  began
 # . NPr/VB . ISg/#r+ NSg/VB D$+  NSg/VB . . ISg+ VP/J      NPr/J/R/P D/P N🅪Sg/I/VB P  NSg/J+ NSg/VB+ . VB/C VPt
 > picking them     up         again as    quickly as    she  could , for   the accident of the goldfish
-# Nᴹ/Vg/J NSg/IPl+ NSg/VB/J/P P     R/C/P R       R/C/P ISg+ VXB   . R/C/P D   NSg/J    P  D   NSgPl
+# Nᴹ/Vg/J NSg/IPl+ NSg/VB/J/P R     R/C/P R       R/C/P ISg+ VXB   . R/C/P D   NSg/J    P  D   NSgPl
 > kept running   in        her     head      , and  she  had a   vague    sort   of idea that      they must    be
 # VP   Nᴹ/Vg/J/P NPr/J/R/P ISg/D$+ NPr/VB/J+ . VB/C ISg+ VP  D/P NSg/VB/J NSg/VB P  NSg+ I/C/Ddem+ IPl+ NSg/VXB NSg/VLXB
 > collected at    once  and  put     back     into the jury      - box     , or    they would die    .
@@ -5529,7 +5529,7 @@
 > in        head      downwards , and  the poor     little     thing was  waving  its     tail      about in        a
 # NPr/J/R/P NPr/VB/J+ R         . VB/C D   NSg/VB/J NPr/I/J/Dq NSg+  VLPt Nᴹ/Vg/J ISg/D$+ NSg/VB/J+ J/P   NPr/J/R/P D/P
 > melancholy way    , being        quite unable   to move   . She  soon got it       out          again , and  put
-# NSg/J      NSg/J+ . N🅪Sg/VLg/J/C R     NSg/VB/J P  NSg/VB . ISg+ J/R  VP  NPr/ISg+ NSg/VB/J/R/P P     . VB/C NSg/VBP
+# NSg/J      NSg/J+ . N🅪Sg/VLg/J/C R     NSg/VB/J P  NSg/VB . ISg+ J/R  VP  NPr/ISg+ NSg/VB/J/R/P R     . VB/C NSg/VBP
 > it       right    ; “ not     that     it       signifies much         , ” she  said to herself ; “ I       should think  it
 # NPr/ISg+ NPr/VB/J . . NSg/R/C I/C/Ddem NPr/ISg+ V3        NSg/I/J/R/Dq . . ISg+ VP/J P  ISg+    . . ISg/#r+ VXB    NSg/VB NPr/ISg+
 > would be       quite as    much         use     in        the trial     one      way    up         as    the other    . ”
@@ -5685,7 +5685,7 @@
 > “ He       must    have    imitated somebody else’s hand    , ” said the King    . ( The jury      all
 # . NPr/ISg+ NSg/VXB NSg/VXB VP/J     NSg/I+   NSg$   NSg/VB+ . . VP/J D   NPr/VB+ . . D+  NSg/VB/J+ NSg/I/J/C/Dq
 > brightened up         again . )
-# VP/J       NSg/VB/J/P P     . .
+# VP/J       NSg/VB/J/P R     . .
 >
 #
 > “ Please your Majesty , ” said the Knave , “ I       didn’t write  it       , and  they can’t prove
@@ -5827,7 +5827,7 @@
 > “ Why    , there they are ! ” said the King    triumphantly , pointing to the tarts  on  the
 # . NSg/VB . R+    IPl+ VLB . . VP/J D+  NPr/VB+ R            . Nᴹ/Vg/J  P  D   NPl/V3 J/P D
 > table   . “ Nothing  can     be       clearer than that      . Then      again — ‘ before she  had this    fit        — ’
-# NSg/VB+ . . NSg/I/J+ NPr/VXB NSg/VLXB NSg/JC  C/P  I/C/Ddem+ . NSg/J/R/C P     . . C/P    ISg+ VP  I/Ddem+ NSg/VBP/J+ . .
+# NSg/VB+ . . NSg/I/J+ NPr/VXB NSg/VLXB NSg/JC  C/P  I/C/Ddem+ . NSg/J/R/C R     . . C/P    ISg+ VP  I/Ddem+ NSg/VBP/J+ . .
 > you    never had fits   , my  dear     , I       think  ? ” he       said to the Queen   .
 # ISgPl+ R     VP  NPl/V3 . D$+ NSg/VB/J . ISg/#r+ NSg/VB . . NPr/ISg+ VP/J P  D+  NPr/VB+ .
 >
@@ -5837,7 +5837,7 @@
 > spoke   . ( The unfortunate little      Bill    had left     off        writing on  his     slate     with one
 # NSg/VPt . . D+  NSg/J+      NPr/I/J/Dq+ NPr/VB+ VP  NPr/VP/J NSg/VB/J/P Nᴹ/Vg/J J/P ISg/D$+ NSg/VB/J+ P    NSg/I/J+
 > finger  , as    he       found  it       made no        mark    ; but     he       now       hastily began again , using   the
-# NSg/VB+ . R/C/P NPr/ISg+ NSg/VP NPr/ISg+ VP   NSg/Dq/P+ NPr/VB+ . NSg/C/P NPr/ISg+ NSg/J/R/C R       VPt   P     . Nᴹ/Vg/J D+
+# NSg/VB+ . R/C/P NPr/ISg+ NSg/VP NPr/ISg+ VP   NSg/Dq/P+ NPr/VB+ . NSg/C/P NPr/ISg+ NSg/J/R/C R       VPt   R     . Nᴹ/Vg/J D+
 > ink      , that      was  trickling down        his     face    , as    long     as    it       lasted . )
 # N🅪Sg/VB+ . I/C/Ddem+ VLPt Nᴹ/Vg/J   N🅪Sg/VB/J/P ISg/D$+ NSg/VB+ . R/C/P NPr/VB/J R/C/P NPr/ISg+ VP/J   . .
 >
@@ -5925,7 +5925,7 @@
 >
 #
 > First , she  dreamed      of little      Alice herself , and  once  again the tiny   hands   were
-# NSg/J . ISg+ VP/J/NoAm/Au P  NPr/I/J/Dq+ NPr+  ISg+    . VB/C NSg/C P     D+  NSg/J+ NPl/V3+ VLPt
+# NSg/J . ISg+ VP/J/NoAm/Au P  NPr/I/J/Dq+ NPr+  ISg+    . VB/C NSg/C R     D+  NSg/J+ NPl/V3+ VLPt
 > clasped upon her     knee    , and  the bright   eager    eyes    were looking up         into hers — she
 # VP/J    P    ISg/D$+ NSg/VB+ . VB/C D   NPr/VB/J NSg/VB/J NPl/V3+ VLPt Nᴹ/Vg/J NSg/VB/J/P P    ISg+ . ISg+
 > could hear the very tones  of her     voice   , and  see    that     queer    little     toss   of her
@@ -5961,7 +5961,7 @@
 > So          she  sat    on  , with closed eyes    , and  half      believed herself in        Wonderland , though
 # NSg/I/J/R/C ISg+ NSg/VP J/P . P    VP/J   NPl/V3+ . VB/C N🅪Sg/J/P+ VP/J     ISg+    NPr/J/R/P NSg+       . C
 > she  knew she  had but     to open     them     again , and  all          would change  to dull
-# ISg+ VPt  ISg+ VP  NSg/C/P P  NSg/VB/J NSg/IPl+ P     . VB/C NSg/I/J/C/Dq VXB   N🅪Sg/VB P  VB/J+
+# ISg+ VPt  ISg+ VP  NSg/C/P P  NSg/VB/J NSg/IPl+ R     . VB/C NSg/I/J/C/Dq VXB   N🅪Sg/VB P  VB/J+
 > reality — the grass      would be       only  rustling in        the wind     , and  the pool    rippling to
 # N🅪Sg+   . D+  NPr🅪Sg/VB+ VXB   NSg/VLXB J/R/C Nᴹ/Vg/J  NPr/J/R/P D   N🅪Sg/VB+ . VB/C D   NSg/VB+ Nᴹ/Vg/J  P
 > the waving  of the reeds — the rattling teacups would change   to tinkling

--- a/harper-core/tests/text/tagged/Difficult sentences.md
+++ b/harper-core/tests/text/tagged/Difficult sentences.md
@@ -281,7 +281,7 @@
 > It       is  unreasonable for   our boss      to withhold our wages   .
 # NPr/ISg+ VL3 J            R/C/P D$+ NSg/VB/J+ P  NSg/VB   D$+ NPl/V3+ .
 > I       don't think  it's a   good     idea for   you    and  me       to meet     ever again .
-# ISg/#r+ VXB   NSg/VB +    D/P NPr/VB/J NSg+ R/C/P ISgPl+ VB/C NPr/ISg+ P  NSg/VB/J J/R  P     .
+# ISg/#r+ VXB   NSg/VB +    D/P NPr/VB/J NSg+ R/C/P ISgPl+ VB/C NPr/ISg+ P  NSg/VB/J J/R  R     .
 > I       am        aiming  for   completion by the end    of business Thursday .
 # ISg/#r+ NPr/VLB/J Nᴹ/Vg/J R/C/P NSg+       P  D   NSg/VB P  N🅪Sg/J+  NSg+     .
 > He's going   for   his     doctorate .
@@ -713,7 +713,7 @@
 > Can     I       see    you    on  a    different day     ?
 # NPr/VXB ISg/#r+ NSg/VB ISgPl+ J/P D/P+ NSg/J+    NPr🅪Sg+ .
 > Smith   scored again on  twelve minutes , doubling Mudchester Rovers ' lead      .
-# NPr/VB+ VP/J   P     J/P NSg+   NPl/V3+ . Nᴹ/Vg/J  ?          W?     . N🅪Sg/VB/J .
+# NPr/VB+ VP/J   R     J/P NSg+   NPl/V3+ . Nᴹ/Vg/J  ?          W?     . N🅪Sg/VB/J .
 > I       was  reading     a   book   on  history .
 # ISg/#r+ VLPt NPr🅪Sg/Vg/J D/P NSg/VB J/P N🅪Sg+   .
 > The city hosted the World   Summit  on  the Information Society

--- a/harper-core/tests/text/tagged/The Great Gatsby.md
+++ b/harper-core/tests/text/tagged/The Great Gatsby.md
@@ -85,7 +85,7 @@
 > gift    for   hope      , a   romantic readiness such  as    I       have    never found  in        any    other
 # NSg/VB+ R/C/P NPr🅪Sg/VB . D/P NSg/J    NSg       NSg/I R/C/P ISg/#r+ NSg/VXB R     NSg/VP NPr/J/R/P I/R/Dq NSg/VB/J
 > person  and  which it       is  not     likely I       shall ever find   again . No       — Gatsby turned out
-# NSg/VB+ VB/C I/C+  NPr/ISg+ VL3 NSg/R/C NSg/J  ISg/#r+ VXB   J/R  NSg/VB P     . NSg/Dq/P . NPr    VP/J   NSg/VB/J/R/P
+# NSg/VB+ VB/C I/C+  NPr/ISg+ VL3 NSg/R/C NSg/J  ISg/#r+ VXB   J/R  NSg/VB R     . NSg/Dq/P . NPr    VP/J   NSg/VB/J/R/P
 > all          right    at    the end     ; it       is  what   preyed on  Gatsby , what   foul     dust   floated in        the
 # NSg/I/J/C/Dq NPr/VB/J NSg/P D   NSg/VB+ . NPr/ISg+ VL3 NSg/I+ VP/J   J/P NPr    . NSg/I+ NSg/VB/J Nᴹ/VB+ VP/J    NPr/J/R/P D
 > wake   of his     dreams  that      temporarily closed out          my  interest in        the abortive
@@ -177,7 +177,7 @@
 > just as    things grow in        fast        movies , I       had that     familiar conviction that      life     was
 # J/R  R/C/P NPl+   VB   NPr/J/R/P NSg/VB/J/R+ NPl+   . ISg/#r+ VP  I/C/Ddem NSg/J+   N🅪Sg+      I/C/Ddem+ N🅪Sg/VB+ VLPt
 > beginning over    again with the summer     .
-# NSg/Vg/J  NSg/J/P P     P    D+  NPr🅪Sg/VB+ .
+# NSg/Vg/J  NSg/J/P R     P    D+  NPr🅪Sg/VB+ .
 >
 #
 > There was  so          much         to read    , for   one      thing , and  so          much         fine     health to be       pulled
@@ -195,7 +195,7 @@
 > of very solemn and  obvious editorials for   the Yale News   — and  now       I       was  going   to
 # P  J/R  J      VB/C J       NPl        R/C/P D+  NPr+ Nᴹ/VB+ . VB/C NSg/J/R/C ISg/#r+ VLPt Nᴹ/Vg/J P
 > bring back     all          such  things into my  life     and  become again that     most         limited  of
-# VB    NSg/VB/J NSg/I/J/C/Dq NSg/I NPl+   P    D$+ N🅪Sg/VB+ VB/C VBPp   P     I/C/Ddem NSg/I/J/R/Dq NSg/VP/J P
+# VB    NSg/VB/J NSg/I/J/C/Dq NSg/I NPl+   P    D$+ N🅪Sg/VB+ VB/C VBPp   R     I/C/Ddem NSg/I/J/R/Dq NSg/VP/J P
 > all          specialists , the “ well       - rounded man     . ” This   isn’t   just an  epigram — life     is  much
 # NSg/I/J/C/Dq NPl+        . D   . NSg/VB/J/R . VP/J    NPr/VB+ . . I/Ddem NSg/VX3 J/R  D/P NSg     . N🅪Sg/VB+ VL3 NSg/I/J/R/Dq
 > more         successfully looked at    from a   single   window  , after all          .
@@ -375,7 +375,7 @@
 >
 #
 > “ It       belonged to Demaine , the oil      man     . ” He       turned me       around again , politely and
-# . NPr/ISg+ VP/J     P  ?       . D   N🅪Sg/VB+ NPr/VB+ . . NPr/ISg+ VP/J   NPr/ISg+ J/P    P     . R        VB/C
+# . NPr/ISg+ VP/J     P  ?       . D   N🅪Sg/VB+ NPr/VB+ . . NPr/ISg+ VP/J   NPr/ISg+ J/P    R     . R        VB/C
 > abruptly . “ We'll go       inside  . ”
 # R        . . K     NSg/VB/J NSg/J/P . .
 >
@@ -439,7 +439,7 @@
 >
 #
 > She  laughed again , as    if    she  said something very witty , and  held my  hand    for   a
-# ISg+ VP/J    P     . R/C/P NSg/C ISg+ VP/J NSg/I/J+  J/R  J     . VB/C VP   D$+ NSg/VB+ R/C/P D/P
+# ISg+ VP/J    R     . R/C/P NSg/C ISg+ VP/J NSg/I/J+  J/R  J     . VB/C VP   D$+ NSg/VB+ R/C/P D/P
 > moment , looking up         into my  face    , promising that     there was  no       one      in        the world
 # NSg+   . Nᴹ/Vg/J NSg/VB/J/P P    D$+ NSg/VB+ . Nᴹ/Vg/J   I/C/Ddem R+    VLPt NSg/Dq/P NSg/I/J+ NPr/J/R/P D   NSg/VB+
 > she  so          much         wanted to see    . That      was  a   way   she  had . She  hinted in        a   murmur that
@@ -455,9 +455,9 @@
 > At    any     rate    , Miss   Baker’s lips    fluttered , she  nodded at    me       almost imperceptibly ,
 # NSg/P I/R/Dq+ NSg/VB+ . NSg/VB NPr$    NPl/V3+ VP/J      . ISg+ VP     NSg/P NPr/ISg+ R      R             .
 > and  then      quickly tipped her     head      back     again — the object  she  was  balancing had
-# VB/C NSg/J/R/C R       VP     ISg/D$+ NPr/VB/J+ NSg/VB/J P     . D   NSg/VB+ ISg+ VLPt Nᴹ/Vg/J+  VP
+# VB/C NSg/J/R/C R       VP     ISg/D$+ NPr/VB/J+ NSg/VB/J R     . D   NSg/VB+ ISg+ VLPt Nᴹ/Vg/J+  VP
 > obviously tottered a   little     and  given       her     something of a   fright   . Again a   sort   of
-# R         VP/J     D/P NPr/I/J/Dq VB/C NSg/VPp/J/P ISg/D$+ NSg/I/J+  P  D/P NSg/VB/J . P     D/P NSg/VB P
+# R         VP/J     D/P NPr/I/J/Dq VB/C NSg/VPp/J/P ISg/D$+ NSg/I/J+  P  D/P NSg/VB/J . R     D/P NSg/VB P
 > apology arose to my  lips    . Almost any    exhibition of complete  self        - sufficiency
 # N🅪Sg+   VPt   P  D$+ NPl/V3+ . R      I/R/Dq NSg        P  NSg/VB/J+ NSg/I/VB/J+ . NSg
 > draws  a   stunned tribute from me       .
@@ -469,7 +469,7 @@
 > voice   . It       was  the kind  of voice   that     the ear       follows up         and  down        , as    if    each
 # NSg/VB+ . NPr/ISg+ VLPt D   NSg/J P  NSg/VB+ I/C/Ddem D+  NSg/VB/J+ NPl/V3  NSg/VB/J/P VB/C N🅪Sg/VB/J/P . R/C/P NSg/C Dq+
 > speech   is  an  arrangement of notes   that      will    never be       played again . Her     face    was
-# N🅪Sg/VB+ VL3 D/P NSg         P  NPl/V3+ I/C/Ddem+ NPr/VXB R     NSg/VLXB VP/J   P     . ISg/D$+ NSg/VB+ VLPt
+# N🅪Sg/VB+ VL3 D/P NSg         P  NPl/V3+ I/C/Ddem+ NPr/VXB R     NSg/VLXB VP/J   R     . ISg/D$+ NSg/VB+ VLPt
 > sad      and  lovely with bright   things in        it       , bright   eyes   and  a    bright    passionate
 # NSg/VB/J VB/C NSg/J  P    NPr/VB/J NPl    NPr/J/R/P NPr/ISg+ . NPr/VB/J NPl/V3 VB/C D/P+ NPr/VB/J+ NSg/VB/J+
 > mouth   , but     there was  an  excitement in        her     voice   that      men  who    had cared for   her
@@ -785,7 +785,7 @@
 > infinitesimal hesitation he       included Daisy with a   slight   nod    , and  she  winked at
 # NSg/J         NSg+       NPr/ISg+ VP/J     NPr+  P    D/P NSg/VB/J NSg/VB . VB/C ISg+ VP/J   NSg/P
 > me       again . ‘ ‘ — And  we’ve produced all          the things that      go       to make   civilization — oh     ,
-# NPr/ISg+ P     . . . . VB/C K     VP/J     NSg/I/J/C/Dq D   NPl+   I/C/Ddem+ NSg/VB/J P  NSg/VB NPr🅪Sg+      . NPr/VB .
+# NPr/ISg+ R     . . . . VB/C K     VP/J     NSg/I/J/C/Dq D   NPl+   I/C/Ddem+ NSg/VB/J P  NSg/VB NPr🅪Sg+      . NPr/VB .
 > science and  art        , and  all          that      . Do  you    see    ? ”
 # N🅪Sg/VB VB/C NPr🅪Sg/VB+ . VB/C NSg/I/J/C/Dq I/C/Ddem+ . VXB ISgPl+ NSg/VB . .
 >
@@ -843,7 +843,7 @@
 > frowned , pushed back     his     chair   , and  without a   word    went inside  . As    if    his
 # VP/J    . VP/J   NSg/VB/J ISg/D$+ NSg/VB+ . VB/C C/P     D/P NSg/VB+ VPt  NSg/J/P . R/C/P NSg/C ISg/D$+
 > absence quickened something within  her     , Daisy leaned forward  again , her     voice
-# N🅪Sg+   VP/J      NSg/I/J+  NSg/J/P ISg/D$+ . NPr+  VP/J   NSg/VB/J P     . ISg/D$+ NSg/VB+
+# N🅪Sg+   VP/J      NSg/I/J+  NSg/J/P ISg/D$+ . NPr+  VP/J   NSg/VB/J R     . ISg/D$+ NSg/VB+
 > glowing and  singing .
 # Nᴹ/Vg/J VB/C Nᴹ/Vg/J .
 >
@@ -951,7 +951,7 @@
 > the broken fragments of the last     five minutes at    table   I       remember the candles
 # D   VPp/J  NPl/V3    P  D   NSg/VB/J NSg  NPl/V3+ NSg/P NSg/VB+ ISg/#r+ NSg/VB   D+  NPl/V3+
 > being        lit      again , pointlessly , and  I       was  conscious of wanting to look   squarely at
-# N🅪Sg/VLg/J/C NSg/VP/J P     . R           . VB/C ISg/#r+ VLPt NSg/J     P  Nᴹ/Vg/J P  NSg/VB R        NSg/P
+# N🅪Sg/VLg/J/C NSg/VP/J R     . R           . VB/C ISg/#r+ VLPt NSg/J     P  Nᴹ/Vg/J P  NSg/VB R        NSg/P
 > every one      , and  yet      to avoid all          eyes    . I       couldn’t guess  what   Daisy and  Tom     were
 # Dq    NSg/I/J+ . VB/C NSg/VB/C P  VB    NSg/I/J/C/Dq NPl/V3+ . ISg/#r+ VXB      NSg/VB NSg/I+ NPr   VB/C NPr/VB+ VLPt
 > thinking , but     I       doubt   if    even       Miss   Baker , who    seemed to have    mastered a   certain
@@ -965,7 +965,7 @@
 >
 #
 > The horses  , needless to say    , were not     mentioned again . Tom     and  Miss   Baker , with
-# D+  NPl/V3+ . J        P  NSg/VB . VLPt NSg/R/C VP/J      P     . NPr/VB+ VB/C NSg/VB NPr+  . P
+# D+  NPl/V3+ . J        P  NSg/VB . VLPt NSg/R/C VP/J      R     . NPr/VB+ VB/C NSg/VB NPr+  . P
 > several feet of twilight between them     , strolled back     into the library , as    if    to
 # J/Dq    NPl  P  Nᴹ/VB/J+ NSg/P   NSg/IPl+ . VP/J     NSg/VB/J P    D+  NSg+    . R/C/P NSg/C P
 > a   vigil  beside a   perfectly tangible body    , while      , trying  to look   pleasantly
@@ -1221,7 +1221,7 @@
 >
 #
 > “ But     we   heard it       , ” insisted Daisy , surprising me       by opening up         again in        a
-# . NSg/C/P IPl+ VP/J  NPr/ISg+ . . VP/J     NPr+  . Nᴹ/Vg/J    NPr/ISg+ P  Nᴹ/Vg/J NSg/VB/J/P P     NPr/J/R/P D/P+
+# . NSg/C/P IPl+ VP/J  NPr/ISg+ . . VP/J     NPr+  . Nᴹ/Vg/J    NPr/ISg+ P  Nᴹ/Vg/J NSg/VB/J/P R     NPr/J/R/P D/P+
 > flower  - like         way    . “ We   heard it       from three people  , so          it       must    be       true     . ”
 # NSg/VB+ . NSg/VB/J/C/P NSg/J+ . . IPl+ VP/J  NPr/ISg+ P    NSg+  NPl/VB+ . NSg/I/J/R/C NPr/ISg+ NSg/VXB NSg/VLXB NSg/VB/J . .
 >
@@ -1291,7 +1291,7 @@
 > a   single   green       light      , minute    and  far      away , that      might    have    been   the end    of a
 # D/P NSg/VB/J NPr🅪Sg/VB/J N🅪Sg/VB/J+ . NSg/VB/J+ VB/C NSg/VB/J VB/J . I/C/Ddem+ Nᴹ/VXB/J NSg/VXB VLPp/B D   NSg/VB P  D/P
 > dock    . When    I       looked once  more         for   Gatsby he       had vanished , and  I       was  alone again
-# NSg/VB+ . NSg/I/C ISg/#r+ VP/J   NSg/C NPr/I/J/R/Dq R/C/P NPr    NPr/ISg+ VP  VP/J     . VB/C ISg/#r+ VLPt J     P
+# NSg/VB+ . NSg/I/C ISg/#r+ VP/J   NSg/C NPr/I/J/R/Dq R/C/P NPr    NPr/ISg+ VP  VP/J     . VB/C ISg/#r+ VLPt J     R
 > in        the unquiet darkness .
 # NPr/J/R/P D   VB/J    Nᴹ+      .
 >
@@ -1663,7 +1663,7 @@
 >
 #
 > We   went on  , cutting  back     again over    the Park    toward the West      Hundreds . At    158th
-# IPl+ VPt  J/P . NSg/Vg/J NSg/VB/J P     NSg/J/P D   NPr/VB+ J/P    D+  NPr/VB/J+ NPl+     . NSg/P #
+# IPl+ VPt  J/P . NSg/Vg/J NSg/VB/J R     NSg/J/P D   NPr/VB+ J/P    D+  NPr/VB/J+ NPl+     . NSg/P #
 > Street    the cab     stopped at    one     slice     in        a   long     white       cake    of apartment - houses  .
 # NSg/VB/J+ D   NSg/VB+ VP/J    NSg/P NSg/I/J NSg/VB/J+ NPr/J/R/P D/P NPr/VB/J NPr🅪Sg/VB/J N🅪Sg/VB P  NSg+      . NPl/V3+ .
 > Throwing a   regal homecoming glance  around the neighborhood , Mrs  . Wilson gathered
@@ -1703,7 +1703,7 @@
 > large , hard      dog       - biscuits — one     of which decomposed apathetically in        the saucer of
 # NSg/J . N🅪Sg/J/R+ NSg/VB/J+ . NPl      . NSg/I/J P  I/C+  VP/J       R             NPr/J/R/P D   NSg/VB P
 > milk     all          afternoon . Meanwhile Tom     brought out          a   bottle of whiskey from a   locked
-# N🅪Sg/VB+ NSg/I/J/C/Dq N🅪Sg+     . NSg       NPr/VB+ VP      NSg/VB/J/R/P D/P NSg/VB P  N🅪Sg    P    D/P VP/J
+# N🅪Sg/VB+ NSg/I/J/C/Dq N🅪Sg+     . NSg/R     NPr/VB+ VP      NSg/VB/J/R/P D/P NSg/VB P  N🅪Sg    P    D/P VP/J
 > bureau door    .
 # NSg+   NSg/VB+ .
 >
@@ -1739,7 +1739,7 @@
 > solid , sticky   bob    of red    hair     , and  a   complexion powdered milky white       . Her
 # NSg/J . NSg/VB/J NPr/VB P  N🅪Sg/J N🅪Sg/VB+ . VB/C D/P NSg/VB+    VP/J     J     NPr🅪Sg/VB/J . ISg/D$+
 > eyebrows had been   plucked and  then      drawn on  again at    a   more         rakish angle   , but
-# NPl/V3+  VP  VLPp/B VP/J    VB/C NSg/J/R/C VPp/J J/P P     NSg/P D/P NPr/I/J/R/Dq J      NSg/VB+ . NSg/C/P
+# NPl/V3+  VP  VLPp/B VP/J    VB/C NSg/J/R/C VPp/J J/P R     NSg/P D/P NPr/I/J/R/Dq J      NSg/VB+ . NSg/C/P
 > the efforts of nature   toward the restoration of the old   alignment gave a   blurred
 # D   NPl/V3  P  N🅪Sg/VB+ J/P    D   NPr🅪Sg      P  D   NSg/J N🅪Sg+     VPt  D/P VP/J
 > air      to her     face    . When    she  moved about there was  an  incessant clicking as
@@ -1853,7 +1853,7 @@
 >
 #
 > Her     husband said “ Sh ! ” and  we   all          looked at    the subject   again , whereupon Tom
-# ISg/D$+ NSg/VB+ VP/J . W? . . VB/C IPl+ NSg/I/J/C/Dq VP/J+  NSg/P D+  NSg/VB/J+ P     . C         NPr/VB+
+# ISg/D$+ NSg/VB+ VP/J . W? . . VB/C IPl+ NSg/I/J/C/Dq VP/J+  NSg/P D+  NSg/VB/J+ R     . C         NPr/VB+
 > Buchanan yawned audibly and  got to his     feet .
 # NPr+     VP/J   R       VB/C VP  P  ISg/D$+ NPl+ .
 >
@@ -2011,7 +2011,7 @@
 >
 #
 > “ You    see    , ” cried Catherine triumphantly . She  lowered her     voice   again . “ It’s
-# . ISgPl+ NSg/VB . . VP/J  NPr+      R            . ISg+ VP/J    ISg/D$+ NSg/VB+ P     . . K
+# . ISgPl+ NSg/VB . . VP/J  NPr+      R            . ISg+ VP/J    ISg/D$+ NSg/VB+ R     . . K
 > really his     wife      that’s keeping them     apart . She’s a   Catholic , and  they don’t
 # R      ISg/D$+ NSg/VB/J+ K      Nᴹ/Vg/J NSg/IPl+ J     . K     D/P NSg/J    . VB/C IPl+ VXB
 > believe in        divorce . ”
@@ -2889,7 +2889,7 @@
 >
 #
 > “ Much         better     . ” I       turned again to my  new    acquaintance . “ This    is  an  unusual party
-# . NSg/I/J/R/Dq NSg/VXB/JC . . ISg/#r+ VP/J   P     P  D$+ NSg/J+ NSg+         . . I/Ddem+ VL3 D/P NSg/J   NSg/VB/J
+# . NSg/I/J/R/Dq NSg/VXB/JC . . ISg/#r+ VP/J   R     P  D$+ NSg/J+ NSg+         . . I/Ddem+ VL3 D/P NSg/J   NSg/VB/J
 > for   me       . I       haven’t even       seen    the host    . I       live over    there — ” I       waved my  hand    at    the
 # R/C/P NPr/ISg+ . ISg/#r+ VXB     NSg/VB/J/R NSg/VPp D   NSg/VB+ . ISg/#r+ VB/J NSg/J/P R     . . ISg/#r+ VP/J  D$+ NSg/VB+ NSg/P D
 > invisible hedge   in        the distance , “ and  this    man     Gatsby sent   over    his     chauffeur
@@ -3121,7 +3121,7 @@
 > not     only  singing , she  was  weeping  too . Whenever there was  a   pause  in        the song
 # NSg/R/C J/R/C Nᴹ/Vg/J . ISg+ VLPt Nᴹ/Vg/J+ R   . C        R+    VLPt D/P NSg/VB NPr/J/R/P D+  N🅪Sg+
 > she  filled it       with gasping , broken sobs   , and  then      took up         the lyric again in        a
-# ISg+ VP/J   NPr/ISg+ P    Nᴹ/Vg/J . VPp/J  NPl/V3 . VB/C NSg/J/R/C VPt  NSg/VB/J/P D   NSg/J P     NPr/J/R/P D/P
+# ISg+ VP/J   NPr/ISg+ P    Nᴹ/Vg/J . VPp/J  NPl/V3 . VB/C NSg/J/R/C VPt  NSg/VB/J/P D   NSg/J R     NPr/J/R/P D/P
 > quavering soprano . The tears   coursed down        her     cheeks  — not     freely , however , for
 # Nᴹ/Vg/J   NSg/VB+ . D+  NPl/V3+ VP/J    N🅪Sg/VB/J/P ISg/D$+ NPl/V3+ . NSg/R/C R      . C       . R/C/P
 > when    they came      into contact  with her     heavily beaded eyelashes they assumed an
@@ -3525,7 +3525,7 @@
 >
 #
 > Again at    eight o’clock , when    the dark     lanes of the Forties were lined five deep
-# P     NSg/P NSg/J R       . NSg/I/C D   NSg/VB/J NPl   P  D+  NPl+    VLPt VP/J  NSg  NSg/J
+# R     NSg/P NSg/J R       . NSg/I/C D   NSg/VB/J NPl   P  D+  NPl+    VLPt VP/J  NSg  NSg/J
 > with throbbing taxicabs , bound    for   the theatre    district  , I       felt      a   sinking  in        my
 # P    NSg/Vg/J  NPl/V3   . NSg/VP/J R/C/P D   N🅪Sg/Comm+ NSg/VB/J+ . ISg/#r+ N🅪Sg/VP/J D/P Nᴹ/Vg/J+ NPr/J/R/P D$+
 > heart    . Forms   leaned together in        the taxis   as    they waited , and  voices  sang    , and
@@ -3541,7 +3541,7 @@
 > For   a    while       I       lost sight   of Jordan Baker , and  then      in        midsummer I       found  her
 # R/C/P D/P+ NSg/VB/C/P+ ISg/#r+ VP/J N🅪Sg/VB P  NPr+   NPr+  . VB/C NSg/J/R/C NPr/J/R/P NSg/J     ISg/#r+ NSg/VP ISg/D$+
 > again . At    first I       was  flattered to go       places  with her     , because she  was  a   golf
-# P     . NSg/P NSg/J ISg/#r+ VLPt VP/J      P  NSg/VB/J NPl/V3+ P    ISg/D$+ . C/P     ISg+ VLPt D/P NSg/VB
+# R     . NSg/P NSg/J ISg/#r+ VLPt VP/J      P  NSg/VB/J NPl/V3+ P    ISg/D$+ . C/P     ISg+ VLPt D/P NSg/VB
 > champion , and  every one      knew her     name    . Then      it       was  something more         . I       wasn’t
 # NSg/VB/J . VB/C Dq+   NSg/I/J+ VPt  ISg/D$+ NSg/VB+ . NSg/J/R/C NPr/ISg+ VLPt NSg/I/J+  NPr/I/J/R/Dq . ISg/#r+ VPt
 > actually in        love      , but     I       felt      a   sort   of tender   curiosity . The bored haughty face
@@ -4325,7 +4325,7 @@
 > atmosphere of the old   Metropole , began to eat with ferocious delicacy . His     eyes    ,
 # N🅪Sg       P  D   NSg/J ?         . VPt   P  VB  P    J         NSg+     . ISg/D$+ NPl/V3+ .
 > meanwhile , roved very slowly all          around the room     — he       completed the arc       by turning
-# NSg       . VP/J  J/R  R      NSg/I/J/C/Dq J/P    D   N🅪Sg/VB+ . NPr/ISg+ VP/J      D   NPr/VB/J+ P  Nᴹ/Vg/J
+# NSg/R     . VP/J  J/R  R      NSg/I/J/C/Dq J/P    D   N🅪Sg/VB+ . NPr/ISg+ VP/J      D   NPr/VB/J+ P  Nᴹ/Vg/J
 > to inspect the people  directly behind  . I       think  that      , except for   my  presence , he
 # P  VB      D   NPl/VB+ R/C      NSg/J/P . ISg/#r+ NSg/VB I/C/Ddem+ . VB/C/P R/C/P D$+ N🅪Sg/VB+ . NPr/ISg+
 > would have    taken one     short       glance  beneath our own       table   .
@@ -4339,7 +4339,7 @@
 >
 #
 > There was  the smile   again , but     this    time       I       held out          against it       .
-# R+    VLPt D+  NSg/VB+ P     . NSg/C/P I/Ddem+ N🅪Sg/VB/J+ ISg/#r+ VP   NSg/VB/J/R/P C/P     NPr/ISg+ .
+# R+    VLPt D+  NSg/VB+ R     . NSg/C/P I/Ddem+ N🅪Sg/VB/J+ ISg/#r+ VP   NSg/VB/J/R/P C/P     NPr/ISg+ .
 >
 #
 > “ I       don’t like         mysteries , ” I       answered , “ and  I       don’t understand why    you    won’t come
@@ -4629,7 +4629,7 @@
 > remembered the incident ever since . His     name    was  Jay  Gatsby , and  I       didn’t lay
 # VP/J       D+  NSg/J+   J/R  C/P   . ISg/D$+ NSg/VB+ VLPt NPr+ NPr    . VB/C ISg/#r+ VXPt   NSg/VBPt/J
 > eyes    on  him  again for   over    four years — even       after I'd met him  on  Long     Island  I
-# NPl/V3+ J/P ISg+ P     R/C/P NSg/J/P NSg  NPl+  . NSg/VB/J/R P     K   VP  ISg+ J/P NPr/VB/J NSg/VB+ ISg/#r+
+# NPl/V3+ J/P ISg+ R     R/C/P NSg/J/P NSg  NPl+  . NSg/VB/J/R P     K   VP  ISg+ J/P NPr/VB/J NSg/VB+ ISg/#r+
 > didn’t realize      it       was  the same man     .
 # VXPt   VB/Comm/NoAm NPr/ISg+ VLPt D   I/J  NPr/VB+ .
 >
@@ -4655,7 +4655,7 @@
 >
 #
 > By the next     autumn     she  was  gay      again , gay      as    ever . She  had a   début after the
-# P  D+  NSg/J/P+ NPr🅪Sg/VB+ ISg+ VLPt NPr/VB/J P     . NPr/VB/J R/C/P J/R  . ISg+ VP  D/P ?     P     D
+# P  D+  NSg/J/P+ NPr🅪Sg/VB+ ISg+ VLPt NPr/VB/J R     . NPr/VB/J R/C/P J/R  . ISg+ VP  D/P ?     P     D
 > armistice , and  in        February she  was  presumably engaged to a   man     from New   Orleans .
 # NPr🅪Sg    . VB/C NPr/J/R/P NPr+     ISg+ VLPt R          VP/J    P  D/P NPr/VB+ P    NSg/J NPr+    .
 > In        June she  married  Tom     Buchanan of Chicago , with more         pomp   and  circumstance
@@ -4939,7 +4939,7 @@
 > and  blinding signs   , and  so          I       drew    up         the girl    beside me       , tightening my  arms    . Her
 # VB/C Nᴹ/Vg/J  NPl/V3+ . VB/C NSg/I/J/R/C ISg/#r+ NPr/VPt NSg/VB/J/P D   NSg/VB+ P      NPr/ISg+ . Nᴹ/Vg/J    D$+ NPl/V3+ . ISg/D$+
 > wan      , scornful mouth   smiled , and  so          I       drew    her     up         again closer , this   time       to my
-# NSg/VB/J . J        NSg/VB+ VP/J   . VB/C NSg/I/J/R/C ISg/#r+ NPr/VPt ISg/D$+ NSg/VB/J/P P     NSg/JC . I/Ddem N🅪Sg/VB/J+ P  D$+
+# NSg/VB/J . J        NSg/VB+ VP/J   . VB/C NSg/I/J/R/C ISg/#r+ NPr/VPt ISg/D$+ NSg/VB/J/P R     NSg/JC . I/Ddem N🅪Sg/VB/J+ P  D$+
 > face    .
 # NSg/VB+ .
 >
@@ -4967,7 +4967,7 @@
 > to the game      . But     there wasn’t a   sound      . Only  wind     in        the trees   , which blew      the
 # P  D+  NSg/VB/J+ . NSg/C/P R+    VPt    D/P N🅪Sg/VB/J+ . J/R/C N🅪Sg/VB+ NPr/J/R/P D+  NPl/V3+ . I/C+  NSg/VPt/J D+
 > wires   and  made the lights  go        off        and  on  again as    if    the house   had winked into
-# NPl/V3+ VB/C VP   D+  NPl/V3+ NSg/VB/J+ NSg/VB/J/P VB/C J/P P     R/C/P NSg/C D+  NPr/VB+ VP  VP/J   P
+# NPl/V3+ VB/C VP   D+  NPl/V3+ NSg/VB/J+ NSg/VB/J/P VB/C J/P R     R/C/P NSg/C D+  NPr/VB+ VP  VP/J   P
 > the darkness . As    my  taxi    groaned away I       saw     Gatsby walking toward me       across his
 # D+  Nᴹ+      . R/C/P D$+ NSg/VB+ VP/J    VB/J ISg/#r+ NSg/VPt NPr    Nᴹ/Vg/J J/P    NPr/ISg+ NSg/P  ISg/D$+
 > lawn    .
@@ -5331,7 +5331,7 @@
 >
 #
 > “ I       certainly am        awfully glad     to see    you    again . ”
-# . ISg/#r+ R         NPr/VLB/J R       NSg/VB/J P  NSg/VB ISgPl+ P     . .
+# . ISg/#r+ R         NPr/VLB/J R       NSg/VB/J P  NSg/VB ISgPl+ R     . .
 >
 #
 > A    pause   ; it       endured horribly . I       had nothing  to do  in        the hall , so          I       went into
@@ -5499,7 +5499,7 @@
 >
 #
 > After half      an   hour , the sun     shone again , and  the grocer’s automobile rounded
-# P     N🅪Sg/J/P+ D/P+ NSg+ . D+  NPr/VB+ VB    P     . VB/C D   NSg$     NSg/VB/J   VP/J
+# P     N🅪Sg/J/P+ D/P+ NSg+ . D+  NPr/VB+ VB    R     . VB/C D   NSg$     NSg/VB/J   VP/J
 > Gatsby’s drive   with the raw      material   for   his     servants ’ dinner   — I       felt      sure he
 # NPr$     N🅪Sg/VB P    D   NSg/VB/J N🅪Sg/VB/J+ R/C/P ISg/D$+ NPl/V3+  . N🅪Sg/VB+ . ISg/#r+ N🅪Sg/VP/J J    NPr/ISg+
 > wouldn’t eat a   spoonful . A    maid began opening the upper windows  of his     house   ,
@@ -5775,7 +5775,7 @@
 > hydroplane and  the midsummer flowers   — but     outside   Gatsby’s window  it       began to
 # NSg/VB     VB/C D   NSg/J     NPrPl/V3+ . NSg/C/P Nᴹ/VB/J/P NPr$     NSg/VB+ NPr/ISg+ VPt   P
 > rain    again , so          we   stood in        a   row     looking at    the corrugated surface of the Sound      .
-# N🅪Sg/VB P     . NSg/I/J/R/C IPl+ VP    NPr/J/R/P D/P NSg/VB+ Nᴹ/Vg/J NSg/P D   VP/J       NSg/VB  P  D   N🅪Sg/VB/J+ .
+# N🅪Sg/VB R     . NSg/I/J/R/C IPl+ VP    NPr/J/R/P D/P NSg/VB+ Nᴹ/Vg/J NSg/P D   VP/J       NSg/VB  P  D   N🅪Sg/VB/J+ .
 >
 #
 > “ If    it       wasn’t for   the mist     we   could see    your home      across the bay       , ” said Gatsby .
@@ -5793,7 +5793,7 @@
 > separated him  from Daisy it       had seemed very near       to her     , almost touching  her     . It
 # VP/J      ISg+ P    NPr+  NPr/ISg+ VP  VP/J   J/R  NSg/VB/J/P P  ISg/D$+ . R      Nᴹ/Vg/J/P ISg/D$+ . NPr/ISg+
 > had seemed as    close    as    a   star   to the moon    . Now       it       was  again a   green       light     on  a
-# VP  VP/J   R/C/P NSg/VB/J R/C/P D/P NSg/VB P  D+  NPr/VB+ . NSg/J/R/C NPr/ISg+ VLPt P     D/P NPr🅪Sg/VB/J N🅪Sg/VB/J J/P D/P+
+# VP  VP/J   R/C/P NSg/VB/J R/C/P D/P NSg/VB P  D+  NPr/VB+ . NSg/J/R/C NPr/ISg+ VLPt R     D/P NPr🅪Sg/VB/J N🅪Sg/VB/J J/P D/P+
 > dock    . His     count  of enchanted objects had diminished by one     .
 # NSg/VB+ . ISg/D$+ NSg/VB P  VP/J      NPl/V3+ VP  VP/J       P  NSg/I/J .
 >
@@ -6479,7 +6479,7 @@
 > with its     own      standards and  its     own       great  figures , second   to nothing  because it
 # P    ISg/D$+ NSg/VB/J NPl       VB/C ISg/D$+ NSg/VB/J+ NSg/J+ NPl/V3+ . NSg/VB/J P  NSg/I/J+ C/P     NPr/ISg+
 > had no       consciousness of being        so          , and  now       I       was  looking at    it       again , through
-# VP  NSg/Dq/P Nᴹ            P  N🅪Sg/VLg/J/C NSg/I/J/R/C . VB/C NSg/J/R/C ISg/#r+ VLPt Nᴹ/Vg/J NSg/P NPr/ISg+ P     . J/P
+# VP  NSg/Dq/P Nᴹ            P  N🅪Sg/VLg/J/C NSg/I/J/R/C . VB/C NSg/J/R/C ISg/#r+ VLPt Nᴹ/Vg/J NSg/P NPr/ISg+ R     . J/P
 > Daisy’s eyes    . It       is  invariably saddening to look   through new   eyes    at    things upon
 # NPr$    NPl/V3+ . NPr/ISg+ VL3 R          Nᴹ/Vg/J   P  NSg/VB J/P     NSg/J NPl/V3+ NSg/P NPl+   P
 > which you    have    expended your own      powers   of adjustment .
@@ -6777,7 +6777,7 @@
 > Daisy began to sing     with the music      in        a   husky , rythmic whisper , bringing out          a
 # NPr+  VPt   P  NSg/VB/J P    D+  N🅪Sg/VB/J+ NPr/J/R/P D/P NSg/J . ?       NSg/VB  . Nᴹ/Vg/J  NSg/VB/J/R/P D/P
 > meaning    in        each word    that      it       had never had before and  would never have    again .
-# N🅪Sg/Vg/J+ NPr/J/R/P Dq   NSg/VB+ I/C/Ddem+ NPr/ISg+ VP  R     VP  C/P    VB/C VXB   R     NSg/VXB P     .
+# N🅪Sg/Vg/J+ NPr/J/R/P Dq   NSg/VB+ I/C/Ddem+ NPr/ISg+ VP  R     VP  C/P    VB/C VXB   R     NSg/VXB R     .
 > When    the melody rose      her     voice   broke     up         sweetly , following   it       , in        a   way
 # NSg/I/C D   NPr🅪Sg NPr/VPt/J ISg/D$+ NSg/VB+ NSg/VPt/J NSg/VB/J/P R       . N🅪Sg/Vg/J/P NPr/ISg+ . NPr/J/R/P D/P NSg/J+
 > contralto voices  have    , and  each change   tipped out          a   little     of her     warm     human
@@ -6959,7 +6959,7 @@
 > knew that     when    he       kissed this    girl    , and  forever wed    his     unutterable visions to
 # VPt  I/C/Ddem NSg/I/C NPr/ISg+ VP/J   I/Ddem+ NSg/VB+ . VB/C NSg/J   NSg/VB ISg/D$+ NSg/J       NPl/V3+ P
 > her     perishable breath     , his     mind    would never romp   again like         the mind   of God     . So
-# ISg/D$+ NSg/J      N🅪Sg/VB/J+ . ISg/D$+ NSg/VB+ VXB   R     NSg/VB P     NSg/VB/J/C/P D   NSg/VB P  NPr/VB+ . NSg/I/J/R/C
+# ISg/D$+ NSg/J      N🅪Sg/VB/J+ . ISg/D$+ NSg/VB+ VXB   R     NSg/VB R     NSg/VB/J/C/P D   NSg/VB P  NPr/VB+ . NSg/I/J/R/C
 > he       waited , listening for   a    moment longer to the tuning   - fork    that      had been   struck
 # NPr/ISg+ VP/J   . Nᴹ/Vg/J   R/C/P D/P+ NSg+   NSg/JC P  D+  Nᴹ/Vg/J+ . NSg/VB+ I/C/Ddem+ VP  VLPp/B VB
 > upon a    star    . Then      he       kissed her     . At    his     lips    ’ touch   she  blossomed for   him  like         a
@@ -7243,7 +7243,7 @@
 >
 #
 > As    he       left     the room     again she  got up         and  went over    to Gatsby and  pulled his     face
-# R/C/P NPr/ISg+ NPr/VP/J D+  N🅪Sg/VB+ P     ISg+ VP  NSg/VB/J/P VB/C VPt  NSg/J/P P  NPr    VB/C VP/J   ISg/D$+ NSg/VB+
+# R/C/P NPr/ISg+ NPr/VP/J D+  N🅪Sg/VB+ R     ISg+ VP  NSg/VB/J/P VB/C VPt  NSg/J/P P  NPr    VB/C VP/J   ISg/D$+ NSg/VB+
 > down        , kissing him  on  the mouth   .
 # N🅪Sg/VB/J/P . Nᴹ/Vg/J ISg+ J/P D   NSg/VB+ .
 >
@@ -7427,7 +7427,7 @@
 >
 #
 > “ Don’t be       morbid , ” Jordan said . “ Life     starts all          over    again when    it       gets   crisp
-# . VXB   NSg/VLXB J      . . NPr+   VP/J . . N🅪Sg/VB+ NPl/V3 NSg/I/J/C/Dq NSg/J/P P     NSg/I/C NPr/ISg+ NPl/V3 NSg/VB/J
+# . VXB   NSg/VLXB J      . . NPr+   VP/J . . N🅪Sg/VB+ NPl/V3 NSg/I/J/C/Dq NSg/J/P R     NSg/I/C NPr/ISg+ NPl/V3 NSg/VB/J
 > in        the fall     . ”
 # NPr/J/R/P D+  N🅪Sg/VB+ . .
 >
@@ -8645,7 +8645,7 @@
 >
 #
 > That     unfamiliar yet      recognizable look    was  back     again in        Gatsby’s face    .
-# I/C/Ddem NSg/J      NSg/VB/C J+           NSg/VB+ VLPt NSg/VB/J P     NPr/J/R/P NPr$     NSg/VB+ .
+# I/C/Ddem NSg/J      NSg/VB/C J+           NSg/VB+ VLPt NSg/VB/J R     NPr/J/R/P NPr$     NSg/VB+ .
 >
 #
 > “ That     drug    - store   business was  just small     change   , ” continued Tom     slowly , “ but
@@ -8683,7 +8683,7 @@
 >
 #
 > The voice   begged again to go       .
-# D+  NSg/VB+ VP     P     P  NSg/VB/J .
+# D+  NSg/VB+ VP     R     P  NSg/VB/J .
 >
 #
 > “ Please , Tom     ! I       can’t stand  this   any    more         . ”
@@ -8731,7 +8731,7 @@
 >
 #
 > “ Nick    ? ” He       asked again .
-# . NPr/VB+ . . NPr/ISg+ VP/J  P     .
+# . NPr/VB+ . . NPr/ISg+ VP/J  R     .
 >
 #
 > “ What   ? ”
@@ -8827,7 +8827,7 @@
 > back     later . But     he       didn’t . He       supposed he       forgot to , that’s all          . When    he       came
 # NSg/VB/J JC    . NSg/C/P NPr/ISg+ VXPt   . NPr/ISg+ VP/J     NPr/ISg+ VPt    P  . K      NSg/I/J/C/Dq . NSg/I/C NPr/ISg+ NSg/VPt/P
 > outside   again , a   little     after seven , he       was  reminded of the conversation because
-# Nᴹ/VB/J/P P     . D/P NPr/I/J/Dq P     NSg   . NPr/ISg+ VLPt VP/J     P  D+  N🅪Sg/VB+     C/P
+# Nᴹ/VB/J/P R     . D/P NPr/I/J/Dq P     NSg   . NPr/ISg+ VLPt VP/J     P  D+  N🅪Sg/VB+     C/P
 > he       heard Mrs  . Wilson’s voice   , loud  and  scolding , down        - stairs in        the garage  .
 # NPr/ISg+ VP/J  NPl+ . NPr$     NSg/VB+ . NSg/J VB/C Nᴹ/Vg/J  . N🅪Sg/VB/J/P . NPl+   NPr/J/R/P D   NSg/VB+ .
 >
@@ -8921,7 +8921,7 @@
 >
 #
 > The circle  closed up         again with a   running   murmur of expostulation ; it       was  a
-# D+  NSg/VB+ VP/J   NSg/VB/J/P P     P    D/P Nᴹ/Vg/J/P NSg/VB P  NSg+          . NPr/ISg+ VLPt D/P
+# D+  NSg/VB+ VP/J   NSg/VB/J/P R     P    D/P Nᴹ/Vg/J/P NSg/VB P  NSg+          . NPr/ISg+ VLPt D/P
 > minute    before I       could see    anything  at    all          . Then      new   arrivals deranged the line    ,
 # NSg/VB/J+ C/P    ISg/#r+ VXB   NSg/VB NSg/I/VB+ NSg/P NSg/I/J/C/Dq . NSg/J/R/C NSg/J NPl      VP/J     D   NSg/VB+ .
 > and  Jordan and  I       were pushed suddenly inside  .
@@ -8949,7 +8949,7 @@
 > heard nor   saw     . His     eyes    would drop    slowly from the swinging light      to the laden
 # VP/J  NSg/C NSg/VPt . ISg/D$+ NPl/V3+ VXB   NSg/VB+ R      P    D   Nᴹ/Vg/J  N🅪Sg/VB/J+ P  D+  VB/J+
 > table   by the wall    , and  then      jerk    back     to the light      again , and  he       gave out
-# NSg/VB+ P  D+  NPr/VB+ . VB/C NSg/J/R/C NSg/VB+ NSg/VB/J P  D+  N🅪Sg/VB/J+ P     . VB/C NPr/ISg+ VPt  NSg/VB/J/R/P
+# NSg/VB+ P  D+  NPr/VB+ . VB/C NSg/J/R/C NSg/VB+ NSg/VB/J P  D+  N🅪Sg/VB/J+ R     . VB/C NPr/ISg+ VPt  NSg/VB/J/R/P
 > incessantly his     high       , horrible call    :
 # R           ISg/D$+ NSg/VB/J/R . NSg/J    NSg/VB+ .
 >
@@ -9131,7 +9131,7 @@
 >
 #
 > “ Now       , if    you'll let     me       have    that     name    again correct  — — — ”
-# . NSg/J/R/C . NSg/C K      NSg/VBP NPr/ISg+ NSg/VXB I/C/Ddem NSg/VB+ P     NSg/VB/J . . . .
+# . NSg/J/R/C . NSg/C K      NSg/VBP NPr/ISg+ NSg/VXB I/C/Ddem NSg/VB+ R     NSg/VB/J . . . .
 >
 #
 > Picking up         Wilson like         a    doll , Tom     carried him  into the office  , set       him  down        in
@@ -9369,7 +9369,7 @@
 > She’s locked herself into her     room     , and  if    he       tries  any    brutality she’s going   to
 # K     VP/J   ISg+    P    ISg/D$+ N🅪Sg/VB+ . VB/C NSg/C NPr/ISg+ NPl/V3 I/R/Dq Nᴹ+       K     Nᴹ/Vg/J P
 > turn   the light      out          and  on  again . ”
-# NSg/VB D   N🅪Sg/VB/J+ NSg/VB/J/R/P VB/C J/P P     . .
+# NSg/VB D   N🅪Sg/VB/J+ NSg/VB/J/R/P VB/C J/P R     . .
 >
 #
 > “ He       won’t touch   her     , ” I       said . “ He’s not     thinking about her     . ”
@@ -9619,7 +9619,7 @@
 >
 #
 > When    they met again , two  days later , it       was  Gatsby who    was  breathless , who    was  ,
-# NSg/I/C IPl+ VP  P     . NSg+ NPl+ JC    . NPr/ISg+ VLPt NPr    NPr/I+ VLPt J          . NPr/I+ VLPt .
+# NSg/I/C IPl+ VP  R     . NSg+ NPl+ JC    . NPr/ISg+ VLPt NPr    NPr/I+ VLPt J          . NPr/I+ VLPt .
 > somehow , betrayed . Her     porch was  bright   with the bought luxury of star    - shine    ;
 # R       . VP/J     . ISg/D$+ NSg+  VLPt NPr/VB/J P    D   NSg/VP N🅪Sg/J P  NSg/VB+ . N🅪Sg/VB+ .
 > the wicker of the settee squeaked fashionably as    she  turned toward him  and  he
@@ -9709,9 +9709,9 @@
 >
 #
 > Through this    twilight universe Daisy began to move   again with the season  ;
-# J/P     I/Ddem+ Nᴹ/VB/J+ NPr+     NPr+  VPt   P  NSg/VB P     P    D+  NSg/VB+ .
+# J/P     I/Ddem+ Nᴹ/VB/J+ NPr+     NPr+  VPt   P  NSg/VB R     P    D+  NSg/VB+ .
 > suddenly she  was  again keeping half      a    dozen dates   a   day    with half      a    dozen men  ,
-# R        ISg+ VLPt P     Nᴹ/Vg/J N🅪Sg/J/P+ D/P+ NSg   NPl/V3+ D/P NPr🅪Sg P    N🅪Sg/J/P+ D/P+ NSg+  NPl+ .
+# R        ISg+ VLPt R     Nᴹ/Vg/J N🅪Sg/J/P+ D/P+ NSg   NPl/V3+ D/P NPr🅪Sg P    N🅪Sg/J/P+ D/P+ NSg+  NPl+ .
 > and  drowsing asleep at    dawn       with the beads   and  chiffon of an  evening    dress
 # VB/C Nᴹ/Vg/J  J      NSg/P NPr🅪Sg/VB+ P    D   NPl/V3+ VB/C NSg     P  D/P N🅪Sg/Vg/J+ NSg/VB+
 > tangled among dying   orchids on  the floor   beside her     bed        . And  all          the time
@@ -10011,7 +10011,7 @@
 > care     . I       couldn’t have    talked to her     across a   tea      - table   that      day     if    I       never
 # N🅪Sg/VB+ . ISg/#r+ VXB      NSg/VXB VP/J   P  ISg/D$+ NSg/P  D/P N🅪Sg/VB+ . NSg/VB+ I/C/Ddem+ NPr🅪Sg+ NSg/C ISg/#r+ R
 > talked to her     again in        this   world   .
-# VP/J   P  ISg/D$+ P     NPr/J/R/P I/Ddem NSg/VB+ .
+# VP/J   P  ISg/D$+ R     NPr/J/R/P I/Ddem NSg/VB+ .
 >
 #
 > I       called Gatsby’s house   a   few      minutes later , but     the line    was  busy     . I       tried four
@@ -10091,7 +10091,7 @@
 > But     when    he       heard himself say    this    , he       flinched and  began to cry    “ Oh     , my  God     ! ”
 # NSg/C/P NSg/I/C NPr/ISg+ VP/J  ISg+    NSg/VB I/Ddem+ . NPr/ISg+ VP/J     VB/C VPt   P  NSg/VB . NPr/VB . D$+ NPr/VB+ . .
 > again in        his     groaning voice   . Michaelis made a   clumsy attempt to distract him  .
-# P     NPr/J/R/P ISg/D$+ Nᴹ/Vg/J  NSg/VB+ . ?         VP   D/P NSg/J  NSg/VB+ P  NSg/VB/J ISg+ .
+# R     NPr/J/R/P ISg/D$+ Nᴹ/Vg/J  NSg/VB+ . ?         VP   D/P NSg/J  NSg/VB+ P  NSg/VB/J ISg+ .
 >
 #
 > “ How   long     have    you    been   married  , George ? Come       on  there , try      and  sit    still      a
@@ -10207,7 +10207,7 @@
 > some     of these   same explanations before , from Myrtle , because he       began saying
 # I/J/R/Dq P  I/Ddem+ I/J+ NPl+         C/P    . P    NPr    . C/P     NPr/ISg+ VPt   N🅪Sg/Vg/J
 > “ Oh     , my  God     ! ” again in        a   whisper — his     comforter left     several explanations in        the
-# . NPr/VB . D$+ NPr/VB+ . . P     NPr/J/R/P D/P NSg/VB+ . ISg/D$+ NSg+      NPr/VP/J J/Dq    NPl          NPr/J/R/P D+
+# . NPr/VB . D$+ NPr/VB+ . . R     NPr/J/R/P D/P NSg/VB+ . ISg/D$+ NSg+      NPr/VP/J J/Dq    NPl          NPr/J/R/P D+
 > air      .
 # N🅪Sg/VB+ .
 >
@@ -10269,7 +10269,7 @@
 >
 #
 > He       began to rock      again , and  Michaelis stood twisting the leash   in        his     hand    .
-# NPr/ISg+ VPt   P  NPr🅪Sg/VB P     . VB/C ?         VP    Nᴹ/Vg/J  D+  NSg/VB+ NPr/J/R/P ISg/D$+ NSg/VB+ .
+# NPr/ISg+ VPt   P  NPr🅪Sg/VB R     . VB/C ?         VP    Nᴹ/Vg/J  D+  NSg/VB+ NPr/J/R/P ISg/D$+ NSg/VB+ .
 >
 #
 > “ Maybe   you    got some      friend    that      I       could telephone for   , George ? ”
@@ -10563,7 +10563,7 @@
 >
 #
 > “ Will    you    ring    again ? ”
-# . NPr/VXB ISgPl+ NSg/VB+ P     . .
+# . NPr/VXB ISgPl+ NSg/VB+ R     . .
 >
 #
 > “ I’ve rung      them     three times   . ”
@@ -10993,7 +10993,7 @@
 >
 #
 > “ Oh     - h      ! ” She  looked at    me       over    again . ‘ ‘ Will    you    just — What   was  your name    ? ”
-# . NPr/VB . NSg/J+ . . ISg+ VP/J   NSg/P NPr/ISg+ NSg/J/P P     . . . NPr/VXB ISgPl+ J/R  . NSg/I+ VLPt D$+  NSg/VB+ . .
+# . NPr/VB . NSg/J+ . . ISg+ VP/J   NSg/P NPr/ISg+ NSg/J/P R     . . . NPr/VXB ISgPl+ J/R  . NSg/I+ VLPt D$+  NSg/VB+ . .
 >
 #
 > She  vanished . In        a    moment Meyer Wolfsheim stood solemnly in        the doorway , holding
@@ -11305,7 +11305,7 @@
 >
 #
 > He       took off        his     glasses and  wiped them     again , outside   and  in        .
-# NPr/ISg+ VPt  NSg/VB/J/P ISg/D$+ NPl/V3+ VB/C VP/J  NSg/IPl+ P     . Nᴹ/VB/J/P VB/C NPr/J/R/P .
+# NPr/ISg+ VPt  NSg/VB/J/P ISg/D$+ NPl/V3+ VB/C VP/J  NSg/IPl+ R     . Nᴹ/VB/J/P VB/C NPr/J/R/P .
 >
 #
 > “ The poor     son     - of - a   - bitch  , ” he       said .
@@ -11347,7 +11347,7 @@
 > cold  vestibules , unutterably aware of our identity with this   country for   one
 # NSg/J NPl/V3     . R           VB/J  P  D$+ NSg+     P    I/Ddem NSg/J+  R/C/P NSg/I/J
 > strange  hour , before we   melted indistinguishably into it       again .
-# NSg/VB/J NSg+ . C/P    IPl+ VP/J   R                 P    NPr/ISg+ P     .
+# NSg/VB/J NSg+ . C/P    IPl+ VP/J   R                 P    NPr/ISg+ R     .
 >
 #
 > That’s my  Middle   West      — not     the wheat  or    the prairies or    the lost Swede   towns , but
@@ -11431,7 +11431,7 @@
 > head      , but     I       pretended to be       surprised . For   just a    minute    I       wondered if    I       wasn’t
 # NPr/VB/J+ . NSg/C/P ISg/#r+ VP/J      P  NSg/VLXB VP/J      . R/C/P J/R  D/P+ NSg/VB/J+ ISg/#r+ VP/J     NSg/C ISg/#r+ VPt
 > making  a   mistake , then      I       thought it       all          over    again quickly and  got up         to say
-# Nᴹ/Vg/J D/P NSg/VB+ . NSg/J/R/C ISg/#r+ N🅪Sg/VP NPr/ISg+ NSg/I/J/C/Dq NSg/J/P P     R       VB/C VP  NSg/VB/J/P P  NSg/VB
+# Nᴹ/Vg/J D/P NSg/VB+ . NSg/J/R/C ISg/#r+ N🅪Sg/VP NPr/ISg+ NSg/I/J/C/Dq NSg/J/P R     R       VB/C VP  NSg/VB/J/P P  NSg/VB
 > good     - by .
 # NPr/VB/J . P  .
 >


### PR DESCRIPTION
# Issues 
Fixes #3960
Fixes #4013
Fixes #4014
Fixes #4015
Fixes #4016

# Description

I discovered a couple of very common adverbs had the wrong POS while working on my [`posslq`](https://github.com/Automattic/harper/pull/3968) tool.
A few GitHub issues had been file about words missing from the dictionary which I'm not adding or correcting.

-again - preposition→again
-meanwhile - add adverb, don't generate possessive +analyte
+interfacility
+bazzite
+SteamOS
-untoasted - typo fixed

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
