### PR TITLE
fix(desktop): restore tray-only window behavior

### DIFF
--- a/harper-desktop/src-tauri/src/lib.rs
+++ b/harper-desktop/src-tauri/src/lib.rs
@@ -166,7 +166,22 @@ pub fn run_tauri() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_os::init())
         .invoke_handler(commands::application_message_handler())
+        .on_window_event(|window, event| {
+            if windows::is_user_window(window.label())
+                && let tauri::WindowEvent::CloseRequested { api, .. } = event
+            {
+                api.prevent_close();
+
+                if let Err(error) = windows::hide_user_window(window) {
+                    error!("failed to hide {} window: {error}", window.label());
+                }
+            }
+        })
         .setup(move |app| {
+            #[cfg(target_os = "macos")]
+            app.handle()
+                .set_activation_policy(tauri::ActivationPolicy::Accessory)?;
+
             app.handle()
                 .plugin(tauri_plugin_updater::Builder::new().build())?;
 

--- a/harper-desktop/src-tauri/src/windows.rs
+++ b/harper-desktop/src-tauri/src/windows.rs
@@ -1,21 +1,40 @@
 //! Functions to manage the main windows involved in Harper Desktop
 
-use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri::{Manager, WebviewUrl, WebviewWindow, WebviewWindowBuilder, Window};
 use tauri_plugin_opener::OpenerExt;
 use tracing::error;
 
+const EDITOR_WINDOW_LABEL: &str = "editor";
+const SETTINGS_WINDOW_LABEL: &str = "settings";
+const USER_WINDOW_LABELS: [&str; 2] = [EDITOR_WINDOW_LABEL, SETTINGS_WINDOW_LABEL];
+
+pub fn is_user_window(label: &str) -> bool {
+    USER_WINDOW_LABELS.contains(&label)
+}
+
+fn show_existing_window(window: &WebviewWindow) -> tauri::Result<()> {
+    window.unminimize()?;
+    window.show()?;
+    window.set_focus()
+}
+
 /// Open the editor window, focusing it if it already exists.
 pub fn show_editor_window(app: &tauri::AppHandle) -> tauri::Result<()> {
-    if let Some(window) = app.get_webview_window("editor") {
-        window.show()?;
-        window.set_focus()?;
-        return Ok(());
+    #[cfg(target_os = "macos")]
+    app.set_activation_policy(tauri::ActivationPolicy::Regular)?;
+
+    if let Some(window) = app.get_webview_window(EDITOR_WINDOW_LABEL) {
+        return show_existing_window(&window);
     }
 
-    let window = WebviewWindowBuilder::new(app, "editor", WebviewUrl::App("index.html".into()))
-        .title("Harper")
-        .inner_size(800.0, 600.0)
-        .build()?;
+    let window = WebviewWindowBuilder::new(
+        app,
+        EDITOR_WINDOW_LABEL,
+        WebviewUrl::App("index.html".into()),
+    )
+    .title("Harper")
+    .inner_size(800.0, 600.0)
+    .build()?;
     window.set_focus()?;
 
     Ok(())
@@ -23,24 +42,55 @@ pub fn show_editor_window(app: &tauri::AppHandle) -> tauri::Result<()> {
 
 /// Open the settings window, focusing it if it already exists.
 pub fn show_settings_window(app: &tauri::AppHandle) -> tauri::Result<()> {
-    if let Some(window) = app.get_webview_window("settings") {
-        window.show()?;
-        window.set_focus()?;
-        return Ok(());
+    #[cfg(target_os = "macos")]
+    app.set_activation_policy(tauri::ActivationPolicy::Regular)?;
+
+    if let Some(window) = app.get_webview_window(SETTINGS_WINDOW_LABEL) {
+        return show_existing_window(&window);
     }
 
-    WebviewWindowBuilder::new(app, "settings", WebviewUrl::App("index.html".into()))
-        .title("Harper Settings")
-        .inner_size(920.0, 680.0)
-        .min_inner_size(780.0, 520.0)
-        .center()
-        .build()?;
+    WebviewWindowBuilder::new(
+        app,
+        SETTINGS_WINDOW_LABEL,
+        WebviewUrl::App("index.html".into()),
+    )
+    .title("Harper Settings")
+    .inner_size(920.0, 680.0)
+    .min_inner_size(780.0, 520.0)
+    .center()
+    .build()?;
 
     Ok(())
 }
 
+pub fn hide_user_window(window: &Window) -> tauri::Result<()> {
+    window.hide()?;
+
+    #[cfg(target_os = "macos")]
+    if !has_visible_or_minimized_user_window(window.app_handle())? {
+        window
+            .app_handle()
+            .set_activation_policy(tauri::ActivationPolicy::Accessory)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn has_visible_or_minimized_user_window(app: &tauri::AppHandle) -> tauri::Result<bool> {
+    for label in USER_WINDOW_LABELS {
+        if let Some(window) = app.get_webview_window(label)
+            && (window.is_visible()? || window.is_minimized()?)
+        {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
 /// Open the browser to an issue report page.
-pub fn open_issue_report(app: &AppHandle) {
+pub fn open_issue_report(app: &tauri::AppHandle) {
     let _ = app
         .opener()
         .open_url(


### PR DESCRIPTION
> This PR was implemented by an AI agent working interactively under @mauropereiira's direction. The diff and test results were reviewed before submission.

# Issues

Fixes #3705.

This also restores close handling that was removed unintentionally while window and tray code were reorganized in #3779.

# Description

Harper previously intercepted close requests for Editor and Settings, prevented destruction, and hid those windows. After #3779, the red close button destroys the window instead. The main process also remains a regular macOS application while tray-only, leaving a permanent Dock icon.

This change:

- Restores `CloseRequested -> prevent_close -> hide` for Editor and Settings.
- Switches macOS to Accessory activation policy when Harper starts tray-only.
- Switches to Regular before showing Editor or Settings.
- Returns to Accessory after the final visible user window is hidden.
- Keeps Regular while another Harper window is visible or minimized.
- Unminimizes existing windows before showing and focusing them from the tray.
- Leaves the yellow minimize button's native Dock behavior unchanged.
- Leaves tray Quit and Command-Q on Tauri's normal exit path.

No Dock preference, single-instance plugin, reopen handler, or tray refresh changes are included.

# Demo

The built macOS app reported Regular activation policy (`0`) while Settings was visible and Accessory (`1`) after a tray-only relaunch. The parent and highlighter processes remained active in tray-only mode.

# How Has This Been Tested?

- `cargo check -p harper-desktop --all-targets`
- `cargo clippy -p harper-desktop --all-targets -- -D warnings`
- `cargo test -p harper-desktop --lib` (52 passed)
- `just format`
- `just check-desktop` on a combined branch containing all three desktop fixes
- Built and launched an Apple Silicon `.app` bundle with Tauri
- Manually verified Regular policy with Settings visible and Accessory policy on tray-only startup

The native red-close and yellow-minimize interactions still need a final hands-on pass because synthetic clicks are blocked by macOS Accessibility permissions in the test shell.

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [x] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter

Not applicable.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.