### PR TITLE
Fix/slack quill editor linting

### DIFF
--- a/packages/chrome-plugin/src/contentScript/index.ts
+++ b/packages/chrome-plugin/src/contentScript/index.ts
@@ -165,12 +165,18 @@ function scan() {
 		}
 
 		const isLexicalEditor = element.getAttribute('data-lexical-editor') === 'true';
+		// Slack's message compose box (Quill-based) sets spellcheck="false" and provides its own
+		// spelling/autocomplete UI, but otherwise behaves like a normal rich-text contenteditable
+		// editor, so treat it the same way we treat Lexical editors: don't skip it purely because
+		// spellcheck is disabled.
+		const isQuillEditor = element.classList.contains('ql-editor');
 
 		if (
 			element.matches('[role="combobox"]') ||
 			element.getAttribute('data-enable-grammarly') === 'false' ||
 			(element.getAttribute('spellcheck') === 'false' &&
 				!isLexicalEditor &&
+				!isQuillEditor &&
 				element.getAttribute('data-language') !== 'markdown')
 		) {
 			return;

--- a/packages/lint-framework/src/lint/LintFramework.ts
+++ b/packages/lint-framework/src/lint/LintFramework.ts
@@ -240,6 +240,10 @@ export default class LintFramework {
 					if (caretPosition != null) {
 						const closestIdx = closestBox(caretPosition, this.lastBoxes);
 
+						if (closestIdx < 0) {
+							return;
+						}
+
 						const previousBox = this.lastBoxes[closestIdx];
 						const suggestions = previousBox.lint.suggestions;
 						if (suggestions.length > 0) {


### PR DESCRIPTION
# Issues
Fixes #4032

# Description
Harper's browser extension does not lint text in Slack's web app (app.slack.com). No underlines appear under obvious typos in the message compose box, and manually triggering the linter via the lint hotkey (e.g. Ctrl+E) throws a JS error instead of running.

Two separate bugs combine to produce this symptom:

1. **Slack's compose box is never added as a lint target.** Slack's message compose box is a Quill-based `contenteditable` div. Slack sets `spellcheck="false"` on it because it provides its own spelling/autocomplete UI. The content script's scanning logic in `packages/chrome-plugin/src/contentScript/index.ts` already carves out an exception for Lexical editors so they aren't skipped just for having `spellcheck="false"`, but no equivalent exception existed for Quill editors. As a result, Slack's compose box was silently excluded from every scan and Harper never lints it.

2. **The lint hotkey crashes when there are no lint boxes.** In `packages/lint-framework/src/lint/LintFramework.ts`, the hotkey handler calls `closestBox(caretPosition, this.lastBoxes)`, which returns `-1` when there is nothing to match against. The handler then indexed into `this.lastBoxes[-1]` (`undefined` in JS) and immediately read `.lint` off it, throwing:

```
TypeError: can't access property "lint", m is undefined
```

`PopupHandler.ts` already guards this exact case with `if (closestIdx >= 0)`; the hotkey path was just missing the same guard.

Bug 2 is why pressing the lint hotkey on Slack throws instead of silently doing nothing, but bug 1 is the actual reason no linting/underlining ever happens on Slack in the first place.

**Fix**
- `packages/chrome-plugin/src/contentScript/index.ts`: treat Quill editors (`element.classList.contains('ql-editor')`) the same way Lexical editors are already treated, so `spellcheck="false"` alone doesn't exclude them from scanning.
- `packages/lint-framework/src/lint/LintFramework.ts`: add the missing `if (closestIdx < 0) return;` bounds check in the hotkey handler, mirroring the existing guard in `PopupHandler.ts`.

# Demo
N/A — see console error quoted in the linked issue (#4032) and repro steps below; no screenshot attached.

# How Has This Been Tested?
Built the extension from source (`just build-firefox-plugin`), loaded it as a temporary add-on in Firefox, and manually verified against a live Slack workspace:

1. Installed Harper's Firefox extension and confirmed it's enabled on the site.
2. Went to a Slack workspace at app.slack.com.
3. Typed text with an obvious typo into a message compose box, e.g. `this text is fuul of errrors.`
4. Before the fix: no underlines appeared, and pressing Ctrl+E threw the TypeError described in #4032.
5. After the fix: typos in the compose box are underlined by Harper, and the lint hotkey works without throwing.

Platform tested: Firefox extension, macOS. Chrome-based browsers likely affected too since both packages share `packages/chrome-plugin/src/contentScript/index.ts`, though not explicitly tested there.

# AI Disclosure
- [x] I used an AI agent interactively.

# If Your PR Implements or Enhances a Linter
N/A — not a linter rule change.

# Checklist
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.