### PR TITLE
fix(core): flag possessive "it's" after "has" and "had"

### DIFF
--- a/harper-core/src/linting/its_possessive.rs
+++ b/harper-core/src/linting/its_possessive.rs
@@ -23,7 +23,13 @@ impl Default for ItsPossessive {
             .t_ws()
             .then(UPOSSet::new(&[UPOS::ADJ]));
 
-        let mid_sentence = SequenceExpr::with(UPOSSet::new(&[UPOS::VERB, UPOS::ADP]))
+        // The Brill tagger labels possessive "has" and "had" as AUX rather than
+        // VERB, so they are not covered by the sets above. Other forms ("have",
+        // "hasn't", "hadn't") already tag as VERB and need no special handling.
+        let mid_sentence_lead =
+            UPOSSet::new(&[UPOS::VERB, UPOS::ADP]).or(SequenceExpr::word_set(&["has", "had"]));
+
+        let mid_sentence = SequenceExpr::with(mid_sentence_lead)
             .t_ws()
             .t_aco("it's")
             .then_optional(adj_term_mid_sentence)
@@ -180,6 +186,52 @@ mod tests {
     #[test]
     fn engine_lost_its_compression() {
         assert_lint_count("The engine lost it's compression.", test_linter(), 1);
+    }
+
+    #[test]
+    fn issue_3627_has_its_own_stack() {
+        assert_suggestion_result(
+            "The child process has it's own stack.",
+            test_linter(),
+            "The child process has its own stack.",
+        );
+    }
+
+    #[test]
+    fn company_has_its_own_rules() {
+        assert_suggestion_result(
+            "The company has it's own rules.",
+            test_linter(),
+            "The company has its own rules.",
+        );
+    }
+
+    #[test]
+    fn process_had_its_own_stack() {
+        assert_suggestion_result(
+            "The process had it's own stack.",
+            test_linter(),
+            "The process had its own stack.",
+        );
+    }
+
+    #[test]
+    fn company_has_its_new_rules() {
+        assert_suggestion_result(
+            "The company has it's new rules.",
+            test_linter(),
+            "The company has its new rules.",
+        );
+    }
+
+    #[test]
+    fn allows_problem_is_its_poor_design() {
+        assert_no_lints("The problem is it's poor design.", test_linter());
+    }
+
+    #[test]
+    fn allows_reason_is_its_bad_code() {
+        assert_no_lints("The reason is it's bad code.", test_linter());
     }
 
     #[test]


### PR DESCRIPTION
# Issues

Fixes #3627

# Description

`ItsPossessive`'s mid-sentence expression required the token immediately before `it's` to tag as `VERB` or `ADP`:

```rust
let mid_sentence = SequenceExpr::with(UPOSSet::new(&[UPOS::VERB, UPOS::ADP]))
```

Harper's Brill tagger labels possessive **"has"** and **"had"** as `AUX`, not `VERB`. So the whole `has it's <adjective> <noun>` class was never matched, which is why the reporter's "but has **it's** own stack" went unflagged.

The word "own" turned out to be a red herring. It tags as `ADJ` and already matched fine after a true verb. On master, before this patch:

```
The company lost it's own rules.   ->  ItsPossessive fires
The company has  it's own rules.   ->  no lint
The company lost it's new rules.   ->  ItsPossessive fires
The company has  it's new rules.   ->  no lint
```

Only the preceding word differs between those pairs, so the gap is the tag on the verb, not anything about the noun phrase.

This adds "has" and "had" to the leading token set. I deliberately did **not** add `UPOS::AUX` wholesale, because the copula also tags `AUX`, and that would introduce false positives on sentences like "The problem is it's poor design.", where `it's` genuinely means "it is". Both of those cases are covered by new regression tests.

I also checked "have", "hasn't" and "hadn't": they already tag as `VERB` in this position and match without any change, so they are not in the set.

Scope note: this touches one file and does not modify `default_config.json`, since `ItsPossessive` is already registered and enabled.

# Demo

Not applicable, this is a linter rule change. CLI output is below.

# How Has This Been Tested?

`cargo test -p harper-core` — 6125 + 41 tests pass, 0 failures, no snapshot changes.

Manually with `cargo run --bin harper-cli --release -- lint`, comparing a build of `master` against this branch.

Now flagged, previously silent:

```
The child process has it's own stack.   ->  ItsPossessive
The company has it's own rules.         ->  ItsPossessive
The process had it's own stack.         ->  ItsPossessive
The company has it's new rules.         ->  ItsPossessive
```

Still clean, regression guards:

```
The problem is it's poor design.
The reason is it's bad code.
It's hard to tell from here.
it's good practice to review the general settings
```

Unchanged, paths that already worked:

```
Some libraries have it's own parser.    ->  ItsPossessive
The process hasn't it's own stack.      ->  ItsPossessive
The company lost it's various colors.   ->  ItsPossessive
```

# AI Disclosure

- [x] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter

- [x] I'm using examples from the bug report / feature request.

The "has it's own stack" case comes directly from the issue. The remaining sentences are minimal variations built to isolate the `AUX` vs `VERB` distinction and to pin the copular false positives.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.

Related but deliberately excluded, happy to open these separately:

1. `ItsPossessive` does not match typographic apostrophes. `The project drifted from it’s goal.` is silent, while the straight-quote version flags. That is issue #3202, and the cause is different: `t_aco` is backed by `Word`, which compares chars directly, whereas `WordSet` normalises the apostrophe (see the `supports_typographic_apostrophes` test in `word_set.rs`). Worth deciding whether `Word` should normalise too, since that would affect many linters, so I did not touch it here.
2. Possible pre-existing false positive, unrelated to this change: `I have heard it's good news.` flags on master today, where `it's` correctly means "it is".
