### PR TITLE
fix(core): add "understand" to the irregular verb list

### DIFF
--- a/harper-core/irregular_verbs.json
+++ b/harper-core/irregular_verbs.json
@@ -134,6 +134,7 @@
 	["think", "thought", "thought"],
 	["throw", "threw", "thrown"],
 	["tread", "trod", "trodden"],
+	["understand", "understood", "understood"],
 	["undo", "undid", "undone"],
 	["wake", "woke", "woken"],
 	["wear", "wore", "worn"],

--- a/harper-core/src/linting/did_past.rs
+++ b/harper-core/src/linting/did_past.rs
@@ -303,4 +303,30 @@ mod tests {
             DidPast::new(FstDictionary::curated()),
         );
     }
+
+    #[test]
+    fn issue_3916_didnt_understood() {
+        assert_suggestion_result(
+            "I didn't understood the problem.",
+            DidPast::new(FstDictionary::curated()),
+            "I didn't understand the problem.",
+        );
+    }
+
+    #[test]
+    fn issue_3916_did_understood() {
+        assert_suggestion_result(
+            "I did understood the problem.",
+            DidPast::new(FstDictionary::curated()),
+            "I did understand the problem.",
+        );
+    }
+
+    #[test]
+    fn issue_3916_correct_usage() {
+        assert_no_lints(
+            "I didn't understand the problem.",
+            DidPast::new(FstDictionary::curated()),
+        );
+    }
 }


### PR DESCRIPTION
# Issues

Fixes #3916

# Description

The issue title points at the negation, but that turned out not to be the cause. `DidPast` already handles "didn't" fine:

```
I didn't went there.         ->  DidPast fires
I didn't brought the book.   ->  DidPast fires
I didn't broke it.           ->  DidPast fires
I did understood it.         ->  no lint     <- fails in the POSITIVE form too
I didn't understood it.      ->  no lint
```

Since it fails without the negation as well, the problem is the verb.

`DidPast` derives the base form through `harper-core/irregular_verbs.json`, and "understand" is simply not in that file. Without an entry it cannot map "understood" back to "understand", so it produces no suggestion and emits no lint at all. The control case proves it: `I did stood there.` **does** flag, because `["stand", "stood", "stood"]` is already present.

The fix is one data entry:

```json
["understand", "understood", "understood"],
```

Inserted in the file's existing alphabetical position, between "tread" and "undo".

# Demo

Not applicable, CLI output below.

# How Has This Been Tested?

`cargo test -p harper-core` — 6164 passed, 0 failed, 290 ignored. No snapshot changes.

Manually with `cargo run --bin harper-cli --release -- lint`, comparing a build of `master` against this branch:

Now flagged, previously silent:

```
I didn't understood anything about the thread.  ->  DidPast
I didn't understood the problem.                ->  DidPast
I did understood the problem.                   ->  DidPast
```

Still clean:

```
I didn't understand the problem.
I understood the problem.
She understood it perfectly.
```

Unchanged, already worked before:

```
I didn't went there.   ->  DidPast
I did stood there.     ->  DidPast
```

# AI Disclosure

- [x] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter

- [x] I'm using examples from the bug report / feature request.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.

Deliberately kept out of scope, happy to open a follow-up if you want it:

While confirming the cause I checked the rest of the file. `irregular_verbs.json` has the base verbs but is missing a number of their common derived forms, so the same false negative applies to all of these:

`misunderstand`, `withstand`, `undertake`, `forgive`, `overcome`, `undergo`, `foresee`, `oversee`, `rewrite`, `withdraw`, `uphold`, `withhold`, `forsake`, `beset`, `rebuild`, `unwind`, `outgrow`, `overhear`, `retake`, `befall`

For example `I did misunderstood it.` and `I did withdrew the money.` are both silent today. That looked like a curation change rather than a bug fix, and it seemed better to keep this PR to the one verb the issue actually reports. Let me know if you would like the rest as a separate PR.
