### PR TITLE
chore: add "first founded" to `RedundantFirsts`

### DIFF
--- a/harper-core/src/linting/redundant_firsts.rs
+++ b/harper-core/src/linting/redundant_firsts.rs
@@ -14,6 +14,7 @@ enum RedundancyLevel {
 const VERBS: &[(&str, RedundancyLevel)] = &[
     ("coined", RedundancyLevel::Probable),
     ("discovered", RedundancyLevel::Probable),
+    ("founded", RedundancyLevel::Probable),
     ("introduced", RedundancyLevel::Possible),
     ("invented", RedundancyLevel::Probable),
     ("originated", RedundancyLevel::Probable),
@@ -170,6 +171,16 @@ mod tests {
             "I've just discovered Harper for the first time, but already struck a number of issues, which I have raised in GitHub",
             RedundantFirsts::default(),
             "I've just discovered Harper, but already struck a number of issues, which I have raised in GitHub",
+        );
+    }
+
+    // Gröna Lund (a name which translates to “Green Grove”) was first founded in 1883, when German showman Jacob Schultheis rented a patch of land on the waterfront in Stockholm.
+    #[test]
+    fn fix_first_founded() {
+        assert_suggestion_result(
+            "Gröna Lund (a name which translates to “Green Grove”) was first founded in 1883, when German showman Jacob Schultheis rented a patch of land on the waterfront in Stockholm.",
+            RedundantFirsts::default(),
+            "Gröna Lund (a name which translates to “Green Grove”) was founded in 1883, when German showman Jacob Schultheis rented a patch of land on the waterfront in Stockholm.",
         );
     }
 }

--- a/harper-core/src/linting/redundant_firsts.rs
+++ b/harper-core/src/linting/redundant_firsts.rs
@@ -174,7 +174,6 @@ mod tests {
         );
     }
 
-    // Gröna Lund (a name which translates to “Green Grove”) was first founded in 1883, when German showman Jacob Schultheis rented a patch of land on the waterfront in Stockholm.
     #[test]
     fn fix_first_founded() {
         assert_suggestion_result(


### PR DESCRIPTION
# Issues 
N/A

# Description

Watching a YouTube video I heard them say a company or something was "first founded" in a certain year. No mention of any of the other times it was founded. So it seems like a perfect candidate for the `RedundantFirsts` linter.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
