### PR TITLE
feat: look-a-like→lookalike/look-alike

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -2604,6 +2604,13 @@
 						},
 						{
 							"Bool": {
+								"name": "Lookalike",
+								"state": true,
+								"label": "Lookalike"
+							}
+						},
+						{
+							"Bool": {
 								"name": "LooksLikes",
 								"state": true,
 								"label": "Looks Likes"

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -32928,6 +32928,7 @@ loofahs/N9Vh
 look/~Vd>GSNgZ
 look up/V/
 lookalike/NgS
+look-alike/NgS
 looker/NgS
 lookout/~NgS
 lookup/~NSV

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -892,6 +892,15 @@ pub fn lint_group() -> LintGroup {
             "Corrects `level of details` to `level of detail` or `levels of detail`.",
             LintKind::Usage
         ),
+        "Lookalike" => (
+            &[
+                (&["look-a-like"], &["lookalike", "look-alike"]),
+                (&["look-a-likes"], &["lookalikes", "look-alikes"])
+            ],
+            "Use `look alike` or `look-alike` instead of `look-a-like`.",
+            "Corrects `look-a-like` to `look alike` or `look-alike`.",
+            LintKind::Spelling
+        ),
         "MakeItSeem" => (
             &[
                 (&["make it seems"], &["make it seem"]),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -2967,6 +2967,34 @@ fn corrects_levels_of_details_real_world() {
     );
 }
 
+// Lookalike
+
+#[test]
+fn corrects_look_a_like() {
+    assert_good_and_bad_suggestions(
+        "Define the look-a-like of the cursor/mouse pointer:",
+        test_linter(),
+        &[
+            "Define the lookalike of the cursor/mouse pointer:",
+            "Define the look-alike of the cursor/mouse pointer:",
+        ],
+        &[],
+    );
+}
+
+#[test]
+fn corrects_look_a_likes() {
+    assert_good_and_bad_suggestions(
+        "Attempt at using AWS facial recognition to find look-a-likes in the Rijksmuseum's art collection.",
+        test_linter(),
+        &[
+            "Attempt at using AWS facial recognition to find lookalikes in the Rijksmuseum's art collection.",
+            "Attempt at using AWS facial recognition to find look-alikes in the Rijksmuseum's art collection.",
+        ],
+        &[],
+    );
+}
+
 // MakeItSeem
 
 #[test]


### PR DESCRIPTION
# Issues 
N/A

# Description

I remember spotting "look-a-like" instead of "lookalike" some time ago but apparently I never added it to Harper. Tonight I saw it in a YouTube video thumbnail so implemented it as a phrase set correction.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
