### PR TITLE
fix: keep suggestion popup within viewport

### DIFF
--- a/packages/chrome-plugin/tests/simple_textarea.spec.ts
+++ b/packages/chrome-plugin/tests/simple_textarea.spec.ts
@@ -184,30 +184,3 @@ test('Can dismiss with escape key', async ({ page }) => {
 
 	await assertLocatorIsFocused(page, editor);
 });
-
-test('Right-aligns the suggestion popup near the viewport edge', async ({ page }) => {
-	const viewportWidth = 500;
-	const viewportMargin = 8;
-	await page.setViewportSize({ width: viewportWidth, height: 500 });
-	await page.goto(TEST_PAGE_URL);
-
-	const editor = getTextarea(page);
-	await editor.evaluate((element) => {
-		Object.assign(element.style, {
-			position: 'fixed',
-			right: '0',
-			top: '40px',
-			width: '110px',
-		});
-	});
-	await replaceEditorContent(editor, 'This is an test');
-
-	expect(await clickHarperHighlight(page)).toBe(true);
-	const popup = page.locator('.harper-container');
-	await expect(popup).toBeVisible();
-	await expect(popup).toHaveCSS('right', `${viewportMargin}px`);
-
-	const popupBox = await popup.boundingBox();
-	expect(popupBox).not.toBeNull();
-	expect(popupBox!.x + popupBox!.width).toBeLessThanOrEqual(viewportWidth - viewportMargin);
-});

--- a/packages/chrome-plugin/tests/simple_textarea.spec.ts
+++ b/packages/chrome-plugin/tests/simple_textarea.spec.ts
@@ -184,3 +184,30 @@ test('Can dismiss with escape key', async ({ page }) => {
 
 	await assertLocatorIsFocused(page, editor);
 });
+
+test('Right-aligns the suggestion popup near the viewport edge', async ({ page }) => {
+	const viewportWidth = 500;
+	const viewportMargin = 8;
+	await page.setViewportSize({ width: viewportWidth, height: 500 });
+	await page.goto(TEST_PAGE_URL);
+
+	const editor = getTextarea(page);
+	await editor.evaluate((element) => {
+		Object.assign(element.style, {
+			position: 'fixed',
+			right: '0',
+			top: '40px',
+			width: '110px',
+		});
+	});
+	await replaceEditorContent(editor, 'This is an test');
+
+	expect(await clickHarperHighlight(page)).toBe(true);
+	const popup = page.locator('.harper-container');
+	await expect(popup).toBeVisible();
+	await expect(popup).toHaveCSS('right', `${viewportMargin}px`);
+
+	const popupBox = await popup.boundingBox();
+	expect(popupBox).not.toBeNull();
+	expect(popupBox!.x + popupBox!.width).toBeLessThanOrEqual(viewportWidth - viewportMargin);
+});

--- a/packages/lint-framework/src/lint/SuggestionBox.ts
+++ b/packages/lint-framework/src/lint/SuggestionBox.ts
@@ -16,6 +16,8 @@ function iconSvg(definition: IconDefinition): string {
 
 const settingsIconSvg = iconSvg(faSliders);
 const disableIconSvg = iconSvg(faToggleOff);
+const SUGGESTION_BOX_MAX_WIDTH = 420;
+const SUGGESTION_BOX_VIEWPORT_MARGIN = 8;
 
 /** Saved cursor restore function, captured when the popup steals focus. */
 let savedRestore: (() => void) | null = null;
@@ -299,7 +301,8 @@ function styleTag(lintKind: LintKind) {
       border-radius:0.25rem
       }
       .harper-container{
-      max-width:420px;
+      max-width:${SUGGESTION_BOX_MAX_WIDTH}px;
+      box-sizing:border-box;
       max-height:400px;
       overflow-y:auto;
       background:#ffffff;
@@ -506,6 +509,9 @@ export default function SuggestionBox(
 	const top = box.y + box.height + 3;
 	let bottom: number | undefined;
 	const left = box.x;
+	const alignRight =
+		left + SUGGESTION_BOX_MAX_WIDTH > window.innerWidth - SUGGESTION_BOX_VIEWPORT_MARGIN;
+	const horizontalOrigin = alignRight ? 'right' : 'left';
 
 	if (top + 400 > window.innerHeight) {
 		bottom = window.innerHeight - box.y - 3;
@@ -515,8 +521,9 @@ export default function SuggestionBox(
 		position: 'fixed',
 		top: bottom ? '' : `${top}px`,
 		bottom: bottom ? `${bottom}px` : '',
-		left: `${left}px`,
-		transformOrigin: `${bottom ? 'bottom' : 'top'} left`,
+		left: alignRight ? '' : `${left}px`,
+		right: alignRight ? `${SUGGESTION_BOX_VIEWPORT_MARGIN}px` : '',
+		transformOrigin: `${bottom ? 'bottom' : 'top'} ${horizontalOrigin}`,
 	};
 
 	const ignoreLintCallback = box.ignoreLint;


### PR DESCRIPTION
> [!NOTE]
> This pull request was developed with AI assistance. The submitter reviewed the implementation and tests before submission.

## Summary

- Conservatively right-align suggestion popups whose configured maximum width would cross the viewport's right margin.
- Keep positioning fully represented in the virtual DOM, including an 8 px margin and the matching transform origin.
- Include padding and borders within the 420 px maximum width.

## Design decisions

I considered measuring the rendered popup and then adjusting the real DOM. That would use the popup's exact width, but `.harper-container` is owned by `virtual-dom`; changing it outside the VNode would allow the cached virtual tree and real DOM to disagree and require extra synchronization.

I also prototyped a two-pass virtual-DOM approach: render a provisional left-aligned VNode, measure its real DOM, then create and patch a right-aligned VNode when necessary. That preserves virtual/real DOM consistency, but it adds another render and VNode construction and requires preserving child and hook identity to avoid unnecessary lifecycle work.

This PR instead uses the existing 420 px maximum width as a conservative pre-render estimate. It stays single-pass and declarative, with no layout measurement. A short popup near the right edge can be right-aligned even if its rendered content would have fit; that is an accepted tradeoff for the smaller implementation and lower runtime overhead.

## Testing

- `just format`
- `pnpm --dir packages/lint-framework build`
- `pnpm --dir packages/chrome-plugin zip-for-firefox`
- Manually loaded the unpacked extension in Firefox and reproduced the Gmail right-edge scenario; both compact and expanded suggestion panels remained fully inside the viewport ([screenshots](https://github.com/Automattic/harper/pull/4079#discussion_r3849520020)).

Fixes #3972
