### PR TITLE
feat: curious on/of→curious about

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -3352,6 +3352,13 @@
 						},
 						{
 							"Bool": {
+								"name": "CuriousAbout",
+								"state": true,
+								"label": "Curious About"
+							}
+						},
+						{
+							"Bool": {
 								"name": "DoIAdjective",
 								"state": true,
 								"label": "Do I Adjective"

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -757,15 +757,6 @@ pub fn lint_group() -> LintGroup {
             "Corrects `copywrite` to `copyright`. `Copywrite` refers to writing copy, while `copyright` is the legal right to creative works.",
             LintKind::WordChoice
         ),
-        "Payed" => (
-            &[
-                (&["payed"], &["paid"]),
-                (&["overpayed"], &["overpaid"]),
-            ],
-            "Use `paid` or `overpaid` here. `Payed` is a rare nautical spelling.",
-            "Corrects `payed` to `paid` and `overpayed` to `overpaid`.",
-            LintKind::Spelling
-        ),
         "DateBackFrom" => (
             &[
                 (&["date back from"], &["date from", "date back to"]),
@@ -946,6 +937,15 @@ pub fn lint_group() -> LintGroup {
             "Corrects common misspellings of `nowadays`.",
             LintKind::Usage
         ),
+        "Payed" => (
+            &[
+                (&["payed"], &["paid"]),
+                (&["overpayed"], &["overpaid"]),
+            ],
+            "Use `paid` or `overpaid` here. `Payed` is a rare nautical spelling.",
+            "Corrects `payed` to `paid` and `overpayed` to `overpaid`.",
+            LintKind::Spelling
+        ),
         "RiseTheQuestion" => (
             &[
                 (&["rise the question", "arise the question"], &["raise the question"]),
@@ -972,6 +972,15 @@ pub fn lint_group() -> LintGroup {
             "The word `side` is redundant in this phrase.",
             "Corrects redundant `side tangent` and `side tangents` to more concise alternatives.",
             LintKind::Redundancy
+        ),
+        "ToTo" => (
+            &[
+                (&["to to"], &["to do"]),
+                (&["to-to"], &["to-do"]),
+            ],
+            "Did you mean to write `do` instead of a second `to`?",
+            "Corrects `to to` to `to do` and `to-to` to `to-do`, as they may be typos.",
+            LintKind::Typo
         ),
         "ToTooIdioms" => (
             &[
@@ -1060,15 +1069,6 @@ pub fn lint_group() -> LintGroup {
             "`Worse` is for comparing and `worst` is for the extreme case.",
             "Corrects `worse` and `worst` used in contexts where the other belongs.",
             LintKind::Agreement
-        ),
-        "ToTo" => (
-            &[
-                (&["to to"], &["to do"]),
-                (&["to-to"], &["to-do"]),
-            ],
-            "Did you mean to write `do` instead of a second `to`?",
-            "Corrects `to to` to `to do` and `to-to` to `to-do`, as they may be typos.",
-            LintKind::Typo
         ),
     });
 

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -2445,26 +2445,6 @@ fn copywrote() {
     );
 }
 
-// Payed
-
-#[test]
-fn correct_payed() {
-    assert_suggestion_result(
-        "He payed the bill yesterday.",
-        test_linter(),
-        "He paid the bill yesterday.",
-    );
-}
-
-#[test]
-fn correct_overpayed() {
-    assert_suggestion_result(
-        "He overpayed in part to have the specification met.",
-        test_linter(),
-        "He overpaid in part to have the specification met.",
-    );
-}
-
 // DateBackFrom
 
 #[test]
@@ -3231,6 +3211,26 @@ fn fix_now_aday() {
         "OF all Occupations that now aday is used,I would not be a butcher",
         test_linter(),
         "OF all Occupations that nowadays is used,I would not be a butcher",
+    );
+}
+
+// Payed
+
+#[test]
+fn correct_payed() {
+    assert_suggestion_result(
+        "He payed the bill yesterday.",
+        test_linter(),
+        "He paid the bill yesterday.",
+    );
+}
+
+#[test]
+fn correct_overpayed() {
+    assert_suggestion_result(
+        "He overpayed in part to have the specification met.",
+        test_linter(),
+        "He overpaid in part to have the specification met.",
     );
 }
 

--- a/harper-core/src/linting/weir_rules/CuriousAbout.weir
+++ b/harper-core/src/linting/weir_rules/CuriousAbout.weir
@@ -1,0 +1,11 @@
+expr main [(curious of), (curious on)]
+
+let message "Did you mean `curious about`?"
+let description "Corrects `curious of` and `curious on` to `curious about`."
+let kind "Usage"
+let becomes ["curious about"]
+
+test "we are working on in Docker in AWS but curious on recommended requirements" "we are working on in Docker in AWS but curious about recommended requirements"
+test "Curious on why QUIC works on 3.2 but not 3.3 in PUT on NonStop." "Curious about why QUIC works on 3.2 but not 3.3 in PUT on NonStop."
+test "started to get curious of how small a purpose trained LLM could be for the task" "started to get curious about how small a purpose trained LLM could be for the task"
+test "I'm curious of why this is a major performance problem for you." "I'm curious about why this is a major performance problem for you."


### PR DESCRIPTION
# Issues 
N/A

# Description

"Curious on" has been in my inbox for a while. When I started implementing it I discovered that "curious of" is also common.

I started implementing this using `phrase_set_corrections`, where I noticed a couple of entries were out of order so I sorted them. But then I decided Weir was more appropriate for this rule.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
