### PR TITLE
feat: finish touches→finishing touches

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -4552,6 +4552,13 @@
 						},
 						{
 							"Bool": {
+								"name": "FinishingTouches",
+								"state": true,
+								"label": "Finishing Touches"
+							}
+						},
+						{
+							"Bool": {
 								"name": "FirstAidKit",
 								"state": true,
 								"label": "First Aid Kit"

--- a/harper-core/src/linting/weir_rules/FinishingTouches.weir
+++ b/harper-core/src/linting/weir_rules/FinishingTouches.weir
@@ -1,0 +1,11 @@
+expr main (finish touches)
+
+let message "Use `finishing touches` instead of `finish touches`."
+let description "Corrects `finish touches` to `finishing touches`."
+let kind "Usage"
+let becomes "finishing touches"
+
+# The singular 'finishing touch' is less common and the instances of 'finish touch' are harder to classify as errors or not.
+
+test "I do not really care for user input or any other \"finish touches,\" just want to make the code more efficient" "I do not really care for user input or any other \"finishing touches,\" just want to make the code more efficient"
+test "In the meantime, the customer got talked into using Oracle as we were getting the finish touches for delivery." "In the meantime, the customer got talked into using Oracle as we were getting the finishing touches for delivery."


### PR DESCRIPTION
# Issues 
N/A

# Description

I just noticed "finish touches" used instead of "finishing touches" for the first time today.
Even the legitimate use is not common in the singular and it was harder to judge whether "finish touch" examples found in the wild were legit or not, so the Weir rule only deals with the plural.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
