### PR TITLE
fix(core): stop `LetsConfusion` flagging quantifiers after `let's`

### DIFF
--- a/harper-core/src/linting/lets_confusion/let_us_redundancy.rs
+++ b/harper-core/src/linting/lets_confusion/let_us_redundancy.rs
@@ -16,7 +16,9 @@ pub struct LetUsRedundancy {
 
 impl Default for LetUsRedundancy {
     fn default() -> Self {
-        let pattern = SequenceExpr::aco("let's").then_whitespace().then_pronoun();
+        let pattern = SequenceExpr::aco("let's")
+            .then_whitespace()
+            .then_object_pronoun();
 
         Self {
             expr: Box::new(pattern),

--- a/harper-core/src/linting/lets_confusion/mod.rs
+++ b/harper-core/src/linting/lets_confusion/mod.rs
@@ -76,4 +76,24 @@ mod tests {
             0,
         );
     }
+
+    #[test]
+    fn issue_4037_all() {
+        assert_lint_count("Let's all go home.", LetsConfusion::default(), 0);
+    }
+
+    #[test]
+    fn issue_4037_both() {
+        assert_lint_count("Let's both try again.", LetsConfusion::default(), 0);
+    }
+
+    #[test]
+    fn issue_4037_everyone() {
+        assert_lint_count("Let's everyone take a seat.", LetsConfusion::default(), 0);
+    }
+
+    #[test]
+    fn issue_4037_everybody() {
+        assert_lint_count("Let's everybody take a seat.", LetsConfusion::default(), 0);
+    }
 }


### PR DESCRIPTION
# Issues

Fixes #4037

# Description

`LetUsRedundancy` matched `let's` followed by any pronoun:

```rust
SequenceExpr::aco("let's").then_whitespace().then_pronoun()
```

The curated dictionary tags `all`, `both`, `everyone` and `everybody` as pronouns, so ordinary sentences got flagged as a redundant subject. `all` and `both` are floating quantifiers in apposition to the `us` already inside `let's`. "Let's all go home." expands to "Let us all go home.", not "Let us us go home."

This matches an object pronoun instead. In the curated metadata, `is_object` separates the two groups exactly:

| word | `pronoun.is_object` | `determiner.is_quantifier` |
| --- | --- | --- |
| us | true | not set |
| me | true | not set |
| him | true | not set |
| her | true | not set |
| them | true | not set |
| it | true | not set |
| you | true | not set |
| all | not set | true |
| both | not set | true |
| everyone | not set | not set |
| everybody | not set | not set |

In the issue thread @hippietrail suggested filtering on `is_quantifier`, or a shortlist. I tried the `is_quantifier` route first and it does not cover the set: `everyone` and `everybody` carry no quantifier tag, so they would keep firing. `then_object_pronoun` already exists in `expr/sequence_expr.rs`, so no new helper is needed.

No snapshot files change. The Alice in Wonderland line in `harper-core/tests/text/` is written `let’s all move one place on.` with a typographic apostrophe, and `aco("let's")` cannot match that, so this false positive never fired on the corpus. It becomes visible only once `Word` normalises apostrophes, which is #3202.

#3696 covers `let's you`. Since `you` is an object pronoun, this change leaves that behaviour exactly as it was.

# Demo

Before:

```
harper-cli lint "Let's all go home."          ->  <LetsConfusion: 1>
harper-cli lint "Let's both try again."       ->  <LetsConfusion: 1>
harper-cli lint "Let's everyone take a seat." ->  <LetsConfusion: 1>
```

After:

```
Let's all go home.            ->  (none)
Let's both try again.         ->  (none)
Let's everyone take a seat.   ->  (none)
Let's everybody take a seat.  ->  (none)
let's all move one place on.  ->  (none)

let's us do                   ->  <LetsConfusion: 1>
let's me do                   ->  <LetsConfusion: 1>
The crutch let's him walk.    ->  <LetsConfusion: 1>
let's them do                 ->  <LetsConfusion: 1>
```

# How Has This Been Tested?

`cargo test -p harper-core --lib`

```
test result: ok. 6133 passed; 0 failed; 290 ignored; 0 measured; 0 filtered out
```

The existing `LetsConfusion` tests still pass unchanged, including `walking` ("The crutch let's him walk."), `issue_426_us`, `issue_426_me` and `issue_548`. `cargo fmt` is clean and no files under `harper-core/tests/text/` are modified.

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter

- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

Three of the four test sentences are verbatim from the issue. The fourth, "Let's everybody take a seat.", comes from @hippietrail's question in the issue thread about whether `everybody` behaves the same way. It does, and it is the case the `is_quantifier` approach would have missed, so it seemed worth pinning.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
