### PR TITLE
fix(core): don't flag "no thanks to" as a missing refusal comma

### DIFF
--- a/harper-core/src/linting/weir_rules/IntroCueCommaBeforeThanks.weir
+++ b/harper-core/src/linting/weir_rules/IntroCueCommaBeforeThanks.weir
@@ -1,4 +1,4 @@
-expr main (no thanks)
+expr main <(no !(thanks to)), (no thanks)>
 
 let message "Set off `no` with a comma in the response phrase `no, thanks`."
 let description "Normalizes the common refusal phrase by inserting the missing comma."
@@ -31,3 +31,5 @@ allows "No thank you, I am good."
 allows "Yes thanks I am fine."
 allows "No-thanks messages are short."
 allows "Nothing to say, thanks."
+allows "The project shipped late, no thanks to the vendor."
+allows "We finished on time, no thanks to him."


### PR DESCRIPTION
# Issues

Fixes #3933

# Description

`IntroCueCommaBeforeThanks` normalizes the refusal phrase "no thanks" to "no, thanks". It matched every occurrence of "no thanks", including the idiom "no thanks to X", which means "not helped by X" and has nothing to do with a refusal. Inserting the comma there corrupts the sentence.

The expression now declines when "no" is followed by "thanks to":

```diff
-expr main (no thanks)
+expr main <(no !(thanks to)), (no thanks)>
```

The guard keys on "to" specifically rather than on prepositions generally, because "No thanks for asking." is a genuine positive and must keep firing.

# Demo

```
The project shipped late, no thanks to the vendor.   clean     (was IntroCueCommaBeforeThanks)
We finished on time, no thanks to him.               clean     (was IntroCueCommaBeforeThanks)

No thanks I am fine.                                 flagged   (unchanged)
No thanks for asking.                                flagged   (unchanged)
```

# How Has This Been Tested?

`cargo test -p harper-core`

```
test result: ok. 6129 passed; 0 failed; 290 ignored; 0 measured; 0 filtered out
```

Every existing `test` line in the rule still passes, and the two reported sentences were added as `allows` lines. No files under `harper-core/tests/text/` change.

One thing worth flagging for anyone verifying locally: editing a `.weir` file does not trigger a rebuild, because `build.rs` registers `cargo:rerun-if-changed` on the rules *directory*, and a directory's mtime only changes when files are added or removed. I got a false negative from a stale binary before touching a `.rs` file to force the rebuild.

# AI Disclosure

- [x] I used an AI agent interactively.

# If Your PR Implements or Enhances a Linter

- [x] I'm using examples from the bug report / feature request.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
