### PR TITLE
fix(core): don't flag `MissingTo` after a possessive nominal

### DIFF
--- a/harper-core/src/linting/missing_to.rs
+++ b/harper-core/src/linting/missing_to.rs
@@ -265,6 +265,12 @@ impl ExprLinter for MissingTo {
         let controller_text = controller.get_str(source).to_lowercase();
         let controller_text = controller_text.as_str();
 
+        if controller.kind.is_noun()
+            && preceded_by_word(context, |tok| tok.kind.is_possessive_nominal())
+        {
+            return None;
+        }
+
         if controller.kind.is_verb()
             && controller.kind.is_adjective()
             && preceded_by_word(context, |tok| tok.kind.is_nominal())
@@ -532,6 +538,14 @@ mod tests {
             "She resolved solve the case.",
             test_linter(),
             "She resolved to solve the case.",
+        );
+    }
+
+    #[test]
+    fn issue_3951_possessive_noun() {
+        assert_no_lints(
+            "This Article's aims are both theoretical and historical.",
+            test_linter(),
         );
     }
 


### PR DESCRIPTION
# Issues

Fixes #3951

# Description

`MissingTo` flagged "This Article's aims are both theoretical and historical.", wanting an infinitive after "aims".

The cause is a chain of defaults rather than one bug:

- "aims" is in the controller list.
- Its dictionary entry supports both noun and verb readings.
- The tagger defaults the ambiguous token to `UPOS::VERB`.
- "are" carries verb metadata without explicit verb-form flags, so the lemma check passes.

So the pattern accepts "aims are", and nothing in the rule looked left. As the reporter put it, the rule pattern-matches the token without resolving its part of speech from the frame it sits in: `X's aims are`, not `X aims to`.

The guard is structural. A noun-capable controller immediately preceded by a possessive nominal is the head of a noun phrase, not a predicate missing an infinitive:

```rust
if controller.kind.is_noun()
    && preceded_by_word(context, |tok| tok.kind.is_possessive_nominal())
{
    return None;
}
```

This covers possessive nouns like "Article's" as well as possessive determiners, without keying on any specific word.

I also considered guarding on the *following* token being a finite verb, and rejected it: Harper cannot generally separate a finite base form from an infinitive using UPOS alone, so it would have suppressed legitimate missing-`to` cases before infinitive auxiliaries such as "be".

# Demo

```
This Article's aims are both theoretical and historical.   clean     (was MissingTo)

She wants finish early.                                    flagged   (unchanged)
We need talk about pricing.                                flagged   (unchanged)
```

# How Has This Been Tested?

`cargo test -p harper-core`

```
test result: ok. 6130 passed; 0 failed; 290 ignored; 0 measured; 0 filtered out
```

Each existing positive in `missing_to.rs` was checked against the guard; none has a preceding possessive nominal, so all remain eligible. No files under `harper-core/tests/text/` change.

# AI Disclosure

- [x] I used an AI agent interactively.

# If Your PR Implements or Enhances a Linter

- [x] I'm using examples from the bug report / feature request.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
