### PR TITLE
fix(core): don't flag a comma-bracketed parenthetical as a list

### DIFF
--- a/harper-core/src/linting/oxford_comma.rs
+++ b/harper-core/src/linting/oxford_comma.rs
@@ -74,6 +74,18 @@ impl Linter for OxfordComma {
             let sentence = &sentence[skip..];
 
             for match_span in self.expr.iter_matches(sentence, document.get_source()) {
+                // A match closed by a comma and followed by a finite linking verb is likely
+                // parenthetical, with the second comma separating it from the continuing clause.
+                if let [comma, whitespace, verb, ..] = &sentence[match_span.end..]
+                    && comma.kind.is_comma()
+                    && whitespace.kind.is_whitespace()
+                    && verb.kind.is_linking_verb()
+                    && !verb.kind.is_verb_progressive_form()
+                    && !verb.kind.is_verb_past_participle_form()
+                {
+                    continue;
+                }
+
                 let lint = self.match_to_lint(
                     &sentence[match_span.start..match_span.end],
                     document.get_source(),
@@ -208,6 +220,15 @@ mod tests {
     fn allow_standoff() {
         assert_lint_count(
             "In a tense standoff, Alex and his reflection engage in a battle of wills.",
+            OxfordComma::default(),
+            0,
+        );
+    }
+
+    #[test]
+    fn issue_2803_parenthetical() {
+        assert_lint_count(
+            "Any resemblance to real persons, living or dead, is purely coincidental.",
             OxfordComma::default(),
             0,
         );


### PR DESCRIPTION
# Issues

Fixes #2803

# Description

`OxfordComma` flagged "Any resemblance to real persons, living or dead, is purely coincidental.", proposing a serial comma after "living". As the reporter noted, applying that suggestion introduces a punctuation error.

"living or dead" is a non-restrictive appositive bracketed by a matched pair of commas, not a two-item list. The expression reads "persons, living or dead" as three nominal items and stops before the closing comma, so nothing told it the phrase was already closed.

The guard looks at what follows the match. A closing comma followed by a finite linking verb marks the end of a parenthetical, because the clause continues afterwards rather than terminating:

```rust
if let [comma, whitespace, verb, ..] = &sentence[match_span.end..]
    && comma.kind.is_comma()
    && whitespace.kind.is_whitespace()
    && verb.kind.is_linking_verb()
    && !verb.kind.is_verb_progressive_form()
    && !verb.kind.is_verb_past_participle_form()
{
    continue;
}
```

Two narrower alternatives were rejected. A blanket closing-comma guard would hide genuine lists followed by comma-delimited material. Using `is_verb()` rather than `is_linking_verb()` would pull in participles and hide genuine lists before participial adjuncts, which is why the progressive and past-participle forms are excluded explicitly.

This is deliberately conservative and does not claim to recognise every parenthetical.

# Demo

```
Any resemblance to real persons, living or dead, is purely coincidental.   clean     (was OxfordComma)
The report, dense or sparse, was useful.                                   clean
The winners, Ann or Bob, is announced tomorrow.                            clean

We invited the cooks, Ann and Bob.                                         flagged   (unchanged)
I bought apples, pears and oranges.                                        flagged   (unchanged)
My favourite colours are red, green and blue.                              flagged   (unchanged)
```

# How Has This Been Tested?

`cargo test -p harper-core`

```
test result: ok. 6130 passed; 0 failed; 290 ignored; 0 measured; 0 filtered out
```

Every existing test in `oxford_comma.rs` was checked against the guard; no positive case has the `comma + finite linking verb` boundary, so all remain eligible. No files under `harper-core/tests/text/` change.

# AI Disclosure

- [x] I used an AI agent interactively.

# If Your PR Implements or Enhances a Linter

- [x] I'm using examples from the bug report / feature request.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
