### PR TITLE
feat: upcoming actor/artist→up-and-coming

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5497,6 +5497,13 @@
 						},
 						{
 							"Bool": {
+								"name": "UpcomingUpAndComing",
+								"state": true,
+								"label": "Upcoming Up And Coming"
+							}
+						},
+						{
+							"Bool": {
 								"name": "UpdatePlaceNames",
 								"state": true,
 								"label": "Update Place Names"

--- a/harper-core/src/linting/weir_rules/UpcomingUpAndComing.weir
+++ b/harper-core/src/linting/weir_rules/UpcomingUpAndComing.weir
@@ -1,0 +1,47 @@
+# People and their trades. `upcoming` cannot mean "due to happen soon" in front of any of these.
+expr risingNouns [artist, artists, actor, actors, actress, actresses, singer, singers, songwriter, songwriters, musician, musicians, rapper, rappers, dancer, dancers, comedian, comedians, filmmaker, filmmakers, novelist, novelists, poet, poets, painter, painters, photographer, photographers, designer, designers, chef, chefs, athlete, athletes, player, players, star, stars, coder, coders, programmer, programmers]
+
+# Event nouns the POS tagger reads as verbs here, so the NOUN and PROPN guards below miss them.
+expr eventNouns [showcase, showcases, audition, auditions, signing, signings]
+
+expr main <(upcoming @risingNouns![( NOUN), ( PROPN), ( @eventNouns)]), upcoming>
+
+let message "Did you mean `up-and-coming`?"
+let description "`Upcoming` means due to happen soon, so it does not describe a person. Use `up-and-coming` for someone who is gaining prominence."
+let kind "WordChoice"
+let becomes "up-and-coming"
+let strategy "MatchCase"
+
+test "Have you ever met an upcoming actor who you knew would go far in their career?" "Have you ever met an up-and-coming actor who you knew would go far in their career?"
+test "This app allows upcoming artists to post songs." "This app allows up-and-coming artists to post songs."
+test "Crescendo is a music discovery platform that promotes upcoming artists." "Crescendo is a music discovery platform that promotes up-and-coming artists."
+test "The PICO is an UPCOMING STAR in my opinion." "The PICO is an UP-AND-COMING STAR in my opinion."
+test "That night, a world lost one of the greatest upcoming stars." "That night, a world lost one of the greatest up-and-coming stars."
+test "Her boyfriend is an upcoming actor in the entertainment industry." "Her boyfriend is an up-and-coming actor in the entertainment industry."
+test "I am an upcoming rapper and I would love you to check out my channel." "I am an up-and-coming rapper and I would love you to check out my channel."
+test "He falls in love with Roma, also an upcoming singer and dancer." "He falls in love with Roma, also an up-and-coming singer and dancer."
+test "His music continues to inspire upcoming artists in the genre." "His music continues to inspire up-and-coming artists in the genre."
+test "Lee Jungwoo is an upcoming star in high school baseball." "Lee Jungwoo is an up-and-coming star in high school baseball."
+test "We brought Rahul Subramanian, an upcoming comedian, to our campus." "We brought Rahul Subramanian, an up-and-coming comedian, to our campus."
+test "Watch an upcoming comedian trying to figure out how to make all of this." "Watch an up-and-coming comedian trying to figure out how to make all of this."
+test "Our club trains young and upcoming athletes a few times a week." "Our club trains young and up-and-coming athletes a few times a week."
+test "The festival gives upcoming filmmakers a room of their own." "The festival gives up-and-coming filmmakers a room of their own."
+test "Upcoming artists deserve a bigger stage." "Up-and-coming artists deserve a bigger stage."
+
+allows "The upcoming release is scheduled for March."
+allows "We discussed the upcoming election at length."
+allows "Tickets for the upcoming tour go on sale Friday."
+allows "He is an up-and-coming actor with two credits."
+
+# The word after the trade is the head noun, so `upcoming` really is describing the event.
+
+allows "First rendered frame of an upcoming Star Wars vid!"
+allows "Sign up for the upcoming artist showcase."
+allows "The upcoming singer auditions close on Friday."
+allows "The upcoming artist signing at the record store sold out."
+allows "Check the upcoming player draft results."
+
+# Accepted gaps: an adjective between `upcoming` and the noun is not matched yet.
+
+allows "The upcoming young players led him to seek pastures new."
+allows "You are strengthening upcoming young curious minds."


### PR DESCRIPTION
Everything in the testing section below was actually run, not assumed.

# Issues

Closes #1079

# Description

Adds a Weir rule, `UpcomingUpAndComing`, that flags `upcoming` sitting directly in front of a person noun and suggests `up-and-coming`. `Upcoming` means "due to happen soon", so it works on an event but not on a person, and "an upcoming actor" is nearly always meant as "an up-and-coming actor".

The rule is deliberately narrow. The issue is right about heuristics being hard here:

- It only fires on a closed list of trade nouns (artist, actor, singer, rapper, comedian, athlete, filmmaker, star, coder, and so on), which must come immediately after `upcoming`.
- It backs off when the next token is another noun, since that means `upcoming` is modifying the real head noun. "Sign up for the upcoming artist showcase" and "First rendered frame of an upcoming Star Wars vid!" are both left alone, and both are `allows` tests.

Six of the ten examples in #1079 lint now. The other four are out of scope on purpose rather than guessed at:

- "an upcoming company" and "an upcoming force in the indie metal scene" - organization and abstract nouns, far less clear-cut than a person.
- "upcoming young curious minds" and "the upcoming young players" - an adjective sits between `upcoming` and the noun, which this pattern does not reach across. Both are pinned as `allows` so a later PR that widens the pattern has to deal with them consciously.

One residual false positive I know about and would rather name than hide: text where `upcoming` modifies an implied event, like osu-wiki's "You're given all available songs for an upcoming artist", where the artist feature is the thing being announced. `talent` and `talents` came out of the noun list for the same reason. It looks rare next to how often the misuse shows up, but it is real.

`default_config.json`: the entry went into "Word Choice and Usage", whose description is "Suggests more standard or idiomatic wording when a phrase is technically understandable but poorly chosen". That reads like an exact fit here. Easy to move if you'd rather have it elsewhere.

# Demo

The ten examples from the issue body, in one file, through `harper-cli lint --only UpcomingUpAndComing`:

| example | flagged |
|---|---|
| which is an **UPCOMING** STAR in my opinion | yes |
| Have you ever met an **upcoming** actor, actress or singer | yes |
| This app allows **upcoming** artists to post songs | yes |
| promotes **upcoming** artists | yes |
| just an **upcoming** coder lookin to change the world | yes |
| one of the greatest **upcoming** stars | yes |
| an **upcoming** company that wants to join the market | no, organization noun |
| an **upcoming** force in the indie metal scene | no, abstract noun |
| strengthening ... **upcoming** young curious minds | no, adjective in between |
| the **upcoming** young players and fierce competition | no, adjective in between |

```
harper-1079-examples.md: 6 lints
lint kinds:  [Word Choice: 6]
rules:       <UpcomingUpAndComing: 6>
```

The all-caps one comes back as `UP-AND-COMING STAR`, since the rule uses `MatchCase`.

# How Has This Been Tested?

- `cargo test -p harper-core` passes: 6132 passed, 0 failed, 290 ignored, including the generated `run_tests_in_upcoming_up_and_coming` test. No snapshot changes.
- `cargo fmt --check` clean, and `cargo clippy -p harper-core -- -Dwarnings -D clippy::dbg_macro -D clippy::needless_raw_string_hashes` clean. I scoped clippy to the crate because the workspace build needs the Tauri system libraries and this machine does not have them.
- 26 in-file assertions: 15 `test` and 11 `allows`.
- `harper-cli lint --only UpcomingUpAndComing` on the ten examples from the issue body, as in the demo above.
- `harper-cli lint --ignore UpcomingUpAndComing` on the same text: 7 lints and none of them are about this, so the rule is not duplicating an existing one. They are `SpellCheck`, `AnA`, `CapitalizePersonalPronouns`, `OxfordComma` and `SplitWords`, all from quirks in the quoted source text.
- Linting the corrected sentences produces no `UpcomingUpAndComing` lints and no new lints of any kind.
- Before settling the guard I probed roughly 85 different words in the slot after the trade noun to find where the POS tagger mislabels the head noun as a verb. That found `showcase`, `audition` and `signing`, which is why the rule carries a small `eventNouns` list on top of the NOUN/PROPN check.

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [x] I got an agent to do this work with me.

# If Your PR Implements or Enhances a Linter

- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

Where the collected ones came from, all found through the GitHub code search API:

- A baka-db anime synopsis: "her boyfriend, Hiro, is an upcoming actor in the entertainment industry"
- A YouTube comment-spam corpus: "Hi Guys im an Upcoming Rapper"
- A Wikipedia plot summary: "also an upcoming singer and dancer"
- `domerin0/seq2seq-chatbot`: "an upcoming star in high school baseball!"
- A campus newsletter: "Rahul Subramanian, an upcoming comedian"
- `UKPLab/TWEAC-qa-agent-selection`, for the Star Wars false positive
- `ppy/osu-wiki`, for the residual false positive described above

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.

---

I am new to open source, and this pull request was made with AI assistance.
