### PR TITLE
fix(core): six panics reachable from document text

### DIFF
--- a/harper-core/src/char_string.rs
+++ b/harper-core/src/char_string.rs
@@ -305,7 +305,10 @@ mod tests {
     /// through `BarelyUn`.
     #[test]
     fn strip_prefix_handles_prefix_longer_than_haystack() {
-        assert_eq!(['b'].strip_prefix_ignore_ascii_case_chars(&['u', 'n']), None);
+        assert_eq!(
+            ['b'].strip_prefix_ignore_ascii_case_chars(&['u', 'n']),
+            None
+        );
         assert_eq!([].strip_prefix_ignore_ascii_case_chars(&['u', 'n']), None);
     }
 

--- a/harper-core/src/char_string.rs
+++ b/harper-core/src/char_string.rs
@@ -210,12 +210,14 @@ impl CharStringExt for [char] {
     }
 
     fn strip_prefix_ignore_ascii_case_chars(&self, prefix: &[char]) -> Option<&[char]> {
+        // `then` rather than `then_some`: the latter takes its argument by value and
+        // would index the slice even when the guard is false.
         (self.len() >= prefix.len()
             && self
                 .iter()
                 .zip(prefix)
                 .all(|(a, b)| a.eq_ignore_ascii_case(b)))
-        .then_some(&self[prefix.len()..])
+        .then(|| &self[prefix.len()..])
     }
 }
 
@@ -296,5 +298,30 @@ mod tests {
     #[should_panic]
     fn right_side_must_be_all_lowercase_ch() {
         assert!(['c'].eq_ch(&['C']))
+    }
+
+    /// The guard must be evaluated before the slice is indexed. Passing a prefix
+    /// longer than the haystack previously panicked, which `barely b` reached
+    /// through `BarelyUn`.
+    #[test]
+    fn strip_prefix_handles_prefix_longer_than_haystack() {
+        assert_eq!(['b'].strip_prefix_ignore_ascii_case_chars(&['u', 'n']), None);
+        assert_eq!([].strip_prefix_ignore_ascii_case_chars(&['u', 'n']), None);
+    }
+
+    #[test]
+    fn strip_prefix_is_case_insensitive() {
+        assert_eq!(
+            ['U', 'N', 'f', 'i', 't'].strip_prefix_ignore_ascii_case_chars(&['u', 'n']),
+            Some(['f', 'i', 't'].as_slice())
+        );
+    }
+
+    #[test]
+    fn strip_prefix_rejects_a_non_matching_prefix() {
+        assert_eq!(
+            ['f', 'i', 't'].strip_prefix_ignore_ascii_case_chars(&['u', 'n']),
+            None
+        );
     }
 }

--- a/harper-core/src/document.rs
+++ b/harper-core/src/document.rs
@@ -512,7 +512,6 @@ impl Document {
                         *start_count += n;
                         start_tok.span.end = child_tok.span.end;
                         remove_these.push_back(cursor);
-                        cursor += 1;
                     } else {
                         break;
                     };
@@ -589,7 +588,6 @@ impl Document {
                         *start_count += n;
                         start_tok.span.end = child_tok.span.end;
                         remove_these.push_back(cursor);
-                        cursor += 1;
                     } else {
                         break;
                     };

--- a/harper-core/src/expr/step.rs
+++ b/harper-core/src/expr/step.rs
@@ -14,6 +14,39 @@ where
     P: Pattern,
 {
     fn step(&self, tokens: &[Token], cursor: usize, source: &[char]) -> Option<isize> {
-        self.matches(&tokens[cursor..], source).map(|i| i as isize)
+        // Callers may hand us a cursor that sits past the end, which happens when the
+        // preceding step consumed the final token. That is a failed match, not a bug.
+        self.matches(tokens.get(cursor..)?, source)
+            .map(|i| i as isize)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Step;
+    use crate::Document;
+    use crate::patterns::NominalPhrase;
+
+    /// `QuantifierNumeralConflict` steps a pattern at cursor 1 over the tokens that
+    /// follow a match. When the match ends the chunk, that slice is empty and the
+    /// cursor sits past the end, which used to panic instead of failing to match.
+    #[test]
+    fn cursor_past_the_end_is_a_failed_match() {
+        let doc = Document::new_plain_english_curated("both 2");
+        let empty: &[crate::Token] = &[];
+
+        assert_eq!(NominalPhrase.step(empty, 1, doc.get_source()), None);
+        assert_eq!(NominalPhrase.step(empty, 0, doc.get_source()), None);
+    }
+
+    #[test]
+    fn cursor_at_the_end_is_a_failed_match() {
+        let doc = Document::new_plain_english_curated("both 2");
+        let toks: Vec<crate::Token> = doc.tokens().cloned().collect();
+
+        assert_eq!(
+            NominalPhrase.step(&toks, toks.len(), doc.get_source()),
+            None
+        );
     }
 }

--- a/harper-core/src/linting/criteria_phenomena/singular_criteria_phenomena.rs
+++ b/harper-core/src/linting/criteria_phenomena/singular_criteria_phenomena.rs
@@ -38,22 +38,22 @@ impl ExprLinter for SingularCriteriaPhenomena {
     }
 
     fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
-        let mut second_word: String = matched_tokens[2]
-            .span
-            .get_content(source)
-            .iter()
-            .copied()
-            .collect();
+        // The plural word is the last token of the match, not the third. A
+        // `then_whitespace()` step consumes a whole run, and a run spanning a line
+        // break is several tokens because `Space` and `Newline` never merge.
+        let plural = matched_tokens.last()?;
+
+        let mut second_word: String = plural.span.get_content(source).iter().copied().collect();
         second_word.make_ascii_lowercase();
 
         let suggestions = match second_word.as_str() {
             "criteria" => vec![Suggestion::ReplaceWith("criterion".chars().collect())],
             "phenomena" => vec![Suggestion::ReplaceWith("phenomenon".chars().collect())],
-            _ => panic!("Don't know what to say about '{second_word}'!"),
+            _ => return None,
         };
 
         Some(Lint {
-            span: matched_tokens[2].span,
+            span: plural.span,
             lint_kind: LintKind::Repetition,
             message: "You used a plural noun as singular.".to_owned(),
             priority: 63,

--- a/harper-core/src/linting/damages.rs
+++ b/harper-core/src/linting/damages.rs
@@ -67,7 +67,10 @@ impl ExprLinter for Damages {
         }
 
         // The word before "damages" may help us narrow down whether it's a noun or verb.
-        let prev_word_tok = match (pretoks.get(pretoks.len() - 2), pretoks.last()) {
+        let prev_word_tok = match (
+            pretoks.len().checked_sub(2).and_then(|i| pretoks.get(i)),
+            pretoks.last(),
+        ) {
             (Some(w), Some(sp)) if sp.kind.is_whitespace() && w.kind.is_word() => Some(w),
             _ => None,
         };

--- a/harper-core/src/linting/modal_of.rs
+++ b/harper-core/src/linting/modal_of.rs
@@ -97,10 +97,12 @@ impl ExprLinter for ModalOf {
             }
             // False positive: <word> _ might _ of _ course
             7 => return None,
-            _ => unreachable!(),
+            // A `then_whitespace()` step consumes a whole run, and a run spanning a
+            // line break is several tokens, so other lengths are representable.
+            _ => return None,
         };
 
-        let span_modal_of = matched_toks[modal_index..modal_index + 3].span().unwrap();
+        let span_modal_of = matched_toks.get(modal_index..modal_index + 3)?.span()?;
 
         let modal_have = format!(
             "{} have",

--- a/harper-core/src/linting/multiple_frequency_adverbs.rs
+++ b/harper-core/src/linting/multiple_frequency_adverbs.rs
@@ -41,7 +41,10 @@ impl ExprLinter for MultipleFrequencyAdverbs {
         let (adv1span, adv2span) = (adv1tok.span, adv2tok.span);
         let (adv1ch, adv2ch) = (adv1span.get_content(src), adv2span.get_content(src));
 
-        if !adv1ch.eq_ch(adv2ch) {
+        // `eq_ch` only lowercases its receiver, so the argument has to arrive
+        // lowercase. Both sides come from the document here, and passing raw text
+        // made two spellings of the same adverb compare unequal.
+        if !adv1ch.eq_ch(&adv2ch.to_lower()) {
             Some(Lint {
                 span: toks.span()?,
                 lint_kind: LintKind::Usage,

--- a/harper-core/src/linting/redundant_acronyms.rs
+++ b/harper-core/src/linting/redundant_acronyms.rs
@@ -51,7 +51,10 @@ impl Default for RedundantAcronyms {
         let exprs: Vec<Box<dyn Expr>> = ACRONYMS
             .iter()
             .map(|&(acronym, _, last_str, _)| {
-                let last_string = last_str.to_string();
+                // `eq_str` only lowercases its receiver, so the argument has to
+                // arrive lowercase. `ACRONYMS` holds display casing ("Party"),
+                // which made this branch unmatchable for those entries.
+                let last_string = last_str.to_lowercase();
                 Box::new(SequenceExpr::aco(acronym).t_ws().then_any_of([
                     Box::new(Word::new(last_str)) as Box<dyn Expr>,
                     Box::new(move |t: &Token, src: &[char]| {

--- a/harper-core/src/linting/there_is_agreement.rs
+++ b/harper-core/src/linting/there_is_agreement.rs
@@ -143,7 +143,10 @@ fn match_to_lint<D: Dictionary>(
         first.last(),
     ) {
         (false, _) if second.eq_str("there") => handle_question(toks, src, ctx, dict),
-        (true, Some(&'s')) => handle_theres(toks, src, ctx, dict),
+        // Case-insensitive to match the `starts_with` test above it. An uppercase
+        // `S` used to fall through to `handle_statement`, which expects the
+        // five-token statement shape rather than the three-token `there's` one.
+        (true, Some(c)) if c.eq_ignore_ascii_case(&'s') => handle_theres(toks, src, ctx, dict),
         (true, _) => handle_statement(toks, src, ctx, dict),
         _ => None, // unreachable
     }
@@ -244,7 +247,7 @@ fn handle_statement<D: Dictionary>(
     // NOTE - for a statement we only need to replace two words.
     // NOTE - (there) "are man" -> "there is (a) man"
     //                          -> "there are men"
-    let replacement_template = toks[2..=4].get_ch(src)?;
+    let replacement_template = toks.get(2..=4)?.get_ch(src)?;
 
     // tok 2 is form of "be": is are was were
     // tok 4 is noun that doesn't agree in number with the form of "be"


### PR DESCRIPTION
> Disclaimer: this patch was produced with the assistance of an LLM agent, per
> AGENT_POLICY.md. Every crash below was reproduced against `harper-cli` before
> and after the fix.

## Problem

`harper-core` aborts on ordinary text. The release profile sets `panic = "abort"`,
so each of these is a SIGABRT (exit 134), not a catchable error. In `harper-ls`
that kills the language server mid-edit; in WASM the module traps and stays
unusable for the rest of the page session. There is no `catch_unwind` anywhere in
`harper-core`, `harper-ls`, `harper-cli` or `harper-wasm`.

| Input | Site |
|---|---|
| `barely b` | `char_string.rs` — `then_some` evaluates its argument eagerly |
| `both 2` | `expr/step.rs` — cursor past the end of the slice |
| `There'S cats` | `there_is_agreement.rs` — case-sensitive dispatch on a case-insensitive match |
| `would \t of` | `modal_of.rs` — `unreachable!()` on a reachable match length |
| `One \n criteria is essential.` | `singular_criteria_phenomena.rs` — fixed index past a variable-width whitespace step |
| `Damages` | `damages.rs` — `usize` underflow |

Two are also silent correctness bugs in release, not only aborts. `eq_ch` and
`eq_str` lowercase only their receiver, so `MultipleFrequencyAdverbs` reported
`always ALWAYS` as "redundant or contradictory" despite being one repeated word,
and `RedundantAcronyms` built `eq_str("Partys")` from the display-cased
`ACRONYMS` table — a lowercased receiver can never equal that, so the branch was
unmatchable rather than merely wrong.

## Root cause behind two of them

`condense_spaces` incremented its cursor twice per merge — once at the top of the
inner loop and again after pushing to `remove_these` — so it skipped the token
after each merge and left runs of three or more only partly condensed:

```
a<SP><TAB>b  ->  [Space(3), Space(1)]
a<TAB><SP>b  ->  [Space(3)]
```

`condense_newlines` had the identical structure. `then_whitespace()` consumes a
whole run, so rules indexing a fixed offset past it read a whitespace token
instead of the word they expected.

`Space` and `Newline` are distinct kinds that never merge, so whitespace crossing
a line break is still legitimately several tokens. The two rules that crashed are
hardened accordingly rather than relying on the condensing fix alone.

## Notes for review

Six commits, one per root cause, so they can be taken or dropped separately.

Roughly 264 `matched_tokens[i]` sites in `src/linting` share the fixed-width
whitespace assumption. I fixed the two that crash; the assumption is latent
elsewhere and probably deserves its own issue.

## Testing

- `cargo test` — 6375 passed, 0 failed, no snapshot changes
- `cargo clippy -- -Dwarnings -D clippy::dbg_macro -D clippy::needless_raw_string_hashes` — exit 0
- `cargo fmt --check` — clean
- Each input above verified to abort before the fix and lint cleanly after

## Breaking changes

None.
