### PR TITLE
feat(editor): add placeholder text to the web editor

### DIFF
--- a/packages/harper-editor/src/lib/Editor.svelte
+++ b/packages/harper-editor/src/lib/Editor.svelte
@@ -144,7 +144,7 @@ async function updateLintFrameworkElements() {
 
 	if (quill == null) {
 		let { default: Quill } = await import('quill');
-		quill = new Quill(editor, {});
+		quill = new Quill(editor, { placeholder: 'Start writing...' });
 		const container = quill.container ?? quill.root?.parentElement;
 		container?.classList.add('harper-editor-quill-container');
 

--- a/packages/harper-editor/src/lib/styles.css
+++ b/packages/harper-editor/src/lib/styles.css
@@ -52,6 +52,7 @@
 
 .harper-editor-surface,
 .harper-editor-surface.ql-editor {
+	position: relative;
 	padding: 0;
 	border: 0;
 	outline: 0;
@@ -67,6 +68,16 @@
 .harper-editor-surface:focus,
 .harper-editor-surface:focus-visible {
 	outline: 0;
+}
+
+.harper-editor-surface.ql-editor.ql-blank::before {
+	position: absolute;
+	top: 0;
+	right: 0;
+	left: 0;
+	color: var(--color-stone-500);
+	content: attr(data-placeholder);
+	pointer-events: none;
 }
 
 .harper-editor-surface p,


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

N/A

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

It realized that, when the Harper web editor has no text in it, it isn't immediately obvious that it is a text editor. To remedy the situation, I've added some descriptive placeholder text.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
