### PR TITLE
feat: enhance the `ToTo` linter

### DIFF
--- a/harper-core/src/linting/expr_linter.rs
+++ b/harper-core/src/linting/expr_linter.rs
@@ -200,6 +200,13 @@ pub fn at_start_of_sentence(context: Option<(&[Token], &[Token])>) -> bool {
     false
 }
 
+/// Check for sentence context immediately before a matched span.
+///
+/// Validates that the "before" context ends with a word token followed by whitespace,
+/// allowing flexible inspection of that word's properties (POS tags, etc.) via the predicate.
+/// The predicate can be used to confirm matches, suppress false positives, or apply conditional logic.
+///
+/// Returns `false` if context is `None`, missing tokens, or the structure is malformed.
 pub fn preceded_by_word(
     context: Option<(&[Token], &[Token])>,
     predicate: impl Fn(&Token) -> bool,
@@ -209,6 +216,29 @@ pub fn preceded_by_word(
         && ws.kind.is_whitespace()
     {
         return predicate(word);
+    }
+    false
+}
+
+/// Check for sentence context surrounding a matched span on both sides.
+///
+/// Validates that the "before" context ends with a word token followed by whitespace,
+/// and the "after" context starts with whitespace followed by a word token, allowing
+/// flexible inspection of both words' properties (POS tags, etc.) via the predicate.
+/// The predicate can be used to confirm matches, suppress false positives, or apply conditional logic.
+///
+/// Returns `false` if context is `None`, missing tokens, or the structure is malformed.
+pub fn surrounded_by_words(
+    context: Option<(&[Token], &[Token])>,
+    predicate: impl Fn(&Token, &Token) -> bool,
+) -> bool {
+    if let Some((before, after)) = context
+        && let [.., word_before, ws_before] = before
+        && let [ws_after, word_after, ..] = after
+        && ws_before.kind.is_whitespace()
+        && ws_after.kind.is_whitespace()
+    {
+        return predicate(word_before, word_after);
     }
     false
 }

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -276,6 +276,7 @@ use super::throw_baby_with_bathwater::ThrowBabyWithBathwater;
 use super::throw_rubbish::ThrowRubbish;
 use super::till_date::TillDate;
 use super::to_adverb::ToAdverb;
+use super::to_to::ToTo;
 use super::to_two_too::ToTwoToo;
 use super::touristic::Touristic;
 use super::transposed_space::TransposedSpace;
@@ -863,6 +864,7 @@ impl LintGroup {
         insert_struct_rule!(ThrowRubbish);
         insert_expr_rule_with_dialect!(TillDate);
         insert_expr_rule!(ToAdverb);
+        insert_expr_rule!(ToTo);
         insert_struct_rule!(ToTwoToo);
         insert_expr_rule!(Touristic);
         insert_expr_rule_with_dict!(TransposedSpace);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -295,6 +295,7 @@ mod throw_baby_with_bathwater;
 mod throw_rubbish;
 mod till_date;
 mod to_adverb;
+mod to_to;
 mod to_two_too;
 mod touristic;
 mod transposed_space;

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -982,15 +982,6 @@ pub fn lint_group() -> LintGroup {
             "Corrects redundant `side tangent` and `side tangents` to more concise alternatives.",
             LintKind::Redundancy
         ),
-        "ToTo" => (
-            &[
-                (&["to to"], &["to do"]),
-                (&["to-to"], &["to-do"]),
-            ],
-            "Did you mean to write `do` instead of a second `to`?",
-            "Corrects `to to` to `to do` and `to-to` to `to-do`, as they may be typos.",
-            LintKind::Typo
-        ),
         "ToTooIdioms" => (
             &[
                 (&["a bridge to far"], &["a bridge too far"]),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -4021,23 +4021,3 @@ fn detect_making_them_worst_atomic() {
         "As for the last part about Apple deliberately making them worse in order for us to buy the 3s",
     );
 }
-
-// -to to-
-#[test]
-fn corrects_to_to() {
-    assert_suggestion_result(
-        "I need to add that to my to to list first.",
-        test_linter(),
-        "I need to add that to my to do list first.",
-    );
-}
-
-// -to-to-
-#[test]
-fn corrects_to_to_with_hyphen() {
-    assert_suggestion_result(
-        "I need to add that to my to-to list first.",
-        test_linter(),
-        "I need to add that to my to-do list first.",
-    );
-}

--- a/harper-core/src/linting/to_to.rs
+++ b/harper-core/src/linting/to_to.rs
@@ -1,0 +1,284 @@
+use crate::{
+    CharStringExt, Lint, Token, TokenStringExt,
+    expr::{Expr, SequenceExpr},
+    linting::{
+        ExprLinter, LintKind, Suggestion,
+        expr_linter::{Chunk, surrounded_by_words},
+    },
+};
+
+pub struct ToTo {
+    expr: SequenceExpr,
+}
+
+impl Default for ToTo {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::aco("to").t_ws_h().t_aco("to"),
+        }
+    }
+}
+
+impl ExprLinter for ToTo {
+    type Unit = Chunk;
+
+    fn match_to_lint_with_context(
+        &self,
+        toks: &[Token],
+        src: &[char],
+        ctx: Option<(&[Token], &[Token])>,
+    ) -> Option<Lint> {
+        if surrounded_by_words(ctx, |before, after| {
+            if after.kind.is_verb_lemma()
+                && before.get_ch(src).eq_any_ignore_ascii_case_str(&[
+                    // Prepositions
+                    "according",
+                    // Verbs. If this list grows large, adding a dictionary annotation flag should be considered.
+                    "appeal",
+                    "appealed",
+                    "appealing",
+                    "appeals",
+                    "apply",
+                    "applied",
+                    "applies",
+                    "applying",
+                    "connect",
+                    "connected",
+                    "connecting",
+                    "connects",
+                    "have",
+                    "had",
+                    "having",
+                    "has",
+                    "need",
+                    "needed",
+                    "needing",
+                    "needs",
+                    "pray",
+                    "prayed",
+                    "praying",
+                    "prays",
+                    "refer",
+                    "referred",
+                    "referring",
+                    "refers",
+                    "resort",
+                    "resorted",
+                    "resorting",
+                    "resorts",
+                ])
+            {
+                return true;
+            }
+            false
+        }) {
+            return None;
+        }
+
+        let to_to_span = toks.span()?;
+        let first_to_w_sep = &toks[0..=1].span()?;
+
+        let to_do = first_to_w_sep
+            .get_content(src)
+            .iter()
+            .chain(['d', 'o'].iter())
+            .copied()
+            .collect::<Vec<char>>();
+
+        let suggestions = vec![
+            Suggestion::replace_with_match_case_str("to", to_to_span.get_content(src)),
+            Suggestion::replace_with_match_case(to_do, to_to_span.get_content(src)),
+        ];
+
+        Some(Lint {
+            span: to_to_span,
+            lint_kind: LintKind::Typo,
+            suggestions,
+            message: "Is the second `to` supposed to be `do` or not there at all?".to_owned(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects the typo `to to` by either removing the duplication or changing it to `to do`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    use super::ToTo;
+
+    // to do / to-do tests
+
+    #[test]
+    fn should_be_to_do_with_space() {
+        assert_suggestion_result(
+            "I need to add that to my to to list first.",
+            ToTo::default(),
+            "I need to add that to my to do list first.",
+        );
+    }
+
+    #[test]
+    fn should_be_to_do_with_hyphen() {
+        assert_suggestion_result(
+            "I need to add that to my to-to list first.",
+            ToTo::default(),
+            "I need to add that to my to-do list first.",
+        );
+    }
+
+    #[test]
+    fn triple_to_should_be_to_do_to() {
+        assert_suggestion_result(
+            "a little example of what you'd need to to to create and resolve a promise off the main thread",
+            ToTo::default(),
+            "a little example of what you'd need to do to create and resolve a promise off the main thread",
+        );
+    }
+
+    // extraneous "to" tests
+
+    #[test]
+    fn should_be_single_to() {
+        assert_suggestion_result(
+            "What is the modern way to to do XML transforms in Python?",
+            ToTo::default(),
+            "What is the modern way to do XML transforms in Python?",
+        );
+    }
+
+    // exceptions where "to to" is legit
+
+    #[test]
+    fn dont_flag_applied_to_to_stand_out() {
+        assert_no_lints(
+            "Indeed says to store messages to jobs I've applied to to stand out",
+            ToTo::default(),
+        )
+    }
+
+    #[test]
+    fn dont_flag_apply_to_to_be() {
+        assert_no_lints(
+            "I'm expecting the company that I'm applying to to be efficient, to assign me tasks that aren't a waste of time",
+            ToTo::default(),
+        )
+    }
+
+    #[test]
+    fn dont_flag_connected_to_to_allow() {
+        assert_no_lints(
+            "Create headless \"VS Code Server\" that can be connected to to allow editing remote code within it's environment",
+            ToTo::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_have_to_to_take() {
+        assert_no_lints(
+            "Do what you have to to take care of yourself and get what you need.",
+            ToTo::default(),
+        )
+    }
+
+    #[test]
+    fn dont_flag_need_to_to_increase() {
+        assert_no_lints(
+            "something that they're wasting their time doing, so adjust as you need to to increase their productivity",
+            ToTo::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_pray_to_to_find() {
+        assert_no_lints(
+            "what dieties would you pray to to find lost things and for a housing opportunity?",
+            ToTo::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_referred_to_to_exist() {
+        assert_no_lints(
+            "IsValid requires a drive being referred to to exist",
+            ToTo::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_referred_to_to_write() {
+        assert_no_lints(
+            "Could you tell me which paper you referred to to write this algorithm?",
+            ToTo::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_refer_to_to_create() {
+        assert_no_lints(
+            "Which Packages do I need to refer to to create my own NUnit console runner?",
+            ToTo::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_need_to_to_stay() {
+        assert_no_lints(
+            "Yes, if I fail of course I'll do whatever I need to to stay healthy",
+            ToTo::default(),
+        )
+    }
+
+    #[test]
+    fn dont_flag_refer_to_to_ensure() {
+        assert_no_lints(
+            "It could be a convenience list that one could refer to to ensure that they're not about to say a banned word.",
+            ToTo::default(),
+        );
+    }
+
+    // Still mistakes after keywords above since they lack the required following infitive verb
+
+    #[test]
+    fn fix_according_to_to() {
+        assert_suggestion_result(
+            "this URL is not formatted strictly according to to RFC2396",
+            ToTo::default(),
+            "this URL is not formatted strictly according to RFC2396",
+        );
+    }
+
+    #[test]
+    fn fix_applied_to_to() {
+        assert_suggestion_result(
+            "TG_IR.corr(xlim) is not applied to to correction graphs",
+            ToTo::default(),
+            "TG_IR.corr(xlim) is not applied to correction graphs",
+        );
+    }
+
+    #[test]
+    fn fix_refer_refer_to() {
+        assert_suggestion_result(
+            "but there may be a chance to to refer non existing actor",
+            ToTo::default(),
+            "but there may be a chance to refer non existing actor",
+        )
+    }
+
+    #[test]
+    fn fix_refers_to_to() {
+        assert_suggestion_result(
+            "Getting \"{{component}} refers to to a value, but is being used as a type\" error when attemping to identify an argument that refers to a Vue Component",
+            ToTo::default(),
+            "Getting \"{{component}} refers to a value, but is being used as a type\" error when attemping to identify an argument that refers to a Vue Component",
+        );
+    }
+}

--- a/harper-core/src/linting/to_to.rs
+++ b/harper-core/src/linting/to_to.rs
@@ -28,50 +28,52 @@ impl ExprLinter for ToTo {
         src: &[char],
         ctx: Option<(&[Token], &[Token])>,
     ) -> Option<Lint> {
-        if surrounded_by_words(ctx, |before, after| {
-            if after.kind.is_verb_lemma()
-                && before.get_ch(src).eq_any_ignore_ascii_case_str(&[
-                    // Prepositions
-                    "according",
-                    // Verbs. If this list grows large, adding a dictionary annotation flag should be considered.
-                    "appeal",
-                    "appealed",
-                    "appealing",
-                    "appeals",
-                    "apply",
-                    "applied",
-                    "applies",
-                    "applying",
-                    "connect",
-                    "connected",
-                    "connecting",
-                    "connects",
-                    "have",
-                    "had",
-                    "having",
-                    "has",
-                    "need",
-                    "needed",
-                    "needing",
-                    "needs",
-                    "pray",
-                    "prayed",
-                    "praying",
-                    "prays",
-                    "refer",
-                    "referred",
-                    "referring",
-                    "refers",
-                    "resort",
-                    "resorted",
-                    "resorting",
-                    "resorts",
-                ])
-            {
-                return true;
-            }
-            false
-        }) {
+        if toks[1].kind.is_whitespace()
+            && surrounded_by_words(ctx, |before, after| {
+                if after.kind.is_verb_lemma()
+                    && before.get_ch(src).eq_any_ignore_ascii_case_str(&[
+                        // Prepositions
+                        "according",
+                        // Verbs. If this list grows large, adding a dictionary annotation flag should be considered.
+                        "appeal",
+                        "appealed",
+                        "appealing",
+                        "appeals",
+                        "apply",
+                        "applied",
+                        "applies",
+                        "applying",
+                        "connect",
+                        "connected",
+                        "connecting",
+                        "connects",
+                        "have",
+                        "had",
+                        "having",
+                        "has",
+                        "need",
+                        "needed",
+                        "needing",
+                        "needs",
+                        "pray",
+                        "prayed",
+                        "praying",
+                        "prays",
+                        "refer",
+                        "referred",
+                        "referring",
+                        "refers",
+                        "resort",
+                        "resorted",
+                        "resorting",
+                        "resorts",
+                    ])
+                {
+                    return true;
+                }
+                false
+            })
+        {
             return None;
         }
 


### PR DESCRIPTION
# Issues 
N/A

# Description

Previously it always flagged "to to" and only suggested "to do".

It did not cooperate with `RepeatedWords` to suggest dropping the second "to", since that's not possible.

It was not aware of patterns where "to to" is grammatically correct, such as after certain verbs and before a verb in the infinitive.

This PR moved the old linter out of `phrase_set_corrections` into a custom Rust linter.

I also added a new `surrounded_by_words()` method to `ExprLinter` that combines the existing `followed_by_token()` and `preceded_by_word()`.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

I asked Google's AI to suggest how best to implement `surrounded_by_words()` and to write the doc comments.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
