### PR TITLE
feat: surrealness→surreality

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5406,6 +5406,13 @@
 						},
 						{
 							"Bool": {
+								"name": "Surreality",
+								"state": true,
+								"label": "Surreality"
+							}
+						},
+						{
+							"Bool": {
 								"name": "TakeItPersonally",
 								"state": true,
 								"label": "Take It Personally"

--- a/harper-core/src/linting/weir_rules/Surreality.weir
+++ b/harper-core/src/linting/weir_rules/Surreality.weir
@@ -1,0 +1,9 @@
+expr main (surrealness)
+
+let message "Did you mean `surreality`?"
+let description "Suggests changing `surrealness` to the more standard `surreality`."
+let kind "WordChoice"
+let becomes "surreality"
+
+test "I can make a version that is more realistic but I will always keep this because the surrealness is appealing to me." "I can make a version that is more realistic but I will always keep this because the surreality is appealing to me."
+test "A major element to the surrealness of Silent Hill 2's original PlayStation 2 FMVs was that they played at 60 frames per second." "A major element to the surreality of Silent Hill 2's original PlayStation 2 FMVs was that they played at 60 frames per second."


### PR DESCRIPTION
# Issues 
N/A

# Description

This has been in my inbox for a while now. The word "surreality" isn't very common but has exisited for a century and is in several professionally edited dictionaries. The word "surrealness" isn't in any professionally edited dictionary and seems to have popped into existence in the late '80s but only really took off around the late 2010s and is still not as common as the standard term:

<img width="1163" height="407" alt="image" src="https://github.com/user-attachments/assets/ffeea4c7-321f-4493-abc5-3847073be586" />

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
