### PR TITLE
feat: (wip) similar than/similar with → similar to

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5329,6 +5329,13 @@
 						},
 						{
 							"Bool": {
+								"name": "SimilarTo",
+								"state": true,
+								"label": "Similar To"
+							}
+						},
+						{
+							"Bool": {
 								"name": "SimpleGrammatical",
 								"state": true,
 								"label": "Simple Grammatical"

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -236,6 +236,7 @@ use super::safe_to_save::SafeToSave;
 use super::save_to_safe::SaveToSafe;
 use super::sentence_capitalization::SentenceCapitalization;
 use super::shoot_oneself_in_the_foot::ShootOneselfInTheFoot;
+use super::similar_to::SimilarTo;
 use super::simple_past_to_past_participle::SimplePastToPastParticiple;
 use super::since_duration::SinceDuration;
 use super::single_be::SingleBe;
@@ -826,6 +827,7 @@ impl LintGroup {
         insert_expr_rule!(SaveToSafe);
         insert_struct_rule_with_dict!(SentenceCapitalization);
         insert_expr_rule!(ShootOneselfInTheFoot);
+        insert_expr_rule!(SimilarTo);
         insert_expr_rule!(SimplePastToPastParticiple);
         insert_expr_rule!(SinceDuration);
         insert_expr_rule!(SingleBe);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -253,6 +253,7 @@ mod safe_to_save;
 mod save_to_safe;
 mod sentence_capitalization;
 mod shoot_oneself_in_the_foot;
+mod similar_to;
 mod simple_past_to_past_participle;
 mod since_duration;
 mod single_be;

--- a/harper-core/src/linting/similar_to.rs
+++ b/harper-core/src/linting/similar_to.rs
@@ -1,0 +1,147 @@
+use crate::{
+    Lint, Token,
+    expr::{Expr, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, debug::format_lint_match, expr_linter::Chunk},
+    patterns::Word,
+};
+
+pub struct SimilarTo {
+    expr: SequenceExpr,
+}
+
+impl Default for SimilarTo {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::aco("similar").t_ws().then_any_of([
+                Box::new(Word::new("with")) as Box<dyn Expr>,
+                Box::new(
+                    SequenceExpr::optional(SequenceExpr::default().then_noun().t_ws())
+                        .t_aco("than"),
+                ),
+            ]),
+        }
+    }
+}
+
+impl ExprLinter for SimilarTo {
+    type Unit = Chunk;
+
+    fn match_to_lint_with_context(
+        &self,
+        toks: &[Token],
+        src: &[char],
+        ctx: Option<(&[Token], &[Token])>,
+    ) -> Option<Lint> {
+        eprintln!("🚨 {}", format_lint_match(toks, ctx, src));
+
+        let span = toks.last()?.span;
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::WordChoice,
+            suggestions: vec![Suggestion::replace_with_match_case_str(
+                "to",
+                span.get_content(src),
+            )],
+            message: "The correct preposition to use with `similar` is `to`.".to_owned(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects `similar than` and `similar with` to `similar to`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    use super::SimilarTo;
+
+    #[test]
+    fn fix_similar_function_than() {
+        assert_suggestion_result(
+            "Request: Patreon skip duplicate files && implement a similar function than \"chapter-range\"",
+            SimilarTo::default(),
+            "Request: Patreon skip duplicate files && implement a similar function to \"chapter-range\"",
+        );
+    }
+
+    #[test]
+    fn fix_similar_with_goland() {
+        assert_suggestion_result(
+            "Is there a plan to develop a stand-alone IDE for Rust? Similar with goland, webstorm.",
+            SimilarTo::default(),
+            "Is there a plan to develop a stand-alone IDE for Rust? Similar to goland, webstorm.",
+        )
+    }
+
+    #[test]
+    fn fix_api_similar_with_model_analyzer() {
+        assert_suggestion_result(
+            "Is there a API similar with model_analyzer in pycolmap?",
+            SimilarTo::default(),
+            "Is there a API similar with model_analyzer in pycolmap?",
+        )
+    }
+
+    // Edge cases, would-be false positives
+
+    #[test]
+    fn two_similar_tables_with_similar_access() {
+        assert_no_lints(
+            "I have two similar tables with similar access, both I can read by CURL",
+            SimilarTo::default(),
+        )
+    }
+
+    #[test]
+    fn similar_code_with_deleted_lines() {
+        assert_no_lints(
+            "This function searches similar code with deleted lines.",
+            SimilarTo::default(),
+        )
+    }
+
+    #[test]
+    fn seeing_similar_problems_with_both_node_x_and_node_y() {
+        assert_no_lints(
+            "I am seeing similar problems with both node 0.10.29 and 0.10.30.",
+            SimilarTo::default(),
+        )
+    }
+
+    #[test]
+    fn extend_credentials_and_similar_with_custom_msgs() {
+        assert_no_lints(
+            "Extend CustomCredentials and similar with custom messages",
+            SimilarTo::default(),
+        );
+    }
+
+    #[test]
+    fn identifying_similar_images_with_tensorflow() {
+        assert_no_lints(
+            "tutorial identifying similar images with tensorflow",
+            SimilarTo::default(),
+        )
+    }
+
+    #[test]
+    fn find_similar_issues_with_ai() {
+        assert_no_lints("Find Similar Issues with AI", SimilarTo::default())
+    }
+
+    #[test]
+    fn similar_rather_than_identical() {
+        assert_no_lints(
+            "As a result, she wanted only similar rather than identical symbols.",
+            SimilarTo::default(),
+        )
+    }
+}


### PR DESCRIPTION
# Issues 

#4127

# Description

Attempts to correct "similar than" and "similar with" to standard "similar to".

Work in progress as there are many edge cases and potential false positives.

# How Has This Been Tested?

`cargo test` - not fully passing yet

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

I wrote the code but I've asked an AI for tips on how to separate legit uses of these from mistakes for "similar to".

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
