### PR TITLE
feat: a whole another/nother/'nother → a whole other

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -4167,6 +4167,13 @@
 						},
 						{
 							"Bool": {
+								"name": "AWholeOther",
+								"state": true,
+								"label": "A Whole Other"
+							}
+						},
+						{
+							"Bool": {
 								"name": "BadRap",
 								"state": true,
 								"label": "Bad Rap"

--- a/harper-core/src/linting/weir_rules/AWholeOther.weir
+++ b/harper-core/src/linting/weir_rules/AWholeOther.weir
@@ -1,0 +1,13 @@
+expr main [(a whole another), (a whole nother), (a whole 'nother)]
+
+let message "Did you mean the standard `a whole other`?"
+let description "Corrects `a whole another`/`a whole 'nother` to `a whole other`."
+let kind "Usage"
+let becomes "a whole other"
+
+test "Andrew was toxic in his article but had some arguments, Theo is in a whole another level of toxicity" "Andrew was toxic in his article but had some arguments, Theo is in a whole other level of toxicity"
+test "Why it's there is a whole nother problem." "Why it's there is a whole other problem."
+test "but it adds a whole 'nother layer onto what is already 2 (or 3, I forget) layers of complexity" "but it adds a whole other layer onto what is already 2 (or 3, I forget) layers of complexity"
+test "smart apostrophes are a whole ’nother thing" "smart apostrophes are a whole other thing"
+
+allows "one workflow may need to be singular across the host as a whole, another maybe singular across that tenant, and yet another may be ..."


### PR DESCRIPTION
# Issues 
N/A

# Description

This one has been in my inbox for a while. It corrects "a whole another", "a whole nother", and "a whole 'nother" to "a whole other".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [x] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
