### PR TITLE
feat: 'npm' requires 'an', not 'a'

### DIFF
--- a/harper-core/src/indefinite_article.rs
+++ b/harper-core/src/indefinite_article.rs
@@ -6,11 +6,11 @@ use crate::case::Case::Upper;
 use crate::char_ext::CharExt;
 use crate::{CaseIterExt, Dialect};
 
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum InitialSound {
     Vowel,
     Consonant,
-    Either, // for SQL
+    Either,
 }
 
 /// Checks whether a provided word begins with a vowel _sound_. Returns `None` if `word` is empty.
@@ -71,6 +71,11 @@ pub fn starts_with_vowel(word: &[char], dialect: Dialect) -> Option<InitialSound
     // Treat formats like `mp3` the same as `MP3`: the leading `m` is read as
     // the letter name “em”, so it takes `an` rather than `a`.
     if matches!(word, ['m', 'p', digit, ..] if digit.is_ascii_digit()) {
+        return Some(InitialSound::Vowel);
+    }
+
+    // `npm` is officially an all-lowercase initialism pronounced letter-by-letter
+    if matches!(word, ['n', 'p', 'm']) {
         return Some(InitialSound::Vowel);
     }
 
@@ -212,5 +217,18 @@ fn is_likely_acronym(word: &[char]) -> bool {
         matches!(vowel_map, [false, true, false] | [false, true, true])
     } else {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_npm_4139() {
+        assert_eq!(
+            starts_with_vowel(&['n', 'p', 'm'].to_vec(), Dialect::American),
+            Some(InitialSound::Vowel)
+        );
     }
 }

--- a/harper-core/src/linting/an_a.rs
+++ b/harper-core/src/linting/an_a.rs
@@ -394,4 +394,21 @@ mod tests {
     fn dont_flag_is_80_an_a_3715() {
         assert_no_lints("Is 80 an A in Malaysia?", AnA::new(Dialect::American));
     }
+
+    #[test]
+    fn dont_flag_an_npm_4139() {
+        assert_no_lints(
+            "Why lib/ or light-base/ alone forces an npm bump",
+            AnA::new(Dialect::American),
+        );
+    }
+
+    #[test]
+    fn correct_a_npm_4139() {
+        assert_suggestion_result(
+            "Why lib/ or light-base/ alone forces a npm bump",
+            AnA::new(Dialect::American),
+            "Why lib/ or light-base/ alone forces an npm bump",
+        );
+    }
 }


### PR DESCRIPTION
# Issues 

Fixes #4139

# Description

Support for "npm" being an all-lowercase initialism pronounced letter-by-letter and hence requiring the indefinite article "an" rather than "a".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
