### PR TITLE
feat: flag confusing "tote" and "tout"

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5490,6 +5490,13 @@
 						},
 						{
 							"Bool": {
+								"name": "ToteTout",
+								"state": true,
+								"label": "Tote/Tout"
+							}
+						},
+						{
+							"Bool": {
 								"name": "ToTheMannerBorn",
 								"state": true,
 								"label": "To The Manner Born"

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -278,6 +278,7 @@ use super::till_date::TillDate;
 use super::to_adverb::ToAdverb;
 use super::to_to::ToTo;
 use super::to_two_too::ToTwoToo;
+use super::tote_tout::ToteTout;
 use super::touristic::Touristic;
 use super::transposed_space::TransposedSpace;
 use super::try_ones_hand_at::TryOnesHandAt;
@@ -866,6 +867,7 @@ impl LintGroup {
         insert_expr_rule!(ToAdverb);
         insert_expr_rule!(ToTo);
         insert_struct_rule!(ToTwoToo);
+        insert_struct_rule!(ToteTout);
         insert_expr_rule!(Touristic);
         insert_expr_rule_with_dict!(TransposedSpace);
         insert_expr_rule!(TryOnesHandAt);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -297,6 +297,7 @@ mod till_date;
 mod to_adverb;
 mod to_to;
 mod to_two_too;
+mod tote_tout;
 mod touristic;
 mod transposed_space;
 mod try_ones_hand_at;

--- a/harper-core/src/linting/tote_tout.rs
+++ b/harper-core/src/linting/tote_tout.rs
@@ -1,0 +1,186 @@
+use crate::{
+    CharStringExt, Lint, Token,
+    expr::{Expr, FirstMatchOf, SequenceExpr},
+    linting::{
+        ExprLinter, LintKind, Suggestion,
+        expr_linter::{Chunk, find_the_only_token_matching},
+    },
+};
+
+const TOTE: &[&str] = &["tote", "toted", "totes", "toting"];
+const TOUT: &[&str] = &["tout", "touted", "touting", "touts"];
+
+const WEIRD_BEFORE_TOTE: &[&str] = &["ads", "highly", "much", "often", "ticket", "widely"];
+const WEIRD_BEFORE_TOUT: &[&str] = &["canvas", "gun", "pistol", "plastic"];
+const WEIRD_AFTER_TOTE: &[&str] = &["as"];
+const WEIRD_AFTER_TOUT: &[&str] = &["bag", "bags", "boxes"];
+
+pub struct ToteTout {
+    expr: FirstMatchOf,
+}
+
+impl Default for ToteTout {
+    fn default() -> Self {
+        Self {
+            expr: FirstMatchOf::new([
+                Box::new(
+                    SequenceExpr::word_set(WEIRD_BEFORE_TOTE)
+                        .t_ws_h()
+                        .t_set(TOTE),
+                ),
+                Box::new(
+                    SequenceExpr::word_set(WEIRD_BEFORE_TOUT)
+                        .t_ws_h()
+                        .t_set(TOUT),
+                ),
+                Box::new(SequenceExpr::word_set(TOTE).t_ws().t_set(WEIRD_AFTER_TOTE)),
+                Box::new(SequenceExpr::word_set(TOUT).t_ws().t_set(WEIRD_AFTER_TOUT)),
+            ]),
+        }
+    }
+}
+
+impl ExprLinter for ToteTout {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        let span = find_the_only_token_matching(toks, src, |t, _| {
+            let ch = t.get_ch(src);
+            ch.eq_any_ignore_ascii_case_str(TOTE) || ch.eq_any_ignore_ascii_case_str(TOUT)
+        })?
+        .span;
+        let ch = span.get_content(src);
+
+        // This is the place to rule out collocations with specific inflected forms, if need be.
+
+        // Map from wrong word to right word.
+        let (third, last) = (ch.get(2)?, ch.last()?);
+        let corr = match (third, last) {
+            ('u', 't') => "tote",
+            ('u', 'd') => "toted",
+            ('u', 'g') => "toting",
+            ('u', 's') => "totes",
+            ('t', 'e') => "tout",
+            ('t', 'd') => "touted",
+            ('t', 's') => "touts",
+            ('t', 'g') => "touting",
+            _ => return None,
+        };
+
+        let suggestions = vec![Suggestion::replace_with_match_case_str(
+            corr,
+            span.get_content(src),
+        )];
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::WordChoice,
+            suggestions,
+            message: "Are you confusng `tote` (carry, bag) with `tout` (promote, promoter)?"
+                .to_owned(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Flags places where `tote` and `tout` may be confused."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    use super::ToteTout;
+
+    #[test]
+    fn fix_toted_as_a_tool() {
+        assert_suggestion_result(
+            "remember cloudformation is toted as a tool for resource creation, not orchestration",
+            ToteTout::default(),
+            "remember cloudformation is touted as a tool for resource creation, not orchestration",
+        );
+    }
+
+    #[test]
+    fn fix_often_toted_as_the_worst() {
+        assert_suggestion_result(
+            "He is often toted as the worst killer in history",
+            ToteTout::default(),
+            "He is often touted as the worst killer in history",
+        )
+    }
+
+    #[test]
+    fn fix_gun_touting_space() {
+        assert_suggestion_result(
+            "Batman doesn't use guns now is because his back-story includes a gun touting coward stealing away his parents",
+            ToteTout::default(),
+            "Batman doesn't use guns now is because his back-story includes a gun toting coward stealing away his parents",
+        )
+    }
+
+    #[test]
+    fn fix_much_toted_space() {
+        assert_suggestion_result(
+            "I realize it's much toted for having a brilliant API, but unfortunately that's not sufficient",
+            ToteTout::default(),
+            "I realize it's much touted for having a brilliant API, but unfortunately that's not sufficient",
+        )
+    }
+
+    #[test]
+    fn fix_often_toted() {
+        assert_suggestion_result(
+            "The NN being often toted as a black box (even some say model free) model or function of its input vector.",
+            ToteTout::default(),
+            "The NN being often touted as a black box (even some say model free) model or function of its input vector.",
+        )
+    }
+
+    #[test]
+    fn fix_much_toted_hyphen() {
+        assert_suggestion_result(
+            "The much-toted \"93% hire rate\" is certainly not true for my class.",
+            ToteTout::default(),
+            "The much-touted \"93% hire rate\" is certainly not true for my class.",
+        )
+    }
+
+    #[test]
+    fn dont_flag_ad_toting() {
+        assert_no_lints(
+            "Uber's Ad-Toting Drones Are Heckling Drivers Stuck in Traffic.",
+            ToteTout::default(),
+        )
+    }
+
+    #[test]
+    fn dont_flag_plenty_of_touts_around() {
+        assert_no_lints(
+            "there are plenty of pathetic touts around the hotel",
+            ToteTout::default(),
+        )
+    }
+
+    #[test]
+    fn dont_flag_touting_box() {
+        assert_no_lints(
+            "distracting from the dysfunction by touting box office revenue as the solution for paltry royalty earnings",
+            ToteTout::default(),
+        )
+    }
+
+    #[test]
+    fn fix_widely_toted() {
+        assert_suggestion_result(
+            "It is widely toted as the smart, capable and economically insightful newspaper for the white, liberal elite.",
+            ToteTout::default(),
+            "It is widely touted as the smart, capable and economically insightful newspaper for the white, liberal elite.",
+        )
+    }
+}


### PR DESCRIPTION
# Issues 
N/A

# Description

Flags mixing up "tote" (carry) and "tout" (promote).

Made with the help of my ["ctx" tool](https://github.com/hippietrail/ctx).

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
