### PR TITLE
feat: underneath of→underneath/under

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5497,6 +5497,13 @@
 						},
 						{
 							"Bool": {
+								"name": "UnderneathOf",
+								"state": true,
+								"label": "Underneath of"
+							}
+						},
+						{
+							"Bool": {
 								"name": "Unless",
 								"state": true,
 								"label": "Unless"

--- a/harper-core/src/linting/weir_rules/UnderneathOf.weir
+++ b/harper-core/src/linting/weir_rules/UnderneathOf.weir
@@ -1,0 +1,9 @@
+expr main (underneath of)
+
+let message "`Underneath of` is not idiomatic English. `Underneath`, and `under` express a position below without requiring a second preposition such as `of`."
+let description "Corrects `underneath of`."
+let kind "Usage"
+let becomes ["underneath", "under"]
+
+test "When user tries to pick a date, the display is hidden underneath of my map." "When user tries to pick a date, the display is hidden underneath my map."
+test "At the top is the YouTube channel's name; underneath of that is the hyperlinked YouTube video's title with the hyperlink" "At the top is the YouTube channel's name; under that is the hyperlinked YouTube video's title with the hyperlink"


### PR DESCRIPTION
# Issues 
N/A

# Description

Another one that's been in my inbox for a while. "Underneath of" is not natural/idiomatic English. Flags instances of it to be replaced with just "underneath" or "under".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
