### PR TITLE
feat: three simple linters

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -406,6 +406,20 @@
 						},
 						{
 							"Bool": {
+								"name": "Codebase",
+								"state": true,
+								"label": "Codebase"
+							}
+						},
+						{
+							"Bool": {
+								"name": "Codebases",
+								"state": true,
+								"label": "Codebases"
+							}
+						},
+						{
+							"Bool": {
 								"name": "Deadlift",
 								"state": true,
 								"label": "Deadlift"
@@ -703,6 +717,13 @@
 								"name": "Somewhere",
 								"state": true,
 								"label": "Somewhere"
+							}
+						},
+						{
+							"Bool": {
+								"name": "Tenfold",
+								"state": true,
+								"label": "Tenfold"
 							}
 						},
 						{
@@ -4156,6 +4177,13 @@
 								"name": "AtTheVeryLeast",
 								"state": true,
 								"label": "At The Very Least"
+							}
+						},
+						{
+							"Bool": {
+								"name": "Audible",
+								"state": true,
+								"label": "Audible"
 							}
 						},
 						{

--- a/harper-core/src/linting/closed_compounds.rs
+++ b/harper-core/src/linting/closed_compounds.rs
@@ -27,6 +27,8 @@ pub fn lint_group() -> LintGroup {
         "Backplane"       => (&["back plane"][..], "backplane"),
         "Bypass"          => (&["by pass"][..], "bypass"),
         "Chalkboard"      => (&["chalk board"][..], "chalkboard"),
+        "Codebase"        => (&["code base"][..], "codebase"),
+        "Codebases"       => (&["code bases"][..], "codebases"),
         "Deadlift"        => (&["dead lift"][..], "deadlift"),
         "Desktop"         => (&["desk top"][..], "desktop"),
         "Devops"          => (&["dev ops"][..], "devops"),
@@ -70,6 +72,7 @@ pub fn lint_group() -> LintGroup {
         "Somehow"         => (&["some how"][..], "somehow"),
         "Someone"         => (&["some one"][..], "someone"),
         "Somewhere"       => (&["some where"][..], "somewhere"),
+        "Tenfold"         => (&["ten fold"][..], "tenfold"),
         "There"           => (&["the re"][..], "there"),
         "Therefore"       => (&["there fore"][..], "therefore"),
         "Thereupon"       => (&["there upon"][..], "thereupon"),
@@ -337,5 +340,32 @@ mod tests {
         let test_sentence = "I feel that the special case of looping over sequences that follow a standard iterator protocol (i.e. optionals) is important enough to be worth-while.";
         let expected = "I feel that the special case of looping over sequences that follow a standard iterator protocol (i.e. optionals) is important enough to be worthwhile.";
         assert_suggestion_result(test_sentence, lint_group(), expected);
+    }
+
+    #[test]
+    fn tenfold() {
+        assert_suggestion_result(
+            "If Andrew Kelly has done something wrong hasn’t Theo done that ten fold",
+            lint_group(),
+            "If Andrew Kelly has done something wrong hasn’t Theo done that tenfold",
+        )
+    }
+
+    #[test]
+    fn codebase() {
+        assert_suggestion_result(
+            "Having trouble communicating the problems in your code base?",
+            lint_group(),
+            "Having trouble communicating the problems in your codebase?",
+        )
+    }
+
+    #[test]
+    fn codebases() {
+        assert_suggestion_result(
+            "Tools to visualize large code bases in different ways.",
+            lint_group(),
+            "Tools to visualize large codebases in different ways.",
+        )
     }
 }

--- a/harper-core/src/linting/for_the_nth_time.rs
+++ b/harper-core/src/linting/for_the_nth_time.rs
@@ -1,7 +1,7 @@
 use crate::{
     Lint, Token,
     expr::{AnchorEnd, Expr, SequenceExpr},
-    linting::{ExprLinter, LintKind, Suggestion, debug::format_lint_match, expr_linter::Chunk},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
 };
 
 pub struct ForTheNthTime {
@@ -68,14 +68,7 @@ impl Default for ForTheNthTime {
 impl ExprLinter for ForTheNthTime {
     type Unit = Chunk;
 
-    fn match_to_lint_with_context(
-        &self,
-        matched_tokens: &[Token],
-        source: &[char],
-        context: Option<(&[Token], &[Token])>,
-    ) -> Option<Lint> {
-        eprintln!("🚨 {}", format_lint_match(matched_tokens, context, source));
-
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
         Some(Lint {
             span: matched_tokens[0].span,
             lint_kind: LintKind::Usage,

--- a/harper-core/src/linting/for_the_nth_time.rs
+++ b/harper-core/src/linting/for_the_nth_time.rs
@@ -68,7 +68,7 @@ impl Default for ForTheNthTime {
 impl ExprLinter for ForTheNthTime {
     type Unit = Chunk;
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint(&self, matched_tokens: &[Token], _source: &[char]) -> Option<Lint> {
         Some(Lint {
             span: matched_tokens[0].span,
             lint_kind: LintKind::Usage,

--- a/harper-core/src/linting/weir_rules/Audible.weir
+++ b/harper-core/src/linting/weir_rules/Audible.weir
@@ -1,0 +1,9 @@
+expr main hearable
+
+let message "The standard word for this is `audible`."
+let description "Corrects `hearable` to `audible`."
+let kind "WordChoice"
+let becomes "audible"
+
+test "Alexa devices speak works, but announcements is not hearable" "Alexa devices speak works, but announcements is not audible"
+test "The digital sound may be disturbing, so we can try to use waves outside of hearable range." "The digital sound may be disturbing, so we can try to use waves outside of audible range."


### PR DESCRIPTION
# Issues 
N/A

# Description

Two additions to `closed_compounds` and one Weir rule:

1. code base → codebase
2. hearable → audible
3. ten fold → tenfold

A leftover debug printf is also removed from `ForTheNthTime`

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
