### PR TITLE
feat: backhand compliment→backhanded compliment

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -2422,6 +2422,13 @@
 						},
 						{
 							"Bool": {
+								"name": "BackhandedCompliment",
+								"state": true,
+								"label": "Backhanded Compliment"
+							}
+						},
+						{
+							"Bool": {
 								"name": "BeenThere",
 								"state": true,
 								"label": "Been There"

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -737,6 +737,15 @@ pub fn lint_group() -> LintGroup {
             "Suggests using either `await` or `wait for` but not both, as they express the same meaning.",
             LintKind::Redundancy
         ),
+        "BackhandedCompliment" => (
+            &[
+                (&["backhand compliment", "back-hand compliment", "back hand compliment"], &["backhanded compliment"]),
+                (&["backhand compliments", "back-hand compliments", "back hand compliments"], &["backhanded compliments"]),
+            ],
+            "The correct spelling is `backhanded`.",
+            "Corrects `backhand compliment` to `backhanded compliment`.",
+            LintKind::Spelling
+        ),
         "CommitmentTo" => (
             &[
                 (&["commitment toward", "commitment towards"], &["commitment to"]),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -2360,6 +2360,72 @@ fn correct_awaited_for() {
     );
 }
 
+// BackhandedCompliment
+
+#[test]
+fn correct_backhand_compliment() {
+    assert_suggestion_result(
+        "What's the Most insulting /backhand compliment you have ever received?",
+        test_linter(),
+        "What's the Most insulting /backhanded compliment you have ever received?",
+    );
+}
+
+#[test]
+fn correct_back_hand_compliment_space() {
+    assert_suggestion_result(
+        "Thankfully, I'm a little young to receive that back hand compliment",
+        test_linter(),
+        "Thankfully, I'm a little young to receive that backhanded compliment",
+    );
+}
+
+#[test]
+fn correct_back_hand_compliment_hyphen() {
+    assert_suggestion_result(
+        "They \"have it all\", but still need to back-hand compliment, condescend, \"politely\" hurl passive-aggressive compliments/insults",
+        test_linter(),
+        "They \"have it all\", but still need to backhanded compliment, condescend, \"politely\" hurl passive-aggressive compliments/insults",
+    );
+}
+
+#[test]
+fn correct_backhand_compliments() {
+    assert_suggestion_result(
+        "If backhand compliments or flattery are frequent and come with ulterior motives, it's a red flag.",
+        test_linter(),
+        "If backhanded compliments or flattery are frequent and come with ulterior motives, it's a red flag.",
+    );
+}
+
+#[test]
+fn correct_back_hand_compliments() {
+    assert_suggestion_result(
+        "I am laughing so hard watching the \"commercial\" with her back hand compliments.",
+        test_linter(),
+        "I am laughing so hard watching the \"commercial\" with her backhanded compliments.",
+    );
+}
+
+#[test]
+fn correct_back_hand_compliments_caps() {
+    assert_suggestion_result(
+        "JUST SAY YOU DON'T LIKE THEM STOP GIVING FAKE BACK HAND COMPLIMENTS.",
+        test_linter(),
+        "JUST SAY YOU DON'T LIKE THEM STOP GIVING FAKE BACKHANDED COMPLIMENTS.",
+    );
+}
+
+// no praises, just tons of unnecessary back-hand compliments and lack of support
+#[test]
+fn correct_back_hand_compliments_hyphen() {
+    assert_suggestion_result(
+        "no praises, just tons of unnecessary back-hand compliments and lack of support",
+        test_linter(),
+        "no praises, just tons of unnecessary backhanded compliments and lack of support",
+    );
+}
+
 // CommitmentTo
 
 #[test]


### PR DESCRIPTION
# Issues 
N/A

# Description

Corrects backhand/back-hand/back hand compliment to backhanded compliment.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
