### PR TITLE
refactor(desktop): remove default implementations of `OsBroker`

### DIFF
--- a/harper-desktop/src-tauri/src/mac_broker/app_catalog.rs
+++ b/harper-desktop/src-tauri/src/mac_broker/app_catalog.rs
@@ -6,12 +6,12 @@ const APPLICATION_BUNDLE_CONTENT_TYPE: &str = "com.apple.application-bundle";
 
 pub fn app_search_result_from_bundle_id(bundle_id: &str) -> AppSearchResult {
     AppSearchResult {
-        name: system_integration_display_name(bundle_id),
+        name: integration_display_name(bundle_id),
         bundle_id: bundle_id.to_string(),
     }
 }
 
-pub fn system_integration_display_name(bundle_id: &str) -> String {
+pub fn integration_display_name(bundle_id: &str) -> String {
     application_path_for_bundle_id(bundle_id)
         .and_then(|path| display_name_from_app_path(&path))
         .unwrap_or_else(|| bundle_id.to_owned())

--- a/harper-desktop/src-tauri/src/mac_broker/mod.rs
+++ b/harper-desktop/src-tauri/src/mac_broker/mod.rs
@@ -386,8 +386,8 @@ impl OsBroker for MacBroker {
         }
     }
 
-    fn system_integration_display_name(&self, bundle_id: &str) -> String {
-        app_catalog::system_integration_display_name(bundle_id)
+    fn integration_display_name(&self, bundle_id: &str) -> String {
+        app_catalog::integration_display_name(bundle_id)
     }
 
     fn application_icon_png(&self, bundle_id: &str) -> Result<Vec<u8>, String> {

--- a/harper-desktop/src-tauri/src/mac_broker/mod.rs
+++ b/harper-desktop/src-tauri/src/mac_broker/mod.rs
@@ -430,6 +430,10 @@ impl OsBroker for MacBroker {
         Ok(())
     }
 
+    fn installed_application_bundle_ids(&self) -> Result<Vec<String>, String> {
+        app_catalog::installed_application_bundle_ids()
+    }
+
     fn search_apps(&self, query: &str) -> Result<Vec<AppSearchResult>, String> {
         let mut lock = self
             .installed_app_search_index

--- a/harper-desktop/src-tauri/src/os_broker.rs
+++ b/harper-desktop/src-tauri/src/os_broker.rs
@@ -34,18 +34,16 @@ pub trait OsBroker {
     /// Request permission to access the OS' native accessibility API.
     fn request_accessibility_permission(&self) -> AccessibilityPermissionStatus;
 
-    /// Given an application identifier, find that bundle's human-readable name.
-    fn system_integration_display_name(&self, bundle_id: &str) -> String;
-
+    /// Given an application identifier, find that integration's human-readable name.
     fn integration_display_name(&self, bundle_id: &str) -> String {
-        self.system_integration_display_name(bundle_id)
+        bundle_id.to_owned()
     }
 
     /// Returns the bundle identifiers for installed graphical applications.
     ///
     /// Implementations should return stable bundle ID strings, sorted and deduplicated where
     /// possible. Platforms that do not support bundle IDs should return an error.
-    fn installed_application_bundle_ids(&self) -> Result<Vec<String>, String> ;
+    fn installed_application_bundle_ids(&self) -> Result<Vec<String>, String>;
 
     /// Returns the application icon for `bundle_id` encoded as PNG bytes.
     ///
@@ -54,10 +52,10 @@ pub trait OsBroker {
     fn application_icon_png(&self, _bundle_id: &str) -> Result<Vec<u8>, String>;
 
     /// Start an application given its bundle ID.
-    fn launch_app_bundle(&self, _bundle_id: &str) -> Result<(), String>; 
+    fn launch_app_bundle(&self, _bundle_id: &str) -> Result<(), String>;
 
     /// Search for an application in the OS' global list of installed apps.
-    fn search_apps(&self, _query: &str) -> Result<Vec<AppSearchResult>, String> ;
+    fn search_apps(&self, _query: &str) -> Result<Vec<AppSearchResult>, String>;
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -85,31 +83,23 @@ impl OsBroker for NoopBroker {
         None
     }
 
-    fn accessibility_permission_status(&self) -> AccessibilityPermissionStatus{
+    fn accessibility_permission_status(&self) -> AccessibilityPermissionStatus {
         AccessibilityPermissionStatus::Unsupported
     }
 
-    fn request_accessibility_permission(&self) -> AccessibilityPermissionStatus{
+    fn request_accessibility_permission(&self) -> AccessibilityPermissionStatus {
         AccessibilityPermissionStatus::Unsupported
-    }
-
-    fn system_integration_display_name(&self, bundle_id: &str) -> String{
-        bundle_id.to_string()
-    }
-
-    fn integration_display_name(&self, bundle_id: &str) -> String {
-        self.system_integration_display_name(bundle_id)
     }
 
     fn installed_application_bundle_ids(&self) -> Result<Vec<String>, String> {
-            Ok(Vec::new())
+        Ok(Vec::new())
     }
 
-    fn application_icon_png(&self, _bundle_id: &str) -> Result<Vec<u8>, String>{
+    fn application_icon_png(&self, _bundle_id: &str) -> Result<Vec<u8>, String> {
         Err("Cannot get application icons.".to_string())
     }
 
-    fn launch_app_bundle(&self, _bundle_id: &str) -> Result<(), String>{
+    fn launch_app_bundle(&self, _bundle_id: &str) -> Result<(), String> {
         Ok(())
     }
 

--- a/harper-desktop/src-tauri/src/os_broker.rs
+++ b/harper-desktop/src-tauri/src/os_broker.rs
@@ -19,24 +19,23 @@ pub enum AccessibilityPermissionStatus {
 /// those APIs are platform-specific. This trait keeps the event loop and renderer independent from
 /// macOS accessibility and pointer APIs.
 pub trait OsBroker {
+    /// Get the actionable lint boxes from the OS, provided a linting source.
     fn get_boxes(
         &mut self,
         lint_text: &mut dyn FnMut(&str) -> BTreeMap<String, Vec<Lint>>,
     ) -> Vec<ActionableLint>;
 
+    /// Grab the position of the user's cursor on the screen.
     fn cursor_position(&self) -> Option<egui::Pos2>;
 
-    fn accessibility_permission_status(&self) -> AccessibilityPermissionStatus {
-        AccessibilityPermissionStatus::Unsupported
-    }
+    /// Check whether Harper has permission to access the OS' native accessibility API.
+    fn accessibility_permission_status(&self) -> AccessibilityPermissionStatus;
 
-    fn request_accessibility_permission(&self) -> AccessibilityPermissionStatus {
-        self.accessibility_permission_status()
-    }
+    /// Request permission to access the OS' native accessibility API.
+    fn request_accessibility_permission(&self) -> AccessibilityPermissionStatus;
 
-    fn system_integration_display_name(&self, bundle_id: &str) -> String {
-        bundle_id.to_owned()
-    }
+    /// Given an application identifier, find that bundle's human-readable name.
+    fn system_integration_display_name(&self, bundle_id: &str) -> String;
 
     fn integration_display_name(&self, bundle_id: &str) -> String {
         self.system_integration_display_name(bundle_id)
@@ -46,25 +45,19 @@ pub trait OsBroker {
     ///
     /// Implementations should return stable bundle ID strings, sorted and deduplicated where
     /// possible. Platforms that do not support bundle IDs should return an error.
-    fn installed_application_bundle_ids(&self) -> Result<Vec<String>, String> {
-        Err("Listing installed application bundle IDs is only supported on macOS.".to_string())
-    }
+    fn installed_application_bundle_ids(&self) -> Result<Vec<String>, String> ;
 
     /// Returns the application icon for `bundle_id` encoded as PNG bytes.
     ///
     /// The broker returns raw bytes so callers can choose their own transport format, such as a
     /// Tauri command converting them into a data URL.
-    fn application_icon_png(&self, _bundle_id: &str) -> Result<Vec<u8>, String> {
-        Err("Reading application icons by bundle ID is only supported on macOS.".to_string())
-    }
+    fn application_icon_png(&self, _bundle_id: &str) -> Result<Vec<u8>, String>;
 
-    fn launch_app_bundle(&self, _bundle_id: &str) -> Result<(), String> {
-        Err("Launching apps by bundle ID is only supported on macOS.".to_string())
-    }
+    /// Start an application given its bundle ID.
+    fn launch_app_bundle(&self, _bundle_id: &str) -> Result<(), String>; 
 
-    fn search_apps(&self, _query: &str) -> Result<Vec<AppSearchResult>, String> {
-        Err("App search is only supported on macOS.".to_string())
-    }
+    /// Search for an application in the OS' global list of installed apps.
+    fn search_apps(&self, _query: &str) -> Result<Vec<AppSearchResult>, String> ;
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -77,11 +70,9 @@ pub struct AppSearchResult {
 ///
 /// This lets the highlighter compile on non-macOS platforms while making it explicit that there is
 /// currently no accessibility or cursor integration there.
-#[cfg(not(target_os = "macos"))]
 #[derive(Default)]
 pub struct NoopBroker;
 
-#[cfg(not(target_os = "macos"))]
 impl OsBroker for NoopBroker {
     fn get_boxes(
         &mut self,
@@ -92,5 +83,37 @@ impl OsBroker for NoopBroker {
 
     fn cursor_position(&self) -> Option<egui::Pos2> {
         None
+    }
+
+    fn accessibility_permission_status(&self) -> AccessibilityPermissionStatus{
+        AccessibilityPermissionStatus::Unsupported
+    }
+
+    fn request_accessibility_permission(&self) -> AccessibilityPermissionStatus{
+        AccessibilityPermissionStatus::Unsupported
+    }
+
+    fn system_integration_display_name(&self, bundle_id: &str) -> String{
+        bundle_id.to_string()
+    }
+
+    fn integration_display_name(&self, bundle_id: &str) -> String {
+        self.system_integration_display_name(bundle_id)
+    }
+
+    fn installed_application_bundle_ids(&self) -> Result<Vec<String>, String> {
+            Ok(Vec::new())
+    }
+
+    fn application_icon_png(&self, _bundle_id: &str) -> Result<Vec<u8>, String>{
+        Err("Cannot get application icons.".to_string())
+    }
+
+    fn launch_app_bundle(&self, _bundle_id: &str) -> Result<(), String>{
+        Ok(())
+    }
+
+    fn search_apps(&self, _query: &str) -> Result<Vec<AppSearchResult>, String> {
+        Ok(Vec::new())
     }
 }

--- a/harper-desktop/src-tauri/src/windows_broker/automation_service.rs
+++ b/harper-desktop/src-tauri/src/windows_broker/automation_service.rs
@@ -1,8 +1,7 @@
-use std::fmt::Arguments;
 use std::iter::once;
-use std::sync::mpsc::{Receiver, Sender, SyncSender, TryRecvError, TrySendError, sync_channel};
+use std::sync::mpsc::{Receiver, SyncSender, TryRecvError, TrySendError, sync_channel};
 use std::thread::{JoinHandle, sleep};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use crate::rect::Rect;
 use crate::windows_broker::get_focused_monitor_scale;
@@ -14,16 +13,12 @@ use uiautomation::{
     patterns::{UITextPattern, UIValuePattern},
 };
 use windows::Win32::Foundation::HWND;
-use windows::Win32::Graphics::Gdi::{
-    MONITOR_DEFAULTTONEAREST, MONITOR_DEFAULTTONULL, MonitorFromWindow,
-};
 use windows::Win32::UI::Accessibility::IUIAutomationTextRange;
-use windows::Win32::UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI};
 use windows::Win32::UI::WindowsAndMessaging::{GetForegroundWindow, GetWindowThreadProcessId};
 
 /// Information about a worker thread.
 struct WorkerData {
-    thread_handle: JoinHandle<()>,
+    _thread_handle: JoinHandle<()>,
     sender: SyncSender<(WorkerJob, Vec<JobArgument>)>,
     receiver: Receiver<JobResult>,
 }
@@ -136,7 +131,7 @@ impl AutomationService {
         self.worker_data = Some(WorkerData {
             receiver: result_receiver,
             sender: job_sender,
-            thread_handle: handle,
+            _thread_handle: handle,
         });
     }
 
@@ -229,6 +224,12 @@ impl AutomationService {
 
         self.last_focused_window = Some(focused_window);
         Some((focused_window, false))
+    }
+}
+
+impl Drop for AutomationService {
+    fn drop(&mut self) {
+        self.stop_worker_thread();
     }
 }
 

--- a/harper-desktop/src-tauri/src/windows_broker/mod.rs
+++ b/harper-desktop/src-tauri/src/windows_broker/mod.rs
@@ -1,8 +1,4 @@
-use std::{
-    cell::RefCell,
-    collections::BTreeMap,
-    rc::Rc,
-};
+use std::{cell::RefCell, collections::BTreeMap, rc::Rc};
 
 use crate::windows_broker::automation_service::AutomationService;
 use crate::{
@@ -14,9 +10,7 @@ use harper_core::linting::Lint;
 use windows::Win32::Foundation::POINT;
 use windows::Win32::Graphics::Gdi::{MONITOR_DEFAULTTONEAREST, MonitorFromWindow};
 use windows::Win32::UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI};
-use windows::Win32::UI::WindowsAndMessaging::{
-    GetCursorPos, GetForegroundWindow,
-};
+use windows::Win32::UI::WindowsAndMessaging::{GetCursorPos, GetForegroundWindow};
 mod automation_service;
 
 pub struct WindowsBroker {

--- a/harper-desktop/src-tauri/src/windows_broker/mod.rs
+++ b/harper-desktop/src-tauri/src/windows_broker/mod.rs
@@ -1,20 +1,21 @@
 use std::{
     cell::RefCell,
-    collections::{self, BTreeMap},
+    collections::BTreeMap,
     rc::Rc,
 };
 
 use crate::windows_broker::automation_service::AutomationService;
-use crate::{os_broker::AccessibilityPermissionStatus, os_broker::OsBroker, rect::ActionableLint};
+use crate::{
+    os_broker::{AccessibilityPermissionStatus, AppSearchResult, OsBroker},
+    rect::ActionableLint,
+};
 use egui::Pos2;
 use harper_core::linting::Lint;
-use uiautomation::Result;
-use uiautomation::{UIAutomation, UIElement, UITreeWalker};
 use windows::Win32::Foundation::POINT;
 use windows::Win32::Graphics::Gdi::{MONITOR_DEFAULTTONEAREST, MonitorFromWindow};
 use windows::Win32::UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI};
 use windows::Win32::UI::WindowsAndMessaging::{
-    GetCursorPos, GetForegroundWindow, GetPhysicalCursorPos,
+    GetCursorPos, GetForegroundWindow,
 };
 mod automation_service;
 
@@ -105,6 +106,31 @@ impl OsBroker for WindowsBroker {
 
     fn accessibility_permission_status(&self) -> AccessibilityPermissionStatus {
         AccessibilityPermissionStatus::Granted
+    }
+
+    fn request_accessibility_permission(&self) -> AccessibilityPermissionStatus {
+        AccessibilityPermissionStatus::Granted
+    }
+
+    fn integration_display_name(&self, bundle_id: &str) -> String {
+        bundle_id.to_string()
+    }
+
+    fn installed_application_bundle_ids(&self) -> Result<Vec<String>, String> {
+        Ok(Vec::new())
+    }
+
+    fn application_icon_png(&self, _bundle_id: &str) -> Result<Vec<u8>, String> {
+        Err("Not supported".to_string())
+    }
+
+    fn launch_app_bundle(&self, _bundle_id: &str) -> Result<(), String> {
+        Ok(())
+    }
+
+    /// Search for an application in the OS' global list of installed apps.
+    fn search_apps(&self, _query: &str) -> Result<Vec<AppSearchResult>, String> {
+        Ok(Vec::new())
     }
 }
 

--- a/harper-desktop/src-tauri/src/windows_broker/mod.rs
+++ b/harper-desktop/src-tauri/src/windows_broker/mod.rs
@@ -142,7 +142,7 @@ fn get_focused_monitor_scale() -> f64 {
         let mut x = 0;
         let mut y = 0;
 
-        GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut x, &mut y);
+        let _ = GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut x, &mut y);
 
         let effective_scale = x as f64 / 96.;
         effective_scale


### PR DESCRIPTION
# Description

I noticed that the `OsBroker` has default implementations for most of its functions. This repeats the functionality found in `NoopBroker`.

I have removed the default implementations and updated the downstream implementations of the trait.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->


- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
