### PR TITLE
feat: combinate→combine

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -4398,6 +4398,13 @@
 						},
 						{
 							"Bool": {
+								"name": "Combinate",
+								"state": true,
+								"label": "Combinate"
+							}
+						},
+						{
+							"Bool": {
 								"name": "ComprisesOf",
 								"state": true,
 								"label": "Comprises Of"

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -111,6 +111,17 @@ pub fn lint_group() -> LintGroup {
             "Corrects extraneous apostrophe in `client's side` and `server's side`.",
             LintKind::Punctuation
         ),
+        "Combinate" => (
+            &[
+                ("combinate", "combine"),
+                ("combinated", "combined"),
+                ("combinating", "combining"),
+                ("combinates", "combines"),
+            ],
+            "Did you mean `combine` rather than the nonstandard `combinate`?",
+            "Suggests replacing the nonstandard verb `combinate` with the standard `combine`.",
+            LintKind::Nonstandard
+        ),
         "CompulseToCompel" => (
             &[
                 ("compulse", "compel"),

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -254,6 +254,44 @@ fn correct_servers_side() {
     );
 }
 
+// Combinate
+
+#[test]
+fn correct_combinate() {
+    assert_suggestion_result(
+        "I'm at chapter 11 and I can't craft and combinate abyss gear, what should I do to unlock both of them",
+        test_linter(),
+        "I'm at chapter 11 and I can't craft and combine abyss gear, what should I do to unlock both of them",
+    );
+}
+
+#[test]
+fn correct_combinated() {
+    assert_suggestion_result(
+        "NFS WORLD COMBINATED MAP (NEW!)",
+        test_linter(),
+        "NFS WORLD COMBINED MAP (NEW!)",
+    );
+}
+
+#[test]
+fn correct_combinates() {
+    assert_suggestion_result(
+        "is there a game that combinates ottd and rts?",
+        test_linter(),
+        "is there a game that combines ottd and rts?",
+    );
+}
+
+#[test]
+fn correct_combinating() {
+    assert_suggestion_result(
+        "This section discusses how the color combinating is accomplished",
+        test_linter(),
+        "This section discusses how the color combining is accomplished",
+    );
+}
+
 // CompulseToCompel
 
 #[test]


### PR DESCRIPTION
# Issues 
N/A

# Description

Corrects the non-word "combinate" to standard "combine".
Works with all inflections.

The spellchecker did already suggest the right fixes for all forms except "combinating".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
