### PR TITLE
feat: in/on the grand scale of things→grand scheme

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -4860,6 +4860,13 @@
 						},
 						{
 							"Bool": {
+								"name": "InTheGrandSchemeOfThings",
+								"state": true,
+								"label": "In the Grand Scheme of Things"
+							}
+						},
+						{
+							"Bool": {
 								"name": "InThisThatRegard",
 								"state": true,
 								"label": "In This/That Regard"

--- a/harper-core/src/linting/weir_rules/InTheGrandSchemeOfThings.weir
+++ b/harper-core/src/linting/weir_rules/InTheGrandSchemeOfThings.weir
@@ -1,0 +1,10 @@
+expr main [(in the grand scale of things), (on the grand scale of things), (on the grand scheme of things)]
+
+let message "Did you mean `in the grand scheme of things`?"
+let description "Corrects nonstandard variants of `in the grand scheme of things`."
+let kind "Typo"
+let becomes "in the grand scheme of things"
+
+test "I realise that in the grand scale of things this is a fairly minor issue, but it still annoys me." "I realise that in the grand scheme of things this is a fairly minor issue, but it still annoys me."
+test "Besides, one match is a small sample size and would not change the data that much on the grand scheme of things" "Besides, one match is a small sample size and would not change the data that much in the grand scheme of things"
+test "It might be a while. How important is this on the grand scale of things?" "It might be a while. How important is this in the grand scheme of things?"


### PR DESCRIPTION
# Issues 
N/A

# Description

Corrects wrong variants of "in/on the grand scale of things" to "in the grand scheme of things".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
