### PR TITLE
fix(core): read emphasis all-caps as words in AnA

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -3445,9 +3445,12 @@ FOFL
 FORTRAN/Og
 FOSS/ONV            # free open source software
 FPO/N
+FPS/N               # frames per second; first-person shooter
 FSF/Og
 FSLIC/O
 FTC/O
+FTP/Ng              # file transfer protocol
+FTPS/Ng             # FTP over TLS
 FUD/NS
 FWD/N
 FWIW/
@@ -6267,6 +6270,7 @@ MP/NOgJ             # military police; member of parliament
 MP3/NSg             # audio format
 MP4/NSg             # audio/video format
 MPEG/ON
+MPG/N               # miles per gallon
 MRI/NgV             # magnetic resonance imaging
 MS/NOg              # US state (Mississippi)
 MSG/NOg             # flavour enhancer
@@ -8986,6 +8990,7 @@ SS/NOJ
 SSA/ONJ
 SSD/NSg             # solid-state drive
 SSE/NOgJ
+SSH/Ng              # secure shell
 SSS/ON
 SST/NO
 SSW/NgJ

--- a/harper-core/src/linting/an_a.rs
+++ b/harper-core/src/linting/an_a.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 
 use crate::{
-    CharStringExt, Dialect, Document, TokenStringExt,
+    CharStringExt, Dialect, Document, OrthFlags, TokenStringExt,
     indefinite_article::{InitialSound, starts_with_vowel},
     linting::{Lint, LintKind, Linter, Suggestion},
 };
@@ -75,6 +75,28 @@ impl Linter for AnA {
 
                 let Some(a_an) = is_a_an else {
                     continue;
+                };
+
+                // An all-caps token whose entry licenses a lowercase spelling but no
+                // all-caps one is an ordinary word written for emphasis ("a FREE event"),
+                // not an initialism. Read it as the lowercase word. Entries that do
+                // license all-caps (`LAN`, `NAT`, `MA`) keep the initialism handling, as
+                // do Roman numerals, which are numbers rather than words.
+                let lowered;
+                let chars_second = match second.kind.as_word() {
+                    Some(Some(meta))
+                        if chars_second.len() > 1
+                            && chars_second
+                                .iter()
+                                .all(|c| !c.is_alphabetic() || c.is_uppercase())
+                            && meta.orth_info.contains(OrthFlags::LOWERCASE)
+                            && !meta.orth_info.contains(OrthFlags::ALLCAPS)
+                            && !meta.orth_info.contains(OrthFlags::ROMAN_NUMERALS) =>
+                    {
+                        lowered = chars_second.to_lower();
+                        lowered.as_ref()
+                    }
+                    _ => chars_second,
                 };
 
                 let should_be_a_an = match starts_with_vowel(chars_second, self.dialect)
@@ -276,6 +298,40 @@ mod tests {
             0,
         );
         assert_lint_count("a AM transmitter", AnA::new(Dialect::American), 1);
+    }
+
+    /// Issue #3921: an all-caps token whose entry has no all-caps spelling of its
+    /// own is an ordinary word written for emphasis, not an initialism.
+    #[test]
+    fn reads_emphasis_caps_as_words() {
+        assert_lint_count("a FREE event", AnA::new(Dialect::American), 0);
+        assert_lint_count(
+            "James Bond deals with a SPECTRE agent",
+            AnA::new(Dialect::American),
+            0,
+        );
+        assert_lint_count(
+            "a FLASH based filing system",
+            AnA::new(Dialect::American),
+            0,
+        );
+        assert_lint_count("a SYN flood attack", AnA::new(Dialect::American), 0);
+        assert_lint_count("a STUN server", AnA::new(Dialect::American), 0);
+    }
+
+    /// The same guard must not swallow initialisms whose entries do license an
+    /// all-caps spelling, nor Roman numerals, which are numbers rather than words.
+    #[test]
+    fn keeps_initialisms_and_roman_numerals() {
+        assert_lint_count("an SSH tunnel", AnA::new(Dialect::American), 0);
+        assert_lint_count("an FTP server", AnA::new(Dialect::American), 0);
+        assert_lint_count("an FTPS connection", AnA::new(Dialect::American), 0);
+        assert_lint_count("an FPS multiplayer game", AnA::new(Dialect::American), 0);
+        assert_lint_count("an MPG figure", AnA::new(Dialect::American), 0);
+        assert_lint_count("an ML research project", AnA::new(Dialect::American), 0);
+        assert_lint_count("an XVI century painting", AnA::new(Dialect::American), 0);
+        // Still wrong, and still caught.
+        assert_lint_count("a SSH and Telnet connector", AnA::new(Dialect::American), 1);
     }
 
     #[test]


### PR DESCRIPTION
> **Disclaimer, per [`AGENT_POLICY.md`](https://github.com/Automattic/harper/blob/master/AGENT_POLICY.md):** this patch was produced by an agent (Claude Opus 5) operated by me. The design came out of the discussion in #3921 with @hippietrail, and every number below was measured rather than asserted, but the code and the dictionary lines were written by the model and I reviewed them.

Closes #3921.

## The problem

`AnA` treats every all-caps token as an initialism, so `a FREE event` gets flagged in favour of `an FREE event`. As @jbt found in #3921, the likely-acronym check only looks at the vowel-ness of the first two characters, which cannot tell an ordinary word written for emphasis from a letter-by-letter abbreviation.

## The approach

Use the orthography the dictionary already records, rather than adding a new property. An all-caps token whose entry licenses a lowercase spelling but **no** all-caps one is a word being shouted, so read it as the lowercase word:

- `free` and `spectre` are `LOWERCASE` only, so `FREE` and `SPECTRE` are emphasis caps.
- `LAN`, `NAT`, `MA`, `FBI` and `NASA` carry `ALLCAPS`, because the all-caps form is a real spelling of the entry, so they keep the initialism handling.
- Roman numerals are excluded. They are numbers rather than words, so `an XVI` keeps whatever `master` does today.

This needs no acronym/initialism property and no commitment on what to call these things, which was @hippietrail's objection to my first framing in the issue thread.

## The dictionary lines

The guard is only as good as the all-caps coverage in the dictionary, so five abbreviations it would otherwise misread need their all-caps spelling recorded:

| Entry | Why |
|---|---|
| `FPS/N` | frames per second; first-person shooter — both read letter-by-letter |
| `FTP/Ng` | @hippietrail's call in #3921: "`ftp` and `ssh` are wrong in the dictionary and should both be all-caps" |
| `FTPS/Ng` | the `S` affix on `FTP` produces `FTPs`, not `FTPS`, so the plural does not inherit the all-caps spelling |
| `MPG/N` | miles per gallon |
| `SSH/Ng` | secure shell |

`ml` is deliberately **not** touched. It survives today only because M+L parses as 1050, so the Roman-numeral exclusion catches it by accident. It wants a real entry once the millilitre/megalitre/machine-learning question is settled, which is @hippietrail's to call.

`SYN` needs no entry either: it is read "sin", so the word reading is the correct one.

## Verification

Corpus of 999 GitHub READMEs and 15 Wikipedia articles, 1.9M words. `AnA` goes from **178 lints to 170**:

```
fixed     a FREE provider (no signup needed)     x2
          a FREE graphics generator
          a **FREE System Design Interview
          a FLASH based filing system
          a [SPONSOR](./SPONSORS.md)!
          a SYN flood attack / a SYN to the server / a SYN-ACK

newly     an SYN data packet over an IP network
flagged   (correct — SYN is read "sin")
```

Nine false positives removed, one correct new flag, no regressions. `an SSH` (12 uses), `an FTP` (6) and `an ML` (1) all occur in the corpus and stay clean, and `a SSH and Telnet connector` is still flagged as it should be.

Tests:

- `cargo test -p harper-core an_a` — 67 passed, 0 failed (two new tests cover both directions)
- `cargo test -p harper-core` — passes except `curated_default_config_lists_every_registered_rule`, which fails identically on `master` (`AWholeOther`, `AllWellAndGood`, `UnderneathOf` drift in `default_config.json`, unrelated to this change)
- `cargo fmt` clean
- `cargo clippy -p harper-core --all-targets -- -D warnings` — same 17 errors as `master`, none in `an_a.rs`

## Not in this PR

Sweeping the dictionary, 9,726 entries have an article the guard changes; 143 of those actually occur in the corpus. The frequent end is all shouting and reads correctly now. The tail has about a dozen two-and-three-letter abbreviations I would not decide alone (`RPS`, `RT`, `RM`, `LB`, `HMM`, `SQ`, `MFR`, `MPH`, `FT`, `LTD`, `SH`). Those belong in a dictionary-curation pass, not here — happy to send the full list.
