### PR TITLE
feat: go into sleep→go to sleep

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -4727,6 +4727,13 @@
 						},
 						{
 							"Bool": {
+								"name": "GoToSleep",
+								"state": true,
+								"label": "Go to Sleep"
+							}
+						},
+						{
+							"Bool": {
 								"name": "Handful",
 								"state": true,
 								"label": "Handful"

--- a/harper-core/src/linting/go_to_sleep.rs
+++ b/harper-core/src/linting/go_to_sleep.rs
@@ -1,0 +1,164 @@
+use crate::{
+    Lint, Token,
+    expr::{All, Expr, OwnedExprExt, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+    patterns::WordSet,
+};
+
+pub struct GoToSleep {
+    expr: All,
+}
+
+impl Default for GoToSleep {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::word_set(&["go", "goes", "going", "gone", "went"])
+                .t_ws()
+                .then_word_seq(&["into", "sleep"])
+                .but_not(
+                    SequenceExpr::anything() // go
+                        .t_any() // ws
+                        .t_any() // into
+                        .t_any() // ws
+                        .t_any() // sleep
+                        .then_any_of([
+                            Box::new(
+                                SequenceExpr::whitespace().then_any_of([
+                                    Box::new(WordSet::new(&["mode", "state"])) as Box<dyn Expr>,
+                                    Box::new(
+                                        SequenceExpr::default()
+                                            .then_adjective()
+                                            .t_ws()
+                                            .t_set(&["mode", "state"]),
+                                    ),
+                                ]),
+                            ),
+                            Box::new(SequenceExpr::default().then_slash().t_set(&[
+                                "hibernate",
+                                "hibernation",
+                                "suspend",
+                            ])),
+                        ]),
+                ),
+        }
+    }
+}
+
+impl ExprLinter for GoToSleep {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        let span = toks.get(2)?.span;
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::Usage,
+            suggestions: vec![Suggestion::replace_with_match_case_str(
+                "to",
+                span.get_content(src),
+            )],
+            message: "Use `go to sleep` instead of `go into sleep`.".to_owned(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects `go into sleep` to `go to sleep`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    use super::GoToSleep;
+
+    #[test]
+    fn fix_go_to_sleep() {
+        assert_suggestion_result(
+            "I changed sleep mode to s3 and now my computer cant go into sleep, it just shut down.",
+            GoToSleep::default(),
+            "I changed sleep mode to s3 and now my computer cant go to sleep, it just shut down.",
+        );
+    }
+
+    #[test]
+    fn fix_goes_into_sleep() {
+        assert_suggestion_result(
+            "On macbook with working Internet, close the lid so that mac goes into sleep.",
+            GoToSleep::default(),
+            "On macbook with working Internet, close the lid so that mac goes to sleep.",
+        );
+    }
+
+    #[test]
+    fn fix_going_into_sleep() {
+        assert_suggestion_result(
+            "Either pressing the power button on top of the Deck or going into Sleep from the Launcher freezes the Deck",
+            GoToSleep::default(),
+            "Either pressing the power button on top of the Deck or going to Sleep from the Launcher freezes the Deck",
+        );
+    }
+
+    #[test]
+    fn fix_gone_into_sleep() {
+        assert_suggestion_result(
+            "The last time this happened, it was after the computer had gone into sleep when I was away from my desk",
+            GoToSleep::default(),
+            "The last time this happened, it was after the computer had gone to sleep when I was away from my desk",
+        );
+    }
+
+    #[test]
+    fn fix_went_into_sleep() {
+        assert_suggestion_result(
+            "Broken UI rendering after macOS went into sleep",
+            GoToSleep::default(),
+            "Broken UI rendering after macOS went to sleep",
+        );
+    }
+
+    #[test]
+    fn dont_flag_go_into_sleep_state() {
+        assert_no_lints(
+            "When using Jobber, they either go into sleep state while still retaining memory",
+            GoToSleep::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_goes_into_sleep_mode() {
+        assert_no_lints(
+            "When the computer goes into sleep mode or the screen turns off, the program reports an error and closes.",
+            GoToSleep::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_went_into_sleep_suspend() {
+        assert_no_lints(
+            "The power LED remains ON even when it presumably went into sleep/suspend mode",
+            GoToSleep::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_goes_into_sleep_slash_hibernate() {
+        assert_no_lints(
+            "When the laptop goes into sleep/hibernate mode and they come back to it, it shows Netbird is connected",
+            GoToSleep::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_goes_into_sleep_slash_hibernation() {
+        assert_no_lints(
+            "Whenever system goes into sleep/hibernation and comes back, sometimes the driver will get \"stuck\"",
+            GoToSleep::default(),
+        );
+    }
+}

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -109,6 +109,7 @@ use super::full_to_the_brim::FullToTheBrim;
 use super::get_pass_go_pass::GetPassGoPass;
 use super::go_missing::GoMissing;
 use super::go_so_far_as_to::GoSoFarAsTo;
+use super::go_to_sleep::GoToSleep;
 use super::go_to_war::GoToWar;
 use super::good_at::GoodAt;
 use super::handful::Handful;
@@ -707,6 +708,7 @@ impl LintGroup {
         insert_expr_rule!(GetPassGoPass);
         insert_expr_rule!(GoMissing);
         insert_expr_rule!(GoSoFarAsTo);
+        insert_expr_rule!(GoToSleep);
         insert_expr_rule!(GoToWar);
         insert_expr_rule!(GoodAt);
         insert_expr_rule!(Handful);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -110,6 +110,7 @@ mod full_to_the_brim;
 mod get_pass_go_pass;
 mod go_missing;
 mod go_so_far_as_to;
+mod go_to_sleep;
 mod go_to_war;
 mod good_at;
 mod handful;


### PR DESCRIPTION
# Issues 
N/A

# Description

Corrects "go into sleep" to "go to sleep".

Avoids flagging "sleep mode" or "sleep state".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
