### PR TITLE
feat(harper-core): add GetAccessTo lint rule

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -3443,6 +3443,13 @@
 						},
 						{
 							"Bool": {
+								"name": "GetAccessTo",
+								"state": true,
+								"label": "Get Access To"
+							}
+						},
+						{
+							"Bool": {
 								"name": "GetPassGoPass",
 								"state": true,
 								"label": "Get Pass, Go Pass"

--- a/harper-core/src/linting/get_access_to.rs
+++ b/harper-core/src/linting/get_access_to.rs
@@ -127,9 +127,7 @@ impl Default for GetAccessTo {
                 .t_ws()
                 .then_optional(optional_modifiers)
                 .then_optional(optional_adjectives)
-                .t_aco("access")
-                .t_ws()
-                .t_aco("at"),
+                .then_word_seq(&["access", "at"]),
         }
     }
 }
@@ -152,13 +150,16 @@ impl ExprLinter for GetAccessTo {
         ctx: Option<(&[Token], &[Token])>,
     ) -> Option<Lint> {
         if let Some((_, after)) = ctx {
-            let following_words: Vec<&Token> = after
-                .iter()
-                .filter(|t| !t.kind.is_whitespace())
-                .take(4)
-                .collect();
+            let mut following_words = [None; 4];
+            for (slot, tok) in following_words
+                .iter_mut()
+                .zip(after.iter().filter(|t| !t.kind.is_whitespace()))
+            {
+                *slot = Some(tok);
+            }
+            let following_words_len = following_words.iter().flatten().count();
 
-            if let Some(first_tok) = following_words.first() {
+            if let Some(first_tok) = following_words[0] {
                 // If followed by URL, hostname, email, or unlintable token
                 if matches!(
                     first_tok.kind,
@@ -178,8 +179,8 @@ impl ExprLinter for GetAccessTo {
                 }
 
                 // Check for temporal adverbials like "at this time", "at any point", "at that moment"
-                if following_words.len() >= 2 {
-                    let second_chars = following_words[1].span.get_content(src);
+                if following_words_len >= 2 {
+                    let second_chars = following_words[1].unwrap().span.get_content(src);
                     if first_chars.eq_any_ignore_ascii_case_str(TEMPORAL_DETERMINERS)
                         && second_chars.eq_any_ignore_ascii_case_str(TEMPORAL_NOUNS)
                     {
@@ -189,7 +190,7 @@ impl ExprLinter for GetAccessTo {
 
                 // Check for level expressions like "at the disk level", "at the system level"
                 if first_chars.eq_any_ignore_ascii_case_str(TEMPORAL_DETERMINERS) {
-                    for following_tok in &following_words[1..] {
+                    for following_tok in following_words[1..].iter().flatten() {
                         let word_chars = following_tok.span.get_content(src);
                         if word_chars.eq_any_ignore_ascii_case_str(&["level", "levels"]) {
                             return None;

--- a/harper-core/src/linting/get_access_to.rs
+++ b/harper-core/src/linting/get_access_to.rs
@@ -1,0 +1,350 @@
+use crate::{
+    CharStringExt, Lint, Token, TokenKind,
+    expr::{Expr, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+};
+
+static ACCESS_VERBS: &[&str] = &[
+    "get",
+    "gets",
+    "got",
+    "gotten",
+    "getting",
+    "gain",
+    "gains",
+    "gained",
+    "gaining",
+    "have",
+    "has",
+    "had",
+    "having",
+    "obtain",
+    "obtains",
+    "obtained",
+    "obtaining",
+    "grant",
+    "grants",
+    "granted",
+    "granting",
+    "give",
+    "gives",
+    "gave",
+    "given",
+    "giving",
+    "request",
+    "requests",
+    "requested",
+    "requesting",
+    "provide",
+    "provides",
+    "provided",
+    "providing",
+    "seek",
+    "seeks",
+    "sought",
+    "seeking",
+    "secure",
+    "secures",
+    "secured",
+    "securing",
+    "deny",
+    "denies",
+    "denied",
+    "denying",
+    "allow",
+    "allows",
+    "allowed",
+    "allowing",
+    "lose",
+    "loses",
+    "lost",
+    "losing",
+];
+
+static FALSE_POSITIVE_WORDS: &[&str] = &[
+    "all",
+    "least",
+    "once",
+    "present",
+    "will",
+    "night",
+    "noon",
+    "midnight",
+    "dusk",
+    "dawn",
+    "runtime",
+    "scale",
+    "speed",
+    "index",
+    "indices",
+    "offset",
+    "offsets",
+    "address",
+    "addresses",
+    "port",
+    "ports",
+    "line",
+    "lines",
+    "position",
+    "positions",
+    "branch",
+    "branches",
+    "store",
+    "stores",
+    "site",
+    "sites",
+    "station",
+    "stations",
+];
+
+static TEMPORAL_DETERMINERS: &[&str] = &[
+    "this", "that", "these", "those", "the", "a", "an", "any", "all", "one", "each", "every",
+];
+
+static TEMPORAL_NOUNS: &[&str] = &[
+    "time", "times", "moment", "moments", "stage", "stages", "point", "points",
+];
+
+pub struct GetAccessTo {
+    expr: SequenceExpr,
+}
+
+impl Default for GetAccessTo {
+    fn default() -> Self {
+        let access_verbs = SequenceExpr::word_set(ACCESS_VERBS);
+
+        let optional_modifiers = SequenceExpr::any_of(vec![
+            Box::new(SequenceExpr::default().then_determiner()),
+            Box::new(SequenceExpr::default().then_possessive_determiner()),
+            Box::new(SequenceExpr::default().then_quantifier()),
+        ])
+        .t_ws();
+
+        let optional_adjectives = SequenceExpr::default().then_one_or_more_adjectives().t_ws();
+
+        Self {
+            expr: access_verbs
+                .t_ws()
+                .then_optional(optional_modifiers)
+                .then_optional(optional_adjectives)
+                .t_aco("access")
+                .t_ws()
+                .t_aco("at"),
+        }
+    }
+}
+
+impl ExprLinter for GetAccessTo {
+    type Unit = Chunk;
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects `get access at` to `get access to`."
+    }
+
+    fn match_to_lint_with_context(
+        &self,
+        toks: &[Token],
+        src: &[char],
+        ctx: Option<(&[Token], &[Token])>,
+    ) -> Option<Lint> {
+        if let Some((_, after)) = ctx {
+            let following_words: Vec<&Token> = after
+                .iter()
+                .filter(|t| !t.kind.is_whitespace())
+                .take(4)
+                .collect();
+
+            if let Some(first_tok) = following_words.first() {
+                // If followed by URL, hostname, email, or unlintable token
+                if matches!(
+                    first_tok.kind,
+                    TokenKind::Url
+                        | TokenKind::Hostname
+                        | TokenKind::EmailAddress
+                        | TokenKind::Unlintable
+                ) {
+                    return None;
+                }
+
+                let first_chars = first_tok.span.get_content(src);
+
+                // Check if followed by known false positive words (like "all", "least", etc.)
+                if first_chars.eq_any_ignore_ascii_case_str(FALSE_POSITIVE_WORDS) {
+                    return None;
+                }
+
+                // Check for temporal adverbials like "at this time", "at any point", "at that moment"
+                if following_words.len() >= 2 {
+                    let second_chars = following_words[1].span.get_content(src);
+                    if first_chars.eq_any_ignore_ascii_case_str(TEMPORAL_DETERMINERS)
+                        && second_chars.eq_any_ignore_ascii_case_str(TEMPORAL_NOUNS)
+                    {
+                        return None;
+                    }
+                }
+
+                // Check for level expressions like "at the disk level", "at the system level"
+                if first_chars.eq_any_ignore_ascii_case_str(TEMPORAL_DETERMINERS) {
+                    for following_tok in &following_words[1..] {
+                        let word_chars = following_tok.span.get_content(src);
+                        if word_chars.eq_any_ignore_ascii_case_str(&["level", "levels"]) {
+                            return None;
+                        }
+                    }
+                }
+
+                let next_str = first_tok.span.get_content_string(src);
+                if next_str.starts_with("http://")
+                    || next_str.starts_with("https://")
+                    || next_str.starts_with("www.")
+                    || next_str.contains(".com")
+                    || next_str.contains(".org")
+                    || next_str.contains(".io")
+                    || next_str.contains(".net")
+                    || next_str.contains(".edu")
+                    || next_str.contains(".gov")
+                    || next_str.contains(".dev")
+                    || next_str.contains(".app")
+                {
+                    return None;
+                }
+            }
+        }
+
+        let at_tok = toks.last()?;
+        let at_span = at_tok.span;
+
+        Some(Lint {
+            span: at_span,
+            lint_kind: LintKind::Usage,
+            suggestions: vec![Suggestion::replace_with_match_case_str(
+                "to",
+                at_span.get_content(src),
+            )],
+            message: "Use `to` instead of `at` with `access`.".to_owned(),
+            ..Default::default()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GetAccessTo;
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    #[test]
+    fn test_get_access_at_cpu_time() {
+        assert_suggestion_result(
+            "They really need to tabulate that spreadsheet and they need to get access at some CPU time.",
+            GetAccessTo::default(),
+            "They really need to tabulate that spreadsheet and they need to get access to some CPU time.",
+        );
+    }
+
+    #[test]
+    fn test_get_access_at_the_original_request() {
+        assert_suggestion_result(
+            "To get access at the original request within the hooks, use http middleware.",
+            GetAccessTo::default(),
+            "To get access to the original request within the hooks, use http middleware.",
+        );
+    }
+
+    #[test]
+    fn test_get_access_at_host_system() {
+        assert_suggestion_result(
+            "Succeeded to get access at host system with login command.",
+            GetAccessTo::default(),
+            "Succeeded to get access to host system with login command.",
+        );
+    }
+
+    #[test]
+    fn test_get_access_at_models() {
+        assert_suggestion_result(
+            "In order to get access at models, you typically send information to some server.",
+            GetAccessTo::default(),
+            "In order to get access to models, you typically send information to some server.",
+        );
+    }
+
+    #[test]
+    fn test_got_access_at_server() {
+        assert_suggestion_result(
+            "I still got access at server without any Username or Password.",
+            GetAccessTo::default(),
+            "I still got access to server without any Username or Password.",
+        );
+    }
+
+    #[test]
+    fn test_gain_access_at() {
+        assert_suggestion_result(
+            "The attacker managed to gain access at the database.",
+            GetAccessTo::default(),
+            "The attacker managed to gain access to the database.",
+        );
+    }
+
+    #[test]
+    fn test_have_access_at() {
+        assert_suggestion_result(
+            "Users have access at the internal network.",
+            GetAccessTo::default(),
+            "Users have access to the internal network.",
+        );
+    }
+
+    #[test]
+    fn test_with_adjective() {
+        assert_suggestion_result(
+            "They need to get full access at the database.",
+            GetAccessTo::default(),
+            "They need to get full access to the database.",
+        );
+    }
+
+    #[test]
+    fn test_ignore_get_access_at_all() {
+        assert_no_lints(
+            "I don't manage to get access at all, so I will try another way.",
+            GetAccessTo::default(),
+        );
+    }
+
+    #[test]
+    fn test_ignore_get_access_at_least() {
+        assert_no_lints(
+            "Is it possible to get access at least to file_content_type?",
+            GetAccessTo::default(),
+        );
+    }
+
+    #[test]
+    fn test_ignore_get_access_at_this_time() {
+        assert_no_lints(
+            "The quickest method to get access at this time would be to fill out this form.",
+            GetAccessTo::default(),
+        );
+    }
+
+    #[test]
+    fn test_ignore_get_access_at_url() {
+        assert_no_lints(
+            "Contact us to get access at https://example.com/contact",
+            GetAccessTo::default(),
+        );
+    }
+
+    #[test]
+    fn test_ignore_get_access_at_the_level() {
+        assert_no_lints(
+            "Getting access at the disk level would not normally be called a mount.",
+            GetAccessTo::default(),
+        );
+    }
+}

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -106,6 +106,7 @@ use super::for_the_nth_time::ForTheNthTime;
 use super::free_predicate::FreePredicate;
 use super::friend_of_me::FriendOfMe;
 use super::full_to_the_brim::FullToTheBrim;
+use super::get_access_to::GetAccessTo;
 use super::get_pass_go_pass::GetPassGoPass;
 use super::go_missing::GoMissing;
 use super::go_so_far_as_to::GoSoFarAsTo;
@@ -705,6 +706,7 @@ impl LintGroup {
         insert_expr_rule!(FreePredicate);
         insert_expr_rule!(FriendOfMe);
         insert_expr_rule!(FullToTheBrim);
+        insert_expr_rule!(GetAccessTo);
         insert_expr_rule!(GetPassGoPass);
         insert_expr_rule!(GoMissing);
         insert_expr_rule!(GoSoFarAsTo);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -107,6 +107,7 @@ mod for_the_nth_time;
 mod free_predicate;
 mod friend_of_me;
 mod full_to_the_brim;
+mod get_access_to;
 mod get_pass_go_pass;
 mod go_missing;
 mod go_so_far_as_to;


### PR DESCRIPTION
﻿> Disclaimer: This pull request was prepared with the assistance of an AI coding assistant (Antigravity).

Closes #3309

### Summary
Adds the `GetAccessTo` lint rule in `harper-core` to correct nonstandard usage of `access at` (such as `get access at`, `gain access at`, `have access at`, `obtain access at`, etc.) to `access to`.

### Details
- Matches combinations of access verbs (`get`, `gain`, `have`, `obtain`, `request`, `grant`, `give`, `provide`, `seek`, `secure`, `allow`, `deny`, `lose`) + optional modifiers/adjectives + `access at`.
- Replaces `at` with `to` while preserving case matching.
- Guards against common false positives:
  - Adverbial phrases such as `at all`, `at least`, `at once`, `at present`, `at will`, `at night`, etc.
  - Temporal adverbial constructs like `at this time`, `at that moment`, `at any point`, `at that stage`.
  - Scope expressions like `at the disk level`, `at the system level`.
  - URLs, domains, hostnames, and email addresses following `at`.
- Registered in `harper-core/src/linting/mod.rs`, `harper-core/src/linting/lint_group/mod.rs`, and synced with `harper-core/default_config.json`.
- Comprehensive unit tests added covering positive test cases and false-positive exceptions.
