### PR TITLE
fix(missing_to): avoid false positive on participial verbs in prepositional phrases

### DIFF
--- a/harper-core/src/linting/missing_to.rs
+++ b/harper-core/src/linting/missing_to.rs
@@ -242,28 +242,17 @@ impl MissingTo {
                     break;
                 }
 
+                if tok.kind.is_punctuation() {
+                    break;
+                }
+
                 let word = tok.get_str(source).to_lowercase();
                 let word = word.as_str();
 
-                if tok.kind.is_conjunction()
-                    || matches!(word, "and" | "or" | "but" | "nor")
-                    || tok.kind.is_verb_progressive_form()
-                {
-                    continue;
-                }
-
-                if tok.kind.is_determiner()
-                    || tok.kind.is_upos(UPOS::ADP)
+                if tok.kind.is_upos(UPOS::ADP)
                     || matches!(
                         word,
-                        "a" | "an"
-                            | "the"
-                            | "this"
-                            | "that"
-                            | "these"
-                            | "those"
-                            | "of"
-                            | "for"
+                        "of" | "for"
                             | "in"
                             | "with"
                             | "without"
@@ -283,7 +272,28 @@ impl MissingTo {
                     return true;
                 }
 
-                break;
+                if words_checked == 1
+                    && (tok.kind.is_determiner()
+                        || matches!(
+                            word,
+                            "a" | "an" | "the" | "this" | "that" | "these" | "those"
+                        ))
+                {
+                    return true;
+                }
+
+                if tok.kind.is_conjunction()
+                    || matches!(word, "and" | "or" | "but" | "nor")
+                    || tok.kind.is_verb_progressive_form()
+                    || tok.kind.is_noun()
+                    || tok.kind.is_adjective()
+                {
+                    continue;
+                }
+
+                if tok.kind.is_verb() {
+                    break;
+                }
             }
             return false;
         }

--- a/harper-core/src/linting/missing_to.rs
+++ b/harper-core/src/linting/missing_to.rs
@@ -227,9 +227,67 @@ impl MissingTo {
     }
 
     fn preposition_or_determiner_within_four(
+        context: Option<(&[Token], &[Token])>,
         source: &[char],
         controller_span_start: usize,
     ) -> bool {
+        if let Some((before, _)) = context {
+            let mut words_checked = 0;
+            for tok in before.iter().rev() {
+                if tok.kind.is_space() || tok.kind.is_newline() {
+                    continue;
+                }
+                words_checked += 1;
+                if words_checked > 4 {
+                    break;
+                }
+
+                let word = tok.get_str(source).to_lowercase();
+                let word = word.as_str();
+
+                if tok.kind.is_conjunction()
+                    || matches!(word, "and" | "or" | "but" | "nor")
+                    || tok.kind.is_verb_progressive_form()
+                {
+                    continue;
+                }
+
+                if tok.kind.is_determiner()
+                    || tok.kind.is_upos(UPOS::ADP)
+                    || matches!(
+                        word,
+                        "a" | "an"
+                            | "the"
+                            | "this"
+                            | "that"
+                            | "these"
+                            | "those"
+                            | "of"
+                            | "for"
+                            | "in"
+                            | "with"
+                            | "without"
+                            | "during"
+                            | "after"
+                            | "before"
+                            | "by"
+                            | "about"
+                            | "against"
+                            | "from"
+                            | "on"
+                            | "at"
+                            | "into"
+                            | "through"
+                    )
+                {
+                    return true;
+                }
+
+                break;
+            }
+            return false;
+        }
+
         let mut scan_cursor = controller_span_start;
 
         for _ in 0..4 {
@@ -238,7 +296,7 @@ impl MissingTo {
             };
             let word = word.as_str();
 
-            if matches!(word, "and" | "or" | "but" | "nor") || word.ends_with("ing") {
+            if matches!(word, "and" | "or" | "but" | "nor") {
                 scan_cursor = start;
                 continue;
             }
@@ -351,7 +409,7 @@ impl ExprLinter for MissingTo {
             controller_text.ends_with('d') || controller_text.ends_with("en");
 
         if controller_text_ends_with_d_or_en
-            && Self::preposition_or_determiner_within_four(source, span.start)
+            && Self::preposition_or_determiner_within_four(context, source, span.start)
         {
             return None;
         }
@@ -803,6 +861,15 @@ mod tests {
             "They attempted solve the problem without assistance.",
             test_linter(),
             "They attempted to solve the problem without assistance.",
+        );
+    }
+
+    #[test]
+    fn inserts_to_after_attempted_with_preceding_thing() {
+        assert_suggestion_result(
+            "He found the thing and attempted solve it.",
+            test_linter(),
+            "He found the thing and attempted to solve it.",
         );
     }
 }

--- a/harper-core/src/linting/missing_to.rs
+++ b/harper-core/src/linting/missing_to.rs
@@ -225,6 +225,57 @@ impl MissingTo {
 
         false
     }
+
+    fn preposition_or_determiner_within_four(
+        source: &[char],
+        controller_span_start: usize,
+    ) -> bool {
+        let mut scan_cursor = controller_span_start;
+
+        for _ in 0..4 {
+            let Some((word, start)) = Self::previous_word_with_span(source, scan_cursor) else {
+                break;
+            };
+            let word = word.as_str();
+
+            if matches!(word, "and" | "or" | "but" | "nor") || word.ends_with("ing") {
+                scan_cursor = start;
+                continue;
+            }
+
+            if matches!(
+                word,
+                "a" | "an"
+                    | "the"
+                    | "this"
+                    | "that"
+                    | "these"
+                    | "those"
+                    | "of"
+                    | "for"
+                    | "in"
+                    | "with"
+                    | "without"
+                    | "during"
+                    | "after"
+                    | "before"
+                    | "by"
+                    | "about"
+                    | "against"
+                    | "from"
+                    | "on"
+                    | "at"
+                    | "into"
+                    | "through"
+            ) {
+                return true;
+            }
+
+            scan_cursor = start;
+        }
+
+        false
+    }
 }
 
 impl Default for MissingTo {
@@ -299,7 +350,9 @@ impl ExprLinter for MissingTo {
         let controller_text_ends_with_d_or_en =
             controller_text.ends_with('d') || controller_text.ends_with("en");
 
-        if previous_word == Some("of") && controller_text_ends_with_d_or_en {
+        if controller_text_ends_with_d_or_en
+            && Self::preposition_or_determiner_within_four(source, span.start)
+        {
             return None;
         }
 
@@ -728,6 +781,28 @@ mod tests {
         assert_no_lints(
             "Sometimes too much or too little to do. If too much, might be serious about wanting distance from others.",
             test_linter(),
+        );
+    }
+
+    #[test]
+    fn no_lint_attempted_murder() {
+        assert_no_lints(
+            "You’re under arrest for racketeering and attempted murder of Alek Suvor.",
+            test_linter(),
+        );
+    }
+
+    #[test]
+    fn no_lint_attempted_robbery() {
+        assert_no_lints("He was convicted of attempted robbery.", test_linter());
+    }
+
+    #[test]
+    fn inserts_to_after_attempted() {
+        assert_suggestion_result(
+            "They attempted solve the problem without assistance.",
+            test_linter(),
+            "They attempted to solve the problem without assistance.",
         );
     }
 }


### PR DESCRIPTION
﻿> Disclaimer: This pull request was prepared with the assistance of an AI coding assistant (Antigravity).

Closes #4132

### Summary
Fixes a false positive in the `MissingTo` lint rule where participial controllers ending in `-d` or `-en` (e.g., `attempted`, `prepared`, `arranged`) inside prepositional phrases (such as `for racketeering and attempted murder`, `convicted of attempted robbery`, `with nicely arranged and prepared flowers`) were incorrectly flagged as missing `to`.

### Details
- Introduces `preposition_or_determiner_within_four` to check preceding context across conjunctions (`and`, `or`, `but`, `nor`) and participial nouns/gerunds (e.g. `racketeering`) for prepositions (`of`, `for`, `in`, `with`, `without`, `during`, `after`, `before`, `by`, `about`, `against`, `from`, `on`, `at`, `into`, `through`) as well as determiners.
- Suppresses false-positive `MissingTo` lints on past-participle controller words occurring within prepositional and determiner noun phrases.
- Added test cases covering:
  - `"You’re under arrest for racketeering and attempted murder of Alek Suvor."`
  - `"He was convicted of attempted robbery."`
  - Positive test verification: `"They attempted solve the problem without assistance."` -> correctly suggests `"They attempted to solve the problem without assistance."`
