### PR TITLE
feat: in the same vain/vane/veins → in the same vein

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -4902,6 +4902,13 @@
 						},
 						{
 							"Bool": {
+								"name": "InTheSameVein",
+								"state": true,
+								"label": "In the Same Vein"
+							}
+						},
+						{
+							"Bool": {
 								"name": "InThisThatRegard",
 								"state": true,
 								"label": "In This/That Regard"

--- a/harper-core/src/linting/weir_rules/InTheSameVein.weir
+++ b/harper-core/src/linting/weir_rules/InTheSameVein.weir
@@ -1,10 +1,12 @@
-expr main [(in the same vain), (in the same vane), (in the same veins)]
+expr main [(in the same vain), (in the same vane), (in the same veins), (in same vein), (in same vain)]
 
-let message "The correct word in this idiom is `vein`, meaning blood vessel."
-let description "Corrects wrong spellings of `in the same vein`."
-let kind "Eggcorn"
+let message "This idiom requires the definite article `the` and the correct word `vein`, meaning blood vessel."
+let description "Corrects wrong variants of `in the same vein`."
+let kind "Usage"
 let becomes "in the same vein"
 
 test "In the same vain as ESLint Warnings Are An Anti-Pattern, I think the default pylint.severity setting should be to make all issue types \"Error\"." "In the same vein as ESLint Warnings Are An Anti-Pattern, I think the default pylint.severity setting should be to make all issue types \"Error\"."
 test "And in the same vane, all other PodCommsSession functions that currently need to fail" "And in the same vein, all other PodCommsSession functions that currently need to fail"
 test "A-Frame is an open-source Web3D/WebVR framework in the same veins." "A-Frame is an open-source Web3D/WebVR framework in the same vein."
+test "(in same vein as the SDRAM settings)" "(in the same vein as the SDRAM settings)"
+test "it should work in same vain; you can override deserializer used for Integer.TYPE" "it should work in the same vein; you can override deserializer used for Integer.TYPE"

--- a/harper-core/src/linting/weir_rules/InTheSameVein.weir
+++ b/harper-core/src/linting/weir_rules/InTheSameVein.weir
@@ -1,0 +1,10 @@
+expr main [(in the same vain), (in the same vane), (in the same veins)]
+
+let message "The correct word in this idiom is `vein`, meaning blood vessel."
+let description "Corrects wrong spellings of `in the same vein`."
+let kind "Eggcorn"
+let becomes "in the same vein"
+
+test "In the same vain as ESLint Warnings Are An Anti-Pattern, I think the default pylint.severity setting should be to make all issue types \"Error\"." "In the same vein as ESLint Warnings Are An Anti-Pattern, I think the default pylint.severity setting should be to make all issue types \"Error\"."
+test "And in the same vane, all other PodCommsSession functions that currently need to fail" "And in the same vein, all other PodCommsSession functions that currently need to fail"
+test "A-Frame is an open-source Web3D/WebVR framework in the same veins." "A-Frame is an open-source Web3D/WebVR framework in the same vein."


### PR DESCRIPTION
# Issues 
N/A

# Description

Corrects common mistaken forms of the idiom "in the same vein" using the words "vain", "vane", or "veins".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
