### PR TITLE
feat: strike of genius/luck → stroke of genius/luck

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -2800,6 +2800,20 @@
 						},
 						{
 							"Bool": {
+								"name": "StrikeOfGenius",
+								"state": true,
+								"label": "Strike Of Genius"
+							}
+						},
+						{
+							"Bool": {
+								"name": "StrikeOfLuck",
+								"state": true,
+								"label": "Strike Of Luck"
+							}
+						},
+						{
+							"Bool": {
 								"name": "ThatThis",
 								"state": true,
 								"label": "That This"

--- a/harper-core/src/linting/weir_rules/StrikeOfGenius.weir
+++ b/harper-core/src/linting/weir_rules/StrikeOfGenius.weir
@@ -1,0 +1,9 @@
+expr main (strike of genius)
+
+let message "Did you mean `stroke of genius`?"
+let description "Detects incorrect usage of `strike of genius` and suggests `stroke of genius` as the correct phrase."
+let kind "Usage"
+let becomes "stroke of genius"
+
+test "After I had some incredible strike of genius (a.k.a. dumb luck), I got to see see something" "After I had some incredible stroke of genius (a.k.a. dumb luck), I got to see see something"
+test "What passes for mundane obviousness today was once a strike of genius nobody else saw coming." "What passes for mundane obviousness today was once a stroke of genius nobody else saw coming."

--- a/harper-core/src/linting/weir_rules/StrikeOfLuck.weir
+++ b/harper-core/src/linting/weir_rules/StrikeOfLuck.weir
@@ -1,0 +1,10 @@
+expr main (strike of luck)
+
+let message "Did you mean `stroke of luck`?"
+let description "Detects incorrect usage of `strike of luck` and suggests `stroke of luck` as the correct phrase."
+let kind "Usage"
+let becomes "stroke of luck"
+
+test "But that's a one in a million strike of luck" "But that's a one in a million stroke of luck"
+test "Is this a happy coincidence and a strike of luck?" "Is this a happy coincidence and a stroke of luck?"
+


### PR DESCRIPTION
# Issues 
N/A

# Description

Recently I noticed "strike of luck" or "strike of genius" somewhere instead of the usual "stroke". I've got around to making a pair of Weir rules for them.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
