### PR TITLE
Preserve selected duplicate OneOfMany names

### DIFF
--- a/harper-core/src/linting/lint_group/structured_config/mod.rs
+++ b/harper-core/src/linting/lint_group/structured_config/mod.rs
@@ -47,8 +47,11 @@ impl StructuredConfig {
             match setting {
                 Setting::Bool { name, state } => config.set_rule_enabled(name, *state),
                 Setting::OneOfMany { names, choice, .. } => {
-                    for (i, name) in names.iter().enumerate() {
-                        config.set_rule_enabled(name, choice.is_some_and(|choice| choice == i));
+                    for name in names {
+                        config.set_rule_enabled(name, false);
+                    }
+                    if let Some(choice) = choice {
+                        config.set_rule_enabled(&names[*choice], true);
                     }
                 }
                 Setting::Group { child, .. } => {
@@ -253,9 +256,46 @@ mod tests {
 
         let config = settings.to_flat_config().unwrap();
 
+        assert!(config.has_rule("A"));
+        assert!(config.has_rule("B"));
+        assert!(config.has_rule("C"));
         assert!(!config.is_rule_enabled("A"));
         assert!(!config.is_rule_enabled("B"));
         assert!(config.is_rule_enabled("C"));
+    }
+
+    #[test]
+    fn converts_one_of_many_without_choice() {
+        let settings = StructuredConfig {
+            settings: vec![Setting::OneOfMany {
+                names: vec!["A".to_owned(), "B".to_owned()],
+                labels: vec!["A".to_owned(), "B".to_owned()],
+                choice: None,
+            }],
+        };
+
+        let config = settings.to_flat_config().unwrap();
+
+        assert!(config.has_rule("A"));
+        assert!(config.has_rule("B"));
+        assert!(!config.is_rule_enabled("A"));
+        assert!(!config.is_rule_enabled("B"));
+    }
+
+    #[test]
+    fn keeps_selected_duplicate_name_enabled() {
+        let settings = StructuredConfig {
+            settings: vec![Setting::OneOfMany {
+                names: vec!["A".to_owned(), "A".to_owned()],
+                labels: vec!["A".to_owned(), "A".to_owned()],
+                choice: Some(0),
+            }],
+        };
+
+        let config = settings.to_flat_config().unwrap();
+
+        assert!(config.has_rule("A"));
+        assert!(config.is_rule_enabled("A"));
     }
 
     #[test]


### PR DESCRIPTION
> This pull request was authored and validated autonomously by OpenAI Codex.

# Issues

Related to #4218; rebased after #4211 merged.

# Description

#4211 now includes all `OneOfMany` alternatives in flat configuration, fixing the missing-key failure originally reported in #4218. This PR retains the remaining duplicate-name correction and the existing conversion regressions.

Duplicate names are accepted by validation. With names `["A", "A"]` and `choice = Some(0)`, current master first enables `A` and then overwrites it with `false` when visiting the second entry. The two-phase conversion first disables every key, then enables the selected key once. This preserves the original selected-key behavior while retaining the complete keys added upstream.

The existing tests cover the selected duplicate, no selection, and presence of every declared key. The rebased diff is one Rust file, with no rule defaults, validators, API, or generated assets changed.

# Demo

Not applicable; this is a configuration-map conversion with automated coverage.

# How Has This Been Tested?

On current master `68772e8f523dba5f2164a7e9b358889c75a0303d`, adding only this PR's existing regression tests makes `keeps_selected_duplicate_name_enabled` fail at `config.is_rule_enabled("A")`. It passes with the fix in `9ab102f9795907ea909b898568e74ed2ff054444`.

Current-base validation:

- `cargo test --locked -p harper-core structured_config --lib`: 21 passed;
- `cargo test --locked -p harper-core --lib --quiet`: 6,338 passed, 301 ignored;
- `cargo test --locked --quiet`: workspace unit tests and doctests passed;
- `cargo fmt --all -- --check`: passed;
- `cargo clippy --locked -p harper-core -- -Dwarnings -D clippy::dbg_macro -D clippy::needless_raw_string_hashes`: passed;
- full and slim `wasm-pack build --target web --no-opt` builds: passed;
- harper.js `pnpm@10.10.0 build`: passed;
- Obsidian `pnpm@10.10.0 build` and `test`: passed.

The Windows checks use workspace-isolated Rust 1.98.0 and cached integration tools. `just precommit` remains unavailable locally; the contribution guide permits the pull-request CI fallback. The manual checks above completed, but the hosted matrix must execute on the rebased head before its results count.

# AI Disclosure

- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [x] I am an agent or I got an agent to do the work autonomously.

No human pre-submission review is claimed.

# If Your PR Implements or Enhances a Linter

Not applicable; this changes structured configuration flattening rather than a linter.

- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
