### PR TITLE
fix(web): stop CSRF check silently rejecting extension feedback reports

### DIFF
--- a/packages/chrome-plugin/src/background/index.ts
+++ b/packages/chrome-plugin/src/background/index.ts
@@ -551,15 +551,17 @@ async function handleOpenReportError(
 }
 
 async function handlePostFormData(req: PostFormDataRequest): Promise<PostFormDataResponse> {
-	const formData = new FormData();
-	for (const [key, value] of Object.entries(req.formData)) {
-		formData.append(key, value);
-	}
-
 	try {
+		// Sent as JSON rather than multipart/form-data: the server runs on SvelteKit,
+		// whose built-in CSRF protection rejects cross-origin form-content-type POSTs
+		// (form-urlencoded/multipart/text-plain) unless the origin is on a static
+		// allowlist. Firefox's moz-extension:// origin is randomized per install, so
+		// no such allowlist entry can ever cover it; JSON isn't a form content type,
+		// so it isn't subject to that check.
 		const response = await fetch(req.url, {
 			method: 'POST',
-			body: formData,
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(req.formData),
 		});
 
 		return { kind: 'postFormData', success: response.ok };

--- a/packages/web/src/lib/requestBody.ts
+++ b/packages/web/src/lib/requestBody.ts
@@ -1,3 +1,5 @@
+import { error } from '@sveltejs/kit';
+
 /**
  * Parses a POST body that may arrive as either JSON or a native form submission
  * (`application/x-www-form-urlencoded` or `multipart/form-data`), exposing both
@@ -12,11 +14,24 @@
 export async function parseRequestBody(
 	request: Request,
 ): Promise<{ get(name: string): string | null }> {
-	const isJson = request.headers.get('content-type')?.startsWith('application/json');
+	const isJson = request.headers.get('content-type')?.toLowerCase().startsWith('application/json');
 
 	if (isJson) {
-		const json = await request.json();
-		return { get: (name: string) => (name in json ? (json[name] ?? null) : null) };
+		let json: unknown;
+		try {
+			json = await request.json();
+		} catch {
+			throw error(400, 'Malformed JSON body.');
+		}
+
+		if (typeof json !== 'object' || json === null) {
+			throw error(400, 'JSON body must be an object.');
+		}
+
+		const record = json as Record<string, unknown>;
+		return {
+			get: (name: string) => (typeof record[name] === 'string' ? record[name] : null),
+		};
 	}
 
 	const form = await request.formData();

--- a/packages/web/src/lib/requestBody.ts
+++ b/packages/web/src/lib/requestBody.ts
@@ -24,7 +24,7 @@ export async function parseRequestBody(
 			throw error(400, 'Malformed JSON body.');
 		}
 
-		if (typeof json !== 'object' || json === null) {
+		if (typeof json !== 'object' || json === null || Array.isArray(json)) {
 			throw error(400, 'JSON body must be an object.');
 		}
 

--- a/packages/web/src/lib/requestBody.ts
+++ b/packages/web/src/lib/requestBody.ts
@@ -14,7 +14,9 @@ import { error } from '@sveltejs/kit';
 export async function parseRequestBody(
 	request: Request,
 ): Promise<{ get(name: string): string | null }> {
-	const isJson = request.headers.get('content-type')?.toLowerCase().startsWith('application/json');
+	const contentType =
+		request.headers.get('content-type')?.split(';', 1)[0].trim().toLowerCase() ?? '';
+	const isJson = contentType === 'application/json';
 
 	if (isJson) {
 		let json: unknown;

--- a/packages/web/src/lib/requestBody.ts
+++ b/packages/web/src/lib/requestBody.ts
@@ -1,0 +1,28 @@
+/**
+ * Parses a POST body that may arrive as either JSON or a native form submission
+ * (`application/x-www-form-urlencoded` or `multipart/form-data`), exposing both
+ * through the same `FormData`-style `get()` accessor.
+ *
+ * The browser extension sends JSON specifically so that SvelteKit's CSRF
+ * `checkOrigin` (which only gates `application/x-www-form-urlencoded`,
+ * `multipart/form-data`, and `text/plain`) doesn't reject its cross-origin
+ * request; the website's own `<form>` elements submit url-encoded, same-origin,
+ * and are unaffected by that check either way.
+ */
+export async function parseRequestBody(
+	request: Request,
+): Promise<{ get(name: string): string | null }> {
+	const isJson = request.headers.get('content-type')?.startsWith('application/json');
+
+	if (isJson) {
+		const json = await request.json();
+		return { get: (name: string) => (name in json ? (json[name] ?? null) : null) };
+	}
+
+	const form = await request.formData();
+	// These routes never accept file fields; treat one as absent rather than
+	// forwarding a File where a string is expected.
+	return {
+		get: (name: string) => (typeof form.get(name) === 'string' ? (form.get(name) as string) : null),
+	};
+}

--- a/packages/web/src/routes/api/domain-reviews/+server.ts
+++ b/packages/web/src/routes/api/domain-reviews/+server.ts
@@ -1,14 +1,11 @@
 import { error, type RequestEvent, redirect } from '@sveltejs/kit';
 import DomainReviews from '$lib/db/models/DomainReviews';
+import { parseRequestBody } from '$lib/requestBody';
 
 export const POST = async ({ request }: RequestEvent) => {
-	// The website's own <form> submits url-encoded (same-origin, unaffected by
-	// SvelteKit's CSRF check); the browser extension sends JSON instead of
-	// multipart/form-data specifically to sidestep that check cross-origin.
-	const isJson = request.headers.get('content-type')?.startsWith('application/json');
-	const data = isJson ? await request.json() : Object.fromEntries(await request.formData());
+	const data = await parseRequestBody(request);
 
-	const worksText = data.works;
+	const worksText = data.get('works');
 	let works = null;
 
 	switch (worksText) {
@@ -21,13 +18,13 @@ export const POST = async ({ request }: RequestEvent) => {
 	}
 
 	if (works === null) {
-		error(400, '`works` must be either yes or no.');
+		throw error(400, '`works` must be either yes or no.');
 	}
 
 	await DomainReviews.validateAndCreate({
-		domain: data.domain,
+		domain: data.get('domain'),
 		works,
-		feedback: data.feedback,
+		feedback: data.get('feedback'),
 	});
 
 	throw redirect(303, '/');

--- a/packages/web/src/routes/api/domain-reviews/+server.ts
+++ b/packages/web/src/routes/api/domain-reviews/+server.ts
@@ -2,9 +2,9 @@ import { error, type RequestEvent, redirect } from '@sveltejs/kit';
 import DomainReviews from '$lib/db/models/DomainReviews';
 
 export const POST = async ({ request }: RequestEvent) => {
-	const data = await request.formData();
+	const data = await request.json();
 
-	const worksText = data.get('works');
+	const worksText = data.works;
 	let works = null;
 
 	switch (worksText) {
@@ -21,9 +21,9 @@ export const POST = async ({ request }: RequestEvent) => {
 	}
 
 	await DomainReviews.validateAndCreate({
-		domain: data.get('domain'),
+		domain: data.domain,
 		works,
-		feedback: data.get('feedback'),
+		feedback: data.feedback,
 	});
 
 	throw redirect(303, '/');

--- a/packages/web/src/routes/api/domain-reviews/+server.ts
+++ b/packages/web/src/routes/api/domain-reviews/+server.ts
@@ -2,7 +2,11 @@ import { error, type RequestEvent, redirect } from '@sveltejs/kit';
 import DomainReviews from '$lib/db/models/DomainReviews';
 
 export const POST = async ({ request }: RequestEvent) => {
-	const data = await request.json();
+	// The website's own <form> submits url-encoded (same-origin, unaffected by
+	// SvelteKit's CSRF check); the browser extension sends JSON instead of
+	// multipart/form-data specifically to sidestep that check cross-origin.
+	const isJson = request.headers.get('content-type')?.startsWith('application/json');
+	const data = isJson ? await request.json() : Object.fromEntries(await request.formData());
 
 	const worksText = data.works;
 	let works = null;

--- a/packages/web/src/routes/api/problematic-lints/+server.ts
+++ b/packages/web/src/routes/api/problematic-lints/+server.ts
@@ -2,13 +2,13 @@ import { type RequestEvent, redirect } from '@sveltejs/kit';
 import ProblematicLints from '$lib/db/models/ProblematicLints';
 
 export const POST = async ({ request }: RequestEvent) => {
-	const data = await request.formData();
+	const data = await request.json();
 
 	await ProblematicLints.validateAndCreate({
-		is_false_positive: data.get('is_false_positive') === 'true',
-		example: data.get('example'),
-		rule_id: data.get('rule_id'),
-		feedback: data.get('feedback'),
+		is_false_positive: data.is_false_positive === 'true',
+		example: data.example,
+		rule_id: data.rule_id,
+		feedback: data.feedback,
 	});
 
 	throw redirect(303, '/');

--- a/packages/web/src/routes/api/problematic-lints/+server.ts
+++ b/packages/web/src/routes/api/problematic-lints/+server.ts
@@ -2,7 +2,11 @@ import { type RequestEvent, redirect } from '@sveltejs/kit';
 import ProblematicLints from '$lib/db/models/ProblematicLints';
 
 export const POST = async ({ request }: RequestEvent) => {
-	const data = await request.json();
+	// The website's own <form> submits url-encoded (same-origin, unaffected by
+	// SvelteKit's CSRF check); the browser extension sends JSON instead of
+	// multipart/form-data specifically to sidestep that check cross-origin.
+	const isJson = request.headers.get('content-type')?.startsWith('application/json');
+	const data = isJson ? await request.json() : Object.fromEntries(await request.formData());
 
 	await ProblematicLints.validateAndCreate({
 		is_false_positive: data.is_false_positive === 'true',

--- a/packages/web/src/routes/api/problematic-lints/+server.ts
+++ b/packages/web/src/routes/api/problematic-lints/+server.ts
@@ -1,18 +1,15 @@
 import { type RequestEvent, redirect } from '@sveltejs/kit';
 import ProblematicLints from '$lib/db/models/ProblematicLints';
+import { parseRequestBody } from '$lib/requestBody';
 
 export const POST = async ({ request }: RequestEvent) => {
-	// The website's own <form> submits url-encoded (same-origin, unaffected by
-	// SvelteKit's CSRF check); the browser extension sends JSON instead of
-	// multipart/form-data specifically to sidestep that check cross-origin.
-	const isJson = request.headers.get('content-type')?.startsWith('application/json');
-	const data = isJson ? await request.json() : Object.fromEntries(await request.formData());
+	const data = await parseRequestBody(request);
 
 	await ProblematicLints.validateAndCreate({
-		is_false_positive: data.is_false_positive === 'true',
-		example: data.example,
-		rule_id: data.rule_id,
-		feedback: data.feedback,
+		is_false_positive: data.get('is_false_positive') === 'true',
+		example: data.get('example'),
+		rule_id: data.get('rule_id'),
+		feedback: data.get('feedback'),
 	});
 
 	throw redirect(303, '/');


### PR DESCRIPTION
> **Disclaimer:** This PR was produced by an AI coding agent (Claude, via [Claude Code](https://claude.com/claude-code)) operating under my direction and review, per `AGENT_POLICY.md`. I read the root cause, reviewed the diff, and ran the verification described below myself before opening this.

## Changes

The "Report Problematic Lint" and "Domain Review" popups in `chrome-plugin` both submit through the shared `ProtocolClient.postFormData` helper, which builds a `FormData` and `fetch()`s it (`multipart/form-data`) from the extension's background script to `https://writewithharper.com/api/{problematic-lints,domain-reviews}`.

`packages/web`'s SvelteKit server has built-in CSRF protection (`csrf.checkOrigin`, on by default) that rejects any cross-origin POST whose content type is one of the "form" types (`application/x-www-form-urlencoded`, `multipart/form-data`, `text/plain`) unless the request's `Origin` is on `svelte.config.js`'s `csrf.trustedOrigins` allowlist. That allowlist only contains three hardcoded `chrome-extension://` ids.

Firefox assigns each installed extension a `moz-extension://<uuid>` origin that's randomized per browser profile/install (a deliberate anti-fingerprinting measure) — there is no stable Firefox origin that could ever be added to a static allowlist the way the three Chrome ids are. The practical effect: **every Firefox user's problematic-lint and domain-review feedback report is silently rejected with a 403**, and the same would happen for any Chrome build outside those three specific published ids (e.g. a local unpacked/dev build).

## Root cause

Confirmed directly against the installed `@sveltejs/kit@2.48.5` source (`src/runtime/server/respond.js` + `src/utils/http.js`):

```js
const forbidden =
  is_form_content_type(request) &&
  (request.method === 'POST' || ...) &&
  request_origin !== url.origin &&
  (!request_origin || !options.csrf_trusted_origins.includes(request_origin));
```

`is_form_content_type` only matches `application/x-www-form-urlencoded`, `multipart/form-data`, and `text/plain` — `application/json` is never subject to this check, regardless of origin. That check also only runs when `!DEV`, i.e. it's invisible in `vite dev` and only bites in a real deployment, which is presumably why this has gone unnoticed.

`uninstall-feedback` is not affected — it's submitted via a real top-level page navigation on writewithharper.com itself (same-origin), not through the extension's background-script fetch, so it never hits this CSRF gate in the first place.

## Fix

Switch `handlePostFormData` (chrome-plugin background script) to send the payload as JSON instead of `FormData`. On the server, both `+server.ts` routes now branch on content type: `request.json()` for the extension's request (which sidesteps the CSRF check entirely, rather than trying to extend an allowlist that structurally can't cover Firefox), and `request.formData()` otherwise — which, per the Fetch spec, already parses `application/x-www-form-urlencoded` bodies too, so the website's own native `<form>` submissions on `/report-problematic-lint` and `/domain-review` (same-origin, unaffected by the CSRF check) keep working unchanged. An earlier version of this PR switched the routes to JSON-only and would have broken those two native forms; caught and fixed in the second commit.

Also added an explicit `throw` in front of the pre-existing `error(400, ...)` call in domain-reviews for consistency with the `throw redirect(...)` three lines below — worth noting this turned out to not be a behavioral fix: `@sveltejs/kit`'s `error()` already throws internally regardless of the `throw` keyword (confirmed against its source), so this is a readability/consistency change only, not a bug fix. An earlier draft of this description incorrectly characterized it as fixing a live 500; corrected here after checking the actual library source rather than taking that at face value.

## Testing

- `pnpm exec biome check` — clean on all changed files.
- `pnpm exec tsc --noEmit` (chrome-plugin) / `svelte-check` (web): zero *new* errors. Both packages currently have pre-existing errors from `harper.js`/`components`/`lint-framework` failing to resolve because the `harper-wasm` workspace member isn't built in my environment (no wasm-pack) — unrelated to this change; confirmed none of those errors are in the files this PR touches.
- Ran `packages/web` in `vite dev` and exercised, against both routes: valid JSON from a foreign `moz-extension://` origin, `application/json` with a mixed case / `;charset=...` suffix, `application/x-www-form-urlencoded` from the same origin (matching the native `<form>`), an unrelated content type (`application/jsonp`) to confirm it's *not* misclassified as JSON, malformed JSON, a JSON array body, and an invalid `works` value. All behaved as intended (correct field values reaching the DB insert for the valid cases — failing only past that point on `ECONNREFUSED` since there's no local MySQL in my environment — and a 400 rather than a 500 for the malformed/invalid ones).
- **Caveat:** I could not run a full production build to observe the actual 403→success transition end-to-end (SvelteKit's CSRF check is disabled in dev mode, so `vite dev` never exercises it either way) — building `packages/web` requires the sibling `components`/`harper-editor`/`harper.js` packages, which cascade to the Rust/wasm-pack toolchain for `harper-wasm`, not available in my environment. I'm relying on the source-level verification above (unambiguous: `is_form_content_type` never matches `application/json`) plus the dev-mode round-trip proving no functional regression in either parsing path.
- No automated regression test was added: `packages/web` has no test runner today, and the actual CSRF gate this PR routes around lives in SvelteKit's internal request handling (outside the route handler), so a meaningful automated test would need a running production-mode server rather than a unit test of the handler function. Happy to add one if you'd point me at a preferred approach for this package.

## Related Issues

Closes #4219
