### PR TITLE
fix(web): allow the Firefox extension to POST

### DIFF
--- a/packages/web/svelte.config.js
+++ b/packages/web/svelte.config.js
@@ -11,6 +11,7 @@ const config = {
 				'chrome-extension://lodbfhdipoipcjmlebjbgmmgekckhpfb',
 				'chrome-extension://hkjdmakdmihopipoiplebkelbhebigea',
 				'chrome-extension://ihjkkjfembmnjldmdchmadigpmapkpdh',
+        'moz-extension://a684f72a-270e-4cc2-a215-98cab921e95d'
 			],
 		},
 		prerender: {

--- a/packages/web/svelte.config.js
+++ b/packages/web/svelte.config.js
@@ -11,7 +11,7 @@ const config = {
 				'chrome-extension://lodbfhdipoipcjmlebjbgmmgekckhpfb',
 				'chrome-extension://hkjdmakdmihopipoiplebkelbhebigea',
 				'chrome-extension://ihjkkjfembmnjldmdchmadigpmapkpdh',
-        'moz-extension://a684f72a-270e-4cc2-a215-98cab921e95d'
+				'moz-extension://a684f72a-270e-4cc2-a215-98cab921e95d',
 			],
 		},
 		prerender: {


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

I was told via the Discord server the reports from the Firefox extension fail to POST. As it turns out, this was due to a CORS error. This PR adds the Firefox extension as a valid client.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
