### PR TITLE
feat(desktop): ignore disabled integrations on Windows

### DIFF
--- a/harper-desktop/src-tauri/Cargo.toml
+++ b/harper-desktop/src-tauri/Cargo.toml
@@ -67,7 +67,12 @@ accessibility-sys = "0.2.0"
 core-graphics = "0.25.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.62.2", features = ["Win32_UI_HiDpi"] }
+windows = { version = "0.62.2", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+    "Win32_UI_HiDpi",
+    "Win32_UI_WindowsAndMessaging",
+] }
 uiautomation = { version = "0.25.0", features = ["process"] }
 wintheon = "0.1.0"
 

--- a/harper-desktop/src-tauri/src/commands.rs
+++ b/harper-desktop/src-tauri/src/commands.rs
@@ -4,7 +4,7 @@
 use crate::config::Config;
 use crate::highlighter_service::HighlighterService;
 use crate::os_broker::{AccessibilityPermissionStatus, AppSearchResult, OsBroker};
-use crate::{IntegrationView, PlatformBroker, platform_broker};
+use crate::{IntegrationView, PlatformBroker};
 use base64::{Engine as _, engine::general_purpose};
 use harper_core::{
     Dialect, DictWordMetadata, IgnoredLints,
@@ -336,13 +336,29 @@ async fn get_application_icon_data_url<R: Runtime>(
 }
 
 #[tauri::command]
-fn get_accessibility_permission_status() -> AccessibilityPermissionStatus {
-    platform_broker().accessibility_permission_status()
+fn get_accessibility_permission_status(
+    broker: State<'_, StdMutex<PlatformBroker>>,
+) -> AccessibilityPermissionStatus {
+    match broker.lock() {
+        Ok(broker) => broker.accessibility_permission_status(),
+        Err(error) => {
+            eprintln!("Failed to read platform broker: {error}");
+            AccessibilityPermissionStatus::Unsupported
+        }
+    }
 }
 
 #[tauri::command]
-fn request_accessibility_permission() -> AccessibilityPermissionStatus {
-    platform_broker().request_accessibility_permission()
+fn request_accessibility_permission(
+    broker: State<'_, StdMutex<PlatformBroker>>,
+) -> AccessibilityPermissionStatus {
+    match broker.lock() {
+        Ok(broker) => broker.request_accessibility_permission(),
+        Err(error) => {
+            eprintln!("Failed to read platform broker: {error}");
+            AccessibilityPermissionStatus::Unsupported
+        }
+    }
 }
 
 #[tauri::command]
@@ -384,8 +400,14 @@ pub(crate) async fn stop_highlighter_service(
 }
 
 #[tauri::command]
-fn launch_app(bundle_id: String) -> Result<(), String> {
-    platform_broker().launch_app_bundle(&bundle_id)
+fn launch_app(
+    bundle_id: String,
+    broker: State<'_, StdMutex<PlatformBroker>>,
+) -> Result<(), String> {
+    broker
+        .lock()
+        .map_err(|error| format!("Failed to read platform broker: {error}"))?
+        .launch_app_bundle(&bundle_id)
 }
 
 #[tauri::command]

--- a/harper-desktop/src-tauri/src/config/integration.rs
+++ b/harper-desktop/src-tauri/src/config/integration.rs
@@ -8,20 +8,29 @@ pub struct Integration {
 
 impl Integration {
     pub fn curated_integrations() -> Vec<Self> {
-        [
+        #[cfg(target_os = "macos")]
+        let integrations = [
             "com.apple.TextEdit",
             "com.apple.mail",
             "com.apple.MobileSMS",
             "com.apple.Notes",
             "com.tinyspeck.slackmacgap",
             "com.hnc.Discord",
-        ]
-        .into_iter()
-        .map(|bundle_id| Integration {
-            bundle_id: bundle_id.to_string(),
-            enabled: true,
-        })
-        .collect()
+        ];
+
+        #[cfg(target_os = "windows")]
+        let integrations: [&str; 0] = [];
+
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+        let integrations: [&str; 0] = [];
+
+        integrations
+            .into_iter()
+            .map(|bundle_id| Integration {
+                bundle_id: bundle_id.to_string(),
+                enabled: true,
+            })
+            .collect()
     }
     pub fn is_integration_enabled_in(integrations: &[Self], bundle_id: &str) -> bool {
         integrations

--- a/harper-desktop/src-tauri/src/lib.rs
+++ b/harper-desktop/src-tauri/src/lib.rs
@@ -78,8 +78,21 @@ pub(crate) type PlatformBroker = windows_broker::WindowsBroker;
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 pub(crate) type PlatformBroker = os_broker::NoopBroker;
 
-fn platform_broker() -> PlatformBroker {
-    PlatformBroker::default()
+/// Creates the process-local platform broker.
+///
+/// The Tauri process stores its single broker as managed state, while the highlighter subprocess
+/// creates its own broker because it is a separate process.
+fn platform_broker(integrations: Arc<StdMutex<Vec<Integration>>>) -> PlatformBroker {
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    {
+        PlatformBroker::new(integrations)
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        let _ = integrations;
+        PlatformBroker::default()
+    }
 }
 
 fn warm_app_search_cache(app: tauri::AppHandle) {
@@ -148,11 +161,14 @@ pub fn run_tauri() {
         }
     };
 
+    let integrations = Arc::new(StdMutex::new(config.integrations.clone()));
+    let broker = platform_broker(integrations);
+
     let highlighter_service_enabled = config.highlighter_service_enabled;
     let config = Arc::new(Mutex::new(config));
 
     let highlighter_service = HighlighterService::new(config.clone());
-    if platform_broker().accessibility_permission_status() == AccessibilityPermissionStatus::Granted
+    if broker.accessibility_permission_status() == AccessibilityPermissionStatus::Granted
         && highlighter_service_enabled
     {
         let _ = highlighter_service
@@ -163,7 +179,7 @@ pub fn run_tauri() {
     tauri::Builder::default()
         .manage(config)
         .manage(highlighter_service)
-        .manage(StdMutex::new(platform_broker()))
+        .manage(StdMutex::new(broker))
         .manage(async_runtime)
         .plugin(tauri_plugin_autostart::init(
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,
@@ -221,6 +237,8 @@ pub fn run_highlighter(has_parent: bool) {
     let integrations = Arc::new(StdMutex::new(startup_config.integrations));
     let debounce_ms = Rc::new(RefCell::new(startup_config.debounce_ms));
     let linter = Rc::new(RefCell::new(startup_linter));
+
+    let broker = platform_broker(integrations.clone());
 
     let lint_ignored_lints = ignored_lints.clone();
     let lint_linter = linter.clone();
@@ -345,8 +363,6 @@ pub fn run_highlighter(has_parent: bool) {
             }
         }
     };
-
-    let broker = PlatformBroker::default();
 
     if let Err(error) = Highlighter::new(
         broker,

--- a/harper-desktop/src-tauri/src/windows_broker/automation_service.rs
+++ b/harper-desktop/src-tauri/src/windows_broker/automation_service.rs
@@ -1,6 +1,6 @@
 use std::iter::once;
 use std::sync::mpsc::{Receiver, SyncSender, TryRecvError, TrySendError, sync_channel};
-use std::thread::{JoinHandle, sleep};
+use std::thread::sleep;
 use std::time::Duration;
 
 use crate::rect::Rect;
@@ -98,7 +98,7 @@ impl AutomationService {
         let (job_sender, job_receiver) = sync_channel::<(WorkerJob, Vec<JobArgument>)>(1);
         let (result_sender, result_receiver) = sync_channel(1);
 
-        let handle = std::thread::spawn(move || {
+        std::thread::spawn(move || {
             let mut state = WorkerState {
                 automation: UIAutomation::new().unwrap(),
                 cached_text_element: None,
@@ -213,7 +213,7 @@ impl AutomationService {
         }
     }
 
-    fn resolve_focused_window(&mut self) -> Option<(isize, bool)> {
+    pub fn resolve_focused_window(&mut self) -> Option<(isize, bool)> {
         let (focused_window, focused_process_id) = focused_window()?;
 
         if focused_process_id == std::process::id() {

--- a/harper-desktop/src-tauri/src/windows_broker/automation_service.rs
+++ b/harper-desktop/src-tauri/src/windows_broker/automation_service.rs
@@ -18,7 +18,6 @@ use windows::Win32::UI::WindowsAndMessaging::{GetForegroundWindow, GetWindowThre
 
 /// Information about a worker thread.
 struct WorkerData {
-    _thread_handle: JoinHandle<()>,
     sender: SyncSender<(WorkerJob, Vec<JobArgument>)>,
     receiver: Receiver<JobResult>,
 }
@@ -131,7 +130,6 @@ impl AutomationService {
         self.worker_data = Some(WorkerData {
             receiver: result_receiver,
             sender: job_sender,
-            _thread_handle: handle,
         });
     }
 

--- a/harper-desktop/src-tauri/src/windows_broker/mod.rs
+++ b/harper-desktop/src-tauri/src/windows_broker/mod.rs
@@ -7,7 +7,7 @@ use crate::{
 use cached::cached;
 use egui::Pos2;
 use harper_core::linting::Lint;
-use std::ffi::OsString;
+use std::ffi::{OsString, c_void};
 use std::os::windows::ffi::OsStringExt;
 use std::process::Command;
 use std::{
@@ -43,7 +43,13 @@ impl WindowsBroker {
     }
 
     pub fn should_lint_focused_window(&self) -> bool {
-        let Ok(path) = get_focused_window_path() else {
+        let mut service = self.service.lock().unwrap();
+
+        let Some((focused_window, _)) = service.resolve_focused_window() else {
+            return false;
+        };
+
+        let Ok(path) = get_window_path(focused_window) else {
             return false;
         };
 
@@ -287,11 +293,10 @@ fn gatherer() -> Gatherer {
 }
 
 /// Returns the full executable path for the process that owns `hwnd`.
-pub fn get_focused_window_path() -> WindowsResult<PathBuf> {
+pub fn get_window_path(window_id: isize) -> WindowsResult<PathBuf> {
     unsafe {
-        let hwnd: HWND = GetForegroundWindow();
         let mut process_id = 0;
-        GetWindowThreadProcessId(hwnd, Some(&mut process_id));
+        GetWindowThreadProcessId(HWND(window_id as *mut c_void), Some(&mut process_id));
 
         let process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, process_id)?;
 

--- a/harper-desktop/src-tauri/src/windows_broker/mod.rs
+++ b/harper-desktop/src-tauri/src/windows_broker/mod.rs
@@ -1,42 +1,58 @@
 use crate::windows_broker::automation_service::AutomationService;
 use crate::{
+    config::Integration,
     os_broker::{AccessibilityPermissionStatus, AppSearchResult, OsBroker},
     rect::ActionableLint,
 };
 use cached::cached;
 use egui::Pos2;
 use harper_core::linting::Lint;
+use std::ffi::OsString;
+use std::os::windows::ffi::OsStringExt;
 use std::process::Command;
 use std::{
-    cell::RefCell,
     collections::BTreeMap,
     path::PathBuf,
-    rc::Rc,
     sync::{Arc, Mutex},
 };
-use windows::Win32::Foundation::POINT;
+use windows::Win32::Foundation::{CloseHandle, HWND, POINT};
 use windows::Win32::Graphics::Gdi::{MONITOR_DEFAULTTONEAREST, MonitorFromWindow};
+use windows::Win32::System::Threading::{
+    OpenProcess, PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION, QueryFullProcessImageNameW,
+};
 use windows::Win32::UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI};
-use windows::Win32::UI::WindowsAndMessaging::{GetCursorPos, GetForegroundWindow};
+use windows::Win32::UI::WindowsAndMessaging::{
+    GetCursorPos, GetForegroundWindow, GetWindowThreadProcessId,
+};
+use windows::core::{PWSTR, Result as WindowsResult};
 use wintheon::file::{IconSize, Priority};
 use wintheon::gather::Gatherer;
 mod automation_service;
 
 pub struct WindowsBroker {
     service: Arc<Mutex<AutomationService>>,
+    integrations: Arc<Mutex<Vec<Integration>>>,
 }
 
 impl WindowsBroker {
-    pub fn new() -> Self {
+    pub fn new(integrations: Arc<Mutex<Vec<Integration>>>) -> Self {
         Self {
             service: Arc::new(Mutex::new(AutomationService::create_and_start())),
+            integrations,
         }
     }
-}
 
-impl Default for WindowsBroker {
-    fn default() -> Self {
-        Self::new()
+    pub fn should_lint_focused_window(&self) -> bool {
+        let Ok(path) = get_focused_window_path() else {
+            return false;
+        };
+
+        let path = path.to_string_lossy();
+        let Ok(integrations) = self.integrations.lock() else {
+            return false;
+        };
+
+        Integration::is_integration_enabled_in(&integrations, &path)
     }
 }
 
@@ -45,6 +61,10 @@ impl OsBroker for WindowsBroker {
         &mut self,
         lint_text: &mut dyn FnMut(&str) -> BTreeMap<String, Vec<Lint>>,
     ) -> Vec<ActionableLint> {
+        if !self.should_lint_focused_window() {
+            return Vec::new();
+        }
+
         let text = self.service.lock().unwrap().get_text();
         if let Some(text) = text {
             if text.len() > 16_000 {
@@ -264,4 +284,32 @@ fn gatherer() -> Gatherer {
         .with_desktop(Priority(1.0))
         .with_start_menu(Priority(1.5))
         .with_windows_apps(Priority(2.0))
+}
+
+/// Returns the full executable path for the process that owns `hwnd`.
+pub fn get_focused_window_path() -> WindowsResult<PathBuf> {
+    unsafe {
+        let hwnd: HWND = GetForegroundWindow();
+        let mut process_id = 0;
+        GetWindowThreadProcessId(hwnd, Some(&mut process_id));
+
+        let process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, process_id)?;
+
+        let mut buffer = vec![0u16; 32_768];
+        let mut length = buffer.len() as u32;
+        let path_result = QueryFullProcessImageNameW(
+            process,
+            PROCESS_NAME_WIN32,
+            PWSTR(buffer.as_mut_ptr()),
+            &mut length,
+        );
+        let close_result = CloseHandle(process);
+
+        path_result?;
+        close_result?;
+
+        Ok(PathBuf::from(OsString::from_wide(
+            &buffer[..length as usize],
+        )))
+    }
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

It is crucial that we disable Harper on applications we don't support. This PR configures Harper to do that on Windows.

Before running linting operation, we:

1. Determine the process ID of the active window.
2. Use that ID to determine the path of the executable from which that process was launched.
3. If that path is not in the allowed list, disable linting temporarily.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>