### PR TITLE
fix(desktop): suggestions will close before user interaction

### DIFF
--- a/harper-desktop/src-tauri/src/highlighter/render_state.rs
+++ b/harper-desktop/src-tauri/src/highlighter/render_state.rs
@@ -52,8 +52,8 @@ enum Glyph {
 /// into that plumbing. This keeps future highlight rectangles, styling, and animation state out of
 /// the platform/rendering infrastructure.
 pub struct RenderState {
-    /// Lints with their screen-space bounds, used to draw all highlights and resolve hit tests.
-    rects: Vec<ActionableLint>,
+    /// Last successful accessibility read, retained when a later read fails.
+    last_lints: Option<Vec<ActionableLint>>,
 
     /// Index of the lint whose suggestion popup is currently visible.
     ///
@@ -75,7 +75,7 @@ pub struct RenderState {
 }
 
 impl RenderState {
-    /// Creates render state through `set_rects` so initial lint data gets the same stale-popup guard
+    /// Creates render state through `set_lints` so initial lint data gets the same stale-popup guard
     /// used by later accessibility refreshes.
     pub fn new(
         rects: Vec<ActionableLint>,
@@ -84,28 +84,35 @@ impl RenderState {
         disable_rule: DisableRule,
     ) -> Self {
         let mut state = Self {
-            rects: Vec::new(),
+            last_lints: None,
             highlighted_lint: None,
             markdown_cache: CommonMarkCache::default(),
             ignore_lint,
             add_to_dictionary,
             disable_rule,
         };
-        state.set_rects(rects);
+        state.set_lints(Some(rects));
         state
     }
 
-    /// Replaces the accessibility-derived lint geometry while preventing a popup from pointing at a
-    /// lint index that no longer exists after the latest read.
-    pub fn set_rects(&mut self, rects: Vec<ActionableLint>) {
-        self.rects = rects;
+    /// Saves successful accessibility reads while retaining the previous lints after a failed read.
+    pub fn set_lints(&mut self, lints: Option<Vec<ActionableLint>>) {
+        let Some(lints) = lints else {
+            return;
+        };
+
+        self.last_lints = Some(lints);
 
         if self
             .highlighted_lint
-            .is_some_and(|index| index >= self.rects.len())
+            .is_some_and(|index| index >= self.lints().len())
         {
             self.highlighted_lint = None;
         }
+    }
+
+    fn lints(&self) -> &[ActionableLint] {
+        self.last_lints.as_deref().unwrap_or_default()
     }
 
     /// Updates which lint owns the suggestion popup without exposing render-state internals.
@@ -114,7 +121,7 @@ impl RenderState {
     /// selection. Filtering invalid indexes here keeps stale cursor state from selecting a lint that
     /// disappeared after the latest accessibility read.
     pub fn set_highlighted_lint(&mut self, highlighted_lint: Option<usize>) {
-        self.highlighted_lint = highlighted_lint.filter(|index| *index < self.rects.len());
+        self.highlighted_lint = highlighted_lint.filter(|index| *index < self.lints().len());
     }
 
     /// Centralizes the close behavior so the popup close button only has to clear the selected lint.
@@ -128,7 +135,7 @@ impl RenderState {
             return HitTarget::Popup;
         }
 
-        self.rects
+        self.lints()
             .iter()
             .position(|positioned_lint| {
                 rect_bounds(&positioned_lint.rect.with_friendly_padding()).contains(pos)
@@ -140,19 +147,19 @@ impl RenderState {
     /// rendered bounds, which keeps hit-testing available before the next render pass completes.
     pub fn popup_rect(&self) -> Option<egui::Rect> {
         self.highlighted_lint
-            .and_then(|index| self.rects.get(index))
+            .and_then(|index| self.lints().get(index))
             .map(|positioned_lint| popup_rect_for_lint(&positioned_lint.rect))
     }
 
     /// Draws highlights and the active popup from the same state used by hit-testing so visible
     /// regions and clickable regions do not drift apart.
     pub fn render(&mut self, ui: &mut egui::Ui) {
-        for positioned_lint in &self.rects {
+        for positioned_lint in self.lints() {
             draw_highlight(ui, &positioned_lint.rect, &positioned_lint.lint);
         }
 
         if let Some(index) = self.highlighted_lint
-            && let Some(positioned_lint) = self.rects.get(index)
+            && let Some(positioned_lint) = self.lints().get(index)
         {
             let rect = positioned_lint.rect;
             let lint = positioned_lint.lint.clone();
@@ -161,7 +168,11 @@ impl RenderState {
             match render_lint_card(ui, &rect, &lint, &source_text, &mut self.markdown_cache) {
                 Some(LintCardAction::Close) => self.close_popup(),
                 Some(LintCardAction::ApplySuggestion(suggestion)) => {
-                    if let Some(actionable_lint) = self.rects.get_mut(index) {
+                    if let Some(actionable_lint) = self
+                        .last_lints
+                        .as_mut()
+                        .and_then(|lints| lints.get_mut(index))
+                    {
                         actionable_lint.apply_suggestion(suggestion);
                     }
 
@@ -169,7 +180,7 @@ impl RenderState {
                 }
                 Some(LintCardAction::IgnoreLint) => {
                     if let Some((lint, source_text)) =
-                        self.rects.get(index).map(|actionable_lint| {
+                        self.lints().get(index).map(|actionable_lint| {
                             (
                                 actionable_lint.lint.clone(),
                                 actionable_lint.source_text.clone(),
@@ -184,7 +195,7 @@ impl RenderState {
                 }
                 Some(LintCardAction::AddToDictionary) => {
                     if let Some((lint, source_text)) =
-                        self.rects.get(index).map(|actionable_lint| {
+                        self.lints().get(index).map(|actionable_lint| {
                             (
                                 actionable_lint.lint.clone(),
                                 actionable_lint.source_text.clone(),
@@ -200,7 +211,7 @@ impl RenderState {
                 }
                 Some(LintCardAction::DisableRule) => {
                     if let Some(rule_name) = self
-                        .rects
+                        .lints()
                         .get(index)
                         .map(|actionable_lint| actionable_lint.rule_name.clone())
                     {

--- a/harper-desktop/src-tauri/src/highlighter/render_state.rs
+++ b/harper-desktop/src-tauri/src/highlighter/render_state.rs
@@ -91,16 +91,12 @@ impl RenderState {
             add_to_dictionary,
             disable_rule,
         };
-        state.set_lints(Some(rects));
+        state.set_lints(rects);
         state
     }
 
     /// Saves successful accessibility reads while retaining the previous lints after a failed read.
-    pub fn set_lints(&mut self, lints: Option<Vec<ActionableLint>>) {
-        let Some(lints) = lints else {
-            return;
-        };
-
+    pub fn set_lints(&mut self, lints: Vec<ActionableLint>) {
         self.last_lints = Some(lints);
 
         if self

--- a/harper-desktop/src-tauri/src/highlighter/window_manager.rs
+++ b/harper-desktop/src-tauri/src/highlighter/window_manager.rs
@@ -157,8 +157,8 @@ impl WindowManagerApp {
     /// Refreshes lint geometry from the OS broker inside the event loop so repaint requests happen on
     /// the same thread that owns the overlay windows.
     fn read_rect_updates(&mut self) {
-        let rects = self.os_broker.get_boxes(self.lint_text.as_mut());
-        self.render_state.set_rects(rects);
+        let lints = self.os_broker.get_boxes(self.lint_text.as_mut());
+        self.render_state.set_lints(lints);
 
         for window in &self.windows {
             window.request_redraw();

--- a/harper-desktop/src-tauri/src/highlighter/window_manager.rs
+++ b/harper-desktop/src-tauri/src/highlighter/window_manager.rs
@@ -158,7 +158,9 @@ impl WindowManagerApp {
     /// the same thread that owns the overlay windows.
     fn read_rect_updates(&mut self) {
         let lints = self.os_broker.get_boxes(self.lint_text.as_mut());
-        self.render_state.set_lints(lints);
+        if let Some(lints) = lints {
+            self.render_state.set_lints(lints);
+        }
 
         for window in &self.windows {
             window.request_redraw();

--- a/harper-desktop/src-tauri/src/mac_broker/accessibility_text.rs
+++ b/harper-desktop/src-tauri/src/mac_broker/accessibility_text.rs
@@ -12,7 +12,10 @@ use core_foundation::base::{CFRange, CFType, TCFType};
 use core_foundation::string::CFString;
 use harper_core::linting::{Lint, Suggestion};
 use objc2_foundation::NSRect;
-use std::{cell::RefCell, ptr};
+use std::{
+    cell::{Cell, RefCell},
+    ptr,
+};
 
 use crate::rect::{ActionableLint, Rect};
 
@@ -133,48 +136,57 @@ fn rect_has_usable_text_metrics(rect: Rect) -> bool {
 /// Collects lint rectangles while walking supported text elements in an AX tree.
 pub struct RectCollector<'a> {
     rects: RefCell<Vec<ActionableLint>>,
+    expected_rect_count: Cell<usize>,
+    read_failed: Cell<bool>,
     lint_text: RefCell<&'a mut LintCallback<'a>>,
 }
 
 impl TreeVisitor for RectCollector<'_> {
     fn enter_element(&self, element: &AXUIElement) -> TreeWalkerFlow {
-        if let Ok(value) = element.value()
-            && is_supported_text_element(element)
-        {
-            let string =
-                unsafe { CFString::wrap_under_get_rule(value.as_CFTypeRef() as _).to_string() };
+        if !is_supported_text_element(element) {
+            return TreeWalkerFlow::Continue;
+        }
 
-            let mut rects = self.rects.borrow_mut();
-            let organized_lints = (self.lint_text.borrow_mut())(&string);
+        let Ok(value) = element.value() else {
+            self.read_failed.set(true);
+            return TreeWalkerFlow::Continue;
+        };
 
-            for (rule_name, lints) in organized_lints {
-                for lint in lints {
-                    if let Some(rect) = element_rect_for_text_range_with_fallback(
-                        element,
-                        &string,
-                        lint.span.start,
-                        lint.span.len(),
-                    ) {
-                        let element = element.clone();
-                        let source_text = string.clone();
-                        let suggestion_source_text = string.clone();
-                        let suggestion_lint = lint.clone();
+        let string =
+            unsafe { CFString::wrap_under_get_rule(value.as_CFTypeRef() as _).to_string() };
+        let mut rects = self.rects.borrow_mut();
+        let organized_lints = (self.lint_text.borrow_mut())(&string);
 
-                        rects.push(ActionableLint::new(
-                            rect,
-                            rule_name.clone(),
-                            lint,
-                            source_text,
-                            move |suggestion| {
-                                apply_suggestion_to_element(
-                                    element,
-                                    suggestion_source_text,
-                                    suggestion_lint,
-                                    suggestion,
-                                );
-                            },
-                        ));
-                    }
+        for (rule_name, lints) in organized_lints {
+            for lint in lints {
+                self.expected_rect_count
+                    .set(self.expected_rect_count.get() + 1);
+
+                if let Some(rect) = element_rect_for_text_range_with_fallback(
+                    element,
+                    &string,
+                    lint.span.start,
+                    lint.span.len(),
+                ) {
+                    let element = element.clone();
+                    let source_text = string.clone();
+                    let suggestion_source_text = string.clone();
+                    let suggestion_lint = lint.clone();
+
+                    rects.push(ActionableLint::new(
+                        rect,
+                        rule_name.clone(),
+                        lint,
+                        source_text,
+                        move |suggestion| {
+                            apply_suggestion_to_element(
+                                element,
+                                suggestion_source_text,
+                                suggestion_lint,
+                                suggestion,
+                            );
+                        },
+                    ));
                 }
             }
         }
@@ -188,12 +200,20 @@ impl<'a> RectCollector<'a> {
     pub fn new(lint_text: &'a mut LintCallback) -> Self {
         Self {
             rects: RefCell::new(Vec::new()),
+            expected_rect_count: Cell::new(0),
+            read_failed: Cell::new(false),
             lint_text: RefCell::new(lint_text),
         }
     }
 
-    pub fn unwrap_rects(self) -> Vec<ActionableLint> {
-        self.rects.into_inner()
+    pub fn unwrap_rects(self) -> Option<Vec<ActionableLint>> {
+        let rects = self.rects.into_inner();
+
+        if rects.is_empty() && (self.expected_rect_count.get() > 0 || self.read_failed.get()) {
+            None
+        } else {
+            Some(rects)
+        }
     }
 }
 

--- a/harper-desktop/src-tauri/src/mac_broker/mod.rs
+++ b/harper-desktop/src-tauri/src/mac_broker/mod.rs
@@ -288,19 +288,19 @@ impl Drop for MacBroker {
 pub(super) type LintCallback<'a> = dyn FnMut(&str) -> BTreeMap<String, Vec<Lint>> + 'a;
 
 impl OsBroker for MacBroker {
-    fn get_boxes(&mut self, lint_text: &mut LintCallback) -> Vec<ActionableLint> {
+    fn get_boxes(&mut self, lint_text: &mut LintCallback) -> Option<Vec<ActionableLint>> {
         let pid = match self.target_pid() {
             Ok(Some(pid)) => pid,
             Ok(None) => {
                 self.window_movement = None;
                 self.reset_accessibility_activation();
-                return Vec::new();
+                return Some(Vec::new());
             }
             Err(err) => {
                 self.window_movement = None;
                 self.reset_accessibility_activation();
                 eprintln!("Unable to identify focused window: {err}");
-                return Vec::new();
+                return None;
             }
         };
 
@@ -309,13 +309,13 @@ impl OsBroker for MacBroker {
             Ok(None) => {
                 self.window_movement = None;
                 self.reset_accessibility_activation();
-                return Vec::new();
+                return None;
             }
             Err(error) => {
                 self.window_movement = None;
                 self.reset_accessibility_activation();
                 eprintln!("Unable to identify focused app bundle: {error}");
-                return Vec::new();
+                return None;
             }
         };
 
@@ -325,24 +325,24 @@ impl OsBroker for MacBroker {
             }
             Err(error) => {
                 eprintln!("Unable to read integrations: {error}");
-                false
+                return None;
             }
         };
 
         if !integration_enabled {
             self.window_movement = None;
             self.reset_accessibility_activation();
-            return Vec::new();
+            return Some(Vec::new());
         }
 
         // Hide highlights while window is moving to avoid "sliding" behavior.
         if self.window_is_moving(pid) {
-            return Vec::new();
+            return Some(Vec::new());
         }
 
         let el = AXUIElement::application(pid);
         if !self.ensure_accessibility_activation(pid, &bundle_identifier, &el) {
-            return Vec::new();
+            return None;
         }
 
         let walker = TreeWalker::new();

--- a/harper-desktop/src-tauri/src/os_broker.rs
+++ b/harper-desktop/src-tauri/src/os_broker.rs
@@ -20,10 +20,12 @@ pub enum AccessibilityPermissionStatus {
 /// macOS accessibility and pointer APIs.
 pub trait OsBroker {
     /// Get the actionable lint boxes from the OS, provided a linting source.
+    ///
+    /// `None` means the accessibility read failed and the last successful result should be retained.
     fn get_boxes(
         &mut self,
         lint_text: &mut dyn FnMut(&str) -> BTreeMap<String, Vec<Lint>>,
-    ) -> Vec<ActionableLint>;
+    ) -> Option<Vec<ActionableLint>>;
 
     /// Grab the position of the user's cursor on the screen.
     fn cursor_position(&self) -> Option<egui::Pos2>;
@@ -75,8 +77,8 @@ impl OsBroker for NoopBroker {
     fn get_boxes(
         &mut self,
         _lint_text: &mut dyn FnMut(&str) -> BTreeMap<String, Vec<Lint>>,
-    ) -> Vec<ActionableLint> {
-        Vec::new()
+    ) -> Option<Vec<ActionableLint>> {
+        Some(Vec::new())
     }
 
     fn cursor_position(&self) -> Option<egui::Pos2> {

--- a/harper-desktop/src-tauri/src/windows_broker/automation_service.rs
+++ b/harper-desktop/src-tauri/src/windows_broker/automation_service.rs
@@ -303,38 +303,37 @@ fn text_element_for_window(
         Variant::from(true),
         None,
     )?;
-    let cursor = cursor_position();
-    let mut first_candidate = None;
-    let mut cursor_candidate = None;
+    let keyboard_condition = automation.create_property_condition(
+        UIProperty::HasKeyboardFocus,
+        Variant::from(true),
+        None,
+    )?;
+    let condition = automation.create_and_condition(text_condition, keyboard_condition)?;
 
-    for element in root.find_all(TreeScope::Subtree, &text_condition)? {
-        let Ok(text) = get_text(&element) else {
-            continue;
-        };
-        if expected_text.is_some_and(|expected| expected != text) {
-            continue;
-        }
-        if element.has_keyboard_focus().unwrap_or(false) {
-            return Ok(element);
+    for (index, element) in root
+        .find_all(TreeScope::Subtree, &condition)?
+        .into_iter()
+        .enumerate()
+    {
+        if let Some(expected) = expected_text {
+            let text = get_text(&element);
+
+            let Ok(text) = text else {
+                continue;
+            };
+
+            if expected_text.is_some_and(|expected| expected != text) {
+                continue;
+            }
         }
 
-        if first_candidate.is_none() {
-            first_candidate = Some(element.clone());
-        }
-
-        if let Some(area) = cursor_overlap_area(&element, cursor)
-            && cursor_candidate
-                .as_ref()
-                .is_none_or(|(best_area, _)| area < *best_area)
-        {
-            cursor_candidate = Some((area, element));
-        }
+        return Ok(element);
     }
 
-    cursor_candidate
-        .map(|(_, element)| element)
-        .or(first_candidate)
-        .ok_or_else(|| Error::new(uiautomation::errors::ERR_NOTFOUND, "no text element found"))
+    Err(Error::new(
+        uiautomation::errors::ERR_NOTFOUND,
+        "no text element found",
+    ))
 }
 
 fn cursor_overlap_area(element: &UIElement, cursor: Option<POINT>) -> Option<i64> {

--- a/harper-desktop/src-tauri/src/windows_broker/mod.rs
+++ b/harper-desktop/src-tauri/src/windows_broker/mod.rs
@@ -42,23 +42,16 @@ impl WindowsBroker {
         }
     }
 
-    pub fn should_lint_focused_window(&self) -> bool {
-        let mut service = self.service.lock().unwrap();
+    pub fn should_lint_focused_window(&self) -> Option<bool> {
+        let mut service = self.service.lock().ok()?;
+        let focused_window = service.resolve_focused_window()?;
+        let path = get_window_path(focused_window).ok()?;
+        let integrations = self.integrations.lock().ok()?;
 
-        let Some(focused_window) = service.resolve_focused_window() else {
-            return false;
-        };
-
-        let Ok(path) = get_window_path(focused_window) else {
-            return false;
-        };
-
-        let path = path.to_string_lossy();
-        let Ok(integrations) = self.integrations.lock() else {
-            return false;
-        };
-
-        Integration::is_integration_enabled_in(&integrations, &path)
+        Some(Integration::is_integration_enabled_in(
+            &integrations,
+            &path.to_string_lossy(),
+        ))
     }
 }
 
@@ -66,43 +59,41 @@ impl OsBroker for WindowsBroker {
     fn get_boxes(
         &mut self,
         lint_text: &mut dyn FnMut(&str) -> BTreeMap<String, Vec<Lint>>,
-    ) -> Vec<ActionableLint> {
-        if !self.should_lint_focused_window() {
-            return Vec::new();
+    ) -> Option<Vec<ActionableLint>> {
+        match self.should_lint_focused_window() {
+            Some(true) => {}
+            Some(false) => return Some(Vec::new()),
+            None => return None,
         }
 
-        let text = self.service.lock().unwrap().get_text();
-        if let Some(text) = text {
-            if text.len() > 16_000 {
-                return Vec::new();
-            }
+        let text = self.service.lock().ok()?.get_text()?;
+        if text.len() > 16_000 {
+            return Some(Vec::new());
+        }
 
-            let lints = lint_text(text.as_str());
+        let lints = lint_text(&text);
+        let rects = self
+            .service
+            .lock()
+            .ok()?
+            .get_bounding_boxes(&text, lints.values().flatten().map(|lint| lint.span))?;
 
-            let all_lint_iter = lints.values().map(|r| r.iter()).flatten();
-            let Some(rects) = self
-                .service
-                .lock()
-                .unwrap()
-                .get_bounding_boxes(&text, all_lint_iter.map(|l| l.span))
-            else {
-                return Vec::new();
-            };
-
+        Some(
             lints
                 .into_iter()
-                .map(|(lint_id, lints)| lints.into_iter().map(move |l| (lint_id.clone(), l)))
-                .flatten()
+                .flat_map(|(lint_id, lints)| {
+                    lints.into_iter().map(move |lint| (lint_id.clone(), lint))
+                })
                 .zip(rects)
-                .map(|((lint_id, lint), rects)| {
+                .flat_map(|((lint_id, lint), rects)| {
                     let text = text.clone();
                     let service = self.service.clone();
-                    rects.into_iter().map(move |r| {
+                    rects.into_iter().map(move |rect| {
                         let service = service.clone();
                         let suggestion_text = text.clone();
                         let suggestion_span = lint.span;
                         ActionableLint::new(
-                            r,
+                            rect,
                             lint_id.clone(),
                             lint.clone(),
                             text.clone(),
@@ -116,11 +107,8 @@ impl OsBroker for WindowsBroker {
                         )
                     })
                 })
-                .flatten()
-                .collect()
-        } else {
-            Vec::new()
-        }
+                .collect(),
+        )
     }
 
     fn cursor_position(&self) -> Option<Pos2> {


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

This issue was reported to me initially by @anyllmarkevich.

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

It turns out that during the transition of focus from the target application (like Notepad, for example) to the highlighter's rendering window, the text read could fail. This failure led to the lints being hidden. This was not ideal, since it resulted in the suggestion popup closing prematurely.

I've fixed that by displaying a saved copy of the lints during that transition period.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually on Windows.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>