### PR TITLE
feat: final nail on the coffin → in

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5189,6 +5189,13 @@
 						},
 						{
 							"Bool": {
+								"name": "NailInCoffin",
+								"state": true,
+								"label": "Nail in Coffin"
+							}
+						},
+						{
+							"Bool": {
 								"name": "NeitherHereNorThere",
 								"state": true,
 								"label": "Neither Here Nor There"

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -175,6 +175,7 @@ use super::most_number::MostNumber;
 use super::most_of_the_times::MostOfTheTimes;
 use super::multiple_frequency_adverbs::MultipleFrequencyAdverbs;
 use super::multiple_sequential_pronouns::MultipleSequentialPronouns;
+use super::nail_in_coffin::NailInCoffin;
 use super::nail_on_the_head::NailOnTheHead;
 use super::naked_eye::NakedEye;
 use super::need_to_noun::NeedToNoun;
@@ -780,6 +781,7 @@ impl LintGroup {
         insert_expr_rule!(MostNumber);
         insert_expr_rule!(MostOfTheTimes);
         insert_expr_rule!(MultipleSequentialPronouns);
+        insert_expr_rule!(NailInCoffin);
         insert_expr_rule!(NailOnTheHead);
         insert_expr_rule!(NakedEye);
         insert_expr_rule!(NeedToNoun);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -189,6 +189,7 @@ mod most_number;
 mod most_of_the_times;
 mod multiple_frequency_adverbs;
 mod multiple_sequential_pronouns;
+mod nail_in_coffin;
 mod nail_on_the_head;
 mod naked_eye;
 mod need_to_noun;

--- a/harper-core/src/linting/nail_in_coffin.rs
+++ b/harper-core/src/linting/nail_in_coffin.rs
@@ -1,0 +1,109 @@
+use crate::{
+    Lint, Token,
+    char_string::CharStringExt,
+    expr::{Expr, SequenceExpr},
+    linting::{
+        ExprLinter, LintKind, Suggestion,
+        expr_linter::{Chunk, find_the_only_token_matching},
+    },
+};
+
+pub struct NailInCoffin {
+    expr: SequenceExpr,
+}
+
+impl Default for NailInCoffin {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::word_set(&["final", "last"])
+                .t_ws()
+                .t_set(&["nail", "nails"])
+                .t_ws()
+                .t_aco("on")
+                .t_ws()
+                .then_determiner()
+                .t_ws()
+                .t_set(&["coffin", "coffins"]),
+        }
+    }
+}
+
+impl ExprLinter for NailInCoffin {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        let span =
+            find_the_only_token_matching(toks, src, |t, c| t.get_ch(c).eq_ch(&['o', 'n']))?.span;
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::Usage,
+            suggestions: vec![Suggestion::replace_with_match_case_str(
+                "in",
+                span.get_content(src),
+            )],
+            message: "This idiom uses the preposition `in` rather than `on`".to_owned(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects `nail on the coffin` to `nail in the coffin`"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::assert_suggestion_result;
+
+    use super::NailInCoffin;
+
+    #[test]
+    fn fix_final_the() {
+        assert_suggestion_result(
+            "Maybe this will be the final nail on the coffin for the console.",
+            NailInCoffin::default(),
+            "Maybe this will be the final nail in the coffin for the console.",
+        );
+    }
+
+    #[test]
+    fn fix_final_his() {
+        assert_suggestion_result(
+            "A single hit whether blocked or not is going to put the final nail on his coffin.",
+            NailInCoffin::default(),
+            "A single hit whether blocked or not is going to put the final nail in his coffin.",
+        );
+    }
+
+    #[test]
+    fn fix_last_his() {
+        assert_suggestion_result(
+            "and as the last nail on his coffin",
+            NailInCoffin::default(),
+            "and as the last nail in his coffin",
+        );
+    }
+
+    #[test]
+    fn fix_final_her() {
+        assert_suggestion_result(
+            "That's literally the final nail on her coffin since she's the dead ass only one that can't use that card.",
+            NailInCoffin::default(),
+            "That's literally the final nail in her coffin since she's the dead ass only one that can't use that card.",
+        );
+    }
+
+    #[test]
+    fn fix_last_their() {
+        assert_suggestion_result(
+            "So I just sent Khalida to put the last nail on their coffin",
+            NailInCoffin::default(),
+            "So I just sent Khalida to put the last nail in their coffin",
+        );
+    }
+}


### PR DESCRIPTION
# Issues 
N/A

# Description

Corrects "final/last nail on the coffin" to use the correct preposition "in".
It also works with plural "nails" and "coffins" and possessives instead of "the".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
