### PR TITLE
feat: introduce `ContextIterators` for `match_to_lint_with_context()`

### DIFF
--- a/harper-core/src/linting/aspire_to.rs
+++ b/harper-core/src/linting/aspire_to.rs
@@ -3,7 +3,7 @@ use crate::{
     expr::{Expr, SequenceExpr},
     linting::{
         ExprLinter, LintKind, Suggestion,
-        expr_linter::{Sentence, at_start_of_sentence, followed_by_word, preceded_by_word},
+        expr_linter::{ContextIterators, Sentence, at_start_of_sentence},
     },
 };
 
@@ -47,22 +47,24 @@ impl ExprLinter for AspireTo {
             return None;
         }
 
-        if preceded_by_word(ctx, |wt| {
-            // .NET is unlintable and we can't use `.get_content()` on unlintable
-            if wt.kind.is_preposition() || wt.kind.is_unlintable() {
-                true
-            } else {
-                let chars = wt.span.get_content(src);
+        let ContextIterators {
+            mut before,
+            mut after,
+        } = ContextIterators::new(ctx)?;
 
-                chars == ['N', 'E', 'T']
-                    || chars.eq_any_ignore_ascii_case_str(&[
-                        // verbs that indicate Aspire is a tool or product
-                        "use", "used", "uses", "using",
-                        // other words that precede Aspire when it's not a verb
-                        "dotnet",
-                    ])
+        if before.prev_word().is_some_and(|w| {
+            w.kind.is_preposition() || w.kind.is_unlintable() || {
+                let ch = w.get_ch(src);
+                ch == ['N', 'E', 'T']
+                    || ch.eq_any_ignore_ascii_case_str(&["use", "used", "uses", "using", "dotnet"])
             }
-        }) || followed_by_word(ctx, |wt| wt.span.get_content(src) == ['A', 'W', 'S'])
+        }) {
+            return None;
+        }
+
+        if after
+            .next_word()
+            .is_some_and(|w| w.get_ch(src) == ['A', 'W', 'S'])
         {
             return None;
         }

--- a/harper-core/src/linting/aspire_to.rs
+++ b/harper-core/src/linting/aspire_to.rs
@@ -53,10 +53,16 @@ impl ExprLinter for AspireTo {
         } = ContextIterators::new(ctx)?;
 
         if before.prev_word().is_some_and(|w| {
+            // .NET is unlintable and we can't use `.get_content()` on unlintable
             w.kind.is_preposition() || w.kind.is_unlintable() || {
                 let ch = w.get_ch(src);
                 ch == ['N', 'E', 'T']
-                    || ch.eq_any_ignore_ascii_case_str(&["use", "used", "uses", "using", "dotnet"])
+                    || ch.eq_any_ignore_ascii_case_str(&[
+                        // verbs that indicate Aspire is a tool or product
+                        "use", "used", "uses", "using",
+                        // other words that precede Aspire when it's not a verb
+                        "dotnet",
+                    ])
             }
         }) {
             return None;

--- a/harper-core/src/linting/expr_linter.rs
+++ b/harper-core/src/linting/expr_linter.rs
@@ -192,12 +192,7 @@ pub fn followed_by_hyphen(context: Option<(&[Token], &[Token])>) -> bool {
 /// Counterintuitively, a sentence includes the whitespace after
 /// the sentence-final punctuation.
 pub fn at_start_of_sentence(context: Option<(&[Token], &[Token])>) -> bool {
-    if let Some((before, _)) = context
-        && (before.is_empty() || (before.len() == 1 && before[0].kind.is_whitespace()))
-    {
-        return true;
-    }
-    false
+    matches!(context, Some((before, _)) if before.is_empty() || (before.len() == 1 && before[0].kind.is_whitespace()))
 }
 
 /// Check for sentence context immediately before a matched span.
@@ -241,6 +236,87 @@ pub fn surrounded_by_words(
         return predicate(word_before, word_after);
     }
     false
+}
+
+pub struct AfterContextIter<'a> {
+    toks: &'a [Token],
+    idx: usize,
+}
+
+pub struct BeforeContextIter<'a> {
+    toks: &'a [Token],
+    idx: usize,
+}
+
+pub struct ContextIterators<'a> {
+    pub before: BeforeContextIter<'a>,
+    pub after: AfterContextIter<'a>,
+}
+
+impl<'a> AfterContextIter<'a> {
+    pub fn new(toks: &'a [Token]) -> Self {
+        Self { toks, idx: 0 }
+    }
+}
+
+impl<'a> BeforeContextIter<'a> {
+    pub fn new(toks: &'a [Token]) -> Self {
+        Self {
+            toks,
+            idx: toks.len(),
+        }
+    }
+}
+
+impl<'a> ContextIterators<'a> {
+    pub fn new(ctx: Option<(&'a [Token], &'a [Token])>) -> Option<Self> {
+        let (before, after) = ctx?;
+        Some(Self {
+            before: BeforeContextIter::new(before),
+            after: AfterContextIter::new(after),
+        })
+    }
+}
+
+impl<'a> AfterContextIter<'a> {
+    pub fn next_tok(&mut self) -> Option<&'a Token> {
+        if self.idx < self.toks.len() {
+            let tok = &self.toks[self.idx];
+            self.idx += 1;
+            Some(tok)
+        } else {
+            None
+        }
+    }
+
+    pub fn next_word(&mut self) -> Option<&'a Token> {
+        let nt = self.next_tok()?;
+        if !nt.kind.is_whitespace() {
+            return None;
+        }
+        let nw = self.next_tok()?;
+        nw.kind.is_word().then_some(nw)
+    }
+}
+
+impl<'a> BeforeContextIter<'a> {
+    pub fn prev_tok(&mut self) -> Option<&'a Token> {
+        if self.idx > 0 {
+            self.idx -= 1;
+            Some(&self.toks[self.idx])
+        } else {
+            None
+        }
+    }
+
+    pub fn prev_word(&mut self) -> Option<&'a Token> {
+        let pt = self.prev_tok()?;
+        if !pt.kind.is_whitespace() {
+            return None;
+        }
+        let pw = self.prev_tok()?;
+        pw.kind.is_word().then_some(pw)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Issues 
N/A

# Description

For some time I've thought about needing to explore forwards and backwards through the context before and after the matched `Expr` in `match_to_lint_with_context()` to help disambiguate possible errors and the grammar around words that can have multiple POSes.

This PR brings iterators that allow prev token, prev word, next token, and next word on the context.

I'll refactor some existing `ExprLinter`s to make use of it and illustrate how to use it. First is `AspireTo`.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

I asked some coding AIs to analyse the codebase and decide which variants of my ideas would work best and to give me some code snippets. I used those as a guide but wrote my own different logic.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
