### PR TITLE
feat: take control over→take control of

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5581,6 +5581,13 @@
 						},
 						{
 							"Bool": {
+								"name": "TakeControlOf",
+								"state": true,
+								"label": "Take Control of"
+							}
+						},
+						{
+							"Bool": {
 								"name": "TakeItPersonally",
 								"state": true,
 								"label": "Take It Personally"

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -666,6 +666,18 @@ pub fn lint_group() -> LintGroup {
             "Ensures proper use of the subjunctive mood in counterfactual conditional statements starting with `if only` or `I wish`.",
             LintKind::Grammar
         ),
+        "TakeControlOf" => (
+            &[
+                ("take control over", "take control of"),
+                ("taken control over", "taken control of"),
+                ("takes control over", "takes control of"),
+                ("taking control over", "taking control of"),
+                ("took control over", "took control of"),
+            ],
+            "Use `take control of` instead of `take control over`.",
+            "Corrects `take control over` to `take control of`.",
+            LintKind::Usage
+        ),
         "UseToUsedTo" => (
             &[
                 // "be" verbs + "use to" -> "used to" (accustomed to)

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -2157,6 +2157,53 @@ fn i_wish_it_was() {
     );
 }
 
+// TakeControlOf
+
+#[test]
+fn take() {
+    assert_suggestion_result(
+        "allowed .editorconfig to set editor ruler and take control over soft-wrap",
+        test_linter(),
+        "allowed .editorconfig to set editor ruler and take control of soft-wrap",
+    );
+}
+
+#[test]
+fn taken() {
+    assert_suggestion_result(
+        "I've taken control over the inputValue to be able to render the wanted menu items",
+        test_linter(),
+        "I've taken control of the inputValue to be able to render the wanted menu items",
+    );
+}
+
+#[test]
+fn takes() {
+    assert_suggestion_result(
+        "AI takes control over players hand",
+        test_linter(),
+        "AI takes control of players hand",
+    );
+}
+
+#[test]
+fn taking() {
+    assert_suggestion_result(
+        "this inconsistent behavior is very annoying for taking control over your dependency graph",
+        test_linter(),
+        "this inconsistent behavior is very annoying for taking control of your dependency graph",
+    );
+}
+
+#[test]
+fn took() {
+    assert_suggestion_result(
+        "Noted drone was NOT stoping and manually took control over it to stop it.",
+        test_linter(),
+        "Noted drone was NOT stoping and manually took control of it to stop it.",
+    );
+}
+
 // UseToUsedTo
 
 #[test]


### PR DESCRIPTION
# Issues 
N/A

# Description

Corrects "take control over" to "take control of".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
