### PR TITLE
chore(chrome-ext): remove Prettier dep

### DIFF
--- a/packages/chrome-plugin/package.json
+++ b/packages/chrome-plugin/package.json
@@ -19,7 +19,6 @@
 		"dev": "vite",
 		"build": "vite build -l warn",
 		"preview": "vite preview",
-		"fmt": "prettier --write '**/*.{svelte,ts,json,css,scss,md}'",
 		"zip-for-chrome": "TARGET_BROWSER=chrome npm run build && node src/zip.js harper-chrome-plugin.zip",
 		"zip-for-firefox": "TARGET_BROWSER=firefox npm run build && node src/zip.js harper-firefox-plugin.zip",
 		"test": "playwright test --headed"
@@ -38,8 +37,6 @@
 		"http-server": "^14.1.1",
 		"playwright": "1.60.0",
 		"playwright-webextext": "^0.0.5",
-		"prettier": "^3.1.0",
-		"prettier-plugin-svelte": "^3.2.6",
 		"rollup-plugin-copy": "^3.5.0",
 		"svelte": "^5.0.0",
 		"svelte-preprocess": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,12 +162,6 @@ importers:
       playwright-webextext:
         specifier: ^0.0.5
         version: 0.0.5(@playwright/test@1.60.0)(playwright@1.60.0)
-      prettier:
-        specifier: ^3.1.0
-        version: 3.5.3
-      prettier-plugin-svelte:
-        specifier: ^3.2.6
-        version: 3.3.3(prettier@3.5.3)(svelte@5.43.12)
       rollup-plugin-copy:
         specifier: ^3.5.0
         version: 3.5.0
@@ -10251,17 +10245,6 @@ packages:
   prettier-linter-helpers@1.0.0:
     resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
     engines: {node: '>=6.0.0'}
-
-  prettier-plugin-svelte@3.3.3:
-    resolution: {integrity: sha512-yViK9zqQ+H2qZD1w/bH7W8i+bVfKrD8GIFjkFe4Thl6kCT9SlAsXVNmt3jCvQOCsnOhcvYgsoVlRV/Eu6x5nNw==}
-    peerDependencies:
-      prettier: ^3.0.0
-      svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
-
-  prettier@3.5.3:
-    resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
-    engines: {node: '>=14'}
-    hasBin: true
 
   pretty-bytes@5.6.0:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
@@ -24885,13 +24868,6 @@ snapshots:
   prettier-linter-helpers@1.0.0:
     dependencies:
       fast-diff: 1.3.0
-
-  prettier-plugin-svelte@3.3.3(prettier@3.5.3)(svelte@5.43.12):
-    dependencies:
-      prettier: 3.5.3
-      svelte: 5.43.12
-
-  prettier@3.5.3: {}
 
   pretty-bytes@5.6.0: {}
 


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

N/A

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

I noticed that we were pulling in Prettier as a dependancy. We don't use it! Off it goes into the trash.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
