### PR TITLE
feat(web): add dashboard for user-submitted domain problem reports

### DIFF
--- a/packages/web/src/lib/db/models/DomainReviews.ts
+++ b/packages/web/src/lib/db/models/DomainReviews.ts
@@ -20,9 +20,6 @@ export default class DomainReviews {
 	}
 
 	public static async getAllSince(date: Date) {
-		return await db
-			.select()
-			.from(domainReviewTable)
-			.where(gte(domainReviewTable.timestamp, date));
+		return await db.select().from(domainReviewTable).where(gte(domainReviewTable.timestamp, date));
 	}
 }

--- a/packages/web/src/lib/db/models/DomainReviews.ts
+++ b/packages/web/src/lib/db/models/DomainReviews.ts
@@ -1,3 +1,4 @@
+import { gte } from 'drizzle-orm';
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
 import { db } from '..';
 import { domainReviewTable } from '../schema';
@@ -16,5 +17,12 @@ export default class DomainReviews {
 
 	public static async create(rec: DomainReviewSubmission) {
 		await db.insert(domainReviewTable).values(rec);
+	}
+
+	public static async getAllSince(date: Date) {
+		return await db
+			.select()
+			.from(domainReviewTable)
+			.where(gte(domainReviewTable.timestamp, date));
 	}
 }

--- a/packages/web/src/routes/admin/ext-site-problems/[slug]/+page.server.ts
+++ b/packages/web/src/routes/admin/ext-site-problems/[slug]/+page.server.ts
@@ -29,6 +29,11 @@ export const load = async ({ params }) => {
 	for (const item of domainReviews) {
 		const id = item.domain ?? 'OTHER';
 
+		// We are looking for _problematic_ domains, not ones that Harper already works on.
+		if (item.works) {
+			continue;
+		}
+
 		if (counts[id] === undefined) {
 			counts[id] = 1;
 		} else {

--- a/packages/web/src/routes/admin/ext-site-problems/[slug]/+page.server.ts
+++ b/packages/web/src/routes/admin/ext-site-problems/[slug]/+page.server.ts
@@ -1,0 +1,42 @@
+import { redirect } from '@sveltejs/kit';
+import DomainReviews from '$lib/db/models/DomainReviews';
+
+export const load = async ({ params }) => {
+	const slug = params.slug;
+
+	let date = null;
+
+	switch (slug) {
+		case 'last30days':
+			date = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+			break;
+		case 'lastday':
+			date = new Date(Date.now() - 24 * 60 * 60 * 1000);
+			break;
+		case 'all':
+			date = new Date(0);
+			break;
+	}
+
+	if (date == null) {
+		redirect(302, '/admin/ext-site-problems/all');
+	}
+
+	const domainReviews = await DomainReviews.getAllSince(date);
+
+	const counts: Record<string, number> = {};
+
+	for (const item of domainReviews) {
+		const id = item.domain ?? 'OTHER';
+
+		if (counts[id] === undefined) {
+			counts[id] = 1;
+		} else {
+			counts[id] += 1;
+		}
+	}
+
+	return {
+		counts,
+	};
+};

--- a/packages/web/src/routes/admin/ext-site-problems/[slug]/+page.svelte
+++ b/packages/web/src/routes/admin/ext-site-problems/[slug]/+page.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+import AnalyticsPage from '$lib/components/AnalyticsPage.svelte';
+import type { PageProps } from './$types';
+
+let { data }: PageProps = $props();
+let links = {
+	All: '/admin/ext-site-problems/all',
+	'Last 30 Days': '/admin/ext-site-problems/last30days',
+	'Last Day': '/admin/ext-site-problems/lastday',
+};
+</script>
+
+<AnalyticsPage data={data.counts} title="Domains with the most reported problems." {links}/>


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

N/A

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

To properly allocate resources to the websites that Harper works _worst_ on, I have added a dashboard for analyzing the reports that users are able to send in via the Chrome Extension.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
