### PR TITLE
feat: take pride of → take pride in

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5595,6 +5595,13 @@
 						},
 						{
 							"Bool": {
+								"name": "TakePrideIn",
+								"state": true,
+								"label": "Take Pride in"
+							}
+						},
+						{
+							"Bool": {
 								"name": "ThatChallenged",
 								"state": true,
 								"label": "That Challenged"

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -265,6 +265,7 @@ use super::subject_pronoun::SubjectPronoun;
 use super::take_a_look_to::TakeALookTo;
 use super::take_care_of::TakeCareOf;
 use super::take_medicine::TakeMedicine;
+use super::take_pride_in::TakePrideIn;
 use super::that_than::ThatThan;
 use super::that_which::ThatWhich;
 use super::the_how_why::TheHowWhy;
@@ -868,6 +869,7 @@ impl LintGroup {
         insert_expr_rule!(TakeALookTo);
         insert_expr_rule!(TakeCareOf);
         insert_expr_rule!(TakeMedicine);
+        insert_expr_rule!(TakePrideIn);
         insert_expr_rule!(ThatThan);
         insert_expr_rule!(ThatWhich);
         insert_expr_rule!(TheHowWhy);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -283,6 +283,7 @@ mod suggestion;
 mod take_a_look_to;
 mod take_care_of;
 mod take_medicine;
+mod take_pride_in;
 mod take_serious;
 mod that_than;
 mod that_which;

--- a/harper-core/src/linting/take_pride_in.rs
+++ b/harper-core/src/linting/take_pride_in.rs
@@ -1,0 +1,148 @@
+use crate::{
+    Lint, Token,
+    expr::{All, Expr, OwnedExprExt, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+};
+
+pub struct TakePrideIn {
+    expr: All,
+}
+
+impl Default for TakePrideIn {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::word_set(&["take", "taken", "takes", "taking", "took"])
+                .t_ws()
+                .then_word_seq(&["pride", "of"])
+                .but_not(
+                    SequenceExpr::anything()
+                        .t_any()
+                        .t_any()
+                        .t_any()
+                        .t_any()
+                        .t_ws()
+                        .t_aco("place"),
+                ),
+        }
+    }
+}
+
+impl ExprLinter for TakePrideIn {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        let span = toks.last()?.span;
+        Some(Lint {
+            span,
+            lint_kind: LintKind::Usage,
+            suggestions: vec![Suggestion::replace_with_match_case_str(
+                "in",
+                span.get_content(src),
+            )],
+            message: "This idiom uses the preposition `in` rather than `of`.".to_owned(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects `take pride of` to `take pride in`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    use super::TakePrideIn;
+
+    #[test]
+    fn take() {
+        assert_suggestion_result(
+            "I take pride of my work and go out of my way to support people who honored me with building their product using it.",
+            TakePrideIn::default(),
+            "I take pride in my work and go out of my way to support people who honored me with building their product using it.",
+        );
+    }
+
+    #[test]
+    fn taken() {
+        assert_suggestion_result(
+            "... the variety and multifaceted society that we Malaysians have always taken pride of?",
+            TakePrideIn::default(),
+            "... the variety and multifaceted society that we Malaysians have always taken pride in?",
+        );
+    }
+
+    #[test]
+    fn takes() {
+        assert_suggestion_result(
+            "Being a part of the team that takes pride of their work.",
+            TakePrideIn::default(),
+            "Being a part of the team that takes pride in their work.",
+        )
+    }
+
+    #[test]
+    fn took() {
+        assert_suggestion_result(
+            "and somehow we always took pride of well written and maintainble code",
+            TakePrideIn::default(),
+            "and somehow we always took pride in well written and maintainble code",
+        );
+    }
+
+    #[test]
+    fn dont_flag_take_pride_of_place() {
+        assert_no_lints(
+            "Any better alternatives will take pride of place, but for now, this is fine.",
+            TakePrideIn::default(),
+        )
+    }
+
+    #[test]
+    fn dont_flag_taken_pride_of_place() {
+        assert_no_lints(
+            "The venture-backed model has taken pride of place, but we should celebrate forks",
+            TakePrideIn::default(),
+        )
+    }
+
+    #[test]
+    fn dont_flag_taken_pride_of_place_hyphenated() {
+        assert_no_lints(
+            "\"sometimes some strange errors might occur\" has now taken pride-of-place as my favorite bug report of all time",
+            TakePrideIn::default(),
+        )
+    }
+
+    #[test]
+    fn dont_flag_takes_pride_of_place() {
+        assert_no_lints(
+            "this magnificent family residence takes pride of place just footsteps from the tranquil shores of Vaucluse Bay",
+            TakePrideIn::default(),
+        )
+    }
+
+    #[test]
+    fn dont_flag_took_pride_of_place() {
+        assert_no_lints(
+            "They were built to be exceptionally robust, and that took pride of place (for a while) over technical and luxury features.",
+            TakePrideIn::default(),
+        )
+    }
+
+    // Known edge cases
+
+    #[test]
+    #[ignore = "Surely too rare to address"]
+    fn dont_flag_edge_case() {
+        assert_no_lints(
+            "what is known as “dune bashing” has taken pride of honour on my list of “don’t ever do such a stupid thing again.”",
+            TakePrideIn::default(),
+        )
+    }
+}


### PR DESCRIPTION
# Issues 
N/A

# Description

I just heard "take pride of" in a YouTube video instead of the usual "take pride in".
Googling showed it's common so I made a linter.
It handles all inflections avoids the false positive "take pride of place".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
