### PR TITLE
feat: provocate → provoke

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -1312,6 +1312,13 @@
 						},
 						{
 							"Bool": {
+								"name": "Provocate",
+								"state": true,
+								"label": "Provocate"
+							}
+						},
+						{
+							"Bool": {
 								"name": "RedundantSuperlatives",
 								"state": true,
 								"label": "Redundant Superlatives"

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -582,6 +582,17 @@ pub fn lint_group() -> LintGroup {
             "Corrects the eggcorn `piggy bag` to `piggyback`, which is the proper term for riding on someone’s back or using an existing system.",
             LintKind::Eggcorn
         ),
+        "Provocate" => (
+            &[
+                ("provocate", "provoke"),
+                ("provocated", "provoked"),
+                ("provocates", "provokes"),
+                ("provocating", "provoking"),
+            ],
+            "Did you mean `provoke`?",
+            "Corrects the misspelling `provocate` to `provoke`.",
+            LintKind::WordChoice
+        ),
         // Redundant degree modifiers on positives (double positives) → base form
         "RedundantSuperlatives" => (
             &[

--- a/harper-core/src/linting/phrase_set_corrections/tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/tests.rs
@@ -1700,6 +1700,44 @@ fn fix_peaks() {
 // Piggyback
 // -none-
 
+// Provocate
+
+#[test]
+fn fix_provocate() {
+    assert_suggestion_result(
+        "Hardcoded chainId can provocate a possible replay attacks between chains in the event of a future chain split.",
+        test_linter(),
+        "Hardcoded chainId can provoke a possible replay attacks between chains in the event of a future chain split.",
+    );
+}
+
+#[test]
+fn fix_provocated() {
+    assert_suggestion_result(
+        "tempering with inconsistent content lengths provocated the error which lead me to encoding?",
+        test_linter(),
+        "tempering with inconsistent content lengths provoked the error which lead me to encoding?",
+    );
+}
+
+#[test]
+fn fix_provocates() {
+    assert_suggestion_result(
+        "it wont mark the check on the solving square, it provocates a timeout and return 500 Server Error",
+        test_linter(),
+        "it wont mark the check on the solving square, it provokes a timeout and return 500 Server Error",
+    );
+}
+
+#[test]
+fn fix_provocating() {
+    assert_suggestion_result(
+        "could return incorrect balances provocating an incorrect calculation of rsETH price",
+        test_linter(),
+        "could return incorrect balances provoking an incorrect calculation of rsETH price",
+    );
+}
+
 // RedundantSuperlatives
 
 #[test]


### PR DESCRIPTION
# Issues 
N/A

# Description

This non-word has been in my inbox for a while. "Provocate" is pretty common and just about always the writer intended "provoke" but got confused by the noun "provocation".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
