### PR TITLE
fix: add missing "themself" to the curated dictionary

### DIFF
--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -49242,6 +49242,7 @@ them/~Ia3o:g        # I~pronoun a~personal 3~person :~plural o~object (g=them's 
 thematic/~JNQ
 thematically/Ry
 theme/~NSgVdG
+themself/~Ia3F.     # I~pronoun a~personal 3~person .~singular F~reflexive
 themselves/~Ia3F:   # I~pronoun a~personal 3~person :~plural F~reflexive
 then/~RJNgC
 thence/~

--- a/harper-core/src/dict_word_metadata.rs
+++ b/harper-core/src/dict_word_metadata.rs
@@ -1853,10 +1853,9 @@ pub mod tests {
 
         // nonstandard pronouns
         #[test]
-        #[ignore = "not in dictionary"]
         fn nonstandard_pronouns() {
             assert!(md("themself").pronoun.is_some());
-            assert!(md("y'all'").pronoun.is_some());
+            assert!(md("y'all").pronoun.is_some());
         }
     }
 

--- a/harper-core/src/expr/reflexive_pronoun.rs
+++ b/harper-core/src/expr/reflexive_pronoun.rs
@@ -6,13 +6,7 @@ use crate::{
 
 // These are considered ungrammatical, or are at least not in `dictionary.dict` but are commonly used anyway.
 // The tests below check if this changes so we can update this `Expr`
-const BAD_REFLEXIVE_PRONOUNS: &[&str] = &[
-    "hisself",
-    "oneselves",
-    "theirself",
-    "theirselves",
-    "themself",
-];
+const BAD_REFLEXIVE_PRONOUNS: &[&str] = &["hisself", "oneselves", "theirself", "theirselves"];
 
 /// Matches reflexive pronouns with configurable strictness.
 ///
@@ -78,6 +72,7 @@ mod tests {
         "oneself",
         "ourself",
         "ourselves",
+        "themself",
         "themselves",
         "thyself",
         "yourself",

--- a/harper-core/src/linting/spell_check.rs
+++ b/harper-core/src/linting/spell_check.rs
@@ -532,6 +532,14 @@ mod tests {
     }
 
     #[test]
+    fn dont_flag_themself() {
+        assert_no_lints(
+            "Avery caught themself staring at the stranger.",
+            test_linter(),
+        );
+    }
+
+    #[test]
     fn no_improper_suggestion_for_macos() {
         assert_good_and_bad_suggestions("MacOS", test_linter(), &["macOS"], &["MacOS"]);
     }


### PR DESCRIPTION
## Summary
Per #4269, "themself" (a standard singular gender-neutral reflexive pronoun — [Cambridge Dictionary](https://dictionary.cambridge.org/dictionary/english/themself)) was flagged as a spelling error, since it had no entry in `harper-core/dictionary.dict`.

- Added `themself/~Ia3F.` to `dictionary.dict`, alphabetically before `themselves`, using the same flag pattern as `itself`/`myself`/`yourself` (3rd-person **singular** reflexive — `themselves` uses the plural `:` flag instead of `.`).
- `harper-core/src/expr/reflexive_pronoun.rs` explicitly listed `"themself"` in `BAD_REFLEXIVE_PRONOUNS` with the comment "not in dictionary.dict but commonly used anyway", and that module's own tests assert bad pronouns must **not** be in the dictionary. Moved it to `GOOD_REFLEXIVE_PRONOUNS` instead, which is exactly what the existing test comments say to do "if this changes."
- `harper-core/src/dict_word_metadata.rs` already had a test asserting `themself` has pronoun metadata, marked `#[ignore = "not in dictionary"]` — removed the `#[ignore]` now that it's true. That test also checked `"y'all'"` (a stray trailing apostrophe, not the real dictionary entry `"y'all"`), which would have kept the un-ignored test failing for an unrelated reason — fixed that typo too since it's a one-character fix directly blocking the same test.
- Added `dont_flag_themself` in `harper-core/src/linting/spell_check.rs` using the exact example from the issue, following the existing `dont_flag_pr`-style pattern.

## Testing
- `cargo test -p harper-core --lib`: 6365 passed, 0 failed, 303 ignored (one fewer than before, since the stale `#[ignore]` is now gone).
- Verified the new `dont_flag_themself` test fails on `master` (confirms it's exercising the fix, not a tautology) and passes with the dictionary entry added.
- `cargo fmt --check -p harper-core` and `cargo clippy -p harper-core --lib -- -D warnings`: clean.

Closes #4269

🤖 Generated with [Claude Code](https://claude.com/claude-code)