### PR TITLE
feat: various mistakes with `lots`, `lot's`, and `a lot`

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5161,6 +5161,13 @@
 						},
 						{
 							"Bool": {
+								"name": "Lots",
+								"state": true,
+								"label": "Lots"
+							}
+						},
+						{
+							"Bool": {
 								"name": "LowHangingFruit",
 								"state": true,
 								"label": "Low Hanging Fruit"

--- a/harper-core/src/linting/weir_rules/Lots/ALots.weir
+++ b/harper-core/src/linting/weir_rules/Lots/ALots.weir
@@ -1,6 +1,6 @@
 expr main (a lots)
 
-let message "Are you confusing `lots` and `let's`? There is no apostrophe in `lots`."
+let message "Are you confusing `lot's` and `lots`? The contraction of `lot is` and `lot has` is `lot's`."
 let description "Corrects `a lots` to `a lot's`."
 let kind "Punctuation"
 let becomes "a lot's"

--- a/harper-core/src/linting/weir_rules/Lots/ALots.weir
+++ b/harper-core/src/linting/weir_rules/Lots/ALots.weir
@@ -1,0 +1,8 @@
+expr main (a lots)
+
+let message "Are you confusing `lots` and `let's`? There is no apostrophe in `lots`."
+let description "Corrects `a lots` to `a lot's`."
+let kind "Punctuation"
+let becomes "a lot's"
+
+test "a lots changed overtime, add latest depends support" "a lot's changed overtime, add latest depends support"

--- a/harper-core/src/linting/weir_rules/Lots/ALots.weir
+++ b/harper-core/src/linting/weir_rules/Lots/ALots.weir
@@ -5,4 +5,7 @@ let description "Corrects `a lots` to `a lot's`."
 let kind "Punctuation"
 let becomes "a lot's"
 
+# a lot has ...
 test "a lots changed overtime, add latest depends support" "a lot's changed overtime, add latest depends support"
+# a lot is ...
+test "A lots changing around here!" "A lot's changing around here!"

--- a/harper-core/src/linting/weir_rules/Lots/ALotsOf.weir
+++ b/harper-core/src/linting/weir_rules/Lots/ALotsOf.weir
@@ -1,0 +1,9 @@
+expr main (a lots of)
+
+let message "Are you confusing `a lot` and `lots`?"
+let description "Corrects `a lots of` to `a lot of` or `lots of`."
+let kind "Usage"
+let becomes ["a lot of", "lots of"]
+
+test "I found a lots of compiler errors." "I found a lot of compiler errors."
+test "I found a lots of compiler errors." "I found lots of compiler errors."

--- a/harper-core/src/linting/weir_rules/Lots/LotsAndLots.weir
+++ b/harper-core/src/linting/weir_rules/Lots/LotsAndLots.weir
@@ -1,0 +1,8 @@
+expr main [(lot's and lot's), (lot's and lots), (lots and lot's)]
+
+let message "Are you confusing `lots` and `let's`? There is no apostrophe in `lots`."
+let description "Corrects `lot's and lot's` to `lots and lots`."
+let kind "Punctuation"
+let becomes "lots and lots"
+
+test "and repeat the 2 and 3 lot's and lot's of times" "and repeat the 2 and 3 lots and lots of times"

--- a/harper-core/src/linting/weir_rules/Lots/LotsOf.weir
+++ b/harper-core/src/linting/weir_rules/Lots/LotsOf.weir
@@ -1,0 +1,8 @@
+expr main (lot's of)
+
+let message "Are you confusing `lots` and `let's`? There is no apostrophe in `lots`."
+let description "Corrects `lot's of` to `lots of`."
+let kind "Punctuation"
+let becomes "lots of"
+
+test "Lot's of (rough WIP) work to bring the repo current with gpui-ce v0.3.3." "Lots of (rough WIP) work to bring the repo current with gpui-ce v0.3.3."

--- a/harper-core/src/linting/weir_rules/Lots/LotsOn.weir
+++ b/harper-core/src/linting/weir_rules/Lots/LotsOn.weir
@@ -1,0 +1,8 @@
+expr main (lot's on)
+
+let message "Are you confusing `lots` and `let's`? There is no apostrophe in `lots`."
+let description "Corrects `lot's on` to `lots on`."
+let kind "Punctuation"
+let becomes "lots on"
+
+test "I'm finding lot's on how to do this once the array is created" "I'm finding lots on how to do this once the array is created"

--- a/harper-core/src/linting/weir_rules/Lots/LotsTo.weir
+++ b/harper-core/src/linting/weir_rules/Lots/LotsTo.weir
@@ -1,0 +1,8 @@
+expr main (lot's to)
+
+let message "Are you confusing `lots` and `let's`? There is no apostrophe in `lots`."
+let description "Corrects `lot's to` to `lots to`."
+let kind "Punctuation"
+let becomes "lots to"
+
+test "security, i/o support, token cost - lot's to improve!" "security, i/o support, token cost - lots to improve!"


### PR DESCRIPTION
# Issues 

Fixes #4287

# Description

Corrects various mistakes with "lots", especially but not only, mixing it up with "lot's":

lots of, a lots, a lots of, lots and lots, lots on, lots to

I think there's more problems with "lots" that I didn't foresee, made especially by nonnative English speakers. Addressing those all might involve moving this set of linters from Weir to Rust, or complementing this one with a second on in Rusty.

Then again I still haven't learned how to handle context and variations in Weird, so maybe it's possible to add more to this one?

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
