### PR TITLE
fix: correct also with singular "purpose"

### DIFF
--- a/harper-core/src/linting/all_intents_and_purposes.rs
+++ b/harper-core/src/linting/all_intents_and_purposes.rs
@@ -57,7 +57,7 @@ impl ExprLinter for AllIntentsAndPurposes {
 
         let (rest_lo, rest_up) = (" all intents and purposes", " ALL INTENTS AND PURPOSES");
 
-        let (for_prefix, to_prefix, rest) = match (prep_ch.get(0), prep_ch.get(1)) {
+        let (for_prefix, to_prefix, rest) = match (prep_ch.first(), prep_ch.get(1)) {
             (Some(f), Some(s)) if f.is_uppercase() && s.is_uppercase() => ("FOR", "TO", rest_up),
             (Some(f), _) if f.is_uppercase() => ("For", "To", rest_lo),
             _ => ("for", "to", rest_lo),

--- a/harper-core/src/linting/all_intents_and_purposes.rs
+++ b/harper-core/src/linting/all_intents_and_purposes.rs
@@ -1,12 +1,12 @@
-use crate::Token;
-use crate::char_string::CharStringExt;
-use crate::expr::{Expr, SequenceExpr};
-use crate::linting::expr_linter::Chunk;
-use crate::linting::{ExprLinter, Lint, LintKind, Suggestion};
-use crate::token_string_ext::TokenStringExt;
+use crate::{
+    CharStringExt, Token,
+    expr::{All, Expr, OwnedExprExt, SequenceExpr},
+    linting::{ExprLinter, Lint, LintKind, Suggestion, expr_linter::Chunk},
+    token_string_ext::TokenStringExt,
+};
 
 pub struct AllIntentsAndPurposes {
-    expr: SequenceExpr,
+    expr: All,
 }
 
 impl Default for AllIntentsAndPurposes {
@@ -34,7 +34,12 @@ impl Default for AllIntentsAndPurposes {
                     ])),
                 ])
                 .t_ws()
-                .t_aco("purposes"),
+                .t_set(&["purposes", "purpose"])
+                .but_not(
+                    SequenceExpr::word_set(&["for", "to"])
+                        .t_ws()
+                        .then_word_seq(&["all", "intents", "and", "purposes"]),
+                ),
         }
     }
 }
@@ -48,41 +53,42 @@ impl ExprLinter for AllIntentsAndPurposes {
 
     fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
         let whole_span = toks.span()?;
-        let whole_str = whole_span.get_content_string(src);
+        let prep_ch = toks.first()?.get_ch(src);
 
-        // "for" is first since "to" is listed as a UK variant in some dictionaries
-        const LEGIT: [&str; 2] = [
-            "for all intents and purposes",
-            "to all intents and purposes",
-        ];
+        let (rest_lo, rest_up) = (" all intents and purposes", " ALL INTENTS AND PURPOSES");
 
-        if LEGIT.iter().any(|s| s.eq_ignore_ascii_case(&whole_str)) {
-            return None;
+        let (for_prefix, to_prefix, rest) = match (prep_ch.get(0), prep_ch.get(1)) {
+            (Some(f), Some(s)) if f.is_uppercase() && s.is_uppercase() => ("FOR", "TO", rest_up),
+            (Some(f), _) if f.is_uppercase() => ("For", "To", rest_lo),
+            _ => ("for", "to", rest_lo),
+        };
+
+        let is_to = prep_ch.starts_with_ignore_ascii_case_str("to");
+
+        let build_sugg =
+            |prefix: &str| -> Vec<char> { prefix.chars().chain(rest.chars()).collect() };
+
+        let suggestions = if is_to {
+            vec![build_sugg(to_prefix), build_sugg(for_prefix)]
+        } else {
+            vec![build_sugg(for_prefix), build_sugg(to_prefix)]
         }
-
-        let prep_text = toks.first().unwrap().get_ch(src);
-
-        let mut suggs = LEGIT.to_vec();
-
-        // Suggest "to" first if the text uses "to", otherwise "for" first
-        if prep_text.eq_ch(&['t', 'o']) {
-            suggs.swap(0, 1);
-        }
-
-        let suggs = suggs
-            .into_iter()
-            .map(|s| Suggestion::replace_with_match_case_str(s, whole_span.get_content(src)))
-            .collect::<Vec<_>>();
+        .into_iter()
+        .map(Suggestion::ReplaceWith)
+        .collect();
 
         let message = format!(
             "The correct form is '{} all intents and purposes'.",
-            prep_text.iter().collect::<String>().to_ascii_lowercase()
+            prep_ch
+                .iter()
+                .map(|c| c.to_ascii_lowercase())
+                .collect::<String>()
         );
 
         Some(Lint {
             span: whole_span,
             lint_kind: LintKind::Nonstandard,
-            suggestions: suggs,
+            suggestions,
             message,
             priority: 50,
         })
@@ -344,6 +350,24 @@ mod tests {
         assert_no_lints(
             "Amendments, which, in either Case, shall be valid to all Intents and\nPurposes, as Part of this Constitution",
             AllIntentsAndPurposes::default(),
+        );
+    }
+
+    #[test]
+    fn fix_all_intents_and_purpose() {
+        assert_suggestion_result(
+            "To all intents and purpose, the SEC no longer exists",
+            AllIntentsAndPurposes::default(),
+            "To all intents and purposes, the SEC no longer exists",
+        );
+    }
+
+    #[test]
+    fn dont_flag_constitution() {
+        assert_suggestion_result(
+            "Amendments, which, in either Case, shall be valid to all Intents and Purposes, as Part of this Constitution",
+            AllIntentsAndPurposes::default(),
+            "Amendments, which, in either Case, shall be valid to all Intents and Purposes, as Part of this Constitution",
         );
     }
 }

--- a/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
+++ b/harper-core/tests/text/linters/The Constitution of the United States.snap.yml
@@ -1763,18 +1763,6 @@ Message: |
 
 
 
-Lint:    Nonstandard (50 priority)
-Message: |
-     668 | proposing Amendments, which, in either Case, shall be valid to all Intents and
-         |                                                             ^~~~~~~~~~~~~~~~~~~
-     669 | Purposes, as Part of this Constitution, when ratified by the Legislatures of
-         | ~~~~~~~~ The correct form is 'to all intents and purposes'.
-Suggest:
-  - Replace with: “to all Intents and Purposes”
-  - Replace with: “for alL intents anD purposes”
-
-
-
 Lint:    Capitalization (127 priority)
 Message: |
      677 | ## Article. VI.


### PR DESCRIPTION
# Issues 
N/A

# Description

I found a new variant of this mistake we didn't catch, with singular "purpose".

Adding the fix in the obvious way led to a previously flagged sentence in the snapshots now passing. \o/

I noticed that the way `replace_with_match_case` works by index rather than by logic/heuristics could lead to wrong letters getting uppercased like in **`for alL intents anD purposes`**, so I replaced that with custom logic for deciding how to apply case to the suggestions.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I consulted one or more coding AIs, but didn't use an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

I alternated between modding the code by hand and getting either the agent built into Devin IDE or the AI in Google Search looking for what I missed or making the code more Rusty.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
