### PR TITLE
feat: on a fence → on the fence

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5357,6 +5357,13 @@
 						},
 						{
 							"Bool": {
+								"name": "OnTheFence",
+								"state": true,
+								"label": "On The Fence"
+							}
+						},
+						{
+							"Bool": {
 								"name": "OnTheSpurOfTheMoment",
 								"state": true,
 								"label": "On The Spur Of The Moment"

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -198,6 +198,7 @@ use super::of_course::OfCourse;
 use super::off_limits::OffLimits;
 use super::oldest_in_the_book::OldestInTheBook;
 use super::on_floor::OnFloor;
+use super::on_the_fence::OnTheFence;
 use super::once_or_twice::OnceOrTwice;
 use super::one_and_the_same::OneAndTheSame;
 use super::one_of_the_singular::OneOfTheSingular;
@@ -804,6 +805,7 @@ impl LintGroup {
         insert_expr_rule!(OffLimits);
         insert_expr_rule!(OldestInTheBook);
         insert_expr_rule!(OnFloor);
+        insert_expr_rule!(OnTheFence);
         insert_expr_rule!(OnceOrTwice);
         insert_expr_rule!(OneAndTheSame);
         insert_expr_rule_with_dict!(OneOfTheSingular);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -212,6 +212,7 @@ mod of_course;
 mod off_limits;
 mod oldest_in_the_book;
 mod on_floor;
+mod on_the_fence;
 mod once_or_twice;
 mod one_and_the_same;
 mod one_of_the_singular;

--- a/harper-core/src/linting/on_the_fence.rs
+++ b/harper-core/src/linting/on_the_fence.rs
@@ -1,0 +1,199 @@
+use crate::{
+    Lint, Token,
+    char_string::CharStringExt,
+    expr::{AnchorEnd, Expr, SequenceExpr},
+    linting::{
+        ExprLinter, LintKind, Suggestion,
+        expr_linter::{Chunk, find_the_only_token_index_matching},
+    },
+    patterns::WordSet,
+};
+
+pub struct OnTheFence {
+    expr: SequenceExpr,
+}
+
+impl Default for OnTheFence {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::any_of([
+                Box::new(WordSet::new(&[
+                    // "it's" is intentionally omitted
+                    "i'm", "we're", "you're", "he's", "she's", "they're",
+                ])) as Box<dyn Expr>,
+                Box::new(SequenceExpr::aco("i").t_ws().t_set(&["am", "was"])),
+                Box::new(
+                    SequenceExpr::word_set(&["we", "you", "they"])
+                        .t_ws()
+                        .t_set(&["are", "were"]),
+                ),
+                Box::new(
+                    // "it" is intentionally omitted
+                    SequenceExpr::word_set(&["he", "she", "anybody", "anyone"])
+                        .t_ws()
+                        .t_set(&["is", "was"]),
+                ),
+            ])
+            .then_optional(SequenceExpr::whitespace().t_set(&["also", "still"]))
+            .t_ws()
+            .then_word_seq(&["on", "a", "fence"])
+            .then_any_of([
+                Box::new(AnchorEnd) as Box<dyn Expr>,
+                Box::new(SequenceExpr::whitespace().then_any_of([
+                    Box::new(SequenceExpr::default().then_preposition()) as Box<dyn Expr>,
+                    Box::new(AnchorEnd),
+                ])),
+            ]),
+        }
+    }
+}
+
+impl ExprLinter for OnTheFence {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+        let fence_index =
+            find_the_only_token_index_matching(toks, src, |t, s| t.get_ch(s).eq_str("fence"))?;
+        let span = toks.get(fence_index - 2)?.span;
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::Usage,
+            suggestions: vec![Suggestion::replace_with_match_case_str(
+                "the",
+                span.get_content(src),
+            )],
+            message: "If this is the idiom meaning `undecided`, it should be `on the fence`."
+                .to_owned(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "A linter skeleton for contributors to copy into `harper_core/src/linting/` and rename."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    use super::OnTheFence;
+
+    // Contrived minimal tests
+
+    #[test]
+    fn on_the_fence_end_no_punc() {
+        assert_suggestion_result("I'm on a fence", OnTheFence::default(), "I'm on the fence");
+    }
+
+    #[test]
+    fn on_the_fence_end_period() {
+        assert_suggestion_result(
+            "You're on a fence.",
+            OnTheFence::default(),
+            "You're on the fence.",
+        );
+    }
+
+    #[test]
+    fn on_the_fence_end_space_period() {
+        assert_suggestion_result(
+            "He is on a fence .",
+            OnTheFence::default(),
+            "He is on the fence .",
+        );
+    }
+
+    // Real-world tests
+
+    #[test]
+    fn fix_anyone_is_on_a_fence() {
+        assert_suggestion_result(
+            "If anyone is still on a fence, the new Joyride update changes a lot.",
+            OnTheFence::default(),
+            "If anyone is still on the fence, the new Joyride update changes a lot.",
+        );
+    }
+
+    #[test]
+    fn fix_i_am_about_this() {
+        assert_suggestion_result(
+            "I am on a fence about this.",
+            OnTheFence::default(),
+            "I am on the fence about this.",
+        );
+    }
+
+    #[test]
+    fn fix_i_am_also() {
+        assert_suggestion_result(
+            "I am also on a fence, especially b/c the morning check-in might end up being a duplicate of previous EOD meeting",
+            OnTheFence::default(),
+            "I am also on the fence, especially b/c the morning check-in might end up being a duplicate of previous EOD meeting",
+        );
+    }
+
+    #[test]
+    fn fix_im_of() {
+        assert_suggestion_result(
+            "I'm on a fence of scripting it myself for good or improving the initial experience for everyone :)",
+            OnTheFence::default(),
+            "I'm on the fence of scripting it myself for good or improving the initial experience for everyone :)",
+        );
+    }
+
+    #[test]
+    fn fix_im_still_with() {
+        assert_suggestion_result(
+            "I'm still on a fence with Rust at this point.",
+            OnTheFence::default(),
+            "I'm still on the fence with Rust at this point.",
+        );
+    }
+
+    #[test]
+    fn fix_you_are_of() {
+        assert_suggestion_result(
+            "They have a one month contract so if you are on a fence of trying them out, that's a great starter option. ",
+            OnTheFence::default(),
+            "They have a one month contract so if you are on the fence of trying them out, that's a great starter option. ",
+        );
+    }
+
+    #[test]
+    fn dont_flag_it() {
+        assert_no_lints(
+            "I would like to remove it but it is on a fence between the neighbors yard and mine.",
+            OnTheFence::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_posted() {
+        assert_no_lints(
+            "A private property sign is posted on a fence.",
+            OnTheFence::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_scrolling() {
+        assert_no_lints(
+            "My only issue is scrolling on a fence is a bit slow and laggy.",
+            OnTheFence::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_verse() {
+        assert_no_lints(
+            "My daddy is a dollar / I wrote it on a fence / My daddy is a dollar / not worth a hundred cents.",
+            OnTheFence::default(),
+        );
+    }
+}


### PR DESCRIPTION
# Issues 
N/A

# Description

I read "on a fence" in a Hacker News thread when the context made it clear it should be "on the fence".
This linter fixes all the variants I could find by Googling.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
