### PR TITLE
feat: (wip) trying to doing → trying to do etc.

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -3968,6 +3968,13 @@
 						},
 						{
 							"Bool": {
+								"name": "TryingToDoing",
+								"state": true,
+								"label": "Trying to Doing"
+							}
+						},
+						{
+							"Bool": {
 								"name": "TryOnesHandAt",
 								"state": true,
 								"label": "Try Ones Hand At"

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -298,6 +298,7 @@ use super::touristic::Touristic;
 use super::transposed_space::TransposedSpace;
 use super::try_ones_hand_at::TryOnesHandAt;
 use super::try_ones_luck::TryOnesLuck;
+use super::trying_to_doing::TryingToDoing;
 use super::unclosed_quotes::UnclosedQuotes;
 use super::update_place_names::UpdatePlaceNames;
 use super::use_ellipsis_character::UseEllipsisCharacter;
@@ -903,6 +904,7 @@ impl LintGroup {
         insert_expr_rule_with_dict!(TransposedSpace);
         insert_expr_rule!(TryOnesHandAt);
         insert_expr_rule!(TryOnesLuck);
+        insert_expr_rule!(TryingToDoing);
         insert_struct_rule!(UnclosedQuotes);
         insert_expr_rule!(UpdatePlaceNames);
         insert_struct_rule!(UseEllipsisCharacter);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -317,6 +317,7 @@ mod touristic;
 mod transposed_space;
 mod try_ones_hand_at;
 mod try_ones_luck;
+mod trying_to_doing;
 mod unclosed_quotes;
 mod update_place_names;
 mod use_ellipsis_character;

--- a/harper-core/src/linting/trying_to_doing.rs
+++ b/harper-core/src/linting/trying_to_doing.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Lint, Token, TokenStringExt,
+    Lint, Token,
     char_string::CharStringExt,
     expr::{Expr, SequenceExpr},
     linting::{

--- a/harper-core/src/linting/trying_to_doing.rs
+++ b/harper-core/src/linting/trying_to_doing.rs
@@ -1,0 +1,109 @@
+use crate::{
+    Lint, Token, TokenStringExt,
+    char_string::CharStringExt,
+    expr::{Expr, SequenceExpr},
+    linting::{
+        ExprLinter, LintKind, Suggestion,
+        debug::format_lint_match,
+        expr_linter::{Chunk, preceded_by_word},
+    },
+};
+
+pub struct TryingToDoing {
+    expr: SequenceExpr,
+}
+
+impl Default for TryingToDoing {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::default()
+                .then_verb_progressive_form()
+                .t_ws()
+                .t_set(&["to", "too"])
+                .t_ws()
+                .then_verb_progressive_form(),
+        }
+    }
+}
+
+impl ExprLinter for TryingToDoing {
+    type Unit = Chunk;
+
+    fn match_to_lint_with_context(
+        &self,
+        matched_tokens: &[Token],
+        source: &[char],
+        context: Option<(&[Token], &[Token])>,
+    ) -> Option<Lint> {
+        eprintln!("🚨 {}", format_lint_match(matched_tokens, context, source));
+
+        if preceded_by_word(context, |t| {
+            t.get_ch(source)
+                .eq_any_ignore_ascii_case_chars(&[&['f', 'r', 'o', 'm'], &['w', 'h', 'e', 'n']])
+        }) {
+            return None;
+        }
+
+        let span = matched_tokens.last()?.span;
+
+        let suggestions = vec![Suggestion::replace_with_match_case_str(
+            "correction",
+            span.get_content(source),
+        )];
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::Grammar,
+            suggestions,
+            message: "When the verb before `to` ends with `-ing`, the verb after `to` should be the base form.".to_owned(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Flags when verbs both before and after `to` end in `-ing`, such as `trying to doing` instead of `trying to do`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    use super::TryingToDoing;
+
+    #[test]
+    fn need_think() {
+        assert_suggestion_result(
+            "When You Are Tired of Always Needing To Thinking About Your Weight.",
+            TryingToDoing::default(),
+            "When You Are Tired of Always Needing To Think About Your Weight.",
+        );
+    }
+
+    #[test]
+    fn try_compete() {
+        assert_suggestion_result(
+            "if this is trying to competing with v8/llm",
+            TryingToDoing::default(),
+            "if this is trying to compete with v8/llm",
+        );
+    }
+
+    #[test]
+    fn try_live() {
+        assert_suggestion_result(
+            "We spend a lot of time trying to living in the world and surviving in it",
+            TryingToDoing::default(),
+            "We spend a lot of time trying to live in the world and survive in it",
+        );
+    }
+
+    #[test]
+    fn dont_flag_after_from() {
+        assert_no_lints("From needing to wanting.", TryingToDoing::default());
+    }
+}


### PR DESCRIPTION
# Issues 
#4304

# Description

Made start of correcting two gerunds/present participles separated by "to" such as "trying to doing" 
→ "trying to do".

Please feel free to work on this linter.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

work in progress

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
