### PR TITLE
feat: not without a lack of → not for lack of

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -1270,6 +1270,13 @@
 						},
 						{
 							"Bool": {
+								"name": "NotForLackOf",
+								"state": true,
+								"label": "Not for Lack of"
+							}
+						},
+						{
+							"Bool": {
 								"name": "NotOnly",
 								"state": true,
 								"label": "Not Only"

--- a/harper-core/dictionary.dict
+++ b/harper-core/dictionary.dict
@@ -32470,6 +32470,7 @@ librettist/~NgS
 libretto/~NSg
 lice/~N9
 licence/NgSV!@_₹
+licensable/J
 license/~NgSVGd
 licensed/~JVtTU
 licensee/~NgS

--- a/harper-core/src/linting/weir_rules/NotForLackOf.weir
+++ b/harper-core/src/linting/weir_rules/NotForLackOf.weir
@@ -1,0 +1,18 @@
+expr main (not without a lack of)
+
+let message "This is a confusing double negative. The idiom you're looking for is `not for lack of`."
+let description "Replaces `not without a lack of` with `not for lack of`."
+let kind "Usage"
+let becomes "not for lack of"
+
+test "... even harder to implement, and that’s not without a lack of trying!" "... even harder to implement, and that’s not for lack of trying!"
+test "I'm sorry, I am leaving, but it is not without a lack of trying, though." "I'm sorry, I am leaving, but it is not for lack of trying, though."
+test "I am without a Software Engineering job, though, not without a lack of trying." "I am without a Software Engineering job, though, not for lack of trying."
+test "In 2025, sadly we had no kittens, not without a lack of trying." "In 2025, sadly we had no kittens, not for lack of trying."
+test "Not without a lack of fans, everyone from the Barbie director Greta Gerwig to the Safdie brothers" "Not for lack of fans, everyone from the Barbie director Greta Gerwig to the Safdie brothers"
+test "Not without a lack of trying, but a 6pm start time would just be pushing it and the track isn't cooperating the way we need." "Not for lack of trying, but a 6pm start time would just be pushing it and the track isn't cooperating the way we need."
+test "We don't really understand why or how she ticks in the films and it's not without a lack of trying from the charismatic Shailene Woodley." "We don't really understand why or how she ticks in the films and it's not for lack of trying from the charismatic Shailene Woodley."
+test "Not without a lack of ideas and cool stop motion, miniatures, and matte paintings, but maybe someone should've told him to pick idk, two ideas" "Not for lack of ideas and cool stop motion, miniatures, and matte paintings, but maybe someone should've told him to pick idk, two ideas"
+
+# Known edge case that fails. Left here for future contributors who might want to tackle it.
+# allows "as my father would have said, \“they were not without a lack of couth.\”"


### PR DESCRIPTION
# Issues 
N/A

# Description

The other day in a YouTube video I heard a new kind of double-negative: "now without a lack of trying".
Googling I could find a number of other instances, so I've written a rule in Weir.

The correct idiom, of course, is "nor for lack of trying".

I suspect there might be some variants of this out there which we could add to this if and when we spot them in the wild.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
