### PR TITLE
feat: pleaded vs pled

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5441,6 +5441,13 @@
 						},
 						{
 							"OneOfMany": {
+								"names": ["PreferPleaded", "PreferPled"],
+								"name": "PreferPleaded",
+								"labels": ["Prefer ‘Pleaded’", "Prefer ‘Pled’"]
+							}
+						},
+						{
+							"OneOfMany": {
 								"names": ["PreferSneaked", "PreferSnuck"],
 								"name": "PreferSneaked",
 								"labels": ["Prefer ‘Sneaked’", "Prefer ‘Snuck’"]

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -217,6 +217,7 @@ use super::passionate_about::PassionateAbout;
 use super::pay_for_price::PayForPrice;
 use super::phrasal_verb_as_compound_noun::PhrasalVerbAsCompoundNoun;
 use super::pique_interest::PiqueInterest;
+use super::pleaded_pled::{PreferPleaded, PreferPled};
 use super::plural_decades::PluralDecades;
 use super::plural_wrong_word_of_phrase::PluralWrongWordOfPhrase;
 use super::possessive_noun::PossessiveNoun;
@@ -824,6 +825,8 @@ impl LintGroup {
         insert_expr_rule!(PayForPrice);
         insert_struct_rule!(PhrasalVerbAsCompoundNoun);
         insert_expr_rule!(PiqueInterest);
+        insert_struct_rule!(PreferPleaded);
+        insert_struct_rule!(PreferPled);
         insert_expr_rule!(PluralWrongWordOfPhrase);
         insert_struct_rule_with_dict!(PossessiveNoun);
         insert_expr_rule!(PossessiveYour);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -232,6 +232,7 @@ mod pay_for_price;
 mod phrasal_verb_as_compound_noun;
 mod phrase_set_corrections;
 mod pique_interest;
+mod pleaded_pled;
 mod plural_decades;
 mod plural_wrong_word_of_phrase;
 mod pooled_linter;

--- a/harper-core/src/linting/pleaded_pled.rs
+++ b/harper-core/src/linting/pleaded_pled.rs
@@ -1,0 +1,137 @@
+use crate::{
+    CharStringExt, Lint, Token,
+    expr::Expr,
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+    patterns::Word,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Prefer {
+    Pled,
+    Pleaded,
+}
+
+pub struct PreferPled {
+    expr: Word,
+}
+pub struct PreferPleaded {
+    expr: Word,
+}
+
+fn build_expr(flag: Prefer) -> Word {
+    match flag {
+        Prefer::Pled => Word::new("pleaded"),
+        Prefer::Pleaded => Word::new("pled"),
+    }
+}
+
+const PLEADED: &str = "pleaded";
+const PLED: &str = "pled";
+
+fn to_lint(toks: &[Token], src: &[char], pref: Prefer) -> Option<Lint> {
+    let tokspan = toks.first()?.span;
+    let word = tokspan.get_content(src);
+
+    let (target_word, source_word) = match pref {
+        Prefer::Pled => {
+            if word.eq_ch(&['p', 'l', 'e', 'a', 'd', 'e', 'd']) {
+                (PLED, PLEADED)
+            } else {
+                return None;
+            }
+        }
+        Prefer::Pleaded => {
+            if word.eq_ch(&['p', 'l', 'e', 'd']) {
+                (PLEADED, PLED)
+            } else {
+                return None;
+            }
+        }
+    };
+
+    Some(Lint {
+        span: tokspan,
+        lint_kind: LintKind::Usage,
+        suggestions: vec![Suggestion::replace_with_match_case_str(target_word, word)],
+        message: format!("Use `{}` instead of `{}`.", target_word, source_word),
+        ..Default::default()
+    })
+}
+
+macro_rules! impl_expr_linter {
+    ($name:ident, $pref:expr, $desc:expr) => {
+        impl Default for $name {
+            fn default() -> Self {
+                Self {
+                    expr: build_expr($pref),
+                }
+            }
+        }
+
+        impl ExprLinter for $name {
+            type Unit = Chunk;
+
+            fn description(&self) -> &str {
+                $desc
+            }
+
+            fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
+                to_lint(toks, src, $pref)
+            }
+
+            fn expr(&self) -> &dyn Expr {
+                &self.expr
+            }
+        }
+    };
+}
+
+impl_expr_linter!(PreferPled, Prefer::Pled, "Prefer `pled` over `pleaded`.");
+
+impl_expr_linter!(
+    PreferPleaded,
+    Prefer::Pleaded,
+    "Prefer `pleaded` over `pled`."
+);
+
+#[cfg(test)]
+mod tests {
+    use super::{PreferPleaded, PreferPled};
+    use crate::linting::tests::{assert_lint_count, assert_suggestion_result};
+
+    // Prefer "pled"
+
+    #[test]
+    fn correct_pleaded_to_pled() {
+        assert_suggestion_result(
+            "Reality Winner pleaded guilty in June to a single count of transmitting national security information.",
+            PreferPled::default(),
+            "Reality Winner pled guilty in June to a single count of transmitting national security information.",
+        );
+    }
+
+    // Prefer "pleaded"
+
+    #[test]
+    fn correct_pled_to_pleaded() {
+        assert_suggestion_result(
+            "2005 Samsung pled guilty in connection with the cartel and paid a fine.",
+            PreferPleaded::default(),
+            "2005 Samsung pleaded guilty in connection with the cartel and paid a fine.",
+        );
+    }
+
+    // OneOfMany / Mutual exclusivity
+
+    #[test]
+    fn by_default_one_must_be_enabled_and_one_must_be_disabled() {
+        use crate::Dialect;
+        use crate::spell::FstDictionary;
+
+        let mut lg =
+            crate::linting::LintGroup::new_curated(FstDictionary::curated(), Dialect::American);
+        lg.config.unset_rule_enabled("SpellCheck");
+
+        assert_lint_count("I say 'pled' but you say 'pleaded'.", lg, 1);
+    }
+}


### PR DESCRIPTION
# Issues 
N/A

# Description

Allows choosing which past tense of "to plead" you prefer and flags the other one.
Adapted directly off the `SneakedSnuck` linter.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
