### PR TITLE
feat: OTOH → on the other hand

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -333,6 +333,13 @@
 						},
 						{
 							"Bool": {
+								"name": "OnTheOtherHand",
+								"state": true,
+								"label": "On the Other Hand"
+							}
+						},
+						{
+							"Bool": {
 								"name": "PleaseTakeALook",
 								"state": true,
 								"label": "Please Take A Look"

--- a/harper-core/src/linting/initialisms.rs
+++ b/harper-core/src/linting/initialisms.rs
@@ -36,6 +36,7 @@ pub fn lint_group() -> LintGroup {
         "LetMeKnow"              => ("lmk", &["let me know"]),
         "NeverMind"              => ("nvm", &["never mind"]),
         "OhMyGod"                => ("omg", &["oh my god"]),
+        "OnTheOtherHand"         => ("otoh", &["on the other hand"]),
         "PleaseTakeALook"        => ("ptal", &["please take a look"]),
         "Really"                 => ("rly", &["really"]),
         "TalkToYouLater"         => ("ttyl", &["talk to you later"]),
@@ -248,6 +249,15 @@ mod tests {
             "AFAICT the other drivers of recent progress in LLMs have been: ploughing in lots and lots of specialised training data",
             lint_group(),
             "As far as i can tell the other drivers of recent progress in LLMs have been: ploughing in lots and lots of specialised training data",
+        );
+    }
+
+    #[test]
+    fn corrects_otoh() {
+        assert_suggestion_result(
+            "\"Actual consequences\", OTOH, most directly relates to the camp(s) focused on \"embodiment\"",
+            lint_group(),
+            "\"Actual consequences\", On the other hand, most directly relates to the camp(s) focused on \"embodiment\"",
         );
     }
 }


### PR DESCRIPTION
# Issues 
N/A

# Description

I noticed we don't yet expand the initialism "OTOH" for "on the other hand". We do now.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
