### PR TITLE
feat: Handle sale/sell cases

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -3485,6 +3485,13 @@
 						},
 						{
 							"Bool": {
+								"name": "ForSell",
+								"state": true,
+								"label": "For Sell"
+							}
+						},
+						{
+							"Bool": {
 								"name": "FullToTheBrim",
 								"state": true,
 								"label": "Full to the Brim"

--- a/harper-core/src/linting/noun_verb_confusion/mod.rs
+++ b/harper-core/src/linting/noun_verb_confusion/mod.rs
@@ -1,4 +1,5 @@
 use super::merge_linters::merge_linters;
+use crate::{CharStringExt, Token, TokenKind};
 
 mod effect_affect;
 mod noun_instead_of_verb;
@@ -19,6 +20,27 @@ pub(crate) const NOUN_VERB_PAIRS: &[(&str, &str)] = &[
     ("weight", "weigh"),
     // Add more pairs here as needed
 ];
+
+/// Conjugate a noun/verb pair's replacement verb for the subject pronoun,
+/// which requires the third-person singular form after `he`/`she`/`it`
+/// (per dictionary metadata) and `who` (whose entry lacks that data).
+pub(crate) fn conjugate_pair_verb(verb: &str, subject: &Token, source: &[char]) -> String {
+    if is_third_person_singular_subject(subject, source) {
+        format!("{verb}s")
+    } else {
+        verb.to_owned()
+    }
+}
+
+/// Whether the token requires the third-person singular verb form.
+fn is_third_person_singular_subject(token: &Token, source: &[char]) -> bool {
+    if !matches!(token.kind, TokenKind::Word(_)) {
+        return false;
+    }
+
+    token.kind.is_third_person_singular_pronoun()
+        || token.get_ch(source).eq_any_ignore_ascii_case_str(&["who"])
+}
 
 use noun_instead_of_verb::NounInsteadOfVerb;
 use verb_instead_of_noun::VerbInsteadOfNoun;
@@ -239,6 +261,16 @@ mod tests {
     }
 
     #[test]
+    fn fix_breathes_after_she() {
+        assert_suggestion_result("She breath deeply.", test_linter(), "She breathes deeply.");
+    }
+
+    #[test]
+    fn fix_breathe_kept_after_they() {
+        assert_suggestion_result("They breath deeply.", test_linter(), "They breathe deeply.");
+    }
+
+    #[test]
     fn fix_can_you_advice_me() {
         assert_suggestion_result(
             "Can you advice me how to train?",
@@ -254,6 +286,11 @@ mod tests {
             test_linter(),
             "Feel free to share more details about your use case, so we can advise you specifically based on your case.",
         );
+    }
+
+    #[test]
+    fn fix_advises_after_he() {
+        assert_suggestion_result("He advice me.", test_linter(), "He advises me.");
     }
 
     #[test]
@@ -453,6 +490,11 @@ mod tests {
             test_linter(),
             "We measured the effect of caffeine on reaction time.",
         );
+    }
+
+    #[test]
+    fn fix_affects_after_it() {
+        assert_suggestion_result("It effect me.", test_linter(), "It affects me.");
     }
 
     #[test]
@@ -1382,6 +1424,11 @@ mod tests {
         );
     }
 
+    #[test]
+    fn fix_weighs_after_he() {
+        assert_suggestion_result("He weight 80 kg.", test_linter(), "He weighs 80 kg.");
+    }
+
     // Tests for issue #2958: "side effect" must not be flagged.
     // Legitimate verb uses like "padding side affects the results" should also pass.
 
@@ -1450,7 +1497,16 @@ mod tests {
         assert_suggestion_result(
             "She sale cars every weekend.",
             test_linter(),
-            "She sell cars every weekend.",
+            "She sells cars every weekend.",
+        );
+    }
+
+    #[test]
+    fn fix_sale_houses_after_he() {
+        assert_suggestion_result(
+            "He sale houses downtown.",
+            test_linter(),
+            "He sells houses downtown.",
         );
     }
 
@@ -1497,7 +1553,29 @@ mod tests {
 
     #[test]
     fn fix_who_sale_this() {
-        assert_suggestion_result("Who sale this?", test_linter(), "Who sell this?");
+        assert_suggestion_result("Who sale this?", test_linter(), "Who sells this?");
+    }
+
+    #[test]
+    fn fix_sale_fast_after_it() {
+        assert_suggestion_result("It sale fast.", test_linter(), "It sells fast.");
+    }
+
+    #[test]
+    fn fix_sale_online_after_it() {
+        assert_suggestion_result("It sale online.", test_linter(), "It sells online.");
+    }
+
+    #[test]
+    fn dont_flag_object_case_it() {
+        // "it" is the indirect object; "sale records" is a noun phrase.
+        assert_lint_count("Send it sale records.", test_linter(), 0);
+    }
+
+    #[test]
+    fn dont_flag_it_sales_records_noun_phrase() {
+        // "IT" is the acronym and "sales records" a noun phrase.
+        assert_lint_count("IT sales records show growth.", test_linter(), 0);
     }
 
     // "Hard sell", "soft sell", etc. are idioms where "sell" is a noun.
@@ -1539,6 +1617,11 @@ mod tests {
     #[test]
     fn dont_flag_correct_sell() {
         assert_lint_count("I want to sell my house.", test_linter(), 0);
+    }
+
+    #[test]
+    fn dont_flag_conjugated_sells_after_she() {
+        assert_lint_count("She sells cars every weekend.", test_linter(), 0);
     }
 
     #[test]

--- a/harper-core/src/linting/noun_verb_confusion/mod.rs
+++ b/harper-core/src/linting/noun_verb_confusion/mod.rs
@@ -2,6 +2,7 @@ use super::merge_linters::merge_linters;
 
 mod effect_affect;
 mod noun_instead_of_verb;
+mod sale_sell;
 mod verb_instead_of_noun;
 
 // Common noun-verb pairs that are often confused
@@ -13,6 +14,7 @@ pub(crate) const NOUN_VERB_PAIRS: &[(&str, &str)] = &[
     ("effect", "affect"), // "Effect" is also a verb meaning "to bring about". "Affect" is a noun in psychology.
     ("emphasis", "emphasize"), // TODO how to handle "emphasise" as well as "emphasize"?
     ("intent", "intend"),
+    ("sale", "sell"), // "Sell" is also a noun ("a hard sell"); "for sell" is handled by the `ForSell` Weir rule.
     // ("proof", "prove"),  // "Proof" is also a verb, a synonym of "proofread".
     ("weight", "weigh"),
     // Add more pairs here as needed
@@ -1430,5 +1432,132 @@ mod tests {
             test_linter(),
             0,
         );
+    }
+
+    // `sale` mistakenly used as the verb `sell`.
+
+    #[test]
+    fn fix_sale_clothes() {
+        assert_suggestion_result(
+            "I sale clothes online.",
+            test_linter(),
+            "I sell clothes online.",
+        );
+    }
+
+    #[test]
+    fn fix_sale_cars() {
+        assert_suggestion_result(
+            "She sale cars every weekend.",
+            test_linter(),
+            "She sell cars every weekend.",
+        );
+    }
+
+    #[test]
+    fn fix_sale_phones() {
+        assert_suggestion_result(
+            "We sale phones at the mall.",
+            test_linter(),
+            "We sell phones at the mall.",
+        );
+    }
+
+    #[test]
+    fn fix_sale_my_car() {
+        assert_suggestion_result(
+            "I sale my car tomorrow.",
+            test_linter(),
+            "I sell my car tomorrow.",
+        );
+    }
+
+    #[test]
+    fn fix_will_sale_it() {
+        assert_suggestion_result("I will sale it.", test_linter(), "I will sell it.");
+    }
+
+    #[test]
+    fn fix_should_sale_the_house() {
+        assert_suggestion_result(
+            "You should sale the house.",
+            test_linter(),
+            "You should sell the house.",
+        );
+    }
+
+    #[test]
+    fn fix_dont_sale_your_guitar() {
+        assert_suggestion_result(
+            "Don't sale your guitar.",
+            test_linter(),
+            "Don't sell your guitar.",
+        );
+    }
+
+    #[test]
+    fn fix_who_sale_this() {
+        assert_suggestion_result("Who sale this?", test_linter(), "Who sell this?");
+    }
+
+    // "Hard sell", "soft sell", etc. are idioms where "sell" is a noun.
+
+    #[test]
+    fn dont_flag_hard_sell() {
+        assert_lint_count("It's a hard sell.", test_linter(), 0);
+    }
+
+    #[test]
+    fn dont_flag_tough_sell() {
+        assert_lint_count("The new policy is a tough sell.", test_linter(), 0);
+    }
+
+    #[test]
+    fn dont_flag_soft_sell() {
+        assert_lint_count("Their product is a soft sell.", test_linter(), 0);
+    }
+
+    #[test]
+    fn dont_flag_easy_sell() {
+        assert_lint_count("That car is an easy sell.", test_linter(), 0);
+    }
+
+    // Correct uses of "sale" and "sell".
+
+    #[test]
+    fn dont_flag_sale_records_after_object_pronoun() {
+        // "sale records" here is a noun phrase.
+        assert_lint_count("They will send you sale records.", test_linter(), 0);
+    }
+
+    #[test]
+    fn dont_flag_sale_items_as_question_subject() {
+        // "sale items" here is a noun phrase.
+        assert_lint_count("Should sale items be returned?", test_linter(), 0);
+    }
+
+    #[test]
+    fn dont_flag_correct_sell() {
+        assert_lint_count("I want to sell my house.", test_linter(), 0);
+    }
+
+    #[test]
+    fn dont_flag_to_sell() {
+        assert_lint_count("Remember to sell quickly.", test_linter(), 0);
+    }
+
+    #[test]
+    fn dont_flag_correct_sale_noun() {
+        assert_lint_count("The sale ends on Friday.", test_linter(), 0);
+    }
+
+    #[test]
+    fn dont_flag_sale_as_noun_modifier() {
+        assert_lint_count("I bought sale clothes.", test_linter(), 0);
+    }
+
+    #[test]
+    fn dont_flag_for_sell_handled_by_weir_rule() {
+        assert_lint_count("This house is for sell.", test_linter(), 0);
     }
 }

--- a/harper-core/src/linting/noun_verb_confusion/noun_instead_of_verb/general.rs
+++ b/harper-core/src/linting/noun_verb_confusion/noun_instead_of_verb/general.rs
@@ -5,7 +5,7 @@ use crate::{
     patterns::{ModalVerb, Word, WordSet},
 };
 
-use super::super::NOUN_VERB_PAIRS;
+use super::super::{NOUN_VERB_PAIRS, conjugate_pair_verb};
 
 /// Pronouns that can come before verbs but not nouns
 const PRONOUNS: &[&str] = &["he", "I", "it", "she", "they", "we", "who", "you"];
@@ -107,7 +107,9 @@ impl ExprLinter for GeneralNounInsteadOfVerb {
         let verb = NOUN_VERB_PAIRS
             .iter()
             .find(|(noun, _)| *noun == noun_lower)
-            .map(|(_, verb)| verb)?;
+            .map(|&(_, verb)| verb)?;
+
+        let verb = conjugate_pair_verb(verb, prev_tok, src);
 
         Some(Lint {
             span: noun_tok.span,

--- a/harper-core/src/linting/noun_verb_confusion/noun_instead_of_verb/general.rs
+++ b/harper-core/src/linting/noun_verb_confusion/noun_instead_of_verb/general.rs
@@ -7,8 +7,11 @@ use crate::{
 
 use super::super::{NOUN_VERB_PAIRS, conjugate_pair_verb};
 
-/// Pronouns that can come before verbs but not nouns
-const PRONOUNS: &[&str] = &["he", "I", "it", "she", "they", "we", "who", "you"];
+/// TODO: Remove the explicit `who` match once the curated dictionary
+/// marks `who` as a subject pronoun.
+fn is_subject_pronoun_like(token: &Token, source: &[char]) -> bool {
+    token.kind.is_subject_pronoun() || token.get_ch(source).eq_str("who")
+}
 
 /// Linter that corrects common noun/verb confusions
 pub(super) struct GeneralNounInsteadOfVerb {
@@ -24,7 +27,7 @@ impl Default for GeneralNounInsteadOfVerb {
         };
 
         let pre_context = FirstMatchOf::new(vec![
-            Box::new(WordSet::new(PRONOUNS)) as Box<dyn Expr>,
+            Box::new(is_subject_pronoun_like) as Box<dyn Expr>,
             Box::new(ModalVerb::with_common_errors()),
             Box::new(WordSet::new(&["do", "don't", "dont"])),
             Box::new(adverb_of_frequency),

--- a/harper-core/src/linting/noun_verb_confusion/noun_instead_of_verb/mod.rs
+++ b/harper-core/src/linting/noun_verb_confusion/noun_instead_of_verb/mod.rs
@@ -1,12 +1,14 @@
 mod general;
 
 use super::effect_affect::EffectAffect;
+use super::sale_sell::SaleToSell;
 use crate::linting::merge_linters::merge_linters;
 use general::GeneralNounInsteadOfVerb;
 
 merge_linters! {
     NounInsteadOfVerb =>
         GeneralNounInsteadOfVerb,
-        EffectAffect
+        EffectAffect,
+        SaleToSell
     => "Corrects noun/verb confusions such as `advice/advise` and handles the common `effect/affect` mix-up."
 }

--- a/harper-core/src/linting/noun_verb_confusion/sale_sell/mod.rs
+++ b/harper-core/src/linting/noun_verb_confusion/sale_sell/mod.rs
@@ -1,0 +1,3 @@
+mod sale_to_sell;
+
+pub(super) use sale_to_sell::SaleToSell;

--- a/harper-core/src/linting/noun_verb_confusion/sale_sell/sale_to_sell.rs
+++ b/harper-core/src/linting/noun_verb_confusion/sale_sell/sale_to_sell.rs
@@ -1,0 +1,81 @@
+use harper_brill::UPOS;
+
+use crate::linting::expr_linter::Chunk;
+use crate::{
+    CharStringExt, Token, TokenKind,
+    expr::{Expr, ExprMap, SequenceExpr},
+    linting::{ExprLinter, Lint, LintKind, Suggestion},
+    patterns::UPOSSet,
+};
+
+pub(crate) struct SaleToSell {
+    expr: ExprMap<usize>,
+}
+
+impl Default for SaleToSell {
+    fn default() -> Self {
+        let mut map = ExprMap::default();
+
+        // "I sale clothes", "She sale cars": a subject pronoun cannot precede a noun
+        // phrase, so a following noun means `sale` is being used as a verb.
+        let pronoun_then_noun_follow = SequenceExpr::with(|tok: &Token, source: &[char]| {
+            is_unambiguous_subject_pronoun(tok, source)
+        })
+        .t_ws()
+        .then(|tok: &Token, source: &[char]| is_sale_word(tok, source))
+        .t_ws()
+        .then(UPOSSet::new(&[UPOS::NOUN]));
+
+        map.insert(pronoun_then_noun_follow, 2);
+
+        Self { expr: map }
+    }
+}
+
+impl ExprLinter for SaleToSell {
+    type Unit = Chunk;
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let offending_index = *self.expr.lookup(0, matched_tokens, source)?;
+        let target = &matched_tokens[offending_index];
+
+        Some(Lint {
+            span: target.span,
+            lint_kind: LintKind::WordChoice,
+            suggestions: vec![Suggestion::replace_with_match_case_str(
+                "sell",
+                target.get_ch(source),
+            )],
+            message: "`sale` is a noun, the verb should be `sell`.".into(),
+            priority: 63,
+        })
+    }
+
+    fn description(&self) -> &'static str {
+        "Corrects `sale` to `sell` when a subject pronoun shows the verb is intended."
+    }
+}
+
+/// Pronouns that can only be sentence subjects, unlike "you" or "it".
+/// "Send you sale records" shows why the ambiguous ones must be excluded.
+fn is_unambiguous_subject_pronoun(token: &Token, source: &[char]) -> bool {
+    if !matches!(token.kind, TokenKind::Word(_)) {
+        return false;
+    }
+
+    token
+        .get_ch(source)
+        .eq_any_ignore_ascii_case_str(&["he", "i", "she", "they", "we", "who"])
+}
+
+fn is_sale_word(token: &Token, source: &[char]) -> bool {
+    if !matches!(token.kind, TokenKind::Word(_)) {
+        return false;
+    }
+
+    token.get_ch(source).eq_any_ignore_ascii_case_str(&["sale"])
+}

--- a/harper-core/src/linting/noun_verb_confusion/sale_sell/sale_to_sell.rs
+++ b/harper-core/src/linting/noun_verb_confusion/sale_sell/sale_to_sell.rs
@@ -1,11 +1,10 @@
-use harper_brill::UPOS;
+use super::super::conjugate_pair_verb;
 
 use crate::linting::expr_linter::Chunk;
 use crate::{
     CharStringExt, Token, TokenKind,
     expr::{Expr, ExprMap, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
-    patterns::UPOSSet,
 };
 
 pub(crate) struct SaleToSell {
@@ -18,13 +17,14 @@ impl Default for SaleToSell {
 
         // "I sale clothes", "She sale cars": a subject pronoun cannot precede a noun
         // phrase, so a following noun means `sale` is being used as a verb.
-        let pronoun_then_noun_follow = SequenceExpr::with(|tok: &Token, source: &[char]| {
-            is_unambiguous_subject_pronoun(tok, source)
-        })
-        .t_ws()
-        .then(|tok: &Token, source: &[char]| is_sale_word(tok, source))
-        .t_ws()
-        .then(UPOSSet::new(&[UPOS::NOUN]));
+        let pronoun_then_noun_follow =
+            SequenceExpr::with(|tok: &Token, source: &[char]| is_subject_pronoun(tok, source))
+                .t_ws()
+                .then(|tok: &Token, source: &[char]| is_sale_word(tok, source))
+                .t_ws()
+                // Match the dictionary kind rather than the context tag:
+                // "fast" is tagged as an adjective in "It sale fast."
+                .then_noun();
 
         map.insert(pronoun_then_noun_follow, 2);
 
@@ -39,37 +39,51 @@ impl ExprLinter for SaleToSell {
         &self.expr
     }
 
-    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+    fn match_to_lint_with_context(
+        &self,
+        matched_tokens: &[Token],
+        source: &[char],
+        ctx: Option<(&[Token], &[Token])>,
+    ) -> Option<Lint> {
+        // "It" is only a subject at the start of a clause.
+        if matched_tokens[0].get_ch(source).eq_str("it")
+            && ctx.is_some_and(|(before, _)| before.iter().any(|t| !t.kind.is_whitespace()))
+        {
+            return None;
+        }
+
         let offending_index = *self.expr.lookup(0, matched_tokens, source)?;
         let target = &matched_tokens[offending_index];
+
+        let verb = conjugate_pair_verb("sell", &matched_tokens[0], source);
 
         Some(Lint {
             span: target.span,
             lint_kind: LintKind::WordChoice,
             suggestions: vec![Suggestion::replace_with_match_case_str(
-                "sell",
+                &verb,
                 target.get_ch(source),
             )],
-            message: "`sale` is a noun, the verb should be `sell`.".into(),
+            message: format!("`sale` is a noun, the verb should be `{verb}`."),
             priority: 63,
         })
     }
 
     fn description(&self) -> &'static str {
-        "Corrects `sale` to `sell` when a subject pronoun shows the verb is intended."
+        "Corrects `sale` to the correctly conjugated `sell`/`sells` when a subject pronoun shows the verb is intended."
     }
 }
 
-/// Pronouns that can only be sentence subjects, unlike "you" or "it".
-/// "Send you sale records" shows why the ambiguous ones must be excluded.
-fn is_unambiguous_subject_pronoun(token: &Token, source: &[char]) -> bool {
+/// Pronouns that can act as sentence subjects; see `match_to_lint_with_context`
+/// for how "it" is handled.
+fn is_subject_pronoun(token: &Token, source: &[char]) -> bool {
     if !matches!(token.kind, TokenKind::Word(_)) {
         return false;
     }
 
     token
         .get_ch(source)
-        .eq_any_ignore_ascii_case_str(&["he", "i", "she", "they", "we", "who"])
+        .eq_any_ignore_ascii_case_str(&["he", "i", "it", "she", "they", "we", "who"])
 }
 
 fn is_sale_word(token: &Token, source: &[char]) -> bool {

--- a/harper-core/src/linting/noun_verb_confusion/verb_instead_of_noun.rs
+++ b/harper-core/src/linting/noun_verb_confusion/verb_instead_of_noun.rs
@@ -1,6 +1,6 @@
 use crate::linting::expr_linter::Chunk;
 use crate::{
-    Lrc, Token,
+    CharStringExt, Lrc, Token,
     expr::{Expr, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
     patterns::{UPOSSet, WordSet},
@@ -63,6 +63,16 @@ impl ExprLinter for VerbInsteadOfNoun {
         // "Sound" is both adjective and noun. We want to flag the common "sound advise"
         // But not "sound affect", which is just as correct as "sound effect".
         if adj_text == "sound" && verb_text == "affect" {
+            return None;
+        }
+
+        // "Hard sell", "soft sell", "tough sell", and "easy sell" are idioms where
+        // "sell" is a noun, not a verb.
+        if verb_lower == "sell"
+            && adj_tok
+                .get_ch(src)
+                .eq_any_ignore_ascii_case_str(&["hard", "soft", "tough", "easy"])
+        {
             return None;
         }
 

--- a/harper-core/src/linting/weir_rules/ForSell.weir
+++ b/harper-core/src/linting/weir_rules/ForSell.weir
@@ -1,0 +1,35 @@
+expr main (for sell)
+
+let message "The standard phrase is `for sale`. `Sell` is the verb; the noun `sale` is required after `for`."
+let description "Corrects the common eggcorn `for sell` to the fixed idiom `for sale`."
+let kind "WordChoice"
+let becomes "for sale"
+
+# True positives
+
+test "This house is for sell." "This house is for sale."
+test "The car is for sell." "The car is for sale."
+test "Put the bike up for sell on the marketplace." "Put the bike up for sale on the marketplace."
+test "FOR SELL: vintage records." "FOR SALE: vintage records."
+test "is this jacket for sell?" "is this jacket for sale?"
+test "The boat was listed for sell last week." "The boat was listed for sale last week."
+test "FOR SELL!" "FOR SALE!"
+test "A sign read \"for sell\", but nobody bought." "A sign read \"for sale\", but nobody bought."
+test "These plots are for sell, cheap." "These plots are for sale, cheap."
+test "Everything here is for sell." "Everything here is for sale."
+test "FOR SELL" "FOR SALE"
+test "Looking for a dog for sell." "Looking for a dog for sale."
+test "is for sell, not for rent" "is for sale, not for rent"
+test "For sell: antique desk." "For sale: antique desk."
+test "For Sell" "For Sale"
+
+# The rule must not touch correct uses of "sale" or "sell"
+
+allows "This house is for sale."
+allows "I want to sell my house."
+allows "They sell cars here."
+allows "The sale ends on Friday."
+allows "The boat was for sale last week."
+allows "The car is for sale on the marketplace."
+allows "FOR SALE"
+allows "This tool is great for selling houses."


### PR DESCRIPTION
# Description

Handle noun/verb confusion around sale/sell, including sentences such as "it'll be a tough sell".

# How Has This Been Tested?

Test cases and using `harper-cli` on example sentences.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [X] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [X] I made up the sentences in the unit tests.
- [X] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [ ] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [X] I have performed a self-review of my own code
- [X] I have added tests to cover my changes
- [X] I have considered splitting this into smaller pull requests.
