### PR TITLE
feat: a waist of → a waste of

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5791,6 +5791,13 @@
 						},
 						{
 							"Bool": {
+								"name": "WaistWaste",
+								"state": true,
+								"label": "Waist / Waste"
+							}
+						},
+						{
+							"Bool": {
 								"name": "WasAloud",
 								"state": true,
 								"label": "Was Aloud"

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -308,6 +308,7 @@ use super::very_less::VeryLess;
 use super::very_unique::VeryUnique;
 use super::vice_versa::ViceVersa;
 use super::vicious_loop::{ViciousCircle, ViciousCircleOrCycle, ViciousCycle};
+use super::waist_waste::WaistWaste;
 use super::was_aloud::WasAloud;
 use super::way_too_adjective::WayTooAdjective;
 use super::web_scraping::WebScraping;
@@ -917,6 +918,7 @@ impl LintGroup {
         insert_expr_rule!(ViciousCircle);
         insert_expr_rule!(ViciousCircleOrCycle);
         insert_expr_rule!(ViciousCycle);
+        insert_expr_rule!(WaistWaste);
         insert_expr_rule!(WasAloud);
         insert_expr_rule!(WayTooAdjective);
         insert_expr_rule!(WellEducated);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -327,6 +327,7 @@ mod very_less;
 mod very_unique;
 mod vice_versa;
 mod vicious_loop;
+mod waist_waste;
 mod was_aloud;
 mod way_too_adjective;
 mod web_scraping;

--- a/harper-core/src/linting/waist_waste.rs
+++ b/harper-core/src/linting/waist_waste.rs
@@ -1,0 +1,121 @@
+use crate::{
+    Lint, Token,
+    char_string::CharStringExt,
+    expr::{Expr, FirstMatchOf, SequenceExpr},
+    linting::{
+        ExprLinter, LintKind, Suggestion,
+        expr_linter::{Chunk, find_the_only_token_matching},
+    },
+    patterns::InflectionOfBe,
+};
+
+pub struct WaistWaste {
+    expr: FirstMatchOf,
+}
+
+impl Default for WaistWaste {
+    fn default() -> Self {
+        Self {
+            expr: FirstMatchOf::new([
+                Box::new(
+                    SequenceExpr::any_word()
+                        .t_ws()
+                        .then(InflectionOfBe::default())
+                        .t_ws()
+                        .then_word_seq(&["a", "waist", "of"]),
+                ),
+                Box::new(
+                    SequenceExpr::word_set(&["a", "waist", "of"])
+                        .t_ws()
+                        .t_set(&["money", "space", "time"]),
+                ),
+            ]),
+        }
+    }
+}
+
+impl ExprLinter for WaistWaste {
+    type Unit = Chunk;
+
+    fn match_to_lint(
+        &self,
+        toks: &[Token],
+        src: &[char],
+    ) -> Option<Lint> {
+        let span =
+            find_the_only_token_matching(toks, src, |t, s| t.get_ch(s).eq_str("waist"))?.span;
+
+        let suggestions = vec![Suggestion::replace_with_match_case_str(
+            "waste",
+            span.get_content(src),
+        )];
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::WordChoice,
+            suggestions,
+            message: "Did you mean `waste` (careless use) rather than `waist` (body part)?"
+                .to_owned(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects misspelling `waste` (careless use) as `waist` (body part)."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    use super::WaistWaste;
+
+    #[test]
+    fn it_is_a_waist_of_space() {
+        assert_suggestion_result(
+            "The problem is, I think it is a waist of space pushing to remote all the software just because I have changed some files.",
+            WaistWaste::default(),
+            "The problem is, I think it is a waste of space pushing to remote all the software just because I have changed some files.",
+        );
+    }
+
+    #[test]
+    fn this_is_a_waist_of() {
+        assert_suggestion_result(
+            "This is a waist of Bs resources.",
+            WaistWaste::default(),
+            "This is a waste of Bs resources.",
+        );
+    }
+
+    #[test]
+    fn is_a_waist_of_space() {
+        assert_suggestion_result(
+            "The whole height takes only 19 rows, I think this is a waist of space",
+            WaistWaste::default(),
+            "The whole height takes only 19 rows, I think this is a waste of space",
+        );
+    }
+
+    #[test]
+    fn is_a_waist_of_time() {
+        assert_suggestion_result(
+            "Digging a hole with a toothpick is a waist of time.",
+            WaistWaste::default(),
+            "Digging a hole with a toothpick is a waste of time.",
+        );
+    }
+
+    #[test]
+    fn dont_flag_at_start() {
+        assert_no_lints(
+            "Is a waist of 46 inches around the belly button unhealthy??",
+            WaistWaste::default(),
+        );
+    }
+}

--- a/harper-core/src/linting/waist_waste.rs
+++ b/harper-core/src/linting/waist_waste.rs
@@ -24,10 +24,43 @@ impl Default for WaistWaste {
                         .t_ws()
                         .then_word_seq(&["a", "waist", "of"]),
                 ),
+                Box::new(SequenceExpr::word_seq(&["waist", "of"]).t_ws().t_set(&[
+                    "effort",
+                    "money",
+                    "resources",
+                    "space",
+                    "time",
+                ])),
                 Box::new(
-                    SequenceExpr::word_set(&["a", "waist", "of"])
+                    SequenceExpr::word_set(&[
+                        "complete",
+                        "confusing",
+                        "great",
+                        "horrible",
+                        "huge",
+                        "real",
+                        "total",
+                        "utter",
+                    ])
+                    .t_ws()
+                    .then_word_seq(&["waist", "of"]),
+                ),
+                Box::new(
+                    SequenceExpr::word_seq(&["a", "waist", "of"])
                         .t_ws()
-                        .t_set(&["money", "space", "time"]),
+                        .then_possessive_determiner(),
+                ),
+                Box::new(
+                    SequenceExpr::word_set(&[
+                        "definitely",
+                        "just",
+                        "mostly",
+                        "probably",
+                        "quite",
+                        "really",
+                    ])
+                    .t_ws()
+                    .then_word_seq(&["a", "waist", "of"]),
                 ),
             ]),
         }
@@ -37,11 +70,7 @@ impl Default for WaistWaste {
 impl ExprLinter for WaistWaste {
     type Unit = Chunk;
 
-    fn match_to_lint(
-        &self,
-        toks: &[Token],
-        src: &[char],
-    ) -> Option<Lint> {
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
         let span =
             find_the_only_token_matching(toks, src, |t, s| t.get_ch(s).eq_str("waist"))?.span;
 
@@ -116,6 +145,60 @@ mod tests {
         assert_no_lints(
             "Is a waist of 46 inches around the belly button unhealthy??",
             WaistWaste::default(),
+        );
+    }
+
+    #[test]
+    fn waist_of_money() {
+        assert_suggestion_result(
+            "Copilot ==Waist of money. It's full of bugs",
+            WaistWaste::default(),
+            "Copilot ==Waste of money. It's full of bugs",
+        );
+    }
+
+    #[test]
+    fn huge_waist_of() {
+        assert_suggestion_result(
+            "A huge waist of time. If the goal cannot be fullfulled, the model will not fallback to debugging",
+            WaistWaste::default(),
+            "A huge waste of time. If the goal cannot be fullfulled, the model will not fallback to debugging",
+        );
+    }
+
+    #[test]
+    fn complete_waist() {
+        assert_suggestion_result(
+            "but what a complete waist of time to be stuck in a job for 8 hours a day",
+            WaistWaste::default(),
+            "but what a complete waste of time to be stuck in a job for 8 hours a day",
+        );
+    }
+
+    #[test]
+    fn total_waist() {
+        assert_suggestion_result(
+            "Total Waist Of Money & Time !! NOT RECOMMENDED !!!",
+            WaistWaste::default(),
+            "Total Waste Of Money & Time !! NOT RECOMMENDED !!!",
+        );
+    }
+
+    #[test]
+    fn a_waist_of_your_time() {
+        assert_suggestion_result(
+            "Nevertheless I learned some things form your answer so it wasn't a waist of your time.",
+            WaistWaste::default(),
+            "Nevertheless I learned some things form your answer so it wasn't a waste of your time.",
+        );
+    }
+
+    #[test]
+    fn just_a_waist_of() {
+        assert_suggestion_result(
+            "The \"temporary\" bitmap is just a waist of CPU resources.",
+            WaistWaste::default(),
+            "The \"temporary\" bitmap is just a waste of CPU resources.",
         );
     }
 }

--- a/harper-core/src/linting/with_open_arms.rs
+++ b/harper-core/src/linting/with_open_arms.rs
@@ -1,7 +1,7 @@
 use crate::{
     CharStringExt, Lint, Token, TokenStringExt,
     expr::{All, Expr, OwnedExprExt, SequenceExpr},
-    linting::{ExprLinter, LintKind, Suggestion, debug::format_lint_match, expr_linter::Chunk},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
     patterns::{InflectionOfBe, WordSet},
 };
 
@@ -40,13 +40,7 @@ impl Default for WithOpenArms {
 impl ExprLinter for WithOpenArms {
     type Unit = Chunk;
 
-    fn match_to_lint_with_context(
-        &self,
-        toks: &[Token],
-        src: &[char],
-        ctx: Option<(&[Token], &[Token])>,
-    ) -> Option<Lint> {
-        eprintln!("🚨 {}", format_lint_match(toks, ctx, src));
+    fn match_to_lint(&self, toks: &[Token], src: &[char]) -> Option<Lint> {
         let [verb, ws_with_ws @ .., open, ws4, arms] = &toks[2..] else {
             return None;
         };


### PR DESCRIPTION
# Issues 
N/A

# Description

Corrects spelling "waste" as "waist".

(I also removed some debug output from `WithOpenArms` I happened to find.)

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

Just a bit of autocomplete steroids.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
