### PR TITLE
feat: (wip) each things → thing / each of the thing → things

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -3485,6 +3485,13 @@
 						},
 						{
 							"Bool": {
+								"name": "Each",
+								"state": true,
+								"label": "Each"
+							}
+						},
+						{
+							"Bool": {
 								"name": "EachAndEveryOne",
 								"state": true,
 								"label": "Each And Every One"

--- a/harper-core/src/linting/each.rs
+++ b/harper-core/src/linting/each.rs
@@ -1,0 +1,130 @@
+use crate::{
+    Lint, Token, TokenStringExt,
+    char_string::CharStringExt,
+    expr::{Expr, LongestMatchOf, OwnedExprExt, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, debug::format_lint_match, expr_linter::Chunk},
+};
+
+pub struct Each {
+    expr: SequenceExpr,
+}
+
+impl Default for Each {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::any_capitalization_of("each")
+                .t_ws()
+                .then_any_of([
+                    Box::new(
+                        SequenceExpr::default().then_plural_noun_only().but_not(
+                            LongestMatchOf::new([
+                                // don't flag "each drinks" because that's valid when "drinks" is a verb
+                                Box::new(
+                                    SequenceExpr::default()
+                                        .then_verb_third_person_singular_present_form(),
+                                ),
+                                // don't flag "each data point" because "data" is part of a compound noun/noun phrase
+                                Box::new(SequenceExpr::anything().t_ws().then_noun()),
+                            ]),
+                        ),
+                    ) as Box<dyn Expr>,
+                    Box::new(
+                        SequenceExpr::word_seq(&["of", "the"])
+                            .t_ws()
+                            .then_singular_noun_only(),
+                    ),
+                ]),
+        }
+    }
+}
+
+fn each_of_the_noun(
+    _toks: &[Token],
+    _src: &[char],
+    _ctx: Option<(&[Token], &[Token])>,
+) -> Option<Lint> {
+    todo!()
+}
+
+fn each_nouns(toks: &[Token], src: &[char], _ctx: Option<(&[Token], &[Token])>) -> Option<Lint> {
+    let span = toks.span()?;
+
+    let lint_kind = LintKind::Miscellaneous;
+    let suggestions = vec![Suggestion::replace_with_match_case_str(
+        "correction",
+        span.get_content(src),
+    )];
+    let message = "Fix this erorr".to_owned();
+
+    Some(Lint {
+        span,
+        lint_kind,
+        suggestions,
+        message,
+        ..Default::default()
+    })
+}
+
+impl ExprLinter for Each {
+    type Unit = Chunk;
+
+    fn match_to_lint_with_context(
+        &self,
+        toks: &[Token],
+        src: &[char],
+        ctx: Option<(&[Token], &[Token])>,
+    ) -> Option<Lint> {
+        eprintln!("🚨 {}", format_lint_match(toks, ctx, src));
+        let (each, of, the) = (0, 2, 4);
+        let (_each, of, the) = (toks.get(each)?, toks.get(of)?, toks.get(the)?);
+
+        // Which pattern did we match?
+        if of.get_ch(src).eq_ch(&['o', 'f']) && the.get_ch(src).eq_ch(&['t', 'h', 'e']) {
+            each_of_the_noun(toks, src, ctx)
+        } else {
+            each_nouns(toks, src, ctx)
+        }
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Detects wrong noun number after `each`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    use super::Each;
+
+    #[test]
+    fn fix_each_data() {
+        assert_suggestion_result(
+            "Remember that each data has its own trade-offs.",
+            Each::default(),
+            "correction",
+        );
+    }
+
+    #[test]
+    fn dont_flag_each_data_point() {
+        assert_no_lints(
+            "Each data point is a pair comprising a topic and the user’s goal for conducting deep search on the topic.",
+            Each::default(),
+        );
+    }
+
+    #[test]
+    #[ignore = "this is mass noun rather than plural. confusing it with plural is #407"]
+    fn each_news() {
+        assert_suggestion_result(
+            "implement TFIDF on each news to find out the key",
+            Each::default(),
+            "implement TFIDF on all news to find out the key",
+        );
+    }
+}

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -85,6 +85,7 @@ use super::do_mistake::DoMistake;
 use super::dot_initialisms::DotInitialisms;
 use super::double_click::DoubleClick;
 use super::double_modal::DoubleModal;
+use super::each::Each;
 use super::ellipsis_length::EllipsisLength;
 use super::else_possessive::ElsePossessive;
 use super::ever_every::EverEvery;
@@ -695,6 +696,7 @@ impl LintGroup {
         insert_expr_rule!(DotInitialisms);
         insert_expr_rule!(DoubleClick);
         insert_expr_rule!(DoubleModal);
+        insert_expr_rule!(Each);
         insert_struct_rule!(EllipsisLength);
         insert_expr_rule!(ElsePossessive);
         insert_expr_rule!(EverEvery);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -85,6 +85,7 @@ mod do_mistake;
 mod dot_initialisms;
 mod double_click;
 mod double_modal;
+mod each;
 mod ellipsis_length;
 mod else_possessive;
 mod ever_every;


### PR DESCRIPTION
# Issues 
N/A

# Description

I started work on a linter that flags two grammar problems with "each" that are commonly made by nonnative speakers:
- each things
- each of the thing

I'm putting it aside for now because I don't have many real-world test sentences.

This is a perfect use case for the `regular_nouns.rs` file since one fix for each problem will involve converting between singular and plural.

Anyone looking for something to work on is welcome to take this up.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

work in progress...

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [ ] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
