### PR TITLE
fix: feeded → fed

### DIFF
--- a/harper-core/src/linting/regular_irregulars.rs
+++ b/harper-core/src/linting/regular_irregulars.rs
@@ -82,7 +82,7 @@ impl<D: Dictionary> ExprLinter for RegularIrregulars<D> {
                 irregulars, word
             ),
             suggestions,
-            ..Default::default()
+            priority: 62, // higher priority (lower number) than `SpellCheck` (which is 63)
         })
     }
 }
@@ -349,6 +349,18 @@ mod tests {
                 "I digged a bit deeper.",
                 RegularIrregulars::new(FstDictionary::curated()),
                 "I dug a bit deeper.",
+            );
+        }
+
+        #[test]
+        fn fix_feeded() {
+            use crate::Dialect;
+            use crate::spell::FstDictionary;
+
+            assert_suggestion_result(
+                "Rune is a TUI editor, so I feeded the same terminal sequences to the old and new apps.",
+                crate::linting::LintGroup::new_curated(FstDictionary::curated(), Dialect::American),
+                "Rune is a TUI editor, so I fed the same terminal sequences to the old and new apps.",
             );
         }
     }


### PR DESCRIPTION
# Issues 

Fixes #4326

# Description

"Feeded" was not getting corrected to "fed" and it turned out to be that `SpellCheck` had a higher priority (lower number) than `RegularIrregulars`

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
