### PR TITLE
feat: (wip) Apple Silicone → Apple Silicon

### DIFF
--- a/harper-core/src/linting/weir_rules/AppleSilicon.weir
+++ b/harper-core/src/linting/weir_rules/AppleSilicon.weir
@@ -1,0 +1,20 @@
+expr main <((Apple Silicone) ![case, cover, iPhone]), (Apple Silicone)>
+#expr main <(Apple Silicone)> ![case, cover, iPhone]
+
+let message "If you're referring to the chip and not the phone cover, use `Silicon` not `Silicone`."
+let description "Corrects `Apple Silicone` to `Apple Silicon`."
+let kind "Spelling"
+let becomes "Apple Silicon"
+
+# basic test while debugging
+test "Apple Silicone" "Apple Silicon"
+
+# real-world examples - this first one is failing just like the basic test for now
+#test "I am testing it on Google Docs, Google Chrome, and Apple Silicone." "I am testing it on Google Docs, Google Chrome, and Apple Silicon."
+
+# real-world examples - these are passing
+allows "Apple Silicone case is honestly the worst case I've ever had on any phone."
+allows "It's The Case That Never Changes! - Apple Silicone iPhone 16 Case Review"
+
+# contrived - replace with real-world found example
+allows "The new MacBook is powered by an Apple Silicon chip."


### PR DESCRIPTION
# Issues 
Will fix #4333
See the Weir documentation issue #4334

# Description

Attempts to correct "Apple Silicone" to "Apple Silicon" except when it's correctly referring to the Iphone cover.

But I can't figure out how to get this to work, hence the issue I filed against the Weir documentation: #4334 

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test silicon`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [x] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

Google Search's AI can do a bit of Weir, but it struggled as much as I did and didn't solve the problem.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [x] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [x] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
