### PR TITLE
feat: slippy slope → slippery slope

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -4089,6 +4089,13 @@
 						},
 						{
 							"Bool": {
+								"name": "SlipperySlope",
+								"state": true,
+								"label": "Slippery Slope"
+							}
+						},
+						{
+							"Bool": {
 								"name": "AheadAnd",
 								"state": true,
 								"label": "Ahead and"

--- a/harper-core/src/linting/weir_rules/SlipperySlope.weir
+++ b/harper-core/src/linting/weir_rules/SlipperySlope.weir
@@ -1,0 +1,9 @@
+expr main (slippy slope)
+
+let message "The correct idiom is `slippery slope`."
+let description "Corrects `slippy slope` to `slippery slope`."
+let kind "Usage"
+let becomes "slippery slope"
+
+test "Using the same trio loop with different tests is a very slippy slope" "Using the same trio loop with different tests is a very slippery slope"
+test "Without the ability to verify it, except with even more AI maybe, you're starting on a slippy slope to slop." "Without the ability to verify it, except with even more AI maybe, you're starting on a slippery slope to slop."


### PR DESCRIPTION
# Issues 
N/A

# Description

I read "slippy slope" the other day and though I hear "slippy" used to mean "slippery" by British English speakers, it's not used in this idiom. I checked all online US and UK dictionaries and none include a "slippy" variant.

Although the singular mistake is common online, every instance of the plural "slippy slopes" was literal, or the name of some song/game/etc.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test slope`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
