### PR TITLE
feat: show case → showcase

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -707,6 +707,13 @@
 						},
 						{
 							"Bool": {
+								"name": "ShowCase",
+								"state": true,
+								"label": "Show Case"
+							}
+						},
+						{
+							"Bool": {
 								"name": "Somebody",
 								"state": true,
 								"label": "Somebody"

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -253,6 +253,7 @@ use super::safe_to_save::SafeToSave;
 use super::save_to_safe::SaveToSafe;
 use super::sentence_capitalization::SentenceCapitalization;
 use super::shoot_oneself_in_the_foot::ShootOneselfInTheFoot;
+use super::show_case::ShowCase;
 use super::simple_past_to_past_participle::SimplePastToPastParticiple;
 use super::since_duration::SinceDuration;
 use super::single_be::SingleBe;
@@ -866,6 +867,7 @@ impl LintGroup {
         insert_expr_rule!(SaveToSafe);
         insert_struct_rule_with_dict!(SentenceCapitalization);
         insert_expr_rule!(ShootOneselfInTheFoot);
+        insert_expr_rule!(ShowCase);
         insert_expr_rule!(SimplePastToPastParticiple);
         insert_expr_rule!(SinceDuration);
         insert_expr_rule!(SingleBe);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -270,6 +270,7 @@ mod safe_to_save;
 mod save_to_safe;
 mod sentence_capitalization;
 mod shoot_oneself_in_the_foot;
+mod show_case;
 mod simple_past_to_past_participle;
 mod since_duration;
 mod single_be;

--- a/harper-core/src/linting/show_case.rs
+++ b/harper-core/src/linting/show_case.rs
@@ -1,0 +1,125 @@
+use crate::{
+    Lint, Token, TokenStringExt,
+    expr::{All, Expr, OwnedExprExt, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+};
+
+pub struct ShowCase {
+    expr: All,
+}
+
+impl Default for ShowCase {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::aco("show").t_ws_h().t_aco("case").but_not(
+                SequenceExpr::anything().t_any().t_any().then_any_of([
+                    Box::new(SequenceExpr::with(|t: &Token, _: &[char]| {
+                        t.kind.is_hyphen()
+                    })),
+                    Box::new(SequenceExpr::whitespace().t_set([
+                        "folded",
+                        "folding",
+                        "history",
+                        "histories",
+                        "number",
+                        "numbers",
+                        "sensitive",
+                        "insensitive",
+                        "study",
+                        "studies",
+                    ])),
+                ]),
+            ),
+        }
+    }
+}
+
+impl ExprLinter for ShowCase {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let span = matched_tokens.span()?;
+
+        let suggestions = vec![Suggestion::replace_with_match_case_str(
+            "showcase",
+            span.get_content(source),
+        )];
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::Miscellaneous, // as used in `closed_compounds.rs`
+            suggestions,
+            message: "Did you mean `showcase` (highlight the best qualities of something)?"
+                .to_owned(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects `show case` to `showcase`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    use super::ShowCase;
+
+    #[test]
+    #[ignore = "Fails due to `replace_with_match_case_str` copying case based on character index"]
+    fn fix_show_case_noun_title_case() {
+        assert_suggestion_result(
+            "Progressive Web Apps (PWA) Show Case.",
+            ShowCase::default(),
+            "Progressive Web Apps (PWA) Showcase.",
+        );
+    }
+
+    #[test]
+    fn fix_show_case_noun_lowercase() {
+        assert_suggestion_result(
+            "Hello,How to run the show case in release mode.",
+            ShowCase::default(),
+            "Hello,How to run the showcase in release mode.",
+        );
+    }
+
+    #[test]
+    fn dont_flag_case_insensitive() {
+        assert_no_lints(
+            "Show case insensitive results when searching for a branch.",
+            ShowCase::default(),
+        )
+    }
+
+    #[test]
+    fn dont_flag_case_sensitive() {
+        assert_no_lints(
+            "starship shows case-sensitive behavior on case-insensitive file system (macOS)",
+            ShowCase::default(),
+        )
+    }
+
+    #[test]
+    fn fix_verb() {
+        assert_suggestion_result(
+            "Some stories don't show case how the component should be used.",
+            ShowCase::default(),
+            "Some stories don't showcase how the component should be used.",
+        );
+    }
+
+    #[test]
+    fn fix_verb_hyphenated() {
+        assert_suggestion_result(
+            "It's pretty simple to show-case a feature in your App by using BubbleShowCase framework.",
+            ShowCase::default(),
+            "It's pretty simple to showcase a feature in your App by using BubbleShowCase framework.",
+        )
+    }
+}


### PR DESCRIPTION
# Issues 
N/A

# Description

Many people incorrectly write the noun & verb "showcase" as two words "show case".

This linter avoids flagging when "case" is part of a phrase to its right such as "case number", "case sensitive", etc.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [x] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
