### PR TITLE
feat: deny offer → decline/reject

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -4621,6 +4621,13 @@
 						},
 						{
 							"Bool": {
+								"name": "DenyOffer",
+								"state": true,
+								"label": "Deny Offer"
+							}
+						},
+						{
+							"Bool": {
 								"name": "DigUnderTheHood",
 								"state": true,
 								"label": "Dig Under The Hood"

--- a/harper-core/src/linting/deny_offer.rs
+++ b/harper-core/src/linting/deny_offer.rs
@@ -1,0 +1,115 @@
+use crate::{
+    Lint, Token,
+    expr::{Expr, SequenceExpr},
+    linting::{ExprLinter, LintKind, Suggestion, expr_linter::Chunk},
+};
+
+pub struct DenyOffer {
+    expr: SequenceExpr,
+}
+
+impl Default for DenyOffer {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::word_set(["deny", "denies", "denied", "denying"])
+                .t_ws()
+                .then_optional(SequenceExpr::default().then_determiner().t_ws())
+                .t_set(["offer", "offers"]),
+        }
+    }
+}
+
+impl ExprLinter for DenyOffer {
+    type Unit = Chunk;
+
+    fn match_to_lint(&self, matched_tokens: &[Token], source: &[char]) -> Option<Lint> {
+        let span = matched_tokens.first()?.span;
+
+        let corrections = match matched_tokens.first()?.get_ch(source).last()? {
+            'y' | 'Y' => &["decline", "reject"],
+            'd' | 'D' => &["declined", "rejected"],
+            's' | 'S' => &["declines", "rejects"],
+            'g' | 'G' => &["declining", "rejecting"],
+            _ => return None,
+        };
+
+        let suggestions = corrections
+            .iter()
+            .map(|correction| {
+                Suggestion::replace_with_match_case_str(correction, span.get_content(source))
+            })
+            .collect();
+
+        let message =
+            "You would `deny` permission or a request, but `decline` or `reject` an offer."
+                .to_owned();
+
+        Some(Lint {
+            span,
+            lint_kind: LintKind::WordChoice,
+            suggestions,
+            message,
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects `deny` when used with `offer` to `decline` or `reject`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::assert_suggestion_result;
+
+    use super::DenyOffer;
+
+    #[test]
+    fn fix_deny_the_offer() {
+        assert_suggestion_result(
+            "I did not want to accept or deny the offer without floating to other maintainers",
+            DenyOffer::default(),
+            "I did not want to accept or decline the offer without floating to other maintainers",
+        );
+    }
+
+    #[test]
+    fn deny_your_offer() {
+        assert_suggestion_result(
+            "I understand, why you'd want this, but must deny your offer to expand my participation in your project quite so dramatically at this time.",
+            DenyOffer::default(),
+            "I understand, why you'd want this, but must reject your offer to expand my participation in your project quite so dramatically at this time.",
+        );
+    }
+
+    #[test]
+    fn denied_their_offer() {
+        assert_suggestion_result(
+            "So I denied their offer of employment and went back to finish my masters degree",
+            DenyOffer::default(),
+            "So I declined their offer of employment and went back to finish my masters degree",
+        );
+    }
+
+    #[test]
+    fn dying_offers() {
+        assert_suggestion_result(
+            "Seemingly denying an offer is translated as accepting it",
+            DenyOffer::default(),
+            "Seemingly rejecting an offer is translated as accepting it",
+        );
+    }
+
+    #[test]
+    fn deny_offers_and_denying_offers() {
+        assert_suggestion_result(
+            "For details about how a Marketplace administrator can deny offers in the Back Office, see Approving or denying offers.",
+            DenyOffer::default(),
+            "For details about how a Marketplace administrator can decline offers in the Back Office, see Approving or declining offers.",
+        );
+    }
+}

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -73,6 +73,7 @@ use super::cure_for::CureFor;
 use super::currency_placement::CurrencyPlacement;
 use super::damages::Damages;
 use super::day_and_age::DayAndAge;
+use super::deny_offer::DenyOffer;
 use super::despite_it_is::DespiteItIs;
 use super::despite_of::DespiteOf;
 use super::did_past::DidPast;
@@ -687,6 +688,7 @@ impl LintGroup {
         insert_struct_rule!(CurrencyPlacement);
         insert_expr_rule!(Dashes);
         insert_expr_rule!(DayAndAge);
+        insert_expr_rule!(DenyOffer);
         insert_expr_rule!(DespiteItIs);
         insert_expr_rule!(DespiteOf);
         insert_expr_rule_with_dict!(DidPast);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -72,6 +72,7 @@ mod currency_placement;
 mod damages;
 mod dashes;
 mod day_and_age;
+mod deny_offer;
 mod despite_it_is;
 mod despite_of;
 mod determiner_without_noun;


### PR DESCRIPTION
# Issues 
N/A

# Description

Corrects "deny" when used with "offer" to "decline" or "reject". "Deny" is correct when used with permission or requests.

Works with all inflections of the verb and with singular or plural noun, with or without a determiner.

It does not yet work with adjectives before "offer". Can add that when needed.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
