### PR TITLE
fix(web): color of the logo used in loading animation

### DIFF
--- a/packages/web/src/lib/components/Loader.svelte
+++ b/packages/web/src/lib/components/Loader.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
 import { onMount } from 'svelte';
-import AppLogoTile from '$lib/marketing/AppLogoTile.svelte';
-import IntegrationTile from '$lib/marketing/IntegrationTile.svelte';
 
 let logoImg: HTMLImageElement | null = $state(null);
 
 onMount(() => {
 	logoImg = new Image();
-	logoImg.src = '/android-chrome-512x512.png';
+	logoImg.src = '/harper-logo.svg';
 });
 
 let canvasElement: HTMLCanvasElement | null = $state(null);
@@ -174,7 +172,7 @@ function renderFace(ctx: CanvasRenderingContext2D) {
 
 	ctx.fillStyle = '#000';
 	if (logoImg) {
-		ctx.drawImage(logoImg, -100, -100, 200, 200);
+		ctx.drawImage(logoImg, -50, -50, 100, 100);
 	}
 
 	ctx.restore();

--- a/packages/web/static/harper-logo.svg
+++ b/packages/web/static/harper-logo.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg
+	width="100%"
+	height="100%"
+	viewBox="0 0 695 411"
+	version="1.1"
+	xmlns="http://www.w3.org/2000/svg"
+	xml:space="preserve"
+	style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;"
+>
+	<g transform="matrix(1,0,0,1,-5,-1720)">
+		<g transform="matrix(0.824576,0,0,0.749254,0.365685,430.856)">
+			<rect x="5.62" y="1720.57" width="842.425" height="547.24" fill="none" />
+			<g transform="matrix(1.21274,0,0,1.33466,-2183.71,393.157)">
+				<g transform="matrix(1,0,0,1,-22.3927,1.08043)">
+					<path
+						d="M1930.93,1121.75C1930.93,1121.75 1974.66,1080.73 2041.34,1094.1C2086.61,1103.18 2122.83,1145.4 2122.83,1145.4"
+						stroke="currentColor"
+						fill="transparent"
+						stroke-width="22.92px"
+					/>
+				</g>
+				<g transform="matrix(1,0,0,1,-47.3485,12.3935)">
+					<path
+						d="M2250.3,1107.1C2250.3,1107.1 2261.8,1065.58 2311.59,1047.05C2361.62,1028.44 2422.42,1051.13 2422.42,1051.13"
+						stroke="currentColor"
+						fill="transparent"
+						stroke-width="22.92px"
+					/>
+				</g>
+				<g transform="matrix(1.10085,0,0,1.10085,-212.096,-122.054)">
+					<g transform="matrix(1,0,0,1,14.3186,-0.853887)">
+						<ellipse
+							cx="1981.62"
+							cy="1247.49"
+							rx="87.401"
+							ry="87.881"
+							stroke="currentColor"
+							fill="transparent"
+							stroke-width="22.92px"
+						/>
+					</g>
+					<rect
+						x="2083.34"
+						y="1231.11"
+						width="66.702"
+						height="15.521"
+						stroke="currentColor"
+						fill="transparent"
+						stroke-width="22.92px"
+					/>
+					<rect
+						x="1892.23"
+						y="1208.69"
+						width="16.306"
+						height="30.182"
+						stroke="currentColor"
+						fill="transparent"
+						stroke-width="22.92px"
+					/>
+					<g transform="matrix(-1,0,0,1,4281.79,-0.853887)">
+						<ellipse
+							cx="1981.62"
+							cy="1247.49"
+							rx="87.401"
+							ry="87.881"
+							stroke="currentColor"
+							fill="transparent"
+							stroke-width="22.92px"
+						/>
+					</g>
+					<g transform="matrix(-1,0,0,1,4296.11,0)">
+						<rect
+							x="2083.34"
+							y="1231.11"
+							width="66.702"
+							height="15.521"
+							stroke="currentColor"
+							fill="transparent"
+							stroke-width="22.92px"
+						/>
+					</g>
+					<g transform="matrix(-1,0,0,1,4296.11,0)">
+						<rect
+							x="1892.23"
+							y="1208.69"
+							width="16.306"
+							height="30.182"
+							stroke="currentColor"
+							fill="transparent"
+							stroke-width="22.92px"
+						/>
+					</g>
+				</g>
+			</g>
+		</g>
+	</g>
+</svg>


### PR DESCRIPTION
# Issues 
<!-- Link any relevant GitHub issues here. -->
<!-- If this PR resolves the issue(s), write closes/fixes/resolves before the issue number(s) (e.g. Fixes #____, closes #____). -->

#4340 

# Description
<!-- Please include a summary of the change. -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

I noticed that the logo used in the loading animation was not transparent. I made it transparent.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

Manually.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [ ] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [x] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
