### PR TITLE
feat: gonna, gotta, and wanna

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -3146,6 +3146,20 @@
 						},
 						{
 							"Bool": {
+								"name": "Gonna",
+								"state": true,
+								"label": "Gonna"
+							}
+						},
+						{
+							"Bool": {
+								"name": "Gotta",
+								"state": true,
+								"label": "Gotta"
+							}
+						},
+						{
+							"Bool": {
 								"name": "Hedging",
 								"state": true,
 								"label": "Hedging"
@@ -3296,6 +3310,13 @@
 								"name": "VeryUnique",
 								"state": true,
 								"label": "Very Unique"
+							}
+						},
+						{
+							"Bool": {
+								"name": "Wanna",
+								"state": true,
+								"label": "Wanna"
 							}
 						},
 						{

--- a/harper-core/src/linting/gonna_gotta_wanna.rs
+++ b/harper-core/src/linting/gonna_gotta_wanna.rs
@@ -1,0 +1,213 @@
+use crate::{
+    Lint, Token, TokenStringExt,
+    expr::{Expr, SequenceExpr},
+    linting::{
+        ExprLinter, LintGroup, LintKind, Suggestion, debug::format_lint_match, expr_linter::Chunk,
+    },
+};
+
+struct GonnaGottaWanna {
+    expr: SequenceExpr, // TODO
+    informal: &'static str,
+    formal: &'static str,
+}
+
+impl GonnaGottaWanna {
+    fn new(informal: &'static str, formal: &'static str) -> Self {
+        Self {
+            expr: SequenceExpr::aco(informal)
+                .then_optional(SequenceExpr::whitespace().t_set(["to", "a"])),
+            informal,
+            formal,
+        }
+    }
+}
+
+impl ExprLinter for GonnaGottaWanna {
+    type Unit = Chunk;
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn match_to_lint_with_context(
+        &self,
+        toks: &[Token],
+        src: &[char],
+        ctx: Option<(&[Token], &[Token])>,
+    ) -> Option<Lint> {
+        eprintln!("🚨 {}", format_lint_match(toks, ctx, src));
+        let span = toks.span()?;
+        let suggestions = vec![Suggestion::replace_with_match_case_str(
+            self.formal,
+            span.get_content(src),
+        )];
+        Some(Lint {
+            span,
+            lint_kind: LintKind::Style,
+            suggestions,
+            message: format!("Use '{}' instead of '{}'", self.formal, self.informal),
+            ..Default::default()
+        })
+    }
+
+    fn description(&self) -> &str {
+        "gonna gotta wanna"
+    }
+}
+
+pub fn lint_group() -> LintGroup {
+    let mut group = LintGroup::empty();
+
+    macro_rules! add_ggw {
+        ($group:expr, { $($name:expr => ($informal:expr, $formal:expr)),+ $(,)? }) => {
+            $(
+                $group.add(
+                    $name,
+                    Box::new(GonnaGottaWanna::new($informal, $formal)),
+                );
+            )+
+        };
+    }
+
+    add_ggw!(group, {
+        "Gonna" => ("gonna", "going"),
+        "Gotta" => ("gotta", "got"),
+        "Wanna" => ("wanna", "want"),
+    });
+
+    group.set_all_rules_to(Some(true));
+    group
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_good_and_bad_suggestions, assert_suggestion_result};
+
+    use super::lint_group;
+
+    #[test]
+    fn fix_gonna() {
+        // We think you're gonna like it here."
+        assert_suggestion_result(
+            "We think you're gonna like it here.",
+            lint_group(),
+            // fix the grammar and the informality
+            "We think you're going to like it here.",
+        )
+    }
+
+    #[test]
+    fn fix_gonna_to() {
+        // "gonna" already means "going to", so adding "to" is redundant
+        assert_good_and_bad_suggestions(
+            "I am gonna to create the region by clicking and dragging the mouse on waveform but I couldn't find the way to do that.",
+            lint_group(),
+            &[
+                // fix the grammar but remain informal
+                "I am gonna create the region by clicking and dragging the mouse on waveform but I couldn't find the way to do that.",
+                // fix the grammar and the informality
+                "I am going to create the region by clicking and dragging the mouse on waveform but I couldn't find the way to do that.",
+            ],
+            &[],
+        )
+    }
+
+    #[test]
+    fn fix_gotta() {
+        assert_suggestion_result(
+            "Gotta Hear Them All: Towards Sound Source Aware Audio Generation.",
+            lint_group(),
+            "Got to Hear Them All: Towards Sound Source Aware Audio Generation.",
+            // What about "have to"?
+        )
+    }
+
+    #[test]
+    fn fix_gotta_a_error() {
+        // "gotta" only means "(have) got to", using it as "got a" is incorrect
+        // but adding "a" is also redundant
+        assert_good_and_bad_suggestions(
+            "when I try to create a c/c++ database,I gotta a error",
+            lint_group(),
+            &[
+                // fix the grammar but remain informal
+                "when I try to create a c/c++ database,I got a error",
+                // fix the grammar and the informality
+                "when I try to create a c/c++ database,I got an error",
+            ],
+            &[],
+        )
+    }
+
+    // You gotta a 20% OFF coupom.
+    #[test]
+    fn fix_gotta_a_coupom() {
+        // "gotta" only means "(have) got to", using it as "got a" is incorrect
+        // but adding "a" is also redundant
+        assert_good_and_bad_suggestions(
+            "You gotta a 20% OFF coupom.",
+            lint_group(),
+            &[
+                // fix the grammar but remain informal
+                "You got a 20% OFF coupom.",
+                // what about "you get", "you receive", "you received"?
+            ],
+            &[],
+        )
+    }
+
+    #[test]
+    // it works well enough for me and gotta to get back working on other stuff
+    fn fix_gotta_to() {
+        // "gotta" already means "got to", so adding "to" is redundant
+        assert_good_and_bad_suggestions(
+            "it works well enough for me and gotta to get back working on other stuff",
+            lint_group(),
+            &[
+                // fix the grammar but remain informal
+                "it works well enough for me and gotta get back working on other stuff",
+                // fix the grammar and the informality
+                "it works well enough for me and have to get back working on other stuff",
+                // What about "has to", "had to"?
+            ],
+            &[],
+        )
+    }
+
+    #[test]
+    fn fix_wanna_control() {
+        assert_suggestion_result(
+            "I wanna control G1 arms while walking using gamepad. But ...",
+            lint_group(),
+            "I want to control G1 arms while walking using gamepad. But ...",
+        )
+    }
+
+    #[test]
+    fn fix_wanna_a() {
+        // "wanna" only means "want to", using it as "want a" is incorrect
+        // Only way to fix fixes both the informality and the grammar goether
+        assert_suggestion_result(
+            "And then I remember from the beginning I just wanna a very simple array with some simple opreations.",
+            lint_group(),
+            "And then I remember from the beginning I just want a very simple array with some simple opreations.",
+        )
+    }
+
+    #[test]
+    fn fix_wanna_to() {
+        // "wanna" already means "want to", so adding "to" is redundant
+        assert_good_and_bad_suggestions(
+            "it is stoped but i wanna to continue",
+            lint_group(),
+            &[
+                // fix the grammar but remain informal
+                "it is stoped but i wanna continue",
+                // fix the grammar and the informality
+                "it is stoped but i want to continue",
+            ],
+            &[],
+        )
+    }
+}

--- a/harper-core/src/linting/gonna_gotta_wanna.rs
+++ b/harper-core/src/linting/gonna_gotta_wanna.rs
@@ -11,15 +11,17 @@ use crate::{
 
 struct GonnaGottaWanna {
     expr: SequenceExpr,
+    dialect: Dialect,
     informal: &'static str,
     formal: &'static str,
 }
 
 impl GonnaGottaWanna {
-    fn new(informal: &'static str, formal: &'static str) -> Self {
+    fn new(dialect: Dialect, informal: &'static str, formal: &'static str) -> Self {
         Self {
             expr: SequenceExpr::aco(informal)
                 .then_optional(SequenceExpr::whitespace().t_set(["to", "a"])),
+            dialect,
             informal,
             formal,
         }
@@ -102,7 +104,7 @@ impl ExprLinter for GonnaGottaWanna {
             (Verb::Gotta, Rest::A) => {
                 let followed_by_vowel = followed_by_word(ctx, |t| {
                     matches!(
-                        starts_with_vowel(t.get_ch(src), Dialect::American),
+                        starts_with_vowel(t.get_ch(src), self.dialect),
                         Some(InitialSound::Vowel)
                     )
                 });
@@ -153,10 +155,9 @@ impl ExprLinter for GonnaGottaWanna {
     }
 }
 
-pub fn lint_group() -> LintGroup {
+pub fn lint_group(dialect: Dialect) -> LintGroup {
     let mut group = LintGroup::empty();
 
-    // 4. Replaced custom macro with a clean slice iteration
     let rules = [
         ("Gonna", "gonna", "going"),
         ("Gotta", "gotta", "got"),
@@ -164,7 +165,10 @@ pub fn lint_group() -> LintGroup {
     ];
 
     for &(name, informal, formal) in &rules {
-        group.add(name, Box::new(GonnaGottaWanna::new(informal, formal)));
+        group.add(
+            name,
+            Box::new(GonnaGottaWanna::new(dialect, informal, formal)),
+        );
     }
 
     group.set_all_rules_to(Some(true));
@@ -173,7 +177,10 @@ pub fn lint_group() -> LintGroup {
 
 #[cfg(test)]
 mod tests {
-    use crate::linting::tests::{assert_good_and_bad_suggestions, assert_suggestion_result};
+    use crate::{
+        Dialect,
+        linting::tests::{assert_good_and_bad_suggestions, assert_suggestion_result},
+    };
 
     use super::lint_group;
 
@@ -182,7 +189,7 @@ mod tests {
         // We think you're gonna like it here."
         assert_suggestion_result(
             "We think you're gonna like it here.",
-            lint_group(),
+            lint_group(Dialect::American),
             // fix the grammar and the informality
             "We think you're going to like it here.",
         )
@@ -193,7 +200,7 @@ mod tests {
         // "gonna" already means "going to", so adding "to" is redundant
         assert_good_and_bad_suggestions(
             "I am gonna to create the region by clicking and dragging the mouse on waveform but I couldn't find the way to do that.",
-            lint_group(),
+            lint_group(Dialect::American),
             &[
                 // fix the grammar but remain informal
                 "I am gonna create the region by clicking and dragging the mouse on waveform but I couldn't find the way to do that.",
@@ -208,7 +215,7 @@ mod tests {
     fn fix_gotta() {
         assert_suggestion_result(
             "Gotta Hear Them All: Towards Sound Source Aware Audio Generation.",
-            lint_group(),
+            lint_group(Dialect::American),
             "Got to Hear Them All: Towards Sound Source Aware Audio Generation.",
             // What about "have to"?
         )
@@ -220,20 +227,19 @@ mod tests {
         // but adding "a" is also redundant
         assert_suggestion_result(
             "when I try to create a c/c++ database,I gotta a error",
-            lint_group(),
+            lint_group(Dialect::American),
             // fix the grammar and the informality
             "when I try to create a c/c++ database,I got an error",
         )
     }
 
-    // You gotta a 20% OFF coupom.
     #[test]
     fn fix_gotta_a_coupom() {
         // "gotta" only means "(have) got to", using it as "got a" is incorrect
         // but adding "a" is also redundant
         assert_suggestion_result(
             "You gotta a 20% OFF coupom.",
-            lint_group(),
+            lint_group(Dialect::American),
             "You got a 20% OFF coupom.",
         )
     }
@@ -244,7 +250,7 @@ mod tests {
         // "gotta" already means "got to", so adding "to" is redundant
         assert_good_and_bad_suggestions(
             "it works well enough for me and gotta to get back working on other stuff",
-            lint_group(),
+            lint_group(Dialect::American),
             &[
                 // fix the grammar but remain informal
                 "it works well enough for me and gotta get back working on other stuff",
@@ -260,7 +266,7 @@ mod tests {
     fn fix_wanna_control() {
         assert_suggestion_result(
             "I wanna control G1 arms while walking using gamepad. But ...",
-            lint_group(),
+            lint_group(Dialect::American),
             "I want to control G1 arms while walking using gamepad. But ...",
         )
     }
@@ -271,7 +277,7 @@ mod tests {
         // Only way to fix fixes both the informality and the grammar goether
         assert_suggestion_result(
             "And then I remember from the beginning I just wanna a very simple array with some simple opreations.",
-            lint_group(),
+            lint_group(Dialect::American),
             "And then I remember from the beginning I just want a very simple array with some simple opreations.",
         )
     }
@@ -281,7 +287,7 @@ mod tests {
         // "wanna" already means "want to", so adding "to" is redundant
         assert_good_and_bad_suggestions(
             "it is stoped but i wanna to continue",
-            lint_group(),
+            lint_group(Dialect::American),
             &[
                 // fix the grammar but remain informal
                 "it is stoped but i wanna continue",

--- a/harper-core/src/linting/gonna_gotta_wanna.rs
+++ b/harper-core/src/linting/gonna_gotta_wanna.rs
@@ -1,13 +1,16 @@
 use crate::{
-    Lint, Token, TokenStringExt,
+    Dialect, Lint, Token, TokenStringExt,
+    char_string::CharStringExt,
     expr::{Expr, SequenceExpr},
+    indefinite_article::{InitialSound, starts_with_vowel},
     linting::{
-        ExprLinter, LintGroup, LintKind, Suggestion, debug::format_lint_match, expr_linter::Chunk,
+        ExprLinter, LintGroup, LintKind, Suggestion,
+        expr_linter::{Chunk, followed_by_word},
     },
 };
 
 struct GonnaGottaWanna {
-    expr: SequenceExpr, // TODO
+    expr: SequenceExpr,
     informal: &'static str,
     formal: &'static str,
 }
@@ -23,6 +26,18 @@ impl GonnaGottaWanna {
     }
 }
 
+enum Verb {
+    Gonna,
+    Gotta,
+    Wanna,
+}
+#[derive(PartialEq)]
+enum Rest {
+    None,
+    To,
+    A,
+}
+
 impl ExprLinter for GonnaGottaWanna {
     type Unit = Chunk;
 
@@ -36,15 +51,80 @@ impl ExprLinter for GonnaGottaWanna {
         src: &[char],
         ctx: Option<(&[Token], &[Token])>,
     ) -> Option<Lint> {
-        eprintln!("🚨 {}", format_lint_match(toks, ctx, src));
-        let span = toks.span()?;
-        let suggestions = vec![Suggestion::replace_with_match_case_str(
-            self.formal,
-            span.get_content(src),
-        )];
+        let verb_ch = &toks.first()?.get_ch(src)[..5];
+        let full_span = toks.span()?;
+        let content = full_span.get_content(src);
+
+        // 1. Rustier token slicing & string matching via CharStringExt
+        let verb_enum = match () {
+            _ if verb_ch.eq_str("gonna") => Verb::Gonna,
+            _ if verb_ch.eq_str("gotta") => Verb::Gotta,
+            _ if verb_ch.eq_str("wanna") => Verb::Wanna,
+            _ => return None,
+        };
+
+        let rest = match toks.get(2).map(|t| t.get_ch(src)) {
+            Some(ch) if ch.eq_str("to") => Rest::To,
+            Some(ch) if ch.eq_str("a") => Rest::A,
+            _ => Rest::None,
+        };
+
+        let mut suggestions = Vec::new();
+
+        // 2. DRY up standard "formal to" replacements
+        if rest != Rest::A {
+            let formal_to: Vec<char> = self.formal.chars().chain(" to".chars()).collect();
+            suggestions.push(Suggestion::replace_with_match_case(formal_to, content));
+        }
+
+        // 3. Flattened pattern matching logic
+        match (verb_enum, rest) {
+            (Verb::Gonna, Rest::To) => {
+                suggestions.push(Suggestion::ReplaceWith(verb_ch.to_vec()));
+            }
+            (Verb::Gotta, Rest::None) => {
+                suggestions.push(Suggestion::replace_with_match_case(
+                    "have to".chars().collect(),
+                    content,
+                ));
+            }
+            (Verb::Gotta, Rest::To) => {
+                suggestions.push(Suggestion::ReplaceWith(verb_ch.to_vec()));
+                suggestions.push(Suggestion::replace_with_match_case(
+                    "have to".chars().collect(),
+                    content,
+                ));
+            }
+            (Verb::Gotta, Rest::A) => {
+                // Simplified vowel detection logic with `.is_some_and`
+                let followed_by_vowel = followed_by_word(ctx, |t| {
+                    matches!(
+                        starts_with_vowel(t.get_ch(src), Dialect::American),
+                        Some(InitialSound::Vowel)
+                    )
+                });
+
+                let text = if followed_by_vowel { "got an" } else { "got a" };
+                suggestions.push(Suggestion::replace_with_match_case(
+                    text.chars().collect(),
+                    content,
+                ));
+            }
+            (Verb::Wanna, Rest::To) => {
+                suggestions.push(Suggestion::ReplaceWith(verb_ch.to_vec()));
+            }
+            (Verb::Wanna, Rest::A) => {
+                suggestions.push(Suggestion::replace_with_match_case(
+                    "want a".chars().collect(),
+                    content,
+                ));
+            }
+            _ => {} // Covers Gonna/Wanna + None/A scenarios gracefully
+        }
+
         Some(Lint {
-            span,
-            lint_kind: LintKind::Style,
+            span: full_span,
+            lint_kind: LintKind::Miscellaneous,
             suggestions,
             message: format!("Use '{}' instead of '{}'", self.formal, self.informal),
             ..Default::default()
@@ -52,29 +132,23 @@ impl ExprLinter for GonnaGottaWanna {
     }
 
     fn description(&self) -> &str {
-        "gonna gotta wanna"
+        "Corrects the informal contractions `gonna`, `gotta`, and `wanna` to their full forms."
     }
 }
 
 pub fn lint_group() -> LintGroup {
     let mut group = LintGroup::empty();
 
-    macro_rules! add_ggw {
-        ($group:expr, { $($name:expr => ($informal:expr, $formal:expr)),+ $(,)? }) => {
-            $(
-                $group.add(
-                    $name,
-                    Box::new(GonnaGottaWanna::new($informal, $formal)),
-                );
-            )+
-        };
-    }
+    // 4. Replaced custom macro with a clean slice iteration
+    let rules = [
+        ("Gonna", "gonna", "going"),
+        ("Gotta", "gotta", "got"),
+        ("Wanna", "wanna", "want"),
+    ];
 
-    add_ggw!(group, {
-        "Gonna" => ("gonna", "going"),
-        "Gotta" => ("gotta", "got"),
-        "Wanna" => ("wanna", "want"),
-    });
+    for &(name, informal, formal) in &rules {
+        group.add(name, Box::new(GonnaGottaWanna::new(informal, formal)));
+    }
 
     group.set_all_rules_to(Some(true));
     group
@@ -127,16 +201,11 @@ mod tests {
     fn fix_gotta_a_error() {
         // "gotta" only means "(have) got to", using it as "got a" is incorrect
         // but adding "a" is also redundant
-        assert_good_and_bad_suggestions(
+        assert_suggestion_result(
             "when I try to create a c/c++ database,I gotta a error",
             lint_group(),
-            &[
-                // fix the grammar but remain informal
-                "when I try to create a c/c++ database,I got a error",
-                // fix the grammar and the informality
-                "when I try to create a c/c++ database,I got an error",
-            ],
-            &[],
+            // fix the grammar and the informality
+            "when I try to create a c/c++ database,I got an error",
         )
     }
 
@@ -145,15 +214,10 @@ mod tests {
     fn fix_gotta_a_coupom() {
         // "gotta" only means "(have) got to", using it as "got a" is incorrect
         // but adding "a" is also redundant
-        assert_good_and_bad_suggestions(
+        assert_suggestion_result(
             "You gotta a 20% OFF coupom.",
             lint_group(),
-            &[
-                // fix the grammar but remain informal
-                "You got a 20% OFF coupom.",
-                // what about "you get", "you receive", "you received"?
-            ],
-            &[],
+            "You got a 20% OFF coupom.",
         )
     }
 

--- a/harper-core/src/linting/gonna_gotta_wanna.rs
+++ b/harper-core/src/linting/gonna_gotta_wanna.rs
@@ -79,19 +79,19 @@ impl ExprLinter for GonnaGottaWanna {
             ));
         }
 
-        let (made_formal, fixed_grammar) = match (verb_enum, rest) {
-            (Verb::Gonna, Rest::None) => (true, false),
+        let fixed_grammar = rest != Rest::None;
+
+        match (verb_enum, rest) {
+            (Verb::Gonna, Rest::None) => {}
             (Verb::Gonna, Rest::To) => {
                 suggestions.push(Suggestion::ReplaceWith(verb_ch.to_vec()));
-                (false, true)
             }
-            (Verb::Gonna, Rest::A) => (true, false),
+            (Verb::Gonna, Rest::A) => {}
             (Verb::Gotta, Rest::None) => {
                 suggestions.push(Suggestion::replace_with_match_case(
                     "have to".chars().collect(),
                     full_ch,
                 ));
-                (true, false)
             }
             (Verb::Gotta, Rest::To) => {
                 suggestions.push(Suggestion::ReplaceWith(verb_ch.to_vec()));
@@ -99,7 +99,6 @@ impl ExprLinter for GonnaGottaWanna {
                     "have to".chars().collect(),
                     full_ch,
                 ));
-                (true, true)
             }
             (Verb::Gotta, Rest::A) => {
                 let followed_by_vowel = followed_by_word(ctx, |t| {
@@ -114,31 +113,26 @@ impl ExprLinter for GonnaGottaWanna {
                     text.chars().collect(),
                     full_ch,
                 ));
-
-                (true, true)
             }
-            (Verb::Wanna, Rest::None) => (true, false),
+            (Verb::Wanna, Rest::None) => {}
             (Verb::Wanna, Rest::To) => {
                 suggestions.push(Suggestion::ReplaceWith(verb_ch.to_vec()));
-                (false, true)
             }
             (Verb::Wanna, Rest::A) => {
                 suggestions.push(Suggestion::replace_with_match_case(
                     "want a".chars().collect(),
                     full_ch,
                 ));
-                (true, true)
             }
         };
 
-        let message = match (made_formal, fixed_grammar) {
-            (true, true) => format!(
+        let message = if fixed_grammar {
+            format!(
                 "`{}` is very informal and the final `a` means `to`.",
                 self.informal
-            ),
-            (true, false) => format!("`{}` is very informal.", self.informal),
-            (false, true) => format!("The final `a` of `{}` means `to`.", self.informal),
-            (false, false) => return None,
+            )
+        } else {
+            format!("`{}` is very informal.", self.informal)
         };
 
         Some(Lint {
@@ -179,7 +173,9 @@ pub fn lint_group(dialect: Dialect) -> LintGroup {
 mod tests {
     use crate::{
         Dialect,
-        linting::tests::{assert_good_and_bad_suggestions, assert_suggestion_result},
+        linting::tests::{
+            assert_good_and_bad_suggestions, assert_lint_message, assert_suggestion_result,
+        },
     };
 
     use super::lint_group;
@@ -295,6 +291,89 @@ mod tests {
                 "it is stoped but i want to continue",
             ],
             &[],
+        )
+    }
+
+    // Check lint messages
+
+    #[test]
+    fn gonna_none_msg() {
+        assert_lint_message(
+            "gonna",
+            lint_group(Dialect::American),
+            "`gonna` is very informal.",
+        )
+    }
+
+    #[test]
+    fn gonna_a_msg() {
+        assert_lint_message(
+            "gonna a",
+            lint_group(Dialect::American),
+            "`gonna` is very informal and the final `a` means `to`.",
+        )
+    }
+
+    #[test]
+    fn gonna_to_msg() {
+        assert_lint_message(
+            "gonna to",
+            lint_group(Dialect::American),
+            "`gonna` is very informal and the final `a` means `to`.",
+        )
+    }
+
+    #[test]
+    fn gotta_noun_msg() {
+        assert_lint_message(
+            "gotta",
+            lint_group(Dialect::American),
+            "`gotta` is very informal.",
+        )
+    }
+
+    #[test]
+    fn gotta_a_msg() {
+        assert_lint_message(
+            "gotta a",
+            lint_group(Dialect::American),
+            "`gotta` is very informal and the final `a` means `to`.",
+        )
+    }
+
+    #[test]
+    fn gotta_to_msg() {
+        assert_lint_message(
+            "gotta to",
+            lint_group(Dialect::American),
+            "`gotta` is very informal and the final `a` means `to`.",
+        )
+    }
+
+    #[test]
+    fn wanna_none_msg() {
+        assert_lint_message(
+            "wanna",
+            lint_group(Dialect::American),
+            "`wanna` is very informal.",
+        )
+    }
+
+    #[test]
+    fn wanna_a_msg() {
+        assert_lint_message(
+            "wanna a",
+            lint_group(Dialect::American),
+            "`wanna` is very informal and the final `a` means `to`.",
+        )
+    }
+
+    #[test]
+    fn wanna_to_msg() {
+        assert_lint_message(
+            "wanna to",
+            lint_group(Dialect::American),
+            "`wanna` is very informal and the final `a` means `to`.",
         )
     }
 }

--- a/harper-core/src/linting/gonna_gotta_wanna.rs
+++ b/harper-core/src/linting/gonna_gotta_wanna.rs
@@ -51,11 +51,10 @@ impl ExprLinter for GonnaGottaWanna {
         src: &[char],
         ctx: Option<(&[Token], &[Token])>,
     ) -> Option<Lint> {
-        let verb_ch = &toks.first()?.get_ch(src)[..5];
+        let verb_ch = &toks.first()?.get_ch(src).get(..5)?;
         let full_span = toks.span()?;
-        let content = full_span.get_content(src);
+        let full_ch = full_span.get_content(src);
 
-        // 1. Rustier token slicing & string matching via CharStringExt
         let verb_enum = match () {
             _ if verb_ch.eq_str("gonna") => Verb::Gonna,
             _ if verb_ch.eq_str("gotta") => Verb::Gotta,
@@ -71,32 +70,36 @@ impl ExprLinter for GonnaGottaWanna {
 
         let mut suggestions = Vec::new();
 
-        // 2. DRY up standard "formal to" replacements
         if rest != Rest::A {
-            let formal_to: Vec<char> = self.formal.chars().chain(" to".chars()).collect();
-            suggestions.push(Suggestion::replace_with_match_case(formal_to, content));
+            suggestions.push(Suggestion::replace_with_match_case(
+                self.formal.chars().chain(" to".chars()).collect(),
+                full_ch,
+            ));
         }
 
-        // 3. Flattened pattern matching logic
-        match (verb_enum, rest) {
+        let (made_formal, fixed_grammar) = match (verb_enum, rest) {
+            (Verb::Gonna, Rest::None) => (true, false),
             (Verb::Gonna, Rest::To) => {
                 suggestions.push(Suggestion::ReplaceWith(verb_ch.to_vec()));
+                (false, true)
             }
+            (Verb::Gonna, Rest::A) => (true, false),
             (Verb::Gotta, Rest::None) => {
                 suggestions.push(Suggestion::replace_with_match_case(
                     "have to".chars().collect(),
-                    content,
+                    full_ch,
                 ));
+                (true, false)
             }
             (Verb::Gotta, Rest::To) => {
                 suggestions.push(Suggestion::ReplaceWith(verb_ch.to_vec()));
                 suggestions.push(Suggestion::replace_with_match_case(
                     "have to".chars().collect(),
-                    content,
+                    full_ch,
                 ));
+                (true, true)
             }
             (Verb::Gotta, Rest::A) => {
-                // Simplified vowel detection logic with `.is_some_and`
                 let followed_by_vowel = followed_by_word(ctx, |t| {
                     matches!(
                         starts_with_vowel(t.get_ch(src), Dialect::American),
@@ -107,26 +110,40 @@ impl ExprLinter for GonnaGottaWanna {
                 let text = if followed_by_vowel { "got an" } else { "got a" };
                 suggestions.push(Suggestion::replace_with_match_case(
                     text.chars().collect(),
-                    content,
+                    full_ch,
                 ));
+
+                (true, true)
             }
+            (Verb::Wanna, Rest::None) => (true, false),
             (Verb::Wanna, Rest::To) => {
                 suggestions.push(Suggestion::ReplaceWith(verb_ch.to_vec()));
+                (false, true)
             }
             (Verb::Wanna, Rest::A) => {
                 suggestions.push(Suggestion::replace_with_match_case(
                     "want a".chars().collect(),
-                    content,
+                    full_ch,
                 ));
+                (true, true)
             }
-            _ => {} // Covers Gonna/Wanna + None/A scenarios gracefully
-        }
+        };
+
+        let message = match (made_formal, fixed_grammar) {
+            (true, true) => format!(
+                "`{}` is very informal and the final `a` means `to`.",
+                self.informal
+            ),
+            (true, false) => format!("`{}` is very informal.", self.informal),
+            (false, true) => format!("The final `a` of `{}` means `to`.", self.informal),
+            (false, false) => return None,
+        };
 
         Some(Lint {
             span: full_span,
             lint_kind: LintKind::Miscellaneous,
             suggestions,
-            message: format!("Use '{}' instead of '{}'", self.formal, self.informal),
+            message,
             ..Default::default()
         })
     }

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -620,7 +620,7 @@ impl LintGroup {
         out.merge_from(closed_compounds::lint_group());
         out.merge_from(initialisms::lint_group());
         out.merge_from(be_adjective_confusions::lint_group());
-        out.merge_from(gonna_gotta_wanna::lint_group());
+        out.merge_from(gonna_gotta_wanna::lint_group(dialect));
 
         // Add all the more complex rules to the group.
         // Please maintain alphabetical order.

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -334,6 +334,7 @@ use super::wrong_negative::WrongNegative;
 // Modules that create multiple linters each
 use super::be_adjective_confusions;
 use super::closed_compounds;
+use super::gonna_gotta_wanna;
 use super::initialisms;
 use super::phrase_set_corrections;
 use super::proper_noun_capitalization_linters;
@@ -619,6 +620,7 @@ impl LintGroup {
         out.merge_from(closed_compounds::lint_group());
         out.merge_from(initialisms::lint_group());
         out.merge_from(be_adjective_confusions::lint_group());
+        out.merge_from(gonna_gotta_wanna::lint_group());
 
         // Add all the more complex rules to the group.
         // Please maintain alphabetical order.

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -711,8 +711,6 @@ pub mod tests {
         // Check if we've reached the expected result
         if text == needle {
             return true;
-        } else {
-            eprintln!(" 👉 {text}");
         }
 
         // Lint current text and try each suggestion branch

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -711,6 +711,8 @@ pub mod tests {
         // Check if we've reached the expected result
         if text == needle {
             return true;
+        } else {
+            eprintln!(" 👉 {text}");
         }
 
         // Lint current text and try each suggestion branch

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -122,6 +122,7 @@ mod go_missing;
 mod go_so_far_as_to;
 mod go_to_sleep;
 mod go_to_war;
+mod gonna_gotta_wanna;
 mod good_at;
 mod handful;
 mod handful_of_more;

--- a/harper-core/tests/test_sources/misc_closed_compound_clean.md
+++ b/harper-core/tests/test_sources/misc_closed_compound_clean.md
@@ -4,7 +4,7 @@ I got there after him.
 
 Go back there after dinner and finish it.
 
-We've gotta go down right here.
+We've got to go down right here.
 
 I hereby state that I got here by way of the "issues" link.
 


### PR DESCRIPTION
# Issues 
N/A

# Description

Linting "gonna", "gotta", and "wanna".

Firstly they're all informal and can be corrected to "going to", "got to", and "want to".

Secondly, nonnative speakers commonly make the mistake of following them with a redundant "to": "gonna to", "gotta to", and "wanna to". In these cases both an informal and formal suggestion can be made, just removing the redundant "to" or also changing the informal word.

Thirdly, nonnative speakers also commonly follow some of them wrongly with "a": "gotta a", "wanna a". These can be corrected to "got a", "want a".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

I had to change `harper-core/tests/test_sources/misc_closed_compound_clean.md`, which had "gotta" in one line.

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [x] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

After I got it working and all tests passing, I asked Google Search's AI for refactoring ideas to make it more DRY / more Rusty.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] I have considered splitting this into smaller pull requests.
