### PR TITLE
feat: mixing up "bane" (of one's existence) and "bain" (marie)

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -871,6 +871,13 @@
 						},
 						{
 							"Bool": {
+								"name": "BainBane",
+								"state": true,
+								"label": "Bain / Bane"
+							}
+						},
+						{
+							"Bool": {
 								"name": "Bollocks",
 								"state": true,
 								"label": "Bollocks"

--- a/harper-core/src/linting/phrase_set_corrections/many_to_many_tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/many_to_many_tests.rs
@@ -137,6 +137,58 @@ fn correct_back_hand_compliments_hyphen() {
     );
 }
 
+// BainBane
+
+#[test]
+fn fix_bain_of_my_existance() {
+    assert_suggestion_result(
+        "This is the bain of my existance, please help.",
+        test_linter(),
+        "This is the bane of my existence, please help.",
+    );
+}
+
+#[test]
+fn fix_bain_of_our() {
+    assert_suggestion_result(
+        "They are the bain of our existence on Apple hardware",
+        test_linter(),
+        "They are the bane of our existence on Apple hardware",
+    );
+}
+
+#[test]
+fn fix_bain_of_their() {
+    assert_suggestion_result(
+        "individual people in Apple might decide port scanning is the bain of their existence and send something",
+        test_linter(),
+        "individual people in Apple might decide port scanning is the bane of their existence and send something",
+    );
+}
+
+#[test]
+fn fix_bane_marie() {
+    assert_suggestion_result(
+        "The bane-marie is a favorite metaphor in my life for adding 'heat' (usually stress) to any idea, process, or person",
+        test_linter(),
+        "The bain-marie is a favorite metaphor in my life for adding 'heat' (usually stress) to any idea, process, or person",
+    );
+}
+
+#[test]
+fn fix_bane_maries() {
+    assert_good_and_bad_suggestions(
+        "They have bane Maries which is just a double broiler (water heated high under pans).",
+        test_linter(),
+        &[
+            // The way `replace_with_match_case` works by index breaks this
+            // "They have bains Marie which is just a double broiler (water heated high under pans).",
+            "They have bain Maries which is just a double broiler (water heated high under pans).",
+        ],
+        &[],
+    );
+}
+
 // CommitmentTo
 
 #[test]

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -788,6 +788,24 @@ pub fn lint_group() -> LintGroup {
             "Corrects `backhand compliment` to `backhanded compliment`.",
             LintKind::Spelling
         ),
+        "BainBane" => (
+            &[
+                (&["bain of my existence","bain of my existance"], &["bane of my existence"]),
+                (&["bain of our existence","bain of our existance"], &["bane of our existence"]),
+                (&["bain of your existence","bain of your existance"], &["bane of your existence"]),
+                (&["bain of his existence","bain of his existance"], &["bane of his existence"]),
+                (&["bain of her existence","bain of her existance"], &["bane of her existence"]),
+                (&["bain of its existence","bain of its existance"], &["bane of its existence"]),
+                (&["bain of their existence","bain of their existance"], &["bane of their existence"]),
+                (&["bane marie"], &["bain marie"]),
+                (&["bane-marie"], &["bain-marie"]),
+                (&["bane maries", "banes marie"], &["bains marie", "bain maries"]),
+                (&["bane-maries", "banes-marie"], &["bains-marie", "bain-maries"]),
+            ],
+            "Don't confuse `bane` (source of misery) with `bain` in `bain-marie` (double boiler).",
+            "Detects mixing up `bain` and `bane`.",
+            LintKind::Spelling
+        ),
         "CommitmentTo" => (
             &[
                 (&["commitment toward", "commitment towards"], &["commitment to"]),


### PR DESCRIPTION
# Issues 
N/A

# Description

I noticed that Harper doesn't suggest "bane" when it flags "bain" as a spelling mistake.

This linter fixes the spelling mistakes resulting from mixing up "bain" used in "bain marie", a double-boiler, and "bane" in the idiom "bane of one's existence".

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
