### PR TITLE
feat: add a debug printf to the linter asserts using `cfg!(debug_assertions)`

### DIFF
--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -710,6 +710,8 @@ pub mod tests {
         // Check if we've reached the expected result
         if text == needle {
             return true;
+        } else if cfg!(debug_assertions) {
+            eprintln!(" 🔎 \"{text}\"");
         }
 
         // Lint current text and try each suggestion branch


### PR DESCRIPTION
# Issues 
N/A

# Description

I keep adding a debug printf in `linting::search_for_suggestion()` to print attempts that don't match the desired result.

I just discovered `cfg!(debug_assertions)`, which lets us have it there permanently without it affecting release builds.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
