### PR TITLE
feat: hi-jack/high jack → hijack

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -1193,6 +1193,13 @@
 						},
 						{
 							"Bool": {
+								"name": "Hijack",
+								"state": true,
+								"lable": "Hijack"
+							}
+						},
+						{
+							"Bool": {
 								"name": "HitTheNailOnTheHead",
 								"state": true,
 								"label": "Hit The Nail On The Head"

--- a/harper-core/src/linting/phrase_set_corrections/many_to_many_tests.rs
+++ b/harper-core/src/linting/phrase_set_corrections/many_to_many_tests.rs
@@ -536,6 +536,116 @@ fn got_ride_of() {
     );
 }
 
+// Hijack
+
+#[test]
+fn fix_hi_hyphen_jacked() {
+    assert_suggestion_result(
+        "Empty message in hi-jacked POST from javascript to C# MVC",
+        test_linter(),
+        "Empty message in hijacked POST from javascript to C# MVC",
+    );
+}
+
+#[test]
+fn fix_hi_hyphen_jackers() {
+    assert_suggestion_result(
+        "hi-jackers, including one with no experience at all, survived jumps",
+        test_linter(),
+        "hijackers, including one with no experience at all, survived jumps",
+    );
+}
+
+#[test]
+fn fix_hi_hyphen_jacking() {
+    assert_suggestion_result(
+        "should be thrown instead of hi-jacking the Error class to dynamically add a property to the object",
+        test_linter(),
+        "should be thrown instead of hijacking the Error class to dynamically add a property to the object",
+    );
+}
+
+#[test]
+fn fix_hi_hyphen_jacks() {
+    assert_suggestion_result(
+        "Instruments' UI Recorder hi-jacks my entire system",
+        test_linter(),
+        "Instruments' UI Recorder hijacks my entire system",
+    );
+}
+
+#[test]
+fn fix_high_space_jack() {
+    assert_suggestion_result(
+        "ISPs that high jack the nxdomain result to send you sponsored results of vaguely similar sounding websites",
+        test_linter(),
+        "ISPs that hijack the nxdomain result to send you sponsored results of vaguely similar sounding websites",
+    );
+}
+
+#[test]
+fn fix_high_hyphen_jack() {
+    assert_suggestion_result(
+        "because now we no longer high-jack the API calls",
+        test_linter(),
+        "because now we no longer hijack the API calls",
+    );
+}
+
+#[test]
+fn fix_high_hyphen_jacked() {
+    assert_suggestion_result(
+        "not possible for the moment because the click event is high-jacked",
+        test_linter(),
+        "not possible for the moment because the click event is hijacked",
+    );
+}
+
+#[test]
+fn fix_high_hyphen_jacker() {
+    assert_suggestion_result(
+        "Driving a #Polo will get you treated like some high-jacker or car thief on the road",
+        test_linter(),
+        "Driving a #Polo will get you treated like some hijacker or car thief on the road",
+    );
+}
+
+#[test]
+fn fix_high_space_jackers() {
+    assert_suggestion_result(
+        "America and the high jackers are both referring to the same act of terror.",
+        test_linter(),
+        "America and the hijackers are both referring to the same act of terror.",
+    );
+}
+
+#[test]
+fn fix_high_space_jacking() {
+    assert_suggestion_result(
+        "Security issue , Session high jacking prevention",
+        test_linter(),
+        "Security issue , Session hijacking prevention",
+    );
+}
+
+#[test]
+fn fix_high_hyphen_jacks() {
+    assert_suggestion_result(
+        "Kotlin Compiler Plugin which high-jacks Kotlin assert function calls",
+        test_linter(),
+        "Kotlin Compiler Plugin which hijacks Kotlin assert function calls",
+    );
+}
+
+#[test]
+fn fix_high_space_jacks() {
+    assert_suggestion_result(
+        "This high jacks the issue somewhat but, the Computation Scheduler only runs as many concurrent threads as there are cores",
+        test_linter(),
+        "This hijacks the issue somewhat but, the Computation Scheduler only runs as many concurrent threads as there are cores",
+    );
+}
+
 // HolyWar
 
 #[test]

--- a/harper-core/src/linting/phrase_set_corrections/mod.rs
+++ b/harper-core/src/linting/phrase_set_corrections/mod.rs
@@ -896,6 +896,21 @@ pub fn lint_group() -> LintGroup {
             "Corrects common misspellings of the idiom `get rid of`.",
             LintKind::Typo
         ),
+        "Hijack" => (
+            &[
+                // "hi jack" would result in false positives
+                (&["hi-jack", "high jack", "high-jack"], &["hijack"]),
+                (&["hi jacked", "hi-jacked", "high jacked", "high-jacked"], &["hijacked"]),
+                (&["hi jacker", "hi-jacker", "high jacker", "high-jacker"], &["hijacker"]),
+                (&["hi jackers", "hi-jackers", "high jackers", "high-jackers"], &["hijackers"]),
+                (&["hi jacking", "hi-jacking", "high jacking", "high-jacking"], &["hijacking"]),
+                (&["hi jackings", "hi-jackings", "high jackings", "high-jackings"], &["hijackings"]),
+                (&["hi jacks", "hi-jacks", "high jacks", "high-jacks"], &["hijacks"]),
+            ],
+            "The correct spelling is `hijack`.",
+            "Corrects misspellings of `hijack`.",
+            LintKind::Spelling
+        ),
         "HolyWar" => (
             &[
                 (&["holey war", "holly war"], &["holy war"]),


### PR DESCRIPTION
# Issues 
N/A

# Description

I read "high jacker" in a YouTube comment and made a `phrase_set_corrections` linter.
It covers all inflections of the verb "hijack" and the nouns "hijack", "hijacking", and "hijacker".
It supports variants with "hi" and "high" as separate words or hyphenated.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
