### PR TITLE
feat: such shame → such a shame

### DIFF
--- a/harper-core/default_config.json
+++ b/harper-core/default_config.json
@@ -5713,6 +5713,13 @@
 						},
 						{
 							"Bool": {
+								"name": "SuchShame",
+								"state": true,
+								"label": "Such Shame"
+							}
+						},
+						{
+							"Bool": {
 								"name": "SufficeItToSay",
 								"state": true,
 								"label": "Suffice It To Say"

--- a/harper-core/src/linting/lint_group/mod.rs
+++ b/harper-core/src/linting/lint_group/mod.rs
@@ -269,6 +269,7 @@ use super::spell_check::SpellCheck;
 use super::spelled_numbers::SpelledNumbers;
 use super::split_words::SplitWords;
 use super::subject_pronoun::SubjectPronoun;
+use super::such_shame::SuchShame;
 use super::take_a_look_to::TakeALookTo;
 use super::take_care_of::TakeCareOf;
 use super::take_medicine::TakeMedicine;
@@ -882,6 +883,7 @@ impl LintGroup {
         insert_struct_rule!(SpelledNumbers);
         insert_expr_rule!(SplitWords);
         insert_struct_rule!(SubjectPronoun);
+        insert_expr_rule!(SuchShame);
         insert_expr_rule!(TakeALookTo);
         insert_expr_rule!(TakeCareOf);
         insert_expr_rule!(TakeMedicine);

--- a/harper-core/src/linting/mod.rs
+++ b/harper-core/src/linting/mod.rs
@@ -286,6 +286,7 @@ mod spell_check;
 mod spelled_numbers;
 mod split_words;
 mod subject_pronoun;
+mod such_shame;
 mod suggestion;
 mod take_a_look_to;
 mod take_care_of;

--- a/harper-core/src/linting/such_shame.rs
+++ b/harper-core/src/linting/such_shame.rs
@@ -1,0 +1,138 @@
+use crate::{
+    CharStringExt, Lint, Token,
+    expr::{Expr, SequenceExpr},
+    linting::{
+        ExprLinter, LintKind, Suggestion,
+        expr_linter::{Chunk, preceded_by_word},
+    },
+};
+
+pub struct SuchShame {
+    expr: SequenceExpr,
+}
+
+impl Default for SuchShame {
+    fn default() -> Self {
+        Self {
+            expr: SequenceExpr::word_set(["is", "it's", "its", "that's", "thats", "was"])
+                .t_ws()
+                .then_word_seq(&["such", "shame"]),
+        }
+    }
+}
+
+impl ExprLinter for SuchShame {
+    type Unit = Chunk;
+
+    fn match_to_lint_with_context(
+        &self,
+        toks: &[Token],
+        src: &[char],
+        ctx: Option<(&[Token], &[Token])>,
+    ) -> Option<Lint> {
+        let (first, such, ws) = (0, 2, 3);
+        let (first, such, ws) = (toks.get(first)?, toks.get(such)?, toks.get(ws)?);
+
+        if first
+            .get_ch(src)
+            .eq_any_ignore_ascii_case_chars(&[&['i', 's'], &['w', 'a', 's']])
+            && preceded_by_word(ctx, |t| {
+                t.get_ch(src).eq_any_ignore_ascii_case_chars(&[
+                    &['t', 'h', 'e', 'r', 'e'],
+                    &['t', 'h', 'e', 'i', 'r'],
+                ])
+            })
+        {
+            return None;
+        }
+
+        let c = *such.get_ch(src).get(2)?;
+        let a = (c as u8 - 2) as char;
+
+        let mut new_chars = vec![a];
+        new_chars.extend(ws.get_ch(src));
+
+        Some(Lint {
+            span: ws.span,
+            lint_kind: LintKind::Usage,
+            suggestions: vec![Suggestion::InsertAfter(new_chars)],
+            message: "This expression requires `a shame`.".to_owned(),
+            ..Default::default()
+        })
+    }
+
+    fn expr(&self) -> &dyn Expr {
+        &self.expr
+    }
+
+    fn description(&self) -> &str {
+        "Corrects `such shame` to `such a shame`."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::linting::tests::{assert_no_lints, assert_suggestion_result};
+
+    use super::SuchShame;
+
+    #[test]
+    fn its_apostrope() {
+        assert_suggestion_result(
+            "it's such shame that for large datasets the usage of this wonderful package becomes not pracitcal",
+            SuchShame::default(),
+            "it's such a shame that for large datasets the usage of this wonderful package becomes not pracitcal",
+        );
+    }
+
+    #[test]
+    fn it_is() {
+        assert_suggestion_result(
+            "It is such shame that the TV adaptation changed this fundamental part of the story for no reason",
+            SuchShame::default(),
+            "It is such a shame that the TV adaptation changed this fundamental part of the story for no reason",
+        );
+    }
+
+    #[test]
+    fn dont_flag_there_was() {
+        assert_no_lints(
+            "but I think there was such shame in that at the time most conversations on the subject would be ...",
+            SuchShame::default(),
+        );
+    }
+
+    #[test]
+    fn dont_flag_there_is() {
+        assert_no_lints(
+            "There is such shame that seems to come from not being able to handle your house.",
+            SuchShame::default(),
+        );
+    }
+
+    #[test]
+    fn it_was() {
+        assert_suggestion_result(
+            "It was such shame to lose such a talented composer.",
+            SuchShame::default(),
+            "It was such a shame to lose such a talented composer.",
+        );
+    }
+
+    #[test]
+    fn its_no_apostrophe() {
+        assert_suggestion_result(
+            "Its such shame to because this update had such potential",
+            SuchShame::default(),
+            "Its such a shame to because this update had such potential",
+        );
+    }
+
+    #[test]
+    fn dont_flag_their_was() {
+        assert_no_lints(
+            "Partially because their was such shame among black people if they had darker skin. ",
+            SuchShame::default(),
+        );
+    }
+}


### PR DESCRIPTION
# Issues 
N/A

# Description

I read "such shame" in a comment I think on Hacker News that obviously should've been "such a shame".
Some research taught me that the problem comes after 3rd person singular forms of "to be" in the present or past tense, but not after "there" (or misspelled "their).

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

`cargo test`

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
