### PR TITLE
feat: add "FFT" and "BWT" transforms to `RedundantAcronyms`

### DIFF
--- a/harper-core/src/linting/redundant_acronyms.rs
+++ b/harper-core/src/linting/redundant_acronyms.rs
@@ -24,6 +24,8 @@ const ACRONYMS: &[(&str, &[&str], &str, Flag)] = &[
         "machine",
         None,
     ),
+    ("BWT", &["Burrows-Wheeler"], "transform", None),
+    ("FFT", &["Fast Fourier"], "transform", None),
     ("GOP", &["Grand Old"], "Party", None),
     ("GUI", &["graphical user"], "interface", None),
     ("LCD", &["liquid crystal"], "display", None),
@@ -451,6 +453,32 @@ mod tests {
             &[
                 "course project aimed to classify PCBs as defect or non-defect - ChethanaVaisali/PCB_Classification.",
                 "course project aimed to classify printed circuit boards as defect or non-defect - ChethanaVaisali/PCB_Classification.",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn correct_bwt_transform() {
+        assert_good_and_bad_suggestions(
+            "TSuffix Arrays: It turns out the way we generated the BWT transform above was quite inefficient.",
+            RedundantAcronyms::default(),
+            &[
+                "TSuffix Arrays: It turns out the way we generated the BWT above was quite inefficient.",
+                "TSuffix Arrays: It turns out the way we generated the Burrows-Wheeler transform above was quite inefficient.",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
+    fn correct_fft_transform() {
+        assert_good_and_bad_suggestions(
+            "In fact, the FFT transform does not have to process functions of equally spaced time samples",
+            RedundantAcronyms::default(),
+            &[
+                "In fact, the FFT does not have to process functions of equally spaced time samples",
+                "In fact, the Fast Fourier transform does not have to process functions of equally spaced time samples",
             ],
             &[],
         );


### PR DESCRIPTION
# Issues 
N/A

# Description

Earlier today I read "BWT transform" which led me to think people must also write "FFT transform". Indeed they do so I've added both to `RedundantAcronyms`.

# How Has This Been Tested?
<!-- Please describe how you tested your changes. -->

# AI Disclosure
<!-- It helps us review PRs when we know about AI assistance. -->
- [ ] I am a human and didn't use any AI.
- [x] I used LLM features of my editor, but not an agent.
- [ ] I consulted one or more coding AIs, but didn't use an agent.
- [ ] I used an AI agent interactively.
- [ ] I am an agent or I got an agent to do the work autonomously.

# If Your PR Implements or Enhances a Linter
<!-- Humans don't always bring ideal test cases, but unlike AIs, they can learn how to find real-world examples -->
- [ ] I made up the sentences in the unit tests.
- [ ] The sentences in the unit tests were generated by an AI.
- [ ] I'm using examples from the bug report / feature request.
- [x] I collected real-world sentences for the unit tests.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] I have considered splitting this into smaller pull requests.
